### PR TITLE
Dedent a section head nudged off its level instead of the generic hint

### DIFF
--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -325,6 +325,8 @@ function misplacedOpenerFix(
  *   moves), a property at the markers' own indent (re-indent it to the
  *   content column), or a property out of line with siblings already
  *   sitting at the marker's content column (re-indent the blamed line).
+ * - Blamed key strictly between a list's parent level and its markers
+ *   (a section head nudged off the parent level): dedent it back.
  */
 export function analyzeIndentMismatch(
   readLine: ReadLine,
@@ -420,14 +422,33 @@ export function analyzeIndentMismatch(
         reason: "props-below",
       };
     }
+    const markerIndent = indentOf(text);
     // A property at the markers' own indent, or between it and the content
     // column, can't be part of the sequence — re-indent it to the content
     // column where the item's properties sit.
-    if (propIndent < marker.contentCol && propIndent >= indentOf(text) && errKey) {
+    if (propIndent < marker.contentCol && propIndent >= markerIndent && errKey) {
       return {
         markerLine: errorLine,
         markerKey: errKey,
         delta: marker.contentCol - propIndent,
+        reason: "align",
+      };
+    }
+    // A key strictly between the list's parent level and its markers closes
+    // the list at a level nothing occupies — a section head nudged off the
+    // parent level (` i2c:` between top-level sections). Dedent it back.
+    const parentLevel = markerIndent - YAML_INDENT_STEP;
+    if (
+      errKey &&
+      parentLevel >= 0 &&
+      propIndent > parentLevel &&
+      propIndent < markerIndent &&
+      propIndent - parentLevel <= MAX_SIBLING_ALIGN
+    ) {
+      return {
+        markerLine: errorLine,
+        markerKey: errKey,
+        delta: parentLevel - propIndent,
         reason: "align",
       };
     }

--- a/test/util/yaml-error-analysis.test.ts
+++ b/test/util/yaml-error-analysis.test.ts
@@ -442,6 +442,43 @@ describe("analyzeIndentMismatch", () => {
       reason: "align",
     });
   });
+
+  // A section head nudged off its level: the key sits strictly between the
+  // list's parent level and its markers, closing the list at a level
+  // nothing occupies.
+  it("dedents a section head sitting between the parent level and the markers", async () => {
+    const { analyzeIndentMismatch } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "rtttl:", // 1
+        "  - output: buzzer_output", // 2
+        "    id: rtttl_player", // 3
+        "", // 4
+        " i2c:", // 5
+        "  - scl: 0", // 6
+        "    sda: 1", // 7
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 5)).toEqual({
+      markerLine: 5,
+      markerKey: "i2c",
+      delta: -1,
+      reason: "align",
+    });
+  });
+
+  it("won't claim a shallow key when the parent level isn't adjacent", async () => {
+    const { analyzeIndentMismatch } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "    effects:", // 1
+        "      - addressable_twinkle:", // 2
+        "      - flicker:", // 3
+        " i2c:", // 4
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 4)).toBeNull();
+  });
 });
 
 describe("describeYamlError", () => {
@@ -668,6 +705,33 @@ describe("describeYamlError", () => {
       text: 'yaml_editor.error_misaligned_dedent_fix:{"line":3,"key":"name","spaces":1}',
       jumpLine: 3,
       fix: { line: 3, indent: -1, key: "name", fromIndent: 5 },
+    });
+  });
+
+  // Real PyYAML shape for a section head nudged off its level: the problem
+  // mark blames the key line itself, one space into the closed list.
+  it("dedents the nudged section head from a block-mapping message", async () => {
+    const { describeYamlError, parseYamlErrorPosition } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = [
+      "rtttl:", // 1
+      "  - output: buzzer_output", // 2
+      "    id: rtttl_player", // 3
+      "", // 4
+      " i2c:", // 5
+      "  - scl: 0", // 6
+      "    sda: 1", // 7
+    ];
+    const read = (n: number): string | undefined => doc[n - 1];
+    const msg =
+      "while parsing a block mapping\n" +
+      '  in "x.yaml", line 1, column 1\n' +
+      "expected <block end>, but found '<block mapping start>'\n" +
+      '  in "x.yaml", line 5, column 2';
+    expect(describeYamlError(msg, parseYamlErrorPosition(msg), localize, read)).toEqual({
+      text: 'yaml_editor.error_misaligned_dedent_fix:{"line":5,"key":"i2c","spaces":1}',
+      jumpLine: 5,
+      fix: { line: 5, indent: -1, key: "i2c", fromIndent: 1 },
     });
   });
 


### PR DESCRIPTION
# What does this implement/fix?

A top level section key nudged one space to the right, for example i2c: indented to column 1, closes the list above it at a level nothing occupies; the scanner blames the key line but the analysis had no matching shape, so the banner showed the generic indentation hint with no auto fix. A key sitting strictly between a list's parent level and its markers now dedents back to the parent level, with the usual one click repair.

**Related issue or feature (if applicable):**

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
