### PR TITLE
Keep the app header and dashboard toolbar pinned on page-scroll views

### DIFF
--- a/src/components/dashboard/device-grid-styles.ts
+++ b/src/components/dashboard/device-grid-styles.ts
@@ -159,13 +159,14 @@ export const deviceGridStyles = css`
     padding: var(--wa-space-l) var(--content-gutter);
   }
 
-  /* When the grid follows the toolbar's count row (whether directly
-     or with the empty-search pivot wedged between), the count row
-     already provides spacing above the first card. Tighten the
-     grid's top padding so the two rows don't double up. */
+  /* When the grid follows the toolbar (whether directly or with the
+     empty-search pivot wedged between), the toolbar's own bottom
+     padding owns the seam — it has to live on the toolbar side so it
+     survives sticking. Zero the grid's top padding so the gap isn't
+     paid twice. */
   .toolbar + .devices-grid,
   .toolbar + .empty-search + .devices-grid {
-    padding-top: var(--wa-space-xs);
+    padding-top: 0;
   }
 
   /* Only the configured-device grid needs FAB clearance: it's the

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -97,6 +97,27 @@ export const dashboardStyles = css`
     flex-shrink: 0;
   }
 
+  /* On the page-scroll views the toolbar pins below the sticky app
+     header, matching the table view where it sits outside the scroll
+     region — search / view toggle stay reachable on a long grid or
+     YAML hit list (#1923; the legacy dashboard's fixed header gave
+     the same guarantee). top tracks --esphome-header-height so the
+     compact mobile header stacks correctly. Opaque background so
+     cards don't show through while stuck; the bottom padding keeps
+     scrolled-under content off the count row (the grid's own top
+     padding scrolls away with it). z-index stays below the
+     discovered pill (5, device-grid-styles.ts) whose expanded panel
+     hangs over the toolbar, and above the unpositioned grid/list
+     content. */
+  :host([view="cards"]) .toolbar,
+  :host([yaml]) .toolbar {
+    position: sticky;
+    top: var(--esphome-header-height);
+    z-index: 4;
+    background: var(--wa-color-surface-default);
+    padding-bottom: var(--wa-space-xs);
+  }
+
   /* Table-view counterpart to .toolbar (sits inside the
      device-table's named toolbar slot, where the slotted rule on
      .controls handles the outer padding). Without this rule the

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -89,33 +89,28 @@ export const dashboardStyles = css`
 
   /* ─── Search toolbar ─── */
 
+  /* Pins below the sticky app header so search / view toggle stay
+     reachable on a long card grid or YAML hit list (#1923). Only the
+     page-scroll views render .toolbar (table view slots
+     .toolbar-stack into the device-table, and its fixed-height host
+     never scrolls), so no per-view scoping is needed. top tracks
+     --esphome-header-height so the compact mobile header stacks
+     correctly. Opaque background so cards don't show through while
+     stuck; the bottom padding keeps scrolled-under content off the
+     count row (the grid's own top padding scrolls away with it).
+     z-index stays below the discovered pill (5,
+     device-grid-styles.ts) whose expanded panel hangs over the
+     toolbar, and above the unpositioned grid/list content. */
   .toolbar {
     display: flex;
     flex-direction: column;
     gap: var(--toolbar-row-gap);
-    padding: var(--toolbar-pad-top) var(--content-gutter) 0;
+    padding: var(--toolbar-pad-top) var(--content-gutter) var(--toolbar-row-gap);
     flex-shrink: 0;
-  }
-
-  /* On the page-scroll views the toolbar pins below the sticky app
-     header, matching the table view where it sits outside the scroll
-     region — search / view toggle stay reachable on a long grid or
-     YAML hit list (#1923; the legacy dashboard's fixed header gave
-     the same guarantee). top tracks --esphome-header-height so the
-     compact mobile header stacks correctly. Opaque background so
-     cards don't show through while stuck; the bottom padding keeps
-     scrolled-under content off the count row (the grid's own top
-     padding scrolls away with it). z-index stays below the
-     discovered pill (5, device-grid-styles.ts) whose expanded panel
-     hangs over the toolbar, and above the unpositioned grid/list
-     content. */
-  :host([view="cards"]) .toolbar,
-  :host([yaml]) .toolbar {
     position: sticky;
     top: var(--esphome-header-height);
     z-index: 4;
     background: var(--wa-color-surface-default);
-    padding-bottom: var(--wa-space-xs);
   }
 
   /* Table-view counterpart to .toolbar (sits inside the

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -136,11 +136,9 @@ export class ESPHomeLayout extends LitElement {
         overflow: hidden;
         /* Pinned to the top of the app-shell scrollport so the actions
            menu stays reachable on page-scroll views (card grid, YAML
-           search); inert on views that scroll internally. z-index sits
-           above the dashboard's sticky toolbar (4) and discovered pill
-           (5) so scrolled content slides under, and below the fixed
-           overlays (select bar 20, dropdown menus 100, device drawer
-           998). */
+           search); inert on views that scroll internally. 6 keeps it
+           above the dashboard's sticky toolbar (4) and the discovered
+           pill (5), and under the fixed overlays. */
         position: sticky;
         top: 0;
         z-index: 6;

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -134,6 +134,16 @@ export class ESPHomeLayout extends LitElement {
         height: var(--esphome-header-height);
         box-sizing: border-box;
         overflow: hidden;
+        /* Pinned to the top of the app-shell scrollport so the actions
+           menu stays reachable on page-scroll views (card grid, YAML
+           search); inert on views that scroll internally. z-index sits
+           above the dashboard's sticky toolbar (4) and discovered pill
+           (5) so scrolled content slides under, and below the fixed
+           overlays (select bar 20, dropdown menus 100, device drawer
+           998). */
+        position: sticky;
+        top: 0;
+        z-index: 6;
       }
 
       .header-logos {

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -82,8 +82,9 @@ export const espHomeStyles = css`
      sidebar-collapse breakpoint, so embedded in the HA panel this
      fires exactly when HA swaps to its own 40px top bar — matching
      its height avoids a chunky doubled-up bar. Defined on the shared
-     token so the header element, the content-area height calcs, and
-     the actions-menu top offset all shrink together. */
+     token so the header element, the content-area height calcs, the
+     actions-menu top offset, and the dashboard toolbar's sticky top
+     all shrink together. */
   @media (max-width: 870px) {
     :host {
       --esphome-header-height: 40px;


### PR DESCRIPTION
# What does this implement/fix?

In List view the app header and the toolbar (view switcher, search, Filters, count row) never scroll away because the table scrolls internally. Grid and YAML views scroll the whole page, so all of those controls scroll off the top and reaching search or the view switcher on a long device list means scrolling all the way back up. The legacy dashboard kept its command header position fixed while the card grid scrolled, so the controls were always reachable there; the page-scroll views lost that.

This pins both on the page-scroll views with position sticky: the app header sticks to the top of the scrollport, and the dashboard toolbar sticks directly below it in cards and yaml modes, tracking the compact mobile header via the existing height token. The toolbar gets an opaque surface background and a small bottom padding so content clips cleanly while stuck. Table view is untouched (its host never scrolls, so sticky never engages), and the page-scroll override from #438 is unchanged; sticky relies on it. z-indexes slot under the discovered-devices pill (5) so its expanded panel still paints over the toolbar, and under every fixed overlay (select bar, dropdown menus, drawer).

Verified headlessly against a 36-device backend: cards and yaml scrolled 900px keep header + toolbar pinned with the actions menu usable, the expanded discovered panel paints above the stuck toolbar and slides under the header, the drawer covers everything, table view still does not page-scroll, and the 390px viewport stacks the 40px compact header correctly.

The sticky strip also stays on mobile, where the wrapped toolbar rows take more height; that matches List view, which already keeps the same rows permanently visible there. If the maintainers prefer, the sticky rules could be scoped to desktop widths only.

No backend change; this is CSS only.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1923

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
