### PR TITLE
Add a device actions menu (Logs, Validate, Clean build) to the editor

### DIFF
--- a/src/components/device/device-actions-menu.ts
+++ b/src/components/device/device-actions-menu.ts
@@ -1,5 +1,10 @@
 import { consume } from "@lit/context";
-import { mdiBroom, mdiDotsVertical, mdiTextBoxOutline } from "@mdi/js";
+import {
+  mdiBroom,
+  mdiCheckCircleOutline,
+  mdiDotsVertical,
+  mdiTextBoxOutline,
+} from "@mdi/js";
 import { css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -13,11 +18,12 @@ import "@home-assistant/webawesome/dist/components/icon/icon.js";
 
 registerMdiIcons({
   broom: mdiBroom,
+  "check-circle-outline": mdiCheckCircleOutline,
   "dots-vertical": mdiDotsVertical,
   "text-box-outline": mdiTextBoxOutline,
 });
 
-/** Editor bottom-bar overflow menu: device-scoped actions (Logs, Clean build). */
+/** Editor bottom-bar overflow menu: device-scoped actions (Logs, Validate, Clean build). */
 @customElement("esphome-device-actions-menu")
 export class ESPHomeDeviceActionsMenu extends OverflowMenuElement {
   @consume({ context: localizeContext, subscribe: true })
@@ -26,6 +32,9 @@ export class ESPHomeDeviceActionsMenu extends OverflowMenuElement {
 
   /** A build is in flight — cleaning its files mid-build would corrupt it. */
   @property({ type: Boolean }) busy = false;
+
+  /** Unsaved edits block validation (Install validates too); disable the row. */
+  @property({ type: Boolean, attribute: "validate-disabled" }) validateDisabled = false;
 
   static styles = [
     espHomeStyles,
@@ -107,6 +116,24 @@ export class ESPHomeDeviceActionsMenu extends OverflowMenuElement {
                   >
                 </div>
                 <div
+                  class="menu-item ${this.validateDisabled ? "menu-item--disabled" : ""}"
+                  role="menuitem"
+                  tabindex=${this.validateDisabled ? "-1" : "0"}
+                  aria-disabled=${this.validateDisabled ? "true" : "false"}
+                  title=${
+                    this.validateDisabled
+                      ? this._localize("device.validate_disabled_pending")
+                      : nothing
+                  }
+                  @click=${this.validateDisabled ? undefined : this._onValidate}
+                  @keydown=${this.validateDisabled ? undefined : this._onItemKeydown}
+                >
+                  <wa-icon library="mdi" name="check-circle-outline"></wa-icon>
+                  <span class="menu-item-label"
+                    >${this._localize("device.validate")}</span
+                  >
+                </div>
+                <div
                   class="menu-item ${this.busy ? "menu-item--disabled" : ""}"
                   role="menuitem"
                   tabindex=${this.busy ? "-1" : "0"}
@@ -134,6 +161,12 @@ export class ESPHomeDeviceActionsMenu extends OverflowMenuElement {
   private _onLogs = () => {
     this._close();
     this._emit("open-logs");
+  };
+
+  private _onValidate = () => {
+    if (this.validateDisabled) return;
+    this._close();
+    this._emit("validate");
   };
 
   private _onCleanBuild = () => {

--- a/src/components/device/device-actions-menu.ts
+++ b/src/components/device/device-actions-menu.ts
@@ -109,7 +109,7 @@ export class ESPHomeDeviceActionsMenu extends OverflowMenuElement {
                 <div
                   class="menu-item ${this.busy ? "menu-item--disabled" : ""}"
                   role="menuitem"
-                  tabindex="0"
+                  tabindex=${this.busy ? "-1" : "0"}
                   aria-disabled=${this.busy ? "true" : "false"}
                   title=${
                     this.busy
@@ -117,7 +117,7 @@ export class ESPHomeDeviceActionsMenu extends OverflowMenuElement {
                       : nothing
                   }
                   @click=${this.busy ? undefined : this._onCleanBuild}
-                  @keydown=${this._onItemKeydown}
+                  @keydown=${this.busy ? undefined : this._onItemKeydown}
                 >
                   <wa-icon library="mdi" name="broom"></wa-icon>
                   <span class="menu-item-label"

--- a/src/components/device/device-actions-menu.ts
+++ b/src/components/device/device-actions-menu.ts
@@ -1,0 +1,150 @@
+import { consume } from "@lit/context";
+import { mdiBroom, mdiDotsVertical, mdiTextBoxOutline } from "@mdi/js";
+import { css, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import type { LocalizeFunc } from "../../common/localize.js";
+import { localizeContext } from "../../context/index.js";
+import { dropdownMenuStyles } from "../../styles/dropdown-menu.js";
+import { espHomeStyles } from "../../styles/shared.js";
+import { registerMdiIcons } from "../../util/register-icons.js";
+import { OverflowMenuElement } from "../overflow-menu-element.js";
+
+import "@home-assistant/webawesome/dist/components/icon/icon.js";
+
+registerMdiIcons({
+  broom: mdiBroom,
+  "dots-vertical": mdiDotsVertical,
+  "text-box-outline": mdiTextBoxOutline,
+});
+
+/** Editor bottom-bar overflow menu: device-scoped actions (Logs, Clean build). */
+@customElement("esphome-device-actions-menu")
+export class ESPHomeDeviceActionsMenu extends OverflowMenuElement {
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  private _localize: LocalizeFunc = (key) => key;
+
+  /** A build is in flight — cleaning its files mid-build would corrupt it. */
+  @property({ type: Boolean }) busy = false;
+
+  static styles = [
+    espHomeStyles,
+    dropdownMenuStyles,
+    css`
+      :host {
+        position: relative;
+        display: inline-flex;
+      }
+      .menu-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        box-sizing: border-box;
+        width: 32px;
+        height: 32px;
+        padding: 0;
+        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+        border-radius: var(--wa-border-radius-m);
+        background: transparent;
+        color: var(--wa-color-text-normal);
+        cursor: pointer;
+        transition:
+          background 0.12s,
+          border-color 0.12s;
+      }
+      .menu-btn:hover {
+        background: var(--esphome-tint);
+      }
+      .menu-btn wa-icon {
+        font-size: 18px;
+      }
+      /* Bottom action bar sits at the viewport foot — open upward. */
+      .menu {
+        position: absolute;
+        bottom: calc(100% + var(--wa-space-xs));
+        right: 0;
+        min-width: 200px;
+      }
+      .menu-item--disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+      .menu-item--disabled:hover {
+        background-color: transparent;
+      }
+    `,
+  ];
+
+  protected render() {
+    const menuLabel = this._localize("device.actions_menu");
+    return html`
+      <button
+        type="button"
+        class="menu-btn"
+        @click=${this._toggle}
+        title=${menuLabel}
+        aria-label=${menuLabel}
+        aria-haspopup="menu"
+        aria-expanded=${this._open ? "true" : "false"}
+      >
+        <wa-icon library="mdi" name="dots-vertical"></wa-icon>
+      </button>
+      ${
+        this._open
+          ? html`
+              <div class="backdrop" @click=${this._close}></div>
+              <div class="menu" role="menu">
+                <div
+                  class="menu-item"
+                  role="menuitem"
+                  tabindex="0"
+                  @click=${this._onLogs}
+                  @keydown=${this._onItemKeydown}
+                >
+                  <wa-icon library="mdi" name="text-box-outline"></wa-icon>
+                  <span class="menu-item-label"
+                    >${this._localize("device.show_logs")}</span
+                  >
+                </div>
+                <div
+                  class="menu-item ${this.busy ? "menu-item--disabled" : ""}"
+                  role="menuitem"
+                  tabindex="0"
+                  aria-disabled=${this.busy ? "true" : "false"}
+                  title=${
+                    this.busy
+                      ? this._localize("dashboard.action_clean_build_busy")
+                      : nothing
+                  }
+                  @click=${this.busy ? undefined : this._onCleanBuild}
+                  @keydown=${this._onItemKeydown}
+                >
+                  <wa-icon library="mdi" name="broom"></wa-icon>
+                  <span class="menu-item-label"
+                    >${this._localize("dashboard.action_clean_build")}</span
+                  >
+                </div>
+              </div>
+            `
+          : nothing
+      }
+    `;
+  }
+
+  private _onLogs = () => {
+    this._close();
+    this._emit("open-logs");
+  };
+
+  private _onCleanBuild = () => {
+    if (this.busy) return;
+    this._close();
+    this._emit("clean-build");
+  };
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-device-actions-menu": ESPHomeDeviceActionsMenu;
+  }
+}

--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -102,7 +102,6 @@ export const deviceEditorStyles = css`
   }
 
   .save-button,
-  .validate-button,
   .install-fab {
     display: inline-flex;
     align-items: center;
@@ -186,28 +185,6 @@ export const deviceEditorStyles = css`
     transform: none;
   }
 
-  /* Subordinate to Save: surface-tinted variant so the primary
-     action stays visually dominant. The disabled state (YAML buffer
-     dirty) is the more common one — a bright primary button there
-     would compete with Save for attention. */
-  .validate-button {
-    background: var(--wa-color-surface-default);
-    color: var(--wa-color-text-normal);
-    border-color: var(--wa-color-surface-border);
-  }
-
-  .validate-button:hover:not(:disabled) {
-    background: var(--wa-color-surface-raised);
-    border-color: color-mix(in srgb, var(--wa-color-text-normal), transparent 70%);
-  }
-
-  .validate-button:disabled {
-    background: var(--wa-color-surface-default);
-    color: color-mix(in srgb, var(--wa-color-text-normal), transparent 55%);
-    border-color: var(--wa-color-surface-border);
-    cursor: not-allowed;
-  }
-
   .install-fab {
     background: color-mix(
       in srgb,
@@ -251,7 +228,6 @@ export const deviceEditorStyles = css`
      box from this one font-size, so there's nothing to keep in sync. */
   .save-button wa-icon,
   .save-button wa-spinner,
-  .validate-button wa-icon,
   .install-fab wa-icon {
     font-size: 16px;
   }
@@ -271,13 +247,6 @@ export const deviceEditorStyles = css`
     --track-width: 2px;
     --indicator-color: currentColor;
     --track-color: color-mix(in srgb, currentColor 30%, transparent);
-  }
-
-  /* Tooltip carrier so the "why disabled" hint reaches mouse users
-     even when the underlying button has the disabled attribute
-     (which suppresses pointer events on the button itself). */
-  .validate-button-wrap {
-    display: inline-flex;
   }
 
   .header-actions {

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -49,6 +49,7 @@ import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 import "../confirm-dialog.js";
 import "../yaml-diff.js";
 import "../yaml-editor.js";
+import "./device-actions-menu.js";
 import "./device-board-info.js";
 import "./editor-invalid-banner.js";
 
@@ -300,6 +301,9 @@ export class ESPHomeDeviceEditor extends LitElement {
         </header>
         <div class="card-body">
           <div class="editor-floating-actions">
+            <!-- Leftmost so it stays clear of Save in the lower-right corner:
+                 a mis-tap on Save must not land on the overflow menu. -->
+            <esphome-device-actions-menu ?busy=${this.busy}></esphome-device-actions-menu>
             ${this._renderPrimaryAction()}
             <!-- Span wrapper carries the title because a disabled
                  button isn't focusable and most browsers won't

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -1,6 +1,5 @@
 import { consume } from "@lit/context";
 import {
-  mdiCheckCircleOutline,
   mdiChevronDown,
   mdiContentSave,
   mdiDockLeft,
@@ -54,7 +53,6 @@ import "./device-board-info.js";
 import "./editor-invalid-banner.js";
 
 registerMdiIcons({
-  "check-circle-outline": mdiCheckCircleOutline,
   "chevron-down": mdiChevronDown,
   "content-save": mdiContentSave,
   eye: mdiEye,
@@ -302,33 +300,15 @@ export class ESPHomeDeviceEditor extends LitElement {
         <div class="card-body">
           <div class="editor-floating-actions">
             <!-- Leftmost so it stays clear of Save in the lower-right corner:
-                 a mis-tap on Save must not land on the overflow menu. -->
-            <esphome-device-actions-menu ?busy=${this.busy}></esphome-device-actions-menu>
+                 a mis-tap on Save must not land on the overflow menu.
+                 Carries Validate too (Install validates anyway, so the
+                 explicit button rarely earned its slot on the bar). -->
+            <esphome-device-actions-menu
+              ?busy=${this.busy}
+              ?validate-disabled=${this.hasUnsavedEdits}
+              @validate=${this._onValidate}
+            ></esphome-device-actions-menu>
             ${this._renderPrimaryAction()}
-            <!-- Span wrapper carries the title because a disabled
-                 button isn't focusable and most browsers won't
-                 surface its tooltip on hover. The disabled state
-                 is still announced via the button's own disabled
-                 attribute; the span just makes the why-disabled
-                 hint reachable for mouse users. -->
-            <span
-              class="validate-button-wrap"
-              title=${
-                this.hasUnsavedEdits
-                  ? this._localize("device.validate_disabled_pending")
-                  : this._localize("device.validate_yaml")
-              }
-            >
-              <button
-                type="button"
-                class="validate-button"
-                ?disabled=${this.hasUnsavedEdits}
-                @click=${this._onValidate}
-              >
-                <wa-icon library="mdi" name="check-circle-outline"></wa-icon>
-                ${this._localize("device.validate")}
-              </button>
-            </span>
             <button
               type="button"
               class="save-button"

--- a/src/components/device/device-install-controller.ts
+++ b/src/components/device/device-install-controller.ts
@@ -1,9 +1,17 @@
 import { type ReactiveController, type ReactiveControllerHost } from "lit";
+import type { ESPHomeAPI } from "../../api/index.js";
 import { type ConfiguredDevice, DeviceState } from "../../api/types/devices.js";
+import type { LocalizeFunc } from "../../common/localize.js";
 import { canFlashBootloader } from "../../util/bootloader-flash.js";
+import {
+  launchLogs,
+  launchLogsWithMethod,
+  type LogsLaunchHost,
+} from "../../util/logs-launch.js";
 import { applyInstallMethod } from "../apply-install-method.js";
 import type { CommandType, ESPHomeCommandDialog } from "../command-dialog.js";
 import type { ESPHomeFirmwareInstallDialog } from "../firmware-install-dialog.js";
+import type { ESPHomeLogsDialog } from "../logs-dialog.js";
 
 export interface DeviceInstallControllerHost extends ReactiveControllerHost {
   /** Currently displayed device, or null when not yet loaded. */
@@ -12,11 +20,18 @@ export interface DeviceInstallControllerHost extends ReactiveControllerHost {
   readonly commandDialog: ESPHomeCommandDialog | null;
   /** Resolve the mounted firmware-install-dialog instance. */
   readonly firmwareDialog: ESPHomeFirmwareInstallDialog | null;
+  /** Resolve the mounted logs-dialog instance. */
+  readonly logsDialog: ESPHomeLogsDialog | null;
+  readonly api: ESPHomeAPI;
+  readonly localize: LocalizeFunc;
 }
 
 export class DeviceInstallController implements ReactiveController {
   private _host: DeviceInstallControllerHost;
   installMethodOpen = false;
+  /** Which action the shared method picker is serving; drives its `.mode` so
+   *  Logs shows the logs title/rows, not install. */
+  methodMode: "install" | "logs" = "install";
 
   constructor(host: DeviceInstallControllerHost) {
     this._host = host;
@@ -46,8 +61,21 @@ export class DeviceInstallController implements ReactiveController {
   /** "Install" entry point — opens the install-method picker. */
   onInstall = () => {
     if (!this._host.device) return;
+    this.methodMode = "install";
     this.installMethodOpen = true;
     this._host.requestUpdate();
+  };
+
+  /** "Logs" entry point — picker in logs mode when a serial path exists, else OTA logs. */
+  onLogs = () => {
+    const device = this._host.device;
+    const logsDialog = this._host.logsDialog;
+    if (!device || !logsDialog) return;
+    void launchLogs(this._logsHost(logsDialog), device, () => {
+      this.methodMode = "logs";
+      this.installMethodOpen = true;
+      this._host.requestUpdate();
+    });
   };
 
   /** "Update" entry point — bypasses the picker, runs install via OTA/server. */
@@ -59,21 +87,34 @@ export class DeviceInstallController implements ReactiveController {
 
   onInstallMethodClose = () => {
     this.installMethodOpen = false;
+    this.methodMode = "install";
     this._host.requestUpdate();
   };
 
   onInstallMethodSelect = (e: CustomEvent<{ method: string; port?: string }>) => {
     const device = this._host.device;
+    const mode = this.methodMode;
     this.installMethodOpen = false;
+    this.methodMode = "install";
     this._host.requestUpdate();
     if (!device) return;
     const { method, port } = e.detail;
+    if (mode === "logs") {
+      const logsDialog = this._host.logsDialog;
+      if (!logsDialog) return;
+      void launchLogsWithMethod(this._logsHost(logsDialog), device, method, port);
+      return;
+    }
     applyInstallMethod(method, port, {
       device,
       firmwareDialog: this._host.firmwareDialog,
       openInstall: (p, options) => this._openCommand(device, "install", p, options),
     });
   };
+
+  private _logsHost(logsDialog: ESPHomeLogsDialog): LogsLaunchHost {
+    return { api: this._host.api, logsDialog, localize: this._host.localize };
+  }
 
   private _openCommand(
     device: ConfiguredDevice,

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -323,6 +323,15 @@ export class ESPHomePageDevice extends LitElement {
       get firmwareDialog() {
         return page._firmwareDialog ?? null;
       },
+      get logsDialog() {
+        return page._logsDialog ?? null;
+      },
+      get api() {
+        return page._api;
+      },
+      get localize() {
+        return page._localize;
+      },
     });
   }
 
@@ -961,11 +970,22 @@ export class ESPHomePageDevice extends LitElement {
    *  build files for this device" link works the same way on
    *  the device page. */
   private _onCleanBuild = (e: CustomEvent<ConfiguredDevice>) => {
-    const device = e.detail;
+    this._cleanBuild(e.detail);
+  };
+
+  /** "Logs" from the editor's device-actions menu. */
+  private _onEditorOpenLogs = () => this._installCtrl.onLogs();
+
+  /** "Clean build files" from the editor's device-actions menu. */
+  private _onEditorCleanBuild = () => {
+    if (this._device) this._cleanBuild(this._device);
+  };
+
+  private _cleanBuild(device: ConfiguredDevice) {
     this._commandDialog.configuration = device.configuration;
     this._commandDialog.name = device.friendly_name || device.name;
     this._commandDialog.open("clean");
-  };
+  }
 
   /** Catch ``request-open-editor`` from the post-validation-failure
    *  hint. ``stopPropagation`` to prevent any future higher-level
@@ -1064,6 +1084,8 @@ export class ESPHomePageDevice extends LitElement {
             @just-created-dismiss=${this._dismissJustCreated}
             @goto-line=${this._onEditorGoToLine}
             @change-board=${this._onChangeBoard}
+            @open-logs=${this._onEditorOpenLogs}
+            @clean-build=${this._onEditorCleanBuild}
             ?hasUnsavedEdits=${this._isDirty}
             ?saving=${this._saving}
             ?showModified=${this._device ? showPendingChanges(this._device) : false}
@@ -1126,6 +1148,7 @@ export class ESPHomePageDevice extends LitElement {
           .deviceTargetPlatform=${this._installCtrl.deviceTargetPlatform}
           .deviceCurrentAddress=${this._installCtrl.deviceCurrentAddress}
           .canFlashBootloader=${this._installCtrl.canFlashBootloader}
+          .mode=${this._installCtrl.methodMode}
           @close=${this._installCtrl.onInstallMethodClose}
           @select-method=${this._installCtrl.onInstallMethodSelect}
         ></esphome-install-method-dialog>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -778,7 +778,6 @@
     "save": "Save",
     "save_yaml": "Save YAML",
     "validate": "Validate",
-    "validate_yaml": "Validate YAML",
     "validate_disabled_pending": "Save changes first to validate",
     "loading_config_catalog": "Loading configuration catalog…",
     "loading_automation_catalog": "Loading automation catalog…",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -945,6 +945,8 @@
     "back": "Back",
     "hide_navigator": "Hide navigator",
     "show_navigator": "Show navigator",
+    "actions_menu": "Device actions",
+    "show_logs": "Logs",
     "yaml_preview": "YAML preview",
     "yaml_preview_toggle": "Show YAML",
     "diff_view_diff": "Show diff against saved",

--- a/test/components/device-install-controller.test.ts
+++ b/test/components/device-install-controller.test.ts
@@ -3,6 +3,7 @@
  * runtime_state.state, or UNKNOWN before the device loads.
  */
 import { describe, expect, it, vi } from "vitest";
+import type { ESPHomeAPI } from "../../src/api/index.js";
 import type { ConfiguredDevice } from "../../src/api/types/devices.js";
 import { DeviceState } from "../../src/api/types/devices.js";
 import {
@@ -10,12 +11,26 @@ import {
   type DeviceInstallControllerHost,
 } from "../../src/components/device/device-install-controller.js";
 import { makeConfiguredDevice } from "../_make-configured-device.js";
+import { withWebSerial } from "../_web-serial.js";
 
-function makeHost(device: ConfiguredDevice | null): DeviceInstallControllerHost {
+type LogsDialogStub = {
+  configuration?: string;
+  name?: string;
+  open: ReturnType<typeof vi.fn>;
+  openPassive: ReturnType<typeof vi.fn>;
+};
+
+function makeHost(
+  device: ConfiguredDevice | null,
+  logsDialog: LogsDialogStub | null = null
+): DeviceInstallControllerHost {
   return {
     device,
     commandDialog: null,
     firmwareDialog: null,
+    logsDialog: logsDialog as DeviceInstallControllerHost["logsDialog"],
+    api: {} as ESPHomeAPI,
+    localize: (key: string) => key,
     addController: vi.fn(),
     removeController: vi.fn(),
     requestUpdate: vi.fn(),
@@ -35,5 +50,41 @@ describe("DeviceInstallController.deviceState", () => {
     expect(new DeviceInstallController(makeHost(null)).deviceState).toBe(
       DeviceState.UNKNOWN
     );
+  });
+});
+
+describe("DeviceInstallController.methodMode", () => {
+  it("defaults to install", () => {
+    expect(new DeviceInstallController(makeHost(null)).methodMode).toBe("install");
+  });
+
+  it("flips to logs while the picker serves a Logs request, then back on select", () => {
+    const restore = withWebSerial(true);
+    try {
+      const logsDialog: LogsDialogStub = { open: vi.fn(), openPassive: vi.fn() };
+      const ctrl = new DeviceInstallController(
+        makeHost(makeConfiguredDevice(), logsDialog)
+      );
+
+      ctrl.onLogs();
+      expect(ctrl.installMethodOpen).toBe(true);
+      expect(ctrl.methodMode).toBe("logs");
+
+      ctrl.onInstallMethodSelect(
+        new CustomEvent("select-method", { detail: { method: "ota" } })
+      );
+      expect(ctrl.installMethodOpen).toBe(false);
+      expect(ctrl.methodMode).toBe("install");
+      expect(logsDialog.open).toHaveBeenCalledTimes(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it("stays install for a normal Install request", () => {
+    const ctrl = new DeviceInstallController(makeHost(makeConfiguredDevice()));
+    ctrl.onInstall();
+    expect(ctrl.installMethodOpen).toBe(true);
+    expect(ctrl.methodMode).toBe("install");
   });
 });

--- a/test/components/device/device-actions-menu.test.ts
+++ b/test/components/device/device-actions-menu.test.ts
@@ -67,7 +67,12 @@ describe("esphome-device-actions-menu", () => {
     const [logs, clean] = await openMenu(el);
     expect(clean.classList.contains("menu-item--disabled")).toBe(true);
     expect(clean.getAttribute("aria-disabled")).toBe("true");
+    // Out of the tab order and no keyboard activation while disabled.
+    expect(clean.getAttribute("tabindex")).toBe("-1");
     clean.click();
+    clean.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })
+    );
     expect(onClean).not.toHaveBeenCalled();
     // Logs stays live even while busy.
     const onLogs = vi.fn();

--- a/test/components/device/device-actions-menu.test.ts
+++ b/test/components/device/device-actions-menu.test.ts
@@ -1,8 +1,9 @@
 /**
  * @vitest-environment happy-dom
  *
- * The editor bottom-bar device-actions menu: renders Logs + Clean build,
- * emits open-logs / clean-build, and gates Clean build behind `busy`.
+ * The editor bottom-bar device-actions menu: renders Logs / Validate / Clean
+ * build, emits the matching events, and gates Validate (unsaved edits) and
+ * Clean build (busy) with disabled + out-of-tab-order semantics.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -15,10 +16,13 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-async function mount(busy = false): Promise<ESPHomeDeviceActionsMenu> {
+async function mount(
+  opts: { busy?: boolean; validateDisabled?: boolean } = {}
+): Promise<ESPHomeDeviceActionsMenu> {
   const el = new ESPHomeDeviceActionsMenu();
   (el as unknown as { _localize: typeof identityLocalize })._localize = identityLocalize;
-  el.busy = busy;
+  el.busy = opts.busy ?? false;
+  el.validateDisabled = opts.validateDisabled ?? false;
   document.body.appendChild(el);
   await el.updateComplete;
   return el;
@@ -28,63 +32,90 @@ function items(el: ESPHomeDeviceActionsMenu): HTMLElement[] {
   return Array.from(el.shadowRoot!.querySelectorAll<HTMLElement>(".menu-item"));
 }
 
+// Paint order: Logs, Validate, Clean build.
+const LOGS = 0;
+const VALIDATE = 1;
+const CLEAN = 2;
+
 async function openMenu(el: ESPHomeDeviceActionsMenu): Promise<HTMLElement[]> {
   el.shadowRoot!.querySelector<HTMLElement>(".menu-btn")!.click();
   await el.updateComplete;
   return items(el);
 }
 
+function pressEnter(row: HTMLElement): void {
+  row.dispatchEvent(
+    new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })
+  );
+}
+
 describe("esphome-device-actions-menu", () => {
-  it("is closed until the kebab is clicked", async () => {
+  it("is closed until the kebab is clicked, then shows all three actions", async () => {
     const el = await mount();
     expect(items(el)).toHaveLength(0);
-    const opened = await openMenu(el);
-    expect(opened).toHaveLength(2);
+    expect(await openMenu(el)).toHaveLength(3);
   });
 
   it("emits open-logs when Logs is clicked", async () => {
     const el = await mount();
     const onLogs = vi.fn();
     el.addEventListener("open-logs", onLogs);
-    const [logs] = await openMenu(el);
-    logs.click();
+    (await openMenu(el))[LOGS].click();
     expect(onLogs).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits validate when Validate is clicked", async () => {
+    const el = await mount();
+    const onValidate = vi.fn();
+    el.addEventListener("validate", onValidate);
+    (await openMenu(el))[VALIDATE].click();
+    expect(onValidate).toHaveBeenCalledTimes(1);
   });
 
   it("emits clean-build when Clean build is clicked", async () => {
     const el = await mount();
     const onClean = vi.fn();
     el.addEventListener("clean-build", onClean);
-    const [, clean] = await openMenu(el);
-    clean.click();
+    (await openMenu(el))[CLEAN].click();
     expect(onClean).toHaveBeenCalledTimes(1);
   });
 
-  it("disables Clean build while a build is running", async () => {
-    const el = await mount(true);
+  it("disables Validate while there are unsaved edits", async () => {
+    const el = await mount({ validateDisabled: true });
+    const onValidate = vi.fn();
+    el.addEventListener("validate", onValidate);
+    const validate = (await openMenu(el))[VALIDATE];
+    expect(validate.classList.contains("menu-item--disabled")).toBe(true);
+    expect(validate.getAttribute("aria-disabled")).toBe("true");
+    expect(validate.getAttribute("tabindex")).toBe("-1");
+    validate.click();
+    pressEnter(validate);
+    expect(onValidate).not.toHaveBeenCalled();
+  });
+
+  it("disables Clean build while a build is running, keeping the others live", async () => {
+    const el = await mount({ busy: true });
     const onClean = vi.fn();
     el.addEventListener("clean-build", onClean);
-    const [logs, clean] = await openMenu(el);
+    const rows = await openMenu(el);
+    const clean = rows[CLEAN];
     expect(clean.classList.contains("menu-item--disabled")).toBe(true);
     expect(clean.getAttribute("aria-disabled")).toBe("true");
-    // Out of the tab order and no keyboard activation while disabled.
     expect(clean.getAttribute("tabindex")).toBe("-1");
     clean.click();
-    clean.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })
-    );
+    pressEnter(clean);
     expect(onClean).not.toHaveBeenCalled();
-    // Logs stays live even while busy.
+
+    // busy gates only Clean build — Logs and Validate stay usable.
     const onLogs = vi.fn();
     el.addEventListener("open-logs", onLogs);
-    logs.click();
+    rows[LOGS].click();
     expect(onLogs).toHaveBeenCalledTimes(1);
   });
 
   it("closes after an item is chosen", async () => {
     const el = await mount();
-    const [logs] = await openMenu(el);
-    logs.click();
+    (await openMenu(el))[LOGS].click();
     await el.updateComplete;
     expect(items(el)).toHaveLength(0);
   });

--- a/test/components/device/device-actions-menu.test.ts
+++ b/test/components/device/device-actions-menu.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The editor bottom-bar device-actions menu: renders Logs + Clean build,
+ * emits open-logs / clean-build, and gates Clean build behind `busy`.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomeDeviceActionsMenu } from "../../../src/components/device/device-actions-menu.js";
+import { identityLocalize } from "../../_dom.js";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+async function mount(busy = false): Promise<ESPHomeDeviceActionsMenu> {
+  const el = new ESPHomeDeviceActionsMenu();
+  (el as unknown as { _localize: typeof identityLocalize })._localize = identityLocalize;
+  el.busy = busy;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function items(el: ESPHomeDeviceActionsMenu): HTMLElement[] {
+  return Array.from(el.shadowRoot!.querySelectorAll<HTMLElement>(".menu-item"));
+}
+
+async function openMenu(el: ESPHomeDeviceActionsMenu): Promise<HTMLElement[]> {
+  el.shadowRoot!.querySelector<HTMLElement>(".menu-btn")!.click();
+  await el.updateComplete;
+  return items(el);
+}
+
+describe("esphome-device-actions-menu", () => {
+  it("is closed until the kebab is clicked", async () => {
+    const el = await mount();
+    expect(items(el)).toHaveLength(0);
+    const opened = await openMenu(el);
+    expect(opened).toHaveLength(2);
+  });
+
+  it("emits open-logs when Logs is clicked", async () => {
+    const el = await mount();
+    const onLogs = vi.fn();
+    el.addEventListener("open-logs", onLogs);
+    const [logs] = await openMenu(el);
+    logs.click();
+    expect(onLogs).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits clean-build when Clean build is clicked", async () => {
+    const el = await mount();
+    const onClean = vi.fn();
+    el.addEventListener("clean-build", onClean);
+    const [, clean] = await openMenu(el);
+    clean.click();
+    expect(onClean).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Clean build while a build is running", async () => {
+    const el = await mount(true);
+    const onClean = vi.fn();
+    el.addEventListener("clean-build", onClean);
+    const [logs, clean] = await openMenu(el);
+    expect(clean.classList.contains("menu-item--disabled")).toBe(true);
+    expect(clean.getAttribute("aria-disabled")).toBe("true");
+    clean.click();
+    expect(onClean).not.toHaveBeenCalled();
+    // Logs stays live even while busy.
+    const onLogs = vi.fn();
+    el.addEventListener("open-logs", onLogs);
+    logs.click();
+    expect(onLogs).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes after an item is chosen", async () => {
+    const el = await mount();
+    const [logs] = await openMenu(el);
+    logs.click();
+    await el.updateComplete;
+    expect(items(el)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

This fixes a usability problem: you lose your context every time you want to see a device's logs, because the only way to check them is to leave the editor for the main dashboard and come back.

Today the loop is:

- edit/flash
- return to the main screen
- find the device
- check logs
- return to the editor
- edit/flash
- ...

With this change it becomes:

- edit/flash
- check logs
- edit/flash
- check logs
- ...

You stay on the editor the whole time instead of bouncing out to the dashboard and back, so you keep your place.

The fix adds a device scoped overflow (`⋮`) menu to the editor's bottom action bar with **Logs**, **Validate**, and **Clean build files**, so you open live logs in place without leaving the screen you are working on. Clean build files was already handled reactively (the install dialog's post failure hint); this surfaces it as a direct action too, and Validate moves off the bar into the menu (Install validates anyway, so the standalone button rarely earned its slot).

`Install` and `Save` keep their spots on the bar; nothing is overloaded. The menu is distinct from the app header `⋮` (Secrets, Settings, Search), which is app global, not device scoped.

The logs feature itself already existed (the logs dialog and the `devices/logs` stream are mounted on the editor page, and installing from the editor already auto opens logs); the only gap was a standalone trigger. This PR stacks on #1180, which extracts the shared `src/util/logs-launch.ts` that both the dashboard and this editor path consume, so the change here is just the menu component plus its wiring (`device-install-controller` gains a `logs` intent for the shared source picker; `device.ts` routes the menu events).

## Screenshots

View captured live against the full starter kit config:

Editor bottom bar with the actions menu open, showing Logs, Validate, and Clean build files.

<img width="667" height="301" alt="Screenshot 2026-07-11 at 10 00 10 AM" src="https://github.com/user-attachments/assets/35e7afbb-2939-4526-b895-d3f745bc3605" />
<img width="665" height="214" alt="Screenshot 2026-07-11 at 10 00 01 AM" src="https://github.com/user-attachments/assets/ed344dea-2723-46fb-b48e-cfb1c0ec0cf3" />


**Related issue or feature (if applicable):**

- fixes [esphome/device-builder-frontend discussion #3762](https://github.com/orgs/esphome/discussions/3762)
- fixes [esphome/device-builder-frontend discussion #3740](https://github.com/orgs/esphome/discussions/3740)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

