### PR TITLE
Accept case-only differences when validating select options

### DIFF
--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -288,8 +288,15 @@ export function validateEntry(entry: ConfigEntry, raw: unknown): ValidationError
   // for fields that opt into custom values (combobox-style entries treat
   // `options` as suggestions, not a fixed set).
   if (entry.options && entry.options.length > 0 && !entry.allow_custom_value) {
+    const rawStr = String(raw);
     const allowed = entry.options.map((o) => o.value);
-    if (!allowed.includes(String(raw))) {
+    // A case-only difference is accepted: esphome's `cv.one_of(..., upper=True)`
+    // normalizes case, so a board-written `esp32` against a catalog `ESP32`
+    // option compiles fine and the form already resolves it case-insensitively.
+    if (
+      !allowed.includes(rawStr) &&
+      nearCanonicalOption(rawStr, entry.options) === null
+    ) {
       return { key: entry.key, code: "validation.invalid_option" };
     }
   }

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -279,6 +279,21 @@ describe("validateEntry", () => {
     expect(validateEntry(entry, "2")).toBeNull();
   });
 
+  it("accepts a case-only difference against the options (upper=True enums)", () => {
+    // esp32 `variant` options are uppercase (`ESP32`) but boards write `esp32`;
+    // cv.one_of(..., upper=True) accepts it, so it must not hard-fail.
+    const entry = makeEntry({
+      type: ConfigEntryType.SELECT,
+      options: [
+        { label: "ESP32", value: "ESP32" },
+        { label: "ESP32C2", value: "ESP32C2" },
+      ],
+    });
+    expect(validateEntry(entry, "esp32")).toBeNull();
+    expect(validateEntry(entry, "esp32c2")).toBeNull();
+    expect(validateEntry(entry, "esp32xx")?.code).toBe("validation.invalid_option");
+  });
+
   it("flags empty array when required", () => {
     const entry = makeEntry({ required: true, multi_value: true });
     expect(validateEntry(entry, [])?.code).toBe("validation.required");


### PR DESCRIPTION
# What does this implement/fix?

The ESP32 Platform editor showed a false "Not a valid option" error on the `variant` field for any generic-ESP32 device, even though the config compiles and flashes fine.

The catalog's `variant` options are uppercase (`ESP32`, `ESP32C2`, …, from esphome's `VARIANTS` constants and `cv.one_of(*VARIANTS, upper=True)`), but boards and the field's own description write lowercase (`variant: esp32`). `validateEntry` did an exact-case match against the option values, so `esp32` failed even though `upper=True` normalizes it at validate time and the form already resolves the display value case-insensitively.

The fix accepts a case-only difference: the option check now also passes when `nearCanonicalOption` finds a case-insensitive match (the existing helper that powers the "did you mean" hint), so `esp32` against an `ESP32` option no longer hard-fails. A value that matches no option even case-folded (`esp32xx`) still errors. This is general, not variant-specific: it fixes every `cv.one_of(..., upper=True / lower=True)` enum where the written value's case differs from the catalog option's.

Verified live: a generic-ESP32 device (`variant: esp32`) no longer shows "Not a valid option" on the Variant field.

**Related issue or feature (if applicable):**

Surfaced while testing esphome/device-builder#1948; no tracking issue.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
