### PR TITLE
Resolve depends_on against the component root for nested entries

### DIFF
--- a/src/components/device/add-component-form-filter.ts
+++ b/src/components/device/add-component-form-filter.ts
@@ -17,6 +17,7 @@ import { collectUnsatisfiedConstraints } from "./config-entry-renderers/constrai
  * lockstep with the form's own paint.
  */
 function addFormFilterOptions(
+  values: Record<string, unknown>,
   board: BoardCatalogEntry | null,
   presentComponents: ReadonlySet<string>
 ): RenderFilterOptions {
@@ -25,6 +26,7 @@ function addFormFilterOptions(
     showAdvanced: false,
     presentComponents,
     board,
+    values,
   });
 }
 
@@ -42,7 +44,7 @@ export function addFormRenderablePaths(
   return collectRenderablePaths(
     entries,
     values,
-    addFormFilterOptions(board, presentComponents)
+    addFormFilterOptions(values, board, presentComponents)
   );
 }
 
@@ -62,13 +64,19 @@ export function addFormNeedsUserInput(
   board: BoardCatalogEntry | null,
   presentComponents: ReadonlySet<string>
 ): boolean {
-  const opts = addFormFilterOptions(board, presentComponents);
+  const opts = addFormFilterOptions(values, board, presentComponents);
   const plan = buildFormRenderPlan(entries, values, requiredGroups, opts);
   // Group/cluster members are unfiltered in the plan; gate them on the same
   // visibility the form uses so a hidden unlocked member can't keep the form
   // open when every rendered field is board-locked.
   const isVisible = (entry: ConfigEntry): boolean =>
-    isEntryVisible(entry, values, opts.presentComponents, opts.targetPlatform ?? null);
+    isEntryVisible(
+      entry,
+      values,
+      opts.presentComponents,
+      opts.targetPlatform ?? null,
+      opts.rootValues
+    );
   if (planNeedsUserInput(plan, isVisible)) return true;
   // Pure-cardinality groups with no cluster box surface a banner only when
   // unsatisfied; keys are irrelevant to presence, so format to "".

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -327,12 +327,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
   private _filterRenderable = (
     entries: ConfigEntry[],
     values: Record<string, unknown>
-  ): ConfigEntry[] =>
-    filterRenderable(
-      entries,
-      values,
-      renderFilterOptions(this, { rootValues: this.values })
-    );
+  ): ConfigEntry[] => filterRenderable(entries, values, renderFilterOptions(this));
 
   protected render() {
     const ctx = this._buildCtx();
@@ -359,7 +354,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
       entries,
       this.values,
       this.requiredGroups,
-      renderFilterOptions(this, { rootValues: this.values })
+      renderFilterOptions(this)
     );
     const renderItem = this._makeItemRenderer(plan, ctx);
     return html`${this._renderConstraintBanners(ctx, plan.memberKeys)}${plan.ordered.map(
@@ -378,7 +373,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
       entries,
       this.values,
       this.requiredGroups,
-      renderFilterOptions(this, { showAdvanced: true, rootValues: this.values })
+      renderFilterOptions(this, { showAdvanced: true })
     );
     const renderItem = this._makeItemRenderer(plan, ctx);
     const isAdvanced = this._advancedUnitClassifier(plan);

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -327,7 +327,12 @@ export class ESPHomeConfigEntryForm extends LitElement {
   private _filterRenderable = (
     entries: ConfigEntry[],
     values: Record<string, unknown>
-  ): ConfigEntry[] => filterRenderable(entries, values, renderFilterOptions(this));
+  ): ConfigEntry[] =>
+    filterRenderable(
+      entries,
+      values,
+      renderFilterOptions(this, { rootValues: this.values })
+    );
 
   protected render() {
     const ctx = this._buildCtx();
@@ -354,7 +359,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
       entries,
       this.values,
       this.requiredGroups,
-      renderFilterOptions(this)
+      renderFilterOptions(this, { rootValues: this.values })
     );
     const renderItem = this._makeItemRenderer(plan, ctx);
     return html`${this._renderConstraintBanners(ctx, plan.memberKeys)}${plan.ordered.map(
@@ -373,7 +378,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
       entries,
       this.values,
       this.requiredGroups,
-      renderFilterOptions(this, { showAdvanced: true })
+      renderFilterOptions(this, { showAdvanced: true, rootValues: this.values })
     );
     const renderItem = this._makeItemRenderer(plan, ctx);
     const isAdvanced = this._advancedUnitClassifier(plan);

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -82,6 +82,13 @@ export interface RenderFilterOptions {
    * add-component dialog when no board is selected yet.
    */
   targetPlatform?: string | null;
+  /**
+   * The component-root value map, forwarded to ``isEntryVisible`` so a
+   * nested entry's ``depends_on`` can resolve a top-level field (e.g.
+   * esp32 ``framework.advanced.sram1_as_iram`` gated on ``variant``).
+   * Omit and ``depends_on`` stays sibling-scoped.
+   */
+  rootValues?: Record<string, unknown>;
 }
 
 /** The form-level inputs to ``filterRenderable``. Both the form element
@@ -158,7 +165,15 @@ export function filterRenderable(
 ): ConfigEntry[] {
   const out: ConfigEntry[] = [];
   for (const entry of entries) {
-    if (!isEntryVisible(entry, values, opts.presentComponents, opts.targetPlatform)) {
+    if (
+      !isEntryVisible(
+        entry,
+        values,
+        opts.presentComponents,
+        opts.targetPlatform,
+        opts.rootValues
+      )
+    ) {
       continue;
     }
     if (entry.advanced && !opts.showAdvanced && !hasMaterialValue(entry, values)) {

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -99,6 +99,12 @@ export interface RenderFilterSource {
   showAdvanced: boolean;
   presentComponents: ReadonlySet<string>;
   board: BoardCatalogEntry | null;
+  /** The component-root value map, forwarded as ``rootValues`` so a nested
+   *  entry's ``depends_on`` can resolve a top-level field. Sourced here (not
+   *  per call site) so every caller — the form, the add-component filter — is
+   *  covered without remembering to pass it. A nested-scope caller whose local
+   *  ``values`` isn't the root passes an explicit ``rootValues`` override. */
+  values?: Record<string, unknown>;
 }
 
 /** Build ``RenderFilterOptions`` from a *source*, with optional overrides
@@ -112,6 +118,7 @@ export function renderFilterOptions(
     showAdvanced: source.showAdvanced,
     presentComponents: source.presentComponents,
     targetPlatform: source.board?.esphome.platform ?? null,
+    rootValues: source.values,
     ...overrides,
   };
 }

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -523,7 +523,7 @@ export function renderChildEntries(
     ? filterRenderable(
         entry.config_entries ?? [],
         values,
-        renderFilterOptions(ctx, { showAdvanced: true })
+        renderFilterOptions(ctx, { showAdvanced: true, rootValues: ctx.scopeValues([]) })
       )
     : ctx.filterRenderable(entry.config_entries ?? [], values);
   return children.map((child) => ctx.renderEntry(child, [...path, child.key]));

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -48,6 +48,13 @@ export function platformSupported(
  * without device-wide context — e.g. add-component before insertion
  * with no board picked — should leave them undefined).
  *
+ * `rootValues` is the component-root value map. A nested entry can
+ * depend on a field it isn't a sibling of (e.g. esp32
+ * ``framework.advanced.sram1_as_iram`` gated on the top-level
+ * ``variant``); ``depends_on`` resolves in ``values`` first, then
+ * falls back to ``rootValues``. Omit it and ``depends_on`` stays
+ * sibling-scoped as before.
+ *
  * Used by both ``filterRenderable`` (deciding what to paint) and
  * ``validateEntries`` (deciding what to validate). Keeping the
  * predicate in one place means a hidden-by-platform field can't be
@@ -58,7 +65,8 @@ export function isEntryVisible(
   entry: ConfigEntry,
   values: Record<string, unknown>,
   presentComponents?: ReadonlySet<string>,
-  targetPlatform?: string | null
+  targetPlatform?: string | null,
+  rootValues?: Record<string, unknown>
 ): boolean {
   if (entry.hidden && !isValuePresent(values[entry.key])) return false;
 
@@ -74,8 +82,13 @@ export function isEntryVisible(
 
   if (!entry.depends_on) return true;
   // The backend sets at most one of the three gate fields, so the
-  // check order below is immaterial.
-  const depValue = values[entry.depends_on];
+  // check order below is immaterial. Resolve the dependency in the
+  // local scope first, then fall back to the component root so a
+  // nested entry can gate on a top-level field.
+  const depValue =
+    entry.depends_on in values
+      ? values[entry.depends_on]
+      : rootValues?.[entry.depends_on];
   if (entry.depends_on_value !== null && entry.depends_on_value !== undefined) {
     return depValue === entry.depends_on_value;
   }
@@ -312,7 +325,8 @@ export function validateEntries(
     targetPlatform,
     [],
     errors,
-    sectionKey
+    sectionKey,
+    values
   );
   return errors;
 }
@@ -330,12 +344,14 @@ function _validateEntriesRecursive(
   targetPlatform: string | null | undefined,
   pathPrefix: string[],
   errors: Map<string, ValidationError>,
-  sectionKey: string | undefined
+  sectionKey: string | undefined,
+  rootValues: Record<string, unknown>
 ): void {
   for (const entry of entries) {
     // Skip hidden entries and those whose visibility predicates fail —
     // we don't want to require fields the user can't even see.
-    if (!isEntryVisible(entry, values, presentComponents, targetPlatform)) continue;
+    if (!isEntryVisible(entry, values, presentComponents, targetPlatform, rootValues))
+      continue;
 
     if (entry.type === ConfigEntryType.NESTED) {
       const childSchema = entry.config_entries ?? [];
@@ -374,7 +390,8 @@ function _validateEntriesRecursive(
             targetPlatform,
             [...pathPrefix, entry.key, String(idx)],
             errors,
-            sectionKey
+            sectionKey,
+            rootValues
           );
         });
         continue;
@@ -398,7 +415,8 @@ function _validateEntriesRecursive(
         targetPlatform,
         [...pathPrefix, entry.key],
         errors,
-        sectionKey
+        sectionKey,
+        rootValues
       );
       continue;
     }

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -85,10 +85,9 @@ export function isEntryVisible(
   // check order below is immaterial. Resolve the dependency in the
   // local scope first, then fall back to the component root so a
   // nested entry can gate on a top-level field.
-  const depValue =
-    entry.depends_on in values
-      ? values[entry.depends_on]
-      : rootValues?.[entry.depends_on];
+  const depValue = Object.prototype.hasOwnProperty.call(values, entry.depends_on)
+    ? values[entry.depends_on]
+    : rootValues?.[entry.depends_on];
   if (entry.depends_on_value !== null && entry.depends_on_value !== undefined) {
     return depValue === entry.depends_on_value;
   }

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -55,13 +55,15 @@ export function platformSupported(
  * falls back to ``rootValues``. Omit it and ``depends_on`` stays
  * sibling-scoped as before.
  *
- * Resolution is by key name: a *set* local sibling always wins, but a
+ * Resolution is by key *presence*, not value: a local sibling whose key
+ * exists on ``values`` wins (even if its value is ``undefined``); only a
  * key absent from ``values`` falls through to ``rootValues``. So a
  * ``depends_on`` names either a local sibling or a component-root field
  * — not both. The backend keeps ``depends_on`` targets from colliding
- * across nesting levels, so an unset sibling can't be mistaken for a
- * same-named root field. (A future explicit root-vs-sibling scope
- * marker on the gate would remove the reliance on name uniqueness.)
+ * across nesting levels, so an absent local key can't resolve against a
+ * same-named root field it wasn't meant to. (A future explicit
+ * root-vs-sibling scope marker would remove the reliance on name
+ * uniqueness.)
  *
  * Used by both ``filterRenderable`` (deciding what to paint) and
  * ``validateEntries`` (deciding what to validate). Keeping the

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -55,6 +55,14 @@ export function platformSupported(
  * falls back to ``rootValues``. Omit it and ``depends_on`` stays
  * sibling-scoped as before.
  *
+ * Resolution is by key name: a *set* local sibling always wins, but a
+ * key absent from ``values`` falls through to ``rootValues``. So a
+ * ``depends_on`` names either a local sibling or a component-root field
+ * — not both. The backend keeps ``depends_on`` targets from colliding
+ * across nesting levels, so an unset sibling can't be mistaken for a
+ * same-named root field. (A future explicit root-vs-sibling scope
+ * marker on the gate would remove the reliance on name uniqueness.)
+ *
  * Used by both ``filterRenderable`` (deciding what to paint) and
  * ``validateEntries`` (deciding what to validate). Keeping the
  * predicate in one place means a hidden-by-platform field can't be

--- a/test/components/device/add-component-form-filter.test.ts
+++ b/test/components/device/add-component-form-filter.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { addFormNeedsUserInput } from "../../../src/components/device/add-component-form-filter.js";
-import { makeConfigEntry } from "../../util/_make-config-entry.js";
+import {
+  addFormNeedsUserInput,
+  addFormRenderablePaths,
+} from "../../../src/components/device/add-component-form-filter.js";
+import { makeConfigEntry, makeNestedEntry } from "../../util/_make-config-entry.js";
 
 const NONE = new Set<string>();
 
@@ -97,5 +100,42 @@ describe("addFormNeedsUserInput", () => {
       }),
     ];
     expect(addFormNeedsUserInput(entries, {}, [], ESP32, NONE)).toBe(false);
+  });
+});
+
+describe("addFormRenderablePaths resolves a root-scoped depends_on", () => {
+  // A nested field gated on a top-level sibling (the esp32 sram1_as_iram /
+  // variant case): the add-form paint mirror must resolve `variant` against
+  // the component root, not the empty nested scope, or it drifts from
+  // validateEntries and bails the submit silently.
+  const entries = [
+    makeNestedEntry("advanced", [
+      makeConfigEntry({
+        key: "sram1_as_iram",
+        required: true,
+        depends_on: "variant",
+        depends_on_value_any: ["esp32"],
+      }),
+    ]),
+  ];
+
+  it("paints the nested field when the root variant matches", () => {
+    const paths = addFormRenderablePaths(
+      entries,
+      { variant: "esp32", advanced: {} },
+      null,
+      NONE
+    );
+    expect(paths.has("advanced.sram1_as_iram")).toBe(true);
+  });
+
+  it("drops it when the root variant doesn't match", () => {
+    const paths = addFormRenderablePaths(
+      entries,
+      { variant: "esp32c2", advanced: {} },
+      null,
+      NONE
+    );
+    expect(paths.has("advanced.sram1_as_iram")).toBe(false);
   });
 });

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -3,6 +3,7 @@ import type { ConfigValueOption } from "../../src/api/types/config-entries.js";
 import { ConfigEntryType } from "../../src/api/types/config-entries.js";
 import {
   getDeviceNameWarning,
+  isEntryVisible,
   nearCanonicalOption,
   platformSupported,
   validateDeviceName,
@@ -61,6 +62,45 @@ describe("getDeviceNameWarning", () => {
   it("returns null for clean hyphenated names", () => {
     expect(getDeviceNameWarning("my-device")).toBeNull();
     expect(getDeviceNameWarning("device42")).toBeNull();
+  });
+});
+
+describe("isEntryVisible depends_on resolution", () => {
+  const gated = makeEntry({
+    key: "sram1_as_iram",
+    depends_on: "variant",
+    depends_on_value_any: ["esp32", "ESP32"],
+  });
+
+  it("resolves depends_on against a sibling in the local scope", () => {
+    expect(isEntryVisible(gated, { variant: "esp32" })).toBe(true);
+    expect(isEntryVisible(gated, { variant: "esp32c2" })).toBe(false);
+  });
+
+  it("falls back to rootValues when the dependency isn't a local sibling", () => {
+    // sram1_as_iram is nested under framework.advanced; `variant` lives at
+    // the component root, so the local (advanced-group) scope lacks it.
+    expect(isEntryVisible(gated, {}, undefined, undefined, { variant: "esp32" })).toBe(
+      true
+    );
+    expect(isEntryVisible(gated, {}, undefined, undefined, { variant: "ESP32" })).toBe(
+      true
+    );
+    expect(isEntryVisible(gated, {}, undefined, undefined, { variant: "esp32c2" })).toBe(
+      false
+    );
+  });
+
+  it("prefers a local sibling over rootValues when both carry the key", () => {
+    expect(
+      isEntryVisible(gated, { variant: "esp32c2" }, undefined, undefined, {
+        variant: "esp32",
+      })
+    ).toBe(false);
+  });
+
+  it("without rootValues, an unresolved cross-scope dependency hides the entry", () => {
+    expect(isEntryVisible(gated, {})).toBe(false);
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Lets a nested config entry's `depends_on` predicate resolve against the component-root value map, not just its immediate sibling scope.

`isEntryVisible` resolved `depends_on` against the scoped `values` passed to it, and both the render filter (`renderChildEntries` → `ctx.scopeValues(path)`) and the validation recursion re-scope `values` when descending into a NESTED group. So a nested field could only depend on a sibling in its own group — a field like esp32 `framework.advanced.sram1_as_iram` had no way to gate on the top-level `variant`.

Now `isEntryVisible` takes an optional `rootValues` and resolves `depends_on` in the local scope first (own-key check), then falls back to the component root. `rootValues` is sourced once from `RenderFilterSource.values` inside `renderFilterOptions`, so every caller that builds options gets it without a per-site override — the section-editor form and the add-component filter alike (a nested-scope caller whose local `values` isn't the root passes an explicit override). It's carried unchanged through the render recursion like `targetPlatform`, and threaded through `validateEntries` (the top-level `values` is the root). Omit it and `depends_on` stays sibling-scoped exactly as before, so existing gates (e.g. ethernet type) are unaffected.

Sourcing it centrally keeps the two visibility consumers in lockstep: `validateEntries` (what gets validated) and the add-component form's `collectRenderablePaths` / error-visibility check (what the user can see) resolve a root-gated nested field the same way, so a required cross-scope field can't be validated-visible but paint-hidden (the PR #226 failure mode). Covered by tests through both `isEntryVisible` and `addFormRenderablePaths`.

This is the frontend half of gating esp32 `sram1_as_iram` to the classic ESP32 variant; the backend companion (esphome/device-builder#1950) stamps `depends_on: variant` on the field. Verified together in the editor: with `variant: esp32` the Advanced group + toggle render; with `variant: ESP32C2` both disappear.

**Related issue or feature (if applicable):**

Backend companion: esphome/device-builder#1950. Surfaced from esphome/device-builder#1948.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
