### PR TITLE
Surface only YAML-present advanced fields in the section editor

### DIFF
--- a/src/components/device/config-entry-form-plan.ts
+++ b/src/components/device/config-entry-form-plan.ts
@@ -24,6 +24,8 @@ export interface FormRenderPlan {
   clusters: ConstraintCluster[];
   /** Keys folded into a cluster, dropped from the normal flow. */
   memberKeys: Set<string>;
+  /** Each cluster keyed by its first member's key — the slot it paints at. */
+  clusterByFirstKey: Map<string, ConstraintCluster>;
   /** Plain (non-exclusive, non-cluster) entries that pass the filter. */
   visible: Set<ConfigEntry>;
 }
@@ -36,11 +38,12 @@ export function buildFormRenderPlan(
 ): FormRenderPlan {
   const ordered = orderExclusiveGroups(entries);
   const { clusters, memberKeys } = buildConstraintClusters(entries, requiredGroups);
+  const clusterByFirstKey = new Map(clusters.map((c) => [c.members[0].key, c]));
   const nonExclusive = entries.filter(
     (entry) => !entry.exclusive_group && !memberKeys.has(entry.key)
   );
   const visible = new Set(filterRenderable(nonExclusive, values, opts));
-  return { ordered, clusters, memberKeys, visible };
+  return { ordered, clusters, memberKeys, clusterByFirstKey, visible };
 }
 
 /**

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -421,22 +421,6 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // behind a control, so render it all with no control — unless the owner gates
     // external content (script Parameters) through it, which must stay reachable.
     const allAdvanced = advanced.length > 0 && basic.length === 0;
-    // Pre-filled advanced fields stay visible without a click, matching the
-    // legacy material-value behaviour — open the section when any is set.
-    const forceOpen = this._advancedForceOpen();
-    // A unit "is in the YAML" when it (or any group/cluster member) carries a
-    // material value — the same rule ``filterRenderable`` uses to keep pre-filled
-    // advanced leaves visible. When ``gateAdvanced``, such units surface inline
-    // and only the empty ones stay behind the control.
-    const clusterByFirstKey = new Map(plan.clusters.map((c) => [c.members[0].key, c]));
-    const unitPrefilled = (item: ConfigEntry | ConfigEntry[]): boolean => {
-      if (Array.isArray(item)) return item.some((e) => hasMaterialValue(e, this.values));
-      if (plan.memberKeys.has(item.key)) {
-        const cluster = clusterByFirstKey.get(item.key);
-        return !!cluster?.members.some((m) => hasMaterialValue(m, this.values));
-      }
-      return hasMaterialValue(item, this.values);
-    };
     // all-advanced auto-opens (an all-advanced action shows its fields with no
     // control) EXCEPT when the owner gates external content (script Parameters)
     // through the control, or the device section editor opts out via
@@ -444,20 +428,35 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // fields behind the control instead of painting them open.
     const autoOpenAllAdvanced =
       allAdvanced && !this.forceAdvancedControl && !this.gateAdvanced;
-    // Section editor (gateAdvanced): YAML-present advanced fields paint inline
-    // among the basic fields, and only the empty advanced fields are gated behind
-    // the control — so one filled advanced field can't drag the rest on screen.
-    // Every other host keeps the whole advanced group gated (inline: none).
-    const inlineAdvanced = this.gateAdvanced ? advanced.filter(unitPrefilled) : [];
-    const gatedAdvanced = this.gateAdvanced
-      ? advanced.filter((item) => !unitPrefilled(item))
-      : advanced;
+    // Section editor (gateAdvanced): YAML-present advanced units paint inline
+    // among the basic fields, and only the empty ones are gated behind the
+    // control — so one filled advanced field can't drag the rest on screen. A
+    // unit "is in the YAML" when it (or any group/cluster member) carries a
+    // material value, the same rule ``filterRenderable`` uses to keep pre-filled
+    // advanced leaves visible. Every other host keeps the whole advanced group
+    // gated (inline: none), so the split runs only under gateAdvanced.
+    let inlineAdvanced: (ConfigEntry | ConfigEntry[])[] = [];
+    let gatedAdvanced = advanced;
+    if (this.gateAdvanced) {
+      const unitPrefilled = (item: ConfigEntry | ConfigEntry[]): boolean => {
+        if (Array.isArray(item))
+          return item.some((e) => hasMaterialValue(e, this.values));
+        if (plan.memberKeys.has(item.key)) {
+          const cluster = plan.clusterByFirstKey.get(item.key);
+          return !!cluster?.members.some((m) => hasMaterialValue(m, this.values));
+        }
+        return hasMaterialValue(item, this.values);
+      };
+      gatedAdvanced = [];
+      for (const item of advanced) {
+        (unitPrefilled(item) ? inlineAdvanced : gatedAdvanced).push(item);
+      }
+    }
     // gateAdvanced never force-opens on a pre-filled field (those already paint
     // inline) and never locks the switch — it's a real toggle over the empty
     // advanced fields, off by default.
-    const open =
-      this.showAdvanced || (this.gateAdvanced ? false : forceOpen) || autoOpenAllAdvanced;
-    const locked = !this.gateAdvanced && forceOpen;
+    const locked = this._effectiveForceOpen();
+    const open = this.showAdvanced || locked || autoOpenAllAdvanced;
     const showControl =
       this.forceAdvancedControl || (hasAdvanced && !autoOpenAllAdvanced);
     const count = gatedAdvanced.length + this.advancedExtraCount;
@@ -475,11 +474,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
     plan: ReturnType<typeof buildFormRenderPlan>,
     ctx: RenderCtx
   ) {
-    const clusterByFirstKey = new Map(plan.clusters.map((c) => [c.members[0].key, c]));
     return (item: ConfigEntry | ConfigEntry[]) => {
       if (Array.isArray(item)) return renderExclusiveGroupField(item, ctx);
       if (plan.memberKeys.has(item.key)) {
-        const cluster = clusterByFirstKey.get(item.key);
+        const cluster = plan.clusterByFirstKey.get(item.key);
         if (!cluster) return nothing;
         return isRadioCluster(cluster)
           ? renderConstraintRadioField(cluster, ctx)
@@ -495,6 +493,13 @@ export class ESPHomeConfigEntryForm extends LitElement {
    *  collapsed while a value is set, matching the legacy material-value rule. */
   private _advancedForceOpen(): boolean {
     return this.entries.some((e) => e.advanced && hasMaterialValue(e, this.values));
+  }
+
+  /** The force-open kernel: a pre-filled advanced field opens the section, but
+   *  never under ``gateAdvanced`` (there such fields paint inline). Consumed by
+   *  the render split and the ``updated()`` host mirror so they can't disagree. */
+  private _effectiveForceOpen(): boolean {
+    return !this.gateAdvanced && this._advancedForceOpen();
   }
 
   /** Classify a render unit as advanced. A group (exclusive dropdown or
@@ -605,15 +610,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // mirror it onto the host so externally-gated siblings (the script editor's
     // Parameters block) track the visibly-open section. The host flipping
     // showAdvanced true stops the condition, so this self-limits. Skipped under
-    // gateAdvanced: there a pre-filled advanced field paints inline, so nothing
-    // needs the section forced open (and flipping showAdvanced would reveal every
-    // empty advanced field — the bug this guards against).
-    if (
-      this.advancedSection &&
-      !this.gateAdvanced &&
-      !this.showAdvanced &&
-      this._advancedForceOpen()
-    ) {
+    // gateAdvanced (folded into _effectiveForceOpen): there a pre-filled advanced
+    // field paints inline, so nothing needs the section forced open — and flipping
+    // showAdvanced would reveal every empty advanced field, the bug this guards.
+    if (this.advancedSection && !this.showAdvanced && this._effectiveForceOpen()) {
       this._emitAdvancedToggle(true);
     }
   }

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -200,13 +200,15 @@ export class ESPHomeConfigEntryForm extends LitElement {
   @property({ type: Boolean, attribute: "force-advanced-control" })
   forceAdvancedControl = false;
 
-  /** Keep an all-advanced form gated behind the "Advanced settings" control
-   *  instead of auto-opening it. The device section editor sets this so an
+  /** Gate advanced fields behind the "Advanced settings" control, surfacing
+   *  only the ones present in the YAML. The device section editor sets this so
+   *  a component shows its filled fields (basic or advanced) inline while every
+   *  empty advanced field stays hidden until the toggle is turned on — and so an
    *  all-advanced component (captive_portal) hides its fields with the toggle
-   *  off; automation action/trigger/condition nodes leave it off so their
-   *  all-advanced params still show inline. */
-  @property({ type: Boolean, attribute: "gate-all-advanced" })
-  gateAllAdvanced = false;
+   *  off instead of auto-opening. Automation action/trigger/condition nodes and
+   *  the script editor leave it off, keeping their inline / force-open paint. */
+  @property({ type: Boolean, attribute: "gate-advanced" })
+  gateAdvanced = false;
 
   /** Added to the advanced-section "(N)" count for that external content. */
   @property({ type: Number, attribute: "advanced-extra-count" })
@@ -422,22 +424,48 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // Pre-filled advanced fields stay visible without a click, matching the
     // legacy material-value behaviour — open the section when any is set.
     const forceOpen = this._advancedForceOpen();
+    // A unit "is in the YAML" when it (or any group/cluster member) carries a
+    // material value — the same rule ``filterRenderable`` uses to keep pre-filled
+    // advanced leaves visible. When ``gateAdvanced``, such units surface inline
+    // and only the empty ones stay behind the control.
+    const clusterByFirstKey = new Map(plan.clusters.map((c) => [c.members[0].key, c]));
+    const unitPrefilled = (item: ConfigEntry | ConfigEntry[]): boolean => {
+      if (Array.isArray(item)) return item.some((e) => hasMaterialValue(e, this.values));
+      if (plan.memberKeys.has(item.key)) {
+        const cluster = clusterByFirstKey.get(item.key);
+        return !!cluster?.members.some((m) => hasMaterialValue(m, this.values));
+      }
+      return hasMaterialValue(item, this.values);
+    };
     // all-advanced auto-opens (an all-advanced action shows its fields with no
     // control) EXCEPT when the owner gates external content (script Parameters)
     // through the control, or the device section editor opts out via
-    // gateAllAdvanced so an all-advanced component (captive_portal) still hides
-    // its fields behind the control instead of painting them open.
+    // gateAdvanced so an all-advanced component (captive_portal) still hides its
+    // fields behind the control instead of painting them open.
     const autoOpenAllAdvanced =
-      allAdvanced && !this.forceAdvancedControl && !this.gateAllAdvanced;
-    const open = this.showAdvanced || forceOpen || autoOpenAllAdvanced;
+      allAdvanced && !this.forceAdvancedControl && !this.gateAdvanced;
+    // Section editor (gateAdvanced): YAML-present advanced fields paint inline
+    // among the basic fields, and only the empty advanced fields are gated behind
+    // the control — so one filled advanced field can't drag the rest on screen.
+    // Every other host keeps the whole advanced group gated (inline: none).
+    const inlineAdvanced = this.gateAdvanced ? advanced.filter(unitPrefilled) : [];
+    const gatedAdvanced = this.gateAdvanced
+      ? advanced.filter((item) => !unitPrefilled(item))
+      : advanced;
+    // gateAdvanced never force-opens on a pre-filled field (those already paint
+    // inline) and never locks the switch — it's a real toggle over the empty
+    // advanced fields, off by default.
+    const open =
+      this.showAdvanced || (this.gateAdvanced ? false : forceOpen) || autoOpenAllAdvanced;
+    const locked = !this.gateAdvanced && forceOpen;
     const showControl =
       this.forceAdvancedControl || (hasAdvanced && !autoOpenAllAdvanced);
-    const count = advanced.length + this.advancedExtraCount;
+    const count = gatedAdvanced.length + this.advancedExtraCount;
     return html`${this._renderConstraintBanners(ctx, plan.memberKeys)}${basic.map(
       renderItem
-    )}${showControl ? this._renderAdvancedControl(open, count, forceOpen) : nothing}${
-      open ? advanced.map(renderItem) : nothing
-    }`;
+    )}${inlineAdvanced.map(renderItem)}${
+      showControl ? this._renderAdvancedControl(open, count, locked) : nothing
+    }${open ? gatedAdvanced.map(renderItem) : nothing}`;
   }
 
   /** Per-item renderer shared by both paint paths. An empty key means "this
@@ -576,8 +604,16 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // Force-open (a pre-filled advanced field) is a form-internal decision;
     // mirror it onto the host so externally-gated siblings (the script editor's
     // Parameters block) track the visibly-open section. The host flipping
-    // showAdvanced true stops the condition, so this self-limits.
-    if (this.advancedSection && !this.showAdvanced && this._advancedForceOpen()) {
+    // showAdvanced true stops the condition, so this self-limits. Skipped under
+    // gateAdvanced: there a pre-filled advanced field paints inline, so nothing
+    // needs the section forced open (and flipping showAdvanced would reveal every
+    // empty advanced field — the bug this guards against).
+    if (
+      this.advancedSection &&
+      !this.gateAdvanced &&
+      !this.showAdvanced &&
+      this._advancedForceOpen()
+    ) {
       this._emitAdvancedToggle(true);
     }
   }

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -555,7 +555,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
                 .focusFieldPath=${this.focusFieldPath}
                 .presentComponents=${this._presentComponents}
                 advanced-section
-                gate-all-advanced
+                gate-advanced
                 ?show-advanced=${showAdvanced}
                 @value-change=${this._onValueChange}
                 @advanced-toggle=${this._onAdvancedToggle}

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -3,9 +3,10 @@
  *
  * advanced-section mode: basic fields, then a "Show advanced settings" switch,
  * then the advanced fields below it (revealed when on). All-advanced forms
- * render with no control by default (automation nodes); with gate-all-advanced
- * (the device section editor) they keep the control and stay collapsed. The
- * control emits ``advanced-toggle``.
+ * render with no control by default (automation nodes). With gate-advanced (the
+ * device section editor) the YAML-present fields — basic or advanced — paint
+ * inline, and only the empty advanced fields stay behind the control (off by
+ * default, a real unlocked switch). The control emits ``advanced-toggle``.
  */
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
@@ -36,7 +37,7 @@ function renderForm(
     showAdvanced?: boolean;
     values?: Record<string, unknown>;
     forceAdvancedControl?: boolean;
-    gateAllAdvanced?: boolean;
+    gateAdvanced?: boolean;
   } = {}
 ): HTMLElement {
   const form = new ESPHomeConfigEntryForm();
@@ -45,7 +46,7 @@ function renderForm(
   form.advancedSection = true;
   form.showAdvanced = opts.showAdvanced ?? false;
   form.forceAdvancedControl = opts.forceAdvancedControl ?? false;
-  form.gateAllAdvanced = opts.gateAllAdvanced ?? false;
+  form.gateAdvanced = opts.gateAdvanced ?? false;
   const container = document.createElement("div");
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   render((form as any).render(), container);
@@ -135,8 +136,8 @@ describe("config-entry-form advanced-section", () => {
     expect(c.textContent ?? "").toContain("Only Advanced");
   });
 
-  it("gates an all-advanced form behind the control with gate-all-advanced", () => {
-    // The device section editor sets gate-all-advanced so an all-advanced
+  it("gates an all-advanced form behind the control with gate-advanced", () => {
+    // The device section editor sets gate-advanced so an all-advanced
     // component (captive_portal) shows just the control, fields hidden until
     // toggled — instead of the automation-node auto-open above.
     const onlyAdvanced = makeConfigEntry({
@@ -145,21 +146,20 @@ describe("config-entry-form advanced-section", () => {
       label: "Only Advanced",
       advanced: true,
     });
-    const collapsed = renderForm([onlyAdvanced], { gateAllAdvanced: true });
+    const collapsed = renderForm([onlyAdvanced], { gateAdvanced: true });
     expect(control(collapsed)).toBeTruthy();
     expect(collapsed.textContent ?? "").not.toContain("Only Advanced");
     const expanded = renderForm([onlyAdvanced], {
-      gateAllAdvanced: true,
+      gateAdvanced: true,
       showAdvanced: true,
     });
     expect(control(expanded)).toBeTruthy();
     expect(expanded.textContent ?? "").toContain("Only Advanced");
   });
 
-  it("auto-opens a gated all-advanced form, locked, when a value is pre-filled", () => {
-    // A pre-filled advanced value forces the section open even under
-    // gate-all-advanced; the control stays visible but its switch is locked
-    // (can't collapse while a value is set).
+  it("surfaces a pre-filled advanced field inline under gate-advanced, switch unlocked", () => {
+    // A YAML-present advanced field paints inline (not gated); the switch is a
+    // real toggle, never locked open, and it isn't forced on.
     const onlyAdvanced = makeConfigEntry({
       key: "a",
       type: ConfigEntryType.STRING,
@@ -167,12 +167,172 @@ describe("config-entry-form advanced-section", () => {
       advanced: true,
     });
     const c = renderForm([onlyAdvanced], {
-      gateAllAdvanced: true,
+      gateAdvanced: true,
       values: { a: "set" },
     });
-    expect(control(c)).toBeTruthy();
     expect(c.textContent ?? "").toContain("Only Advanced");
-    expect(c.querySelector("wa-switch")!.hasAttribute("disabled")).toBe(true);
+    const sw = c.querySelector("wa-switch");
+    // The only advanced field is pre-filled, so nothing is gated — the control
+    // may or may not paint, but if it does its switch must be unlocked and off.
+    if (sw) {
+      expect(sw.hasAttribute("disabled")).toBe(false);
+      expect((sw as HTMLElement & { checked?: boolean }).checked ?? false).toBe(false);
+    }
+  });
+
+  it("shows only YAML-present advanced fields, gating the empty ones, under gate-advanced", () => {
+    // The starter-kit switch.gpio shape: basic fields, one pre-filled advanced
+    // field (id/internal), and several empty advanced fields. Only the filled
+    // one surfaces; the empty ones stay behind the control, off by default —
+    // one filled advanced field must NOT drag the rest on screen.
+    const entries = [
+      makeConfigEntry({ key: "name", type: ConfigEntryType.STRING, label: "Name Field" }),
+      makeConfigEntry({
+        key: "internal",
+        type: ConfigEntryType.STRING,
+        label: "Internal Field",
+        advanced: true,
+      }),
+      makeConfigEntry({
+        key: "command_retain",
+        type: ConfigEntryType.STRING,
+        label: "Empty Adv One",
+        advanced: true,
+      }),
+      makeConfigEntry({
+        key: "device_id",
+        type: ConfigEntryType.STRING,
+        label: "Empty Adv Two",
+        advanced: true,
+      }),
+    ];
+    const c = renderForm(entries, {
+      gateAdvanced: true,
+      values: { name: "sw", internal: "true" },
+    });
+    const text = c.textContent ?? "";
+    expect(text).toContain("Name Field");
+    expect(text).toContain("Internal Field"); // YAML-present advanced → inline
+    expect(text).not.toContain("Empty Adv One");
+    expect(text).not.toContain("Empty Adv Two");
+    const sw = c.querySelector<HTMLElement & { checked?: boolean }>("wa-switch")!;
+    expect(sw.hasAttribute("disabled")).toBe(false);
+    expect(sw.checked ?? false).toBe(false);
+  });
+
+  it("counts only the gated (empty) advanced fields, not the inline ones", () => {
+    // Under gate-advanced, the "(N)" count is the empty advanced fields the
+    // toggle reveals; the pre-filled advanced field is already shown inline.
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [
+      makeConfigEntry({
+        key: "internal",
+        type: ConfigEntryType.STRING,
+        label: "Filled Adv",
+        advanced: true,
+      }),
+      makeConfigEntry({
+        key: "command_retain",
+        type: ConfigEntryType.STRING,
+        label: "Empty Adv One",
+        advanced: true,
+      }),
+      makeConfigEntry({
+        key: "device_id",
+        type: ConfigEntryType.STRING,
+        label: "Empty Adv Two",
+        advanced: true,
+      }),
+    ];
+    form.values = { internal: "true" };
+    form.advancedSection = true;
+    form.gateAdvanced = true;
+    form.showAdvanced = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any)._localize = (key: string, params?: { count?: number }) =>
+      key === "device.show_advanced_count"
+        ? `Show advanced settings (${params?.count})`
+        : key;
+    const container = document.createElement("div");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    render((form as any).render(), container);
+    const text = container.textContent ?? "";
+    expect(text).toContain("Show advanced settings (2)");
+    expect(text).not.toContain("Show advanced settings (3)");
+    expect(text).toContain("Filled Adv");
+  });
+
+  it("reveals the gated advanced fields when the toggle is turned on", () => {
+    const entries = [
+      makeConfigEntry({ key: "name", type: ConfigEntryType.STRING, label: "Name Field" }),
+      makeConfigEntry({
+        key: "internal",
+        type: ConfigEntryType.STRING,
+        label: "Internal Field",
+        advanced: true,
+      }),
+      makeConfigEntry({
+        key: "command_retain",
+        type: ConfigEntryType.STRING,
+        label: "Empty Adv",
+        advanced: true,
+      }),
+    ];
+    const c = renderForm(entries, {
+      gateAdvanced: true,
+      showAdvanced: true,
+      values: { name: "sw", internal: "true" },
+    });
+    const text = c.textContent ?? "";
+    expect(text).toContain("Internal Field");
+    expect(text).toContain("Empty Adv");
+  });
+
+  it("counts a pre-filled constraint-cluster member as inline, not gated", () => {
+    // Two advanced fields sharing an inclusive group fold into one cluster box.
+    // A value on either member makes the cluster YAML-present, so it paints
+    // inline and is not counted behind the control.
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [
+      makeConfigEntry({
+        key: "a",
+        type: ConfigEntryType.STRING,
+        label: "Clu A",
+        advanced: true,
+        group: "grp",
+      }),
+      makeConfigEntry({
+        key: "b",
+        type: ConfigEntryType.STRING,
+        label: "Clu B",
+        advanced: true,
+        group: "grp",
+      }),
+      makeConfigEntry({
+        key: "empty",
+        type: ConfigEntryType.STRING,
+        label: "Empty Adv",
+        advanced: true,
+      }),
+    ];
+    form.values = { a: "set" };
+    form.advancedSection = true;
+    form.gateAdvanced = true;
+    form.showAdvanced = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any)._localize = (key: string, params?: { count?: number }) =>
+      key === "device.show_advanced_count"
+        ? `Show advanced settings (${params?.count})`
+        : key;
+    const container = document.createElement("div");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    render((form as any).render(), container);
+    const text = container.textContent ?? "";
+    // The pre-filled cluster surfaces inline; only the lone empty field is gated.
+    expect(text).toContain("Clu A");
+    expect(text).toContain("Show advanced settings (1)");
+    expect(text).not.toContain("Show advanced settings (2)");
+    expect(text).not.toContain("Empty Adv");
   });
 
   it("counts only rendered advanced fields, not hidden ones, in the control label", () => {
@@ -202,7 +362,7 @@ describe("config-entry-form advanced-section", () => {
     ];
     form.values = {};
     form.advancedSection = true;
-    form.gateAllAdvanced = true;
+    form.gateAdvanced = true;
     form.showAdvanced = true;
     // Default _localize returns the key; interpolate so the count is observable.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -243,7 +403,7 @@ describe("config-entry-form advanced-section", () => {
     ];
     form.values = {};
     form.advancedSection = true;
-    form.gateAllAdvanced = true;
+    form.gateAdvanced = true;
     form.showAdvanced = true;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (form as any)._localize = (key: string, params?: { count?: number }) =>
@@ -289,7 +449,7 @@ describe("config-entry-form advanced-section", () => {
     ];
     form.values = {};
     form.advancedSection = true;
-    form.gateAllAdvanced = true;
+    form.gateAdvanced = true;
     form.showAdvanced = true;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (form as any)._localize = (key: string, params?: { count?: number }) =>
@@ -328,7 +488,7 @@ describe("config-entry-form advanced-section", () => {
     ];
     form.values = {};
     form.advancedSection = true;
-    form.gateAllAdvanced = false;
+    form.gateAdvanced = false;
     form.showAdvanced = false;
     const container = document.createElement("div");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -337,6 +497,45 @@ describe("config-entry-form advanced-section", () => {
     expect(control(container)).toBeNull();
     expect(container.textContent ?? "").toContain("Adv Field");
     expect(container.textContent ?? "").not.toContain("Hidden Basic");
+  });
+
+  it("does not force the section open under gate-advanced when a pre-filled advanced field exists", () => {
+    // The bug: the form's updated() mirrors force-open onto the host by emitting
+    // advanced-toggle(true), which flips showAdvanced and reveals every empty
+    // advanced field. Under gate-advanced the pre-filled field paints inline, so
+    // the form must NOT emit — the toggle stays off.
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [ADVANCED];
+    form.values = { reboot_timeout: "5min" };
+    form.advancedSection = true;
+    form.gateAdvanced = true;
+    form.showAdvanced = false;
+    let emitted = false;
+    form.addEventListener("advanced-toggle", () => {
+      emitted = true;
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any).updated(new Map());
+    expect(emitted).toBe(false);
+  });
+
+  it("still force-opens (emits advanced-toggle) without gate-advanced", () => {
+    // Automation / script hosts keep the mirror: a pre-filled advanced field
+    // emits advanced-toggle(true) so an externally-gated sibling tracks the open
+    // section.
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [ADVANCED];
+    form.values = { reboot_timeout: "5min" };
+    form.advancedSection = true;
+    form.gateAdvanced = false;
+    form.showAdvanced = false;
+    let detail: { show: boolean } | null = null;
+    form.addEventListener("advanced-toggle", (e) => {
+      detail = (e as CustomEvent<{ show: boolean }>).detail;
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any).updated(new Map());
+    expect(detail).toEqual({ show: true });
   });
 
   it("emits advanced-toggle when the control is clicked", () => {


### PR DESCRIPTION
# What does this implement/fix?

In the structured (visual) device editor the rule is "a field present in the YAML always shows". That works for basic fields, but for advanced fields it over-fired: as soon as one advanced field carried a value (e.g. `id:` / `internal:` on the starter-kit `switch.gpio`), the whole "Advanced settings" section flipped open and dumped every empty advanced field on screen (`command_retain`, `device_id`, `disabled_by_default`, `entity_category`, …), with the toggle stuck on and showing a large count. So one field the user set in YAML dragged a dozen fields they never touched into view.

Two coupled mechanisms in `config-entry-form.ts` drove it. `_renderWithAdvancedSection` builds its plan with `showAdvanced: true` and paints the entire advanced group whenever `forceOpen` (any material-value advanced field) is set. And the `updated` hook mirrors that by emitting `advanced-toggle(true)`, which flips the host's `showAdvanced` on, re-rendering everything expanded.

The fix broadens the section editor's per-host gate flag (`gate-all-advanced` to `gate-advanced`, set only by `device-section-config.ts`). Under it, YAML-present fields (basic or advanced) paint inline, and only the empty advanced fields stay behind the control, now a real unlocked toggle that is off by default and counts just the hidden ones. The `updated` auto-flip is skipped under the flag (the pre-filled field already paints inline, so nothing needs the section forced open). Automation action/trigger/condition nodes and the script editor leave the flag off and keep their existing inline / force-open paint; the `inlineAdvanced` / `open` / `locked` / `count` expressions all reduce to today's values when the flag is off.

Verified live on the starter-kit config: the GPIO Switch now shows `id` / `internal` / `setup_priority` (the YAML-present fields) inline with "Show advanced settings (6)" off; turning the toggle on reveals the empty fields; `captive_portal` still shows just the control (the earlier all-advanced behaviour is preserved).

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
