### PR TITLE
Keep yaml_only fields in YAML key completion

### DIFF
--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -35,7 +35,9 @@ export function platformSupported(
  * Determine if a config entry is currently visible.
  *
  * Visibility is the AND of four checks:
- *  1. `hidden === false`
+ *  1. `hidden === false`, unless the value is already set — a
+ *     ``yaml_only`` field present in the YAML stays visible so the
+ *     form shows what the config actually contains
  *  2. The `depends_on` predicate against the current form values
  *  3. `depends_on_component` is present in `presentComponents` (when given)
  *  4. The device's target platform is in ``supported_platforms``
@@ -58,7 +60,7 @@ export function isEntryVisible(
   presentComponents?: ReadonlySet<string>,
   targetPlatform?: string | null
 ): boolean {
-  if (entry.hidden) return false;
+  if (entry.hidden && !isValuePresent(values[entry.key])) return false;
 
   // Cross-component dependency: only check when caller provided context.
   if (entry.depends_on_component && presentComponents) {
@@ -177,9 +179,12 @@ export function validateEntry(entry: ConfigEntry, raw: unknown): ValidationError
   // UNKNOWN renders as the YAML-only notice (a mapping-or-list union the
   // form can't edit), so there is nothing to validate; a required one must
   // not block the wizard with an error the user can't clear in the form.
-  if (entry.hidden || entry.type === ConfigEntryType.UNKNOWN) return null;
+  if (entry.type === ConfigEntryType.UNKNOWN) return null;
 
   const isEmpty = !isValuePresent(raw);
+  // An unset hidden field isn't rendered, so never block on it; a set one
+  // is visible and validates normally.
+  if (entry.hidden && isEmpty) return null;
 
   if (entry.required && isEmpty) {
     return { key: entry.key, code: "validation.required" };

--- a/src/util/yaml-completion-items.ts
+++ b/src/util/yaml-completion-items.ts
@@ -112,7 +112,7 @@ export function entryToCompletion(entry: ConfigEntry): Completion {
     type: iconType(entry.type),
     detail: detailParts.join(" · "),
     info: buildEntryInfo(entry),
-    boost: entry.required ? 5 : entry.advanced ? -3 : 0,
+    boost: entry.required ? 5 : entry.advanced || entry.hidden ? -3 : 0,
   };
 }
 

--- a/src/util/yaml-completion-providers.ts
+++ b/src/util/yaml-completion-providers.ts
@@ -95,8 +95,7 @@ interface KeyPositionProvider {
 
 /** Resolve the catalog config-entries for the cursor's parent
  *  exactly once per turn. Both ``catalogEntriesProvider`` and
- *  ``schemaBundleKeyProvider`` need the answer, and the
- *  ``hidden:`` filter is render-time concern — so the providers
+ *  ``schemaBundleKeyProvider`` need the answer, so the providers
  *  read off this memo on the per-turn ``KeyPositionCtx``. The
  *  catalog index plus the in-memory ``fetchComponent`` cache
  *  make this a no-network call, but skipping the duplicate
@@ -128,8 +127,11 @@ async function resolveCatalogEntries(k: KeyPositionCtx): Promise<ConfigEntry[]> 
 const catalogEntriesProvider: KeyPositionProvider = {
   name: "catalog-entries",
   fetch: async (k) => {
+    // ``hidden`` mirrors upstream's ``visibility: yaml_only`` — hide the
+    // field from the visual form, not from YAML. This completion is the
+    // one place those fields are editable, so they stay in (demoted).
     const entries = await resolveCatalogEntries(k);
-    return entries.filter((e) => !e.hidden).map(entryToCompletion);
+    return entries.map(entryToCompletion);
   },
 };
 

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -104,9 +104,15 @@ describe("validateEntry", () => {
     expect(validateEntry(entry, undefined)?.code).toBe("validation.required");
   });
 
-  it("ignores hidden fields entirely", () => {
+  it("skips an unset hidden field but validates a set one", () => {
     const entry = makeEntry({ required: true, hidden: true });
     expect(validateEntry(entry, "")).toBeNull();
+    const numeric = makeEntry({
+      hidden: true,
+      type: ConfigEntryType.INTEGER,
+      display_format: "hex",
+    });
+    expect(validateEntry(numeric, "xyz")?.code).toBe("validation.not_a_number");
   });
 
   it("ignores UNKNOWN (YAML-only) fields even when required", () => {
@@ -324,7 +330,7 @@ describe("validateEntries", () => {
     expect(errors.get("temperature.name")?.code).toBe("validation.required");
   });
 
-  it("does not validate inside a hidden NESTED entry", () => {
+  it("does not validate inside an unset hidden NESTED entry", () => {
     const entries = [
       makeEntry({
         key: "temperature",
@@ -333,8 +339,20 @@ describe("validateEntries", () => {
         config_entries: [makeEntry({ key: "name", required: true })],
       }),
     ];
-    const errors = validateEntries(entries, { temperature: {} });
-    expect(errors.size).toBe(0);
+    expect(validateEntries(entries, {}).size).toBe(0);
+  });
+
+  it("validates inside a hidden NESTED entry once the YAML sets it", () => {
+    const entries = [
+      makeEntry({
+        key: "temperature",
+        type: ConfigEntryType.NESTED,
+        hidden: true,
+        config_entries: [makeEntry({ key: "name", required: true })],
+      }),
+    ];
+    const errors = validateEntries(entries, { temperature: { name: "" } });
+    expect(errors.get("temperature.name")?.code).toBe("validation.required");
   });
 
   it("validates each item of a multi_value NESTED entry with index path segments", () => {

--- a/test/util/yaml-completion-filter.test.ts
+++ b/test/util/yaml-completion-filter.test.ts
@@ -47,6 +47,7 @@ const BODIES: Record<
           ],
         }),
         makeConfigEntry({ key: "version" }),
+        makeConfigEntry({ key: "sdkconfig_options", hidden: true }),
       ]),
     ],
   },
@@ -120,6 +121,15 @@ describe("createYamlCompletionSource (already-set key filtering)", () => {
     );
     expect(labels).toContain("advanced");
     expect(labels).toContain("version");
+  });
+
+  it("keeps yaml_only (hidden) fields in YAML key completion", async () => {
+    // ``hidden`` mirrors upstream ``visibility: yaml_only`` (hide from the
+    // visual form); YAML completion is exactly where those must appear.
+    const labels = await labelsAt(
+      ["esp32:", "  board: esp32-poe-iso", "  framework:", "    s"].join("\n")
+    );
+    expect(labels).toContain("sdkconfig_options");
   });
 
   it("offers nested keys on a blank indented line when triggered explicitly (idle)", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression where YAML key completion stopped suggesting fields the schema marks `visibility: yaml_only`. The 2026.7.0b1 catalog sync (esphome/device-builder#1915) started mapping that upstream hint onto the catalog's `hidden` flag, and the key completion provider dropped hidden entries entirely; under `esp32: framework:` the popup lost `advanced`, `components`, `sdkconfig_options`, `platform_version`, `release` and `source`, which are exactly the fields the hint says must be edited in YAML.

The provider now keeps hidden entries in the completion list, demoted the same way advanced fields are. The visual form also treats them like advanced fields when the YAML already sets them: `isEntryVisible` shows a hidden entry whose value is present so the form reflects what the config contains, and `validateEntry` validates a set value normally while still never blocking on an unset one. New adds and unset fields stay hidden from the form, which is what the hint means.

**Related issue or feature (if applicable):**

- no linked issue, regression surfaced after the 2026.7.0b1 catalog sync

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
