### PR TITLE
Page fetch-all component queries on resp.total

### DIFF
--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -41,13 +41,13 @@ import {
 import { type ValidationError } from "../../util/config-validation.js";
 import { resolveDeviceName } from "../../util/device-name.js";
 import { getErrorMessage } from "../../util/error-message.js";
+import { fetchAllComponents } from "../../util/fetch-all-components.js";
 import { getIn, isPrimitiveOrNullish } from "../../util/nested-values.js";
 import {
   fetchPinRegistryModes,
   getCachedPinRegistryModes,
   subscribePinRegistryModes,
 } from "../../util/pin-registry-modes-cache.js";
-import { PROVIDER_FETCH_LIMIT } from "../../util/provides-cache.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { SessionBlobCacheController } from "../../util/session-blob-cache-controller.js";
 import { looksLikeSubstitution, parseSubstitutions } from "../../util/substitutions.js";
@@ -1027,14 +1027,13 @@ export class ESPHomeConfigEntryForm extends LitElement {
     if (cached) return cached;
     if (this._api && !this._interfaceProvidersPending.has(interfaceName)) {
       this._interfaceProvidersPending.add(interfaceName);
-      // The full dropdown candidate set in one shot, distinct from the
+      // The full dropdown candidate set, distinct from the
       // Add-component picker's paginated grid.
-      this._api
-        .getComponents({ provides: interfaceName, limit: PROVIDER_FETCH_LIMIT })
-        .then((resp) => {
+      fetchAllComponents(this._api, { provides: interfaceName })
+        .then((components) => {
           this._interfaceProviders.set(
             interfaceName,
-            resp.components.map((c) => catalogEntryToProvider(c, interfaceName))
+            components.map((c) => catalogEntryToProvider(c, interfaceName))
           );
           this.requestUpdate();
         })

--- a/src/util/fetch-all-components.ts
+++ b/src/util/fetch-all-components.ts
@@ -1,0 +1,38 @@
+import type { ESPHomeAPI } from "../api/esphome-api.js";
+import type { ComponentCatalogEntry } from "../api/types/components.js";
+
+/** Page size for the fetch-all sweeps below; a stride, not a ceiling. */
+export const COMPONENT_FETCH_PAGE = 500;
+
+type ComponentQuery = Omit<
+  NonNullable<Parameters<ESPHomeAPI["getComponents"]>[0]>,
+  "offset" | "limit"
+>;
+
+/**
+ * Every catalog entry matching `args`, paged on `resp.total` (#1152).
+ *
+ * The catalog is immutable for the process lifetime, so pages are
+ * mutually consistent; a short page also ends the sweep so a
+ * misreported `total` can't loop forever.
+ */
+export async function fetchAllComponents(
+  api: ESPHomeAPI,
+  args: ComponentQuery = {}
+): Promise<ComponentCatalogEntry[]> {
+  const components: ComponentCatalogEntry[] = [];
+  for (;;) {
+    const resp = await api.getComponents({
+      ...args,
+      offset: components.length,
+      limit: COMPONENT_FETCH_PAGE,
+    });
+    components.push(...resp.components);
+    if (
+      components.length >= resp.total ||
+      resp.components.length < COMPONENT_FETCH_PAGE
+    ) {
+      return components;
+    }
+  }
+}

--- a/src/util/fetch-all-components.ts
+++ b/src/util/fetch-all-components.ts
@@ -1,8 +1,10 @@
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { ComponentCatalogEntry } from "../api/types/components.js";
 
-/** Page size for the fetch-all sweeps below; a stride, not a ceiling. */
-export const COMPONENT_FETCH_PAGE = 500;
+/** Page size for the fetch-all sweeps below — a stride, not a ceiling.
+ *  Sized so today's full catalog (~940 entries) still lands in one
+ *  round trip; growth past it pages instead of truncating. */
+export const COMPONENT_FETCH_PAGE = 1000;
 
 type ComponentQuery = Omit<
   NonNullable<Parameters<ESPHomeAPI["getComponents"]>[0]>,

--- a/src/util/provides-cache.ts
+++ b/src/util/provides-cache.ts
@@ -1,11 +1,6 @@
 import type { ESPHomeAPI } from "../api/index.js";
+import { fetchAllComponents } from "./fetch-all-components.js";
 import { KeyedPromiseCache } from "./keyed-promise-cache.js";
-
-/** Page size for the fetch-all `getComponents({provides})` sites. Sized so a
- *  single page covers every known interface today (same-domain sub-entity
- *  providers put `sensor` near 200); a larger catalog would truncate
- *  silently until the callers page on `resp.total` (#1152). */
-export const PROVIDER_FETCH_LIMIT = 500;
 
 /** Ids of the components that provide an interface, board-scoped and cached
  *  for the process lifetime. The backend catalog is immutable for that
@@ -22,14 +17,11 @@ export function providerIds(
 ): Promise<ReadonlySet<string>> {
   const key = `${interfaceName}|${platform ?? ""}|${boardId ?? ""}`;
   return _cache.fetch(key, () =>
-    api
-      .getComponents({
-        provides: interfaceName,
-        platform: platform ?? undefined,
-        board_id: boardId ?? undefined,
-        limit: PROVIDER_FETCH_LIMIT,
-      })
-      .then((resp): ReadonlySet<string> => new Set(resp.components.map((c) => c.id)))
+    fetchAllComponents(api, {
+      provides: interfaceName,
+      platform: platform ?? undefined,
+      board_id: boardId ?? undefined,
+    }).then((components): ReadonlySet<string> => new Set(components.map((c) => c.id)))
   );
 }
 

--- a/src/util/yaml-completion-catalog.ts
+++ b/src/util/yaml-completion-catalog.ts
@@ -15,6 +15,7 @@ import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { ComponentCatalogEntry } from "../api/types/components.js";
 import { ConfigEntryType, type ConfigEntry } from "../api/types/config-entries.js";
 import { fetchComponent } from "./component-name-cache.js";
+import { fetchAllComponents } from "./fetch-all-components.js";
 import { getKeyPath, resolveBundleContext } from "./yaml-ast.js";
 import {
   blankLineContext,
@@ -133,16 +134,16 @@ let catalogPromise: Promise<CatalogIndex> | null = null;
 export function loadCatalog(api: ESPHomeAPI): Promise<CatalogIndex> {
   if (catalogPromise) return catalogPromise;
   catalogPromise = (async () => {
-    const res = await api.getComponents({ limit: 2000 });
+    const components = await fetchAllComponents(api);
     const byId = new Map<string, ComponentCatalogEntry>();
     const byCategory = new Map<string, ComponentCatalogEntry[]>();
-    for (const c of res.components) {
+    for (const c of components) {
       byId.set(c.id, c);
       const list = byCategory.get(c.category) ?? [];
       list.push(c);
       byCategory.set(c.category, list);
     }
-    return { components: res.components, byId, byCategory };
+    return { components, byId, byCategory };
   })().catch((err) => {
     console.debug("[yaml-completion] failed to load catalog:", err);
     catalogPromise = null;

--- a/test/components/device/config-entry-form-providers.test.ts
+++ b/test/components/device/config-entry-form-providers.test.ts
@@ -2,9 +2,9 @@
  * @vitest-environment happy-dom
  *
  * ``_resolveInterfaceProviders`` backs the id-reference dropdown's
- * cross-domain lookup: a per-form cache fed by one ``provides`` fetch,
- * deduped while in flight, and — crucially — NOT poisoned with ``[]`` on a
- * failed fetch so a later render can retry.
+ * cross-domain lookup: a per-form cache fed by one paged ``provides``
+ * fetch, deduped while in flight, and — crucially — NOT poisoned with
+ * ``[]`` on a failed fetch so a later render can retry.
  */
 import { describe, expect, it, vi } from "vitest";
 
@@ -77,6 +77,24 @@ describe("config-entry-form _resolveInterfaceProviders", () => {
     expect(resolve(form, "i2c")).toEqual([]);
     // Cached: no refetch.
     expect(getComponents).toHaveBeenCalledTimes(1);
+  });
+
+  it("collects every page when the provider set exceeds one page", async () => {
+    const all = Array.from({ length: 501 }, (_, i) => `sensor.c${i}`);
+    const getComponents = vi.fn(async (args: { offset?: number; limit?: number }) => ({
+      ...response(all.slice(args.offset ?? 0, (args.offset ?? 0) + (args.limit ?? 50))),
+      total: all.length,
+      offset: args.offset ?? 0,
+    }));
+    const form = withApi(getComponents as unknown as ReturnType<typeof vi.fn>);
+
+    resolve(form, "sensor");
+    await flushMicrotasks(8);
+
+    expect(getComponents).toHaveBeenCalledTimes(2);
+    const providers = resolve(form, "sensor");
+    expect(providers).toHaveLength(501);
+    expect(providers?.[500]).toEqual({ domain: "sensor", stem: "c500" });
   });
 
   it("does not cache [] on a failed fetch, so a later render retries", async () => {

--- a/test/components/device/config-entry-form-providers.test.ts
+++ b/test/components/device/config-entry-form-providers.test.ts
@@ -15,6 +15,7 @@ vi.mock("sonner-js", () => ({
 import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
 import { ESPHomeConfigEntryForm } from "../../../src/components/device/config-entry-form.js";
 import type { ComponentProvider } from "../../../src/util/config-entry-yaml-scan.js";
+import { COMPONENT_FETCH_PAGE } from "../../../src/util/fetch-all-components.js";
 import { flushMicrotasks } from "../../_dom.js";
 
 const resolve = (
@@ -80,7 +81,8 @@ describe("config-entry-form _resolveInterfaceProviders", () => {
   });
 
   it("collects every page when the provider set exceeds one page", async () => {
-    const all = Array.from({ length: 501 }, (_, i) => `sensor.c${i}`);
+    const count = COMPONENT_FETCH_PAGE + 1;
+    const all = Array.from({ length: count }, (_, i) => `sensor.c${i}`);
     const getComponents = vi.fn(async (args: { offset?: number; limit?: number }) => ({
       ...response(all.slice(args.offset ?? 0, (args.offset ?? 0) + (args.limit ?? 50))),
       total: all.length,
@@ -93,8 +95,11 @@ describe("config-entry-form _resolveInterfaceProviders", () => {
 
     expect(getComponents).toHaveBeenCalledTimes(2);
     const providers = resolve(form, "sensor");
-    expect(providers).toHaveLength(501);
-    expect(providers?.[500]).toEqual({ domain: "sensor", stem: "c500" });
+    expect(providers).toHaveLength(count);
+    expect(providers?.[count - 1]).toEqual({
+      domain: "sensor",
+      stem: `c${count - 1}`,
+    });
   });
 
   it("does not cache [] on a failed fetch, so a later render retries", async () => {

--- a/test/util/fetch-all-components.test.ts
+++ b/test/util/fetch-all-components.test.ts
@@ -1,0 +1,94 @@
+/**
+ * ``fetchAllComponents`` drains every page of a ``getComponents`` query by
+ * following ``resp.total``, so fetch-all callers never truncate at a
+ * hardcoded limit (#1152).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { ESPHomeAPI } from "../../src/api/esphome-api.js";
+import type { ComponentCatalogEntry } from "../../src/api/types/components.js";
+import {
+  COMPONENT_FETCH_PAGE,
+  fetchAllComponents,
+} from "../../src/util/fetch-all-components.js";
+
+const entries = (count: number, prefix = "sensor.c"): ComponentCatalogEntry[] =>
+  Array.from(
+    { length: count },
+    (_, i) => ({ id: `${prefix}${i}` }) as ComponentCatalogEntry
+  );
+
+function pagedApi(all: ComponentCatalogEntry[]) {
+  const getComponents = vi.fn(async (args: { offset?: number; limit?: number }) => ({
+    components: all.slice(args.offset ?? 0, (args.offset ?? 0) + (args.limit ?? 50)),
+    categories: [],
+    total: all.length,
+    offset: args.offset ?? 0,
+    limit: args.limit ?? 50,
+  }));
+  return { getComponents, api: { getComponents } as unknown as ESPHomeAPI };
+}
+
+describe("fetchAllComponents", () => {
+  it("returns a small set in one call", async () => {
+    const all = entries(3);
+    const { getComponents, api } = pagedApi(all);
+    expect(await fetchAllComponents(api, { provides: "sensor" })).toEqual(all);
+    expect(getComponents).toHaveBeenCalledTimes(1);
+    expect(getComponents.mock.calls[0][0]).toEqual({
+      provides: "sensor",
+      offset: 0,
+      limit: COMPONENT_FETCH_PAGE,
+    });
+  });
+
+  it("pages until total is reached, forwarding the query on every call", async () => {
+    const all = entries(COMPONENT_FETCH_PAGE * 2 + 7);
+    const { getComponents, api } = pagedApi(all);
+    const result = await fetchAllComponents(api, {
+      provides: "sensor",
+      platform: "esp32",
+      board_id: "esp32-evb",
+    });
+    expect(result).toEqual(all);
+    expect(getComponents).toHaveBeenCalledTimes(3);
+    expect(getComponents.mock.calls.map((c) => c[0])).toEqual(
+      [0, 1, 2].map((page) => ({
+        provides: "sensor",
+        platform: "esp32",
+        board_id: "esp32-evb",
+        offset: page * COMPONENT_FETCH_PAGE,
+        limit: COMPONENT_FETCH_PAGE,
+      }))
+    );
+  });
+
+  it("returns an exact page-multiple without an extra empty fetch", async () => {
+    const all = entries(COMPONENT_FETCH_PAGE);
+    const { getComponents, api } = pagedApi(all);
+    expect(await fetchAllComponents(api)).toEqual(all);
+    expect(getComponents).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops on a short page even when total overreports", async () => {
+    const page = entries(2);
+    const getComponents = vi.fn().mockResolvedValue({
+      components: page,
+      categories: [],
+      total: 9999,
+      offset: 0,
+      limit: COMPONENT_FETCH_PAGE,
+    });
+    const api = { getComponents } as unknown as ESPHomeAPI;
+    expect(await fetchAllComponents(api)).toEqual(page);
+    expect(getComponents).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops on a short page when the response carries no total", async () => {
+    const page = entries(3);
+    const getComponents = vi.fn().mockResolvedValue({ components: page });
+    const api = { getComponents } as unknown as ESPHomeAPI;
+    expect(await fetchAllComponents(api)).toEqual(page);
+    expect(getComponents).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/util/fetch-all-components.test.ts
+++ b/test/util/fetch-all-components.test.ts
@@ -11,12 +11,10 @@ import {
   COMPONENT_FETCH_PAGE,
   fetchAllComponents,
 } from "../../src/util/fetch-all-components.js";
+import { makeComponentEntry } from "./_make-component-entry.js";
 
 const entries = (count: number, prefix = "sensor.c"): ComponentCatalogEntry[] =>
-  Array.from(
-    { length: count },
-    (_, i) => ({ id: `${prefix}${i}` }) as ComponentCatalogEntry
-  );
+  Array.from({ length: count }, (_, i) => makeComponentEntry(`${prefix}${i}`));
 
 function pagedApi(all: ComponentCatalogEntry[]) {
   const getComponents = vi.fn(async (args: { offset?: number; limit?: number }) => ({
@@ -79,14 +77,6 @@ describe("fetchAllComponents", () => {
       offset: 0,
       limit: COMPONENT_FETCH_PAGE,
     });
-    const api = { getComponents } as unknown as ESPHomeAPI;
-    expect(await fetchAllComponents(api)).toEqual(page);
-    expect(getComponents).toHaveBeenCalledTimes(1);
-  });
-
-  it("stops on a short page when the response carries no total", async () => {
-    const page = entries(3);
-    const getComponents = vi.fn().mockResolvedValue({ components: page });
     const api = { getComponents } as unknown as ESPHomeAPI;
     expect(await fetchAllComponents(api)).toEqual(page);
     expect(getComponents).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
# What does this implement/fix?

Adds a shared `fetchAllComponents` helper that pages `getComponents` on `resp.total` and moves the three fetch-all sites onto it: `providerIds` in `provides-cache`, `_resolveInterfaceProviders` in `config-entry-form`, and the completion catalog loader in `yaml-completion-catalog`. Each of these previously issued one call with a hardcoded limit (500, 500, 2000) and ignored `resp.total`, so a catalog crossing the limit would truncate dropdowns and completions silently. The helper also stops on a short page, so a misreported `total` can never loop.

`PROVIDER_FETCH_LIMIT` is gone; the page size now lives inside the helper as a stride, not a ceiling.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1152

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
