### PR TITLE
Collect same-domain sub-entity ids and suppress the hub id in reference scans

### DIFF
--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -47,6 +47,7 @@ import {
   getCachedPinRegistryModes,
   subscribePinRegistryModes,
 } from "../../util/pin-registry-modes-cache.js";
+import { PROVIDER_FETCH_LIMIT } from "../../util/provides-cache.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { SessionBlobCacheController } from "../../util/session-blob-cache-controller.js";
 import { looksLikeSubstitution, parseSubstitutions } from "../../util/substitutions.js";
@@ -1026,12 +1027,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
     if (cached) return cached;
     if (this._api && !this._interfaceProvidersPending.has(interfaceName)) {
       this._interfaceProvidersPending.add(interfaceName);
-      // ``limit: 500`` captures every provider of the interface in one shot
-      // (same-domain sub-entity providers put ``sensor`` near 200); this is
-      // the full dropdown candidate set, distinct from the Add-component
-      // picker's paginated grid.
+      // The full dropdown candidate set in one shot, distinct from the
+      // Add-component picker's paginated grid.
       this._api
-        .getComponents({ provides: interfaceName, limit: 500 })
+        .getComponents({ provides: interfaceName, limit: PROVIDER_FETCH_LIMIT })
         .then((resp) => {
           this._interfaceProviders.set(
             interfaceName,

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -1026,11 +1026,12 @@ export class ESPHomeConfigEntryForm extends LitElement {
     if (cached) return cached;
     if (this._api && !this._interfaceProvidersPending.has(interfaceName)) {
       this._interfaceProvidersPending.add(interfaceName);
-      // ``limit: 200`` captures every provider of the interface in one shot
-      // (interfaces have at most a couple dozen); this is the full dropdown
-      // candidate set, distinct from the Add-component picker's paginated grid.
+      // ``limit: 500`` captures every provider of the interface in one shot
+      // (same-domain sub-entity providers put ``sensor`` near 200); this is
+      // the full dropdown candidate set, distinct from the Add-component
+      // picker's paginated grid.
       this._api
-        .getComponents({ provides: interfaceName, limit: 200 })
+        .getComponents({ provides: interfaceName, limit: 500 })
         .then((resp) => {
           this._interfaceProviders.set(
             interfaceName,

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -389,15 +389,13 @@ export function findComponentsByProviders(
   for (const section of parseYamlTopLevelSections(yaml)) {
     const provs = byDomain.get(section.parentKey ?? section.key);
     if (!provs) continue;
-    // ``stem === ""`` matches every id in the domain block.
-    const matched = provs.filter((p) => p.stem === "" || p.stem === section.platform);
-    // An idPaths provider knows where this section's interface ids live;
-    // its own id is then NOT one of them (a multi-entity platform's
-    // section id is the hub, the wrong type for the reference), so the
-    // implicit stemless provider must not offer it either.
-    const hasIdPathProvider = matched.some((p) => p.idPaths?.length);
-    for (const p of matched) {
+    let ownIdMatched = false;
+    let hasIdPathProvider = false;
+    for (const p of provs) {
+      // ``stem === ""`` matches every id in the domain block.
+      if (p.stem !== "" && p.stem !== section.platform) continue;
       if (p.idPaths?.length) {
+        hasIdPathProvider = true;
         // The interface id is nested (usb_uart channels[].id): collect the
         // ids at those paths, not the section's own (non-interface) id.
         lines ??= yaml.split("\n");
@@ -405,9 +403,16 @@ export function findComponentsByProviders(
           for (const inst of collectIdsAtPath(lines, section, path))
             add(inst.id, inst.name);
         }
-      } else if (section.id && !hasIdPathProvider) {
-        add(section.id, section.name ?? "");
+      } else {
+        ownIdMatched = true;
       }
+    }
+    // An idPaths provider knows where this section's interface ids live; the
+    // section's own id is then NOT one of them (a multi-entity platform's is
+    // the hub, the wrong type for the reference), so the stemless catch-all
+    // provider findReferenceCandidates injects must not offer it either.
+    if (ownIdMatched && !hasIdPathProvider && section.id) {
+      add(section.id, section.name ?? "");
     }
   }
   providerMemo.set(probe, result);

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -389,9 +389,14 @@ export function findComponentsByProviders(
   for (const section of parseYamlTopLevelSections(yaml)) {
     const provs = byDomain.get(section.parentKey ?? section.key);
     if (!provs) continue;
-    for (const p of provs) {
-      // ``stem === ""`` matches every id in the domain block.
-      if (p.stem !== "" && p.stem !== section.platform) continue;
+    // ``stem === ""`` matches every id in the domain block.
+    const matched = provs.filter((p) => p.stem === "" || p.stem === section.platform);
+    // An idPaths provider knows where this section's interface ids live;
+    // its own id is then NOT one of them (a multi-entity platform's
+    // section id is the hub, the wrong type for the reference), so the
+    // implicit stemless provider must not offer it either.
+    const hasIdPathProvider = matched.some((p) => p.idPaths?.length);
+    for (const p of matched) {
       if (p.idPaths?.length) {
         // The interface id is nested (usb_uart channels[].id): collect the
         // ids at those paths, not the section's own (non-interface) id.
@@ -400,7 +405,7 @@ export function findComponentsByProviders(
           for (const inst of collectIdsAtPath(lines, section, path))
             add(inst.id, inst.name);
         }
-      } else if (section.id) {
+      } else if (section.id && !hasIdPathProvider) {
         add(section.id, section.name ?? "");
       }
     }

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -407,10 +407,11 @@ export function findComponentsByProviders(
         ownIdMatched = true;
       }
     }
-    // An idPaths provider knows where this section's interface ids live; the
-    // section's own id is then NOT one of them (a multi-entity platform's is
-    // the hub, the wrong type for the reference), so the stemless catch-all
-    // provider findReferenceCandidates injects must not offer it either.
+    // An idPaths provider enumerates every interface id in this section, so
+    // the stemless catch-all provider findReferenceCandidates injects must
+    // not add the section's own id on top: for a multi-entity platform it is
+    // the hub (the wrong type for the reference), and a hybrid's root entity
+    // already arrived through its ["id"] path.
     if (ownIdMatched && !hasIdPathProvider && section.id) {
       add(section.id, section.name ?? "");
     }

--- a/src/util/provides-cache.ts
+++ b/src/util/provides-cache.ts
@@ -1,9 +1,10 @@
 import type { ESPHomeAPI } from "../api/index.js";
 import { KeyedPromiseCache } from "./keyed-promise-cache.js";
 
-/** One page holds every provider of an interface. Same-domain sub-entity
- *  providers put `sensor` near 200, so headroom keeps a fetch-all
- *  `getComponents({provides})` from truncating. */
+/** Page size for the fetch-all `getComponents({provides})` sites. Sized so a
+ *  single page covers every known interface today (same-domain sub-entity
+ *  providers put `sensor` near 200); a larger catalog would truncate
+ *  silently until the callers page on `resp.total` (#1152). */
 export const PROVIDER_FETCH_LIMIT = 500;
 
 /** Ids of the components that provide an interface, board-scoped and cached

--- a/src/util/provides-cache.ts
+++ b/src/util/provides-cache.ts
@@ -21,9 +21,10 @@ export function providerIds(
         provides: interfaceName,
         platform: platform ?? undefined,
         board_id: boardId ?? undefined,
-        // One page holds every provider; an interface has at most a handful,
-        // so this never truncates (mirrors config-entry-form's provider fetch).
-        limit: 200,
+        // One page holds every provider; same-domain sub-entity providers put
+        // ``sensor`` near 200, so headroom keeps this from truncating
+        // (mirrors config-entry-form's provider fetch).
+        limit: 500,
       })
       .then((resp): ReadonlySet<string> => new Set(resp.components.map((c) => c.id)))
   );

--- a/src/util/provides-cache.ts
+++ b/src/util/provides-cache.ts
@@ -1,6 +1,11 @@
 import type { ESPHomeAPI } from "../api/index.js";
 import { KeyedPromiseCache } from "./keyed-promise-cache.js";
 
+/** One page holds every provider of an interface. Same-domain sub-entity
+ *  providers put `sensor` near 200, so headroom keeps a fetch-all
+ *  `getComponents({provides})` from truncating. */
+export const PROVIDER_FETCH_LIMIT = 500;
+
 /** Ids of the components that provide an interface, board-scoped and cached
  *  for the process lifetime. The backend catalog is immutable for that
  *  lifetime (see `component-name-cache`), so the same `provides` query never
@@ -21,10 +26,7 @@ export function providerIds(
         provides: interfaceName,
         platform: platform ?? undefined,
         board_id: boardId ?? undefined,
-        // One page holds every provider; same-domain sub-entity providers put
-        // ``sensor`` near 200, so headroom keeps this from truncating
-        // (mirrors config-entry-form's provider fetch).
-        limit: 500,
+        limit: PROVIDER_FETCH_LIMIT,
       })
       .then((resp): ReadonlySet<string> => new Set(resp.components.map((c) => c.id)))
   );

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -658,6 +658,82 @@ describe("findComponentsByProviders (nested provider idPaths)", () => {
   });
 });
 
+describe("findComponentsByProviders (same-domain sub-entity idPaths)", () => {
+  // The reported config (#1902): the AHT20's temperature/humidity are the
+  // referenceable sensors; the platform item's own id is the hub component,
+  // the wrong type for a sensor reference.
+  const yaml = [
+    "sensor:",
+    "  - platform: aht10",
+    "    i2c_id: i2c_bus",
+    "    variant: AHT20",
+    "    humidity:",
+    "      id: aht20_humidity",
+    "      name: Humidity",
+    "    temperature:",
+    "      id: aht20_temperature",
+    "      name: Temperature",
+    "    id: aht20",
+    "  - platform: template",
+    "    id: plain_sensor",
+    "",
+  ].join("\n");
+  const aht10 = {
+    domain: "sensor",
+    stem: "aht10",
+    idPaths: [
+      ["humidity", "id"],
+      ["temperature", "id"],
+    ],
+  };
+
+  it("offers the sub-sensor ids and suppresses the hub id (real call path)", () => {
+    const ids = findReferenceCandidates(yaml, "sensor", [aht10]).map((c) => c.id);
+    expect(ids).toContain("aht20_humidity");
+    expect(ids).toContain("aht20_temperature");
+    expect(ids).not.toContain("aht20");
+  });
+
+  it("keeps offering a single-entity platform's own id in the same block", () => {
+    const ids = findReferenceCandidates(yaml, "sensor", [aht10]).map((c) => c.id);
+    expect(ids).toContain("plain_sensor");
+  });
+
+  it("labels a sub-sensor with its sibling name", () => {
+    const humidity = findReferenceCandidates(yaml, "sensor", [aht10]).find(
+      (c) => c.id === "aht20_humidity"
+    );
+    expect(humidity).toEqual({ id: "aht20_humidity", name: "Humidity" });
+  });
+
+  it("keeps the root entity of a hybrid platform via its root path", () => {
+    const hybrid = [
+      "sensor:",
+      "  - platform: pulse_counter",
+      "    id: pulses",
+      "    total:",
+      "      id: pulses_total",
+      "",
+    ].join("\n");
+    const ids = findReferenceCandidates(hybrid, "sensor", [
+      { domain: "sensor", stem: "pulse_counter", idPaths: [["id"], ["total", "id"]] },
+    ]).map((c) => c.id);
+    expect(ids).toEqual(["pulses", "pulses_total"]);
+  });
+
+  it("offers nothing for a sub-block without an id, still suppressing the hub", () => {
+    const idless = [
+      "sensor:",
+      "  - platform: aht10",
+      "    id: aht20",
+      "    temperature:",
+      "      name: Temperature",
+      "",
+    ].join("\n");
+    expect(findReferenceCandidates(idless, "sensor", [aht10])).toEqual([]);
+  });
+});
+
 describe("yamlHasMergedSources", () => {
   it("is true for a top-level packages: block", () => {
     expect(yamlHasMergedSources("packages:\n  base: !include base.yaml\n")).toBe(true);


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#1903 (see esphome/device-builder issue 1902). The catalog now marks multi-entity platforms as same-domain providers with `provides_id_paths` to their sub-entity ids (`sensor.aht10` carries `temperature.id` / `humidity.id`), which the reference scan already consumes; two adjustments keep the dropdowns correct with the richer data:

- On a section matched by a nested-path provider, `findComponentsByProviders` no longer also offers the section's own id through the implicit same-domain provider; that id is the hub component (`aht20`, an `AHT10Component`), the wrong type for a `sensor` reference, and selecting it fails compile. Single-entity platforms in the same block keep offering their own id, and a hybrid platform's root entity (`pulse_counter`) survives via its root path.
- The provider queries in `config-entry-form` and `provides-cache` now request `limit: 500`; same-domain providers put `provides=sensor` near 200 entries, so the old limit was about to truncate.

A previously saved hub id reference now renders as the unresolved option with the dangling-id hint, which matches what `esphome config` says about it.

**Related issue or feature (if applicable):**

- see esphome/device-builder#1902 (closed by the backend PR; not using a closing keyword here so the merge of this PR does not auto-close it)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
