### PR TITLE
Resolve variant depends_on against the board's implied variant

### DIFF
--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -105,6 +105,29 @@ export interface RenderFilterSource {
    *  covered without remembering to pass it. A nested-scope caller whose local
    *  ``values`` isn't the root passes an explicit ``rootValues`` override. */
   values?: Record<string, unknown>;
+  /** The YAML section this form renders (``esp32`` / ``wifi`` / ``sensor`` …).
+   *  Used to seed board-implied values only on the platform section. */
+  sectionKey?: string;
+}
+
+/**
+ * Layer the board's implied ``esphome`` fields under *rootValues* when the form
+ * renders its platform section (``esp32`` / ``esp8266`` / ``rp2040``).
+ *
+ * A board fixes its ``variant`` (``esp32-poe-iso`` → ``esp32``) even when the
+ * user never writes ``variant:`` in YAML, so a field gated on it — esp32
+ * ``framework.advanced.sram1_as_iram`` — must resolve its ``depends_on``
+ * against the board. Explicit YAML wins (spread last); other sections and the
+ * boardless variant-only config are untouched.
+ */
+function seedBoardImpliedRootValues(
+  rootValues: Record<string, unknown> | undefined,
+  source: RenderFilterSource
+): Record<string, unknown> | undefined {
+  const esphome = source.board?.esphome;
+  if (!esphome || source.sectionKey !== esphome.platform) return rootValues;
+  if (esphome.variant == null) return rootValues;
+  return { variant: esphome.variant, ...rootValues };
 }
 
 /** Build ``RenderFilterOptions`` from a *source*, with optional overrides
@@ -113,7 +136,7 @@ export function renderFilterOptions(
   source: RenderFilterSource,
   overrides: Partial<RenderFilterOptions> = {}
 ): RenderFilterOptions {
-  return {
+  const opts: RenderFilterOptions = {
     requiredOnly: source.requiredOnly,
     showAdvanced: source.showAdvanced,
     presentComponents: source.presentComponents,
@@ -121,6 +144,10 @@ export function renderFilterOptions(
     rootValues: source.values,
     ...overrides,
   };
+  // Seed after overrides so an explicit ``rootValues`` (the nested renderer's
+  // ``scopeValues([])``) still inherits the board's variant.
+  opts.rootValues = seedBoardImpliedRootValues(opts.rootValues, source);
+  return opts;
 }
 
 /**

--- a/test/components/device/config-entry-render-filter.test.ts
+++ b/test/components/device/config-entry-render-filter.test.ts
@@ -4,6 +4,8 @@ import {
   ALWAYS_SHOWN_KEYS,
   collectRenderablePaths,
   filterRenderable,
+  renderFilterOptions,
+  type RenderFilterSource,
 } from "../../../src/components/device/config-entry-render-filter.js";
 import { YamlRawValue } from "../../../src/util/yaml-serialize.js";
 import { makeConfigEntry as makeEntry } from "../../util/_make-config-entry.js";
@@ -847,5 +849,75 @@ describe("filterRenderable — NESTED with a scalar value", () => {
       { requiredOnly: false, showAdvanced: false }
     );
     expect(out.map((e) => e.key)).toEqual(["mode"]);
+  });
+});
+
+describe("renderFilterOptions board-implied variant seeding", () => {
+  // esp32 framework.advanced.sram1_as_iram gated on the top-level variant.
+  const sram1 = () =>
+    makeEntry({
+      key: "framework",
+      type: ConfigEntryType.NESTED,
+      config_entries: [
+        makeEntry({
+          key: "advanced",
+          type: ConfigEntryType.NESTED,
+          config_entries: [
+            makeEntry({
+              key: "sram1_as_iram",
+              depends_on: "variant",
+              depends_on_value_any: ["esp32", "ESP32"],
+            }),
+          ],
+        }),
+      ],
+    });
+
+  const boardEsp32 = { esphome: { platform: "esp32", variant: "esp32" } } as never;
+
+  const source = (over: Partial<RenderFilterSource>): RenderFilterSource => ({
+    requiredOnly: false,
+    showAdvanced: true,
+    presentComponents: new Set<string>(),
+    board: null,
+    sectionKey: "esp32",
+    ...over,
+  });
+
+  const sramVisible = (src: RenderFilterSource): boolean => {
+    const fw = filterRenderable([sram1()], src.values ?? {}, renderFilterOptions(src));
+    const adv = fw[0]?.config_entries?.[0]?.config_entries ?? [];
+    // filterRenderable is applied per nested scope by the renderer; re-run it
+    // on the leaf with the same (seeded) opts to mirror the recursion.
+    return (
+      filterRenderable(adv, {}, renderFilterOptions(src)).some(
+        (e) => e.key === "sram1_as_iram"
+      ) && fw.length > 0
+    );
+  };
+
+  it("shows a variant-gated field on the platform section when the board fixes the variant", () => {
+    // board: esp32-poe-iso implies variant esp32; no explicit variant in YAML.
+    expect(sramVisible(source({ board: boardEsp32, values: {} }))).toBe(true);
+  });
+
+  it("keeps the field hidden with no board and no explicit variant", () => {
+    expect(sramVisible(source({ board: null, values: {} }))).toBe(false);
+  });
+
+  it("does not seed the variant outside the platform section", () => {
+    // A different section (sensor) must not inherit the board's variant.
+    expect(
+      sramVisible(source({ board: boardEsp32, sectionKey: "sensor", values: {} }))
+    ).toBe(false);
+  });
+
+  it("lets an explicit YAML variant override the board", () => {
+    // Board says esp32, YAML says esp32s3 → gate fails (s3 not in the any-list).
+    expect(
+      sramVisible(source({ board: boardEsp32, values: { variant: "esp32s3" } }))
+    ).toBe(false);
+    // Explicit matching variant with no board still resolves.
+    expect(sramVisible(source({ board: null, values: { variant: "ESP32" } }))).toBe(true);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

A config field gated on the top-level esp32 `variant` — the clearest case is `framework.advanced.sram1_as_iram` — stayed hidden in the visual editor whenever the board was selected but `variant:` wasn't written in the YAML. With

```yaml
esp32:
  board: esp32-poe-iso
  framework:
    type: esp-idf
    advanced:
      sram1_as_iram: true
```

the field only appeared after manually adding `variant: ESP32`.

The gate is `depends_on: variant` / `depends_on_value_any: ["esp32", "ESP32"]`, and `isEntryVisible` resolves `depends_on` only against explicit form values (local scope, then the component root). A board *fixes* its variant (`esp32-poe-iso` → `esp32`, exposed as `board.esphome.variant`) even when the user never writes `variant:`, but that implied value never entered the resolution, so `depends_on_value_any.includes(undefined)` was false and the field was filtered out.

`renderFilterOptions` now seeds the platform section's `rootValues` with the board's `esphome.variant` before `depends_on` resolution, layered *under* explicit values so YAML still wins. It's scoped to the platform section (`sectionKey === board.esphome.platform`), so other component forms and a boardless variant-only config are untouched. `variant` is the only board-implied `depends_on` target in the whole catalog, so nothing else changes. The seed runs after any `rootValues` override, so the nested renderer's `scopeValues([])` path inherits it too.

**Related issue or feature (if applicable):**

Completes the `sram1_as_iram` surfacing work (backend esphome/device-builder#1952 exposed the field + variant gate; this is the frontend half that makes the gate resolve from the board).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
