### PR TITLE
Pinpoint dedented and over-indented lines in more YAML indent errors

### DIFF
--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -31,11 +31,12 @@ import { ESPHOME_YAML_INDENT, esphomeYaml } from "../util/esphome-yaml-lang.js";
 import { idleCompletion } from "../util/idle-completion.js";
 import { getKeyPath, isInsideBlockScalar } from "../util/yaml-ast.js";
 import { createYamlCompletionSource } from "../util/yaml-completion.js";
-import { analyzeIndentMismatch, type YamlAutoFix } from "../util/yaml-error-analysis.js";
+import { lineKeyToken, type YamlAutoFix } from "../util/yaml-error-analysis.js";
 import { createYamlHoverTooltip } from "../util/yaml-hover.js";
 import {
   blankLineContext,
   fieldPathByIndent,
+  indentOf,
   keyPathByIndent,
 } from "../util/yaml-line-walker.js";
 import {
@@ -639,25 +640,19 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
   ): Promise<AutoFixOutcome> {
     const view = this._view;
     if (!view || !this._api || fix.indent === 0) return "unavailable";
-    // Resolve the target only when re-running the analysis on the fix line
-    // still yields this exact repair — a stale click on an item the user
-    // already re-indented by hand (whose key still matches) can't move it
-    // again. Every analysis shape blames the line it would move except the
-    // classic over-indented-properties case, where re-analyzing the marker
-    // line itself reproduces the fix through the properties below it.
+    // Resolve the target only when the line the fix wants to move is still
+    // the line the analysis saw — same key, same indent — so a stale click
+    // after edits shifted line numbers, or on a line the user already
+    // re-indented by hand, can't move the wrong line. The check is
+    // structural rather than a re-run of the analysis: the diagnosis can be
+    // anchored on a different line than the one it repairs (a continuation
+    // error blames the line below the pair that moves), so re-analyzing at
+    // the fix line can't reproduce every shape.
     const targetFrom = (): number | null => {
       const doc = view.state.doc;
       if (fix.line < 1 || fix.line > doc.lines) return null;
       const t = doc.line(fix.line);
-      const readLine = (n: number) =>
-        n >= 1 && n <= doc.lines ? doc.line(n).text : undefined;
-      const cur = analyzeIndentMismatch(readLine, fix.line);
-      if (
-        !cur ||
-        cur.markerLine !== fix.line ||
-        cur.markerKey !== fix.key ||
-        cur.delta !== fix.indent
-      ) {
+      if (lineKeyToken(t.text) !== fix.key || indentOf(t.text) !== fix.fromIndent) {
         return null;
       }
       // A dedent must have the spaces it wants to remove.

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -656,7 +656,7 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
         return null;
       }
       // A dedent must have the spaces it wants to remove.
-      if (fix.indent < 0 && /[^ ]/.test(t.text.slice(0, -fix.indent))) return null;
+      if (fix.indent < 0 && fix.fromIndent + fix.indent < 0) return null;
       return t.from;
     };
     const from = targetFrom();

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -209,6 +209,101 @@ export interface IndentMismatch {
 }
 
 /**
+ * Continuation-scalar repair: the blamed line sits deeper than the valued
+ * `key: value` directly above it (*prev*), so the scanner reads it as that
+ * value's plain-scalar continuation and chokes on the ':'. Re-indent the
+ * pair back under the value-less `key:` it fell out of, or dedent the
+ * blamed line when there is no such block. Null when the mismatch is too
+ * large to call.
+ */
+function continuationScalarFix(
+  readLine: ReadLine,
+  errorLine: number,
+  errText: string,
+  propIndent: number,
+  prev: { line: number; text: string }
+): IndentMismatch | null {
+  const prevIndent = indentOf(prev.text);
+  const prevKey = lineKeyToken(prev.text);
+  const delta = propIndent - prevIndent;
+  if (prevKey === null || delta > MAX_SIBLING_ALIGN) return null;
+  const parent = contentLineAbove(readLine, prev.line);
+  if (
+    parent &&
+    !parseListItemMarker(parent.text) &&
+    indentOf(parent.text) === prevIndent &&
+    valuelessKeyOf(parent.text) !== null
+  ) {
+    return { markerLine: prev.line, markerKey: prevKey, delta, reason: "align" };
+  }
+  const blamedKey = lineKeyToken(errText);
+  return blamedKey
+    ? { markerLine: errorLine, markerKey: blamedKey, delta: -delta, reason: "align" }
+    : null;
+}
+
+/**
+ * Repairs for a blamed line that closes a value-less opener's too-deep
+ * block: re-indent the opener when a sibling above it sits at the blamed
+ * line's indent (the opener was dedented — `mode:` dropped out of `pin:`,
+ * blamed on `number:`), else dedent the block's first child when the blamed
+ * line already sits at the opener's canonical child indent (the child went
+ * too deep). Null when neither reading holds.
+ */
+function misplacedOpenerFix(
+  readLine: ReadLine,
+  errorLine: number,
+  propIndent: number
+): IndentMismatch | null {
+  // The opener candidate: the nearest line above the blamed one that sits
+  // shallower, provided it is a value-less `key:` still inside the same
+  // marker-less stretch.
+  let opener: { line: number; indent: number; key: string } | null = null;
+  for (let n = errorLine - 1; n >= 1 && n >= errorLine - WALK_BOUND; n--) {
+    const text = readLine(n);
+    if (text === undefined || isBlankOrComment(text)) continue;
+    if (parseListItemMarker(text)) break;
+    const indent = indentOf(text);
+    if (opener === null) {
+      if (indent >= propIndent) continue;
+      if (indent === 0) break;
+      const key = valuelessKeyOf(text);
+      if (key === null) break;
+      opener = { line: n, indent, key };
+      continue;
+    }
+    // Above the opener: a sibling at exactly the blamed line's indent
+    // proves the opener was dedented out of that level.
+    if (indent === propIndent && propIndent - opener.indent <= MAX_SIBLING_ALIGN) {
+      return {
+        markerLine: opener.line,
+        markerKey: opener.key,
+        delta: propIndent - opener.indent,
+        reason: "align",
+      };
+    }
+    // Leaving the opener's block ends the sibling search.
+    if (indent < opener.indent) break;
+  }
+  // The competing reading: the opener sits where it belongs (the blamed
+  // line is at its canonical child indent) and the block's first child is
+  // what went too deep.
+  if (opener === null || propIndent !== opener.indent + YAML_INDENT_STEP) return null;
+  const child = contentLineBelow(readLine, opener.line);
+  const childKey = child === null ? null : lineKeyToken(child.text);
+  if (child === null || childKey === null) return null;
+  const childIndent = indentOf(child.text);
+  return childIndent > propIndent && childIndent - propIndent <= MAX_SIBLING_ALIGN
+    ? {
+        markerLine: child.line,
+        markerKey: childKey,
+        delta: propIndent - childIndent,
+        reason: "align",
+      }
+    : null;
+}
+
+/**
  * Pinpoint the exact indentation fix behind a YAML indentation error.
  *
  * Shapes covered, in priority order:
@@ -261,48 +356,28 @@ export function analyzeIndentMismatch(
     return null;
   }
   const propIndent = errIndent;
-  // Continuation-scalar shape: the blamed line sits deeper than the valued
-  // `key: value` directly above it, so the scanner reads it as that value's
-  // plain-scalar continuation and chokes on the ':'. The repair depends on
-  // which line moved: a value-less `key:` above the pair at the pair's own
-  // indent means the pair was dedented out of that block (indent it back);
-  // otherwise the blamed line itself is over-indented (dedent it to join
-  // the pair as a sibling).
   const prev = contentLineAbove(readLine, errorLine);
   const prevIndent = prev === null ? -1 : indentOf(prev.text);
-  if (prev && !parseListItemMarker(prev.text)) {
-    const prevKey = lineKeyToken(prev.text);
-    if (prevIndent < propIndent && prevKey && lineHasValue(prev.text)) {
-      const delta = propIndent - prevIndent;
-      if (delta > MAX_SIBLING_ALIGN) return null;
-      const parent = contentLineAbove(readLine, prev.line);
-      if (
-        parent &&
-        !parseListItemMarker(parent.text) &&
-        indentOf(parent.text) === prevIndent &&
-        valuelessKeyOf(parent.text) !== null
-      ) {
-        return { markerLine: prev.line, markerKey: prevKey, delta, reason: "align" };
-      }
-      const blamedKey = lineKeyToken(errText);
-      return blamedKey
-        ? { markerLine: errorLine, markerKey: blamedKey, delta: -delta, reason: "align" }
-        : null;
-    }
+  // The line directly above decides the reading: a shallower valued pair
+  // makes the blamed line its plain-scalar continuation; a deeper line means
+  // the blamed line closes a block, the signature of a misplaced value-less
+  // opener (or its over-deep first child) above.
+  if (
+    prev &&
+    !parseListItemMarker(prev.text) &&
+    prevIndent < propIndent &&
+    lineHasValue(prev.text)
+  ) {
+    return continuationScalarFix(readLine, errorLine, errText, propIndent, prev);
   }
-  // The blamed line closes a block deeper than itself when the line directly
-  // above it sits deeper — the signature of a dedented block opener above.
-  const prevDeeper = prevIndent > propIndent;
+  if (prevIndent > propIndent) {
+    const openerFix = misplacedOpenerFix(readLine, errorLine, propIndent);
+    if (openerFix) return openerFix;
+  }
   // Nearest shallower non-marker line passed on the way up — when it sits
   // exactly at the marker's content column, the surrounding structure is
   // consistent and the blamed line is the one to move.
-  let shallower: { line: number; indent: number; text: string } | null = null;
-  // Set on crossing a line shallower than `shallower`: the dedented-opener
-  // reading is dead, a later same-indent line is unrelated structure.
-  let leftShallowerBlock = false;
-  // Over-deep first child of a value-less opener, held until the walk rules
-  // out the dedented-opener reading above it.
-  let openerChild: IndentMismatch | null = null;
+  let shallowerIndent: number | null = null;
   // Bound the walk so a huge doc can't turn one lint pass into a scan.
   for (let n = errorLine - 1; n >= 1 && n >= errorLine - WALK_BOUND; n--) {
     const text = readLine(n);
@@ -310,70 +385,19 @@ export function analyzeIndentMismatch(
     const marker = parseListItemMarker(text);
     if (!marker) {
       const indent = indentOf(text);
-      // Dedented block opener: the blamed line closes a too-deep block run
-      // by a value-less `key:` sitting shallower than the level it should be
-      // on — proven by a sibling at exactly the blamed line's indent above
-      // that key (case: `mode:` dedented out of `pin:`, blamed on `number:`).
-      // The key is what moved; re-indent it to the blamed line's level.
-      if (
-        prevDeeper &&
-        shallower !== null &&
-        !leftShallowerBlock &&
-        indent === propIndent
-      ) {
-        const openerKey = valuelessKeyOf(shallower.text);
-        if (openerKey !== null && propIndent - shallower.indent <= MAX_SIBLING_ALIGN) {
-          return {
-            markerLine: shallower.line,
-            markerKey: openerKey,
-            delta: propIndent - shallower.indent,
-            reason: "align",
-          };
-        }
-      }
       if (indent < propIndent) {
         // A top-level line means we left every block without a marker.
-        if (indent === 0) return openerChild;
-        if (shallower !== null && indent < shallower.indent) leftShallowerBlock = true;
-        if (shallower === null) {
-          shallower = { line: n, indent, text };
-          // The competing reading: the opener sits where it belongs (the
-          // blamed line is at its canonical child indent) and the block's
-          // first child above the blamed line is what went too deep. Held,
-          // not returned — a sibling above the opener at the blamed line's
-          // indent proves the opener moved instead.
-          const child =
-            prevDeeper &&
-            propIndent === indent + YAML_INDENT_STEP &&
-            valuelessKeyOf(text) !== null
-              ? contentLineBelow(readLine, n)
-              : null;
-          const childKey = child === null ? null : lineKeyToken(child.text);
-          if (child !== null && childKey !== null) {
-            const childIndent = indentOf(child.text);
-            if (
-              childIndent > propIndent &&
-              childIndent - propIndent <= MAX_SIBLING_ALIGN
-            ) {
-              openerChild = {
-                markerLine: child.line,
-                markerKey: childKey,
-                delta: propIndent - childIndent,
-                reason: "align",
-              };
-            }
-          }
-        }
+        if (indent === 0) return null;
+        if (shallowerIndent === null) shallowerIndent = indent;
       }
       continue;
     }
-    if (openerChild) return openerChild;
     const errKey = lineKeyToken(errText);
     if (propIndent > marker.contentCol) {
       // Siblings already aligned at the content column — above or below the
       // blamed line — make the blamed line the odd one out; otherwise assume
       // the marker is what needs to move.
-      const alignedAbove = shallower?.indent === marker.contentCol;
+      const alignedAbove = shallowerIndent === marker.contentCol;
       const next =
         !alignedAbove && errKey && propIndent - marker.contentCol <= MAX_SIBLING_ALIGN
           ? contentLineBelow(readLine, errorLine)
@@ -409,7 +433,7 @@ export function analyzeIndentMismatch(
     }
     return null;
   }
-  return openerChild;
+  return null;
 }
 
 /** Matches a value-less `- key:` list item (optionally with a comment). */

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -10,7 +10,7 @@
  * signed one-line repair — live only here.
  */
 import type { LocalizeFunc } from "../common/localize.js";
-import { indentOf, parseListItemMarker } from "./yaml-line-walker.js";
+import { indentOf, parseListItemMarker, stripComment } from "./yaml-line-walker.js";
 
 /** Match `line N, column M` (1-indexed) globally in a YAML parse error message. */
 const YAML_LINE_COL_RE = /line\s+(\d+)\s*,\s*column\s+(\d+)/gi;
@@ -19,6 +19,14 @@ const YAML_LINE_RE = /line\s+(\d+)/gi;
 
 /** A quoted path (POSIX `/` or Windows `\`) — keep the basename, drop the dir. */
 const QUOTED_PATH_RE = /"([^"]*[/\\])([^"/\\]+)"/g;
+
+/** `key:` at line start (no marker), capturing the key. Broader than the
+ *  walker's RE_PAIR_LINE — any non-`:` key token, so quoted or dotted keys
+ *  still match. */
+const KEY_TOKEN_RE = /^\s*([^\s:#][^:]*?)\s*:(?:\s|$)/;
+
+/** `key: value` with a non-empty value, applied after comment stripping. */
+const VALUED_PAIR_RE = /^\s*[^\s:#][^:]*?:\s*\S/;
 
 /**
  * Strip absolute directory paths out of a backend error message.
@@ -135,11 +143,44 @@ function siblingMarkerDelta(
 }
 
 /** First key token of a line — a list item's key, a plain `key:`, or null. */
-function lineKeyToken(text: string): string | null {
+export function lineKeyToken(text: string): string | null {
   const marker = parseListItemMarker(text);
   if (marker) return marker.key;
-  const hit = text.match(/^\s*([^\s:#][^:]*?)\s*:(?:\s|$)/);
+  const hit = text.match(KEY_TOKEN_RE);
   return hit ? hit[1] : null;
+}
+
+/** Whether the line is a `key: value` pair with a non-empty value. */
+function lineHasValue(text: string): boolean {
+  return VALUED_PAIR_RE.test(stripComment(text));
+}
+
+/** Nearest non-blank, non-comment line above *line*, bounded like the walks. */
+function contentLineAbove(
+  readLine: ReadLine,
+  line: number
+): { line: number; text: string } | null {
+  for (let n = line - 1; n >= 1 && n >= line - 50; n--) {
+    const text = readLine(n);
+    if (text === undefined) return null;
+    if (!text.trim() || text.trimStart().startsWith("#")) continue;
+    return { line: n, text };
+  }
+  return null;
+}
+
+/** Nearest non-blank, non-comment line below *line*, bounded like the walks. */
+function contentLineBelow(
+  readLine: ReadLine,
+  line: number
+): { line: number; text: string } | null {
+  for (let n = line + 1; n <= line + 50; n++) {
+    const text = readLine(n);
+    if (text === undefined) return null;
+    if (!text.trim() || text.trimStart().startsWith("#")) continue;
+    return { line: n, text };
+  }
+  return null;
 }
 
 /**
@@ -165,10 +206,19 @@ export interface IndentMismatch {
  *   `expected <block end>, but found '-'`): indent the marker to match.
  * - Blamed marker misaligned with the marker directly above it (one space
  *   off in either direction): re-indent the blamed marker to line up.
+ * - Blamed line deeper than the valued `key: value` directly above it (the
+ *   scanner reads it as a plain-scalar continuation): re-indent the pair
+ *   back under the value-less `key:` it fell out of, or dedent the blamed
+ *   line when there is no such block.
+ * - Blamed line closing a value-less key's too-deep block: re-indent the
+ *   key when a sibling above it sits at the blamed line's indent, else
+ *   dedent the block's first child when the blamed line already sits at
+ *   the key's canonical child indent.
  * - Blamed property line: the classic over-indent (`- platform: dht` then
  *   `    model:` — the scanner blames the property, the marker is what
- *   moves), or a property out of line with siblings already sitting at the
- *   marker's content column (re-indent the blamed line instead).
+ *   moves), a property at the markers' own indent (re-indent it to the
+ *   content column), or a property out of line with siblings already
+ *   sitting at the marker's content column (re-indent the blamed line).
  */
 export function analyzeIndentMismatch(
   readLine: ReadLine,
@@ -200,10 +250,55 @@ export function analyzeIndentMismatch(
     return null;
   }
   const propIndent = errIndent;
+  // Continuation-scalar shape: the blamed line sits deeper than the valued
+  // `key: value` directly above it, so the scanner reads it as that value's
+  // plain-scalar continuation and chokes on the ':'. The repair depends on
+  // which line moved: a value-less `key:` above the pair at the pair's own
+  // indent means the pair was dedented out of that block (indent it back);
+  // otherwise the blamed line itself is over-indented (dedent it to join
+  // the pair as a sibling).
+  const prev = contentLineAbove(readLine, errorLine);
+  if (prev && !parseListItemMarker(prev.text)) {
+    const prevIndent = indentOf(prev.text);
+    const prevKey = lineKeyToken(prev.text);
+    if (prevIndent < propIndent && prevKey && lineHasValue(prev.text)) {
+      const delta = propIndent - prevIndent;
+      if (delta > MAX_SIBLING_ALIGN) return null;
+      const parent = contentLineAbove(readLine, prev.line);
+      if (
+        parent &&
+        !parseListItemMarker(parent.text) &&
+        indentOf(parent.text) === prevIndent &&
+        lineKeyToken(parent.text) &&
+        !lineHasValue(parent.text)
+      ) {
+        return { markerLine: prev.line, markerKey: prevKey, delta, reason: "align" };
+      }
+      const blamedKey = lineKeyToken(errText);
+      return blamedKey
+        ? { markerLine: errorLine, markerKey: blamedKey, delta: -delta, reason: "align" }
+        : null;
+    }
+  }
+  // The blamed line closes a block deeper than itself when the line directly
+  // above it sits deeper — the signature of a dedented block opener above.
+  const prevDeeper = prev !== null && indentOf(prev.text) > propIndent;
   // Nearest shallower non-marker line passed on the way up — when it sits
   // exactly at the marker's content column, the surrounding structure is
   // consistent and the blamed line is the one to move.
-  let shallowerIndent: number | null = null;
+  let shallower: {
+    line: number;
+    indent: number;
+    key: string | null;
+    hasValue: boolean;
+  } | null = null;
+  // The content line processed one iteration ago — physically the line just
+  // below the current one, so at the first shallower line it is that block's
+  // first child.
+  let below: { line: number; indent: number; key: string | null } | null = null;
+  // Over-deep first child of a value-less opener, held until the walk rules
+  // out the dedented-opener reading above it.
+  let openerChild: IndentMismatch | null = null;
   // Bound the walk so a huge doc can't turn one lint pass into a scan.
   for (let n = errorLine - 1; n >= 1 && n >= errorLine - 50; n--) {
     const text = readLine(n);
@@ -213,18 +308,87 @@ export function analyzeIndentMismatch(
     const marker = parseListItemMarker(text);
     if (!marker) {
       const indent = indentOf(text);
+      // Dedented block opener: the blamed line closes a too-deep block run
+      // by a value-less `key:` sitting shallower than the level it should be
+      // on — proven by a sibling at exactly the blamed line's indent above
+      // that key (case: `mode:` dedented out of `pin:`, blamed on `number:`).
+      // The key is what moved; re-indent it to the blamed line's level.
+      if (
+        prevDeeper &&
+        shallower !== null &&
+        indent === propIndent &&
+        shallower.key !== null &&
+        !shallower.hasValue &&
+        propIndent - shallower.indent <= MAX_SIBLING_ALIGN
+      ) {
+        return {
+          markerLine: shallower.line,
+          markerKey: shallower.key,
+          delta: propIndent - shallower.indent,
+          reason: "align",
+        };
+      }
       if (indent < propIndent) {
         // A top-level line means we left every block without a marker.
-        if (indent === 0) return null;
-        if (shallowerIndent === null) shallowerIndent = indent;
+        if (indent === 0) return openerChild;
+        // Leaving the first shallower line's block kills the dedented-
+        // opener theory — a later same-indent line is unrelated structure.
+        if (shallower !== null && indent < shallower.indent) shallower.key = null;
+        if (shallower === null) {
+          shallower = {
+            line: n,
+            indent,
+            key: lineKeyToken(text),
+            hasValue: lineHasValue(text),
+          };
+          // The competing reading: the opener sits where it belongs (the
+          // blamed line is at its canonical child indent) and the block's
+          // first child above the blamed line is what went too deep. Held,
+          // not returned — a sibling above the opener at the blamed line's
+          // indent proves the opener moved instead.
+          if (
+            prevDeeper &&
+            shallower.key !== null &&
+            !shallower.hasValue &&
+            propIndent === indent + 2 &&
+            below !== null &&
+            below.key !== null &&
+            below.indent > propIndent &&
+            below.indent - propIndent <= MAX_SIBLING_ALIGN
+          ) {
+            openerChild = {
+              markerLine: below.line,
+              markerKey: below.key,
+              delta: propIndent - below.indent,
+              reason: "align",
+            };
+          }
+        }
       }
+      below = { line: n, indent, key: lineKeyToken(text) };
       continue;
     }
     const errKey = lineKeyToken(errText);
+    if (openerChild) return openerChild;
     if (propIndent > marker.contentCol) {
-      // Siblings already aligned at the content column → the blamed line is
-      // the odd one out; otherwise assume the marker is what needs to move.
-      if (shallowerIndent === marker.contentCol && errKey) {
+      // Siblings already aligned at the content column — above or below the
+      // blamed line — make the blamed line the odd one out; otherwise assume
+      // the marker is what needs to move.
+      if (shallower?.indent === marker.contentCol && errKey) {
+        return {
+          markerLine: errorLine,
+          markerKey: errKey,
+          delta: marker.contentCol - propIndent,
+          reason: "align",
+        };
+      }
+      const next = contentLineBelow(readLine, errorLine);
+      if (
+        next !== null &&
+        indentOf(next.text) === marker.contentCol &&
+        errKey &&
+        propIndent - marker.contentCol <= MAX_SIBLING_ALIGN
+      ) {
         return {
           markerLine: errorLine,
           markerKey: errKey,
@@ -239,6 +403,16 @@ export function analyzeIndentMismatch(
         reason: "props-below",
       };
     }
+    // A key at the markers' own indent can't be part of the sequence —
+    // re-indent it to the content column where the item's properties sit.
+    if (propIndent === indentOf(text) && errKey) {
+      return {
+        markerLine: errorLine,
+        markerKey: errKey,
+        delta: marker.contentCol - propIndent,
+        reason: "align",
+      };
+    }
     if (propIndent < marker.contentCol && propIndent > indentOf(text) && errKey) {
       return {
         markerLine: errorLine,
@@ -249,7 +423,7 @@ export function analyzeIndentMismatch(
     }
     return null;
   }
-  return null;
+  return openerChild;
 }
 
 /** Matches a value-less `- key:` list item (optionally with a comment). */
@@ -319,6 +493,9 @@ export interface YamlAutoFix {
   /** The target line's own key, so the apply site can confirm the line still
    *  targets the same item after edits shift line numbers. */
   key: string;
+  /** The target line's indent when the fix was computed; the apply site
+   *  refuses when the line no longer starts there. */
+  fromIndent: number;
 }
 
 /** A humanized YAML error: display text, best line to jump to, optional auto-fix. */
@@ -427,7 +604,12 @@ export function describeYamlError(
           spaces: Math.abs(fix.delta),
         }),
         jumpLine: fix.markerLine,
-        fix: { line: fix.markerLine, indent: fix.delta, key: fix.markerKey },
+        fix: {
+          line: fix.markerLine,
+          indent: fix.delta,
+          key: fix.markerKey,
+          fromIndent: indentOf(targetText),
+        },
       };
     }
     return hint("yaml_editor.error_indent_hint");

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -20,13 +20,19 @@ const YAML_LINE_RE = /line\s+(\d+)/gi;
 /** A quoted path (POSIX `/` or Windows `\`) — keep the basename, drop the dir. */
 const QUOTED_PATH_RE = /"([^"]*[/\\])([^"/\\]+)"/g;
 
-/** `key:` at line start (no marker), capturing the key. Broader than the
- *  walker's RE_PAIR_LINE — any non-`:` key token, so quoted or dotted keys
- *  still match. */
-const KEY_TOKEN_RE = /^\s*([^\s:#][^:]*?)\s*:(?:\s|$)/;
+/** `key:` pair line (no marker), capturing (key, value?). Whitespace or EOL
+ *  must follow the ':' — `key:value` is a plain scalar, not a pair. Broader
+ *  than the walker's RE_PAIR_LINE — any non-`:` key token, so quoted or
+ *  dotted keys still match. */
+const PAIR_RE = /^\s*([^\s:#][^:]*?)\s*:(?:\s+(.*))?$/;
 
-/** `key: value` with a non-empty value, applied after comment stripping. */
-const VALUED_PAIR_RE = /^\s*[^\s:#][^:]*?:\s*\S/;
+/** Analysis walks never scan further than this many lines. */
+const WALK_BOUND = 50;
+
+/** Canonical child-indent step. A literal two: this module stays free of
+ *  esphome-yaml-lang's CodeMirror import graph, where ESPHOME_YAML_INDENT
+ *  is the same two spaces. */
+const YAML_INDENT_STEP = 2;
 
 /**
  * Strip absolute directory paths out of a backend error message.
@@ -89,6 +95,38 @@ export function parseYamlErrorContext(
 /** A line accessor over the current document; `undefined` past the ends. */
 export type ReadLine = (line1: number) => string | undefined;
 
+/** Blank or comment-only — every walk skips these. */
+function isBlankOrComment(text: string): boolean {
+  return !text.trim() || text.trimStart().startsWith("#");
+}
+
+/** Nearest content line from *line* in *step* direction, bounded. */
+function adjacentContentLine(
+  readLine: ReadLine,
+  line: number,
+  step: 1 | -1
+): { line: number; text: string } | null {
+  for (let i = 1; i <= WALK_BOUND; i++) {
+    const n = line + step * i;
+    if (n < 1) return null;
+    const text = readLine(n);
+    if (text === undefined) return null;
+    if (isBlankOrComment(text)) continue;
+    return { line: n, text };
+  }
+  return null;
+}
+
+/** Nearest non-blank, non-comment line above *line*. */
+function contentLineAbove(readLine: ReadLine, line: number) {
+  return adjacentContentLine(readLine, line, -1);
+}
+
+/** Nearest non-blank, non-comment line below *line*. */
+function contentLineBelow(readLine: ReadLine, line: number) {
+  return adjacentContentLine(readLine, line, 1);
+}
+
 /**
  * Indent of a list item's first property line minus *contentCol* (where its
  * key starts), or `null` when the item has no property line — the next
@@ -100,15 +138,10 @@ export function firstPropertyDelta(
   line: number,
   contentCol: number
 ): number | null {
-  // Bound the walk so a huge run of blanks can't turn a lint pass into a scan.
-  for (let n = line + 1; n <= line + 50; n++) {
-    const text = readLine(n);
-    if (text === undefined) return null;
-    if (!text.trim() || text.trimStart().startsWith("#")) continue;
-    const indent = indentOf(text);
-    return indent < contentCol ? null : indent - contentCol;
-  }
-  return null;
+  const next = contentLineBelow(readLine, line);
+  if (next === null) return null;
+  const indent = indentOf(next.text);
+  return indent < contentCol ? null : indent - contentCol;
 }
 
 /** Don't guess a sibling alignment beyond this many spaces — a large
@@ -128,10 +161,10 @@ function siblingMarkerDelta(
   line: number,
   markerIndent: number
 ): number | null {
-  for (let n = line - 1; n >= 1 && n >= line - 50; n--) {
+  for (let n = line - 1; n >= 1 && n >= line - WALK_BOUND; n--) {
     const text = readLine(n);
     if (text === undefined) return null;
-    if (!text.trim() || text.trimStart().startsWith("#")) continue;
+    if (isBlankOrComment(text)) continue;
     const indent = indentOf(text);
     if (parseListItemMarker(text)) {
       const delta = indent - markerIndent;
@@ -146,41 +179,19 @@ function siblingMarkerDelta(
 export function lineKeyToken(text: string): string | null {
   const marker = parseListItemMarker(text);
   if (marker) return marker.key;
-  const hit = text.match(KEY_TOKEN_RE);
+  const hit = text.match(PAIR_RE);
   return hit ? hit[1] : null;
 }
 
 /** Whether the line is a `key: value` pair with a non-empty value. */
 function lineHasValue(text: string): boolean {
-  return VALUED_PAIR_RE.test(stripComment(text));
+  return Boolean(stripComment(text).match(PAIR_RE)?.[2]);
 }
 
-/** Nearest non-blank, non-comment line above *line*, bounded like the walks. */
-function contentLineAbove(
-  readLine: ReadLine,
-  line: number
-): { line: number; text: string } | null {
-  for (let n = line - 1; n >= 1 && n >= line - 50; n--) {
-    const text = readLine(n);
-    if (text === undefined) return null;
-    if (!text.trim() || text.trimStart().startsWith("#")) continue;
-    return { line: n, text };
-  }
-  return null;
-}
-
-/** Nearest non-blank, non-comment line below *line*, bounded like the walks. */
-function contentLineBelow(
-  readLine: ReadLine,
-  line: number
-): { line: number; text: string } | null {
-  for (let n = line + 1; n <= line + 50; n++) {
-    const text = readLine(n);
-    if (text === undefined) return null;
-    if (!text.trim() || text.trimStart().startsWith("#")) continue;
-    return { line: n, text };
-  }
-  return null;
+/** The line's key when it is a value-less `key:` opener, else null.
+ *  Callers pre-filter `- ` marker lines. */
+function valuelessKeyOf(text: string): string | null {
+  return lineHasValue(text) ? null : lineKeyToken(text);
 }
 
 /**
@@ -258,8 +269,8 @@ export function analyzeIndentMismatch(
   // otherwise the blamed line itself is over-indented (dedent it to join
   // the pair as a sibling).
   const prev = contentLineAbove(readLine, errorLine);
+  const prevIndent = prev === null ? -1 : indentOf(prev.text);
   if (prev && !parseListItemMarker(prev.text)) {
-    const prevIndent = indentOf(prev.text);
     const prevKey = lineKeyToken(prev.text);
     if (prevIndent < propIndent && prevKey && lineHasValue(prev.text)) {
       const delta = propIndent - prevIndent;
@@ -269,8 +280,7 @@ export function analyzeIndentMismatch(
         parent &&
         !parseListItemMarker(parent.text) &&
         indentOf(parent.text) === prevIndent &&
-        lineKeyToken(parent.text) &&
-        !lineHasValue(parent.text)
+        valuelessKeyOf(parent.text) !== null
       ) {
         return { markerLine: prev.line, markerKey: prevKey, delta, reason: "align" };
       }
@@ -282,29 +292,21 @@ export function analyzeIndentMismatch(
   }
   // The blamed line closes a block deeper than itself when the line directly
   // above it sits deeper — the signature of a dedented block opener above.
-  const prevDeeper = prev !== null && indentOf(prev.text) > propIndent;
+  const prevDeeper = prevIndent > propIndent;
   // Nearest shallower non-marker line passed on the way up — when it sits
   // exactly at the marker's content column, the surrounding structure is
   // consistent and the blamed line is the one to move.
-  let shallower: {
-    line: number;
-    indent: number;
-    key: string | null;
-    hasValue: boolean;
-  } | null = null;
-  // The content line processed one iteration ago — physically the line just
-  // below the current one, so at the first shallower line it is that block's
-  // first child.
-  let below: { line: number; indent: number; key: string | null } | null = null;
+  let shallower: { line: number; indent: number; text: string } | null = null;
+  // Set on crossing a line shallower than `shallower`: the dedented-opener
+  // reading is dead, a later same-indent line is unrelated structure.
+  let leftShallowerBlock = false;
   // Over-deep first child of a value-less opener, held until the walk rules
   // out the dedented-opener reading above it.
   let openerChild: IndentMismatch | null = null;
   // Bound the walk so a huge doc can't turn one lint pass into a scan.
-  for (let n = errorLine - 1; n >= 1 && n >= errorLine - 50; n--) {
+  for (let n = errorLine - 1; n >= 1 && n >= errorLine - WALK_BOUND; n--) {
     const text = readLine(n);
-    if (text === undefined || !text.trim() || text.trimStart().startsWith("#")) {
-      continue;
-    }
+    if (text === undefined || isBlankOrComment(text)) continue;
     const marker = parseListItemMarker(text);
     if (!marker) {
       const indent = indentOf(text);
@@ -316,78 +318,69 @@ export function analyzeIndentMismatch(
       if (
         prevDeeper &&
         shallower !== null &&
-        indent === propIndent &&
-        shallower.key !== null &&
-        !shallower.hasValue &&
-        propIndent - shallower.indent <= MAX_SIBLING_ALIGN
+        !leftShallowerBlock &&
+        indent === propIndent
       ) {
-        return {
-          markerLine: shallower.line,
-          markerKey: shallower.key,
-          delta: propIndent - shallower.indent,
-          reason: "align",
-        };
+        const openerKey = valuelessKeyOf(shallower.text);
+        if (openerKey !== null && propIndent - shallower.indent <= MAX_SIBLING_ALIGN) {
+          return {
+            markerLine: shallower.line,
+            markerKey: openerKey,
+            delta: propIndent - shallower.indent,
+            reason: "align",
+          };
+        }
       }
       if (indent < propIndent) {
         // A top-level line means we left every block without a marker.
         if (indent === 0) return openerChild;
-        // Leaving the first shallower line's block kills the dedented-
-        // opener theory — a later same-indent line is unrelated structure.
-        if (shallower !== null && indent < shallower.indent) shallower.key = null;
+        if (shallower !== null && indent < shallower.indent) leftShallowerBlock = true;
         if (shallower === null) {
-          shallower = {
-            line: n,
-            indent,
-            key: lineKeyToken(text),
-            hasValue: lineHasValue(text),
-          };
+          shallower = { line: n, indent, text };
           // The competing reading: the opener sits where it belongs (the
           // blamed line is at its canonical child indent) and the block's
           // first child above the blamed line is what went too deep. Held,
           // not returned — a sibling above the opener at the blamed line's
           // indent proves the opener moved instead.
-          if (
+          const child =
             prevDeeper &&
-            shallower.key !== null &&
-            !shallower.hasValue &&
-            propIndent === indent + 2 &&
-            below !== null &&
-            below.key !== null &&
-            below.indent > propIndent &&
-            below.indent - propIndent <= MAX_SIBLING_ALIGN
-          ) {
-            openerChild = {
-              markerLine: below.line,
-              markerKey: below.key,
-              delta: propIndent - below.indent,
-              reason: "align",
-            };
+            propIndent === indent + YAML_INDENT_STEP &&
+            valuelessKeyOf(text) !== null
+              ? contentLineBelow(readLine, n)
+              : null;
+          const childKey = child === null ? null : lineKeyToken(child.text);
+          if (child !== null && childKey !== null) {
+            const childIndent = indentOf(child.text);
+            if (
+              childIndent > propIndent &&
+              childIndent - propIndent <= MAX_SIBLING_ALIGN
+            ) {
+              openerChild = {
+                markerLine: child.line,
+                markerKey: childKey,
+                delta: propIndent - childIndent,
+                reason: "align",
+              };
+            }
           }
         }
       }
-      below = { line: n, indent, key: lineKeyToken(text) };
       continue;
     }
-    const errKey = lineKeyToken(errText);
     if (openerChild) return openerChild;
+    const errKey = lineKeyToken(errText);
     if (propIndent > marker.contentCol) {
       // Siblings already aligned at the content column — above or below the
       // blamed line — make the blamed line the odd one out; otherwise assume
       // the marker is what needs to move.
-      if (shallower?.indent === marker.contentCol && errKey) {
-        return {
-          markerLine: errorLine,
-          markerKey: errKey,
-          delta: marker.contentCol - propIndent,
-          reason: "align",
-        };
-      }
-      const next = contentLineBelow(readLine, errorLine);
+      const alignedAbove = shallower?.indent === marker.contentCol;
+      const next =
+        !alignedAbove && errKey && propIndent - marker.contentCol <= MAX_SIBLING_ALIGN
+          ? contentLineBelow(readLine, errorLine)
+          : null;
       if (
-        next !== null &&
-        indentOf(next.text) === marker.contentCol &&
         errKey &&
-        propIndent - marker.contentCol <= MAX_SIBLING_ALIGN
+        (alignedAbove || (next !== null && indentOf(next.text) === marker.contentCol))
       ) {
         return {
           markerLine: errorLine,
@@ -403,17 +396,10 @@ export function analyzeIndentMismatch(
         reason: "props-below",
       };
     }
-    // A key at the markers' own indent can't be part of the sequence —
-    // re-indent it to the content column where the item's properties sit.
-    if (propIndent === indentOf(text) && errKey) {
-      return {
-        markerLine: errorLine,
-        markerKey: errKey,
-        delta: marker.contentCol - propIndent,
-        reason: "align",
-      };
-    }
-    if (propIndent < marker.contentCol && propIndent > indentOf(text) && errKey) {
+    // A property at the markers' own indent, or between it and the content
+    // column, can't be part of the sequence — re-indent it to the content
+    // column where the item's properties sit.
+    if (propIndent < marker.contentCol && propIndent >= indentOf(text) && errKey) {
       return {
         markerLine: errorLine,
         markerKey: errKey,

--- a/test/components/editor-invalid-banner.test.ts
+++ b/test/components/editor-invalid-banner.test.ts
@@ -236,7 +236,7 @@ describe("editor-invalid-banner events", () => {
 
   it("dispatches banner-goto-line and banner-auto-fix from the buttons", async () => {
     const { el } = await mountBanner({ focused: false });
-    const fix = { line: 57, indent: 2, key: "platform" };
+    const fix = { line: 57, indent: 2, key: "platform", fromIndent: 0 };
     el.errors = [{ message: "boom", line: 57, fix, kind: "parse" }];
     await el.updateComplete;
 

--- a/test/components/yaml-editor-auto-fix.test.ts
+++ b/test/components/yaml-editor-auto-fix.test.ts
@@ -23,7 +23,7 @@ const viewOf = (el: ESPHomeYamlEditor): EditorView =>
 // indents line 2 (`- platform`) by 2 so it lines up with its properties.
 const BROKEN = "sensor:\n- platform: dht\n    model: DHT11\n";
 const FIXED = "sensor:\n  - platform: dht\n    model: DHT11\n";
-const FIX: YamlAutoFix = { line: 2, indent: 2, key: "platform" };
+const FIX: YamlAutoFix = { line: 2, indent: 2, key: "platform", fromIndent: 0 };
 
 const CLEAN: EditorValidateResponse = { yaml_errors: [], validation_errors: [] };
 // Proposed document still has an error after the fix.
@@ -154,9 +154,9 @@ describe("yaml-editor applyIndentFix (#1884)", () => {
     const el = await mountEditor(validateYaml, broken);
     const view = viewOf(el);
 
-    expect(await el.applyIndentFix({ line: 6, indent: -1, key: "pulse" })).toBe(
-      "applied"
-    );
+    expect(
+      await el.applyIndentFix({ line: 6, indent: -1, key: "pulse", fromIndent: 7 })
+    ).toBe("applied");
 
     expect(view.state.doc.toString()).toBe(fixed);
     expect(validateYaml).toHaveBeenCalledWith("x.yaml", fixed);
@@ -171,22 +171,32 @@ describe("yaml-editor applyIndentFix (#1884)", () => {
       "      - addressable_twinkle:\n      - flicker:\n      - pulse:\n";
     const el = await mountEditor(validateYaml, doc);
 
-    expect(await el.applyIndentFix({ line: 6, indent: -1, key: "pulse" })).toBe("stale");
+    expect(
+      await el.applyIndentFix({ line: 6, indent: -1, key: "pulse", fromIndent: 7 })
+    ).toBe("stale");
     expect(validateYaml).not.toHaveBeenCalled();
   });
 
-  it("no-ops when the item is followed by a shallower sibling, not a property", async () => {
+  it("applies a fix whose diagnosis was anchored on a different line", async () => {
     const validateYaml = vi.fn(async () => CLEAN);
-    // `- platform: dht` (contentCol 2) followed by a top-level sibling, not a
-    // property: the delta re-check must treat that as "no property" (null),
-    // not a spurious negative delta, and bail.
-    const doc = "sensor:\n- platform: dht\nbinary_sensor:\n  - platform: gpio\n";
-    const el = await mountEditor(validateYaml, doc);
+    // The continuation shape: `input: true` dedented out of `mode:`, blamed
+    // by the scanner on the deeper `pullup` line below it. The fix targets
+    // the `input` line; the guard must accept it on the line's own key +
+    // indent, not by re-running the analysis anchored there.
+    const broken =
+      "binary_sensor:\n  - platform: gpio\n    pin:\n      inverted: true\n" +
+      "      mode:\n      input: true\n        pullup: true\n      number: 9\n";
+    const fixed =
+      "binary_sensor:\n  - platform: gpio\n    pin:\n      inverted: true\n" +
+      "      mode:\n        input: true\n        pullup: true\n      number: 9\n";
+    const el = await mountEditor(validateYaml, broken);
     const view = viewOf(el);
 
-    expect(await el.applyIndentFix(FIX)).toBe("stale");
+    expect(
+      await el.applyIndentFix({ line: 6, indent: 2, key: "input", fromIndent: 6 })
+    ).toBe("applied");
 
-    expect(view.state.doc.toString()).toBe(doc);
-    expect(validateYaml).not.toHaveBeenCalled();
+    expect(view.state.doc.toString()).toBe(fixed);
+    expect(validateYaml).toHaveBeenCalledWith("x.yaml", fixed);
   });
 });

--- a/test/util/yaml-error-analysis.test.ts
+++ b/test/util/yaml-error-analysis.test.ts
@@ -293,6 +293,155 @@ describe("analyzeIndentMismatch", () => {
       reason: "align",
     });
   });
+
+  // Continuation shape: the blamed line sits deeper than the valued pair
+  // above it, so the scanner reads it as that value's plain-scalar
+  // continuation ("mapping values are not allowed here").
+  it("re-indents a valued pair dedented out of the value-less block above it", async () => {
+    const { analyzeIndentMismatch } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "    pin:", // 1
+        "      inverted: true", // 2
+        "      mode:", // 3
+        "      input: true", // 4
+        "        pullup: true", // 5
+        "      number: 9", // 6
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 5)).toEqual({
+      markerLine: 4,
+      markerKey: "input",
+      delta: 2,
+      reason: "align",
+    });
+  });
+
+  it("dedents a blamed line sitting deeper than the valued pair above it", async () => {
+    const { analyzeIndentMismatch } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "    pin:", // 1
+        "      inverted: true", // 2
+        "        pullup: true", // 3
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 3)).toEqual({
+      markerLine: 3,
+      markerKey: "pullup",
+      delta: -2,
+      reason: "align",
+    });
+  });
+
+  it("won't guess the continuation repair beyond a few spaces", async () => {
+    const { analyzeIndentMismatch } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "      mode:", // 1
+        "      input: true", // 2
+        "            pullup: true", // 3
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 3)).toBeNull();
+  });
+
+  // Dedented block opener: `mode:` dropped to the item-property level while
+  // its children stay deep; the scanner blames the block-close line
+  // (`number:`), but the aligned sibling above (`inverted:`) proves the
+  // value-less key is what moved.
+  it("re-indents a dedented value-less key blamed on its block-close line", async () => {
+    const { analyzeIndentMismatch } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "binary_sensor:", // 1
+        "  - platform: gpio", // 2
+        "    name: Boot Button", // 3
+        "    pin:", // 4
+        "      inverted: true", // 5
+        "    mode:", // 6
+        "        input: true", // 7
+        "        pullup: true", // 8
+        "      number: 9", // 9
+        "    id: boot_button", // 10
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 9)).toEqual({
+      markerLine: 6,
+      markerKey: "mode",
+      delta: 2,
+      reason: "align",
+    });
+  });
+
+  // The mirror: the opener sits where it belongs (a sibling shares its
+  // indent, the blamed line is at its canonical child indent) and the
+  // block's first child is what went too deep.
+  it("dedents an over-deep first child blamed on the opener's next child", async () => {
+    const { analyzeIndentMismatch } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "binary_sensor:", // 1
+        "  - platform: gpio", // 2
+        "    name: Button Module", // 3
+        "    pin:", // 4
+        "      inverted: true", // 5
+        "      mode:", // 6
+        "          input: true", // 7
+        "        pullup: true", // 8
+        "      number: 6", // 9
+        "    id: button_module", // 10
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 8)).toEqual({
+      markerLine: 7,
+      markerKey: "input",
+      delta: -2,
+      reason: "align",
+    });
+  });
+
+  // An over-indented property whose FOLLOWING siblings sit at the content
+  // column: the marker aligns with its list, so the blamed line moved.
+  it("dedents an over-indented property when the properties below line up", async () => {
+    const { analyzeIndentMismatch } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "binary_sensor:", // 1
+        "  - platform: gpio", // 2
+        "     name: Button Module", // 3
+        "    pin:", // 4
+        "      inverted: true", // 5
+        "    id: button_module", // 6
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 3)).toEqual({
+      markerLine: 3,
+      markerKey: "name",
+      delta: -1,
+      reason: "align",
+    });
+  });
+
+  it("re-indents a property dedented to its list's marker indent", async () => {
+    const { analyzeIndentMismatch } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "binary_sensor:", // 1
+        "  - platform: gpio", // 2
+        "    name: Motion Module", // 3
+        "    pin: 3", // 4
+        "  device_class: motion", // 5
+        "    id: motion_module", // 6
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 5)).toEqual({
+      markerLine: 5,
+      markerKey: "device_class",
+      delta: 2,
+      reason: "align",
+    });
+  });
 });
 
 describe("describeYamlError", () => {
@@ -310,7 +459,7 @@ describe("describeYamlError", () => {
     ).toEqual({
       text: 'yaml_editor.error_indent_fix:{"line":2,"key":"platform","spaces":2}',
       jumpLine: 2,
-      fix: { line: 2, indent: 2, key: "platform" },
+      fix: { line: 2, indent: 2, key: "platform", fromIndent: 0 },
     });
   });
 
@@ -387,7 +536,7 @@ describe("describeYamlError", () => {
     ).toEqual({
       text: 'yaml_editor.error_misaligned_dedent_fix:{"line":4,"key":"- pulse","spaces":1}',
       jumpLine: 4,
-      fix: { line: 4, indent: -1, key: "pulse" },
+      fix: { line: 4, indent: -1, key: "pulse", fromIndent: 7 },
     });
   });
 
@@ -410,7 +559,141 @@ describe("describeYamlError", () => {
     ).toEqual({
       text: 'yaml_editor.error_misaligned_indent_fix:{"line":4,"key":"id","spaces":1}',
       jumpLine: 4,
-      fix: { line: 4, indent: 1, key: "id" },
+      fix: { line: 4, indent: 1, key: "id", fromIndent: 4 },
+    });
+  });
+
+  // Real PyYAML shape for a pair dedented out of its block: the scanner
+  // blames the ':' on the deeper line below the pair, not the pair itself.
+  it("re-indents the dedented pair from a mapping-values message", async () => {
+    const { describeYamlError } = await import("../../src/util/yaml-error-analysis.js");
+    const doc = [
+      "    pin:", // 1
+      "      inverted: true", // 2
+      "      mode:", // 3
+      "      input: true", // 4
+      "        pullup: true", // 5
+    ];
+    const read = (n: number): string | undefined => doc[n - 1];
+    expect(
+      describeYamlError(
+        'mapping values are not allowed here\n  in "x.yaml", line 5, column 15',
+        { line: 5, col: 15 },
+        localize,
+        read
+      )
+    ).toEqual({
+      text: 'yaml_editor.error_misaligned_indent_fix:{"line":4,"key":"input","spaces":2}',
+      jumpLine: 4,
+      fix: { line: 4, indent: 2, key: "input", fromIndent: 6 },
+    });
+  });
+
+  // Real PyYAML shape for a dedented value-less key: the problem mark blames
+  // the line that closes the key's too-deep block, lines below the key.
+  it("re-indents the dedented block opener from a block-mapping message", async () => {
+    const { describeYamlError, parseYamlErrorPosition } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = [
+      "binary_sensor:", // 1
+      "  - platform: gpio", // 2
+      "    name: Boot Button", // 3
+      "    pin:", // 4
+      "      inverted: true", // 5
+      "    mode:", // 6
+      "        input: true", // 7
+      "        pullup: true", // 8
+      "      number: 9", // 9
+      "    id: boot_button", // 10
+    ];
+    const read = (n: number): string | undefined => doc[n - 1];
+    const msg =
+      "while parsing a block mapping\n" +
+      '  in "x.yaml", line 2, column 5\n' +
+      "expected <block end>, but found '<block mapping start>'\n" +
+      '  in "x.yaml", line 9, column 7';
+    expect(describeYamlError(msg, parseYamlErrorPosition(msg), localize, read)).toEqual({
+      text: 'yaml_editor.error_misaligned_indent_fix:{"line":6,"key":"mode","spaces":2}',
+      jumpLine: 6,
+      fix: { line: 6, indent: 2, key: "mode", fromIndent: 4 },
+    });
+  });
+
+  // Real PyYAML shape for an over-deep first child: the problem mark blames
+  // the opener's next child, which no longer fits the too-deep block.
+  it("dedents the over-deep first child from a block-mapping message", async () => {
+    const { describeYamlError, parseYamlErrorPosition } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = [
+      "binary_sensor:", // 1
+      "  - platform: gpio", // 2
+      "    name: Button Module", // 3
+      "    pin:", // 4
+      "      inverted: true", // 5
+      "      mode:", // 6
+      "          input: true", // 7
+      "        pullup: true", // 8
+      "      number: 6", // 9
+      "    id: button_module", // 10
+    ];
+    const read = (n: number): string | undefined => doc[n - 1];
+    const msg =
+      "while parsing a block mapping\n" +
+      '  in "x.yaml", line 5, column 7\n' +
+      "expected <block end>, but found '<block mapping start>'\n" +
+      '  in "x.yaml", line 8, column 9';
+    expect(describeYamlError(msg, parseYamlErrorPosition(msg), localize, read)).toEqual({
+      text: 'yaml_editor.error_misaligned_dedent_fix:{"line":7,"key":"input","spaces":2}',
+      jumpLine: 7,
+      fix: { line: 7, indent: -2, key: "input", fromIndent: 10 },
+    });
+  });
+
+  // Real PyYAML shape for an over-indented property directly after its
+  // marker: the scanner reads it as a continuation of the marker's value.
+  it("dedents the over-indented first property from a mapping-values message", async () => {
+    const { describeYamlError, parseYamlErrorPosition } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = [
+      "binary_sensor:", // 1
+      "  - platform: gpio", // 2
+      "     name: Button Module", // 3
+      "    pin:", // 4
+      "      inverted: true", // 5
+      "    id: button_module", // 6
+    ];
+    const read = (n: number): string | undefined => doc[n - 1];
+    const msg = 'mapping values are not allowed here\n  in "x.yaml", line 3, column 10';
+    expect(describeYamlError(msg, parseYamlErrorPosition(msg), localize, read)).toEqual({
+      text: 'yaml_editor.error_misaligned_dedent_fix:{"line":3,"key":"name","spaces":1}',
+      jumpLine: 3,
+      fix: { line: 3, indent: -1, key: "name", fromIndent: 5 },
+    });
+  });
+
+  // Real PyYAML shape for a property dedented to the markers' own indent:
+  // the problem mark (last position) blames the property line itself.
+  it("re-indents the marker-indent property from a block-collection message", async () => {
+    const { describeYamlError, parseYamlErrorPosition } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = [
+      "binary_sensor:", // 1
+      "  - platform: gpio", // 2
+      "    name: Motion Module", // 3
+      "    pin: 3", // 4
+      "  device_class: motion", // 5
+      "    id: motion_module", // 6
+    ];
+    const read = (n: number): string | undefined => doc[n - 1];
+    const msg =
+      "while parsing a block collection\n" +
+      '  in "x.yaml", line 2, column 3\n' +
+      "expected <block end>, but found '?'\n" +
+      '  in "x.yaml", line 5, column 3';
+    expect(describeYamlError(msg, parseYamlErrorPosition(msg), localize, read)).toEqual({
+      text: 'yaml_editor.error_misaligned_indent_fix:{"line":5,"key":"device_class","spaces":2}',
+      jumpLine: 5,
+      fix: { line: 5, indent: 2, key: "device_class", fromIndent: 2 },
     });
   });
 

--- a/test/util/yaml-lint-humanize.test.ts
+++ b/test/util/yaml-lint-humanize.test.ts
@@ -76,7 +76,7 @@ describe("backend linter humanizes + banners a locatable parse error", () => {
         {
           message: "yaml_editor.error_indent_fix:2",
           line: 2,
-          fix: { line: 2, indent: 2, key: "platform" },
+          fix: { line: 2, indent: 2, key: "platform", fromIndent: 0 },
           kind: "parse",
         },
       ]);
@@ -119,7 +119,7 @@ describe("backend linter humanizes + banners a locatable parse error", () => {
       expect(actions.map((a) => a.name)).toEqual(["yaml_editor.error_auto_fix"]);
 
       actions[0].apply(view, 0, 0);
-      expect(fixes).toEqual([{ line: 2, indent: 2, key: "platform" }]);
+      expect(fixes).toEqual([{ line: 2, indent: 2, key: "platform", fromIndent: 0 }]);
     } finally {
       view.destroy();
     }


### PR DESCRIPTION
# What does this implement/fix?

The indentation analysis behind the invalid banner and the hover auto fix misread several shapes and blamed a nearby marker instead of the line that moved: a key dedented out of its block, a property dedented to the list marker column, a first child indented too deep, and a property indented too deep right after its marker. Each shape now resolves to a repair on the line the user actually moved, using the sibling structure around the blamed line as evidence.

Applying a fix could also fail with a false "config changed" message; the staleness check re ran the analysis anchored at the fix line, which cannot reproduce a diagnosis anchored at the scanner's blamed line. The check is now structural, the fix records the target line's indent and only applies while that line still has the same key and indent.

**Related issue or feature (if applicable):**

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
