### PR TITLE
Offer a schema-gated auto-fix for dedented invalid-option keys

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1130,6 +1130,7 @@
     "error_go_to_line": "Go to line {line}",
     "error_dash_space_fix": "Missing space: line {line} \"-{key}\" is a list item missing the space after its \"-\". Add the space so it reads \"- {key}\".",
     "error_nest_under_fix": "Indentation mismatch: line {line} \"{key}\" is not an option of the block it sits in, but it is a valid option of \"{parent}\". Indent line {line} by {spaces, plural, one {# space} other {# spaces}} to nest it under \"{parent}\".",
+    "error_unnest_fix": "Indentation mismatch: line {line} \"{key}\" is not an option of \"{parent}\", but it is a valid option of \"{target}\". Remove {spaces, plural, one {# space} other {# spaces}} from the start of line {line} to move it out of \"{parent}\".",
     "error_auto_fix": "Try auto-fix",
     "error_auto_fix_hint": "Best-effort guess: it edits only the marked line. Review the result and undo it if that is not the fix you wanted.",
     "auto_fix_failed": "Couldn't run auto-fix; the config could not be validated. Please try again.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1129,7 +1129,7 @@
     "error_flow_hint": "Unclosed bracket near line {line}; a \"[\" list or \"{\" mapping is missing its closing \"]\" or \"}\".",
     "error_go_to_line": "Go to line {line}",
     "error_dash_space_fix": "Missing space: line {line} \"-{key}\" is a list item missing the space after its \"-\". Add the space so it reads \"- {key}\".",
-    "error_nest_under_fix": "Indentation mismatch: line {line} \"{key}\" is not an option of the block it sits in, but it is a valid option of \"{parent}\". Indent line {line} by {spaces, plural, one {# space} other {# spaces}} to nest it under \"{parent}\".",
+    "error_nest_under_fix": "Indentation mismatch: line {line} \"{key}\" is not an option of the block it sits in, but it is a valid option of \"{target}\". Indent line {line} by {spaces, plural, one {# space} other {# spaces}} to nest it under \"{target}\".",
     "error_unnest_fix": "Indentation mismatch: line {line} \"{key}\" is not an option of \"{parent}\", but it is a valid option of \"{target}\". Remove {spaces, plural, one {# space} other {# spaces}} from the start of line {line} to move it out of \"{parent}\".",
     "error_auto_fix": "Try auto-fix",
     "error_auto_fix_hint": "Best-effort guess: it edits only the marked line. Review the result and undo it if that is not the fix you wanted.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1129,6 +1129,7 @@
     "error_flow_hint": "Unclosed bracket near line {line}; a \"[\" list or \"{\" mapping is missing its closing \"]\" or \"}\".",
     "error_go_to_line": "Go to line {line}",
     "error_dash_space_fix": "Missing space: line {line} \"-{key}\" is a list item missing the space after its \"-\". Add the space so it reads \"- {key}\".",
+    "error_nest_under_fix": "Indentation mismatch: line {line} \"{key}\" is not an option of the block it sits in, but it is a valid option of \"{parent}\". Indent line {line} by {spaces, plural, one {# space} other {# spaces}} to nest it under \"{parent}\".",
     "error_auto_fix": "Try auto-fix",
     "error_auto_fix_hint": "Best-effort guess: it edits only the marked line. Review the result and undo it if that is not the fix you wanted.",
     "auto_fix_failed": "Couldn't run auto-fix; the config could not be validated. Please try again.",

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -630,19 +630,33 @@ export interface DedentedOptionCandidate {
   fromIndent: number;
 }
 
+/** A value-less opener located by ``findValuelessOpener``, with the walk
+ *  facts the two misnested-option analyzers derive their deltas from. */
+interface OpenerAbove {
+  openerLine: number;
+  openerKey: string;
+  openerIndent: number;
+  blamedIndent: number;
+  /** Shallowest strictly-deeper indent passed on the way up — the opener's
+   *  existing children — or null when none. */
+  minDeeper: number | null;
+}
+
 /**
- * Detect the dedented-option shape behind an invalid-option error: the
- * blamed `key:` sits at the same indent as a value-less opener above it
- * (`encryption:` then `key:`), separated only by the opener's deeper
- * children, blanks, or comments. Anything else between them — a valued
- * sibling, a list marker, a shallower line — means a one-line re-indent
- * would nest the key under the wrong node, so return null.
+ * Shared walk behind the misnested-option analyzers: from the blamed
+ * `key:` line, scan upward past blanks, comments, and deeper lines to the
+ * value-less opener the key is one level away from — the *sibling* at the
+ * blamed indent (nest) or the enclosing *parent* at a shallower one
+ * (dedent). Bails on list markers, valued deciders, and (sibling mode) a
+ * shallower line first: each means a one-line re-indent would attach the
+ * key to the wrong node.
  */
-export function analyzeDedentedOption(
+function findValuelessOpener(
   readLine: ReadLine,
   blamedLine: number,
-  blamedKey: string
-): DedentedOptionCandidate | null {
+  blamedKey: string,
+  opener: "sibling" | "parent"
+): OpenerAbove | null {
   const text = readLine(blamedLine);
   if (text === undefined || parseListItemMarker(text)) return null;
   if (lineKeyToken(text) !== blamedKey) return null;
@@ -659,20 +673,40 @@ export function analyzeDedentedOption(
       minDeeper = minDeeper === null ? indent : Math.min(minDeeper, indent);
       continue;
     }
-    if (indent < blamedIndent) return null;
+    if (indent === blamedIndent) {
+      if (opener === "parent") continue;
+    } else if (opener === "sibling") {
+      return null;
+    }
     const openerKey = valuelessKeyOf(above);
     if (openerKey === null) return null;
-    // The opener's existing children set the target indent; a childless
-    // opener gets the canonical step.
-    const target = minDeeper ?? blamedIndent + YAML_INDENT_STEP;
-    return {
-      openerLine: n,
-      openerKey,
-      delta: target - blamedIndent,
-      fromIndent: blamedIndent,
-    };
+    return { openerLine: n, openerKey, openerIndent: indent, blamedIndent, minDeeper };
   }
   return null;
+}
+
+/**
+ * Detect the dedented-option shape behind an invalid-option error: the
+ * blamed `key:` sits at the same indent as a value-less opener above it
+ * (`encryption:` then `key:`), separated only by the opener's deeper
+ * children, blanks, or comments.
+ */
+export function analyzeDedentedOption(
+  readLine: ReadLine,
+  blamedLine: number,
+  blamedKey: string
+): DedentedOptionCandidate | null {
+  const hit = findValuelessOpener(readLine, blamedLine, blamedKey, "sibling");
+  if (hit === null) return null;
+  // The opener's existing children set the target indent; a childless
+  // opener gets the canonical step.
+  const target = hit.minDeeper ?? hit.blamedIndent + YAML_INDENT_STEP;
+  return {
+    openerLine: hit.openerLine,
+    openerKey: hit.openerKey,
+    delta: target - hit.blamedIndent,
+    fromIndent: hit.blamedIndent,
+  };
 }
 
 /**
@@ -687,32 +721,16 @@ export function analyzeOverIndentedOption(
   blamedLine: number,
   blamedKey: string
 ): DedentedOptionCandidate | null {
-  const text = readLine(blamedLine);
-  if (text === undefined || parseListItemMarker(text)) return null;
-  if (lineKeyToken(text) !== blamedKey) return null;
-  const blamedIndent = indentOf(text);
-  if (blamedIndent === 0) return null;
-  for (let n = blamedLine - 1; n >= 1 && n >= blamedLine - WALK_BOUND; n--) {
-    const above = readLine(n);
-    if (above === undefined) return null;
-    if (isBlankOrComment(above)) continue;
-    if (parseListItemMarker(above)) return null;
-    const indent = indentOf(above);
-    if (indent >= blamedIndent) continue;
-    // The first shallower line is the enclosing opener the blamed key
-    // would dedent out of.
-    const openerKey = valuelessKeyOf(above);
-    if (openerKey === null) return null;
-    const next = contentLineBelow(readLine, blamedLine);
-    if (next !== null && indentOf(next.text) > indent) return null;
-    return {
-      openerLine: n,
-      openerKey,
-      delta: indent - blamedIndent,
-      fromIndent: blamedIndent,
-    };
-  }
-  return null;
+  const hit = findValuelessOpener(readLine, blamedLine, blamedKey, "parent");
+  if (hit === null) return null;
+  const next = contentLineBelow(readLine, blamedLine);
+  if (next !== null && indentOf(next.text) > hit.openerIndent) return null;
+  return {
+    openerLine: hit.openerLine,
+    openerKey: hit.openerKey,
+    delta: hit.openerIndent - hit.blamedIndent,
+    fromIndent: hit.blamedIndent,
+  };
 }
 
 /** ReadLine over an in-memory buffer; splits once, indexes 1-based. */

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -620,12 +620,12 @@ export function parseInvalidOptionMessage(
   return hit ? { key: hit[1], parent: hit[2] } : null;
 }
 
-/** A blamed key that reads as dedented out of the value-less opener above
- *  it, with the re-indent that would nest it back. */
+/** A blamed key one indent level away from the value-less opener above it,
+ *  with the signed re-indent that would repair it: positive nests the line
+ *  under a sibling opener, negative dedents it out of its parent. */
 export interface DedentedOptionCandidate {
   openerLine: number;
   openerKey: string;
-  /** Positive leading-space delta nesting the blamed line under the opener. */
   delta: number;
   fromIndent: number;
 }
@@ -669,6 +669,46 @@ export function analyzeDedentedOption(
       openerLine: n,
       openerKey,
       delta: target - blamedIndent,
+      fromIndent: blamedIndent,
+    };
+  }
+  return null;
+}
+
+/**
+ * The mirror shape: the blamed `key:` was over-indented into the block of
+ * the value-less opener above it (`framework:` swallowing `variant:`), so
+ * it reads as the opener's child instead of its sibling. Only offered when
+ * the blamed line closes its block (the next content line sits at or above
+ * the opener's indent) — dedenting a mid-block line would split the block.
+ */
+export function analyzeOverIndentedOption(
+  readLine: ReadLine,
+  blamedLine: number,
+  blamedKey: string
+): DedentedOptionCandidate | null {
+  const text = readLine(blamedLine);
+  if (text === undefined || parseListItemMarker(text)) return null;
+  if (lineKeyToken(text) !== blamedKey) return null;
+  const blamedIndent = indentOf(text);
+  if (blamedIndent === 0) return null;
+  for (let n = blamedLine - 1; n >= 1 && n >= blamedLine - WALK_BOUND; n--) {
+    const above = readLine(n);
+    if (above === undefined) return null;
+    if (isBlankOrComment(above)) continue;
+    if (parseListItemMarker(above)) return null;
+    const indent = indentOf(above);
+    if (indent >= blamedIndent) continue;
+    // The first shallower line is the enclosing opener the blamed key
+    // would dedent out of.
+    const openerKey = valuelessKeyOf(above);
+    if (openerKey === null) return null;
+    const next = contentLineBelow(readLine, blamedLine);
+    if (next !== null && indentOf(next.text) > indent) return null;
+    return {
+      openerLine: n,
+      openerKey,
+      delta: indent - blamedIndent,
       fromIndent: blamedIndent,
     };
   }

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -608,6 +608,73 @@ export function describeValueTypeCause(
   return null;
 }
 
+/** Matches `[X] is an invalid option for [Y].` with any trailing hint
+ *  ("Please check the indentation." / "Did you mean …?" / none). */
+const INVALID_OPTION_RE = /^\[([^\]]+)\] is an invalid option for \[([^\]]+)\]\./;
+
+/** Parse an ESPHome invalid-option message into its key and parent. */
+export function parseInvalidOptionMessage(
+  message: string
+): { key: string; parent: string } | null {
+  const hit = message.match(INVALID_OPTION_RE);
+  return hit ? { key: hit[1], parent: hit[2] } : null;
+}
+
+/** A blamed key that reads as dedented out of the value-less opener above
+ *  it, with the re-indent that would nest it back. */
+export interface DedentedOptionCandidate {
+  openerLine: number;
+  openerKey: string;
+  /** Positive leading-space delta nesting the blamed line under the opener. */
+  delta: number;
+  fromIndent: number;
+}
+
+/**
+ * Detect the dedented-option shape behind an invalid-option error: the
+ * blamed `key:` sits at the same indent as a value-less opener above it
+ * (`encryption:` then `key:`), separated only by the opener's deeper
+ * children, blanks, or comments. Anything else between them — a valued
+ * sibling, a list marker, a shallower line — means a one-line re-indent
+ * would nest the key under the wrong node, so return null.
+ */
+export function analyzeDedentedOption(
+  readLine: ReadLine,
+  blamedLine: number,
+  blamedKey: string
+): DedentedOptionCandidate | null {
+  const text = readLine(blamedLine);
+  if (text === undefined || parseListItemMarker(text)) return null;
+  if (lineKeyToken(text) !== blamedKey) return null;
+  const blamedIndent = indentOf(text);
+  if (blamedIndent === 0) return null;
+  let minDeeper: number | null = null;
+  for (let n = blamedLine - 1; n >= 1 && n >= blamedLine - WALK_BOUND; n--) {
+    const above = readLine(n);
+    if (above === undefined) return null;
+    if (isBlankOrComment(above)) continue;
+    if (parseListItemMarker(above)) return null;
+    const indent = indentOf(above);
+    if (indent > blamedIndent) {
+      minDeeper = minDeeper === null ? indent : Math.min(minDeeper, indent);
+      continue;
+    }
+    if (indent < blamedIndent) return null;
+    const openerKey = valuelessKeyOf(above);
+    if (openerKey === null) return null;
+    // The opener's existing children set the target indent; a childless
+    // opener gets the canonical step.
+    const target = minDeeper ?? blamedIndent + YAML_INDENT_STEP;
+    return {
+      openerLine: n,
+      openerKey,
+      delta: target - blamedIndent,
+      fromIndent: blamedIndent,
+    };
+  }
+  return null;
+}
+
 /** ReadLine over an in-memory buffer; splits once, indexes 1-based. */
 export function lineAccessorFor(content: string): ReadLine {
   const lines = content.split("\n");

--- a/src/util/yaml-invalid-option-fix.ts
+++ b/src/util/yaml-invalid-option-fix.ts
@@ -1,0 +1,130 @@
+/**
+ * Schema-gated auto-fix for ESPHome invalid-option validation errors.
+ *
+ * `[key] is an invalid option for [api]. Please check the indentation.`
+ * usually means the key was dedented one level out of its block (an empty
+ * `encryption:` opener directly above). The buffer walk finds that shape;
+ * the component catalog then has to confirm the key really is an option of
+ * the opener (and not of its current parent) before the one-line re-indent
+ * is offered — the gate fails closed, so packages / `!extend` / unknown
+ * components simply get no fix rather than a wrong one.
+ */
+import type { EditorState } from "@codemirror/state";
+import type { ESPHomeAPI } from "../api/esphome-api.js";
+import type { LocalizeFunc } from "../common/localize.js";
+import { getKeyPath, resolveBundleContext } from "./yaml-ast.js";
+import {
+  loadCatalog,
+  nestedPathForParent,
+  resolveAvailableEntries,
+} from "./yaml-completion-catalog.js";
+import {
+  analyzeDedentedOption,
+  parseInvalidOptionMessage,
+  type ReadLine,
+  type ValueTypeCause,
+} from "./yaml-error-analysis.js";
+import { indentOf } from "./yaml-line-walker.js";
+
+export interface InvalidOptionFixContext {
+  api: ESPHomeAPI;
+  state: EditorState;
+  readLine: ReadLine;
+  /** The sanitized validation-error message. */
+  message: string;
+  /** 1-indexed line the squiggle anchors on. */
+  blamedLine: number;
+  localize: LocalizeFunc;
+}
+
+/** Cause + one-click re-indent for a dedented option, or null when the
+ *  buffer shape or the schema doesn't confirm it. Never throws. */
+export async function describeInvalidOptionFix(
+  ctx: InvalidOptionFixContext
+): Promise<ValueTypeCause | null> {
+  try {
+    return await resolveFix(ctx);
+  } catch {
+    return null;
+  }
+}
+
+async function resolveFix(ctx: InvalidOptionFixContext): Promise<ValueTypeCause | null> {
+  const parsed = parseInvalidOptionMessage(ctx.message);
+  if (!parsed) return null;
+  const cand = analyzeDedentedOption(ctx.readLine, ctx.blamedLine, parsed.key);
+  if (!cand) return null;
+
+  const { state } = ctx;
+  const doc = state.doc;
+  if (ctx.blamedLine > doc.lines) return null;
+  // Anchor inside each key token — side -1 at the line start would resolve
+  // to the preceding node.
+  const blamedPos = doc.line(ctx.blamedLine).from + cand.fromIndent + 1;
+  const openerLineInfo = doc.line(cand.openerLine);
+  const openerPos = openerLineInfo.from + indentOf(openerLineInfo.text) + 1;
+
+  // The AST must agree with the line walk: the blamed key and the opener
+  // are siblings under the same parent chain (rules out block scalars and
+  // anything the indent heuristic misread).
+  const blamedPath = getKeyPath(state, blamedPos);
+  const openerPath = getKeyPath(state, openerPos);
+  if (
+    blamedPath[blamedPath.length - 1] !== parsed.key ||
+    openerPath[openerPath.length - 1] !== cand.openerKey
+  ) {
+    return null;
+  }
+  if (
+    blamedPath.length !== openerPath.length ||
+    blamedPath.slice(0, -1).some((k, i) => openerPath[i] !== k)
+  ) {
+    return null;
+  }
+  // The message's [parent] names the blamed key's current parent; a
+  // mismatch means the error belongs to another occurrence of this key.
+  const topLevelKey = blamedPath[0];
+  const currentParentKey =
+    blamedPath.length >= 2 ? blamedPath[blamedPath.length - 2] : topLevelKey;
+  if (parsed.parent !== currentParentKey) return null;
+
+  const catalog = await loadCatalog(ctx.api);
+  const platformValue = resolveBundleContext(state, openerPos)?.platformValue ?? null;
+  // No CompletionTarget (board/platform): key existence doesn't vary by
+  // board, and the linter doesn't carry one.
+  const [openerEntries, parentEntries] = await Promise.all([
+    resolveAvailableEntries(
+      ctx.api,
+      catalog,
+      cand.openerKey,
+      platformValue,
+      topLevelKey,
+      () => nestedPathForParent(state, openerPos, cand.openerKey)
+    ),
+    resolveAvailableEntries(
+      ctx.api,
+      catalog,
+      currentParentKey,
+      platformValue,
+      topLevelKey,
+      () => nestedPathForParent(state, blamedPos, currentParentKey)
+    ),
+  ]);
+  if (!openerEntries.some((e) => e.key === parsed.key)) return null;
+  if (parentEntries.some((e) => e.key === parsed.key)) return null;
+
+  return {
+    text: ctx.localize("yaml_editor.error_nest_under_fix", {
+      line: ctx.blamedLine,
+      key: parsed.key,
+      parent: cand.openerKey,
+      spaces: cand.delta,
+    }),
+    fix: {
+      line: ctx.blamedLine,
+      indent: cand.delta,
+      key: parsed.key,
+      fromIndent: cand.fromIndent,
+    },
+  };
+}

--- a/src/util/yaml-invalid-option-fix.ts
+++ b/src/util/yaml-invalid-option-fix.ts
@@ -2,25 +2,25 @@
  * Schema-gated auto-fix for ESPHome invalid-option validation errors.
  *
  * `[key] is an invalid option for [api]. Please check the indentation.`
- * usually means the key was dedented one level out of its block (an empty
- * `encryption:` opener directly above). The buffer walk finds that shape;
- * the component catalog then has to confirm the key really is an option of
- * the opener (and not of its current parent) before the one-line re-indent
- * is offered — the gate fails closed, so packages / `!extend` / unknown
+ * usually means the key sits one indent level away from where it belongs:
+ * dedented out of an empty opener directly above (`encryption:` then
+ * `key:`), or over-indented into the block above (`variant:` swallowed by
+ * `framework:`). The buffer walks find those shapes; the component catalog
+ * then has to confirm the key really is an option of the proposed new
+ * parent (and not of its current one) before the one-line re-indent is
+ * offered — the gate fails closed, so packages / `!extend` / unknown
  * components simply get no fix rather than a wrong one.
  */
 import type { EditorState } from "@codemirror/state";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { LocalizeFunc } from "../common/localize.js";
-import { getKeyPath, resolveBundleContext } from "./yaml-ast.js";
-import {
-  loadCatalog,
-  nestedPathForParent,
-  resolveAvailableEntries,
-} from "./yaml-completion-catalog.js";
+import { getKeyPath, getPlatformValue } from "./yaml-ast.js";
+import { loadCatalog, resolveAvailableEntries } from "./yaml-completion-catalog.js";
 import {
   analyzeDedentedOption,
+  analyzeOverIndentedOption,
   parseInvalidOptionMessage,
+  type DedentedOptionCandidate,
   type ReadLine,
   type ValueTypeCause,
 } from "./yaml-error-analysis.js";
@@ -29,7 +29,6 @@ import { indentOf } from "./yaml-line-walker.js";
 export interface InvalidOptionFixContext {
   api: ESPHomeAPI;
   state: EditorState;
-  readLine: ReadLine;
   /** The sanitized validation-error message. */
   message: string;
   /** 1-indexed line the squiggle anchors on. */
@@ -37,7 +36,7 @@ export interface InvalidOptionFixContext {
   localize: LocalizeFunc;
 }
 
-/** Cause + one-click re-indent for a dedented option, or null when the
+/** Cause + one-click re-indent for a misnested option, or null when the
  *  buffer shape or the schema doesn't confirm it. Never throws. */
 export async function describeInvalidOptionFix(
   ctx: InvalidOptionFixContext
@@ -52,74 +51,94 @@ export async function describeInvalidOptionFix(
 async function resolveFix(ctx: InvalidOptionFixContext): Promise<ValueTypeCause | null> {
   const parsed = parseInvalidOptionMessage(ctx.message);
   if (!parsed) return null;
-  const cand = analyzeDedentedOption(ctx.readLine, ctx.blamedLine, parsed.key);
-  if (!cand) return null;
+  const doc = ctx.state.doc;
+  const readLine: ReadLine = (n) =>
+    n >= 1 && n <= doc.lines ? doc.line(n).text : undefined;
+  const nest = analyzeDedentedOption(readLine, ctx.blamedLine, parsed.key);
+  if (nest) {
+    const fix = await gateCandidate(ctx, parsed, nest, true);
+    if (fix) return fix;
+  }
+  const unnest = analyzeOverIndentedOption(readLine, ctx.blamedLine, parsed.key);
+  return unnest ? gateCandidate(ctx, parsed, unnest, false) : null;
+}
 
+/**
+ * Confirm a walk candidate against the AST and the component catalog and
+ * build its cause. *nest* re-indents the blamed key under its sibling
+ * opener; otherwise the key dedents out of its parent (the opener) to
+ * become the grandparent's child.
+ */
+async function gateCandidate(
+  ctx: InvalidOptionFixContext,
+  parsed: { key: string; parent: string },
+  cand: DedentedOptionCandidate,
+  nest: boolean
+): Promise<ValueTypeCause | null> {
   const { state } = ctx;
   const doc = state.doc;
-  if (ctx.blamedLine > doc.lines) return null;
   // Anchor inside each key token — side -1 at the line start would resolve
   // to the preceding node.
   const blamedPos = doc.line(ctx.blamedLine).from + cand.fromIndent + 1;
   const openerLineInfo = doc.line(cand.openerLine);
   const openerPos = openerLineInfo.from + indentOf(openerLineInfo.text) + 1;
 
-  // The AST must agree with the line walk: the blamed key and the opener
-  // are siblings under the same parent chain (rules out block scalars and
-  // anything the indent heuristic misread).
+  // The AST must agree with the line walk (rules out block scalars and
+  // anything the indent heuristic misread): the opener is the blamed key's
+  // sibling (nest) or its parent (unnest), and the message's [parent]
+  // names the blamed key's current parent — a mismatch means the error
+  // belongs to another occurrence of this key.
   const blamedPath = getKeyPath(state, blamedPos);
   const openerPath = getKeyPath(state, openerPos);
+  const expectedOpener = nest
+    ? [...blamedPath.slice(0, -1), cand.openerKey]
+    : blamedPath.slice(0, -1);
   if (
+    blamedPath.length < (nest ? 2 : 3) ||
     blamedPath[blamedPath.length - 1] !== parsed.key ||
-    openerPath[openerPath.length - 1] !== cand.openerKey
+    parsed.parent !== blamedPath[blamedPath.length - 2] ||
+    openerPath.length !== expectedOpener.length ||
+    openerPath.some((k, i) => expectedOpener[i] !== k)
   ) {
     return null;
   }
-  if (
-    blamedPath.length !== openerPath.length ||
-    blamedPath.slice(0, -1).some((k, i) => openerPath[i] !== k)
-  ) {
-    return null;
-  }
-  // The message's [parent] names the blamed key's current parent; a
-  // mismatch means the error belongs to another occurrence of this key.
-  const topLevelKey = blamedPath[0];
-  const currentParentKey =
-    blamedPath.length >= 2 ? blamedPath[blamedPath.length - 2] : topLevelKey;
-  if (parsed.parent !== currentParentKey) return null;
 
+  const topLevelKey = blamedPath[0];
   const catalog = await loadCatalog(ctx.api);
-  const platformValue = resolveBundleContext(state, openerPos)?.platformValue ?? null;
+  const platformValue = getPlatformValue(state, blamedPos);
   // No CompletionTarget (board/platform): key existence doesn't vary by
-  // board, and the linter doesn't carry one.
-  const [openerEntries, parentEntries] = await Promise.all([
+  // board, and the linter doesn't carry one. The nested descent paths are
+  // the AST-verified key chains minus the top-level component.
+  const entriesFor = (key: string, nestedPath: string[]) =>
     resolveAvailableEntries(
       ctx.api,
       catalog,
-      cand.openerKey,
+      key,
       platformValue,
       topLevelKey,
-      () => nestedPathForParent(state, openerPos, cand.openerKey)
-    ),
-    resolveAvailableEntries(
-      ctx.api,
-      catalog,
-      currentParentKey,
-      platformValue,
-      topLevelKey,
-      () => nestedPathForParent(state, blamedPos, currentParentKey)
-    ),
+      () => nestedPath
+    );
+  // Where the key would move to: the opener (nest) or the grandparent.
+  const targetKey = nest ? cand.openerKey : blamedPath[blamedPath.length - 3];
+  const targetPath = nest ? openerPath.slice(1) : blamedPath.slice(1, -2);
+  const [targetEntries, parentEntries] = await Promise.all([
+    entriesFor(targetKey, targetPath),
+    entriesFor(parsed.parent, blamedPath.slice(1, -1)),
   ]);
-  if (!openerEntries.some((e) => e.key === parsed.key)) return null;
+  if (!targetEntries.some((e) => e.key === parsed.key)) return null;
   if (parentEntries.some((e) => e.key === parsed.key)) return null;
 
   return {
-    text: ctx.localize("yaml_editor.error_nest_under_fix", {
-      line: ctx.blamedLine,
-      key: parsed.key,
-      parent: cand.openerKey,
-      spaces: cand.delta,
-    }),
+    text: ctx.localize(
+      nest ? "yaml_editor.error_nest_under_fix" : "yaml_editor.error_unnest_fix",
+      {
+        line: ctx.blamedLine,
+        key: parsed.key,
+        parent: nest ? cand.openerKey : parsed.parent,
+        target: targetKey,
+        spaces: Math.abs(cand.delta),
+      }
+    ),
     fix: {
       line: ctx.blamedLine,
       indent: cand.delta,

--- a/src/util/yaml-invalid-option-fix.ts
+++ b/src/util/yaml-invalid-option-fix.ts
@@ -94,7 +94,8 @@ async function gateCandidate(
     ? [...blamedPath.slice(0, -1), cand.openerKey]
     : blamedPath.slice(0, -1);
   if (
-    blamedPath.length < (nest ? 2 : 3) ||
+    // Only the dedent needs a depth floor: its target is the grandparent.
+    (!nest && blamedPath.length < 3) ||
     blamedPath[blamedPath.length - 1] !== parsed.key ||
     parsed.parent !== blamedPath[blamedPath.length - 2] ||
     openerPath.length !== expectedOpener.length ||
@@ -118,11 +119,11 @@ async function gateCandidate(
       topLevelKey,
       () => nestedPath
     );
-  // Where the key would move to: the opener (nest) or the grandparent.
-  const targetKey = nest ? cand.openerKey : blamedPath[blamedPath.length - 3];
-  const targetPath = nest ? openerPath.slice(1) : blamedPath.slice(1, -2);
+  // Where the key would move to: the opener (nest) or the opener's parent.
+  const targetFull = nest ? openerPath : openerPath.slice(0, -1);
+  const targetKey = targetFull[targetFull.length - 1];
   const [targetEntries, parentEntries] = await Promise.all([
-    entriesFor(targetKey, targetPath),
+    entriesFor(targetKey, targetFull.slice(1)),
     entriesFor(parsed.parent, blamedPath.slice(1, -1)),
   ]);
   if (!targetEntries.some((e) => e.key === parsed.key)) return null;
@@ -134,7 +135,7 @@ async function gateCandidate(
       {
         line: ctx.blamedLine,
         key: parsed.key,
-        parent: nest ? cand.openerKey : parsed.parent,
+        parent: parsed.parent,
         target: targetKey,
         spaces: Math.abs(cand.delta),
       }

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -408,7 +408,6 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
           (await describeInvalidOptionFix({
             api: opts.api,
             state: view.state,
-            readLine,
             message,
             blamedLine: squiggleLineNum,
             localize: opts.localize,

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -36,6 +36,7 @@ import {
   type ReadLine,
   type YamlAutoFix,
 } from "./yaml-error-analysis.js";
+import { describeInvalidOptionFix } from "./yaml-invalid-option-fix.js";
 import { indentOf } from "./yaml-line-walker.js";
 import { isOpenConfigFile } from "./yaml-validation-summary.js";
 
@@ -402,7 +403,16 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
         // list items, a half-typed key with no ':', a dash stuck to its
         // key), name that cause, and carry its repair when it has one.
         const squiggleLineNum = doc.lineAt(from).number;
-        const cause = describeValueTypeCause(readLine, squiggleLineNum, opts.localize);
+        const cause =
+          describeValueTypeCause(readLine, squiggleLineNum, opts.localize) ??
+          (await describeInvalidOptionFix({
+            api: opts.api,
+            state: view.state,
+            readLine,
+            message,
+            blamedLine: squiggleLineNum,
+            localize: opts.localize,
+          }));
         if (cause) message = `${message} ${cause.text}`;
         diagnostics.push({
           from,

--- a/test/components/yaml-editor-auto-fix.test.ts
+++ b/test/components/yaml-editor-auto-fix.test.ts
@@ -239,4 +239,32 @@ describe("yaml-editor applyAutoFix (#1884)", () => {
     expect(view.state.doc.toString()).toBe(fixed);
     expect(validateYaml).toHaveBeenCalledWith("x.yaml", fixed);
   });
+
+  it("applies the schema-gated nest-under fix (dedented api encryption key)", async () => {
+    const validateYaml = vi.fn(async () => CLEAN);
+    const broken = "api:\n  encryption:\n  key: !secret x\n";
+    const fixed = "api:\n  encryption:\n    key: !secret x\n";
+    const el = await mountEditor(validateYaml, broken);
+    const view = viewOf(el);
+
+    expect(await el.applyAutoFix({ line: 3, indent: 2, key: "key", fromIndent: 2 })).toBe(
+      "applied"
+    );
+
+    expect(view.state.doc.toString()).toBe(fixed);
+    expect(validateYaml).toHaveBeenCalledWith("x.yaml", fixed);
+    undo(view);
+    expect(view.state.doc.toString()).toBe(broken);
+  });
+
+  it("no-ops a stale nest-under fix whose key was already re-indented", async () => {
+    const validateYaml = vi.fn(async () => CLEAN);
+    const doc = "api:\n  encryption:\n    key: !secret x\n";
+    const el = await mountEditor(validateYaml, doc);
+
+    expect(await el.applyAutoFix({ line: 3, indent: 2, key: "key", fromIndent: 2 })).toBe(
+      "stale"
+    );
+    expect(validateYaml).not.toHaveBeenCalled();
+  });
 });

--- a/test/util/_make-config-entry.ts
+++ b/test/util/_make-config-entry.ts
@@ -7,4 +7,13 @@
  * synthesise an entry — currently the ``substitutions:`` section —
  * share one source of truth with the test fixtures.
  */
-export { makeConfigEntry } from "../../src/util/config-entry-defaults.js";
+import { ConfigEntryType, type ConfigEntry } from "../../src/api/types/config-entries.js";
+import { makeConfigEntry } from "../../src/util/config-entry-defaults.js";
+
+export { makeConfigEntry };
+
+/** A `nested`-typed entry wrapping *children* — the shape schema groups
+ *  (`api.encryption`, `esp32.framework`) hydrate as. */
+export function makeNestedEntry(key: string, children: ConfigEntry[]): ConfigEntry {
+  return makeConfigEntry({ key, type: ConfigEntryType.NESTED, config_entries: children });
+}

--- a/test/util/yaml-completion-filter.test.ts
+++ b/test/util/yaml-completion-filter.test.ts
@@ -11,10 +11,7 @@ import { _resetSchemaCacheForTests } from "../../src/util/esphome-schema.js";
 import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
 import { createYamlCompletionSource } from "../../src/util/yaml-completion.js";
 import { makeComponentEntry } from "./_make-component-entry.js";
-import { makeConfigEntry } from "./_make-config-entry.js";
-
-const nested = (key: string, children: ReturnType<typeof makeConfigEntry>[]) =>
-  makeConfigEntry({ key, type: ConfigEntryType.NESTED, config_entries: children });
+import { makeConfigEntry, makeNestedEntry as nested } from "./_make-config-entry.js";
 
 const SLIM = [
   ...["esphome", "wifi", "logger", "esp32"].map((id) =>

--- a/test/util/yaml-completion-nested.test.ts
+++ b/test/util/yaml-completion-nested.test.ts
@@ -13,10 +13,7 @@ import {
   resolveAvailableEntries,
 } from "../../src/util/yaml-completion-catalog.js";
 import { makeComponentEntry } from "./_make-component-entry.js";
-import { makeConfigEntry } from "./_make-config-entry.js";
-
-const nested = (key: string, children: ReturnType<typeof makeConfigEntry>[]) =>
-  makeConfigEntry({ key, type: ConfigEntryType.NESTED, config_entries: children });
+import { makeConfigEntry, makeNestedEntry as nested } from "./_make-config-entry.js";
 
 // esp32 → framework (nested) → advanced (nested) → compiler_optimization.
 const FRAMEWORK = nested("framework", [

--- a/test/util/yaml-error-analysis.test.ts
+++ b/test/util/yaml-error-analysis.test.ts
@@ -1024,3 +1024,201 @@ describe("describeYamlError", () => {
     ).toEqual({ text: "mapping values are not allowed here", jumpLine: null });
   });
 });
+
+describe("parseInvalidOptionMessage", () => {
+  it("parses the check-the-indentation variant", async () => {
+    const { parseInvalidOptionMessage } =
+      await import("../../src/util/yaml-error-analysis.js");
+    expect(
+      parseInvalidOptionMessage(
+        "[key] is an invalid option for [api]. Please check the indentation."
+      )
+    ).toEqual({ key: "key", parent: "api" });
+  });
+
+  it("parses the did-you-mean variant", async () => {
+    const { parseInvalidOptionMessage } =
+      await import("../../src/util/yaml-error-analysis.js");
+    expect(
+      parseInvalidOptionMessage(
+        "[sside] is an invalid option for [wifi]. Did you mean [ssid]?"
+      )
+    ).toEqual({ key: "sside", parent: "wifi" });
+  });
+
+  it("parses the bare variant", async () => {
+    const { parseInvalidOptionMessage } =
+      await import("../../src/util/yaml-error-analysis.js");
+    expect(parseInvalidOptionMessage("[foo] is an invalid option for [bar].")).toEqual({
+      key: "foo",
+      parent: "bar",
+    });
+  });
+
+  it("rejects other option messages", async () => {
+    const { parseInvalidOptionMessage } =
+      await import("../../src/util/yaml-error-analysis.js");
+    expect(parseInvalidOptionMessage("'key' is a required option for [api].")).toBeNull();
+    expect(parseInvalidOptionMessage("expected a dictionary.")).toBeNull();
+  });
+});
+
+describe("analyzeDedentedOption", () => {
+  const accessor = (lines: string[]) => (n: number) => lines[n - 1];
+  // The reproduction: `key` dedented to `encryption`'s level.
+  const dedented = accessor([
+    "api:", // 1
+    "  encryption:", // 2
+    "  key: !secret x", // 3
+  ]);
+
+  it("finds the value-less opener above and the re-indent delta", async () => {
+    const { analyzeDedentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    expect(analyzeDedentedOption(dedented, 3, "key")).toEqual({
+      openerLine: 2,
+      openerKey: "encryption",
+      delta: 2,
+      fromIndent: 2,
+    });
+  });
+
+  it("returns null when the blamed line's key differs from the message's", async () => {
+    const { analyzeDedentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    expect(analyzeDedentedOption(dedented, 3, "other")).toBeNull();
+  });
+
+  it("returns null when the opener has a value", async () => {
+    const { analyzeDedentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const valued = accessor(["api:", "  encryption: abc", "  key: !secret x"]);
+    expect(analyzeDedentedOption(valued, 3, "key")).toBeNull();
+  });
+
+  it("returns null when a block-scalar owner sits above", async () => {
+    const { analyzeDedentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const scalar = accessor([
+      "api:",
+      "  description: |",
+      "    some text",
+      "  key: !secret x",
+    ]);
+    expect(analyzeDedentedOption(scalar, 4, "key")).toBeNull();
+  });
+
+  it("returns null when the nearest same-indent line is a valued sibling", async () => {
+    const { analyzeDedentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const sibling = accessor([
+      "api:",
+      "  encryption:",
+      "  reboot_timeout: 0s",
+      "  key: !secret x",
+    ]);
+    expect(analyzeDedentedOption(sibling, 4, "key")).toBeNull();
+  });
+
+  it("returns null when the walk hits a shallower line first", async () => {
+    const { analyzeDedentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const shallower = accessor(["api:", "  key: !secret x"]);
+    expect(analyzeDedentedOption(shallower, 2, "key")).toBeNull();
+  });
+
+  it("returns null for a top-level blamed key", async () => {
+    const { analyzeDedentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const top = accessor(["encryption:", "key: !secret x"]);
+    expect(analyzeDedentedOption(top, 2, "key")).toBeNull();
+  });
+
+  it("targets the opener's existing child indent over the canonical step", async () => {
+    const { analyzeDedentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const children = accessor([
+      "esp32:", // 1
+      "  framework:", // 2
+      "      type: esp-idf", // 3
+      "  version: recommended", // 4
+    ]);
+    expect(analyzeDedentedOption(children, 4, "version")).toEqual({
+      openerLine: 2,
+      openerKey: "framework",
+      delta: 4,
+      fromIndent: 2,
+    });
+  });
+
+  it("uses the shallowest deeper line, not a grandchild's indent", async () => {
+    const { analyzeDedentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const grandchildren = accessor([
+      "esp32:", // 1
+      "  framework:", // 2
+      "    advanced:", // 3
+      "      ignore_efuse_custom_mac: true", // 4
+      "  version: recommended", // 5
+    ]);
+    expect(analyzeDedentedOption(grandchildren, 5, "version")).toEqual({
+      openerLine: 2,
+      openerKey: "framework",
+      delta: 2,
+      fromIndent: 2,
+    });
+  });
+
+  it("skips blanks and comments between the blamed line and the opener", async () => {
+    const { analyzeDedentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const gaps = accessor([
+      "api:", // 1
+      "  encryption:", // 2
+      "", // 3
+      "  # the key", // 4
+      "  key: !secret x", // 5
+    ]);
+    expect(analyzeDedentedOption(gaps, 5, "key")).toEqual({
+      openerLine: 2,
+      openerKey: "encryption",
+      delta: 2,
+      fromIndent: 2,
+    });
+  });
+
+  it("returns null when the blamed line is a list item", async () => {
+    const { analyzeDedentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const item = accessor(["sensor:", "  filters:", "  - offset: 1.0"]);
+    expect(analyzeDedentedOption(item, 3, "offset")).toBeNull();
+  });
+
+  it("returns null when the walk crosses a list-item header", async () => {
+    const { analyzeDedentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const crossed = accessor([
+      "sensor:", // 1
+      "  - platform: adc", // 2
+      "  update_interval: 60s", // 3
+    ]);
+    expect(analyzeDedentedOption(crossed, 3, "update_interval")).toBeNull();
+  });
+
+  it("finds an opener inside a list-item body", async () => {
+    const { analyzeDedentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const inItem = accessor([
+      "sensor:", // 1
+      "  - platform: adc", // 2
+      "    filters:", // 3
+      "    multiply: 3.3", // 4
+    ]);
+    expect(analyzeDedentedOption(inItem, 4, "multiply")).toEqual({
+      openerLine: 3,
+      openerKey: "filters",
+      delta: 2,
+      fromIndent: 4,
+    });
+  });
+});

--- a/test/util/yaml-error-analysis.test.ts
+++ b/test/util/yaml-error-analysis.test.ts
@@ -6,6 +6,9 @@
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+// Static on purpose (the per-test dynamic imports guard module state;
+// lineAccessorFor is a pure function shared by the walk fixtures below).
+import { lineAccessorFor } from "../../src/util/yaml-error-analysis.js";
 
 afterEach(() => {
   vi.resetModules();
@@ -1063,8 +1066,9 @@ describe("parseInvalidOptionMessage", () => {
   });
 });
 
+const accessor = (lines: string[]) => lineAccessorFor(lines.join("\n"));
+
 describe("analyzeDedentedOption", () => {
-  const accessor = (lines: string[]) => (n: number) => lines[n - 1];
   // The reproduction: `key` dedented to `encryption`'s level.
   const dedented = accessor([
     "api:", // 1
@@ -1220,5 +1224,104 @@ describe("analyzeDedentedOption", () => {
       delta: 2,
       fromIndent: 4,
     });
+  });
+});
+
+describe("analyzeOverIndentedOption", () => {
+  // The reproduction: `variant` over-indented into `framework:`'s block.
+  const overindented = accessor([
+    "esp32:", // 1
+    "  framework:", // 2
+    "    type: esp-idf", // 3
+    "    variant: ESP32", // 4
+  ]);
+
+  it("finds the enclosing opener and the dedent delta", async () => {
+    const { analyzeOverIndentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    expect(analyzeOverIndentedOption(overindented, 4, "variant")).toEqual({
+      openerLine: 2,
+      openerKey: "framework",
+      delta: -2,
+      fromIndent: 4,
+    });
+  });
+
+  it("skips trailing blanks and comments before the closing check", async () => {
+    const { analyzeOverIndentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const gaps = accessor([
+      "esp32:", // 1
+      "  framework:", // 2
+      "    type: esp-idf", // 3
+      "    variant: ESP32", // 4
+      "  ", // 5
+      "      ", // 6
+      "ethernet:", // 7
+    ]);
+    expect(analyzeOverIndentedOption(gaps, 4, "variant")).toEqual({
+      openerLine: 2,
+      openerKey: "framework",
+      delta: -2,
+      fromIndent: 4,
+    });
+  });
+
+  it("returns null for a mid-block line (dedenting it would split the block)", async () => {
+    const { analyzeOverIndentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const mid = accessor([
+      "esp32:",
+      "  framework:",
+      "    variant: ESP32",
+      "    type: esp-idf",
+    ]);
+    expect(analyzeOverIndentedOption(mid, 3, "variant")).toBeNull();
+  });
+
+  it("returns null when the blamed line has children of its own", async () => {
+    const { analyzeOverIndentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const withChildren = accessor([
+      "esp32:",
+      "  framework:",
+      "    variant:",
+      "      deep: x",
+    ]);
+    expect(analyzeOverIndentedOption(withChildren, 3, "variant")).toBeNull();
+  });
+
+  it("returns null when the enclosing line has a value", async () => {
+    const { analyzeOverIndentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const valued = accessor(["esp32:", "  framework: abc", "    variant: x"]);
+    expect(analyzeOverIndentedOption(valued, 3, "variant")).toBeNull();
+  });
+
+  it("returns null when the walk crosses a list-item header", async () => {
+    const { analyzeOverIndentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const crossed = accessor(["sensor:", "  - platform: adc", "    variant: x"]);
+    expect(analyzeOverIndentedOption(crossed, 3, "variant")).toBeNull();
+  });
+
+  it("returns null when the blamed line is a list item", async () => {
+    const { analyzeOverIndentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const item = accessor(["sensor:", "  filters:", "    - offset: 1.0"]);
+    expect(analyzeOverIndentedOption(item, 3, "offset")).toBeNull();
+  });
+
+  it("returns null when the blamed line's key differs from the message's", async () => {
+    const { analyzeOverIndentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    expect(analyzeOverIndentedOption(overindented, 4, "other")).toBeNull();
+  });
+
+  it("returns null for a top-level blamed key", async () => {
+    const { analyzeOverIndentedOption } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const top = accessor(["framework:", "variant: x"]);
+    expect(analyzeOverIndentedOption(top, 2, "variant")).toBeNull();
   });
 });

--- a/test/util/yaml-invalid-option-fix.test.ts
+++ b/test/util/yaml-invalid-option-fix.test.ts
@@ -94,7 +94,7 @@ describe("describeInvalidOptionFix", () => {
 
   it("offers the re-indent when the schema confirms the opener owns the key", async () => {
     expect(await run(DEDENTED_KEY, KEY_MESSAGE, 3)).toEqual({
-      text: 'yaml_editor.error_nest_under_fix:{"line":3,"key":"key","parent":"encryption","target":"encryption","spaces":2}',
+      text: 'yaml_editor.error_nest_under_fix:{"line":3,"key":"key","parent":"api","target":"encryption","spaces":2}',
       fix: { line: 3, indent: 2, key: "key", fromIndent: 2 },
     });
   });
@@ -124,6 +124,17 @@ describe("describeInvalidOptionFix", () => {
   it("offers the dedent when the key belongs to the grandparent", async () => {
     expect(await run(OVERINDENTED_VARIANT, VARIANT_MESSAGE, 4)).toEqual({
       text: 'yaml_editor.error_unnest_fix:{"line":4,"key":"variant","parent":"framework","target":"esp32","spaces":2}',
+      fix: { line: 4, indent: -2, key: "variant", fromIndent: 4 },
+    });
+  });
+
+  it("falls through to the dedent when the sibling opener's gate rejects", async () => {
+    // `advanced:` above makes the nest walk fire first, but `variant` is
+    // not an advanced option; the dedent out of `framework` then wins.
+    const yaml = ["esp32:", "  framework:", "    advanced:", "    variant: ESP32"].join(
+      "\n"
+    );
+    expect(await run(yaml, VARIANT_MESSAGE, 4)).toMatchObject({
       fix: { line: 4, indent: -2, key: "variant", fromIndent: 4 },
     });
   });

--- a/test/util/yaml-invalid-option-fix.test.ts
+++ b/test/util/yaml-invalid-option-fix.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the schema-gated invalid-option auto-fix: the buffer walk finds
+ * a dedented key under a value-less opener, and the component catalog must
+ * confirm the key belongs to the opener (and not to its current parent)
+ * before the re-indent is offered.
+ */
+import { EditorState } from "@codemirror/state";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  ComponentCategory,
+  type ComponentCatalogEntry,
+} from "../../src/api/types/components.js";
+import { ConfigEntryType } from "../../src/api/types/config-entries.js";
+import { _clearComponentCache } from "../../src/util/component-name-cache.js";
+import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
+import { lineAccessorFor } from "../../src/util/yaml-error-analysis.js";
+import { describeInvalidOptionFix } from "../../src/util/yaml-invalid-option-fix.js";
+import { makeComponentEntry } from "./_make-component-entry.js";
+import { makeConfigEntry } from "./_make-config-entry.js";
+
+const nested = (key: string, children: ReturnType<typeof makeConfigEntry>[]) =>
+  makeConfigEntry({ key, type: ConfigEntryType.NESTED, config_entries: children });
+
+const SLIMS = ["api", "esp32", "wifi"].map((id) =>
+  makeComponentEntry(id, { category: ComponentCategory.CORE })
+);
+const BODIES: Record<string, ComponentCatalogEntry> = {
+  api: {
+    ...SLIMS[0],
+    config_entries: [
+      nested("encryption", [
+        makeConfigEntry({ key: "key" }),
+        makeConfigEntry({ key: "port" }),
+      ]),
+      makeConfigEntry({ key: "port" }),
+    ],
+  },
+  esp32: {
+    ...SLIMS[1],
+    config_entries: [
+      nested("framework", [
+        nested("advanced", [makeConfigEntry({ key: "ignore_efuse_mac_crc" })]),
+        makeConfigEntry({ key: "version" }),
+      ]),
+    ],
+  },
+  wifi: {
+    ...SLIMS[2],
+    config_entries: [
+      makeConfigEntry({ key: "ssid" }),
+      nested("manual_ip", [makeConfigEntry({ key: "static_ip" })]),
+    ],
+  },
+};
+
+// ``loadCatalog`` caches its promise for the module's lifetime, so every
+// test shares one catalog surface; bodies re-fetch per test through the
+// cleared component cache.
+const fakeApi = (
+  bodies: (ids: string[]) => Record<string, ComponentCatalogEntry> | never
+) =>
+  ({
+    getComponents: async () => ({ components: SLIMS }),
+    getComponentBodies: async (ids: string[]) => bodies(ids),
+  }) as never;
+
+const defaultApi = fakeApi((ids) =>
+  Object.fromEntries(ids.filter((id) => id in BODIES).map((id) => [id, BODIES[id]]))
+);
+
+const localize = (key: string, values?: Record<string, string | number>): string =>
+  `${key}:${JSON.stringify(values)}`;
+
+const run = (yaml: string, message: string, blamedLine: number, api = defaultApi) =>
+  describeInvalidOptionFix({
+    api,
+    state: EditorState.create({ doc: yaml, extensions: [esphomeYaml()] }),
+    readLine: lineAccessorFor(yaml),
+    message,
+    blamedLine,
+    localize,
+  });
+
+const DEDENTED_KEY = ["api:", "  encryption:", "  key: !secret x"].join("\n");
+const KEY_MESSAGE = "[key] is an invalid option for [api]. Please check the indentation.";
+
+describe("describeInvalidOptionFix", () => {
+  beforeEach(() => _clearComponentCache());
+
+  it("offers the re-indent when the schema confirms the opener owns the key", async () => {
+    expect(await run(DEDENTED_KEY, KEY_MESSAGE, 3)).toEqual({
+      text: 'yaml_editor.error_nest_under_fix:{"line":3,"key":"key","parent":"encryption","spaces":2}',
+      fix: { line: 3, indent: 2, key: "key", fromIndent: 2 },
+    });
+  });
+
+  it("offers the fix on the did-you-mean variant too", async () => {
+    const yaml = ["wifi:", "  manual_ip:", "  static_ip: 1.2.3.4"].join("\n");
+    const message =
+      "[static_ip] is an invalid option for [wifi]. Did you mean [use_address]?";
+    expect(await run(yaml, message, 3)).toMatchObject({
+      fix: { line: 3, indent: 2, key: "static_ip", fromIndent: 2 },
+    });
+  });
+
+  it("descends nested openers below the top level", async () => {
+    const yaml = [
+      "esp32:",
+      "  framework:",
+      "    advanced:",
+      "    ignore_efuse_mac_crc: true",
+    ].join("\n");
+    const message = "[ignore_efuse_mac_crc] is an invalid option for [framework].";
+    expect(await run(yaml, message, 4)).toMatchObject({
+      fix: { line: 4, indent: 2, key: "ignore_efuse_mac_crc", fromIndent: 4 },
+    });
+  });
+
+  it("returns null when the key is not an option of the opener", async () => {
+    const yaml = ["api:", "  encryption:", "  bogus: x"].join("\n");
+    const message = "[bogus] is an invalid option for [api].";
+    expect(await run(yaml, message, 3)).toBeNull();
+  });
+
+  it("returns null when the key is also valid under the current parent", async () => {
+    const yaml = ["api:", "  encryption:", "  port: 6053"].join("\n");
+    const message = "[port] is an invalid option for [api].";
+    expect(await run(yaml, message, 3)).toBeNull();
+  });
+
+  it("returns null when the message's parent is not the buffer's parent", async () => {
+    expect(
+      await run(DEDENTED_KEY, "[key] is an invalid option for [wifi].", 3)
+    ).toBeNull();
+  });
+
+  it("returns null for a component the catalog doesn't know", async () => {
+    const yaml = ["nonexistent:", "  encryption:", "  key: x"].join("\n");
+    const message = "[key] is an invalid option for [nonexistent].";
+    expect(await run(yaml, message, 3)).toBeNull();
+  });
+
+  it("returns null when the body fetch fails", async () => {
+    const failing = fakeApi(() => {
+      throw new Error("boom");
+    });
+    expect(await run(DEDENTED_KEY, KEY_MESSAGE, 3, failing)).toBeNull();
+  });
+
+  it("returns null for a message with no dedent shape behind it", async () => {
+    const yaml = ["api:", "  bogus: x"].join("\n");
+    expect(await run(yaml, "[bogus] is an invalid option for [api].", 2)).toBeNull();
+  });
+});

--- a/test/util/yaml-invalid-option-fix.test.ts
+++ b/test/util/yaml-invalid-option-fix.test.ts
@@ -1,8 +1,8 @@
 /**
- * Tests for the schema-gated invalid-option auto-fix: the buffer walk finds
- * a dedented key under a value-less opener, and the component catalog must
- * confirm the key belongs to the opener (and not to its current parent)
- * before the re-indent is offered.
+ * Tests for the schema-gated invalid-option auto-fix: the buffer walks find
+ * a key one indent level away from a value-less opener, and the component
+ * catalog must confirm the key belongs to the proposed new parent (and not
+ * to its current one) before the re-indent is offered.
  */
 import { EditorState } from "@codemirror/state";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -10,16 +10,11 @@ import {
   ComponentCategory,
   type ComponentCatalogEntry,
 } from "../../src/api/types/components.js";
-import { ConfigEntryType } from "../../src/api/types/config-entries.js";
 import { _clearComponentCache } from "../../src/util/component-name-cache.js";
 import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
-import { lineAccessorFor } from "../../src/util/yaml-error-analysis.js";
 import { describeInvalidOptionFix } from "../../src/util/yaml-invalid-option-fix.js";
 import { makeComponentEntry } from "./_make-component-entry.js";
-import { makeConfigEntry } from "./_make-config-entry.js";
-
-const nested = (key: string, children: ReturnType<typeof makeConfigEntry>[]) =>
-  makeConfigEntry({ key, type: ConfigEntryType.NESTED, config_entries: children });
+import { makeConfigEntry, makeNestedEntry as nested } from "./_make-config-entry.js";
 
 const SLIMS = ["api", "esp32", "wifi"].map((id) =>
   makeComponentEntry(id, { category: ComponentCategory.CORE })
@@ -41,7 +36,9 @@ const BODIES: Record<string, ComponentCatalogEntry> = {
       nested("framework", [
         nested("advanced", [makeConfigEntry({ key: "ignore_efuse_mac_crc" })]),
         makeConfigEntry({ key: "version" }),
+        makeConfigEntry({ key: "type" }),
       ]),
+      makeConfigEntry({ key: "variant" }),
     ],
   },
   wifi: {
@@ -75,7 +72,6 @@ const run = (yaml: string, message: string, blamedLine: number, api = defaultApi
   describeInvalidOptionFix({
     api,
     state: EditorState.create({ doc: yaml, extensions: [esphomeYaml()] }),
-    readLine: lineAccessorFor(yaml),
     message,
     blamedLine,
     localize,
@@ -84,12 +80,21 @@ const run = (yaml: string, message: string, blamedLine: number, api = defaultApi
 const DEDENTED_KEY = ["api:", "  encryption:", "  key: !secret x"].join("\n");
 const KEY_MESSAGE = "[key] is an invalid option for [api]. Please check the indentation.";
 
+const OVERINDENTED_VARIANT = [
+  "esp32:",
+  "  framework:",
+  "    type: esp-idf",
+  "    variant: ESP32",
+].join("\n");
+const VARIANT_MESSAGE =
+  "[variant] is an invalid option for [framework]. Please check the indentation.";
+
 describe("describeInvalidOptionFix", () => {
   beforeEach(() => _clearComponentCache());
 
   it("offers the re-indent when the schema confirms the opener owns the key", async () => {
     expect(await run(DEDENTED_KEY, KEY_MESSAGE, 3)).toEqual({
-      text: 'yaml_editor.error_nest_under_fix:{"line":3,"key":"key","parent":"encryption","spaces":2}',
+      text: 'yaml_editor.error_nest_under_fix:{"line":3,"key":"key","parent":"encryption","target":"encryption","spaces":2}',
       fix: { line: 3, indent: 2, key: "key", fromIndent: 2 },
     });
   });
@@ -114,6 +119,35 @@ describe("describeInvalidOptionFix", () => {
     expect(await run(yaml, message, 4)).toMatchObject({
       fix: { line: 4, indent: 2, key: "ignore_efuse_mac_crc", fromIndent: 4 },
     });
+  });
+
+  it("offers the dedent when the key belongs to the grandparent", async () => {
+    expect(await run(OVERINDENTED_VARIANT, VARIANT_MESSAGE, 4)).toEqual({
+      text: 'yaml_editor.error_unnest_fix:{"line":4,"key":"variant","parent":"framework","target":"esp32","spaces":2}',
+      fix: { line: 4, indent: -2, key: "variant", fromIndent: 4 },
+    });
+  });
+
+  it("returns null for a mid-block over-indented key (dedent would split)", async () => {
+    const yaml = [
+      "esp32:",
+      "  framework:",
+      "    variant: ESP32",
+      "    type: esp-idf",
+    ].join("\n");
+    expect(await run(yaml, VARIANT_MESSAGE, 3)).toBeNull();
+  });
+
+  it("returns null for a dedent whose new parent would be the top level", async () => {
+    const yaml = ["esp32:", "  bogus: x"].join("\n");
+    expect(await run(yaml, "[bogus] is an invalid option for [esp32].", 2)).toBeNull();
+  });
+
+  it("returns null for a dedent when the grandparent lacks the key", async () => {
+    const yaml = ["esp32:", "  framework:", "    bogus: x"].join("\n");
+    expect(
+      await run(yaml, "[bogus] is an invalid option for [framework].", 3)
+    ).toBeNull();
   });
 
   it("returns null when the key is not an option of the opener", async () => {
@@ -147,7 +181,7 @@ describe("describeInvalidOptionFix", () => {
     expect(await run(DEDENTED_KEY, KEY_MESSAGE, 3, failing)).toBeNull();
   });
 
-  it("returns null for a message with no dedent shape behind it", async () => {
+  it("returns null for a message with no misnest shape behind it", async () => {
     const yaml = ["api:", "  bogus: x"].join("\n");
     expect(await run(yaml, "[bogus] is an invalid option for [api].", 2)).toBeNull();
   });


### PR DESCRIPTION
# What does this implement/fix?

Offers the one click auto fix for the misnest mistakes behind `[key] is an invalid option for [api]. Please check the indentation.`; today that error is just a squiggle, but the schema already knows where the key belongs, so we can repair it. Both directions are covered: a key dedented out of its block (`api.encryption.key` sitting at `encryption`'s level gets indented back under it) and a key over indented into the block above (`variant` swallowed by `esp32.framework` gets dedented back out).

Detection is conservative: the blamed key must sit one level away from a value less opener with nothing but the block's own lines in between, a dedent is only offered when the line closes its block so the one line edit cannot split anything, and the component catalog must confirm the key is an option of the proposed new parent and not of its current one. When the schema cannot confirm (packages, `!extend`, unknown components) no fix is offered. The repair reuses the existing `YamlAutoFix` pipeline unchanged, staleness guard, revalidate and confirm dialog included; it surfaces on the hover tooltip and the invalid banner like the other fixes.

**Related issue or feature (if applicable):**

- no linked issue, reported directly with `api.encryption.key` and `esp32.framework.variant` configs

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
