### PR TITLE
Add the image platform-domain category

### DIFF
--- a/src/api/types/components.ts
+++ b/src/api/types/components.ts
@@ -49,6 +49,7 @@ export enum ComponentCategory {
   AUDIO_ADC = "audio_adc",
   AUDIO_DAC = "audio_dac",
   CANBUS = "canbus",
+  IMAGE = "image",
   INFRARED = "infrared",
   MEDIA_SOURCE = "media_source",
   MOTION = "motion",


### PR DESCRIPTION
# What does this implement/fix?

Mirror of esphome/device-builder#1913 for the upstream 2026.7.0b1 schema, which turns `image` into a platform domain (`image.online_image`, `image.file`, `image.animation`). Adds the `IMAGE` member to the `ComponentCategory` enum so frontend code can reference the new category; rendering needs no change, the chip label derives from the id and the filter list comes off the wire.

**Related issue or feature (if applicable):**

- companion to esphome/device-builder#1913

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
