### PR TITLE
Make advanced automation params reachable and surface required groups

### DIFF
--- a/src/api/types/automations.ts
+++ b/src/api/types/automations.ts
@@ -3,7 +3,7 @@
  *
  * Part of the src/api/types.ts barrel split.
  */
-import type { ConfigEntry } from "./config-entries.js";
+import type { ConfigEntry, RequiredGroup } from "./config-entries.js";
 
 // ─── Automations ─────────────────────────────────────────────
 //
@@ -59,6 +59,10 @@ export interface AutomationAction {
    *  frontend renders them as recursive action lists, not as form
    *  fields. */
   accepts_action_list: string[];
+  /** Cross-field cardinality constraints over ``config_entries``
+   *  (``homeassistant.service`` requires exactly one of ``service`` /
+   *  ``action``). Members are never advanced. */
+  required_groups?: RequiredGroup[] | null;
 }
 
 /** A condition usable inside an automation's ``if`` / ``while`` /
@@ -74,6 +78,9 @@ export interface AutomationCondition {
    *  ``xor`` — the condition embeds a recursive list of child
    *  conditions. */
   accepts_condition_list: boolean;
+  /** See ``AutomationAction.required_groups`` — e.g. ``sensor.in_range``
+   *  requires at least one of ``above`` / ``below``. */
+  required_groups?: RequiredGroup[] | null;
 }
 
 /** Scalar primitives a polymorphic registry entry can take at the

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -33,6 +33,7 @@ import type {
   ConditionNode,
 } from "../../../api/types/automations.js";
 import type { BoardCatalogEntry } from "../../../api/types/boards.js";
+import type { RequiredGroup } from "../../../api/types/config-entries.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
@@ -74,6 +75,10 @@ registerMdiIcons({
   delete: mdiDelete,
   "pencil-outline": mdiPencilOutline,
 });
+
+// Stable identity for group-less defs — a fresh [] per render would
+// defeat Lit's property change detection on the form mount.
+const NO_REQUIRED_GROUPS: RequiredGroup[] = [];
 
 @customElement("esphome-automation-action-node")
 export class ESPHomeAutomationActionNode extends LitElement {
@@ -397,7 +402,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
     return html`<esphome-config-entry-form
       .entries=${def.config_entries}
       .values=${this.value.params}
-      .requiredGroups=${def.required_groups ?? []}
+      .requiredGroups=${def.required_groups ?? NO_REQUIRED_GROUPS}
       .board=${this.board}
       .yaml=${this.yaml}
       ?disabled=${this.disabled}

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -397,6 +397,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
     return html`<esphome-config-entry-form
       .entries=${def.config_entries}
       .values=${this.value.params}
+      .requiredGroups=${def.required_groups ?? []}
       .board=${this.board}
       .yaml=${this.yaml}
       ?disabled=${this.disabled}

--- a/src/components/device/automation-editor/automation-condition-tree.ts
+++ b/src/components/device/automation-editor/automation-condition-tree.ts
@@ -28,6 +28,7 @@ import type {
   ConditionNode,
 } from "../../../api/types/automations.js";
 import type { BoardCatalogEntry } from "../../../api/types/boards.js";
+import type { RequiredGroup } from "../../../api/types/config-entries.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
@@ -60,6 +61,10 @@ registerMdiIcons({
   "pencil-outline": mdiPencilOutline,
   plus: mdiPlus,
 });
+
+// Stable identity for group-less defs — a fresh [] per render would
+// defeat Lit's property change detection on the form mount.
+const NO_REQUIRED_GROUPS: RequiredGroup[] = [];
 
 @customElement("esphome-automation-condition-tree")
 export class ESPHomeAutomationConditionTree extends LitElement {
@@ -201,7 +206,7 @@ export class ESPHomeAutomationConditionTree extends LitElement {
               ? html`<esphome-config-entry-form
                   .entries=${def.config_entries}
                   .values=${node.params}
-                  .requiredGroups=${def.required_groups ?? []}
+                  .requiredGroups=${def.required_groups ?? NO_REQUIRED_GROUPS}
                   .board=${this.board}
                   .yaml=${this.yaml}
                   ?disabled=${this.disabled}

--- a/src/components/device/automation-editor/automation-condition-tree.ts
+++ b/src/components/device/automation-editor/automation-condition-tree.ts
@@ -106,6 +106,11 @@ export class ESPHomeAutomationConditionTree extends LitElement {
    */
   @state() private _changingIdx = -1;
 
+  /** Rows with "Show advanced settings" open. Keyed by index because the
+   *  list renders by position (no keyed repeat); move / remove / kind
+   *  changes remap or drop entries so the flag follows its row. */
+  @state() private _advancedIdxs: ReadonlySet<number> = new Set();
+
   static styles = [espHomeStyles, inputStyles, automationEditorStyles];
 
   protected render() {
@@ -196,11 +201,16 @@ export class ESPHomeAutomationConditionTree extends LitElement {
               ? html`<esphome-config-entry-form
                   .entries=${def.config_entries}
                   .values=${node.params}
+                  .requiredGroups=${def.required_groups ?? []}
                   .board=${this.board}
                   .yaml=${this.yaml}
                   ?disabled=${this.disabled}
+                  advanced-section
+                  ?show-advanced=${this._advancedIdxs.has(idx)}
                   @value-change=${(e: CustomEvent<ConfigEntryValueChange>) =>
                     this._onParamChange(idx, e)}
+                  @advanced-toggle=${(e: CustomEvent<{ show: boolean }>) =>
+                    this._onAdvancedToggle(idx, e)}
                 ></esphome-config-entry-form>`
               : nothing
           }
@@ -253,6 +263,8 @@ export class ESPHomeAutomationConditionTree extends LitElement {
       node.params = { ...node.params, ...e.detail.preFilledParams };
     }
     if (this._changingIdx >= 0) {
+      // A new kind means a new schema — reopen with advanced collapsed.
+      this._setRowAdvanced(this._changingIdx, false);
       this._emit(replaceAt(this.conditions, this._changingIdx, node));
     } else {
       this._emit([...this.conditions, node]);
@@ -267,6 +279,21 @@ export class ESPHomeAutomationConditionTree extends LitElement {
     this._emit(replaceAt(this.conditions, idx, { ...old, params }));
   }
 
+  private _onAdvancedToggle(idx: number, e: CustomEvent<{ show: boolean }>) {
+    e.stopPropagation();
+    this._setRowAdvanced(idx, e.detail.show);
+  }
+
+  private _setRowAdvanced(idx: number, show: boolean) {
+    const next = new Set(this._advancedIdxs);
+    if (show) {
+      next.add(idx);
+    } else {
+      next.delete(idx);
+    }
+    this._advancedIdxs = next;
+  }
+
   private _onChildrenChange(
     idx: number,
     e: CustomEvent<{ conditions: ConditionNode[] }>
@@ -279,10 +306,19 @@ export class ESPHomeAutomationConditionTree extends LitElement {
   }
 
   private _move(from: number, to: number) {
+    const next = new Set(this._advancedIdxs);
+    if (this._advancedIdxs.has(from)) next.add(to);
+    else next.delete(to);
+    if (this._advancedIdxs.has(to)) next.add(from);
+    else next.delete(from);
+    this._advancedIdxs = next;
     this._emit(swap(this.conditions, from, to));
   }
 
   private _remove(idx: number) {
+    this._advancedIdxs = new Set(
+      [...this._advancedIdxs].filter((i) => i !== idx).map((i) => (i > idx ? i - 1 : i))
+    );
     this._emit(removeAt(this.conditions, idx));
   }
 

--- a/src/components/device/automation-editor/automation-trigger-picker.ts
+++ b/src/components/device/automation-editor/automation-trigger-picker.ts
@@ -17,7 +17,7 @@
  * toggle introduced in section A all work for free.
  */
 import { consume } from "@lit/context";
-import { html, LitElement, nothing } from "lit";
+import { html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import type {
@@ -68,7 +68,15 @@ export class ESPHomeAutomationTriggerPicker extends LitElement {
   @property({ type: Boolean })
   disabled = false;
 
+  /** "Show advanced settings" gate for the trigger params form. */
+  @state() private _showAdvanced = false;
+
   static styles = [espHomeStyles, inputStyles, automationEditorStyles];
+
+  protected willUpdate(changed: PropertyValues<this>): void {
+    // A new trigger means a new schema — start with advanced collapsed.
+    if (changed.has("triggerId")) this._showAdvanced = false;
+  }
 
   protected render() {
     if (!this.target) {
@@ -141,7 +149,10 @@ export class ESPHomeAutomationTriggerPicker extends LitElement {
                 .board=${this.board}
                 .yaml=${this.yaml}
                 ?disabled=${this.disabled}
+                advanced-section
+                ?show-advanced=${this._showAdvanced}
                 @value-change=${this._onParamChange}
+                @advanced-toggle=${this._onAdvancedToggle}
               ></esphome-config-entry-form>`
             : nothing
         }
@@ -174,6 +185,10 @@ export class ESPHomeAutomationTriggerPicker extends LitElement {
         composed: true,
       })
     );
+  };
+
+  private _onAdvancedToggle = (e: CustomEvent<{ show: boolean }>) => {
+    this._showAdvanced = e.detail.show;
   };
 
   private _onParamChange = (e: CustomEvent<ConfigEntryValueChange>) => {

--- a/src/util/automation-body-hydration.ts
+++ b/src/util/automation-body-hydration.ts
@@ -3,7 +3,7 @@ import type {
   AutomationCatalogBody,
   AutomationCatalogBodyType,
 } from "../api/types/automations.js";
-import type { ConfigEntry } from "../api/types/config-entries.js";
+import type { ConfigEntry, RequiredGroup } from "../api/types/config-entries.js";
 import { fetchAutomationBody } from "./automation-body-cache.js";
 
 /** Single source of truth for the per-entry hydration shape. Both
@@ -29,6 +29,7 @@ export interface HydrationResult {
 interface _Hydratable {
   id: string;
   config_entries: ConfigEntry[];
+  required_groups?: RequiredGroup[] | null;
 }
 
 /** Fetch one entry's body and replace ``entry.config_entries`` with
@@ -50,6 +51,10 @@ export async function hydrateEntryConfigEntries(
     // poison the cache. Wire payload is JSON-shaped so
     // structuredClone is faithful.
     entry.config_entries = structuredClone(body.config_entries);
+    // The slim index drops required_groups; the body is its only carrier.
+    if ("required_groups" in body) {
+      entry.required_groups = structuredClone(body.required_groups);
+    }
     return "ok";
   }
   const reason = body === null ? "no body returned" : "body shape missing config_entries";

--- a/test/components/device/automation-editor/automation-action-node-reset.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-reset.test.ts
@@ -62,6 +62,7 @@ function action(id: string): AutomationAction {
     description: "",
     config_entries: [entry("plain", false), entry("secret", true)],
     accepts_action_list: [],
+    required_groups: [{ kind: "exactly_one", keys: ["plain", "secret"] }],
   } as unknown as AutomationAction;
 }
 
@@ -111,6 +112,14 @@ describe("automation-action-node view-state reset on rebind", () => {
     const el = await mountNode(node("set_variable"));
     expect(collapseButton(el).getAttribute("aria-expanded")).toBe("true");
     expect(bodyPresent(el)).toBe(true);
+  });
+
+  it("forwards the definition's required_groups to the params form", async () => {
+    const el = await mountNode(node("set_variable"));
+    const form = paramsForm(el) as Element & { requiredGroups?: unknown };
+    expect(form.requiredGroups).toEqual([
+      { kind: "exactly_one", keys: ["plain", "secret"] },
+    ]);
   });
 
   it("resets collapsed state when rebound to a different action_id", async () => {

--- a/test/components/device/automation-editor/automation-condition-tree-advanced.test.ts
+++ b/test/components/device/automation-editor/automation-condition-tree-advanced.test.ts
@@ -1,0 +1,154 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Advanced-section wiring tests for ``automation-condition-tree.ts``
+ * (issue #1905: sensor.in_range's above/below were unreachable).
+ *
+ * The tree renders rows with a plain ``conditions.map(...)`` (no keyed
+ * ``repeat()``), so the per-row "Show advanced settings" flag is keyed
+ * by index and must follow its row across kind changes and removals.
+ * ``config-entry-form`` drags CodeMirror in transitively, so ``vi.mock``
+ * no-ops it; the picker dialog gets a stub element with an ``open()``.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
+vi.mock(
+  "../../../../src/components/device/automation-editor/catalog-picker-dialog.js",
+  () => ({})
+);
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import type {
+  AutomationCondition,
+  ConditionNode,
+} from "../../../../src/api/types/automations.js";
+import type { ConfigEntry } from "../../../../src/api/types/config-entries.js";
+import { ESPHomeAutomationConditionTree } from "../../../../src/components/device/automation-editor/automation-condition-tree.js";
+
+customElements.define(
+  "esphome-catalog-picker-dialog",
+  class extends HTMLElement {
+    open() {}
+  }
+);
+
+function entry(key: string, advanced: boolean): ConfigEntry {
+  return {
+    key,
+    advanced,
+    type: "string",
+    label: key,
+    required: false,
+  } as unknown as ConfigEntry;
+}
+
+/** Mixed advanced/basic entries so the in-form advanced control renders. */
+function condition(id: string): AutomationCondition {
+  return {
+    id,
+    name: id,
+    description: "",
+    config_entries: [entry("id", false), entry("extra", true)],
+    accepts_condition_list: false,
+    required_groups: [{ kind: "at_least_one", keys: ["above", "below"] }],
+  } as unknown as AutomationCondition;
+}
+
+function node(condition_id: string): ConditionNode {
+  return { condition_id, params: {} };
+}
+
+const CATALOG = [condition("sensor.in_range"), condition("number.in_range")];
+
+async function mountTree(
+  conditions: ConditionNode[]
+): Promise<ESPHomeAutomationConditionTree> {
+  const el = new ESPHomeAutomationConditionTree();
+  el.conditions = conditions;
+  el.catalog = CATALOG;
+  // Mirror the owner contract: mutations come back through
+  // conditions-change and the parent rebinds the list.
+  el.addEventListener("conditions-change", (e) => {
+    el.conditions = (e as CustomEvent<{ conditions: ConditionNode[] }>).detail.conditions;
+  });
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function forms(el: ESPHomeAutomationConditionTree): Element[] {
+  return [...el.shadowRoot!.querySelectorAll("esphome-config-entry-form")];
+}
+
+function toggleAdvanced(form: Element, show: boolean): void {
+  form.dispatchEvent(
+    new CustomEvent("advanced-toggle", {
+      detail: { show },
+      bubbles: true,
+      composed: true,
+    })
+  );
+}
+
+describe("automation-condition-tree advanced section", () => {
+  it("opts every row's form into the advanced section", async () => {
+    const el = await mountTree([node("sensor.in_range"), node("number.in_range")]);
+    for (const form of forms(el)) {
+      expect(form.hasAttribute("advanced-section")).toBe(true);
+      expect(form.hasAttribute("show-advanced")).toBe(false);
+    }
+  });
+
+  it("forwards the definition's required_groups to the form", async () => {
+    const el = await mountTree([node("sensor.in_range")]);
+    const form = forms(el)[0] as Element & { requiredGroups?: unknown };
+    expect(form.requiredGroups).toEqual([
+      { kind: "at_least_one", keys: ["above", "below"] },
+    ]);
+  });
+
+  it("tracks the advanced toggle per row", async () => {
+    const el = await mountTree([node("sensor.in_range"), node("number.in_range")]);
+
+    toggleAdvanced(forms(el)[1], true);
+    await el.updateComplete;
+
+    expect(forms(el)[0].hasAttribute("show-advanced")).toBe(false);
+    expect(forms(el)[1].hasAttribute("show-advanced")).toBe(true);
+
+    toggleAdvanced(forms(el)[1], false);
+    await el.updateComplete;
+    expect(forms(el)[1].hasAttribute("show-advanced")).toBe(false);
+  });
+
+  it("shifts the flag down when an earlier row is removed", async () => {
+    const el = await mountTree([node("sensor.in_range"), node("number.in_range")]);
+
+    toggleAdvanced(forms(el)[1], true);
+    await el.updateComplete;
+
+    el.shadowRoot!.querySelectorAll<HTMLButtonElement>(".ae-row-delete")[0].click();
+    await el.updateComplete;
+
+    expect(forms(el)).toHaveLength(1);
+    expect(forms(el)[0].hasAttribute("show-advanced")).toBe(true);
+  });
+
+  it("resets the flag when the row's condition kind changes", async () => {
+    const el = await mountTree([node("sensor.in_range")]);
+
+    toggleAdvanced(forms(el)[0], true);
+    await el.updateComplete;
+    expect(forms(el)[0].hasAttribute("show-advanced")).toBe(true);
+
+    // Change the row's kind through the picker flow.
+    el.shadowRoot!.querySelector<HTMLButtonElement>(".ae-row-picker")!.click();
+    el.shadowRoot!.querySelector("esphome-catalog-picker-dialog")!.dispatchEvent(
+      new CustomEvent("catalog-picked", { detail: { id: "number.in_range" } })
+    );
+    await el.updateComplete;
+
+    expect(forms(el)[0].hasAttribute("show-advanced")).toBe(false);
+  });
+});

--- a/test/components/device/automation-editor/automation-condition-tree-advanced.test.ts
+++ b/test/components/device/automation-editor/automation-condition-tree-advanced.test.ts
@@ -26,12 +26,14 @@ import type {
 import type { ConfigEntry } from "../../../../src/api/types/config-entries.js";
 import { ESPHomeAutomationConditionTree } from "../../../../src/components/device/automation-editor/automation-condition-tree.js";
 
-customElements.define(
-  "esphome-catalog-picker-dialog",
-  class extends HTMLElement {
-    open() {}
-  }
-);
+if (!customElements.get("esphome-catalog-picker-dialog")) {
+  customElements.define(
+    "esphome-catalog-picker-dialog",
+    class extends HTMLElement {
+      open() {}
+    }
+  );
+}
 
 function entry(key: string, advanced: boolean): ConfigEntry {
   return {

--- a/test/components/device/automation-editor/automation-trigger-picker-advanced.test.ts
+++ b/test/components/device/automation-editor/automation-trigger-picker-advanced.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Advanced-section wiring tests for ``automation-trigger-picker.ts``
+ * (issue #1905: advanced trigger params were unreachable).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+
+import type { AutomationTrigger } from "../../../../src/api/types/automations.js";
+import type { ConfigEntry } from "../../../../src/api/types/config-entries.js";
+import { ESPHomeAutomationTriggerPicker } from "../../../../src/components/device/automation-editor/automation-trigger-picker.js";
+
+function entry(key: string, advanced: boolean): ConfigEntry {
+  return {
+    key,
+    advanced,
+    type: "string",
+    label: key,
+    required: false,
+  } as unknown as ConfigEntry;
+}
+
+function trigger(id: string): AutomationTrigger {
+  return {
+    id,
+    name: id,
+    description: "",
+    docs_url: "",
+    applies_to: [],
+    is_device_level: true,
+    supports_list: false,
+    config_entries: [entry("plain", false), entry("secret", true)],
+  } as unknown as AutomationTrigger;
+}
+
+const TRIGGERS = [trigger("esphome.on_boot"), trigger("esphome.on_shutdown")];
+
+async function mountPicker(triggerId: string): Promise<ESPHomeAutomationTriggerPicker> {
+  const el = new ESPHomeAutomationTriggerPicker();
+  el.target = { kind: "device_on", trigger: triggerId };
+  el.triggers = TRIGGERS;
+  el.triggerId = triggerId;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function paramsForm(el: ESPHomeAutomationTriggerPicker): Element {
+  return el.shadowRoot!.querySelector("esphome-config-entry-form")!;
+}
+
+describe("automation-trigger-picker advanced section", () => {
+  it("opts the params form into the advanced section", async () => {
+    const el = await mountPicker("esphome.on_boot");
+    expect(paramsForm(el).hasAttribute("advanced-section")).toBe(true);
+    expect(paramsForm(el).hasAttribute("show-advanced")).toBe(false);
+  });
+
+  it("tracks the advanced toggle and resets on trigger change", async () => {
+    const el = await mountPicker("esphome.on_boot");
+
+    paramsForm(el).dispatchEvent(
+      new CustomEvent("advanced-toggle", {
+        detail: { show: true },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await el.updateComplete;
+    expect(paramsForm(el).hasAttribute("show-advanced")).toBe(true);
+
+    el.triggerId = "esphome.on_shutdown";
+    await el.updateComplete;
+    expect(paramsForm(el).hasAttribute("show-advanced")).toBe(false);
+  });
+});

--- a/test/util/automation-body-hydration.test.ts
+++ b/test/util/automation-body-hydration.test.ts
@@ -21,7 +21,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import type { AutomationCatalogBody } from "../../src/api/types/automations.js";
-import type { ConfigEntry } from "../../src/api/types/config-entries.js";
+import type { ConfigEntry, RequiredGroup } from "../../src/api/types/config-entries.js";
 import {
   emptyHydrationResult,
   hydrateEntryConfigEntries,
@@ -213,5 +213,36 @@ describe("tallyOutcome", () => {
     expect(result.succeeded).toBe(2);
     expect(result.missingBody).toBe(1);
     expect(result.rejected).toBe(0);
+  });
+});
+
+describe("hydrateEntryConfigEntries required_groups", () => {
+  it("copies the body's required_groups onto the entry", async () => {
+    const groups = [{ kind: "at_least_one", keys: ["above", "below"] }];
+    const body = {
+      ...bodyWithEntries("sensor.in_range", [configEntry("above")]),
+      required_groups: groups,
+    } as AutomationCatalogBody;
+    const fetchBody = vi.fn(async () => body);
+    const entry = hydratable("sensor.in_range") as ReturnType<typeof hydratable> & {
+      required_groups?: RequiredGroup[] | null;
+    };
+
+    await hydrateEntryConfigEntries(makeApi(), "conditions", entry, fetchBody);
+
+    expect(entry.required_groups).toEqual(groups);
+    // Disjoint copy — mutating the entry's groups must not poison the body.
+    expect(entry.required_groups).not.toBe(groups);
+  });
+
+  it("leaves required_groups unset when the body has none", async () => {
+    const fetchBody = vi.fn(async () => bodyWithEntries("on_boot", []));
+    const entry = hydratable("on_boot") as ReturnType<typeof hydratable> & {
+      required_groups?: RequiredGroup[] | null;
+    };
+
+    await hydrateEntryConfigEntries(makeApi(), "triggers", entry, fetchBody);
+
+    expect("required_groups" in entry).toBe(false);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#1908 for issue esphome/device-builder#1905. The condition tree and trigger picker mounted `esphome-config-entry-form` without the advanced section, so advanced params were silently dropped; a fresh `sensor.in_range` offered only ID and the saved YAML failed validation. Both forms now opt in to `advanced-section` the way the action node already does; the condition tree keys the toggle per row and the flag follows its row across kind changes and removals.

The backend PR also ships `required_groups` on action and condition bodies. `hydrateEntryConfigEntries` copied only `config_entries` off the hydrated body, so the field never reached the forms; it now forwards `required_groups`, the types carry it, and the condition tree and action node pass it through, so the form renders its existing "set at least one of" banner when the constraint is unsatisfied. Against an old backend nothing changes, the field is simply absent.

**Related issue or feature (if applicable):**

- esphome/device-builder#1905 (closed by the backend PR esphome/device-builder#1908)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
