### PR TITLE
Mark every YAML section header with its domain icon

### DIFF
--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -57,6 +57,7 @@ import {
   relintEffect,
   type YamlDiagnosticsDetail,
 } from "../util/yaml-lint-backend.js";
+import { withBase } from "../util/base-path.js";
 import { TOP_LEVEL_KEY_RE } from "../util/yaml-section-lexer.js";
 import type { YamlSection } from "../util/yaml-sections.js";
 import {
@@ -120,10 +121,13 @@ const highlightField = StateField.define<DecorationSet>({
 });
 
 // Quiet domain glyph pinned to the end of every top-level section header, so
-// each section carries the same icon it has in the navigator. Icon only, in a
-// muted tone — the section key is already on the line. Lives in the content
+// each section carries the same icon it has in the navigator (the ``esphome``
+// brand mark for the core section, mirroring the navigator row). Icon only, in
+// a muted tone — the section key is already on the line. Lives in the content
 // flow (not the gutter), so it never shifts the line-number column, and is
-// sized to the line so the row can't grow.
+// sized to the line so the row can't grow. ``pointer-events: none`` (in the CSS)
+// makes it inert: a click falls through to the text beneath and lands the caret
+// at the line end, and the caret cursor shows instead of a pointer.
 class SectionMarkerWidget extends WidgetType {
   constructor(readonly domain: string) {
     super();
@@ -137,13 +141,13 @@ class SectionMarkerWidget extends WidgetType {
     const icon = document.createElement("wa-icon");
     icon.className = "cm-section-marker";
     icon.setAttribute("aria-hidden", "true");
-    icon.setAttribute("library", "mdi");
-    icon.setAttribute("name", iconForDomain(this.domain));
+    if (this.domain === "esphome") {
+      icon.setAttribute("src", withBase("/assets/logo/esphome-mono.svg"));
+    } else {
+      icon.setAttribute("library", "mdi");
+      icon.setAttribute("name", iconForDomain(this.domain));
+    }
     return icon;
-  }
-
-  ignoreEvent() {
-    return true;
   }
 }
 
@@ -317,11 +321,15 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
         },
         // Quiet domain glyph on each section header. Muted so it reads as a
         // marker, not code; sized to the line so it can't grow the row.
+        // ``pointer-events: none`` makes it inert — a click falls through to the
+        // text so the caret lands at the line end and the caret cursor shows,
+        // instead of the widget swallowing the click behind a pointer cursor.
         ".cm-section-marker": {
           marginLeft: "8px",
           fontSize: "1.05em",
           verticalAlign: "middle",
           color: this._darkMode ? "rgba(235, 235, 245, 0.4)" : "rgba(60, 60, 67, 0.45)",
+          pointerEvents: "none",
           userSelect: "none",
         },
         // ─── Diagnostics: red wavy underline + gutter marker ────────

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -2,8 +2,20 @@ import { autocompletion, completionStatus } from "@codemirror/autocomplete";
 import { indentWithTab, undoDepth } from "@codemirror/commands";
 import { indentUnit } from "@codemirror/language";
 import { forceLinting } from "@codemirror/lint";
-import { StateEffect, StateField, Transaction } from "@codemirror/state";
-import { Decoration, keymap, tooltips, type DecorationSet } from "@codemirror/view";
+import {
+  type Range,
+  StateEffect,
+  StateField,
+  type Text,
+  Transaction,
+} from "@codemirror/state";
+import {
+  Decoration,
+  keymap,
+  tooltips,
+  WidgetType,
+  type DecorationSet,
+} from "@codemirror/view";
 import { consume } from "@lit/context";
 import { indentationMarkers } from "@replit/codemirror-indentation-markers";
 import { basicSetup, EditorView } from "codemirror";
@@ -45,6 +57,7 @@ import {
   relintEffect,
   type YamlDiagnosticsDetail,
 } from "../util/yaml-lint-backend.js";
+import { TOP_LEVEL_KEY_RE } from "../util/yaml-section-lexer.js";
 import type { YamlSection } from "../util/yaml-sections.js";
 import {
   sensitiveValueMaskExtension,
@@ -52,6 +65,7 @@ import {
 } from "../util/yaml-sensitive-mask.js";
 import { yamlStickyScroll } from "../util/yaml-sticky-scroll.js";
 import { CodeMirrorEditorElement } from "./codemirror-editor-element.js";
+import { iconForDomain } from "./device/navigator-row-icons.js";
 
 export type HighlightRange = Pick<YamlSection, "fromLine" | "toLine">;
 
@@ -102,6 +116,64 @@ const highlightField = StateField.define<DecorationSet>({
     }
     return deco.map(tr.changes);
   },
+  provide: (f) => EditorView.decorations.from(f),
+});
+
+// Quiet domain glyph pinned to the end of every top-level section header, so
+// each section carries the same icon it has in the navigator. Icon only, in a
+// muted tone — the section key is already on the line. Lives in the content
+// flow (not the gutter), so it never shifts the line-number column, and is
+// sized to the line so the row can't grow.
+class SectionMarkerWidget extends WidgetType {
+  constructor(readonly domain: string) {
+    super();
+  }
+
+  eq(other: SectionMarkerWidget) {
+    return other.domain === this.domain;
+  }
+
+  toDOM() {
+    const icon = document.createElement("wa-icon");
+    icon.className = "cm-section-marker";
+    icon.setAttribute("aria-hidden", "true");
+    icon.setAttribute("library", "mdi");
+    icon.setAttribute("name", iconForDomain(this.domain));
+    return icon;
+  }
+
+  ignoreEvent() {
+    return true;
+  }
+}
+
+function buildSectionMarkers(doc: Text): DecorationSet {
+  const marks: Range<Decoration>[] = [];
+  // Column-0 `key:` lines are the top-level section headers; the anchor keeps
+  // indented block-scalar content from false-matching. One marker per header,
+  // on the header line itself (not the expanded list-item lines the section
+  // parser would return for `switch:` / `sensor:`).
+  for (let n = 1; n <= doc.lines; n++) {
+    const line = doc.line(n);
+    const match = TOP_LEVEL_KEY_RE.exec(line.text);
+    if (!match) continue;
+    marks.push(
+      Decoration.widget({
+        widget: new SectionMarkerWidget(match[1]),
+        side: 1,
+      }).range(line.to)
+    );
+  }
+  return Decoration.set(marks, true);
+}
+
+// Always-on section markers, recomputed from the doc rather than driven by
+// selection, so every section header carries its glyph whether or not it's the
+// active one.
+const sectionMarkersField = StateField.define<DecorationSet>({
+  create: (state) => buildSectionMarkers(state.doc),
+  update: (deco, tr) =>
+    tr.docChanged ? buildSectionMarkers(tr.state.doc) : deco.map(tr.changes),
   provide: (f) => EditorView.decorations.from(f),
 });
 
@@ -210,6 +282,7 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
         colors: INDENT_GUIDE_COLORS,
       }),
       highlightField,
+      sectionMarkersField,
       // Keep every tooltip (lint hover, docs hover, completion) inside the
       // code pane: near the bottom they flip above the line instead of
       // spilling over the invalid banner / action row below the editor.
@@ -241,6 +314,15 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
           background: this._darkMode
             ? "rgba(99, 179, 237, 0.2)"
             : "rgba(59, 130, 246, 0.1)",
+        },
+        // Quiet domain glyph on each section header. Muted so it reads as a
+        // marker, not code; sized to the line so it can't grow the row.
+        ".cm-section-marker": {
+          marginLeft: "8px",
+          fontSize: "1.05em",
+          verticalAlign: "middle",
+          color: this._darkMode ? "rgba(235, 235, 245, 0.4)" : "rgba(60, 60, 67, 0.45)",
+          userSelect: "none",
         },
         // ─── Diagnostics: red wavy underline + gutter marker ────────
         ".cm-lintRange-error": {

--- a/test/components/yaml-editor-section-markers.test.ts
+++ b/test/components/yaml-editor-section-markers.test.ts
@@ -32,23 +32,29 @@ async function mount(value: string): Promise<ESPHomeYamlEditor> {
 const viewOf = (el: ESPHomeYamlEditor): EditorView =>
   (el as unknown as { _view: EditorView })._view;
 
-function markerNames(el: ESPHomeYamlEditor): string[] {
+/** Glyph per marker: the mdi ``name``, or ``logo:esphome`` for the core
+ *  section's brand mark (which uses ``src`` rather than a library glyph). */
+function markerGlyphs(el: ESPHomeYamlEditor): string[] {
   return Array.from(
     viewOf(el).dom.querySelectorAll<HTMLElement>(".cm-section-marker")
-  ).map((m) => m.getAttribute("name") ?? "");
+  ).map((m) => {
+    const name = m.getAttribute("name");
+    if (name) return name;
+    return m.getAttribute("src")?.includes("esphome-mono") ? "logo:esphome" : "";
+  });
 }
 
 describe("yaml-editor section markers", () => {
   it("marks every top-level section header with its domain glyph", async () => {
     const el = await mount(YAML);
-    // esphome → chip, wifi → wifi, switch → toggle-switch-outline.
-    expect(markerNames(el)).toEqual(["chip", "wifi", "toggle-switch-outline"]);
+    // esphome → brand logo, wifi → wifi, switch → toggle-switch-outline.
+    expect(markerGlyphs(el)).toEqual(["logo:esphome", "wifi", "toggle-switch-outline"]);
   });
 
   it("shows markers with no selection active", async () => {
     const el = await mount(YAML);
     expect(el.highlightRange).toBeNull();
-    expect(markerNames(el)).toHaveLength(3);
+    expect(markerGlyphs(el)).toHaveLength(3);
   });
 
   it("tracks a section added by editing the doc", async () => {
@@ -58,8 +64,8 @@ describe("yaml-editor section markers", () => {
       changes: { from: view.state.doc.length, insert: "logger:\n" },
     });
     await el.updateComplete;
-    expect(markerNames(el)).toEqual([
-      "chip",
+    expect(markerGlyphs(el)).toEqual([
+      "logo:esphome",
       "wifi",
       "toggle-switch-outline",
       "card-text-outline",

--- a/test/components/yaml-editor-section-markers.test.ts
+++ b/test/components/yaml-editor-section-markers.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the always-on section markers: every top-level section header carries
+ * its domain glyph (the same one the navigator row shows), independent of any
+ * selection, and the set tracks doc edits.
+ */
+import type { EditorView } from "@codemirror/view";
+import { describe, expect, it } from "vitest";
+
+import { ESPHomeYamlEditor } from "../../src/components/yaml-editor.js";
+
+const YAML = [
+  "esphome:",
+  "  name: x",
+  "wifi:",
+  "  ssid: y",
+  "switch:",
+  "  - platform: gpio",
+  "",
+].join("\n");
+
+async function mount(value: string): Promise<ESPHomeYamlEditor> {
+  const el = new ESPHomeYamlEditor();
+  document.body.appendChild(el);
+  await el.updateComplete;
+  el.value = value;
+  await el.updateComplete;
+  return el;
+}
+
+const viewOf = (el: ESPHomeYamlEditor): EditorView =>
+  (el as unknown as { _view: EditorView })._view;
+
+function markerNames(el: ESPHomeYamlEditor): string[] {
+  return Array.from(
+    viewOf(el).dom.querySelectorAll<HTMLElement>(".cm-section-marker")
+  ).map((m) => m.getAttribute("name") ?? "");
+}
+
+describe("yaml-editor section markers", () => {
+  it("marks every top-level section header with its domain glyph", async () => {
+    const el = await mount(YAML);
+    // esphome → chip, wifi → wifi, switch → toggle-switch-outline.
+    expect(markerNames(el)).toEqual(["chip", "wifi", "toggle-switch-outline"]);
+  });
+
+  it("shows markers with no selection active", async () => {
+    const el = await mount(YAML);
+    expect(el.highlightRange).toBeNull();
+    expect(markerNames(el)).toHaveLength(3);
+  });
+
+  it("tracks a section added by editing the doc", async () => {
+    const el = await mount(YAML);
+    const view = viewOf(el);
+    view.dispatch({
+      changes: { from: view.state.doc.length, insert: "logger:\n" },
+    });
+    await el.updateComplete;
+    expect(markerNames(el)).toEqual([
+      "chip",
+      "wifi",
+      "toggle-switch-outline",
+      "card-text-outline",
+    ]);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Each config section now reads as the same thing in the navigator and the YAML editor. The editor pins a quiet domain icon to the end of every top level section header (`esphome:`, `wifi:`, `switch:`, `sensor:`, and so on), the same glyph the navigator row already shows for that domain, so you can tie a block in the code back to its navigator entry at a glance.

The markers are always on; they are derived from the document rather than the current selection, so every section carries its glyph whether or not it is selected. They are monochrome and sit in the content flow sized to the line, so they never shift the line number gutter. They reuse the existing `iconForDomain` registry and the top level key lexer (`TOP_LEVEL_KEY_RE`), so there is no new YAML parsing, and the marker set tracks live edits as sections are added or removed.

This came out of editor feedback that it was hard to visually tie the navigator, the section form, and the YAML together. Earlier iterations tried per domain colour and a text label chip; both were dialled back to this calmer, icon only, no colour form.

**Related issue or feature (if applicable):**

- Editor UX enhancement from navigator / editor linking feedback; no filed issue.

## Screenshots

Quiet domain icons on each top level section header in the editor, matching the navigator glyphs.
<img width="920" height="667" alt="Screenshot 2026-07-11 at 11 53 40 AM" src="https://github.com/user-attachments/assets/5ccd47e2-c175-4409-aab7-0109fe6e6b71" />



## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
