### PR TITLE
Repair top-level indent slips without marker context

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1120,7 +1120,7 @@
     "error_misaligned_indent_fix": "Indentation mismatch: line {line} \"{key}\" is indented too little. Indent line {line} by {spaces, plural, one {# space} other {# spaces}} so it lines up.",
     "error_misaligned_dedent_fix": "Indentation mismatch: line {line} \"{key}\" is indented too deep. Remove {spaces, plural, one {# space} other {# spaces}} from the start of line {line} so it lines up.",
     "error_nested_list_hint": "The \"- \" items below \"{key}\" are indented as its value. If they should be separate list entries, dedent them to line up with \"- {key}\".",
-    "error_indent_hint": "YAML indentation problem near line {line}. Make sure each list item's properties are indented consistently under its \"- \" marker; an over-indented or under-indented line, or a stray \":\" in a value, causes this.",
+    "error_indent_hint": "YAML indentation problem near line {line}. Make sure the line and its neighbours are indented consistently with their block; an over-indented or under-indented line, or a stray \":\" in a value, causes this.",
     "error_missing_colon_hint": "Line {line}: \"{key}\" looks like an option name without a value. Add \":\" and a value after it, or remove the line.",
     "error_tab_hint": "A tab is used for indentation near line {line}; YAML needs spaces. Replace the tab with spaces.",
     "error_char_hint": "Unexpected character near line {line}; a value starting with a symbol such as @, %, or * must be wrapped in quotes.",

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -310,10 +310,14 @@ function misplacedOpenerFix(
     const indent = indentOf(text);
     if (opener === null) {
       if (indent >= propIndent) continue;
-      if (indent === 0) break;
       const key = valuelessKeyOf(text);
       if (key === null) break;
       opener = { line: n, indent, key };
+      // A top-level opener can't have been dedented out of anything — only
+      // the over-deep-first-child reading applies; skip the sibling search
+      // (a line at the blamed indent above it belongs to the previous
+      // section).
+      if (indent === 0) break;
       continue;
     }
     // Above the opener: a sibling at exactly the blamed line's indent
@@ -432,8 +436,24 @@ export function analyzeIndentMismatch(
     if (!marker) {
       const indent = indentOf(text);
       if (indent < propIndent) {
-        // A top-level line means we left every block without a marker.
-        if (indent === 0) return null;
+        // A top-level line means we left every block without a marker. A
+        // blamed key nudged just off column 0 that opens no deeper block is
+        // a section head — dedent it back to the margin.
+        if (indent === 0) {
+          const errKey = lineKeyToken(errText);
+          if (errKey && propIndent < YAML_INDENT_STEP) {
+            const next = contentLineBelow(readLine, errorLine);
+            if (next === null || indentOf(next.text) <= propIndent) {
+              return {
+                markerLine: errorLine,
+                markerKey: errKey,
+                delta: -propIndent,
+                reason: "align",
+              };
+            }
+          }
+          return null;
+        }
         if (shallowerIndent === null) shallowerIndent = indent;
       }
       continue;

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -440,19 +440,18 @@ export function analyzeIndentMismatch(
         // blamed key nudged just off column 0 that opens no deeper block is
         // a section head — dedent it back to the margin.
         if (indent === 0) {
+          if (propIndent >= YAML_INDENT_STEP) return null;
           const errKey = lineKeyToken(errText);
-          if (errKey && propIndent < YAML_INDENT_STEP) {
-            const next = contentLineBelow(readLine, errorLine);
-            if (next === null || indentOf(next.text) <= propIndent) {
-              return {
+          if (!errKey) return null;
+          const next = contentLineBelow(readLine, errorLine);
+          return next === null || indentOf(next.text) <= propIndent
+            ? {
                 markerLine: errorLine,
                 markerKey: errKey,
                 delta: -propIndent,
                 reason: "align",
-              };
-            }
-          }
-          return null;
+              }
+            : null;
         }
         if (shallowerIndent === null) shallowerIndent = indent;
       }

--- a/test/util/yaml-error-analysis.test.ts
+++ b/test/util/yaml-error-analysis.test.ts
@@ -415,6 +415,70 @@ describe("analyzeIndentMismatch", () => {
     });
   });
 
+  // The same reading under a TOP-LEVEL opener: `wifi:`'s first child went
+  // too deep. The `name:` line above `wifi:` belongs to the previous
+  // section and must not re-indent the top-level key.
+  it("dedents an over-deep first child under a top-level opener", async () => {
+    const { analyzeIndentMismatch } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "esphome:", // 1
+        "  name: newstk", // 2
+        "", // 3
+        "wifi:", // 4
+        "  ", // 5
+        "    ssid: mynet", // 6
+        "  password: mypass", // 7
+        "  ap:", // 8
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 7)).toEqual({
+      markerLine: 6,
+      markerKey: "ssid",
+      delta: -2,
+      reason: "align",
+    });
+  });
+
+  // A childless section head nudged just off column 0, with only plain
+  // mappings above it (no marker context).
+  it("dedents a childless section head nudged off the margin", async () => {
+    const { analyzeIndentMismatch } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "wifi:", // 1
+        "  ssid: mynet", // 2
+        "  ap:", // 3
+        "    ssid: fallback", // 4
+        "", // 5
+        " captive_portal:", // 6
+        "", // 7
+        "switch:", // 8
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 6)).toEqual({
+      markerLine: 6,
+      markerKey: "captive_portal",
+      delta: -1,
+      reason: "align",
+    });
+  });
+
+  it("won't dedent a nudged key that opens a deeper block", async () => {
+    const { analyzeIndentMismatch } =
+      await import("../../src/util/yaml-error-analysis.js");
+    // ` ap:` at 1 with children at 4 could as well belong at 2 inside
+    // `wifi:` — ambiguous, so no confident repair.
+    const doc = (n: number): string | undefined =>
+      [
+        "wifi:", // 1
+        "  ssid: mynet", // 2
+        " ap:", // 3
+        "    ssid: fallback", // 4
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 3)).toBeNull();
+  });
+
   // An over-indented property whose FOLLOWING siblings sit at the content
   // column: the marker aligns with its list, so the blamed line moved.
   it("dedents an over-indented property when the properties below line up", async () => {
@@ -697,6 +761,62 @@ describe("describeYamlError", () => {
       text: 'yaml_editor.error_misaligned_dedent_fix:{"line":7,"key":"input","spaces":2}',
       jumpLine: 7,
       fix: { line: 7, indent: -2, key: "input", fromIndent: 10 },
+    });
+  });
+
+  // Real PyYAML shape for an over-deep first child under a TOP-LEVEL key:
+  // the problem mark blames the next child that no longer fits.
+  it("dedents the over-deep first child of a top-level key from its message", async () => {
+    const { describeYamlError, parseYamlErrorPosition } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = [
+      "esphome:", // 1
+      "  name: newstk", // 2
+      "", // 3
+      "wifi:", // 4
+      "  ", // 5
+      "    ssid: mynet", // 6
+      "  password: mypass", // 7
+      "  ap:", // 8
+    ];
+    const read = (n: number): string | undefined => doc[n - 1];
+    const msg =
+      "while parsing a block mapping\n" +
+      '  in "x.yaml", line 1, column 1\n' +
+      "expected <block end>, but found '<block mapping start>'\n" +
+      '  in "x.yaml", line 7, column 3';
+    expect(describeYamlError(msg, parseYamlErrorPosition(msg), localize, read)).toEqual({
+      text: 'yaml_editor.error_misaligned_dedent_fix:{"line":6,"key":"ssid","spaces":2}',
+      jumpLine: 6,
+      fix: { line: 6, indent: -2, key: "ssid", fromIndent: 4 },
+    });
+  });
+
+  // Real PyYAML shape for a childless section head nudged off column 0
+  // with no marker context above it.
+  it("dedents the nudged section head with no marker context from its message", async () => {
+    const { describeYamlError, parseYamlErrorPosition } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = [
+      "wifi:", // 1
+      "  ssid: mynet", // 2
+      "  ap:", // 3
+      "    ssid: fallback", // 4
+      "", // 5
+      " captive_portal:", // 6
+      "", // 7
+      "switch:", // 8
+    ];
+    const read = (n: number): string | undefined => doc[n - 1];
+    const msg =
+      "while parsing a block mapping\n" +
+      '  in "x.yaml", line 1, column 1\n' +
+      "expected <block end>, but found '<block mapping start>'\n" +
+      '  in "x.yaml", line 6, column 2';
+    expect(describeYamlError(msg, parseYamlErrorPosition(msg), localize, read)).toEqual({
+      text: 'yaml_editor.error_misaligned_dedent_fix:{"line":6,"key":"captive_portal","spaces":1}',
+      jumpLine: 6,
+      fix: { line: 6, indent: -1, key: "captive_portal", fromIndent: 1 },
     });
   });
 


### PR DESCRIPTION
# What does this implement/fix?

Two indent slips at the top level had no repair because the analysis bailed at column 0. First, a top level key such as wifi: whose first child ssid: went one step too deep; the opener walk refused to treat a column 0 key as the block opener, so the over deep child reading never ran. It now does, and the banner offers the dedent on the ssid line. Second, a childless section head nudged one space off the margin, for example captive_portal: at column 1 with only plain mappings above it; the walk reached the top level and gave up. It now dedents the key back to the margin, but only when the key opens no deeper block, since a nudged key with deeper children could as well belong one level in.

The generic indentation hint also claimed every problem was about list item markers; it is now worded for plain mappings too.

**Related issue or feature (if applicable):**

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
