### PR TITLE
Extract the dashboard logs-launch logic into a shared util

### DIFF
--- a/src/components/dashboard/actions-ui.ts
+++ b/src/components/dashboard/actions-ui.ts
@@ -10,13 +10,8 @@ import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
 import { getErrorMessage } from "../../util/error-message.js";
 import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
 import { clearJustCreated } from "../../util/just-created.js";
-import { resolveLogBaudRate } from "../../util/log-baud-rate.js";
+import { launchLogsWithMethod } from "../../util/logs-launch.js";
 import { notifyError, notifySuccess } from "../../util/notify.js";
-import {
-  attachSerialLogStream,
-  reconnectWebSerialLogs,
-  requestAndOpenSerialPort,
-} from "../../util/post-install-logs.js";
 
 export async function executeFriendlyName(
   host: ESPHomePageDashboard,
@@ -173,57 +168,18 @@ export async function deleteLabel(
   }
 }
 
-export async function openLogsWithMethod(
+export function openLogsWithMethod(
   host: ESPHomePageDashboard,
   device: ConfiguredDevice,
   method: string,
   port?: string
 ): Promise<void> {
-  if (method === "ota") {
-    host._logsDialog.configuration = device.configuration;
-    host._logsDialog.name = device.friendly_name || device.name;
-    host._logsDialog.open();
-  } else if (method === "server-serial") {
-    host._logsDialog.configuration = device.configuration;
-    host._logsDialog.name = device.friendly_name || device.name;
-    host._logsDialog.open(port);
-  } else if (method === "web-serial") {
-    if (!("serial" in navigator)) {
-      notifyError(host._localize("dashboard.logs_web_serial_unsupported"));
-      return;
-    }
-    const baudRate = resolveLogBaudRate(device.logger_baud_rate);
-    if (baudRate === null) {
-      // logger: baud_rate: 0 — UART logging is disabled; serial would be silent.
-      notifyError(host._localize("dashboard.logs_serial_disabled"));
-      return;
-    }
-    let serialPort: SerialPort | null;
-    try {
-      serialPort = await requestAndOpenSerialPort(baudRate);
-    } catch {
-      // The user picked a port but it couldn't open (claimed by another tab,
-      // driver error); unlike a picker dismissal this needs feedback.
-      notifyError(host._localize("dashboard.logs_web_serial_open_failed"));
-      return;
-    }
-    if (!serialPort) return; // User dismissed the port picker.
-    host._logsDialog.configuration = device.configuration;
-    host._logsDialog.name = device.friendly_name || device.name;
-    // Reconnect (the dialog's "click Start to reconnect") re-acquires a fresh
-    // port via the picker — the cached handle can be dead after a device reset.
-    host._logsDialog.openPassive({
-      onReconnect: () =>
-        reconnectWebSerialLogs(host._logsDialog, host._localize, baudRate),
-    });
-    // attach toasts the reopen-retry failure itself; cover any other rejection
-    // so it can't escape this fire-and-forget call as an unhandled rejection.
-    try {
-      await attachSerialLogStream(serialPort, host._logsDialog, host._localize, baudRate);
-    } catch {
-      notifyError(host._localize("dashboard.logs_web_serial_open_failed"));
-    }
-  }
+  return launchLogsWithMethod(
+    { api: host._api, logsDialog: host._logsDialog, localize: host._localize },
+    device,
+    method,
+    port
+  );
 }
 
 export function scheduleScrollIntoView(

--- a/src/components/dashboard/install.ts
+++ b/src/components/dashboard/install.ts
@@ -1,6 +1,7 @@
 import type { ConfiguredDevice } from "../../api/types/devices.js";
 import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
 import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
+import { launchLogs } from "../../util/logs-launch.js";
 import { applyInstallMethod } from "../apply-install-method.js";
 import type { CommandType } from "../command-dialog.js";
 import { openLogsWithMethod } from "./actions-ui.js";
@@ -55,38 +56,17 @@ export function showJobProgress(
   );
 }
 
-export async function openLogs(
+export function openLogs(
   host: ESPHomePageDashboard,
   device: ConfiguredDevice
 ): Promise<void> {
-  // Offer the OTA-vs-serial choice whenever a serial path exists — browser
-  // WebSerial, or serial ports on the server (mirrors the old dashboard's
-  // logs-target behavior; see #525). With no serial option at all, skip the
-  // picker and open OTA logs directly. The device's online/offline state is
-  // intentionally not consulted: the picker (or OTA fallback) is purely
-  // serial-path driven, and the picker already gates its own OTA row on state.
-  const hasWebSerial = "serial" in navigator;
-  let hasServerPorts = false;
-  if (!hasWebSerial) {
-    // Only pay the backend round-trip when WebSerial can't already provide a
-    // serial path.
-    try {
-      hasServerPorts = (await host._api.getSerialPorts()).length > 0;
-    } catch (err) {
-      // Lockstep deployment means this command exists, so a rejection is a
-      // real WS/backend fault, not version drift; log it but still fall
-      // through to OTA logs so the user isn't left without any path.
-      console.warn("getSerialPorts failed; falling back to OTA logs", err);
-      hasServerPorts = false;
+  return launchLogs(
+    { api: host._api, logsDialog: host._logsDialog, localize: host._localize },
+    device,
+    () => {
+      host._installMethodDevice = device;
+      host._installMethodMode = "logs";
+      host._installMethodOpen = true;
     }
-  }
-  if (hasWebSerial || hasServerPorts) {
-    host._installMethodDevice = device;
-    host._installMethodMode = "logs";
-    host._installMethodOpen = true;
-    return;
-  }
-  host._logsDialog.configuration = device.configuration;
-  host._logsDialog.name = device.friendly_name || device.name;
-  host._logsDialog.open();
+  );
 }

--- a/src/util/logs-launch.ts
+++ b/src/util/logs-launch.ts
@@ -1,0 +1,107 @@
+import type { ESPHomeAPI } from "../api/index.js";
+import type { ConfiguredDevice } from "../api/types/devices.js";
+import type { LocalizeFunc } from "../common/localize.js";
+import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";
+import { resolveLogBaudRate } from "./log-baud-rate.js";
+import { notifyError } from "./notify.js";
+import {
+  attachSerialLogStream,
+  reconnectWebSerialLogs,
+  requestAndOpenSerialPort,
+} from "./post-install-logs.js";
+
+/** The host bits both logs entry points need, decoupled from any page class. */
+export interface LogsLaunchHost {
+  readonly api: ESPHomeAPI;
+  readonly logsDialog: ESPHomeLogsDialog;
+  readonly localize: LocalizeFunc;
+}
+
+/**
+ * Open live logs, offering the OTA-vs-serial picker when a serial path exists.
+
+ * ``openMethodPicker`` is invoked (host wires the picker in its logs mode) when
+ * WebSerial or a server serial port is available; otherwise OTA logs open
+ * directly. Online/offline state is intentionally not consulted (#525).
+ */
+export async function launchLogs(
+  host: LogsLaunchHost,
+  device: ConfiguredDevice,
+  openMethodPicker: () => void
+): Promise<void> {
+  const hasWebSerial = "serial" in navigator;
+  let hasServerPorts = false;
+  if (!hasWebSerial) {
+    // Only pay the backend round-trip when WebSerial can't already provide a
+    // serial path.
+    try {
+      hasServerPorts = (await host.api.getSerialPorts()).length > 0;
+    } catch (err) {
+      // Lockstep deployment means this command exists, so a rejection is a real
+      // WS/backend fault, not version drift; log it but still fall through to
+      // OTA logs so the user isn't left without any path.
+      console.warn("getSerialPorts failed; falling back to OTA logs", err);
+      hasServerPorts = false;
+    }
+  }
+  if (hasWebSerial || hasServerPorts) {
+    openMethodPicker();
+    return;
+  }
+  host.logsDialog.configuration = device.configuration;
+  host.logsDialog.name = device.friendly_name || device.name;
+  host.logsDialog.open();
+}
+
+/** Route a picked install-method to the logs dialog (OTA / server-serial / web-serial). */
+export async function launchLogsWithMethod(
+  host: LogsLaunchHost,
+  device: ConfiguredDevice,
+  method: string,
+  port?: string
+): Promise<void> {
+  if (method === "ota") {
+    host.logsDialog.configuration = device.configuration;
+    host.logsDialog.name = device.friendly_name || device.name;
+    host.logsDialog.open();
+  } else if (method === "server-serial") {
+    host.logsDialog.configuration = device.configuration;
+    host.logsDialog.name = device.friendly_name || device.name;
+    host.logsDialog.open(port);
+  } else if (method === "web-serial") {
+    if (!("serial" in navigator)) {
+      notifyError(host.localize("dashboard.logs_web_serial_unsupported"));
+      return;
+    }
+    const baudRate = resolveLogBaudRate(device.logger_baud_rate);
+    if (baudRate === null) {
+      // logger: baud_rate: 0 — UART logging is disabled; serial would be silent.
+      notifyError(host.localize("dashboard.logs_serial_disabled"));
+      return;
+    }
+    let serialPort: SerialPort | null;
+    try {
+      serialPort = await requestAndOpenSerialPort(baudRate);
+    } catch {
+      // The user picked a port but it couldn't open (claimed by another tab,
+      // driver error); unlike a picker dismissal this needs feedback.
+      notifyError(host.localize("dashboard.logs_web_serial_open_failed"));
+      return;
+    }
+    if (!serialPort) return; // User dismissed the port picker.
+    host.logsDialog.configuration = device.configuration;
+    host.logsDialog.name = device.friendly_name || device.name;
+    // Reconnect (the dialog's "click Start to reconnect") re-acquires a fresh
+    // port via the picker — the cached handle can be dead after a device reset.
+    host.logsDialog.openPassive({
+      onReconnect: () => reconnectWebSerialLogs(host.logsDialog, host.localize, baudRate),
+    });
+    // attach toasts the reopen-retry failure itself; cover any other rejection
+    // so it can't escape this fire-and-forget call as an unhandled rejection.
+    try {
+      await attachSerialLogStream(serialPort, host.logsDialog, host.localize, baudRate);
+    } catch {
+      notifyError(host.localize("dashboard.logs_web_serial_open_failed"));
+    }
+  }
+}

--- a/src/util/logs-launch.ts
+++ b/src/util/logs-launch.ts
@@ -65,6 +65,10 @@ export async function launchLogsWithMethod(
     host.logsDialog.name = device.friendly_name || device.name;
     host.logsDialog.open();
   } else if (method === "server-serial") {
+    // server-serial always carries the chosen port; guard rather than let a
+    // missing one fall through to open()'s OTA-sentinel default and silently
+    // stream OTA logs (mirrors applyInstallMethod's server-serial guard).
+    if (!port) return;
     host.logsDialog.configuration = device.configuration;
     host.logsDialog.name = device.friendly_name || device.name;
     host.logsDialog.open(port);

--- a/test/_web-serial.ts
+++ b/test/_web-serial.ts
@@ -1,0 +1,17 @@
+/** Toggle `navigator.serial` presence for a test; returns a restore function. */
+export function withWebSerial(present: boolean): () => void {
+  const had = "serial" in navigator;
+  const previous = (navigator as unknown as { serial?: unknown }).serial;
+  if (present) {
+    Object.defineProperty(navigator, "serial", { configurable: true, value: {} });
+  } else if (had) {
+    delete (navigator as unknown as { serial?: unknown }).serial;
+  }
+  return () => {
+    if (had) {
+      Object.defineProperty(navigator, "serial", { configurable: true, value: previous });
+    } else {
+      delete (navigator as unknown as { serial?: unknown }).serial;
+    }
+  };
+}

--- a/test/components/dashboard/open-logs.test.ts
+++ b/test/components/dashboard/open-logs.test.ts
@@ -3,6 +3,7 @@ import type { ESPHomeAPI } from "../../../src/api/index.js";
 import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
 import { openLogs } from "../../../src/components/dashboard/install.js";
 import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
+import { withWebSerial } from "../../_web-serial.js";
 
 function makeDevice(): ConfiguredDevice {
   return {
@@ -25,24 +26,6 @@ function makeHost(getSerialPorts: () => Promise<unknown>): StubHost {
     _api: { getSerialPorts: vi.fn(getSerialPorts) } as unknown as StubHost["_api"],
     _logsDialog: { open: vi.fn() },
     _installMethodOpen: false,
-  };
-}
-
-/** Toggle `navigator.serial` presence; returns a restore function. */
-function withWebSerial(present: boolean): () => void {
-  const had = "serial" in navigator;
-  const previous = (navigator as unknown as { serial?: unknown }).serial;
-  if (present) {
-    Object.defineProperty(navigator, "serial", { configurable: true, value: {} });
-  } else if (had) {
-    delete (navigator as unknown as { serial?: unknown }).serial;
-  }
-  return () => {
-    if (had) {
-      Object.defineProperty(navigator, "serial", { configurable: true, value: previous });
-    } else {
-      delete (navigator as unknown as { serial?: unknown }).serial;
-    }
   };
 }
 

--- a/test/util/logs-launch.test.ts
+++ b/test/util/logs-launch.test.ts
@@ -106,4 +106,10 @@ describe("launchLogsWithMethod", () => {
     await launchLogsWithMethod(host, makeDevice(), "server-serial", "/dev/ttyUSB0");
     expect(host.logsDialog.open).toHaveBeenCalledWith("/dev/ttyUSB0");
   });
+
+  it("ignores server-serial with no port instead of silently opening OTA logs", async () => {
+    const host = makeHost(async () => []);
+    await launchLogsWithMethod(host, makeDevice(), "server-serial");
+    expect(host.logsDialog.open).not.toHaveBeenCalled();
+  });
 });

--- a/test/util/logs-launch.test.ts
+++ b/test/util/logs-launch.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ConfiguredDevice } from "../../src/api/types/devices.js";
+import { launchLogs, launchLogsWithMethod } from "../../src/util/logs-launch.js";
+import type { LogsLaunchHost } from "../../src/util/logs-launch.js";
+import { withWebSerial } from "../_web-serial.js";
+
+function makeDevice(): ConfiguredDevice {
+  return {
+    name: "kitchen",
+    friendly_name: "Kitchen",
+    configuration: "kitchen.yaml",
+  } as ConfiguredDevice;
+}
+
+function makeHost(getSerialPorts: () => Promise<unknown>): LogsLaunchHost & {
+  logsDialog: { configuration?: string; name?: string; open: ReturnType<typeof vi.fn> };
+} {
+  return {
+    api: { getSerialPorts: vi.fn(getSerialPorts) },
+    logsDialog: { open: vi.fn() },
+    localize: (key: string) => key,
+  } as unknown as LogsLaunchHost & {
+    logsDialog: { configuration?: string; name?: string; open: ReturnType<typeof vi.fn> };
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("launchLogs", () => {
+  it("opens the method picker when WebSerial is available, skipping the backend", async () => {
+    const restore = withWebSerial(true);
+    try {
+      const host = makeHost(async () => []);
+      const openPicker = vi.fn();
+      await launchLogs(host, makeDevice(), openPicker);
+
+      expect(openPicker).toHaveBeenCalledTimes(1);
+      expect(host.logsDialog.open).not.toHaveBeenCalled();
+      expect(host.api.getSerialPorts).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("opens the method picker when the server reports serial ports (no WebSerial)", async () => {
+    const restore = withWebSerial(false);
+    try {
+      const host = makeHost(async () => [{ port: "/dev/ttyUSB0", desc: "USB serial" }]);
+      const openPicker = vi.fn();
+      await launchLogs(host, makeDevice(), openPicker);
+
+      expect(host.api.getSerialPorts).toHaveBeenCalledTimes(1);
+      expect(openPicker).toHaveBeenCalledTimes(1);
+      expect(host.logsDialog.open).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("opens OTA logs directly when there is no serial path at all", async () => {
+    const restore = withWebSerial(false);
+    try {
+      const host = makeHost(async () => []);
+      const openPicker = vi.fn();
+      await launchLogs(host, makeDevice(), openPicker);
+
+      expect(openPicker).not.toHaveBeenCalled();
+      expect(host.logsDialog.open).toHaveBeenCalledTimes(1);
+      expect(host.logsDialog.configuration).toBe("kitchen.yaml");
+      expect(host.logsDialog.name).toBe("Kitchen");
+    } finally {
+      restore();
+    }
+  });
+
+  it("falls back to OTA logs when the serial-port lookup fails", async () => {
+    const restore = withWebSerial(false);
+    try {
+      const host = makeHost(async () => {
+        throw new Error("backend unavailable");
+      });
+      const openPicker = vi.fn();
+      await launchLogs(host, makeDevice(), openPicker);
+
+      expect(openPicker).not.toHaveBeenCalled();
+      expect(host.logsDialog.open).toHaveBeenCalledTimes(1);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("launchLogsWithMethod", () => {
+  it("routes ota to a portless open()", async () => {
+    const host = makeHost(async () => []);
+    await launchLogsWithMethod(host, makeDevice(), "ota");
+    expect(host.logsDialog.open).toHaveBeenCalledWith();
+    expect(host.logsDialog.configuration).toBe("kitchen.yaml");
+    expect(host.logsDialog.name).toBe("Kitchen");
+  });
+
+  it("routes server-serial to open(port)", async () => {
+    const host = makeHost(async () => []);
+    await launchLogsWithMethod(host, makeDevice(), "server-serial", "/dev/ttyUSB0");
+    expect(host.logsDialog.open).toHaveBeenCalledWith("/dev/ttyUSB0");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Refactor, no behaviour change. Preparatory extraction split out of #1177 to keep that PR focused on the editor UI.

The dashboard's "open live logs for a device" logic (serial-path detection, then either the OTA-vs-serial picker or a direct OTA open, plus routing a chosen method to the logs dialog) was bolted onto `ESPHomePageDashboard` inside `dashboard/actions-ui.ts` and `dashboard/install.ts`. The editor needs the same behaviour, so this hoists it into a page-agnostic `src/util/logs-launch.ts` over a small `LogsLaunchHost` interface (`api` / `logsDialog` / `localize`):

- `launchLogs(host, device, openMethodPicker)` runs the serial-path detection and either invokes the caller's picker (in its logs mode) or opens OTA logs directly.
- `launchLogsWithMethod(host, device, method, port?)` routes a picked method (`ota` / `server-serial` / `web-serial`) to the logs dialog.

The dashboard's `openLogs` / `openLogsWithMethod` now delegate to these, so there is one code path instead of a page-bound copy. Byte-faithful move: the `#525` serial-path rationale and the OTA fallback on a `getSerialPorts` failure are preserved.

Also adds `test/_web-serial.ts`, a shared `withWebSerial(present)` test helper, and points the existing `open-logs.test.ts` at it (it had its own copy).

The follow-up (#1177, the editor device-actions menu) stacks on top of this and consumes `launchLogs` / `launchLogsWithMethod` from the editor side.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
