### PR TITLE
Treat rp2 and rp2040 blocks as equivalent in dependency checks

### DIFF
--- a/src/components/device/add-component-deps.ts
+++ b/src/components/device/add-component-deps.ts
@@ -1,5 +1,6 @@
 import type { ESPHomeAPI } from "../../api/index.js";
 import { ComponentCategory } from "../../api/types/components.js";
+import { canonicalComponentKey, hasComponentKey } from "../../util/component-presence.js";
 import { providerIds } from "../../util/provides-cache.js";
 import {
   parseConfiguredPlatforms,
@@ -11,17 +12,6 @@ import {
 // another domain: a `binary_sensor: - platform: switch` mirror must not
 // pass for a `switch:` dependency. Guards the stem-match branch below.
 const PLATFORM_DOMAINS: ReadonlySet<string> = new Set(Object.values(ComponentCategory));
-
-// esphome#17145 renames the rp2040 platform key to rp2; either block
-// satisfies a dependency spelled with the other name (the catalog stays
-// keyed on rp2040 until esphome/backlog#155 flips the canonical key).
-const PLATFORM_KEY_ALIASES: ReadonlyMap<string, string> = new Map([["rp2", "rp2040"]]);
-
-const canonicalKey = (id: string): string => PLATFORM_KEY_ALIASES.get(id) ?? id;
-
-function canonicalKeys(present: ReadonlySet<string>): ReadonlySet<string> {
-  return new Set([...present].map(canonicalKey));
-}
 
 /**
  * Catalog dependencies not yet satisfied by the current YAML.
@@ -43,7 +33,7 @@ export function findMissingDependencies(
 ): string[] {
   // Most components declare no dependencies — skip the YAML scans.
   if (dependencies.length === 0) return [];
-  const present = canonicalKeys(presentComponents ?? parseTopLevelComponents(yaml));
+  const present = presentComponents ?? parseTopLevelComponents(yaml);
   const configured = parseConfiguredPlatforms(yaml);
   const platformStems = new Set<string>();
   for (const id of configured) {
@@ -51,7 +41,7 @@ export function findMissingDependencies(
     if (dot !== -1) platformStems.add(id.slice(dot + 1));
   }
   return dependencies.filter((dep) => {
-    if (present.has(canonicalKey(dep))) return false;
+    if (hasComponentKey(present, dep)) return false;
     if (dep.includes(".")) return !configured.has(dep);
     if (!PLATFORM_DOMAINS.has(dep) && platformStems.has(dep)) return false;
     return true;
@@ -82,17 +72,13 @@ export async function depsSatisfiedByProvides(
   // comes back empty — skip them rather than pay the round trip.
   const resolvable = missing.filter((dep) => !dep.includes("."));
   if (resolvable.length === 0) return satisfied;
-  const presentKeys = canonicalKeys(present);
+  // The provides index is keyed on the catalog's canonical platform key.
+  const platform = ctx.platform ? canonicalComponentKey(ctx.platform) : undefined;
   await Promise.all(
     resolvable.map(async (dep) => {
-      const providers = await providerIds(
-        api,
-        dep,
-        ctx.platform ?? undefined,
-        ctx.boardId ?? undefined
-      );
+      const providers = await providerIds(api, dep, platform, ctx.boardId ?? undefined);
       for (const id of providers) {
-        if (presentKeys.has(canonicalKey(id))) {
+        if (hasComponentKey(present, id)) {
           satisfied.add(dep);
           break;
         }

--- a/src/components/device/add-component-deps.ts
+++ b/src/components/device/add-component-deps.ts
@@ -12,6 +12,17 @@ import {
 // pass for a `switch:` dependency. Guards the stem-match branch below.
 const PLATFORM_DOMAINS: ReadonlySet<string> = new Set(Object.values(ComponentCategory));
 
+// esphome#17145 renames the rp2040 platform key to rp2; either block
+// satisfies a dependency spelled with the other name (the catalog stays
+// keyed on rp2040 until esphome/backlog#155 flips the canonical key).
+const PLATFORM_KEY_ALIASES: ReadonlyMap<string, string> = new Map([["rp2", "rp2040"]]);
+
+const canonicalKey = (id: string): string => PLATFORM_KEY_ALIASES.get(id) ?? id;
+
+function canonicalKeys(present: ReadonlySet<string>): ReadonlySet<string> {
+  return new Set([...present].map(canonicalKey));
+}
+
 /**
  * Catalog dependencies not yet satisfied by the current YAML.
  *
@@ -32,7 +43,7 @@ export function findMissingDependencies(
 ): string[] {
   // Most components declare no dependencies — skip the YAML scans.
   if (dependencies.length === 0) return [];
-  const present = presentComponents ?? parseTopLevelComponents(yaml);
+  const present = canonicalKeys(presentComponents ?? parseTopLevelComponents(yaml));
   const configured = parseConfiguredPlatforms(yaml);
   const platformStems = new Set<string>();
   for (const id of configured) {
@@ -40,7 +51,7 @@ export function findMissingDependencies(
     if (dot !== -1) platformStems.add(id.slice(dot + 1));
   }
   return dependencies.filter((dep) => {
-    if (present.has(dep)) return false;
+    if (present.has(canonicalKey(dep))) return false;
     if (dep.includes(".")) return !configured.has(dep);
     if (!PLATFORM_DOMAINS.has(dep) && platformStems.has(dep)) return false;
     return true;
@@ -71,6 +82,7 @@ export async function depsSatisfiedByProvides(
   // comes back empty — skip them rather than pay the round trip.
   const resolvable = missing.filter((dep) => !dep.includes("."));
   if (resolvable.length === 0) return satisfied;
+  const presentKeys = canonicalKeys(present);
   await Promise.all(
     resolvable.map(async (dep) => {
       const providers = await providerIds(
@@ -80,7 +92,7 @@ export async function depsSatisfiedByProvides(
         ctx.boardId ?? undefined
       );
       for (const id of providers) {
-        if (present.has(id)) {
+        if (presentKeys.has(canonicalKey(id))) {
           satisfied.add(dep);
           break;
         }

--- a/src/util/component-presence.ts
+++ b/src/util/component-presence.ts
@@ -1,3 +1,21 @@
+// esphome#17145 renames the rp2040 platform key to rp2; a block spelled
+// either way counts as the other until the catalog flips its canonical key.
+const PLATFORM_KEY_ALIAS: Readonly<Record<string, string>> = {
+  rp2: "rp2040",
+  rp2040: "rp2",
+};
+
+/** The catalog's canonical spelling of a platform key (`rp2` → `rp2040`). */
+export const canonicalComponentKey = (id: string): string =>
+  id === "rp2" ? "rp2040" : id;
+
+/** Whether `present` holds `id` under either alias spelling. */
+export function hasComponentKey(present: ReadonlySet<string>, id: string): boolean {
+  if (present.has(id)) return true;
+  const alias = PLATFORM_KEY_ALIAS[id];
+  return alias !== undefined && present.has(alias);
+}
+
 /**
  * Whether a component id is already configured in the YAML's present set.
  *
@@ -9,5 +27,5 @@ export function isComponentPresent(
   present: ReadonlySet<string>,
   presentPlatforms: ReadonlySet<string>
 ): boolean {
-  return id.includes(".") ? presentPlatforms.has(id) : present.has(id);
+  return id.includes(".") ? presentPlatforms.has(id) : hasComponentKey(present, id);
 }

--- a/test/components/device/add-component-deps.test.ts
+++ b/test/components/device/add-component-deps.test.ts
@@ -155,15 +155,17 @@ describe("depsSatisfiedByProvides", () => {
     expect([...satisfied]).toEqual(["uart"]);
   });
 
-  it("matches a rp2040 provider against a rp2 block", async () => {
+  it("matches a rp2040 provider against a rp2 block and canonicalizes the platform", async () => {
     const getComponents = vi.fn().mockResolvedValue(providersResponse(["rp2040"]));
     const satisfied = await depsSatisfiedByProvides(
       stubApi(getComponents),
       ["pico_w"],
       new Set(["rp2", "logger"]),
-      { platform: "rp2040", boardId: null }
+      { platform: "rp2", boardId: null }
     );
     expect([...satisfied]).toEqual(["pico_w"]);
+    // The provides index is keyed on the catalog's canonical platform key.
+    expect(getComponents.mock.calls[0][0]).toMatchObject({ platform: "rp2040" });
   });
 
   it("short-circuits an empty missing list without an API call", async () => {

--- a/test/components/device/add-component-deps.test.ts
+++ b/test/components/device/add-component-deps.test.ts
@@ -80,6 +80,16 @@ describe("findMissingDependencies", () => {
     // would otherwise report ld2410 missing.
     expect(findMissingDependencies(["ld2410"], "", new Set(["ld2410"]))).toEqual([]);
   });
+
+  it("satisfies a rp2040 dep from a rp2 block", () => {
+    // esphome 2026.7 renames the platform key; a config already migrated
+    // to `rp2:` must not prompt for a duplicate rp2040 platform block.
+    expect(findMissingDependencies(["rp2040"], "rp2:\n  board: rpipicow\n")).toEqual([]);
+  });
+
+  it("satisfies a rp2 dep from a rp2040 block", () => {
+    expect(findMissingDependencies(["rp2"], "rp2040:\n  board: rpipicow\n")).toEqual([]);
+  });
 });
 
 describe("depsSatisfiedByProvides", () => {
@@ -143,6 +153,17 @@ describe("depsSatisfiedByProvides", () => {
       { platform: "esp32", boardId: null }
     );
     expect([...satisfied]).toEqual(["uart"]);
+  });
+
+  it("matches a rp2040 provider against a rp2 block", async () => {
+    const getComponents = vi.fn().mockResolvedValue(providersResponse(["rp2040"]));
+    const satisfied = await depsSatisfiedByProvides(
+      stubApi(getComponents),
+      ["pico_w"],
+      new Set(["rp2", "logger"]),
+      { platform: "rp2040", boardId: null }
+    );
+    expect([...satisfied]).toEqual(["pico_w"]);
   });
 
   it("short-circuits an empty missing list without an API call", async () => {

--- a/test/components/device/component-catalog/filters.test.ts
+++ b/test/components/device/component-catalog/filters.test.ts
@@ -69,6 +69,16 @@ describe("visibleComponents platform gate", () => {
     expect(ids).toEqual(["async_tcp", "bk72xx"]);
   });
 
+  it("hides a single-instance component whose alias block is configured", () => {
+    // A `rp2:` block counts as the shipped rp2040 entry, so the card must
+    // not offer a duplicate platform block.
+    const cat = [entry("rp2040", ["rp2040"], [], false)];
+    const ids = visibleComponents(
+      host(cat, "rp2040", { yaml: "rp2:\n  board: rpipicow\n" })
+    ).map((c) => c.id);
+    expect(ids).toEqual([]);
+  });
+
   it("does not count a platform-incompatible dep as satisfied when core-locked", () => {
     // The variant's only dep is hidden by the platform gate, so it can't be
     // satisfied from this dialog and the variant must drop too.

--- a/test/util/component-presence.test.ts
+++ b/test/util/component-presence.test.ts
@@ -16,4 +16,10 @@ describe("isComponentPresent", () => {
     );
     expect(isComponentPresent("time.sntp", present, presentPlatforms)).toBe(false);
   });
+
+  it("matches rp2 and rp2040 against either block spelling", () => {
+    expect(isComponentPresent("rp2040", new Set(["rp2"]), presentPlatforms)).toBe(true);
+    expect(isComponentPresent("rp2", new Set(["rp2040"]), presentPlatforms)).toBe(true);
+    expect(isComponentPresent("rp2040", present, presentPlatforms)).toBe(false);
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

esphome 2026.7 renames the rp2040 platform key to rp2, so a user on the beta can already have a top level `rp2:` block. The dependency check in `findMissingDependencies` compares literal names, so a component depending on `rp2040` (rp2040_ble, the PIO LED strip, rp2040_pwm after esphome/device-builder#1926) shows the "requires other components, Add RP2040 Platform" banner on such a config; following it writes a second platform block and esphome rejects the config.

This adds a small platform key alias fold to the dependency satisfaction path; `rp2` and `rp2040` blocks now satisfy dependencies spelled either way, in both the literal name scan and the provides lookup. The alias table drops when the catalog flips its canonical key to rp2 (esphome/backlog#155).

**Related issue or feature (if applicable):**

- companion to esphome/device-builder#1926

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
