### PR TITLE
Sort the list view's default order with the shared device collator

### DIFF
--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -144,7 +144,10 @@ export function renderCardGrid(
 }
 
 export function renderTable(host: ESPHomePageDashboard): TemplateResult {
-  const filteredDevices = host._applyFacetFilters(host._devices);
+  // Sorted input so the no-column-sort default matches the card grid's
+  // collator order instead of the backend's path order (#1917); an active
+  // column sort still re-sorts on top.
+  const filteredDevices = host._applyFacetFilters(host._sortedDevices);
   return html`
     <esphome-device-table
       .devices=${filteredDevices}

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -110,7 +110,7 @@ import {
   type FacetSelection,
 } from "../util/device-filter.js";
 import { matchesDeviceName } from "../util/device-search.js";
-import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../util/device-sort.js";
+import { sortDevices } from "../util/device-sort.js";
 import { normalizeUpdateBuckets } from "../util/facets.js";
 import { computeLabelUsage } from "../util/label-usage.js";
 import { navigate } from "../util/navigation.js";
@@ -281,11 +281,7 @@ export class ESPHomePageDashboard extends LitElement {
   _pendingAdoptScroll: string | null = null;
   _actionDevice: ConfiguredDevice | null = null;
 
-  private _sortDevices = memoizeOne((source: ConfiguredDevice[]) =>
-    [...source].sort((a, b) =>
-      DEVICE_SORT_COLLATOR.compare(deviceSortKey(a), deviceSortKey(b))
-    )
-  );
+  private _sortDevices = memoizeOne((source: ConfiguredDevice[]) => sortDevices(source));
   private _computeLabelUsageMemo = memoizeOne(computeLabelUsage);
   /** id → name map rebuilt once per labels-catalog reference change.
    *  ``_syncUrl`` looks up the names for every selected label id; the

--- a/src/util/device-sort.ts
+++ b/src/util/device-sort.ts
@@ -24,3 +24,11 @@ export const deviceSortKey = (d: {
   name?: string;
   configuration?: string;
 }): string => d.friendly_name || d.name || d.configuration || "";
+
+/** Copy of *devices* in collator order of their sort keys. */
+export const sortDevices = <T extends Parameters<typeof deviceSortKey>[0]>(
+  devices: readonly T[]
+): T[] =>
+  [...devices].sort((a, b) =>
+    DEVICE_SORT_COLLATOR.compare(deviceSortKey(a), deviceSortKey(b))
+  );

--- a/test/components/dashboard/render-table-default-order.test.ts
+++ b/test/components/dashboard/render-table-default-order.test.ts
@@ -12,7 +12,7 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
 import { DashboardView } from "../../../src/api/types/system.js";
 import { renderTable } from "../../../src/components/dashboard/render-content.js";
-import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../../src/util/device-sort.js";
+import { sortDevices } from "../../../src/util/device-sort.js";
 import { renderInto } from "../../_dom.js";
 import { makeConfiguredDevice } from "../../_make-configured-device.js";
 import { makeDashboardHost } from "./_host.js";
@@ -27,12 +27,9 @@ const BACKEND_ORDER = ["Garland", "ecu Boiler", "plg Servion"].map((name) =>
 );
 
 function makeHost(devices: ConfiguredDevice[]) {
-  const sorted = [...devices].sort((a, b) =>
-    DEVICE_SORT_COLLATOR.compare(deviceSortKey(a), deviceSortKey(b))
-  );
   return makeDashboardHost({
     _devices: devices,
-    _sortedDevices: sorted,
+    _sortedDevices: sortDevices(devices),
     _applyFacetFilters: (list: ConfiguredDevice[]) => list,
     _activeJobs: new Map(),
     _recentJobs: new Map(),

--- a/test/components/dashboard/render-table-default-order.test.ts
+++ b/test/components/dashboard/render-table-default-order.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins renderTable feeding the table the collator-sorted device list, so
+ * the no-column-sort default order matches the card grid instead of the
+ * backend's capitals-first path order (device-builder#1917).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
+import { DashboardView } from "../../../src/api/types/system.js";
+import { renderTable } from "../../../src/components/dashboard/render-content.js";
+import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../../src/util/device-sort.js";
+import { renderInto } from "../../_dom.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+import { makeDashboardHost } from "./_host.js";
+
+// Backend snapshot order: lexicographic by YAML path, capitals first.
+const BACKEND_ORDER = ["Garland", "ecu Boiler", "plg Servion"].map((name) =>
+  makeConfiguredDevice({
+    name,
+    friendly_name: name,
+    configuration: `${name}.yaml`,
+  })
+);
+
+function makeHost(devices: ConfiguredDevice[]) {
+  const sorted = [...devices].sort((a, b) =>
+    DEVICE_SORT_COLLATOR.compare(deviceSortKey(a), deviceSortKey(b))
+  );
+  return makeDashboardHost({
+    _devices: devices,
+    _sortedDevices: sorted,
+    _applyFacetFilters: (list: ConfiguredDevice[]) => list,
+    _activeJobs: new Map(),
+    _recentJobs: new Map(),
+    _tablePageSize: 25,
+    _tableSorting: [],
+    _tableColumnVisibility: {},
+    _selectMode: false,
+    _visibleImportableDevices: [],
+    _selectedDevices: new Set<string>(),
+    _recentlyAdopted: null,
+    _hideDeviceCreation: true,
+    _view: DashboardView.TABLE,
+    _expertMode: false,
+    _selectedLabels: [],
+    _selectedAreas: [],
+    _selectedPlatforms: [],
+    _selectedStates: [],
+    _selectedUpdateStatus: [],
+    _activeFacetCount: 0,
+    _computeLabelUsage: () => new Map(),
+    _allVisibleSelected: false,
+  });
+}
+
+describe("renderTable default device order", () => {
+  it("passes the collator-sorted list, not the backend snapshot order", () => {
+    const container = renderInto(renderTable(makeHost(BACKEND_ORDER)));
+    const table = container.querySelector("esphome-device-table") as unknown as {
+      devices: ConfiguredDevice[];
+    };
+    expect(table.devices.map((d) => d.friendly_name)).toEqual([
+      "ecu Boiler",
+      "Garland",
+      "plg Servion",
+    ]);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The grid view and the YAML search view render `_sortedDevices`, sorted with the shared case insensitive `DEVICE_SORT_COLLATOR`, but the list view handed the table the raw `_devices` array. With no saved column sort the table renders input order, which is the backend snapshot order, lexicographic by YAML path with capitals first; that is the order reported in the issue. Feeding the table `_sortedDevices` makes the default order match the grid; an active column sort still re-sorts on top, and the facet filter memo stops thrashing between the two arrays in table view.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1917

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
