### PR TITLE
Hydrate the component body in the editor hover's catalog fallback

### DIFF
--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -573,15 +573,16 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
         }),
         lintErrorLineGutter
       );
+      // The device's platform/board, read per invocation so completion
+      // and hover share the structured editor's hydrated-body cache bucket.
+      const getDeviceTarget = () => ({
+        platform: this.board?.esphome.platform,
+        boardId: this.board?.id,
+      });
       // Schema-driven completion off the components catalog.
       extensions.push(
         autocompletion({
-          override: [
-            createYamlCompletionSource(this._api, () => ({
-              platform: this.board?.esphome.platform,
-              boardId: this.board?.id,
-            })),
-          ],
+          override: [createYamlCompletionSource(this._api, getDeviceTarget)],
           activateOnTyping: true,
           icons: true,
           closeOnBlur: true,
@@ -606,7 +607,11 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
       );
       // Catalog-backed hover docs (description + "See also" link).
       extensions.push(
-        createYamlHoverTooltip(this._api, () => this._localize("device.see_also"))
+        createYamlHoverTooltip(
+          this._api,
+          () => this._localize("device.see_also"),
+          getDeviceTarget
+        )
       );
     }
 

--- a/src/util/yaml-hover.ts
+++ b/src/util/yaml-hover.ts
@@ -19,6 +19,7 @@ import { html, nothing, render } from "lit";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { ComponentCatalogEntry } from "../api/types/components.js";
 import type { ConfigEntry } from "../api/types/config-entries.js";
+import { fetchComponent } from "./component-name-cache.js";
 import {
   getActions,
   getComponentDocs,
@@ -35,6 +36,7 @@ import {
   isUnderAutomationItem,
   resolveBundleContext,
 } from "./yaml-ast.js";
+import { descendNestedEntries } from "./yaml-completion-catalog.js";
 import { bundleFor, loadCatalog, type CatalogIndex } from "./yaml-completion.js";
 import {
   findParentKey,
@@ -215,10 +217,17 @@ export async function resolveHoverTarget(
   if (schemaDocs) return docsTarget(schemaDocs);
   // Catalog fallback. The catalog keys platforms as ``<domain>.<stem>``
   // (``binary_sensor.gpio``), the reverse of the schema bundle's
-  // ``<stem>.<domain>`` componentKey — use the catalog form here.
+  // ``<stem>.<domain>`` componentKey — use the catalog form here. The
+  // slim index carries no config_entries, so hydrate the full body;
+  // then prefer the entry at the exact nested path, falling back to a
+  // leaf-key search for YAML structure the body nesting doesn't mirror.
   const catalogId = platformValue ? `${topLevelKey}.${platformValue}` : topLevelKey;
-  const comp = catalog.byId.get(catalogId);
-  const entry = comp ? findConfigEntry(comp.config_entries ?? [], key) : undefined;
+  const comp = await fetchComponent(api, catalogId);
+  if (!comp) return null;
+  const entries = comp.config_entries ?? [];
+  const entry =
+    descendNestedEntries(entries, path.slice(1, -1))?.find((e) => e.key === key) ??
+    findConfigEntry(entries, key);
   return entry ? fieldTarget(entry, comp) : null;
 }
 

--- a/src/util/yaml-hover.ts
+++ b/src/util/yaml-hover.ts
@@ -36,7 +36,10 @@ import {
   isUnderAutomationItem,
   resolveBundleContext,
 } from "./yaml-ast.js";
-import { descendNestedEntries } from "./yaml-completion-catalog.js";
+import {
+  descendNestedEntries,
+  type CompletionTarget,
+} from "./yaml-completion-catalog.js";
 import { bundleFor, loadCatalog, type CatalogIndex } from "./yaml-completion.js";
 import {
   findParentKey,
@@ -124,7 +127,8 @@ export async function resolveHoverTarget(
   state: EditorState,
   pos: number,
   api: ESPHomeAPI,
-  catalog: CatalogIndex
+  catalog: CatalogIndex,
+  deviceTarget?: CompletionTarget
 ): Promise<HoverTarget | null> {
   const line = state.doc.lineAt(pos);
   const stripped = stripComment(line.text);
@@ -218,11 +222,21 @@ export async function resolveHoverTarget(
   // Catalog fallback. The catalog keys platforms as ``<domain>.<stem>``
   // (``binary_sensor.gpio``), the reverse of the schema bundle's
   // ``<stem>.<domain>`` componentKey — use the catalog form here. The
-  // slim index carries no config_entries, so hydrate the full body;
-  // then prefer the entry at the exact nested path, falling back to a
-  // leaf-key search for YAML structure the body nesting doesn't mirror.
+  // slim index carries no config_entries, so hydrate the full body
+  // (the device target keeps this in the cache bucket the completion
+  // source and structured editor already fill); then prefer the entry
+  // at the exact nested path, falling back to a leaf-key search for
+  // YAML structure the body nesting doesn't mirror. The byId guard
+  // keeps non-component blocks (``substitutions:``, typos) from ever
+  // reaching the wire, mirroring the completion source.
   const catalogId = platformValue ? `${topLevelKey}.${platformValue}` : topLevelKey;
-  const comp = await fetchComponent(api, catalogId);
+  if (!catalog.byId.has(catalogId)) return null;
+  const comp = await fetchComponent(
+    api,
+    catalogId,
+    deviceTarget?.platform,
+    deviceTarget?.boardId
+  );
   if (!comp) return null;
   const entries = comp.config_entries ?? [];
   const entry =
@@ -269,9 +283,14 @@ function inComment(state: EditorState, pos: number): boolean {
 /**
  * CodeMirror hover-tooltip extension backed by the component catalog.
  * ``getSeeAlsoLabel`` is read per-tooltip so a locale switch is picked
- * up without rebuilding the editor.
+ * up without rebuilding the editor; ``getTarget`` likewise, so it
+ * tracks the device's platform/board as they load.
  */
-export function createYamlHoverTooltip(api: ESPHomeAPI, getSeeAlsoLabel: () => string) {
+export function createYamlHoverTooltip(
+  api: ESPHomeAPI,
+  getSeeAlsoLabel: () => string,
+  getTarget?: () => CompletionTarget
+) {
   return hoverTooltip(
     async (view, pos): Promise<Tooltip | null> => {
       if (inComment(view.state, pos)) return null;
@@ -280,7 +299,7 @@ export function createYamlHoverTooltip(api: ESPHomeAPI, getSeeAlsoLabel: () => s
       let target: HoverTarget | null;
       try {
         const catalog = await loadCatalog(api);
-        target = await resolveHoverTarget(view.state, pos, api, catalog);
+        target = await resolveHoverTarget(view.state, pos, api, catalog, getTarget?.());
       } catch (err) {
         // The catalog/schema fetches degrade gracefully on their own, so
         // reaching here is an unexpected error — warn (visible by default,

--- a/test/util/yaml-hover.test.ts
+++ b/test/util/yaml-hover.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ESPHomeAPI } from "../../src/api/esphome-api.js";
 import type { ComponentCatalogEntry } from "../../src/api/types/components.js";
 import { ConfigEntryType } from "../../src/api/types/config-entries.js";
-import * as componentCache from "../../src/util/component-name-cache.js";
+import { _clearComponentCache } from "../../src/util/component-name-cache.js";
 import * as schema from "../../src/util/esphome-schema.js";
 import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
 import type { CatalogIndex } from "../../src/util/yaml-completion.js";
@@ -25,12 +25,6 @@ vi.mock("../../src/util/esphome-schema.js", async (importOriginal) => ({
   getConfigVarDocsAtPath: vi.fn(),
 }));
 
-// Stub the body hydration the catalog field fallback goes through.
-vi.mock("../../src/util/component-name-cache.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../../src/util/component-name-cache.js")>()),
-  fetchComponent: vi.fn(),
-}));
-
 // Build the slim catalog index the resolver consumes — used for
 // component / field descriptions once the schema walk comes up empty.
 function catalog(entries: ComponentCatalogEntry[]): CatalogIndex {
@@ -46,27 +40,29 @@ function catalog(entries: ComponentCatalogEntry[]): CatalogIndex {
 }
 
 // The slim index the resolver holds is body-less in production — no
-// ``config_entries`` here; field docs hydrate through fetchComponent.
-const CATALOG: CatalogIndex = catalog([
-  makeComponentEntry("ethernet", {
-    name: "Ethernet",
-    description: "Wired networking for the node.",
-    docs_url: "https://esphome.io/components/ethernet",
-  }),
-  makeComponentEntry("binary_sensor.gpio", {
-    name: "GPIO Binary Sensor",
-    description: "A binary sensor reading a GPIO pin.",
-    docs_url: "https://esphome.io/components/binary_sensor/gpio",
-  }),
-]);
+// ``config_entries`` here; field docs hydrate through get_component_bodies.
+const SLIM_ETHERNET = makeComponentEntry("ethernet", {
+  name: "Ethernet",
+  description: "Wired networking for the node.",
+  docs_url: "https://esphome.io/components/ethernet",
+});
+const SLIM_GPIO = makeComponentEntry("binary_sensor.gpio", {
+  name: "GPIO Binary Sensor",
+  description: "A binary sensor reading a GPIO pin.",
+  docs_url: "https://esphome.io/components/binary_sensor/gpio",
+});
+const SLIM_ESP32 = makeComponentEntry("esp32", {
+  name: "ESP32",
+  docs_url: "https://esphome.io/components/esp32",
+});
+const CATALOG: CatalogIndex = catalog([SLIM_ETHERNET, SLIM_GPIO, SLIM_ESP32]);
 
-// Hydrated component bodies served by the mocked fetchComponent.
+// Hydrated component bodies served by the stubbed WS command.
 const BODIES = new Map<string, ComponentCatalogEntry>([
   [
     "ethernet",
-    makeComponentEntry("ethernet", {
-      name: "Ethernet",
-      docs_url: "https://esphome.io/components/ethernet",
+    {
+      ...SLIM_ETHERNET,
       config_entries: [
         makeConfigEntry({
           key: "type",
@@ -75,13 +71,12 @@ const BODIES = new Map<string, ComponentCatalogEntry>([
           help_link: "https://esphome.io/components/ethernet#type",
         }),
       ],
-    }),
+    },
   ],
   [
     "esp32",
-    makeComponentEntry("esp32", {
-      name: "ESP32",
-      docs_url: "https://esphome.io/components/esp32",
+    {
+      ...SLIM_ESP32,
       config_entries: [
         makeNestedEntry("framework", [
           makeConfigEntry({ key: "type", type: ConfigEntryType.STRING }),
@@ -95,13 +90,12 @@ const BODIES = new Map<string, ComponentCatalogEntry>([
           ]),
         ]),
       ],
-    }),
+    },
   ],
   [
     "binary_sensor.gpio",
-    makeComponentEntry("binary_sensor.gpio", {
-      name: "GPIO Binary Sensor",
-      docs_url: "https://esphome.io/components/binary_sensor/gpio",
+    {
+      ...SLIM_GPIO,
       // Flat entry; the YAML nests it under a pin wrapper the body
       // doesn't model, so lookup must fall back to the leaf-key search.
       config_entries: [
@@ -111,11 +105,16 @@ const BODIES = new Map<string, ComponentCatalogEntry>([
           description: "Invert the reported state.",
         }),
       ],
-    }),
+    },
   ],
 ]);
 
-const API = {} as unknown as ESPHomeAPI;
+const getComponentBodies = vi.fn(async (ids: string[]) =>
+  Object.fromEntries(
+    ids.filter((id) => BODIES.has(id)).map((id) => [id, BODIES.get(id)!])
+  )
+);
+const API = { getComponentBodies } as unknown as ESPHomeAPI;
 
 function stateFor(doc: string): EditorState {
   const state = EditorState.create({ doc, extensions: [esphomeYaml()] });
@@ -140,9 +139,7 @@ beforeEach(() => {
   vi.mocked(schema.getRegistryEntries).mockResolvedValue([]);
   vi.mocked(schema.lookupRegistryRef).mockResolvedValue(null);
   vi.mocked(schema.getConfigVarDocsAtPath).mockResolvedValue(null);
-  vi.mocked(componentCache.fetchComponent).mockImplementation(
-    async (_api, id) => BODIES.get(id) ?? null
-  );
+  _clearComponentCache();
 });
 
 describe("resolveHoverTarget — docs on every documented key (legacy parity)", () => {
@@ -216,10 +213,7 @@ describe("resolveHoverTarget — docs on every documented key (legacy parity)", 
     const target = await hover("ethernet:\n  type: W5500\n", "type");
     expect(target?.description).toBe("**string**: The Ethernet chip type.");
     expect(target?.docsUrl).toBe("https://esphome.io/components/ethernet#type");
-    expect(vi.mocked(componentCache.fetchComponent)).toHaveBeenCalledWith(
-      API,
-      "ethernet"
-    );
+    expect(getComponentBodies).toHaveBeenCalledWith(["ethernet"], undefined, undefined);
   });
 
   it("hydrates the body for a deeply nested catalog-only key", async () => {
@@ -235,22 +229,24 @@ describe("resolveHoverTarget — docs on every documented key (legacy parity)", 
       "**boolean**: Use the SRAM1 memory region as additional IRAM."
     );
     expect(target?.docsUrl).toBe("https://esphome.io/components/esp32");
-    expect(vi.mocked(componentCache.fetchComponent)).toHaveBeenCalledWith(API, "esp32");
+    expect(getComponentBodies).toHaveBeenCalledWith(["esp32"], undefined, undefined);
   });
 
   it("falls back to a leaf-key search when the body doesn't mirror the YAML nesting", async () => {
     const doc = "binary_sensor:\n  - platform: gpio\n    pin:\n      inverted: false\n";
     const target = await hover(doc, "inverted");
     expect(target?.description).toBe("**boolean**: Invert the reported state.");
-    expect(vi.mocked(componentCache.fetchComponent)).toHaveBeenCalledWith(
-      API,
-      "binary_sensor.gpio"
+    expect(getComponentBodies).toHaveBeenCalledWith(
+      ["binary_sensor.gpio"],
+      undefined,
+      undefined
     );
   });
 
-  it("returns null for a nested key when the catalog has no such component", async () => {
-    const target = await hover("mystery:\n  nested:\n    knob: 1\n", "knob");
+  it("fetches nothing for a nested key under a non-component block", async () => {
+    const target = await hover("substitutions:\n  nested:\n    knob: 1\n", "knob");
     expect(target).toBeNull();
+    expect(getComponentBodies).not.toHaveBeenCalled();
   });
 
   it("shows a bare-domain description for a platform domain", async () => {

--- a/test/util/yaml-hover.test.ts
+++ b/test/util/yaml-hover.test.ts
@@ -4,12 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ESPHomeAPI } from "../../src/api/esphome-api.js";
 import type { ComponentCatalogEntry } from "../../src/api/types/components.js";
 import { ConfigEntryType } from "../../src/api/types/config-entries.js";
+import * as componentCache from "../../src/util/component-name-cache.js";
 import * as schema from "../../src/util/esphome-schema.js";
 import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
 import type { CatalogIndex } from "../../src/util/yaml-completion.js";
 import { resolveHoverTarget } from "../../src/util/yaml-hover.js";
 import { makeComponentEntry } from "./_make-component-entry.js";
-import { makeConfigEntry } from "./_make-config-entry.js";
+import { makeConfigEntry, makeNestedEntry } from "./_make-config-entry.js";
 
 // Stub the network-backed schema lookups; keep the rest of the module
 // (bundleFor consumers, parse helpers) real.
@@ -22,6 +23,12 @@ vi.mock("../../src/util/esphome-schema.js", async (importOriginal) => ({
   getRegistryEntries: vi.fn(),
   lookupRegistryRef: vi.fn(),
   getConfigVarDocsAtPath: vi.fn(),
+}));
+
+// Stub the body hydration the catalog field fallback goes through.
+vi.mock("../../src/util/component-name-cache.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/util/component-name-cache.js")>()),
+  fetchComponent: vi.fn(),
 }));
 
 // Build the slim catalog index the resolver consumes — used for
@@ -38,25 +45,74 @@ function catalog(entries: ComponentCatalogEntry[]): CatalogIndex {
   return { components: entries, byId, byCategory };
 }
 
+// The slim index the resolver holds is body-less in production — no
+// ``config_entries`` here; field docs hydrate through fetchComponent.
 const CATALOG: CatalogIndex = catalog([
   makeComponentEntry("ethernet", {
     name: "Ethernet",
     description: "Wired networking for the node.",
     docs_url: "https://esphome.io/components/ethernet",
-    config_entries: [
-      makeConfigEntry({
-        key: "type",
-        type: ConfigEntryType.STRING,
-        description: "The Ethernet chip type.",
-        help_link: "https://esphome.io/components/ethernet#type",
-      }),
-    ],
   }),
   makeComponentEntry("binary_sensor.gpio", {
     name: "GPIO Binary Sensor",
     description: "A binary sensor reading a GPIO pin.",
     docs_url: "https://esphome.io/components/binary_sensor/gpio",
   }),
+]);
+
+// Hydrated component bodies served by the mocked fetchComponent.
+const BODIES = new Map<string, ComponentCatalogEntry>([
+  [
+    "ethernet",
+    makeComponentEntry("ethernet", {
+      name: "Ethernet",
+      docs_url: "https://esphome.io/components/ethernet",
+      config_entries: [
+        makeConfigEntry({
+          key: "type",
+          type: ConfigEntryType.STRING,
+          description: "The Ethernet chip type.",
+          help_link: "https://esphome.io/components/ethernet#type",
+        }),
+      ],
+    }),
+  ],
+  [
+    "esp32",
+    makeComponentEntry("esp32", {
+      name: "ESP32",
+      docs_url: "https://esphome.io/components/esp32",
+      config_entries: [
+        makeNestedEntry("framework", [
+          makeConfigEntry({ key: "type", type: ConfigEntryType.STRING }),
+          // The intermediate group has no description of its own.
+          makeNestedEntry("advanced", [
+            makeConfigEntry({
+              key: "sram1_as_iram",
+              type: ConfigEntryType.BOOLEAN,
+              description: "Use the SRAM1 memory region as additional IRAM.",
+            }),
+          ]),
+        ]),
+      ],
+    }),
+  ],
+  [
+    "binary_sensor.gpio",
+    makeComponentEntry("binary_sensor.gpio", {
+      name: "GPIO Binary Sensor",
+      docs_url: "https://esphome.io/components/binary_sensor/gpio",
+      // Flat entry; the YAML nests it under a pin wrapper the body
+      // doesn't model, so lookup must fall back to the leaf-key search.
+      config_entries: [
+        makeConfigEntry({
+          key: "inverted",
+          type: ConfigEntryType.BOOLEAN,
+          description: "Invert the reported state.",
+        }),
+      ],
+    }),
+  ],
 ]);
 
 const API = {} as unknown as ESPHomeAPI;
@@ -84,6 +140,9 @@ beforeEach(() => {
   vi.mocked(schema.getRegistryEntries).mockResolvedValue([]);
   vi.mocked(schema.lookupRegistryRef).mockResolvedValue(null);
   vi.mocked(schema.getConfigVarDocsAtPath).mockResolvedValue(null);
+  vi.mocked(componentCache.fetchComponent).mockImplementation(
+    async (_api, id) => BODIES.get(id) ?? null
+  );
 });
 
 describe("resolveHoverTarget — docs on every documented key (legacy parity)", () => {
@@ -157,6 +216,41 @@ describe("resolveHoverTarget — docs on every documented key (legacy parity)", 
     const target = await hover("ethernet:\n  type: W5500\n", "type");
     expect(target?.description).toBe("**string**: The Ethernet chip type.");
     expect(target?.docsUrl).toBe("https://esphome.io/components/ethernet#type");
+    expect(vi.mocked(componentCache.fetchComponent)).toHaveBeenCalledWith(
+      API,
+      "ethernet"
+    );
+  });
+
+  it("hydrates the body for a deeply nested catalog-only key", async () => {
+    const doc =
+      "esp32:\n" +
+      "  board: esp32-poe-iso\n" +
+      "  framework:\n" +
+      "    type: esp-idf\n" +
+      "    advanced:\n" +
+      "      sram1_as_iram: true\n";
+    const target = await hover(doc, "sram1_as_iram");
+    expect(target?.description).toBe(
+      "**boolean**: Use the SRAM1 memory region as additional IRAM."
+    );
+    expect(target?.docsUrl).toBe("https://esphome.io/components/esp32");
+    expect(vi.mocked(componentCache.fetchComponent)).toHaveBeenCalledWith(API, "esp32");
+  });
+
+  it("falls back to a leaf-key search when the body doesn't mirror the YAML nesting", async () => {
+    const doc = "binary_sensor:\n  - platform: gpio\n    pin:\n      inverted: false\n";
+    const target = await hover(doc, "inverted");
+    expect(target?.description).toBe("**boolean**: Invert the reported state.");
+    expect(vi.mocked(componentCache.fetchComponent)).toHaveBeenCalledWith(
+      API,
+      "binary_sensor.gpio"
+    );
+  });
+
+  it("returns null for a nested key when the catalog has no such component", async () => {
+    const target = await hover("mystery:\n  nested:\n    knob: 1\n", "knob");
+    expect(target).toBeNull();
   });
 
   it("shows a bare-domain description for a platform domain", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Hovering a catalog-only key in the YAML editor showed no tooltip. Example: `sram1_as_iram` under `esp32: framework: advanced:` has no hover, while the Visual Editor panel renders its full description.

`resolveHoverTarget`'s catalog fallback read `config_entries` off the slim `getComponents` index, which never carries bodies (they hydrate lazily through `components/get_component_bodies`), so the fallback always searched an empty array. Keys whose docs come from the schema bundle (`framework:`) still worked, which made the miss look depth dependent; any key that only the catalog documents was silent.

The fallback now hydrates the component body through the shared `fetchComponent` cache, the same path the completion source uses, and resolves the entry at the exact nested path via `descendNestedEntries`, falling back to the previous leaf-key search when the YAML structure doesn't mirror the body nesting. The hover test fixture no longer puts `config_entries` on the slim index, so the suite exercises the production shape.

**Related issue or feature (if applicable):**

- reported directly with screenshots of the missing sram1_as_iram hover; no issue filed

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
