### PR TITLE
Reopen a deferred install as an Install with the queued message

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -54,6 +54,7 @@ import type {
 import type {
   FirmwareBinary,
   FirmwareJob,
+  FirmwareJobResult,
   RemoteBuildSubmitTarget,
 } from "./types/firmware-jobs.js";
 import type {
@@ -143,11 +144,9 @@ type PendingRequest = {
   reject: (error: Error) => void;
 };
 
-type StreamHandler = {
-  onOutput?: (line: string) => void;
-  onResult?: (data: { success: boolean; code: number }) => void;
-  onError?: (error: string) => void;
-};
+// Type-erased bucket for in-flight streams; each command's real result
+// shape is bound at its sendStreamCommand call site.
+type StreamHandler = StreamCallbacks<unknown>;
 
 export class ESPHomeAPI {
   private _ws: WebSocket | null = null;
@@ -356,7 +355,7 @@ export class ESPHomeAPI {
           stream.onOutput?.(evt.data as string);
         } else if (evt.event === "result") {
           this._streamHandlers.delete(messageId);
-          stream.onResult?.(evt.data as { success: boolean; code: number });
+          stream.onResult?.(evt.data);
         }
       }
       return;
@@ -517,10 +516,10 @@ export class ESPHomeAPI {
    * Send a streaming command (compile, upload, logs, etc.).
    * Returns the message_id for cancellation.
    */
-  sendStreamCommand(
+  sendStreamCommand<TResult = { success: boolean; code: number }>(
     command: string,
     args: Record<string, unknown>,
-    callbacks: StreamCallbacks
+    callbacks: StreamCallbacks<TResult>
   ): string {
     if (!this._ws || this._ws.readyState !== WebSocket.OPEN) {
       callbacks.onError?.("WebSocket not connected");
@@ -528,7 +527,7 @@ export class ESPHomeAPI {
     }
 
     const messageId = this._nextMessageId();
-    this._streamHandlers.set(messageId, callbacks);
+    this._streamHandlers.set(messageId, callbacks as StreamHandler);
 
     const msg: CommandMessage = { command, message_id: messageId, args };
     this._ws.send(JSON.stringify(msg));
@@ -1175,7 +1174,10 @@ export class ESPHomeAPI {
   }
 
   /** Follow a job's output: historical lines + live stream until completion. */
-  firmwareFollowJob(jobId: string, callbacks: StreamCallbacks): string {
+  firmwareFollowJob(
+    jobId: string,
+    callbacks: StreamCallbacks<FirmwareJobResult>
+  ): string {
     return this.sendStreamCommand("firmware/follow_job", { job_id: jobId }, callbacks);
   }
 

--- a/src/api/types/firmware-jobs.ts
+++ b/src/api/types/firmware-jobs.ts
@@ -133,6 +133,18 @@ export interface FirmwareJob {
   device_friendly_name: string;
 }
 
+/** Terminal frame of a ``firmware/follow_job`` stream. */
+export interface FirmwareJobResult {
+  status: JobStatus;
+  exit_code: number | null;
+  /** Human-readable failure reason; null for successful jobs. */
+  error: string | null;
+  /** True only when the finished job armed a queued update (the device
+   *  flashes on its next wake) — unlike the job row's raw
+   *  ``is_deferred_install``, a failed deferred compile reports false. */
+  queued_update_armed: boolean;
+}
+
 export interface FirmwareBinary {
   title: string;
   file: string;

--- a/src/api/types/streaming.ts
+++ b/src/api/types/streaming.ts
@@ -6,9 +6,10 @@
 
 // ─── Streaming Commands ──────────────────────────────────────
 
-/** Callbacks for streaming commands (validate, logs). */
-export interface StreamCallbacks {
+/** Callbacks for streaming commands (validate, logs, follow_job).
+ *  The result frame's shape is per-command; validate/logs use the default. */
+export interface StreamCallbacks<TResult = { success: boolean; code: number }> {
   onOutput?: (line: string) => void;
-  onResult?: (data: { success: boolean; code: number }) => void;
+  onResult?: (data: TResult) => void;
   onError?: (error: string) => void;
 }

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -1,6 +1,12 @@
 import { APIError } from "../../api/api-error.js";
-import { type FirmwareJob, JobStatus, JobType } from "../../api/types/firmware-jobs.js";
+import {
+  type FirmwareJob,
+  type FirmwareJobResult,
+  JobStatus,
+  JobType,
+} from "../../api/types/firmware-jobs.js";
 import { ErrorCode } from "../../api/types/protocol.js";
+import { effectiveJobType } from "../../util/firmware-job-display.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
 import { isValidationFailureLine } from "../../util/validation-log.js";
 import { classifyNoCompatiblePeerReason } from "../../util/version-mismatch.js";
@@ -23,17 +29,12 @@ export function deriveFollowCommandType(
   jobs: Map<string, FirmwareJob>,
   job: FirmwareJob
 ): CommandType {
-  if (job.job_type === JobType.COMPILE) {
-    // A deferred install is a lone COMPILE; the flag is its only install
-    // marker (live or terminal — there is no flash log to chain into).
-    if (job.is_deferred_install) return "install";
-    if (!isTerminalJobStatus(job.status)) {
-      const dependent = [...jobs.values()].find((j) => j.depends_on === job.job_id);
-      if (dependent?.job_type === JobType.RENAME) return "rename";
-      if (dependent?.job_type === JobType.UPLOAD) return "install";
-    }
+  if (job.job_type === JobType.COMPILE && !isTerminalJobStatus(job.status)) {
+    const dependent = [...jobs.values()].find((j) => j.depends_on === job.job_id);
+    if (dependent?.job_type === JobType.RENAME) return "rename";
+    if (dependent?.job_type === JobType.UPLOAD) return "install";
   }
-  return JOB_TYPE_TO_COMMAND[job.job_type] ?? "install";
+  return JOB_TYPE_TO_COMMAND[effectiveJobType(job)] ?? "install";
 }
 
 // An install chain is followed via its COMPILE head, but the flash target
@@ -206,19 +207,13 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
     onResult: (data) => {
       host._streamId = "";
       host._flushPendingLines();
-      const result = data as unknown as Pick<
-        FirmwareJob,
-        "status" | "exit_code" | "is_deferred_install"
-      >;
+      const result = data as unknown as FirmwareJobResult;
       const success = result.status === JobStatus.COMPLETED;
 
-      // The backend sets the flag only when a queued update was actually
-      // armed: a finished deferred compile, a chain converted at release
-      // because the device went offline mid-build, or an OTA upload that
-      // failed against an offline device. Queued is the outcome in every
-      // shape, so check it before chaining into a dependent flash — a
-      // converted chain's upload is already cancelled.
-      if (result.is_deferred_install) {
+      // Queued is the outcome regardless of which job carried it; check
+      // before chaining into a dependent flash — a converted chain's
+      // upload is already cancelled.
+      if (result.queued_update_armed) {
         host._state = "success";
         host._statusMessage = host._localize("dashboard.queued_successfully");
         host._jobId = "";

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -23,10 +23,15 @@ export function deriveFollowCommandType(
   jobs: Map<string, FirmwareJob>,
   job: FirmwareJob
 ): CommandType {
-  if (job.job_type === JobType.COMPILE && !isTerminalJobStatus(job.status)) {
-    const dependent = [...jobs.values()].find((j) => j.depends_on === job.job_id);
-    if (dependent?.job_type === JobType.RENAME) return "rename";
-    if (dependent?.job_type === JobType.UPLOAD) return "install";
+  if (job.job_type === JobType.COMPILE) {
+    // A deferred install is a lone COMPILE; the flag is its only install
+    // marker (live or terminal — there is no flash log to chain into).
+    if (job.is_deferred_install) return "install";
+    if (!isTerminalJobStatus(job.status)) {
+      const dependent = [...jobs.values()].find((j) => j.depends_on === job.job_id);
+      if (dependent?.job_type === JobType.RENAME) return "rename";
+      if (dependent?.job_type === JobType.UPLOAD) return "install";
+    }
   }
   return JOB_TYPE_TO_COMMAND[job.job_type] ?? "install";
 }
@@ -207,6 +212,19 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
       >;
       const success = result.status === JobStatus.COMPLETED;
 
+      // The backend sets the flag only when a queued update was actually
+      // armed: a finished deferred compile, a chain converted at release
+      // because the device went offline mid-build, or an OTA upload that
+      // failed against an offline device. Queued is the outcome in every
+      // shape, so check it before chaining into a dependent flash — a
+      // converted chain's upload is already cancelled.
+      if (result.is_deferred_install) {
+        host._state = "success";
+        host._statusMessage = host._localize("dashboard.queued_successfully");
+        host._jobId = "";
+        return;
+      }
+
       // On a successful install/rename COMPILE, follow the dependent flash —
       // the install's UPLOAD or the rename's flash-and-swap tail — so success
       // reflects the device, not just the build (#1131). Gate on the finished
@@ -230,14 +248,6 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
           // so the remote-builder sub-line doesn't linger on the compile's
           // receiver.
           primeAndFollow(host, flash);
-          return;
-        }
-        // A deferred install compiles now and flashes when the device wakes,
-        // so no dependent flash exists — queued is the success state.
-        if (result.is_deferred_install) {
-          host._state = "success";
-          host._statusMessage = host._localize("dashboard.queued_successfully");
-          host._jobId = "";
           return;
         }
         // No flash step — the device was never flashed, so don't report success.

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -1,10 +1,5 @@
 import { APIError } from "../../api/api-error.js";
-import {
-  type FirmwareJob,
-  type FirmwareJobResult,
-  JobStatus,
-  JobType,
-} from "../../api/types/firmware-jobs.js";
+import { type FirmwareJob, JobStatus, JobType } from "../../api/types/firmware-jobs.js";
 import { ErrorCode } from "../../api/types/protocol.js";
 import { effectiveJobType } from "../../util/firmware-job-display.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
@@ -204,10 +199,9 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
       host._enqueueLine(line);
       if (isValidationFailureLine(line)) host._failedDuringValidate = true;
     },
-    onResult: (data) => {
+    onResult: (result) => {
       host._streamId = "";
       host._flushPendingLines();
-      const result = data as unknown as FirmwareJobResult;
       const success = result.status === JobStatus.COMPLETED;
 
       // Queued is the outcome regardless of which job carried it; check

--- a/src/components/firmware-jobs-dialog/renderers.ts
+++ b/src/components/firmware-jobs-dialog/renderers.ts
@@ -62,8 +62,11 @@ export function renderGroups(
 
 function renderJob(host: ESPHomeFirmwareJobsDialog, job: FirmwareJob): TemplateResult {
   const name = host._jobDisplayName(job);
-  const typeIcon = TYPE_ICONS[job.job_type] ?? "hammer-wrench";
-  const typeLabel = host._localize(`firmware_jobs.type_${job.job_type}`);
+  // A deferred install is a lone COMPILE carrying the whole install
+  // intent; list it as the Install the dialog it opens claims to be.
+  const effectiveType = job.is_deferred_install ? JobType.INSTALL : job.job_type;
+  const typeIcon = TYPE_ICONS[effectiveType] ?? "hammer-wrench";
+  const typeLabel = host._localize(`firmware_jobs.type_${effectiveType}`);
   const showProgress =
     job.status === JobStatus.RUNNING && typeof job.progress === "number";
   const terminal = isTerminal(job);

--- a/src/components/firmware-jobs-dialog/renderers.ts
+++ b/src/components/firmware-jobs-dialog/renderers.ts
@@ -6,6 +6,7 @@ import {
   JobType,
 } from "../../api/types/firmware-jobs.js";
 import { activeLocale, type LocalizeFunc } from "../../common/localize.js";
+import { effectiveJobType } from "../../util/firmware-job-display.js";
 import { isTerminalJob as isTerminal } from "../../util/firmware-job-status.js";
 import { formatAbsoluteTime, formatRelativeTime } from "../../util/format-job-time.js";
 import type { ESPHomeFirmwareJobsDialog } from "../firmware-jobs-dialog.js";
@@ -62,9 +63,7 @@ export function renderGroups(
 
 function renderJob(host: ESPHomeFirmwareJobsDialog, job: FirmwareJob): TemplateResult {
   const name = host._jobDisplayName(job);
-  // A deferred install is a lone COMPILE carrying the whole install
-  // intent; list it as the Install the dialog it opens claims to be.
-  const effectiveType = job.is_deferred_install ? JobType.INSTALL : job.job_type;
+  const effectiveType = effectiveJobType(job);
   const typeIcon = TYPE_ICONS[effectiveType] ?? "hammer-wrench";
   const typeLabel = host._localize(`firmware_jobs.type_${effectiveType}`);
   const showProgress =

--- a/src/util/firmware-job-display.ts
+++ b/src/util/firmware-job-display.ts
@@ -4,6 +4,17 @@ import { JobType } from "../api/types/firmware-jobs.js";
 import type { LocalizeFunc } from "../common/localize.js";
 
 /**
+ * The job type a job presents as: a deferred install is a lone COMPILE
+ * carrying the whole install intent, so it surfaces as an Install.
+ *
+ * Deliberately NOT used by the device card's busy badge — "Compiling"
+ * during a deferred install matches a normal chain's compile phase.
+ */
+export function effectiveJobType(job: FirmwareJob): JobType {
+  return job.is_deferred_install ? JobType.INSTALL : job.job_type;
+}
+
+/**
  * Resolve the human-readable label for a firmware job.
  *
  * Used by both the firmware-tasks dialog and the command dialog's
@@ -30,17 +41,6 @@ import type { LocalizeFunc } from "../common/localize.js";
  * - Otherwise prefer the configured device's friendly name → fall
  *   back to ``name`` → fall back to the raw configuration filename.
  */
-/**
- * The job type a job presents as: a deferred install is a lone COMPILE
- * carrying the whole install intent, so it surfaces as an Install.
- *
- * Deliberately NOT used by the device card's busy badge — "Compiling"
- * during a deferred install matches a normal chain's compile phase.
- */
-export function effectiveJobType(job: FirmwareJob): JobType {
-  return job.is_deferred_install ? JobType.INSTALL : job.job_type;
-}
-
 export function firmwareJobDisplayName(
   job: FirmwareJob,
   devices: ConfiguredDevice[],

--- a/src/util/firmware-job-display.ts
+++ b/src/util/firmware-job-display.ts
@@ -30,6 +30,17 @@ import type { LocalizeFunc } from "../common/localize.js";
  * - Otherwise prefer the configured device's friendly name → fall
  *   back to ``name`` → fall back to the raw configuration filename.
  */
+/**
+ * The job type a job presents as: a deferred install is a lone COMPILE
+ * carrying the whole install intent, so it surfaces as an Install.
+ *
+ * Deliberately NOT used by the device card's busy badge — "Compiling"
+ * during a deferred install matches a normal chain's compile phase.
+ */
+export function effectiveJobType(job: FirmwareJob): JobType {
+  return job.is_deferred_install ? JobType.INSTALL : job.job_type;
+}
+
 export function firmwareJobDisplayName(
   job: FirmwareJob,
   devices: ConfiguredDevice[],

--- a/test/components/command-dialog-deferred-install.test.ts
+++ b/test/components/command-dialog-deferred-install.test.ts
@@ -38,4 +38,58 @@ describe("command-dialog deferred install follow", () => {
     expect(host._compileMissingDependent).toBe(true);
     warn.mockRestore();
   });
+
+  it("reports queued without priming into the cancelled upload of a converted chain", () => {
+    // The backend cancels the held upload when the device goes offline
+    // mid-build; the compile's queued result must win over the flash chase.
+    const compile = makeJob({ job_id: "c1", job_type: JobType.COMPILE });
+    const upload = makeJob({
+      job_id: "u1",
+      job_type: JobType.UPLOAD,
+      depends_on: "c1",
+      status: JobStatus.CANCELLED,
+    });
+    const { host, follows } = makeHost(
+      new Map([
+        ["c1", compile],
+        ["u1", upload],
+      ])
+    );
+    host._jobId = "c1";
+    followJob(host, "c1");
+    follows.c1.onResult({
+      status: JobStatus.COMPLETED,
+      exit_code: 0,
+      is_deferred_install: true,
+    });
+
+    expect(host._state).toBe("success");
+    expect(host._statusMessage).toBe("dashboard.queued_successfully");
+    expect(follows.u1).toBeUndefined();
+  });
+
+  it("reports queued for an OTA upload that failed against an offline device", () => {
+    const upload = makeJob({ job_id: "u1", job_type: JobType.UPLOAD, port: "OTA" });
+    const { host, follows } = makeHost(new Map([["u1", upload]]));
+    host._jobId = "u1";
+    followJob(host, "u1");
+    follows.u1.onResult({
+      status: JobStatus.FAILED,
+      exit_code: 1,
+      is_deferred_install: true,
+    });
+
+    expect(host._state).toBe("success");
+    expect(host._statusMessage).toBe("dashboard.queued_successfully");
+  });
+
+  it("keeps an unflagged failure an error", () => {
+    const { host, follows } = lonelyCompileHost();
+    host._jobId = "c1";
+    followJob(host, "c1");
+    follows.c1.onResult({ status: JobStatus.FAILED, exit_code: 1 });
+
+    expect(host._state).toBe("error");
+    expect(host._statusMessage).toBe("command.install_failed");
+  });
 });

--- a/test/components/command-dialog-deferred-install.test.ts
+++ b/test/components/command-dialog-deferred-install.test.ts
@@ -1,4 +1,4 @@
-// A deferred install's COMPILE has no dependent flash; is_deferred_install on
+// A deferred install's COMPILE has no dependent flash; queued_update_armed on
 // the terminal result reports queued success instead of the missing-flash error.
 import { describe, expect, it, vi } from "vitest";
 import { JobStatus, JobType } from "../../src/api/types/firmware-jobs.js";
@@ -19,7 +19,7 @@ describe("command-dialog deferred install follow", () => {
     follows.c1.onResult({
       status: JobStatus.COMPLETED,
       exit_code: 0,
-      is_deferred_install: true,
+      queued_update_armed: true,
     });
 
     expect(host._state).toBe("success");
@@ -60,7 +60,7 @@ describe("command-dialog deferred install follow", () => {
     follows.c1.onResult({
       status: JobStatus.COMPLETED,
       exit_code: 0,
-      is_deferred_install: true,
+      queued_update_armed: true,
     });
 
     expect(host._state).toBe("success");
@@ -76,7 +76,7 @@ describe("command-dialog deferred install follow", () => {
     follows.u1.onResult({
       status: JobStatus.FAILED,
       exit_code: 1,
-      is_deferred_install: true,
+      queued_update_armed: true,
     });
 
     expect(host._state).toBe("success");

--- a/test/components/command-dialog-deferred-reopen.test.ts
+++ b/test/components/command-dialog-deferred-reopen.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Reopening a deferred install from the firmware-tasks drawer goes through
+ * the public followJob, which derives the command type from the job shape.
+ * A deferred install is a lone COMPILE whose only install marker is
+ * is_deferred_install — it must reopen as an Install and finish with the
+ * queued-update message, not "Compilation complete!".
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type FirmwareJob,
+  JobStatus,
+  JobType,
+} from "../../src/api/types/firmware-jobs.js";
+import { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
+import { makeFirmwareJob } from "../_make-firmware-job.js";
+
+interface StreamCbs {
+  onOutput: (line: string) => void;
+  onResult: (data: unknown) => void;
+  onError: (error: string) => void;
+}
+
+interface Harness {
+  _commandType: string;
+  _state: string;
+  _statusMessage: string;
+  _jobs: Map<string, FirmwareJob>;
+  _streamId: string;
+  _api: unknown;
+  followJob: (job: FirmwareJob, displayName: string) => void;
+}
+
+function mount(jobs: FirmwareJob[]) {
+  const follows: Record<string, StreamCbs> = {};
+  const el = new ESPHomeCommandDialog() as unknown as Harness;
+  el._jobs = new Map(jobs.map((j) => [j.job_id, j]));
+  el._streamId = "";
+  el._api = {
+    firmwareFollowJob: (jobId: string, cbs: StreamCbs): string => {
+      follows[jobId] = cbs;
+      return `stream-${jobId}`;
+    },
+    stopStream: () => Promise.resolve(),
+  } as never;
+  return { el, follows };
+}
+
+describe("command-dialog reopen of a deferred install", () => {
+  it("derives install for a live deferred compile and finishes queued", () => {
+    const compile = makeFirmwareJob({
+      job_id: "c1",
+      job_type: JobType.COMPILE,
+      status: JobStatus.RUNNING,
+      is_deferred_install: true,
+    });
+    const { el, follows } = mount([compile]);
+
+    el.followJob(compile, "gen8266");
+    expect(el._commandType).toBe("install");
+
+    follows.c1.onResult({
+      status: JobStatus.COMPLETED,
+      exit_code: 0,
+      is_deferred_install: true,
+    });
+    expect(el._state).toBe("success");
+    expect(el._statusMessage).toBe("dashboard.queued_successfully");
+  });
+
+  it("derives install for a terminal deferred compile too", () => {
+    const compile = makeFirmwareJob({
+      job_id: "c1",
+      job_type: JobType.COMPILE,
+      status: JobStatus.COMPLETED,
+      is_deferred_install: true,
+    });
+    const { el } = mount([compile]);
+
+    el.followJob(compile, "gen8266");
+
+    expect(el._commandType).toBe("install");
+  });
+
+  it("keeps a plain live compile deriving compile", () => {
+    const compile = makeFirmwareJob({
+      job_id: "c1",
+      job_type: JobType.COMPILE,
+      status: JobStatus.RUNNING,
+    });
+    const { el } = mount([compile]);
+
+    el.followJob(compile, "gen8266");
+
+    expect(el._commandType).toBe("compile");
+  });
+});

--- a/test/components/command-dialog-deferred-reopen.test.ts
+++ b/test/components/command-dialog-deferred-reopen.test.ts
@@ -52,17 +52,14 @@ describe("command-dialog reopen of a deferred install", () => {
 });
 
 describe("deriveFollowCommandType for deferred installs", () => {
-  it.each([JobStatus.RUNNING, JobStatus.COMPLETED, JobStatus.FAILED])(
-    "derives install for a %s deferred compile",
-    (status) => {
-      const compile = makeFirmwareJob({
-        job_type: JobType.COMPILE,
-        status,
-        is_deferred_install: true,
-      });
-      expect(deriveFollowCommandType(new Map(), compile)).toBe("install");
-    }
-  );
+  it("derives install for a terminal deferred compile", () => {
+    const compile = makeFirmwareJob({
+      job_type: JobType.COMPILE,
+      status: JobStatus.COMPLETED,
+      is_deferred_install: true,
+    });
+    expect(deriveFollowCommandType(new Map(), compile)).toBe("install");
+  });
 
   it("keeps a plain compile deriving compile", () => {
     const compile = makeFirmwareJob({

--- a/test/components/command-dialog-deferred-reopen.test.ts
+++ b/test/components/command-dialog-deferred-reopen.test.ts
@@ -8,35 +8,16 @@
  * queued-update message, not "Compilation complete!".
  */
 import { describe, expect, it } from "vitest";
-import {
-  type FirmwareJob,
-  JobStatus,
-  JobType,
-} from "../../src/api/types/firmware-jobs.js";
+import { JobStatus, JobType } from "../../src/api/types/firmware-jobs.js";
 import { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
+import { deriveFollowCommandType } from "../../src/components/command-dialog/commands.js";
 import { makeFirmwareJob } from "../_make-firmware-job.js";
+import type { StreamCbs } from "./_command-dialog-host.js";
 
-interface StreamCbs {
-  onOutput: (line: string) => void;
-  onResult: (data: unknown) => void;
-  onError: (error: string) => void;
-}
-
-interface Harness {
-  _commandType: string;
-  _state: string;
-  _statusMessage: string;
-  _jobs: Map<string, FirmwareJob>;
-  _streamId: string;
-  _api: unknown;
-  followJob: (job: FirmwareJob, displayName: string) => void;
-}
-
-function mount(jobs: FirmwareJob[]) {
+function mount(jobs: ReturnType<typeof makeFirmwareJob>[]) {
   const follows: Record<string, StreamCbs> = {};
-  const el = new ESPHomeCommandDialog() as unknown as Harness;
+  const el = new ESPHomeCommandDialog();
   el._jobs = new Map(jobs.map((j) => [j.job_id, j]));
-  el._streamId = "";
   el._api = {
     firmwareFollowJob: (jobId: string, cbs: StreamCbs): string => {
       follows[jobId] = cbs;
@@ -48,7 +29,7 @@ function mount(jobs: FirmwareJob[]) {
 }
 
 describe("command-dialog reopen of a deferred install", () => {
-  it("derives install for a live deferred compile and finishes queued", () => {
+  it("reopens as an install and finishes queued", () => {
     const compile = makeFirmwareJob({
       job_id: "c1",
       job_type: JobType.COMPILE,
@@ -63,36 +44,31 @@ describe("command-dialog reopen of a deferred install", () => {
     follows.c1.onResult({
       status: JobStatus.COMPLETED,
       exit_code: 0,
-      is_deferred_install: true,
+      queued_update_armed: true,
     });
     expect(el._state).toBe("success");
     expect(el._statusMessage).toBe("dashboard.queued_successfully");
   });
+});
 
-  it("derives install for a terminal deferred compile too", () => {
+describe("deriveFollowCommandType for deferred installs", () => {
+  it.each([JobStatus.RUNNING, JobStatus.COMPLETED, JobStatus.FAILED])(
+    "derives install for a %s deferred compile",
+    (status) => {
+      const compile = makeFirmwareJob({
+        job_type: JobType.COMPILE,
+        status,
+        is_deferred_install: true,
+      });
+      expect(deriveFollowCommandType(new Map(), compile)).toBe("install");
+    }
+  );
+
+  it("keeps a plain compile deriving compile", () => {
     const compile = makeFirmwareJob({
-      job_id: "c1",
-      job_type: JobType.COMPILE,
-      status: JobStatus.COMPLETED,
-      is_deferred_install: true,
-    });
-    const { el } = mount([compile]);
-
-    el.followJob(compile, "gen8266");
-
-    expect(el._commandType).toBe("install");
-  });
-
-  it("keeps a plain live compile deriving compile", () => {
-    const compile = makeFirmwareJob({
-      job_id: "c1",
       job_type: JobType.COMPILE,
       status: JobStatus.RUNNING,
     });
-    const { el } = mount([compile]);
-
-    el.followJob(compile, "gen8266");
-
-    expect(el._commandType).toBe("compile");
+    expect(deriveFollowCommandType(new Map(), compile)).toBe("compile");
   });
 });

--- a/test/components/firmware-jobs-dialog/renderers.test.ts
+++ b/test/components/firmware-jobs-dialog/renderers.test.ts
@@ -7,8 +7,11 @@
 import { nothing } from "lit";
 import { describe, expect, it } from "vitest";
 
-import { JobSource } from "../../../src/api/types/firmware-jobs.js";
-import { renderSourceLine } from "../../../src/components/firmware-jobs-dialog/renderers.js";
+import { JobSource, JobType } from "../../../src/api/types/firmware-jobs.js";
+import {
+  renderGroups,
+  renderSourceLine,
+} from "../../../src/components/firmware-jobs-dialog/renderers.js";
 import { identityLocalize, renderInto } from "../../_dom.js";
 import { makeFirmwareJob } from "../../_make-firmware-job.js";
 
@@ -38,5 +41,33 @@ describe("renderSourceLine", () => {
   it("renders nothing for a plain LOCAL compile", () => {
     const job = makeFirmwareJob({ source: JobSource.LOCAL });
     expect(renderSourceLine(host() as never, job)).toBe(nothing);
+  });
+});
+
+// renderGroups reads _jobDisplayName / _localize / _openJob / _now off the host.
+function groupsHost() {
+  return {
+    _localize: identityLocalize,
+    _jobDisplayName: (job: { configuration: string }) => job.configuration,
+    _openJob: () => {},
+    _now: new Date("2026-01-01T00:01:00Z").getTime(),
+  };
+}
+
+describe("renderJob type label", () => {
+  it("labels a deferred-install compile as the Install its dialog claims to be", () => {
+    const job = makeFirmwareJob({
+      job_type: JobType.COMPILE,
+      is_deferred_install: true,
+    });
+    const el = renderInto(renderGroups(groupsHost() as never, [job], []));
+    expect(el.textContent).toContain("firmware_jobs.type_install");
+    expect(el.textContent).not.toContain("firmware_jobs.type_compile");
+  });
+
+  it("keeps a plain compile labeled Compile", () => {
+    const job = makeFirmwareJob({ job_type: JobType.COMPILE });
+    const el = renderInto(renderGroups(groupsHost() as never, [job], []));
+    expect(el.textContent).toContain("firmware_jobs.type_compile");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Reopening a running deferred install from the Firmware tasks drawer showed it as "Compile — device" and finished with "Compilation complete!" instead of the queued update message. The command type derivation only recognized an install by its dependent upload, and a deferred install is a lone COMPILE with none; the drawer row had the same blind spot. A shared `effectiveJobType` now presents a deferred install as the Install it is, in the drawer row, the reopened dialog title, and the completion banner.

Pairs with the backend change that re-checks reachability after the build: the follow result's queued flag moved to a dedicated `queued_update_armed` key with armed semantics (a failed deferred compile no longer looks queued), and the queued check runs before the dependent flash chase, so a chain the backend converted mid build (device went offline during the compile, held upload cancelled) lands on the queued banner instead of priming into the cancelled upload. The same path shows the queued banner for an OTA upload that failed against an offline device, matching what the backend armed.

Companion backend PR: esphome/device-builder#1964

**Related issue or feature (if applicable):**

- fixes the wrong completion message when reopening a deferred install from Firmware tasks

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
