### PR TITLE
Extract a shared OverflowMenuElement base for kebab/toggle menus

### DIFF
--- a/src/components/dashboard/table-column-toggle.ts
+++ b/src/components/dashboard/table-column-toggle.ts
@@ -1,12 +1,13 @@
 import { consume } from "@lit/context";
 import { mdiCheck, mdiCogOutline } from "@mdi/js";
-import { LitElement, css, html, nothing } from "lit";
+import { css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { dropdownMenuStyles } from "../../styles/dropdown-menu.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { OverflowMenuElement } from "../overflow-menu-element.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 
@@ -19,16 +20,13 @@ export interface ToggleableColumn {
 }
 
 @customElement("esphome-table-column-toggle")
-export class ESPHomeTableColumnToggle extends LitElement {
+export class ESPHomeTableColumnToggle extends OverflowMenuElement {
   @consume({ context: localizeContext, subscribe: true })
   @state()
   private _localize: LocalizeFunc = (key) => key;
 
   @property({ attribute: false })
   columns: ToggleableColumn[] = [];
-
-  @state()
-  private _open = false;
 
   static styles = [
     espHomeStyles,
@@ -245,34 +243,8 @@ export class ESPHomeTableColumnToggle extends LitElement {
     `;
   }
 
-  private _toggle() {
-    this._open = !this._open;
-  }
-
-  private _close() {
-    this._open = false;
-  }
-
-  /* The menu items are ``<div role="menuitemcheckbox">`` rather than
-     <button>s so they sit flush with the checkbox styling. role +
-     tabindex make them focusable; this maps Enter / Space to the same
-     click the mouse would dispatch, reusing the @click handler bound
-     on the element (mirrors esphome-header-actions). */
-  private _onItemKeydown = (e: KeyboardEvent) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      (e.currentTarget as HTMLElement).click();
-    }
-  };
-
   private _onToggle(id: string, visible: boolean) {
-    this.dispatchEvent(
-      new CustomEvent("column-visibility-change", {
-        detail: { id, visible },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    this._emit("column-visibility-change", { id, visible });
   }
 }
 

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -14,7 +14,7 @@ import {
   mdiUpdate,
   mdiWifiCog,
 } from "@mdi/js";
-import { LitElement, html, nothing } from "lit";
+import { html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { AdoptableDevice } from "../api/types/devices.js";
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
@@ -31,11 +31,11 @@ import {
 } from "../context/index.js";
 import { dropdownMenuStyles } from "../styles/dropdown-menu.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { EscapeController } from "../util/escape-controller.js";
 import { navigate } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { OPEN_COMMAND_PALETTE_EVENT } from "./command-palette-actions.js";
 import { headerActionsStyles } from "./esphome-header-actions.styles.js";
+import { OverflowMenuElement } from "./overflow-menu-element.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 
@@ -68,7 +68,7 @@ function isApplePlatform(): boolean {
 }
 
 @customElement("esphome-header-actions")
-export class ESPHomeHeaderActions extends LitElement {
+export class ESPHomeHeaderActions extends OverflowMenuElement {
   @consume({ context: localizeContext, subscribe: true })
   @state()
   private _localize: LocalizeFunc = (key) => key;
@@ -85,9 +85,6 @@ export class ESPHomeHeaderActions extends LitElement {
   @consume({ context: buildOffloadAlertsContext, subscribe: true })
   @state()
   private _offloaderAlerts: Map<string, OffloaderAlertSnapshotEntry> | null = null;
-
-  @state()
-  private _open = false;
 
   /** True on the dashboard route. Dashboard-only menu entries
    *  (Archived Devices) hide elsewhere; their dialog is hosted on the
@@ -201,7 +198,7 @@ export class ESPHomeHeaderActions extends LitElement {
                   role="menuitem"
                   tabindex="0"
                   @click=${this._openFirmwareJobs}
-                  @keydown=${this._onMenuItemKeydown}
+                  @keydown=${this._onItemKeydown}
                 >
                   <wa-icon library="mdi" name="playlist-check"></wa-icon>
                   <span class="menu-item-label"
@@ -218,7 +215,7 @@ export class ESPHomeHeaderActions extends LitElement {
                   role="menuitem"
                   tabindex="0"
                   @click=${this._openSecrets}
-                  @keydown=${this._onMenuItemKeydown}
+                  @keydown=${this._onItemKeydown}
                 >
                   <wa-icon library="mdi" name="key-variant"></wa-icon>
                   <span class="menu-item-label">${this._localize("layout.secrets")}</span>
@@ -228,7 +225,7 @@ export class ESPHomeHeaderActions extends LitElement {
                   role="menuitem"
                   tabindex="0"
                   @click=${this._openOnboarding}
-                  @keydown=${this._onMenuItemKeydown}
+                  @keydown=${this._onItemKeydown}
                 >
                   <wa-icon library="mdi" name="wifi-cog"></wa-icon>
                   <span class="menu-item-label"
@@ -246,7 +243,7 @@ export class ESPHomeHeaderActions extends LitElement {
                         role="menuitem"
                         tabindex="0"
                         @click=${this._openArchivedDevices}
-                        @keydown=${this._onMenuItemKeydown}
+                        @keydown=${this._onItemKeydown}
                       >
                         <wa-icon library="mdi" name="archive-outline"></wa-icon>
                         ${this._localize("layout.archived_devices")}
@@ -261,7 +258,7 @@ export class ESPHomeHeaderActions extends LitElement {
                         tabindex="0"
                         aria-checked=${this._showIgnored ? "true" : "false"}
                         @click=${this._toggleShowIgnoredDiscoveries}
-                        @keydown=${this._onMenuItemKeydown}
+                        @keydown=${this._onItemKeydown}
                       >
                         <wa-icon
                           library="mdi"
@@ -284,7 +281,7 @@ export class ESPHomeHeaderActions extends LitElement {
                   role="menuitem"
                   tabindex="0"
                   @click=${this._openResetBuildEnv}
-                  @keydown=${this._onMenuItemKeydown}
+                  @keydown=${this._onItemKeydown}
                 >
                   <wa-icon library="mdi" name="cog-refresh"></wa-icon>
                   ${this._localize("layout.reset_build_env")}
@@ -295,7 +292,7 @@ export class ESPHomeHeaderActions extends LitElement {
                   role="menuitem"
                   tabindex="0"
                   @click=${this._openSettings}
-                  @keydown=${this._onMenuItemKeydown}
+                  @keydown=${this._onItemKeydown}
                 >
                   <wa-icon library="mdi" name="cog"></wa-icon>
                   <span class="menu-item-label"
@@ -316,7 +313,7 @@ export class ESPHomeHeaderActions extends LitElement {
                         role="menuitem"
                         tabindex="0"
                         @click=${this._openCheckForUpdates}
-                        @keydown=${this._onMenuItemKeydown}
+                        @keydown=${this._onItemKeydown}
                       >
                         <wa-icon library="mdi" name="update"></wa-icon>
                         <span class="menu-item-label"
@@ -330,7 +327,7 @@ export class ESPHomeHeaderActions extends LitElement {
                   role="menuitem"
                   tabindex="0"
                   @click=${this._openSearch}
-                  @keydown=${this._onMenuItemKeydown}
+                  @keydown=${this._onItemKeydown}
                 >
                   <wa-icon library="mdi" name="magnify"></wa-icon>
                   <span class="menu-item-label">${this._localize("layout.search")}</span>
@@ -342,7 +339,7 @@ export class ESPHomeHeaderActions extends LitElement {
                   role="menuitem"
                   tabindex="0"
                   @click=${this._openFeedback}
-                  @keydown=${this._onMenuItemKeydown}
+                  @keydown=${this._onItemKeydown}
                 >
                   <wa-icon library="mdi" name="comment-question-outline"></wa-icon>
                   ${this._localize("layout.feedback_menu")}
@@ -353,36 +350,6 @@ export class ESPHomeHeaderActions extends LitElement {
       }
     `;
   }
-
-  private _toggle() {
-    this._open = !this._open;
-  }
-
-  private _close() {
-    this._open = false;
-  }
-
-  private _escape = new EscapeController(this, (e) => {
-    e.preventDefault();
-    this._close();
-  });
-
-  protected willUpdate(changed: Map<string, unknown>) {
-    if (changed.has("_open")) this._escape.set(this._open);
-  }
-
-  private _onMenuItemKeydown = (e: KeyboardEvent) => {
-    /* The kebab menu items are ``<div role="menuitem">`` rather than
-       <button>s so they sit visually flush with the checkbox-style
-       toggle below. role + tabindex make them focusable; this handler
-       maps Enter / Space to the same click the mouse would dispatch.
-       ``e.currentTarget.click()`` re-uses the @click handler bound on
-       the same element, so any per-item logic stays where it lives. */
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      (e.currentTarget as HTMLElement).click();
-    }
-  };
 
   private _openArchivedDevices = () => {
     /* Dashboard hosts the dialog instance and listens for this

--- a/src/components/overflow-menu-element.ts
+++ b/src/components/overflow-menu-element.ts
@@ -6,12 +6,12 @@ import { EscapeController } from "../util/escape-controller.js";
  * Base for self-triggering kebab / toggle popover menus: owns the open
  * flag, Escape-to-close, keyboard activation of `role="menuitem"` rows, and
  * bubbling-event emit.
-
+ *
  * Subclasses render their own trigger button, menu body, and styles (pairing
  * `dropdownMenuStyles`), wiring `_toggle`/`_close` on the trigger/backdrop,
  * `_onItemKeydown` on focusable rows, and `_emit` for actions. Override
  * `willUpdate` only if you also `super.willUpdate(changed)`.
-
+ *
  * Not for externally-positioned context menus whose open state derives from
  * props and whose close has side effects (see `table-row-menu`).
  */
@@ -35,7 +35,12 @@ export abstract class OverflowMenuElement extends LitElement {
     this._open = false;
   };
 
-  /** Enter/Space activates a focusable `role="menuitem"` row (reuses its @click). */
+  /**
+   * Enter/Space activates a focusable row, re-dispatching its `@click`. Rows
+   * are `role="menuitem"` divs (not `<button>`s) so they sit flush with the
+   * checkbox / icon-label styling; this restores the keyboard path buttons
+   * would give for free.
+   */
   protected _onItemKeydown = (e: KeyboardEvent) => {
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();

--- a/src/components/overflow-menu-element.ts
+++ b/src/components/overflow-menu-element.ts
@@ -1,0 +1,49 @@
+import { LitElement } from "lit";
+import { state } from "lit/decorators.js";
+import { EscapeController } from "../util/escape-controller.js";
+
+/**
+ * Base for self-triggering kebab / toggle popover menus: owns the open
+ * flag, Escape-to-close, keyboard activation of `role="menuitem"` rows, and
+ * bubbling-event emit.
+
+ * Subclasses render their own trigger button, menu body, and styles (pairing
+ * `dropdownMenuStyles`), wiring `_toggle`/`_close` on the trigger/backdrop,
+ * `_onItemKeydown` on focusable rows, and `_emit` for actions. Override
+ * `willUpdate` only if you also `super.willUpdate(changed)`.
+
+ * Not for externally-positioned context menus whose open state derives from
+ * props and whose close has side effects (see `table-row-menu`).
+ */
+export abstract class OverflowMenuElement extends LitElement {
+  @state() protected _open = false;
+
+  private _escape = new EscapeController(this, (e) => {
+    e.preventDefault();
+    this._close();
+  });
+
+  protected willUpdate(changed: Map<string, unknown>) {
+    if (changed.has("_open")) this._escape.set(this._open);
+  }
+
+  protected _toggle = () => {
+    this._open = !this._open;
+  };
+
+  protected _close = () => {
+    this._open = false;
+  };
+
+  /** Enter/Space activates a focusable `role="menuitem"` row (reuses its @click). */
+  protected _onItemKeydown = (e: KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      (e.currentTarget as HTMLElement).click();
+    }
+  };
+
+  protected _emit(type: string, detail?: unknown) {
+    this.dispatchEvent(new CustomEvent(type, { detail, bubbles: true, composed: true }));
+  }
+}

--- a/src/components/overflow-menu-element.ts
+++ b/src/components/overflow-menu-element.ts
@@ -4,7 +4,7 @@ import { EscapeController } from "../util/escape-controller.js";
 
 /**
  * Base for self-triggering kebab / toggle popover menus: owns the open
- * flag, Escape-to-close, keyboard activation of `role="menuitem"` rows, and
+ * flag, Escape-to-close, keyboard activation of focusable menu rows, and
  * bubbling-event emit.
  *
  * Subclasses render their own trigger button, menu body, and styles (pairing
@@ -37,9 +37,9 @@ export abstract class OverflowMenuElement extends LitElement {
 
   /**
    * Enter/Space activates a focusable row, re-dispatching its `@click`. Rows
-   * are `role="menuitem"` divs (not `<button>`s) so they sit flush with the
-   * checkbox / icon-label styling; this restores the keyboard path buttons
-   * would give for free.
+   * are role'd divs (`menuitem` / `menuitemcheckbox`), not `<button>`s, so they
+   * sit flush with the checkbox / icon-label styling; this restores the
+   * keyboard path buttons would give for free.
    */
   protected _onItemKeydown = (e: KeyboardEvent) => {
     if (e.key === "Enter" || e.key === " ") {

--- a/test/components/overflow-menu-element.test.ts
+++ b/test/components/overflow-menu-element.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the shared OverflowMenuElement scaffolding: toggle/close open state,
+ * Escape-to-close, Enter/Space activation of menu rows, and bubbling emit.
+ */
+import { html, nothing } from "lit";
+import { customElement } from "lit/decorators.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OverflowMenuElement } from "../../src/components/overflow-menu-element.js";
+
+@customElement("test-overflow-menu")
+class TestOverflowMenu extends OverflowMenuElement {
+  render() {
+    return html`
+      <button class="trigger" @click=${this._toggle}></button>
+      ${
+        this._open
+          ? html`
+              <div class="backdrop" @click=${this._close}></div>
+              <div
+                class="item"
+                role="menuitem"
+                tabindex="0"
+                @click=${() => this._emit("chosen", { v: 1 })}
+                @keydown=${this._onItemKeydown}
+              ></div>
+            `
+          : nothing
+      }
+    `;
+  }
+}
+
+async function mount(): Promise<TestOverflowMenu> {
+  const el = new TestOverflowMenu();
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function trigger(el: TestOverflowMenu): HTMLElement {
+  return el.shadowRoot!.querySelector<HTMLElement>(".trigger")!;
+}
+
+function item(el: TestOverflowMenu): HTMLElement | null {
+  return el.shadowRoot!.querySelector<HTMLElement>(".item");
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+});
+
+describe("OverflowMenuElement", () => {
+  it("toggles open then closed from the trigger", async () => {
+    const el = await mount();
+    expect(item(el)).toBeNull();
+    trigger(el).click();
+    await el.updateComplete;
+    expect(item(el)).not.toBeNull();
+    trigger(el).click();
+    await el.updateComplete;
+    expect(item(el)).toBeNull();
+  });
+
+  it("closes on the backdrop click", async () => {
+    const el = await mount();
+    trigger(el).click();
+    await el.updateComplete;
+    el.shadowRoot!.querySelector<HTMLElement>(".backdrop")!.click();
+    await el.updateComplete;
+    expect(item(el)).toBeNull();
+  });
+
+  it("closes on Escape while open, and only while open", async () => {
+    const el = await mount();
+    // Escape while closed is a no-op (no listener bound).
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await el.updateComplete;
+    expect(item(el)).toBeNull();
+
+    trigger(el).click();
+    await el.updateComplete;
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", cancelable: true })
+    );
+    await el.updateComplete;
+    expect(item(el)).toBeNull();
+  });
+
+  it("activates a row on Enter and Space", async () => {
+    const el = await mount();
+    trigger(el).click();
+    await el.updateComplete;
+    const onChosen = vi.fn();
+    el.addEventListener("chosen", onChosen);
+
+    item(el)!.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })
+    );
+    expect(onChosen).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits a bubbling, composed event carrying detail", async () => {
+    const el = await mount();
+    trigger(el).click();
+    await el.updateComplete;
+    let received: CustomEvent | null = null;
+    el.addEventListener("chosen", (e) => (received = e as CustomEvent));
+    item(el)!.click();
+    expect(received).not.toBeNull();
+    expect(received!.bubbles).toBe(true);
+    expect(received!.composed).toBe(true);
+    expect(received!.detail).toEqual({ v: 1 });
+  });
+});

--- a/test/components/overflow-menu-element.test.ts
+++ b/test/components/overflow-menu-element.test.ts
@@ -89,17 +89,24 @@ describe("OverflowMenuElement", () => {
     expect(item(el)).toBeNull();
   });
 
-  it("activates a row on Enter and Space", async () => {
+  it("activates a row on Enter and Space, but ignores other keys", async () => {
     const el = await mount();
     trigger(el).click();
     await el.updateComplete;
     const onChosen = vi.fn();
     el.addEventListener("chosen", onChosen);
+    const row = item(el)!;
+    const press = (key: string) =>
+      row.dispatchEvent(
+        new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true })
+      );
 
-    item(el)!.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })
-    );
-    expect(onChosen).toHaveBeenCalledTimes(1);
+    press("Enter");
+    press(" ");
+    expect(onChosen).toHaveBeenCalledTimes(2);
+
+    press("a");
+    expect(onChosen).toHaveBeenCalledTimes(2);
   });
 
   it("emits a bubbling, composed event carrying detail", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Refactor, no user-visible behaviour change (one small consistency gain, noted below). Closes #1178.

Several self-triggering popover menus each hand-roll the same scaffolding around `src/styles/dropdown-menu.ts`: the `_open` flag, `_toggle`/`_close`, Escape-to-close via `EscapeController`, `willUpdate` wiring, keyboard activation of `role="menuitem"` rows, and the bubbling `CustomEvent` emit. This had already drifted: `table-column-toggle` had keyboard activation but no Escape-to-close, and the copies were diverging item by item.

This extracts an abstract `OverflowMenuElement` base (`src/components/overflow-menu-element.ts`) that owns the open flag, Escape wiring, `_onItemKeydown`, `_toggle`/`_close`, and `_emit(type, detail?)`. Subclasses keep their own trigger, menu body, and styles; they just extend the base instead of re-declaring the plumbing. Migrated onto it:

- `esphome-header-actions` (drops its `_open`/`_toggle`/`_close`/`_escape`/`willUpdate`/`_onMenuItemKeydown`)
- `table-column-toggle` (drops the same, and now closes on Escape like the others; `_onToggle` routes through `_emit`)

`table-row-menu` is intentionally left out: it is an externally positioned, prop-driven context menu (no trigger, open state derives from `device`/`position`, and its close clears props plus emits `menu-close`), so sharing the toggle base would be the wrong abstraction. The kebab menu added in #1177 (`device-actions-menu`) will migrate onto this base when that PR rebases on top of this one.

The one behaviour delta: `table-column-toggle` gains Escape-to-close, matching every other menu; this is the consistency the extraction is meant to enforce.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
