### PR TITLE
Hoist the canonical rp2 platform key into shared constants

### DIFF
--- a/src/components/device/navigator-row-icons.ts
+++ b/src/components/device/navigator-row-icons.ts
@@ -77,6 +77,7 @@ import {
   mdiZigbee,
   mdiZWave,
 } from "@mdi/js";
+import { RP2_ALIAS_KEY, RP2_CANONICAL_KEY } from "../../util/component-presence.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 
 /**
@@ -130,9 +131,9 @@ const DOMAIN_ICON: Record<string, readonly [string, string]> = {
   // Board platforms
   esp32: ["cpu-32-bit", mdiCpu32Bit],
   esp8266: ["cpu-32-bit", mdiCpu32Bit],
-  rp2040: ["cpu-32-bit", mdiCpu32Bit],
+  [RP2_CANONICAL_KEY]: ["cpu-32-bit", mdiCpu32Bit],
   // esphome#17145 renames the rp2040 platform key to rp2
-  rp2: ["cpu-32-bit", mdiCpu32Bit],
+  [RP2_ALIAS_KEY]: ["cpu-32-bit", mdiCpu32Bit],
   bk72xx: ["cpu-32-bit", mdiCpu32Bit],
   rtl87xx: ["cpu-32-bit", mdiCpu32Bit],
   ln882x: ["cpu-32-bit", mdiCpu32Bit],

--- a/src/components/wizard/wizard-step-board-platforms.ts
+++ b/src/components/wizard/wizard-step-board-platforms.ts
@@ -19,6 +19,7 @@
  * - ``label`` is the user-facing chip text.
  */
 import { chipPlatformFamily } from "../../util/chip-variant.js";
+import { RP2_CANONICAL_KEY } from "../../util/component-presence.js";
 
 export interface WizardBoardPlatform {
   readonly platform: string;
@@ -43,8 +44,8 @@ export const WIZARD_BOARD_PLATFORMS: readonly WizardBoardPlatform[] = [
   // the newer RP2350; split into two chips (mirroring the per-variant
   // ESP32 chips) so users pick their actual silicon. The backend
   // filters the shared platform by 'mcu'.
-  { platform: "rp2040", variant: "", mcu: "rp2040", label: "RP2040" },
-  { platform: "rp2040", variant: "", mcu: "rp2350", label: "RP2350" },
+  { platform: RP2_CANONICAL_KEY, variant: "", mcu: "rp2040", label: "RP2040" },
+  { platform: RP2_CANONICAL_KEY, variant: "", mcu: "rp2350", label: "RP2350" },
   // LibreTiny platforms bundle genuinely different silicon; split each
   // by 'mcu' (the chip series the backend stamps on every board) the
   // same way rp2040 is. BK7231N/T/Q share the one 'bk7231' filter.

--- a/src/util/component-presence.ts
+++ b/src/util/component-presence.ts
@@ -1,13 +1,17 @@
 // esphome#17145 renames the rp2040 platform key to rp2; a block spelled
-// either way counts as the other until the catalog flips its canonical key.
+// either way counts as the other. Swap the two values to flip the
+// catalog's canonical key once 2026.7 is the runtime floor.
+export const RP2_CANONICAL_KEY = "rp2040";
+export const RP2_ALIAS_KEY = "rp2";
+
 const PLATFORM_KEY_ALIAS: Readonly<Record<string, string>> = {
-  rp2: "rp2040",
-  rp2040: "rp2",
+  [RP2_ALIAS_KEY]: RP2_CANONICAL_KEY,
+  [RP2_CANONICAL_KEY]: RP2_ALIAS_KEY,
 };
 
 /** The catalog's canonical spelling of a platform key (`rp2` → `rp2040`). */
 export const canonicalComponentKey = (id: string): string =>
-  id === "rp2" ? "rp2040" : id;
+  id === RP2_ALIAS_KEY ? RP2_CANONICAL_KEY : id;
 
 /** Whether `present` holds `id` under either alias spelling. */
 export function hasComponentKey(present: ReadonlySet<string>, id: string): boolean {

--- a/src/util/component-presence.ts
+++ b/src/util/component-presence.ts
@@ -1,6 +1,5 @@
-// esphome#17145 renames the rp2040 platform key to rp2; a block spelled
-// either way counts as the other. Swap the two values to flip the
-// catalog's canonical key once 2026.7 is the runtime floor.
+// Canonical and accepted-alias spellings of the RP2 platform key
+// (esphome#17145 rename); a canonical-key flip starts by swapping these.
 export const RP2_CANONICAL_KEY = "rp2040";
 export const RP2_ALIAS_KEY = "rp2";
 
@@ -9,7 +8,7 @@ const PLATFORM_KEY_ALIAS: Readonly<Record<string, string>> = {
   [RP2_CANONICAL_KEY]: RP2_ALIAS_KEY,
 };
 
-/** The catalog's canonical spelling of a platform key (`rp2` → `rp2040`). */
+/** Fold the non-canonical RP2 spelling onto the catalog's canonical key. */
 export const canonicalComponentKey = (id: string): string =>
   id === RP2_ALIAS_KEY ? RP2_CANONICAL_KEY : id;
 

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -1,3 +1,4 @@
+import { RP2_ALIAS_KEY, RP2_CANONICAL_KEY } from "./component-presence.js";
 import { parseYamlAutomations } from "./yaml-automations.js";
 import { TOP_LEVEL_KEY_RE } from "./yaml-section-lexer.js";
 import {
@@ -51,9 +52,9 @@ export const CORE_KEYS = new Set([
   // Target platforms
   "esp32",
   "esp8266",
-  "rp2040",
+  RP2_CANONICAL_KEY,
   // esphome#17145 renames the rp2040 platform key to rp2; keep both
-  "rp2",
+  RP2_ALIAS_KEY,
   "bk72xx",
   "rtl87xx",
   "ln882x",


### PR DESCRIPTION
# What does this implement/fix?

Hoists the canonical rp2 platform spelling into exported `RP2_CANONICAL_KEY` / `RP2_ALIAS_KEY` constants in `component-presence.ts` (the shared alias seam) and points the alias map, `canonicalComponentKey`, and the wizard's platform chip rows at them. Flipping the catalog's canonical key to rp2 (esphome/backlog#155, once 2026.7 is the runtime floor) becomes swapping the two constant values.

MCU strings stay literal (`mcu: "rp2040"` / `"rp2350"` name silicon, not the platform key). The both-spellings membership lists (`CORE_KEYS`, navigator icons) also reference the constants so a grep for them finds every alias site. Tests keep literal spellings so the flip breaks them loudly. No behavior change.

**Related issue or feature (if applicable):**

- companion to esphome/device-builder#1931, groundwork for esphome/backlog#155

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
