### PR TITLE
Re-anchor trailing-space positions onto the line's own pair

### DIFF
--- a/src/util/yaml-ast.ts
+++ b/src/util/yaml-ast.ts
@@ -227,18 +227,23 @@ export function getKeyPathWithListIndices(
 
 /**
  * The deepest node at *pos*, re-anchored for the empty-value case: a
- * cursor in an empty value / trailing whitespace (``key: ``) resolves to
- * the document root, not the pair, so re-resolve on the line's last
- * non-space char (the ``:`` or key) when *pos* has no enclosing pair.
+ * cursor in an empty value / trailing whitespace (``key: ``) resolves
+ * past the line's own pair — to the document root at EOF, or to an
+ * enclosing container mid-document — so re-resolve on the line's last
+ * non-space char (the ``:`` or key). The enclosing-pair check alone
+ * can't detect the mid-document case: the container has an ancestor
+ * pair, just the wrong one.
  */
 function resolveAnchoredNode(state: EditorState, pos: number): SyntaxNode | null {
   const tree = syntaxTree(state);
   const node: SyntaxNode | null = tree.resolveInner(pos, -1);
-  if (findEnclosingPair(node)) return node;
   const line = state.doc.lineAt(pos);
   const upto = line.text.slice(0, pos - line.from).trimEnd();
   if (!upto) return node;
-  return tree.resolveInner(line.from + upto.length - 1, -1);
+  const anchor = line.from + upto.length - 1;
+  if (pos - line.from > upto.length) return tree.resolveInner(anchor, -1);
+  if (findEnclosingPair(node)) return node;
+  return tree.resolveInner(anchor, -1);
 }
 
 /**

--- a/test/util/yaml-ast-keypath.test.ts
+++ b/test/util/yaml-ast-keypath.test.ts
@@ -52,6 +52,34 @@ describe("getKeyPath", () => {
     ]);
   });
 
+  it("resolves a trailing-space empty value mid-document (lines follow)", () => {
+    // With content below, the whitespace after ``key: `` resolves into an
+    // enclosing container that HAS an ancestor pair (the top-level block),
+    // so the re-anchor must fire on trailing whitespace, not only when no
+    // enclosing pair exists.
+    const doc = [
+      "esp32:",
+      "  framework:",
+      "    advanced:",
+      "      minimum_chip_revision: ",
+      "  variant: ESP32",
+      "",
+      "api:",
+      "  encryption:",
+      "    key: x",
+    ].join("\n");
+    const state = EditorState.create({ doc, extensions: [esphomeYaml()] });
+    ensureSyntaxTree(state, state.doc.length);
+    const marker = "minimum_chip_revision: ";
+    const pos = doc.indexOf(marker) + marker.length;
+    expect(getKeyPath(state, pos)).toEqual([
+      "esp32",
+      "framework",
+      "advanced",
+      "minimum_chip_revision",
+    ]);
+  });
+
   it("returns [] outside any mapping pair", () => {
     expect(pathAt("# comment\n", "comment")).toEqual([]);
   });

--- a/test/util/yaml-completion-filter.test.ts
+++ b/test/util/yaml-completion-filter.test.ts
@@ -65,7 +65,11 @@ const fakeApi = {
   getComponent: async () => null,
 } as never;
 
-async function labelsAt(yaml: string, explicit = false): Promise<string[]> {
+async function labelsAt(
+  yaml: string,
+  explicit = false,
+  pos = yaml.length
+): Promise<string[]> {
   // Drive a real view + full parse so the AST helpers see the same tree a
   // live editor does (a bare state parses lazily and misses the cursor's tail).
   const view = new EditorView({
@@ -73,7 +77,7 @@ async function labelsAt(yaml: string, explicit = false): Promise<string[]> {
   });
   try {
     forceParsing(view, yaml.length, 60000);
-    const ctx = new CompletionContext(view.state, yaml.length, explicit);
+    const ctx = new CompletionContext(view.state, pos, explicit);
     const result = await createYamlCompletionSource(fakeApi)(ctx);
     return (result?.options ?? []).map((o) => o.label);
   } finally {
@@ -191,6 +195,17 @@ describe("createYamlCompletionSource (already-set key filtering)", () => {
       ["esp32:", "  framework:", "    advanced:", "      verbose: "].join("\n")
     );
     expect(labels).toEqual(["true", "false"]);
+  });
+
+  it("completes a trailing-space value mid-document (idle popup case)", async () => {
+    // Same shape with content below the caret: the whitespace resolves into
+    // an enclosing container instead of the root, so the re-anchor must fire
+    // for the idle popup to surface options.
+    const head = ["esp32:", "  framework:", "    advanced:", "      verbose: "].join(
+      "\n"
+    );
+    const doc = head + "\n" + ["wifi:", "  ssid: x"].join("\n");
+    expect(await labelsAt(doc, true, head.length)).toEqual(["true", "false"]);
   });
 
   it("auto-offers platform at a fresh list-item dash (no partial typed)", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Fixes idle value completion going silent when the caret rests after `key: ` with a trailing space and more lines follow. `resolveAnchoredNode` only re-anchored onto the line's own pair when the raw resolution found no enclosing pair at all, which covers the end of document case; mid document the trailing whitespace resolves into an enclosing container that does have an ancestor pair, so the anchor stayed on the wrong node, `getKeyPath` collapsed to the top level key and the popup opened with no options. Typing the same key without the space worked, which is how it surfaced.

The re-anchor now always fires when the caret sits in trailing whitespace after the line's content; the no-enclosing-pair fallback stays for the other empty value shapes. Pinned at both layers, `getKeyPath` mid document and the completion source end to end.

**Related issue or feature (if applicable):**

- no linked issue, found while testing #1164 and #1165 together

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
