### PR TITLE
Read monitor-observed device state from runtime_state

### DIFF
--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -17,6 +17,53 @@ export enum DeviceState {
   OFFLINE = "offline",
 }
 
+/** Monitor-observed runtime state, nested under
+ *  ``ConfiguredDevice.runtime_state`` on every device payload
+ *  (initial_state, device_added/updated events, devices/list). */
+export interface DeviceRuntimeState {
+  state: DeviceState;
+  /** Reachability channel currently driving the device's online state
+   *  (``mdns`` > ``mqtt`` > ``ping``). The deployed version / config
+   *  hash come only from the mDNS broadcast, so the out-of-sync /
+   *  update indicators are gated on ``active_source === "mdns"`` (see
+   *  ``src/util/device-sync.ts``): when mDNS is dark those values are
+   *  stale. ``"unknown"`` means no source has claimed the device yet,
+   *  which reads as "not mDNS". */
+  active_source: ReachabilitySource;
+  /** All resolved addresses from mDNS (IPv4 + IPv6) — empty array until
+   *  the device is seen online. ``ip_addresses[0]`` matches the flat
+   *  ``ip`` when populated. */
+  ip_addresses: string[];
+  deployed_version: string;
+  /**
+   * 8-char hex hash the running firmware reports via the
+   * ``config_hash`` TXT record on its ``_esphomelib._tcp`` mDNS
+   * broadcast. Drives ``has_pending_changes`` together with
+   * ``expected_config_hash``. Empty string when the device hasn't
+   * announced yet, or runs firmware older than the broadcast
+   * (esphome/esphome#16145) — the dashboard then falls back to
+   * mtime-based change detection.
+   */
+  deployed_config_hash: string;
+  /** Indicates if an offline update has been compiled and is waiting for the device to wake up */
+  queued_update: boolean;
+  /**
+   * Encryption state observed from the device's
+   * ``_esphomelib._tcp.local.`` mDNS broadcast.
+   *
+   * - ``null`` — mDNS not seen yet. Trust ``api_encrypted`` verbatim
+   *   (assume the device matches the YAML).
+   * - ``""`` — mDNS seen, ``api_encryption`` TXT absent. The device
+   *   is broadcasting plaintext API.
+   * - non-empty (e.g. ``"Noise_NNpsk0_25519_ChaChaPoly_SHA256"``) —
+   *   encryption is confirmed live on the device.
+   *
+   * Drives the four-state lock indicator: active / pending-flash /
+   * mismatch / plaintext.
+   */
+  api_encryption_active: string | null;
+}
+
 /** A configured ESPHome device. */
 export interface ConfiguredDevice {
   name: string;
@@ -37,17 +84,12 @@ export interface ConfiguredDevice {
    *  Prefers IPv4 when both are available. Used for OTA cache args, and as
    *  the Visit-web-UI fallback when ``address`` (mDNS hostname) is empty. */
   ip: string;
-  /** All resolved addresses from mDNS (IPv4 + IPv6) — empty array until
-   *  the device is seen online. ``ip_addresses[0]`` matches ``ip`` when
-   *  populated. */
-  ip_addresses: string[];
   web_port: number | null;
   /** Resolved `logger: baud_rate` for the Web Serial log port. `null` means
    *  unset (open at the 115200 default); `0` means UART logging is disabled;
    *  a positive value is the baud to open at. */
   logger_baud_rate: number | null;
   current_version: string;
-  deployed_version: string;
   loaded_integrations: string[];
   /**
    * Subset of ``loaded_integrations`` the user directly wrote in
@@ -68,9 +110,10 @@ export interface ConfiguredDevice {
    * accepts ``null`` / ``undefined`` / ``[]`` interchangeably.
    */
   directly_referenced_integrations?: string[];
-  state: DeviceState;
-  /** Indicates if an offline update has been compiled and is waiting for the device to wake up */
-  queued_update?: boolean;
+  /** Monitor-observed live state (reachability, deployed firmware,
+   *  encryption-on-the-wire). Nested so the flat fields stay
+   *  YAML/metadata-derived. */
+  runtime_state: DeviceRuntimeState;
   /** esp32 whose `ota: platform: esphome` sets `allow_partition_access` —
    *  the YAML half of the OTA bootloader-update gate (see
    *  `util/bootloader-flash.ts` for the deployed-firmware half). */
@@ -85,24 +128,6 @@ export interface ConfiguredDevice {
    * compiled — the drawer renders an em-dash for that.
    */
   expected_config_hash: string;
-  /**
-   * 8-char hex hash the running firmware reports via the
-   * ``config_hash`` TXT record on its ``_esphomelib._tcp`` mDNS
-   * broadcast. Drives ``has_pending_changes`` together with
-   * ``expected_config_hash``. Empty string when the device hasn't
-   * announced yet, or runs firmware older than the broadcast
-   * (esphome/esphome#16145) — the dashboard then falls back to
-   * mtime-based change detection.
-   */
-  deployed_config_hash: string;
-  /** Reachability channel currently driving the device's online state
-   *  (``mdns`` > ``mqtt`` > ``ping``). The deployed version / config
-   *  hash come only from the mDNS broadcast, so the out-of-sync /
-   *  update indicators are gated on ``active_source === "mdns"`` (see
-   *  ``src/util/device-sync.ts``): when mDNS is dark those values are
-   *  stale. Optional on the wire — absent / ``"unknown"`` means no
-   *  source has claimed the device yet, which reads as "not mDNS". */
-  active_source?: ReachabilitySource;
   /** True until successfully compiled + deployed */
   has_pending_changes: boolean;
   /** True when ``has_pending_changes`` came from the mDNS-sourced
@@ -131,21 +156,6 @@ export interface ConfiguredDevice {
    * ``devices/get_api_key``.
    */
   api_encrypted: boolean;
-  /**
-   * Encryption state observed from the device's
-   * ``_esphomelib._tcp.local.`` mDNS broadcast.
-   *
-   * - ``null`` — mDNS not seen yet. Trust ``api_encrypted`` verbatim
-   *   (assume the device matches the YAML).
-   * - ``""`` — mDNS seen, ``api_encryption`` TXT absent. The device
-   *   is broadcasting plaintext API.
-   * - non-empty (e.g. ``"Noise_NNpsk0_25519_ChaChaPoly_SHA256"``) —
-   *   encryption is confirmed live on the device.
-   *
-   * Drives the four-state lock indicator: active / pending-flash /
-   * mismatch / plaintext.
-   */
-  api_encryption_active: string | null;
   /** Canonical ``XX:XX:XX:XX:XX:XX`` MAC observed in the device's
    *  ``_esphomelib._tcp.local.`` ``mac`` TXT record (e.g.
    *  ``"94:C9:60:1F:8C:F1"``). Empty string when mDNS hasn't surfaced

--- a/src/components/app-shell/events.ts
+++ b/src/components/app-shell/events.ts
@@ -148,9 +148,13 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
       break;
     }
     case DeviceEventType.DEVICE_STATE_CHANGED: {
+      // Narrow event stays flat on the wire; fold it into runtime_state.
+      // New runtime_state object so Lit change detection sees the update.
       const { configuration, state } = data as DeviceStateChangedEventData;
       host._devices = host._devices.map((d) =>
-        d.configuration === configuration ? { ...d, state: state as DeviceState } : d
+        d.configuration === configuration
+          ? { ...d, runtime_state: { ...d.runtime_state, state: state as DeviceState } }
+          : d
       );
       break;
     }

--- a/src/components/dashboard/actions-ui.ts
+++ b/src/components/dashboard/actions-ui.ts
@@ -93,7 +93,7 @@ export async function executeRename(
   // reachable device. Route offline/unknown devices to a confirm before a
   // config-only rename (renames the YAML now; the device keeps its old name
   // until reflashed, which the prompt spells out).
-  if (device.state !== DeviceState.ONLINE) {
+  if (device.runtime_state.state !== DeviceState.ONLINE) {
     host._openConfirm({ kind: "rename-config-only", device, newName });
     return;
   }

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -163,7 +163,12 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
     const showModified = showPendingChanges(d);
     const showUpdate = showUpdateAvailable(d);
     // Four-state encryption indicator. "none" = no Native API surface — no badge.
-    const encState = getEncryptionState(d);
+    const encState = getEncryptionState({
+      api_enabled: d.api_enabled,
+      api_encrypted: d.api_encrypted,
+      api_encryption_active: d.runtime_state.api_encryption_active,
+      has_pending_changes: d.has_pending_changes,
+    });
     const apiEnabled = encState !== "none";
     const showAnyBadge = showModified || showUpdate || apiEnabled;
 

--- a/src/components/dashboard/device-drawer-content/reachability.ts
+++ b/src/components/dashboard/device-drawer-content/reachability.ts
@@ -56,7 +56,7 @@ export function renderReachabilitySection(
   // and the reachability snapshot can be stale (no push fires on the
   // mDNS Removed that took it offline), so trust the live device state.
   const mdnsAge = ageOf(r.mdns_last_seen_seconds_ago, anchor, now);
-  const deviceOffline = host.device?.state === DeviceState.OFFLINE;
+  const deviceOffline = host.device?.runtime_state.state === DeviceState.OFFLINE;
   const rows: ReachabilityRowSpec[] = [
     {
       source: "mdns",

--- a/src/components/dashboard/device-drawer-content/render-sections.ts
+++ b/src/components/dashboard/device-drawer-content/render-sections.ts
@@ -138,7 +138,7 @@ export function renderVersionSection(
   // The deployed version comes only from mDNS; when mDNS is dark it's stale, so
   // treat it as unknown and let the existing empty-deployed path show
   // "waiting for mDNS" instead of a false "out of sync".
-  const deployed = mdnsOnline(d) ? d.deployed_version || "" : "";
+  const deployed = mdnsOnline(d) ? d.runtime_state.deployed_version || "" : "";
   if (!local && !deployed) return nothing;
   const matches = !!local && !!deployed && local === deployed;
   const statusIcon = matches ? "check-circle-outline" : "sync";
@@ -191,7 +191,7 @@ export function renderConfigHashSection(
 ): TemplateResult | typeof nothing {
   const expected = d.expected_config_hash || "";
   // mDNS-sourced; treat as unknown when mDNS is dark (see renderVersionSection).
-  const deployed = mdnsOnline(d) ? d.deployed_config_hash || "" : "";
+  const deployed = mdnsOnline(d) ? d.runtime_state.deployed_config_hash || "" : "";
   if (!expected && !deployed) return nothing;
   const matches = !!expected && !!deployed && expected === deployed;
   const statusIcon = matches ? "check-circle-outline" : "sync";
@@ -269,7 +269,7 @@ export function renderIpAddressRow(
   host: ESPHomeDeviceDrawerContent,
   d: ConfiguredDevice
 ): TemplateResult {
-  const list = d.ip_addresses;
+  const list = d.runtime_state.ip_addresses;
   const label = host._localize("dashboard.drawer_ip_address");
   // ip_addresses isn't persisted across restarts but the primary d.ip is, so
   // fall back to it on a cold scan to keep the IP row and its visit link.

--- a/src/components/dashboard/device-drawer-content/render-sections.ts
+++ b/src/components/dashboard/device-drawer-content/render-sections.ts
@@ -138,7 +138,7 @@ export function renderVersionSection(
   // The deployed version comes only from mDNS; when mDNS is dark it's stale, so
   // treat it as unknown and let the existing empty-deployed path show
   // "waiting for mDNS" instead of a false "out of sync".
-  const deployed = mdnsOnline(d) ? d.runtime_state.deployed_version || "" : "";
+  const deployed = mdnsOnline(d) ? d.runtime_state.deployed_version : "";
   if (!local && !deployed) return nothing;
   const matches = !!local && !!deployed && local === deployed;
   const statusIcon = matches ? "check-circle-outline" : "sync";
@@ -191,7 +191,7 @@ export function renderConfigHashSection(
 ): TemplateResult | typeof nothing {
   const expected = d.expected_config_hash || "";
   // mDNS-sourced; treat as unknown when mDNS is dark (see renderVersionSection).
-  const deployed = mdnsOnline(d) ? d.runtime_state.deployed_config_hash || "" : "";
+  const deployed = mdnsOnline(d) ? d.runtime_state.deployed_config_hash : "";
   if (!expected && !deployed) return nothing;
   const matches = !!expected && !!deployed && expected === deployed;
   const statusIcon = matches ? "check-circle-outline" : "sync";

--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -303,8 +303,9 @@ export class ESPHomeDeviceDrawer extends LitElement {
     const device = this.device;
     if (!device) return nothing;
 
-    const online = device.runtime_state.state === DeviceState.ONLINE;
-    const offline = device.runtime_state.state === DeviceState.OFFLINE;
+    const rt = device.runtime_state;
+    const online = rt.state === DeviceState.ONLINE;
+    const offline = rt.state === DeviceState.OFFLINE;
     const stateClass = online ? "online" : offline ? "offline" : "unknown";
     // Transport-agnostic network icons — wifi/wifi-off implied a
     // wireless link, but plenty of devices on the network are on
@@ -368,7 +369,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
                   @click=${() => this._emitAction("update-device")}
                   title=${updateButtonTitle(
                     this._localize,
-                    device.runtime_state.deployed_version,
+                    rt.deployed_version,
                     device.current_version,
                     "dashboard.drawer_update"
                   )}

--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -303,8 +303,8 @@ export class ESPHomeDeviceDrawer extends LitElement {
     const device = this.device;
     if (!device) return nothing;
 
-    const online = device.state === DeviceState.ONLINE;
-    const offline = device.state === DeviceState.OFFLINE;
+    const online = device.runtime_state.state === DeviceState.ONLINE;
+    const offline = device.runtime_state.state === DeviceState.OFFLINE;
     const stateClass = online ? "online" : offline ? "offline" : "unknown";
     // Transport-agnostic network icons — wifi/wifi-off implied a
     // wireless link, but plenty of devices on the network are on
@@ -368,7 +368,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
                   @click=${() => this._emitAction("update-device")}
                   title=${updateButtonTitle(
                     this._localize,
-                    device.deployed_version,
+                    device.runtime_state.deployed_version,
                     device.current_version,
                     "dashboard.drawer_update"
                   )}

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -263,12 +263,12 @@ export class ESPHomeDeviceTable extends LitElement {
       changed.has("_labelCatalog")
     ) {
       this._rows = this.devices.map((d) => ({
-        status: d.state,
+        status: d.runtime_state.state,
         name: d.name,
         friendly_name: d.friendly_name,
         address: d.address || "",
         ip: d.ip || "",
-        ip_addresses: d.ip_addresses,
+        ip_addresses: d.runtime_state.ip_addresses,
         mac_address: d.mac_address || "",
         // ``ethernet_mac`` / ``bluetooth_mac`` aren't surfaced in
         // the device list — those are drawer-only fields. The table
@@ -277,7 +277,7 @@ export class ESPHomeDeviceTable extends LitElement {
         // interface derived values are diagnostic detail that
         // belongs in the per-device drawer.
         platform: d.target_platform || "",
-        version: d.deployed_version || "",
+        version: d.runtime_state.deployed_version || "",
         build_size_bytes: d.build_size_bytes || 0,
         comment: d.comment || "",
         area: d.area || "",
@@ -290,10 +290,10 @@ export class ESPHomeDeviceTable extends LitElement {
         hasPendingChanges: d.has_pending_changes === true,
         showModified: showPendingChanges(d),
         showUpdate: showUpdateAvailable(d),
-        hasQueuedUpdate: d.queued_update === true,
+        hasQueuedUpdate: d.runtime_state.queued_update,
         api_enabled: d.api_enabled === true,
         api_encrypted: d.api_encrypted === true,
-        api_encryption_active: d.api_encryption_active ?? null,
+        api_encryption_active: d.runtime_state.api_encryption_active,
         busy: this.activeJobs.has(d.configuration),
         recentJob: this.recentJobs.get(d.configuration) ?? null,
         _device: d,

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -262,42 +262,45 @@ export class ESPHomeDeviceTable extends LitElement {
       changed.has("recentJobs") ||
       changed.has("_labelCatalog")
     ) {
-      this._rows = this.devices.map((d) => ({
-        status: d.runtime_state.state,
-        name: d.name,
-        friendly_name: d.friendly_name,
-        address: d.address || "",
-        ip: d.ip || "",
-        ip_addresses: d.runtime_state.ip_addresses,
-        mac_address: d.mac_address || "",
-        // ``ethernet_mac`` / ``bluetooth_mac`` aren't surfaced in
-        // the device list — those are drawer-only fields. The table
-        // column shows the primary MAC (``mac_address``) since
-        // that's the universally-meaningful identifier; the per-
-        // interface derived values are diagnostic detail that
-        // belongs in the per-device drawer.
-        platform: d.target_platform || "",
-        version: d.runtime_state.deployed_version || "",
-        build_size_bytes: d.build_size_bytes || 0,
-        comment: d.comment || "",
-        area: d.area || "",
-        // Resolve labels here once per render rather than from the
-        // cell renderer — TanStack's sortingFn / filterFn read the
-        // accessor value, so they need the resolved objects rather
-        // than opaque ids.
-        labels: resolveLabelIds(d.labels, this._labelCatalog),
-        config: d.configuration,
-        hasPendingChanges: d.has_pending_changes === true,
-        showModified: showPendingChanges(d),
-        showUpdate: showUpdateAvailable(d),
-        hasQueuedUpdate: d.runtime_state.queued_update,
-        api_enabled: d.api_enabled === true,
-        api_encrypted: d.api_encrypted === true,
-        api_encryption_active: d.runtime_state.api_encryption_active,
-        busy: this.activeJobs.has(d.configuration),
-        recentJob: this.recentJobs.get(d.configuration) ?? null,
-        _device: d,
-      }));
+      this._rows = this.devices.map((d) => {
+        const rt = d.runtime_state;
+        return {
+          status: rt.state,
+          name: d.name,
+          friendly_name: d.friendly_name,
+          address: d.address || "",
+          ip: d.ip || "",
+          ip_addresses: rt.ip_addresses,
+          mac_address: d.mac_address || "",
+          // ``ethernet_mac`` / ``bluetooth_mac`` aren't surfaced in
+          // the device list — those are drawer-only fields. The table
+          // column shows the primary MAC (``mac_address``) since
+          // that's the universally-meaningful identifier; the per-
+          // interface derived values are diagnostic detail that
+          // belongs in the per-device drawer.
+          platform: d.target_platform || "",
+          version: rt.deployed_version,
+          build_size_bytes: d.build_size_bytes || 0,
+          comment: d.comment || "",
+          area: d.area || "",
+          // Resolve labels here once per render rather than from the
+          // cell renderer — TanStack's sortingFn / filterFn read the
+          // accessor value, so they need the resolved objects rather
+          // than opaque ids.
+          labels: resolveLabelIds(d.labels, this._labelCatalog),
+          config: d.configuration,
+          hasPendingChanges: d.has_pending_changes === true,
+          showModified: showPendingChanges(d),
+          showUpdate: showUpdateAvailable(d),
+          hasQueuedUpdate: rt.queued_update,
+          api_enabled: d.api_enabled === true,
+          api_encrypted: d.api_encrypted === true,
+          api_encryption_active: rt.api_encryption_active,
+          busy: this.activeJobs.has(d.configuration),
+          recentJob: this.recentJobs.get(d.configuration) ?? null,
+          _device: d,
+        };
+      });
     }
   }
 

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -106,17 +106,17 @@ export function renderCardGrid(
             data-configuration=${device.configuration}
             .name=${device.friendly_name || device.name}
             .configuration=${device.configuration}
-            .state=${device.state}
+            .state=${device.runtime_state.state}
             .labelIds=${device.labels ?? []}
             ?has-pending-changes=${device.has_pending_changes === true}
             ?show-modified=${showPendingChanges(device)}
             ?show-update=${showUpdateAvailable(device)}
-            .installedVersion=${device.deployed_version}
+            .installedVersion=${device.runtime_state.deployed_version}
             .availableVersion=${device.current_version}
             ?api-enabled=${device.api_enabled === true}
             ?api-encrypted=${device.api_encrypted === true}
-            .apiEncryptionActive=${device.api_encryption_active ?? null}
-            ?queued-update=${device.queued_update === true}
+            .apiEncryptionActive=${device.runtime_state.api_encryption_active}
+            ?queued-update=${device.runtime_state.queued_update}
             ?busy=${host._activeJobs.has(device.configuration)}
             .activeJob=${host._activeJobs.get(device.configuration) ?? null}
             ?highlight=${host._recentlyAdopted === device.configuration}

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -101,22 +101,23 @@ export function renderCardGrid(
       ${host._devices.length === 0 ? renderAddDeviceCard(host) : ""}
       ${filtered.map((device) => {
         const webUrl = buildWebUiUrl(device);
+        const rt = device.runtime_state;
         return html`
           <esphome-device-card
             data-configuration=${device.configuration}
             .name=${device.friendly_name || device.name}
             .configuration=${device.configuration}
-            .state=${device.runtime_state.state}
+            .state=${rt.state}
             .labelIds=${device.labels ?? []}
             ?has-pending-changes=${device.has_pending_changes === true}
             ?show-modified=${showPendingChanges(device)}
             ?show-update=${showUpdateAvailable(device)}
-            .installedVersion=${device.runtime_state.deployed_version}
+            .installedVersion=${rt.deployed_version}
             .availableVersion=${device.current_version}
             ?api-enabled=${device.api_enabled === true}
             ?api-encrypted=${device.api_encrypted === true}
-            .apiEncryptionActive=${device.runtime_state.api_encryption_active}
-            ?queued-update=${device.runtime_state.queued_update}
+            .apiEncryptionActive=${rt.api_encryption_active}
+            ?queued-update=${rt.queued_update}
             ?busy=${host._activeJobs.has(device.configuration)}
             .activeJob=${host._activeJobs.get(device.configuration) ?? null}
             ?highlight=${host._recentlyAdopted === device.configuration}

--- a/src/components/dashboard/render-dialogs.ts
+++ b/src/components/dashboard/render-dialogs.ts
@@ -242,7 +242,7 @@ export function renderDialogs(host: ESPHomePageDashboard): TemplateResult {
     <esphome-logs-dialog></esphome-logs-dialog>
     <esphome-install-method-dialog
       ?open=${host._installMethodOpen}
-      .deviceState=${host._installMethodDevice?.state ?? DeviceState.UNKNOWN}
+      .deviceState=${host._installMethodDevice?.runtime_state.state ?? DeviceState.UNKNOWN}
       .deviceTargetPlatform=${host._installMethodDevice?.target_platform ?? ""}
       .deviceCurrentAddress=${
         host._installMethodDevice?.ip || host._installMethodDevice?.address || ""

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -355,7 +355,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
                   aria-label=${localize("dashboard.table_action_update")}
                   title=${updateButtonTitle(
                     localize,
-                    device.deployed_version,
+                    device.runtime_state.deployed_version,
                     device.current_version,
                     "dashboard.table_action_update"
                   )}

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -211,7 +211,7 @@ export class ESPHomeTableRowMenu extends LitElement {
           ${this._localize("dashboard.action_install")}
         </div>
         ${
-          this.device?.queued_update
+          this.device?.runtime_state.queued_update
             ? html`<div
                 class="menu-item ${this.busy ? "menu-item--disabled" : ""}"
                 @click=${this.busy ? undefined : () => this._emit("clear-queued-update")}

--- a/src/components/device/device-install-controller.ts
+++ b/src/components/device/device-install-controller.ts
@@ -28,7 +28,7 @@ export class DeviceInstallController implements ReactiveController {
   }
 
   get deviceState(): DeviceState {
-    return this._host.device?.state ?? DeviceState.UNKNOWN;
+    return this._host.device?.runtime_state.state ?? DeviceState.UNKNOWN;
   }
 
   get deviceTargetPlatform(): string {

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1068,7 +1068,7 @@ export class ESPHomePageDevice extends LitElement {
             ?saving=${this._saving}
             ?showModified=${this._device ? showPendingChanges(this._device) : false}
             ?showUpdate=${this._device ? showUpdateAvailable(this._device) : false}
-            .installedVersion=${this._device?.deployed_version ?? ""}
+            .installedVersion=${this._device?.runtime_state.deployed_version ?? ""}
             .availableVersion=${this._device?.current_version ?? ""}
             ?busy=${this._activeJobs.has(this.id)}
           >

--- a/src/util/bootloader-flash.ts
+++ b/src/util/bootloader-flash.ts
@@ -10,5 +10,5 @@ import type { ConfiguredDevice } from "../api/types/devices.js";
 export const canFlashBootloader = (d: ConfiguredDevice | null | undefined): boolean =>
   !!d &&
   d.ota_partition_access === true &&
-  !!d.deployed_config_hash &&
-  d.deployed_config_hash === d.expected_config_hash;
+  !!d.runtime_state.deployed_config_hash &&
+  d.runtime_state.deployed_config_hash === d.expected_config_hash;

--- a/src/util/device-filter.ts
+++ b/src/util/device-filter.ts
@@ -69,7 +69,7 @@ export function applyFacetFilters(
   }
   if (selectedStates.length > 0) {
     const set = new Set(selectedStates);
-    out = out.filter((d) => set.has(d.state));
+    out = out.filter((d) => set.has(d.runtime_state.state));
   }
   if (selectedUpdateStatus.length > 0) {
     // AND / narrowing: a device must satisfy every selected bucket
@@ -120,7 +120,7 @@ export function matchesDeviceSearch(
   if (!includeAddressFields) return false;
   return (
     device.address.toLowerCase().includes(query) ||
-    device.ip_addresses.some((ip) => ip.toLowerCase().includes(query)) ||
+    device.runtime_state.ip_addresses.some((ip) => ip.toLowerCase().includes(query)) ||
     device.target_platform.toLowerCase().includes(query) ||
     matchesMacAddress(device.mac_address, query)
   );

--- a/src/util/device-sync.ts
+++ b/src/util/device-sync.ts
@@ -6,7 +6,8 @@ import type { ConfiguredDevice } from "../api/types/devices.js";
 // those values go stale, so we gate the out-of-sync / update indicators on a
 // live mDNS rather than flagging a false "out of sync". The device reappears
 // as out-of-sync once mDNS hears from it again.
-export const mdnsOnline = (d: ConfiguredDevice): boolean => d.active_source === "mdns";
+export const mdnsOnline = (d: ConfiguredDevice): boolean =>
+  d.runtime_state.active_source === "mdns";
 
 // Whether to SHOW the "modified" (needs-install) and "update available"
 // indicators, gated so a stale mDNS-dark value can't flag a false "out of

--- a/src/util/encryption-state.ts
+++ b/src/util/encryption-state.ts
@@ -1,9 +1,9 @@
 import { mdiLock, mdiLockAlert, mdiLockClock, mdiLockOpenVariant } from "@mdi/js";
 
-/** Minimal shape needed to derive the encryption state. ``ConfiguredDevice``
- *  satisfies this; the table-row and card components also pass narrowed
- *  versions of the same fields so the helper isn't tied to the full
- *  device record. */
+/** Minimal flat shape needed to derive the encryption state. Each caller
+ *  (drawer, table row, card) adapts its own record — ``ConfiguredDevice``
+ *  nests ``api_encryption_active`` under ``runtime_state``, so no full
+ *  record satisfies this directly. */
 export interface EncryptionInputs {
   api_enabled: boolean;
   api_encrypted: boolean;

--- a/src/util/facets.ts
+++ b/src/util/facets.ts
@@ -109,7 +109,8 @@ export function computeStateFacet(
   counts.set(DeviceState.OFFLINE, 0);
   counts.set(DeviceState.UNKNOWN, 0);
   for (const d of devices) {
-    counts.set(d.state, (counts.get(d.state) ?? 0) + 1);
+    const state = d.runtime_state.state;
+    counts.set(state, (counts.get(state) ?? 0) + 1);
   }
   const labelKeyByState: Record<DeviceState, string> = {
     [DeviceState.ONLINE]: "dashboard.online",

--- a/test/_make-configured-device.ts
+++ b/test/_make-configured-device.ts
@@ -14,7 +14,7 @@
  * care about a particular value pass it via *overrides*; the rest
  * fall through.
  */
-import type { ConfiguredDevice } from "../src/api/types/devices.js";
+import type { ConfiguredDevice, DeviceRuntimeState } from "../src/api/types/devices.js";
 import { DeviceState } from "../src/api/types/devices.js";
 
 const _BASE = {
@@ -27,7 +27,6 @@ const _BASE = {
   target_platform: "esp32",
   address: "kitchen.local",
   ip: "",
-  ip_addresses: [],
   mac_address: "",
   ethernet_mac: "",
   bluetooth_mac: "",
@@ -36,28 +35,45 @@ const _BASE = {
   web_port: null,
   logger_baud_rate: null,
   current_version: "",
-  deployed_version: "",
   loaded_integrations: [],
-  state: DeviceState.UNKNOWN,
-  // Default to a live mDNS source so the happy-path fixture shows its
-  // out-of-sync / update indicators as before; tests covering the mDNS-dark
-  // "hide indicators" behaviour override this to "ping" / "unknown".
-  active_source: "mdns",
+  runtime_state: {
+    state: DeviceState.UNKNOWN,
+    // Default to a live mDNS source so the happy-path fixture shows its
+    // out-of-sync / update indicators as before; tests covering the mDNS-dark
+    // "hide indicators" behaviour override this to "ping" / "unknown".
+    active_source: "mdns",
+    ip_addresses: [],
+    deployed_version: "",
+    deployed_config_hash: "",
+    queued_update: false,
+    api_encryption_active: null,
+  },
   expected_config_hash: "",
-  deployed_config_hash: "",
   has_pending_changes: false,
   update_available: false,
   api_enabled: false,
   api_encrypted: false,
-  api_encryption_active: null,
 } satisfies ConfiguredDevice;
+
+/** Overrides accepted by :func:`makeConfiguredDevice` — flat fields
+ *  plus a partial ``runtime_state`` merged over the baseline's. */
+export type ConfiguredDeviceOverrides = Partial<
+  Omit<ConfiguredDevice, "runtime_state">
+> & {
+  runtime_state?: Partial<DeviceRuntimeState>;
+};
 
 /** Build a ``ConfiguredDevice`` from the shared defaults, with any
  *  fields the test cares about overridden. The return type is the
  *  full ``ConfiguredDevice`` (not ``Partial``) so consumers can
  *  pass the result anywhere a real device object is expected. */
 export function makeConfiguredDevice(
-  overrides: Partial<ConfiguredDevice> = {}
+  overrides: ConfiguredDeviceOverrides = {}
 ): ConfiguredDevice {
-  return { ..._BASE, ...overrides };
+  const { runtime_state, ...flat } = overrides;
+  return {
+    ..._BASE,
+    ...flat,
+    runtime_state: { ..._BASE.runtime_state, ...runtime_state },
+  };
 }

--- a/test/components/app-shell/events-device-state-changed.test.ts
+++ b/test/components/app-shell/events-device-state-changed.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Pins the DEVICE_STATE_CHANGED fold: the flat wire event lands in
+ * runtime_state.state via fresh device + runtime_state objects (Lit
+ * change detection), preserving the other runtime fields.
+ */
+import { describe, expect, it } from "vitest";
+import { DeviceState } from "../../../src/api/types/devices.js";
+import { DeviceEventType } from "../../../src/api/types/event-subscription.js";
+import type { ESPHomeApp } from "../../../src/components/app-shell.js";
+import { handleEvent } from "../../../src/components/app-shell/events.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+
+type Host = Pick<ESPHomeApp, "_devices">;
+
+function dispatch(host: Host, configuration: string, state: DeviceState): void {
+  handleEvent(host as ESPHomeApp, DeviceEventType.DEVICE_STATE_CHANGED, {
+    configuration,
+    state,
+  });
+}
+
+describe("handleEvent DEVICE_STATE_CHANGED", () => {
+  it("folds the flat event state into the device's runtime_state", () => {
+    const device = makeConfiguredDevice({
+      runtime_state: {
+        state: DeviceState.UNKNOWN,
+        deployed_version: "2026.6.1",
+        queued_update: true,
+      },
+    });
+    const host: Host = { _devices: [device] };
+
+    dispatch(host, "kitchen.yaml", DeviceState.ONLINE);
+
+    const updated = host._devices[0];
+    expect(updated.runtime_state.state).toBe(DeviceState.ONLINE);
+    // Sibling runtime fields survive the fold.
+    expect(updated.runtime_state.deployed_version).toBe("2026.6.1");
+    expect(updated.runtime_state.queued_update).toBe(true);
+    // Fresh identities so Lit change detection sees the update.
+    expect(updated).not.toBe(device);
+    expect(updated.runtime_state).not.toBe(device.runtime_state);
+    expect(device.runtime_state.state).toBe(DeviceState.UNKNOWN);
+  });
+
+  it("leaves non-matching devices untouched by reference", () => {
+    const other = makeConfiguredDevice({ configuration: "bedroom.yaml" });
+    const host: Host = { _devices: [other, makeConfiguredDevice()] };
+
+    dispatch(host, "kitchen.yaml", DeviceState.OFFLINE);
+
+    expect(host._devices[0]).toBe(other);
+    expect(host._devices[1].runtime_state.state).toBe(DeviceState.OFFLINE);
+  });
+});

--- a/test/components/app-shell/events-device-state-changed.test.ts
+++ b/test/components/app-shell/events-device-state-changed.test.ts
@@ -22,11 +22,7 @@ function dispatch(host: Host, configuration: string, state: DeviceState): void {
 describe("handleEvent DEVICE_STATE_CHANGED", () => {
   it("folds the flat event state into the device's runtime_state", () => {
     const device = makeConfiguredDevice({
-      runtime_state: {
-        state: DeviceState.UNKNOWN,
-        deployed_version: "2026.6.1",
-        queued_update: true,
-      },
+      runtime_state: { deployed_version: "2026.6.1", queued_update: true },
     });
     const host: Host = { _devices: [device] };
 
@@ -37,9 +33,8 @@ describe("handleEvent DEVICE_STATE_CHANGED", () => {
     // Sibling runtime fields survive the fold.
     expect(updated.runtime_state.deployed_version).toBe("2026.6.1");
     expect(updated.runtime_state.queued_update).toBe(true);
-    // Fresh identities so Lit change detection sees the update.
-    expect(updated).not.toBe(device);
-    expect(updated.runtime_state).not.toBe(device.runtime_state);
+    // The fold replaces, never mutates — fresh identities for Lit
+    // change detection, so the original device is untouched.
     expect(device.runtime_state.state).toBe(DeviceState.UNKNOWN);
   });
 

--- a/test/components/dashboard/actions-ui.test.ts
+++ b/test/components/dashboard/actions-ui.test.ts
@@ -49,12 +49,12 @@ function makeHost(
 ): { host: ESPHomePageDashboard; openConfirm: ReturnType<typeof vi.fn> } {
   const openConfirm = vi.fn();
   const host = makeDashboardHost({
-    _actionDevice: {
+    _actionDevice: makeConfiguredDevice({
       name: "rename_test",
       friendly_name: "Rename_Test",
       configuration: "rename_test.yaml",
-      state,
-    } as ConfiguredDevice,
+      runtime_state: { state },
+    }),
     _api: { renameDevice } as unknown as ESPHomeAPI,
     _localize: localize,
     _openConfirm: openConfirm,

--- a/test/components/dashboard/device-drawer-update-title.test.ts
+++ b/test/components/dashboard/device-drawer-update-title.test.ts
@@ -23,7 +23,7 @@ describe("device-drawer footer Update title", () => {
       open: true,
       device: makeConfiguredDevice({
         update_available: true,
-        deployed_version: "2024.6.0",
+        runtime_state: { deployed_version: "2024.6.0" },
         current_version: "2024.12.0",
       }),
     });
@@ -35,7 +35,7 @@ describe("device-drawer footer Update title", () => {
       open: true,
       device: makeConfiguredDevice({
         update_available: true,
-        deployed_version: "2024.6.0",
+        runtime_state: { deployed_version: "2024.6.0" },
       }),
     });
     expect(footerAccentTitle(el)).toBe("dashboard.drawer_update");

--- a/test/components/dashboard/device-table.test.ts
+++ b/test/components/dashboard/device-table.test.ts
@@ -38,13 +38,10 @@ function makeDevices(n: number): ConfiguredDevice[] {
     name: `demo-${i}`,
     friendly_name: `Demo ${i}`,
     configuration: `demo-${i}.yaml`,
-    state: "ONLINE",
     address: `demo-${i}.local`,
     ip: "",
-    ip_addresses: [],
     mac_address: "",
     target_platform: "ESP32",
-    deployed_version: "",
     build_size_bytes: 0,
     comment: "",
     area: "",
@@ -53,7 +50,15 @@ function makeDevices(n: number): ConfiguredDevice[] {
     update_available: false,
     api_enabled: true,
     api_encrypted: false,
-    api_encryption_active: null,
+    runtime_state: {
+      state: "ONLINE",
+      active_source: "unknown",
+      ip_addresses: [],
+      deployed_version: "",
+      deployed_config_hash: "",
+      queued_update: false,
+      api_encryption_active: null,
+    },
   })) as unknown as ConfiguredDevice[];
 }
 

--- a/test/components/dashboard/device-table.test.ts
+++ b/test/components/dashboard/device-table.test.ts
@@ -18,6 +18,7 @@ import {
   ALL_PAGE_SIZE,
   effectiveTablePageSize,
 } from "../../../src/components/dashboard/pagination.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
 
 describe("effectiveTablePageSize", () => {
   it("passes a normal page size through unchanged", () => {
@@ -34,32 +35,14 @@ describe("effectiveTablePageSize", () => {
 });
 
 function makeDevices(n: number): ConfiguredDevice[] {
-  return Array.from({ length: n }, (_, i) => ({
-    name: `demo-${i}`,
-    friendly_name: `Demo ${i}`,
-    configuration: `demo-${i}.yaml`,
-    address: `demo-${i}.local`,
-    ip: "",
-    mac_address: "",
-    target_platform: "ESP32",
-    build_size_bytes: 0,
-    comment: "",
-    area: "",
-    labels: [],
-    has_pending_changes: false,
-    update_available: false,
-    api_enabled: true,
-    api_encrypted: false,
-    runtime_state: {
-      state: "ONLINE",
-      active_source: "unknown",
-      ip_addresses: [],
-      deployed_version: "",
-      deployed_config_hash: "",
-      queued_update: false,
-      api_encryption_active: null,
-    },
-  })) as unknown as ConfiguredDevice[];
+  return Array.from({ length: n }, (_, i) =>
+    makeConfiguredDevice({
+      name: `demo-${i}`,
+      friendly_name: `Demo ${i}`,
+      configuration: `demo-${i}.yaml`,
+      address: `demo-${i}.local`,
+    })
+  );
 }
 
 async function mount(

--- a/test/components/dashboard/render-card-grid.test.ts
+++ b/test/components/dashboard/render-card-grid.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins renderCardGrid's per-device bindings: runtime_state fields
+ * (state, deployed_version, queued_update, api_encryption_active)
+ * flow onto <esphome-device-card>, and the update indicator stays
+ * gated on a live mDNS source.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+
+import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
+import { DeviceState } from "../../../src/api/types/devices.js";
+import { renderCardGrid } from "../../../src/components/dashboard/render-content.js";
+import { renderInto } from "../../_dom.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+import { makeDashboardHost } from "./_host.js";
+
+function makeHost(devices: ConfiguredDevice[]) {
+  return makeDashboardHost({
+    _devices: devices,
+    _activeJobs: new Map(),
+    _recentJobs: new Map(),
+    _recentlyAdopted: null,
+    _selectMode: false,
+    _selectedDevices: new Set<string>(),
+  });
+}
+
+function renderCard(device: ConfiguredDevice): HTMLElement {
+  const container = renderInto(renderCardGrid(makeHost([device]), [device]));
+  const card = container.querySelector("esphome-device-card");
+  expect(card).not.toBeNull();
+  return card as HTMLElement;
+}
+
+describe("renderCardGrid", () => {
+  it("binds the device's runtime_state onto the card", () => {
+    const cipher = "Noise_NNpsk0_25519_ChaChaPoly_SHA256";
+    const device = makeConfiguredDevice({
+      update_available: true,
+      runtime_state: {
+        state: DeviceState.ONLINE,
+        active_source: "mdns",
+        deployed_version: "2026.6.1",
+        queued_update: true,
+        api_encryption_active: cipher,
+      },
+    });
+    const card = renderCard(device) as HTMLElement & {
+      state: DeviceState;
+      installedVersion: string;
+      apiEncryptionActive: string | null;
+    };
+    expect(card.getAttribute("data-configuration")).toBe("kitchen.yaml");
+    expect(card.state).toBe(DeviceState.ONLINE);
+    expect(card.installedVersion).toBe("2026.6.1");
+    expect(card.apiEncryptionActive).toBe(cipher);
+    expect(card.hasAttribute("queued-update")).toBe(true);
+    expect(card.hasAttribute("show-update")).toBe(true);
+  });
+
+  it("hides the update indicator when mDNS is dark", () => {
+    const device = makeConfiguredDevice({
+      update_available: true,
+      runtime_state: { active_source: "ping" },
+    });
+    const card = renderCard(device);
+    expect(card.hasAttribute("show-update")).toBe(false);
+    expect(card.hasAttribute("queued-update")).toBe(false);
+  });
+});

--- a/test/components/dashboard/render-card-grid.test.ts
+++ b/test/components/dashboard/render-card-grid.test.ts
@@ -43,7 +43,6 @@ describe("renderCardGrid", () => {
       update_available: true,
       runtime_state: {
         state: DeviceState.ONLINE,
-        active_source: "mdns",
         deployed_version: "2026.6.1",
         queued_update: true,
         api_encryption_active: cipher,

--- a/test/components/dashboard/render-dialogs.test.ts
+++ b/test/components/dashboard/render-dialogs.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins renderDialogs' install-method dialog bindings: deviceState
+ * comes from the selected device's runtime_state, falling back to
+ * UNKNOWN when no device is set.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("../../../src/util/post-install-logs.js", () => ({
+  requestAndOpenSerialPort: vi.fn(),
+  attachSerialLogStream: vi.fn(),
+  reconnectWebSerialLogs: vi.fn(),
+}));
+
+import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
+import { DeviceState } from "../../../src/api/types/devices.js";
+import { renderDialogs } from "../../../src/components/dashboard/render-dialogs.js";
+import { renderInto } from "../../_dom.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+import { makeDashboardHost } from "./_host.js";
+
+function renderInstallMethodDialog(device: ConfiguredDevice | null) {
+  const host = makeDashboardHost({
+    _pendingConfirm: null,
+    _selectedDevices: new Set<string>(),
+    _computeLabelUsage: () => ({}),
+    _labelDialogOpen: false,
+    _labelDialogEditing: null,
+    _selectedLabels: [],
+    _installMethodOpen: device !== null,
+    _installMethodDevice: device,
+    _installMethodMode: "install",
+  });
+  const container = renderInto(renderDialogs(host));
+  const dialog = container.querySelector("esphome-install-method-dialog");
+  expect(dialog).not.toBeNull();
+  return dialog as HTMLElement & { deviceState: DeviceState };
+}
+
+describe("renderDialogs install-method dialog", () => {
+  it("binds the selected device's runtime state", () => {
+    const device = makeConfiguredDevice({
+      runtime_state: { state: DeviceState.ONLINE },
+    });
+    expect(renderInstallMethodDialog(device).deviceState).toBe(DeviceState.ONLINE);
+  });
+
+  it("falls back to UNKNOWN when no device is selected", () => {
+    expect(renderInstallMethodDialog(null).deviceState).toBe(DeviceState.UNKNOWN);
+  });
+});

--- a/test/components/dashboard/render-facets.test.ts
+++ b/test/components/dashboard/render-facets.test.ts
@@ -75,7 +75,12 @@ describe("renderFacets", () => {
 
   it("renders the Updates section when a device needs an update", () => {
     const host = makeHost({
-      _devices: [{ update_available: true, runtime_state: { active_source: "mdns" } }],
+      _devices: [
+        {
+          update_available: true,
+          runtime_state: { state: "online", active_source: "mdns" },
+        },
+      ],
     });
     expect(updatesSection(renderInto(renderFacets(host)))).not.toBeUndefined();
   });
@@ -92,7 +97,12 @@ describe("renderFacets", () => {
 
   it("suppresses the Updates section in YAML-search mode", () => {
     const host = makeHost({
-      _devices: [{ has_pending_changes: true, runtime_state: { active_source: "mdns" } }],
+      _devices: [
+        {
+          has_pending_changes: true,
+          runtime_state: { state: "online", active_source: "mdns" },
+        },
+      ],
       _yamlMode: true,
     });
     expect(updatesSection(renderInto(renderFacets(host)))).toBeUndefined();

--- a/test/components/dashboard/render-facets.test.ts
+++ b/test/components/dashboard/render-facets.test.ts
@@ -75,7 +75,7 @@ describe("renderFacets", () => {
 
   it("renders the Updates section when a device needs an update", () => {
     const host = makeHost({
-      _devices: [{ update_available: true, active_source: "mdns" }],
+      _devices: [{ update_available: true, runtime_state: { active_source: "mdns" } }],
     });
     expect(updatesSection(renderInto(renderFacets(host)))).not.toBeUndefined();
   });
@@ -92,7 +92,7 @@ describe("renderFacets", () => {
 
   it("suppresses the Updates section in YAML-search mode", () => {
     const host = makeHost({
-      _devices: [{ has_pending_changes: true, active_source: "mdns" }],
+      _devices: [{ has_pending_changes: true, runtime_state: { active_source: "mdns" } }],
       _yamlMode: true,
     });
     expect(updatesSection(renderInto(renderFacets(host)))).toBeUndefined();
@@ -104,7 +104,10 @@ describe("renderFacets", () => {
   });
 
   const areaDevices = (n: number) =>
-    Array.from({ length: n }, (_, i) => ({ area: `Area ${i}` }));
+    Array.from({ length: n }, (_, i) => ({
+      area: `Area ${i}`,
+      runtime_state: { state: "unknown" },
+    }));
 
   it("keeps the Area section plain at 8 or fewer options", () => {
     const container = renderInto(renderFacets(makeHost({ _devices: areaDevices(8) })));

--- a/test/components/dashboard/render-ip-address-row.test.ts
+++ b/test/components/dashboard/render-ip-address-row.test.ts
@@ -25,7 +25,7 @@ describe("renderIpAddressRow", () => {
   it("falls back to d.ip when ip_addresses is empty (cold scan)", () => {
     const result = renderIpAddressRow(
       _host,
-      _device({ web_port: 80, ip: "10.0.0.5", ip_addresses: [] })
+      _device({ web_port: 80, ip: "10.0.0.5", runtime_state: { ip_addresses: [] } })
     );
     const valueText = findTemplatesByAnchor(result, "address-value-text");
     expect(valueText.flatMap((t) => t.values)).toContain("10.0.0.5");
@@ -35,7 +35,7 @@ describe("renderIpAddressRow", () => {
   it("renders no link when both ip_addresses and d.ip are empty", () => {
     const result = renderIpAddressRow(
       _host,
-      _device({ web_port: 80, ip: "", ip_addresses: [] })
+      _device({ web_port: 80, ip: "", runtime_state: { ip_addresses: [] } })
     );
     expect(findTemplatesByAnchor(result, "<a")).toHaveLength(0);
   });
@@ -43,7 +43,7 @@ describe("renderIpAddressRow", () => {
   it("shows waiting-for-first-signal when no IP is known", () => {
     const result = renderIpAddressRow(
       _host,
-      _device({ web_port: 80, ip: "", ip_addresses: [] })
+      _device({ web_port: 80, ip: "", runtime_state: { ip_addresses: [] } })
     );
     const texts = findTemplatesByAnchor(result, 'class="value').flatMap((t) => t.values);
     expect(texts).toContain("dashboard.drawer_waiting_for_signal");
@@ -52,7 +52,11 @@ describe("renderIpAddressRow", () => {
   it("links the resolved address to its own host", () => {
     const result = renderIpAddressRow(
       _host,
-      _device({ web_port: 8080, ip: "10.0.0.5", ip_addresses: ["192.168.1.9"] })
+      _device({
+        web_port: 8080,
+        ip: "10.0.0.5",
+        runtime_state: { ip_addresses: ["192.168.1.9"] },
+      })
     );
     expect(hrefs(result)).toEqual(["http://192.168.1.9:8080"]);
   });

--- a/test/components/dashboard/render-mac-address-row.test.ts
+++ b/test/components/dashboard/render-mac-address-row.test.ts
@@ -159,7 +159,7 @@ describe("renderVersionSection deployed row", () => {
     // Version is NOT gated on api_enabled: it can still arrive over the
     // _http._tcp mDNS fallback for MQTT-only devices.
     const result = renderVersionSection(
-      _device({ current_version: "2026.5.2", deployed_version: "" }),
+      _device({ current_version: "2026.5.2", runtime_state: { deployed_version: "" } }),
       _localize
     );
     const texts = valueTexts(result);
@@ -173,7 +173,7 @@ describe("renderConfigHashSection deployed row", () => {
     const result = renderConfigHashSection(
       _device({
         expected_config_hash: "abc123",
-        deployed_config_hash: "",
+        runtime_state: { deployed_config_hash: "" },
         api_enabled: true,
       }),
       _localize
@@ -187,7 +187,7 @@ describe("renderConfigHashSection deployed row", () => {
     const result = renderConfigHashSection(
       _device({
         expected_config_hash: "abc123",
-        deployed_config_hash: "",
+        runtime_state: { deployed_config_hash: "" },
         api_enabled: false,
       }),
       _localize

--- a/test/components/dashboard/render-reachability-section.test.ts
+++ b/test/components/dashboard/render-reachability-section.test.ts
@@ -53,7 +53,7 @@ function renderCalls(
 ): Array<[string, Record<string, unknown> | undefined]> {
   const calls: Array<[string, Record<string, unknown> | undefined]> = [];
   const host = {
-    device: { state: deviceState },
+    device: { runtime_state: { state: deviceState } },
     _reachability: r,
     _reachabilityAnchorMs: NOW,
     _localize: (key: string, args?: Record<string, unknown>) => {

--- a/test/components/dashboard/table-row-menu-clear-queued.test.ts
+++ b/test/components/dashboard/table-row-menu-clear-queued.test.ts
@@ -21,7 +21,7 @@ function findClearItem(el: ESPHomeTableRowMenu): Element | undefined {
 describe("table-row-menu clear-queued-update item", () => {
   it("emits clear-queued-update for a device with a queued update", async () => {
     const el = await mount(new ESPHomeTableRowMenu(), {
-      device: makeConfiguredDevice({ queued_update: true }),
+      device: makeConfiguredDevice({ runtime_state: { queued_update: true } }),
       position: { x: 10, y: 10 },
     });
     const item = findClearItem(el);
@@ -35,7 +35,7 @@ describe("table-row-menu clear-queued-update item", () => {
 
   it("hides the item when no update is queued", async () => {
     const el = await mount(new ESPHomeTableRowMenu(), {
-      device: makeConfiguredDevice({ queued_update: false }),
+      device: makeConfiguredDevice({ runtime_state: { queued_update: false } }),
       position: { x: 10, y: 10 },
     });
     expect(findClearItem(el)).toBeUndefined();

--- a/test/components/device-install-controller.test.ts
+++ b/test/components/device-install-controller.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Pins DeviceInstallController.deviceState: the host device's
+ * runtime_state.state, or UNKNOWN before the device loads.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { ConfiguredDevice } from "../../src/api/types/devices.js";
+import { DeviceState } from "../../src/api/types/devices.js";
+import {
+  DeviceInstallController,
+  type DeviceInstallControllerHost,
+} from "../../src/components/device/device-install-controller.js";
+import { makeConfiguredDevice } from "../_make-configured-device.js";
+
+function makeHost(device: ConfiguredDevice | null): DeviceInstallControllerHost {
+  return {
+    device,
+    commandDialog: null,
+    firmwareDialog: null,
+    addController: vi.fn(),
+    removeController: vi.fn(),
+    requestUpdate: vi.fn(),
+    updateComplete: Promise.resolve(true),
+  };
+}
+
+describe("DeviceInstallController.deviceState", () => {
+  it("returns the device's runtime state", () => {
+    const host = makeHost(
+      makeConfiguredDevice({ runtime_state: { state: DeviceState.OFFLINE } })
+    );
+    expect(new DeviceInstallController(host).deviceState).toBe(DeviceState.OFFLINE);
+  });
+
+  it("falls back to UNKNOWN with no device loaded", () => {
+    expect(new DeviceInstallController(makeHost(null)).deviceState).toBe(
+      DeviceState.UNKNOWN
+    );
+  });
+});

--- a/test/components/filters/facet-sections.test.ts
+++ b/test/components/filters/facet-sections.test.ts
@@ -21,14 +21,14 @@ import { makeConfiguredDevice } from "../../_make-configured-device.js";
 const DEVICES = [
   makeConfiguredDevice({
     configuration: "a.yaml",
-    state: DeviceState.ONLINE,
+    runtime_state: { state: DeviceState.ONLINE },
     update_available: true,
     target_platform: "esp32",
     area: "Kitchen",
   }),
   makeConfiguredDevice({
     configuration: "b.yaml",
-    state: DeviceState.OFFLINE,
+    runtime_state: { state: DeviceState.OFFLINE },
     has_pending_changes: true,
     target_platform: "esp8266",
     area: "",

--- a/test/components/update-all-dialog.test.ts
+++ b/test/components/update-all-dialog.test.ts
@@ -62,17 +62,17 @@ function primaryButton(el: ESPHomeUpdateAllDialog): HTMLButtonElement {
 
 const onlineUpdatable = makeConfiguredDevice({
   configuration: "a.yaml",
-  state: DeviceState.ONLINE,
+  runtime_state: { state: DeviceState.ONLINE },
   update_available: true,
 });
 const onlineCurrent = makeConfiguredDevice({
   configuration: "b.yaml",
-  state: DeviceState.ONLINE,
+  runtime_state: { state: DeviceState.ONLINE },
   update_available: false,
 });
 const offlineUpdatable = makeConfiguredDevice({
   configuration: "c.yaml",
-  state: DeviceState.OFFLINE,
+  runtime_state: { state: DeviceState.OFFLINE },
   update_available: true,
 });
 

--- a/test/pages/device-platform-ready.test.ts
+++ b/test/pages/device-platform-ready.test.ts
@@ -35,6 +35,10 @@ import type { ConfiguredDevice } from "../../src/api/types/devices.js";
 import { ESPHomePageDevice } from "../../src/pages/device.js";
 import { _clearBoardBodyCache } from "../../src/util/board-body-cache.js";
 import { flushMicrotasks } from "../_dom.js";
+import {
+  type ConfiguredDeviceOverrides,
+  makeConfiguredDevice,
+} from "../_make-configured-device.js";
 
 const board = (overrides: Partial<BoardCatalogEntry> = {}): BoardCatalogEntry =>
   ({
@@ -44,13 +48,8 @@ const board = (overrides: Partial<BoardCatalogEntry> = {}): BoardCatalogEntry =>
     ...overrides,
   }) as BoardCatalogEntry;
 
-const device = (overrides: Partial<ConfiguredDevice> = {}): ConfiguredDevice =>
-  ({
-    configuration: "kitchen.yaml",
-    name: "kitchen",
-    board_id: "esp32cam",
-    ...overrides,
-  }) as ConfiguredDevice;
+const device = (overrides: ConfiguredDeviceOverrides = {}): ConfiguredDevice =>
+  makeConfiguredDevice({ board_id: "esp32cam", ...overrides });
 
 interface FakeApi {
   getConfig: ReturnType<typeof vi.fn>;

--- a/test/util/bootloader-flash.test.ts
+++ b/test/util/bootloader-flash.test.ts
@@ -10,7 +10,7 @@ describe("canFlashBootloader", () => {
         makeConfiguredDevice({
           ota_partition_access: true,
           expected_config_hash: "aa11bb22",
-          deployed_config_hash: "aa11bb22",
+          runtime_state: { deployed_config_hash: "aa11bb22" },
         })
       )
     ).toBe(true);
@@ -21,7 +21,7 @@ describe("canFlashBootloader", () => {
       canFlashBootloader(
         makeConfiguredDevice({
           expected_config_hash: "aa11bb22",
-          deployed_config_hash: "aa11bb22",
+          runtime_state: { deployed_config_hash: "aa11bb22" },
         })
       )
     ).toBe(false);
@@ -30,7 +30,7 @@ describe("canFlashBootloader", () => {
         makeConfiguredDevice({
           ota_partition_access: true,
           expected_config_hash: "aa11bb22",
-          deployed_config_hash: "ff00ff00",
+          runtime_state: { deployed_config_hash: "ff00ff00" },
         })
       )
     ).toBe(false);
@@ -39,7 +39,7 @@ describe("canFlashBootloader", () => {
         makeConfiguredDevice({
           ota_partition_access: true,
           expected_config_hash: "",
-          deployed_config_hash: "",
+          runtime_state: { deployed_config_hash: "" },
         })
       )
     ).toBe(false);

--- a/test/util/device-filter.test.ts
+++ b/test/util/device-filter.test.ts
@@ -15,26 +15,19 @@ import {
   hasActiveFilters,
   matchesDeviceSearch,
 } from "../../src/util/device-filter.js";
+import {
+  type ConfiguredDeviceOverrides,
+  makeConfiguredDevice,
+} from "../_make-configured-device.js";
 
-function device(over: Partial<ConfiguredDevice> = {}): ConfiguredDevice {
-  return {
-    name: "kitchen",
+function device(over: ConfiguredDeviceOverrides = {}): ConfiguredDevice {
+  // Online + live mDNS by default so update/modified filters match; mDNS-dark
+  // cases override active_source.
+  return makeConfiguredDevice({
     friendly_name: "Kitchen Lamp",
-    configuration: "kitchen.yaml",
-    address: "kitchen.local",
-    ip_addresses: [],
-    state: DeviceState.ONLINE,
-    target_platform: "esp32",
-    mac_address: "",
-    labels: [],
-    area: "",
-    // Live mDNS by default so update/modified filters match; mDNS-dark cases
-    // override active_source.
-    active_source: "mdns",
-    update_available: false,
-    has_pending_changes: false,
     ...over,
-  } as ConfiguredDevice;
+    runtime_state: { state: DeviceState.ONLINE, ...over.runtime_state },
+  });
 }
 
 const emptySelection: FacetSelection = {
@@ -98,8 +91,8 @@ describe("applyFacetFilters", () => {
   });
 
   it("state facet matches the device state", () => {
-    const online = device({ name: "a", state: DeviceState.ONLINE });
-    const offline = device({ name: "b", state: DeviceState.OFFLINE });
+    const online = device({ name: "a", runtime_state: { state: DeviceState.ONLINE } });
+    const offline = device({ name: "b", runtime_state: { state: DeviceState.OFFLINE } });
     const out = applyFacetFilters(
       [online, offline],
       selection({ selectedStates: [DeviceState.OFFLINE] })
@@ -167,7 +160,7 @@ describe("matchesDeviceSearch", () => {
   const d = device({
     friendly_name: "Kitchen Lamp",
     address: "10.0.0.5",
-    ip_addresses: ["192.168.1.20"],
+    runtime_state: { ip_addresses: ["192.168.1.20"] },
     target_platform: "esp32",
     mac_address: "94:C9:60:AA:BB:CC",
   });

--- a/test/util/device-search.test.ts
+++ b/test/util/device-search.test.ts
@@ -1,34 +1,18 @@
 import { describe, expect, it } from "vitest";
 import type { ConfiguredDevice } from "../../src/api/types/devices.js";
-import { DeviceState } from "../../src/api/types/devices.js";
 import {
   matchesDeviceName,
   matchesDeviceRow,
   matchesMacAddress,
   type DeviceRowSearchFields,
 } from "../../src/util/device-search.js";
+import {
+  type ConfiguredDeviceOverrides,
+  makeConfiguredDevice,
+} from "../_make-configured-device.js";
 
-function _device(overrides: Partial<ConfiguredDevice> = {}): ConfiguredDevice {
-  return {
-    name: "kitchen",
-    friendly_name: "Kitchen Lamp",
-    configuration: "kitchen.yaml",
-    address: "kitchen.local",
-    ip_addresses: [],
-    state: DeviceState.ONLINE,
-    target_platform: "esp32",
-    target_variant: "",
-    deployed_version: null,
-    deployed_config_hash: null,
-    expected_config_hash: null,
-    api_encryption_active: null,
-    has_pending_changes: null,
-    last_seen: null,
-    just_created: null,
-    loaded_integrations: [],
-    archived: false,
-    ...overrides,
-  } as ConfiguredDevice;
+function _device(overrides: ConfiguredDeviceOverrides = {}): ConfiguredDevice {
+  return makeConfiguredDevice({ friendly_name: "Kitchen Lamp", ...overrides });
 }
 
 describe("matchesDeviceName", () => {

--- a/test/util/device-sync.test.ts
+++ b/test/util/device-sync.test.ts
@@ -9,17 +9,19 @@ import { makeConfiguredDevice } from "../_make-configured-device.js";
 
 describe("device-sync mDNS gating", () => {
   it("is mDNS-online only when the live source is mDNS", () => {
-    expect(mdnsOnline(makeConfiguredDevice({ active_source: "mdns" }))).toBe(true);
+    expect(
+      mdnsOnline(makeConfiguredDevice({ runtime_state: { active_source: "mdns" } }))
+    ).toBe(true);
     for (const s of ["ping", "mqtt", "unknown"] as const) {
-      expect(mdnsOnline(makeConfiguredDevice({ active_source: s }))).toBe(false);
+      expect(
+        mdnsOnline(makeConfiguredDevice({ runtime_state: { active_source: s } }))
+      ).toBe(false);
     }
-    // Absent on the wire (older / unclaimed) reads as not mDNS.
-    expect(mdnsOnline(makeConfiguredDevice({ active_source: undefined }))).toBe(false);
   });
 
   it("hides the hash-driven modified / update signals while mDNS is dark", () => {
     const dark = makeConfiguredDevice({
-      active_source: "ping",
+      runtime_state: { active_source: "ping" },
       has_pending_changes: true,
       pending_changes_via_hash: true,
       update_available: true,
@@ -33,7 +35,7 @@ describe("device-sync mDNS gating", () => {
     // without mDNS, so the needs-install cue stays. update_available is still
     // mDNS-sourced, so it stays hidden.
     const dark = makeConfiguredDevice({
-      active_source: "ping",
+      runtime_state: { active_source: "ping" },
       has_pending_changes: true,
       update_available: true,
     });
@@ -43,7 +45,7 @@ describe("device-sync mDNS gating", () => {
 
   it("shows the modified / update signals once mDNS is the live source", () => {
     const live = makeConfiguredDevice({
-      active_source: "mdns",
+      runtime_state: { active_source: "mdns" },
       has_pending_changes: true,
       update_available: true,
     });

--- a/test/util/facets.test.ts
+++ b/test/util/facets.test.ts
@@ -6,22 +6,16 @@
  */
 import { describe, expect, it } from "vitest";
 
-import type { ConfiguredDevice } from "../../src/api/types/devices.js";
 import type { LocalizeFunc } from "../../src/common/localize.js";
 import { computeUpdateFacet, normalizeUpdateBuckets } from "../../src/util/facets.js";
 import { identityLocalize } from "../_dom.js";
-import {
-  type ConfiguredDeviceOverrides,
-  makeConfiguredDevice,
-} from "../_make-configured-device.js";
+import { makeConfiguredDevice } from "../_make-configured-device.js";
 
 // computeUpdateFacet reads update_available / has_pending_changes, gated on
 // active_source via showUpdateAvailable / showPendingChanges. The shared
 // fixture defaults to a live mDNS source so update/modified buckets surface;
 // mDNS-dark cases pass runtime_state.active_source explicitly.
-function device(over: ConfiguredDeviceOverrides): ConfiguredDevice {
-  return makeConfiguredDevice(over);
-}
+const device = makeConfiguredDevice;
 
 // Echo the key so assertions key off the i18n id, not display copy.
 const localize = identityLocalize as unknown as LocalizeFunc;

--- a/test/util/facets.test.ts
+++ b/test/util/facets.test.ts
@@ -10,13 +10,17 @@ import type { ConfiguredDevice } from "../../src/api/types/devices.js";
 import type { LocalizeFunc } from "../../src/common/localize.js";
 import { computeUpdateFacet, normalizeUpdateBuckets } from "../../src/util/facets.js";
 import { identityLocalize } from "../_dom.js";
+import {
+  type ConfiguredDeviceOverrides,
+  makeConfiguredDevice,
+} from "../_make-configured-device.js";
 
 // computeUpdateFacet reads update_available / has_pending_changes, gated on
-// active_source via showUpdateAvailable / showPendingChanges.
-function device(over: Partial<ConfiguredDevice>): ConfiguredDevice {
-  // Default to a live mDNS source so update/modified buckets surface; the
-  // mDNS-dark cases pass active_source explicitly.
-  return { active_source: "mdns", ...over } as ConfiguredDevice;
+// active_source via showUpdateAvailable / showPendingChanges. The shared
+// fixture defaults to a live mDNS source so update/modified buckets surface;
+// mDNS-dark cases pass runtime_state.active_source explicitly.
+function device(over: ConfiguredDeviceOverrides): ConfiguredDevice {
+  return makeConfiguredDevice(over);
 }
 
 // Echo the key so assertions key off the i18n id, not display copy.


### PR DESCRIPTION
# What does this implement/fix?

Frontend half of esphome/device-builder#1941. The backend moved the seven monitor observed device fields (`state`, `active_source`, `ip_addresses`, `deployed_version`, `deployed_config_hash`, `queued_update`, `api_encryption_active`) into a nested `runtime_state` object on every device payload, so a rebuild carries one object instead of a hand maintained field list. This updates the `ConfiguredDevice` type and every read site to the nested shape; the narrow `device_state_changed` event stays flat on the wire and the handler folds it into `runtime_state` immutably. No compatibility shim, the repos ship lockstep.

**Related issue or feature (if applicable):**

- companion to esphome/device-builder#1941, merge together with a version bump

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
