### PR TITLE
Gate all-advanced component sections behind the advanced control

### DIFF
--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -200,6 +200,14 @@ export class ESPHomeConfigEntryForm extends LitElement {
   @property({ type: Boolean, attribute: "force-advanced-control" })
   forceAdvancedControl = false;
 
+  /** Keep an all-advanced form gated behind the "Advanced settings" control
+   *  instead of auto-opening it. The device section editor sets this so an
+   *  all-advanced component (captive_portal) hides its fields with the toggle
+   *  off; automation action/trigger/condition nodes leave it off so their
+   *  all-advanced params still show inline. */
+  @property({ type: Boolean, attribute: "gate-all-advanced" })
+  gateAllAdvanced = false;
+
   /** Added to the advanced-section "(N)" count for that external content. */
   @property({ type: Number, attribute: "advanced-extra-count" })
   advancedExtraCount = 0;
@@ -392,11 +400,14 @@ export class ESPHomeConfigEntryForm extends LitElement {
     const forceOpen = this._advancedForceOpen();
     // all-advanced auto-opens (an all-advanced action shows its fields with no
     // control) EXCEPT when the owner gates external content (script Parameters)
-    // through the control: there the user must drive it, or the host's
-    // showAdvanced never flips and the external block stays unreachable.
-    const open =
-      this.showAdvanced || forceOpen || (allAdvanced && !this.forceAdvancedControl);
-    const showControl = this.forceAdvancedControl || (hasAdvanced && !allAdvanced);
+    // through the control, or the device section editor opts out via
+    // gateAllAdvanced so an all-advanced component (captive_portal) still hides
+    // its fields behind the control instead of painting them open.
+    const autoOpenAllAdvanced =
+      allAdvanced && !this.forceAdvancedControl && !this.gateAllAdvanced;
+    const open = this.showAdvanced || forceOpen || autoOpenAllAdvanced;
+    const showControl =
+      this.forceAdvancedControl || (hasAdvanced && !autoOpenAllAdvanced);
     const count = advanced.length + this.advancedExtraCount;
     return html`${this._renderConstraintBanners(ctx, plan.memberKeys)}${basic.map(
       renderItem

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -385,8 +385,16 @@ export class ESPHomeConfigEntryForm extends LitElement {
     );
     const renderItem = this._makeItemRenderer(plan, ctx);
     const isAdvanced = this._advancedUnitClassifier(plan);
-    const basic = plan.ordered.filter((item) => !isAdvanced(item));
-    const advanced = plan.ordered.filter((item) => isAdvanced(item));
+    // Split only units that actually paint: a plain entry filtered out of
+    // ``plan.visible`` (advanced+hidden like captive_portal's setup_priority, or
+    // a depends_on that isn't met) renders nothing, so it must not inflate the
+    // "(N)" count or tip the all-advanced check. Groups/clusters paint via their
+    // own path, so they always count.
+    const willRender = (item: ConfigEntry | ConfigEntry[]): boolean =>
+      Array.isArray(item) || plan.memberKeys.has(item.key) || plan.visible.has(item);
+    const rendered = plan.ordered.filter(willRender);
+    const basic = rendered.filter((item) => !isAdvanced(item));
+    const advanced = rendered.filter((item) => isAdvanced(item));
     // Control visibility is recursive: a nested advanced field reveals in place
     // (it can't move to the bottom section), so the control must surface even
     // when no top-level unit is advanced, or that field stays unreachable.

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -38,7 +38,7 @@ import {
   catalogEntryToProvider,
   type ComponentProvider,
 } from "../../util/config-entry-yaml-scan.js";
-import { type ValidationError } from "../../util/config-validation.js";
+import { isEntryVisible, type ValidationError } from "../../util/config-validation.js";
 import { resolveDeviceName } from "../../util/device-name.js";
 import { getErrorMessage } from "../../util/error-message.js";
 import { fetchAllComponents } from "../../util/fetch-all-components.js";
@@ -389,12 +389,23 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // ``plan.visible`` (advanced+hidden like captive_portal's setup_priority, or
     // a depends_on that isn't met) renders nothing, so it must not inflate the
     // "(N)" count or tip the all-advanced check. An exclusive group is one
-    // dropdown; a constraint cluster is one box painted at its *first* member's
-    // slot (the other member slots render nothing), so it counts once.
-    const clusterFirstKeys = new Set(plan.clusters.map((c) => c.members[0].key));
+    // dropdown. A constraint cluster is one box painted at its *first* member's
+    // slot, and only when a member is renderable — ``renderConstraintClusterField``
+    // returns nothing when every member is gated off, so mirror that predicate
+    // here or a fully-gated cluster still counts.
+    const targetPlatform = ctx.board?.esphome.platform ?? null;
+    const clusterRenders = (cluster: (typeof plan.clusters)[number]): boolean =>
+      cluster.members.some(
+        (m) =>
+          getIn(this.values, [m.key]) !== undefined ||
+          isEntryVisible(m, this.values, this.presentComponents, targetPlatform)
+      );
+    const renderedClusterKeys = new Set(
+      plan.clusters.filter(clusterRenders).map((c) => c.members[0].key)
+    );
     const willRender = (item: ConfigEntry | ConfigEntry[]): boolean => {
       if (Array.isArray(item)) return true;
-      if (plan.memberKeys.has(item.key)) return clusterFirstKeys.has(item.key);
+      if (plan.memberKeys.has(item.key)) return renderedClusterKeys.has(item.key);
       return plan.visible.has(item);
     };
     const rendered = plan.ordered.filter(willRender);

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -388,10 +388,15 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // Split only units that actually paint: a plain entry filtered out of
     // ``plan.visible`` (advanced+hidden like captive_portal's setup_priority, or
     // a depends_on that isn't met) renders nothing, so it must not inflate the
-    // "(N)" count or tip the all-advanced check. Groups/clusters paint via their
-    // own path, so they always count.
-    const willRender = (item: ConfigEntry | ConfigEntry[]): boolean =>
-      Array.isArray(item) || plan.memberKeys.has(item.key) || plan.visible.has(item);
+    // "(N)" count or tip the all-advanced check. An exclusive group is one
+    // dropdown; a constraint cluster is one box painted at its *first* member's
+    // slot (the other member slots render nothing), so it counts once.
+    const clusterFirstKeys = new Set(plan.clusters.map((c) => c.members[0].key));
+    const willRender = (item: ConfigEntry | ConfigEntry[]): boolean => {
+      if (Array.isArray(item)) return true;
+      if (plan.memberKeys.has(item.key)) return clusterFirstKeys.has(item.key);
+      return plan.visible.has(item);
+    };
     const rendered = plan.ordered.filter(willRender);
     const basic = rendered.filter((item) => !isAdvanced(item));
     const advanced = rendered.filter((item) => isAdvanced(item));

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -555,6 +555,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
                 .focusFieldPath=${this.focusFieldPath}
                 .presentComponents=${this._presentComponents}
                 advanced-section
+                gate-all-advanced
                 ?show-advanced=${showAdvanced}
                 @value-change=${this._onValueChange}
                 @advanced-toggle=${this._onAdvancedToggle}

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -3,7 +3,9 @@
  *
  * advanced-section mode: basic fields, then a "Show advanced settings" switch,
  * then the advanced fields below it (revealed when on). All-advanced forms
- * render with no control; the control emits ``advanced-toggle``.
+ * render with no control by default (automation nodes); with gate-all-advanced
+ * (the device section editor) they keep the control and stay collapsed. The
+ * control emits ``advanced-toggle``.
  */
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
@@ -34,6 +36,7 @@ function renderForm(
     showAdvanced?: boolean;
     values?: Record<string, unknown>;
     forceAdvancedControl?: boolean;
+    gateAllAdvanced?: boolean;
   } = {}
 ): HTMLElement {
   const form = new ESPHomeConfigEntryForm();
@@ -42,6 +45,7 @@ function renderForm(
   form.advancedSection = true;
   form.showAdvanced = opts.showAdvanced ?? false;
   form.forceAdvancedControl = opts.forceAdvancedControl ?? false;
+  form.gateAllAdvanced = opts.gateAllAdvanced ?? false;
   const container = document.createElement("div");
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   render((form as any).render(), container);
@@ -129,6 +133,27 @@ describe("config-entry-form advanced-section", () => {
     ]);
     expect(control(c)).toBeNull();
     expect(c.textContent ?? "").toContain("Only Advanced");
+  });
+
+  it("gates an all-advanced form behind the control with gate-all-advanced", () => {
+    // The device section editor sets gate-all-advanced so an all-advanced
+    // component (captive_portal) shows just the control, fields hidden until
+    // toggled — instead of the automation-node auto-open above.
+    const onlyAdvanced = makeConfigEntry({
+      key: "a",
+      type: ConfigEntryType.STRING,
+      label: "Only Advanced",
+      advanced: true,
+    });
+    const collapsed = renderForm([onlyAdvanced], { gateAllAdvanced: true });
+    expect(control(collapsed)).toBeTruthy();
+    expect(collapsed.textContent ?? "").not.toContain("Only Advanced");
+    const expanded = renderForm([onlyAdvanced], {
+      gateAllAdvanced: true,
+      showAdvanced: true,
+    });
+    expect(control(expanded)).toBeTruthy();
+    expect(expanded.textContent ?? "").toContain("Only Advanced");
   });
 
   it("emits advanced-toggle when the control is clicked", () => {

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -221,6 +221,43 @@ describe("config-entry-form advanced-section", () => {
     expect(text).not.toContain("Hidden Adv");
   });
 
+  it("counts a constraint cluster as one advanced unit, not per member", () => {
+    // Two advanced fields sharing an inclusive group fold into one cluster box
+    // painted at the first member's slot; the "(N)" count must be 1, not 2.
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [
+      makeConfigEntry({
+        key: "a",
+        type: ConfigEntryType.STRING,
+        label: "Clu A",
+        advanced: true,
+        group: "grp",
+      }),
+      makeConfigEntry({
+        key: "b",
+        type: ConfigEntryType.STRING,
+        label: "Clu B",
+        advanced: true,
+        group: "grp",
+      }),
+    ];
+    form.values = {};
+    form.advancedSection = true;
+    form.gateAllAdvanced = true;
+    form.showAdvanced = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any)._localize = (key: string, params?: { count?: number }) =>
+      key === "device.show_advanced_count"
+        ? `Show advanced settings (${params?.count})`
+        : key;
+    const container = document.createElement("div");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    render((form as any).render(), container);
+    const text = container.textContent ?? "";
+    expect(text).toContain("Show advanced settings (1)");
+    expect(text).not.toContain("Show advanced settings (2)");
+  });
+
   it("emits advanced-toggle when the control is clicked", () => {
     const form = new ESPHomeConfigEntryForm();
     form.entries = [BASIC, ADVANCED];

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -156,6 +156,25 @@ describe("config-entry-form advanced-section", () => {
     expect(expanded.textContent ?? "").toContain("Only Advanced");
   });
 
+  it("auto-opens a gated all-advanced form, locked, when a value is pre-filled", () => {
+    // A pre-filled advanced value forces the section open even under
+    // gate-all-advanced; the control stays visible but its switch is locked
+    // (can't collapse while a value is set).
+    const onlyAdvanced = makeConfigEntry({
+      key: "a",
+      type: ConfigEntryType.STRING,
+      label: "Only Advanced",
+      advanced: true,
+    });
+    const c = renderForm([onlyAdvanced], {
+      gateAllAdvanced: true,
+      values: { a: "set" },
+    });
+    expect(control(c)).toBeTruthy();
+    expect(c.textContent ?? "").toContain("Only Advanced");
+    expect(c.querySelector("wa-switch")!.hasAttribute("disabled")).toBe(true);
+  });
+
   it("counts only rendered advanced fields, not hidden ones, in the control label", () => {
     // captive_portal shape: two shown advanced fields + one advanced+hidden
     // field (setup_priority) that renders nothing. The "(N)" count must be 2.

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -258,6 +258,54 @@ describe("config-entry-form advanced-section", () => {
     expect(text).not.toContain("Show advanced settings (2)");
   });
 
+  it("does not count a constraint cluster whose members are all gated off", () => {
+    // The cluster renderer paints nothing when every member is hidden/gated, so
+    // it must not add to the count. One shown advanced field + a fully-hidden
+    // cluster ⇒ count is 1, not 2.
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [
+      makeConfigEntry({
+        key: "shown",
+        type: ConfigEntryType.STRING,
+        label: "Shown Adv",
+        advanced: true,
+      }),
+      makeConfigEntry({
+        key: "g1",
+        type: ConfigEntryType.STRING,
+        label: "Gated 1",
+        advanced: true,
+        group: "grp",
+        hidden: true,
+      }),
+      makeConfigEntry({
+        key: "g2",
+        type: ConfigEntryType.STRING,
+        label: "Gated 2",
+        advanced: true,
+        group: "grp",
+        hidden: true,
+      }),
+    ];
+    form.values = {};
+    form.advancedSection = true;
+    form.gateAllAdvanced = true;
+    form.showAdvanced = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any)._localize = (key: string, params?: { count?: number }) =>
+      key === "device.show_advanced_count"
+        ? `Show advanced settings (${params?.count})`
+        : key;
+    const container = document.createElement("div");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    render((form as any).render(), container);
+    const text = container.textContent ?? "";
+    expect(text).toContain("Show advanced settings (1)");
+    expect(text).not.toContain("Show advanced settings (2)");
+    expect(text).toContain("Shown Adv");
+    expect(text).not.toContain("Gated");
+  });
+
   it("emits advanced-toggle when the control is clicked", () => {
     const form = new ESPHomeConfigEntryForm();
     form.entries = [BASIC, ADVANCED];

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -306,6 +306,39 @@ describe("config-entry-form advanced-section", () => {
     expect(text).not.toContain("Gated");
   });
 
+  it("auto-opens an off-flag form whose only painting unit is advanced", () => {
+    // A non-painting basic unit (hidden, no value) alongside a painting advanced
+    // field is effectively all-advanced: an automation node (gate off) should
+    // auto-open it inline rather than gate the only visible field behind a
+    // control. The non-painting basic must not keep basic.length > 0.
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [
+      makeConfigEntry({
+        key: "hidden_basic",
+        type: ConfigEntryType.STRING,
+        label: "Hidden Basic",
+        hidden: true,
+      }),
+      makeConfigEntry({
+        key: "adv",
+        type: ConfigEntryType.STRING,
+        label: "Adv Field",
+        advanced: true,
+      }),
+    ];
+    form.values = {};
+    form.advancedSection = true;
+    form.gateAllAdvanced = false;
+    form.showAdvanced = false;
+    const container = document.createElement("div");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    render((form as any).render(), container);
+    // All-advanced auto-open: no control, the advanced field paints inline.
+    expect(control(container)).toBeNull();
+    expect(container.textContent ?? "").toContain("Adv Field");
+    expect(container.textContent ?? "").not.toContain("Hidden Basic");
+  });
+
   it("emits advanced-toggle when the control is clicked", () => {
     const form = new ESPHomeConfigEntryForm();
     form.entries = [BASIC, ADVANCED];

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -156,6 +156,52 @@ describe("config-entry-form advanced-section", () => {
     expect(expanded.textContent ?? "").toContain("Only Advanced");
   });
 
+  it("counts only rendered advanced fields, not hidden ones, in the control label", () => {
+    // captive_portal shape: two shown advanced fields + one advanced+hidden
+    // field (setup_priority) that renders nothing. The "(N)" count must be 2.
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [
+      makeConfigEntry({
+        key: "a",
+        type: ConfigEntryType.STRING,
+        label: "Adv A",
+        advanced: true,
+      }),
+      makeConfigEntry({
+        key: "b",
+        type: ConfigEntryType.STRING,
+        label: "Adv B",
+        advanced: true,
+      }),
+      makeConfigEntry({
+        key: "setup_priority",
+        type: ConfigEntryType.STRING,
+        label: "Hidden Adv",
+        advanced: true,
+        hidden: true,
+      }),
+    ];
+    form.values = {};
+    form.advancedSection = true;
+    form.gateAllAdvanced = true;
+    form.showAdvanced = true;
+    // Default _localize returns the key; interpolate so the count is observable.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any)._localize = (key: string, params?: { count?: number }) =>
+      key === "device.show_advanced_count"
+        ? `Show advanced settings (${params?.count})`
+        : key;
+    const container = document.createElement("div");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    render((form as any).render(), container);
+    const text = container.textContent ?? "";
+    expect(text).toContain("Show advanced settings (2)");
+    expect(text).not.toContain("Show advanced settings (3)");
+    expect(text).toContain("Adv A");
+    expect(text).toContain("Adv B");
+    expect(text).not.toContain("Hidden Adv");
+  });
+
   it("emits advanced-toggle when the control is clicked", () => {
     const form = new ESPHomeConfigEntryForm();
     form.entries = [BASIC, ADVANCED];


### PR DESCRIPTION
# What does this implement/fix?

In the device visual editor, an **all-advanced** component section rendered its advanced fields inline with the Advanced toggle off and no way to collapse them. The clearest case is `captive_portal:`, whose every field is advanced (`id`, `web_server_base_id`, `compression`; `setup_priority` is also `hidden`) — all three showed up even though they should sit behind "Advanced settings".

The advanced-section renderer (`config-entry-form.ts` `_renderWithAdvancedSection`) has an "all-advanced auto-opens with no control" branch. That's right for an automation **action** node (an all-advanced action should show its params inline rather than behind a toggle), but it fired unconditionally, so all-advanced component **sections** in the editor got the action behavior. This regressed when the section editor moved onto the advanced-section renderer (#1035); before that it used the flat path, which dropped advanced fields with the toggle off.

Fix: add a `gate-all-advanced` opt-out and set it on the device section editor (`device-section-config.ts`). When set, an all-advanced form keeps the "Advanced settings" control and stays collapsed (fields hidden until toggled; still auto-opens, locked, when a value is pre-filled). The default is off, so the gate/auto-open **expression** is unchanged for automation action/trigger/condition nodes and the script editor — it reduces algebraically to today's `allAdvanced && !forceAdvancedControl` when the flag is off.

One related refinement applies to **all** callers, not just gated sections: the `(N)` count and the `allAdvanced`/`basic`/`advanced` split are now taken from units that actually paint (`willRender`), not from `plan.ordered`, so non-painting entries (advanced+hidden like captive_portal's `setup_priority`, unmet-`depends_on` fields, fully-gated constraint clusters) no longer inflate the count or skew `allAdvanced`. This is a deliberate correctness improvement — not a behavioral no-op for off-flag callers: an automation node whose only painting unit is advanced (a non-painting hidden basic field beside it) now auto-opens inline instead of gating that sole visible field behind a control. Pinned by tests.

**Related issue or feature (if applicable):**

Regression from #1035 (advanced settings below the show-advanced switch). Reported for `captive_portal`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

