### PR TITLE
Show the resolved substitution hint under multi-value list rows

### DIFF
--- a/src/components/device/config-entry-form.styles.ts
+++ b/src/components/device/config-entry-form.styles.ts
@@ -295,6 +295,15 @@ export const configEntryFormStyles = css`
     cursor: not-allowed;
   }
 
+  /* Stacks a row's input above its substitution hint while the remove
+     button stays beside the input column. */
+  .multi-row .multi-value-cell {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
   .combobox-input {
     font-family: inherit;
     font-size: var(--wa-font-size-s);

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -11,6 +11,7 @@ import {
   labelFor,
   renderFieldError,
   renderLabel,
+  renderSubstitutionHint,
   renderYamlOnlyField,
   type RenderCtx,
 } from "../config-entry-renderers-shared.js";
@@ -137,16 +138,27 @@ export function renderMultiValueField(
       ${items.map(
         (item, i) => html`
           <div class="multi-row">
-            <input
-              type=${numeric ? "number" : "text"}
-              step=${
-                numeric ? (entry.type === ConfigEntryType.FLOAT ? "any" : "1") : nothing
+            <div class="multi-value-cell">
+              <input
+                type=${numeric ? "number" : "text"}
+                step=${
+                  numeric ? (entry.type === ConfigEntryType.FLOAT ? "any" : "1") : nothing
+                }
+                class="multi-input ${invalid ? "invalid" : ""}"
+                .value=${item}
+                ?disabled=${disabled}
+                @input=${(e: Event) => updateAt(i, (e.target as HTMLInputElement).value)}
+              />
+              ${
+                // Resolve against the stored value, not the escaped display
+                // form the input shows.
+                renderSubstitutionHint(
+                  String(raw[i] ?? ""),
+                  ctx.substitutions,
+                  ctx.localize
+                )
               }
-              class="multi-input ${invalid ? "invalid" : ""}"
-              .value=${item}
-              ?disabled=${disabled}
-              @input=${(e: Event) => updateAt(i, (e.target as HTMLInputElement).value)}
-            />
+            </div>
             ${renderListRemoveButton(ctx, disabled, () => removeAt(i))}
           </div>
         `

--- a/test/components/device/render-multi-value-field-substitution.test.ts
+++ b/test/components/device/render-multi-value-field-substitution.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Pins that ``renderMultiValueField`` previews resolved substitutions per
+ * row, matching the single-value string renderer (sntp ``servers:`` holding
+ * three server substitutions).
+ */
+import { describe, expect, it } from "vitest";
+
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
+import { renderMultiValueField } from "../../../src/components/device/config-entry-renderers.js";
+import { makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
+
+const YAML = [
+  "substitutions:",
+  "  sntp_server_1: 0.pool.ntp.org",
+  "  sntp_server_2: 1.pool.ntp.org",
+  "time:",
+  "  - platform: sntp",
+  "",
+].join("\n");
+
+function ctxFor(items: unknown[]): RenderCtx {
+  return makeRenderCtx(
+    { servers: items },
+    { overrides: { sectionKey: "time", yaml: YAML } }
+  );
+}
+
+const serialize = (tpl: unknown): string =>
+  JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+
+describe("renderMultiValueField — substitution preview", () => {
+  it("previews the resolved value for each row that references a substitution", () => {
+    const json = serialize(
+      renderMultiValueField(
+        makeEntry(ConfigEntryType.STRING),
+        ["servers"],
+        ctxFor(["${sntp_server_1}", "${sntp_server_2}"])
+      )
+    );
+    expect(json).toContain("substitution-note");
+    expect(json).toContain("0.pool.ntp.org");
+    expect(json).toContain("1.pool.ntp.org");
+  });
+
+  it("shows no preview for plain rows", () => {
+    const json = serialize(
+      renderMultiValueField(
+        makeEntry(ConfigEntryType.STRING),
+        ["servers"],
+        ctxFor(["2.pool.ntp.org"])
+      )
+    );
+    expect(json).not.toContain("substitution-note");
+  });
+
+  it("flags an unresolved reference with the external marker", () => {
+    const json = serialize(
+      renderMultiValueField(
+        makeEntry(ConfigEntryType.STRING),
+        ["servers"],
+        ctxFor(["${sntp_server_3}"])
+      )
+    );
+    expect(json).toContain("substitution-note--external");
+    expect(json).toContain("substitution-warn");
+  });
+});

--- a/test/util/device-search.test.ts
+++ b/test/util/device-search.test.ts
@@ -7,8 +7,8 @@ import {
   type DeviceRowSearchFields,
 } from "../../src/util/device-search.js";
 import {
-  type ConfiguredDeviceOverrides,
   makeConfiguredDevice,
+  type ConfiguredDeviceOverrides,
 } from "../_make-configured-device.js";
 
 function _device(overrides: ConfiguredDeviceOverrides = {}): ConfiguredDevice {


### PR DESCRIPTION
# What does this implement/fix?

Single-value string fields show a resolved-substitution chip under the input (the `{}` badge with the value the `${var}` resolves to), but rows of a multi-value list never did. An sntp `servers:` list holding `${sntp_server_1}` / `${sntp_server_2}` / `${sntp_server_3}` rendered three bare inputs with no hint of what they resolve to, while `update_interval: ${sntp_update_interval}` right above showed its `6h` chip.

`renderMultiValueField` now renders the same `renderSubstitutionHint` under each row, resolved from the stored item value (not the escaped display form). Each row's input and hint stack in a new `multi-value-cell` column so the remove button stays beside the input; rows without a substitution reference render exactly as before. The unresolved-reference marker works per row too.

A first commit formats `test/util/device-search.test.ts` (one import-order line); it landed on main unformatted and the pre-commit `format:check` blocks every commit until it's fixed.

Verified live against a config mirroring the report: all three server rows show their resolved `pool.ntp.org` chips, matching Update Interval.

**Related issue or feature (if applicable):**

- reported directly with a screenshot of the sntp time editor; no issue filed

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
