### PR TITLE
Consolidate the compact duration formatters onto one ladder

### DIFF
--- a/src/common/localize.ts
+++ b/src/common/localize.ts
@@ -200,11 +200,14 @@ function invalidateActiveLocale(): void {
   cachedActiveLocale = null;
 }
 
-// Browser-language and cross-tab-storage changes invalidate too; same-tab
-// writes go through write/clearStoredLocale below.
+// Browser-language and cross-tab locale changes invalidate too (a storage
+// event's null key is a full clear); same-tab writes go through
+// write/clearStoredLocale below.
 if (typeof window !== "undefined") {
   window.addEventListener("languagechange", invalidateActiveLocale);
-  window.addEventListener("storage", invalidateActiveLocale);
+  window.addEventListener("storage", (e) => {
+    if (e.key === LOCALE_STORAGE_KEY || e.key === null) invalidateActiveLocale();
+  });
 }
 
 /** The active locale: stored override, else browser detection. */

--- a/src/common/localize.ts
+++ b/src/common/localize.ts
@@ -182,16 +182,35 @@ export function readStoredLocale(): SupportedLocale | null {
 
 export function writeStoredLocale(locale: SupportedLocale): void {
   localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+  invalidateActiveLocale();
 }
 
 /** Drop the explicit override so subsequent loads follow the browser. */
 export function clearStoredLocale(): void {
   localStorage.removeItem(LOCALE_STORAGE_KEY);
+  invalidateActiveLocale();
+}
+
+// Memoized: activeLocale() sits on 1Hz-and-faster render paths (timer
+// readouts re-render per streamed log line), and an uncached resolve pays a
+// localStorage read plus matchLocale's per-candidate normalization each call.
+let cachedActiveLocale: SupportedLocale | null = null;
+
+function invalidateActiveLocale(): void {
+  cachedActiveLocale = null;
+}
+
+// Browser-language and cross-tab-storage changes invalidate too; same-tab
+// writes go through write/clearStoredLocale below.
+if (typeof window !== "undefined") {
+  window.addEventListener("languagechange", invalidateActiveLocale);
+  window.addEventListener("storage", invalidateActiveLocale);
 }
 
 /** The active locale: stored override, else browser detection. */
 export function activeLocale(): SupportedLocale {
-  return readStoredLocale() ?? detectLocale();
+  cachedActiveLocale ??= readStoredLocale() ?? detectLocale();
+  return cachedActiveLocale;
 }
 
 /** Traverse a nested object using a dot-notation key. */

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -1,5 +1,6 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { type FirmwareJob, JobSource, JobStatus } from "../../api/types/firmware-jobs.js";
+import { activeLocale } from "../../common/localize.js";
 import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
 import { formatElapsed } from "../../util/format-job-time.js";
@@ -167,18 +168,19 @@ export function renderCompileTimer(
 ): TemplateResult | typeof nothing {
   if (!showRunTimer(host)) return nothing;
   const total = host._timer.totalRunElapsedMs!;
+  const lang = activeLocale();
   return html`
     <div class="compile-timer-wrap" slot="toolbar-left">
       <button
         class="compile-timer ${host._timer.isRunFrozen ? "" : "compile-timer--live"}"
         aria-expanded=${host._timer.showDetail ? "true" : "false"}
         aria-haspopup="dialog"
-        aria-label="${formatElapsed(total)}. ${host._localize("command.run_elapsed_title")}"
+        aria-label="${formatElapsed(total, lang)}. ${host._localize("command.run_elapsed_title")}"
         title=${host._localize("command.run_elapsed_title")}
         @click=${host._timer.toggleDetail}
       >
         <wa-icon library="mdi" name="timer-outline"></wa-icon>
-        <span>${formatElapsed(total)}</span>
+        <span>${formatElapsed(total, lang)}</span>
       </button>
       ${host._timer.showDetail ? renderTimerDetail(host, total) : nothing}
     </div>
@@ -189,6 +191,7 @@ export function renderCompileTimer(
 // offload nudge attached to it (a long local compile is what offloading fixes).
 function renderTimerDetail(host: ESPHomeCommandDialog, totalMs: number): TemplateResult {
   const compile = host._timer.compileDetailMs;
+  const lang = activeLocale();
   const showHint =
     // While the compile is live the inline suggestion already carries this
     // nudge; only add it here once that's gone, so they never double up.
@@ -212,12 +215,12 @@ function renderTimerDetail(host: ESPHomeCommandDialog, totalMs: number): Templat
           ? nothing
           : html`<div class="compile-timer-row">
               <span>${host._localize("command.compile_time_label")}</span>
-              <span>${formatElapsed(compile)}</span>
+              <span>${formatElapsed(compile, lang)}</span>
             </div>`
       }
       <div class="compile-timer-row">
         <span>${host._localize("command.total_run_time_label")}</span>
-        <span>${formatElapsed(totalMs)}</span>
+        <span>${formatElapsed(totalMs, lang)}</span>
       </div>
       ${
         showHint

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -182,16 +182,19 @@ export function renderCompileTimer(
         <wa-icon library="mdi" name="timer-outline"></wa-icon>
         <span>${formatElapsed(total, lang)}</span>
       </button>
-      ${host._timer.showDetail ? renderTimerDetail(host, total) : nothing}
+      ${host._timer.showDetail ? renderTimerDetail(host, total, lang) : nothing}
     </div>
   `;
 }
 
 // The breakdown revealed on click: the compile-only slice of the run, and the
 // offload nudge attached to it (a long local compile is what offloading fixes).
-function renderTimerDetail(host: ESPHomeCommandDialog, totalMs: number): TemplateResult {
+function renderTimerDetail(
+  host: ESPHomeCommandDialog,
+  totalMs: number,
+  lang: string
+): TemplateResult {
   const compile = host._timer.compileDetailMs;
-  const lang = activeLocale();
   const showHint =
     // While the compile is live the inline suggestion already carries this
     // nudge; only add it here once that's gone, so they never double up.

--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { type FirmwareBinary, JobSource } from "../../api/types/firmware-jobs.js";
 import { FLASHER_HOST } from "../../common/docs.js";
+import { activeLocale } from "../../common/localize.js";
 import { configurationStem, downloadAnsiText } from "../../util/download-text.js";
 import { formatElapsed } from "../../util/format-job-time.js";
 import type { ESPHomeFirmwareInstallDialog } from "../firmware-install-dialog.js";
@@ -156,7 +157,7 @@ export function cardStatusDetail(host: ESPHomeFirmwareInstallDialog): string {
   }
   // Once compilation begins, surface the elapsed so a slow build reads as slow.
   if (host._step === "compiling" && host._timer.compileElapsedMs !== null) {
-    return formatElapsed(host._timer.compileElapsedMs);
+    return formatElapsed(host._timer.compileElapsedMs, activeLocale());
   }
   return "";
 }

--- a/src/util/format-job-time.ts
+++ b/src/util/format-job-time.ts
@@ -1,3 +1,5 @@
+import { formatDuration } from "./relative-time.js";
+
 /**
  * Render an ISO timestamp as a short relative phrase ("2m ago",
  * "in 30s") via Intl.RelativeTimeFormat. Picks the coarsest unit that
@@ -27,20 +29,12 @@ export function parseIsoMs(iso: string | null | undefined): number | null {
 }
 
 /**
- * Render a running duration in milliseconds as a compact counter —
- * ``45s``, ``4m 32s``, ``1h 05m``. Negative deltas clamp to ``0s`` so a
- * clock skew never prints a leading minus.
+ * :func:`formatDuration` for a running millisecond counter — ``45s``,
+ * ``4m 32s``, ``1h 05m``. Negative deltas clamp to ``0s`` so a clock skew
+ * never prints a leading minus.
  */
 export function formatElapsed(ms: number): string {
-  const totalSec = Math.max(0, Math.floor(ms / 1000));
-  if (totalSec < 60) return `${totalSec}s`;
-  if (totalSec < 3600) {
-    const m = Math.floor(totalSec / 60);
-    return `${m}m ${totalSec % 60}s`;
-  }
-  const h = Math.floor(totalSec / 3600);
-  const m = Math.floor((totalSec % 3600) / 60);
-  return `${h}h ${String(m).padStart(2, "0")}m`;
+  return formatDuration(ms / 1000, { showSeconds: true });
 }
 
 /**

--- a/src/util/format-job-time.ts
+++ b/src/util/format-job-time.ts
@@ -31,10 +31,12 @@ export function parseIsoMs(iso: string | null | undefined): number | null {
 /**
  * :func:`formatDuration` for a running millisecond counter — ``45s``,
  * ``4m 32s``, ``1h 05m``. Negative deltas clamp to ``0s`` so a clock skew
- * never prints a leading minus.
+ * never prints a leading minus. Pass the app locale as *language* (render
+ * call sites use ``activeLocale()``) so digits match the UI language
+ * rather than the browser default.
  */
-export function formatElapsed(ms: number): string {
-  return formatDuration(ms / 1000, { showSeconds: true });
+export function formatElapsed(ms: number, language?: string): string {
+  return formatDuration(ms / 1000, { showSeconds: true, language });
 }
 
 /**

--- a/src/util/format-job-time.ts
+++ b/src/util/format-job-time.ts
@@ -29,14 +29,12 @@ export function parseIsoMs(iso: string | null | undefined): number | null {
 }
 
 /**
- * :func:`formatDuration` for a running millisecond counter — ``45s``,
- * ``4m 32s``, ``1h 05m``. Negative deltas clamp to ``0s`` so a clock skew
- * never prints a leading minus. Pass the app locale as *language* (render
- * call sites use ``activeLocale()``) so digits match the UI language
- * rather than the browser default.
+ * :func:`formatDuration`'s counter variant for a running millisecond
+ * clock — ``45s``, ``4m 32s``, ``1h 05m``. Negative deltas clamp to ``0s``
+ * so a clock skew never prints a leading minus.
  */
 export function formatElapsed(ms: number, language?: string): string {
-  return formatDuration(ms / 1000, { showSeconds: true, language });
+  return formatDuration(ms / 1000, { variant: "counter", language });
 }
 
 /**

--- a/src/util/relative-time.ts
+++ b/src/util/relative-time.ts
@@ -139,8 +139,7 @@ export function remainingOf(
  * Mirrors the ``RelativeTimeFormat`` cache above, just keyed on the
  * joint of language + ``maximumFractionDigits`` +
  * ``minimumIntegerDigits`` so call sites don't share each other's
- * precision or padding (padded and unpadded formatters are distinct
- * instances).
+ * precision or padding.
  */
 const numberFormatterCache = new Map<string, Intl.NumberFormat>();
 
@@ -162,29 +161,34 @@ export function getNumberFormatter(
 }
 
 /**
- * Format a duration in seconds as a compact readout — ``45s`` / ``8m`` /
- * ``1h 14m`` (zero minutes dropped: ``1h``). With ``showSeconds`` it keeps
- * the finer unit for a live ticking counter: ``4m 32s``, and ``1h 05m`` with
- * minutes padded so the counter's width stays stable across ticks.
+ * Format a duration in seconds as a compact readout. The ``compact``
+ * variant (default) reads as a static value: ``45s`` / ``8m`` / ``1h 14m``
+ * (zero minutes dropped: ``1h``). The ``counter`` variant is for a live
+ * ticking readout whose width must not jitter: seconds kept in the minute
+ * range (``4m 32s``) and hour-range minutes padded (``1h 05m``).
  * Locale-aware digits via the shared number formatter; the unit letters
  * aren't localized. Negative input clamps to ``0s``.
  */
 export function formatDuration(
   seconds: number,
-  { showSeconds = false, language }: { showSeconds?: boolean; language?: string } = {}
+  {
+    variant = "compact",
+    language,
+  }: { variant?: "counter" | "compact"; language?: string } = {}
 ): string {
+  const counter = variant === "counter";
   const total = Math.max(0, Math.floor(seconds));
   const fmt = getNumberFormatter(language, 0);
   if (total < 60) return `${fmt.format(total)}s`;
   if (total < 3600) {
     const minutes = Math.floor(total / 60);
-    return showSeconds
+    return counter
       ? `${fmt.format(minutes)}m ${fmt.format(total % 60)}s`
       : `${fmt.format(minutes)}m`;
   }
   const hours = Math.floor(total / 3600);
   const minutes = Math.floor((total % 3600) / 60);
-  if (showSeconds) {
+  if (counter) {
     return `${fmt.format(hours)}h ${getNumberFormatter(language, 0, 2).format(minutes)}m`;
   }
   return minutes > 0

--- a/src/util/relative-time.ts
+++ b/src/util/relative-time.ts
@@ -164,8 +164,8 @@ export function getNumberFormatter(
  * Format a duration in seconds as a compact readout. The ``compact``
  * variant (default) reads as a static value: ``45s`` / ``8m`` / ``1h 14m``
  * (zero minutes dropped: ``1h``). The ``counter`` variant is for a live
- * ticking readout whose width must not jitter: seconds kept in the minute
- * range (``4m 32s``) and hour-range minutes padded (``1h 05m``).
+ * ticking readout: seconds kept in the minute range (``4m 32s``) and
+ * hour-range minutes zero-padded (``1h 05m``, stable width per minute tick).
  * Locale-aware digits via the shared number formatter; the unit letters
  * aren't localized. Negative input clamps to ``0s``.
  */

--- a/src/util/relative-time.ts
+++ b/src/util/relative-time.ts
@@ -126,7 +126,8 @@ export function remainingOf(
 }
 
 /**
- * Memoized ``Intl.NumberFormat`` per (locale, fraction-digits) key.
+ * Memoized ``Intl.NumberFormat`` per (locale, fraction-digits,
+ * integer-padding) key.
  *
  * Both the drawer's RTT row ("4.2 ms", 1 fraction digit) and TTL
  * row ("38s", 0 fraction digits) need a locale-aware number
@@ -135,9 +136,11 @@ export function remainingOf(
  * has up to three Reachability rows visible, so that's 3
  * allocations/sec for what should be a stable lookup.
  *
- * Mirrors the ``RelativeTimeFormat`` cache above, just keyed on
- * the joint of language + ``maximumFractionDigits`` so the two
- * call sites don't share each other's precision.
+ * Mirrors the ``RelativeTimeFormat`` cache above, just keyed on the
+ * joint of language + ``maximumFractionDigits`` +
+ * ``minimumIntegerDigits`` so call sites don't share each other's
+ * precision or padding (padded and unpadded formatters are distinct
+ * instances).
  */
 const numberFormatterCache = new Map<string, Intl.NumberFormat>();
 

--- a/src/util/relative-time.ts
+++ b/src/util/relative-time.ts
@@ -143,39 +143,61 @@ const numberFormatterCache = new Map<string, Intl.NumberFormat>();
 
 export function getNumberFormatter(
   language: string | undefined,
-  maximumFractionDigits: number
+  maximumFractionDigits: number,
+  minimumIntegerDigits?: number
 ): Intl.NumberFormat {
-  const key = `${language ?? "default"}|${maximumFractionDigits}`;
+  const key = `${language ?? "default"}|${maximumFractionDigits}|${minimumIntegerDigits ?? ""}`;
   let formatter = numberFormatterCache.get(key);
   if (formatter === undefined) {
-    formatter = new Intl.NumberFormat(language, { maximumFractionDigits });
+    formatter = new Intl.NumberFormat(language, {
+      maximumFractionDigits,
+      minimumIntegerDigits,
+    });
     numberFormatterCache.set(key, formatter);
   }
   return formatter;
 }
 
 /**
- * Format a remaining-seconds countdown as a compact duration:
- * ``45s`` / ``8m`` / ``1h 14m`` / ``0s``. Locale-aware digits via
- * the shared number formatter; the unit letters aren't localized
- * (matches the drawer's other compact readouts).
- *
- * Pairs with :func:`remainingOf` for the device drawer's mDNS
- * expiry fold-down, recomputed each 1Hz tick against ``Date.now()``.
- * ``null`` / ``undefined`` → empty string (caller gates the row).
+ * Format a duration in seconds as a compact readout — ``45s`` / ``8m`` /
+ * ``1h 14m`` (zero minutes dropped: ``1h``). With ``showSeconds`` it keeps
+ * the finer unit for a live ticking counter: ``4m 32s``, and ``1h 05m`` with
+ * minutes padded so the counter's width stays stable across ticks.
+ * Locale-aware digits via the shared number formatter; the unit letters
+ * aren't localized. Negative input clamps to ``0s``.
+ */
+export function formatDuration(
+  seconds: number,
+  { showSeconds = false, language }: { showSeconds?: boolean; language?: string } = {}
+): string {
+  const total = Math.max(0, Math.floor(seconds));
+  const fmt = getNumberFormatter(language, 0);
+  if (total < 60) return `${fmt.format(total)}s`;
+  if (total < 3600) {
+    const minutes = Math.floor(total / 60);
+    return showSeconds
+      ? `${fmt.format(minutes)}m ${fmt.format(total % 60)}s`
+      : `${fmt.format(minutes)}m`;
+  }
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  if (showSeconds) {
+    return `${fmt.format(hours)}h ${getNumberFormatter(language, 0, 2).format(minutes)}m`;
+  }
+  return minutes > 0
+    ? `${fmt.format(hours)}h ${fmt.format(minutes)}m`
+    : `${fmt.format(hours)}h`;
+}
+
+/**
+ * :func:`formatDuration` with the null-gating the device drawer's mDNS
+ * expiry fold-down needs: ``null`` / ``undefined`` → empty string (caller
+ * gates the row). Pairs with :func:`remainingOf`, recomputed each 1Hz tick.
  */
 export function formatCountdown(
   seconds: number | null | undefined,
   language?: string
 ): string {
   if (seconds === null || seconds === undefined) return "";
-  const total = Math.max(0, Math.floor(seconds));
-  const fmt = getNumberFormatter(language, 0);
-  if (total < 60) return `${fmt.format(total)}s`;
-  if (total < 3600) return `${fmt.format(Math.floor(total / 60))}m`;
-  const hours = Math.floor(total / 3600);
-  const minutes = Math.floor((total % 3600) / 60);
-  return minutes > 0
-    ? `${fmt.format(hours)}h ${fmt.format(minutes)}m`
-    : `${fmt.format(hours)}h`;
+  return formatDuration(seconds, { language });
 }

--- a/test/common/localize-active-locale.test.ts
+++ b/test/common/localize-active-locale.test.ts
@@ -23,7 +23,8 @@ beforeEach(() => {
 
 afterEach(() => {
   clearStoredLocale();
-  AVAILABLE_LOCALES.splice(AVAILABLE_LOCALES.indexOf(TEST_LOCALE), 1);
+  const i = AVAILABLE_LOCALES.indexOf(TEST_LOCALE);
+  if (i !== -1) AVAILABLE_LOCALES.splice(i, 1);
 });
 
 describe("activeLocale caching", () => {

--- a/test/common/localize-active-locale.test.ts
+++ b/test/common/localize-active-locale.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins activeLocale()'s memoization contract: cached between calls,
+ * invalidated by the same-tab stored-locale writers and by cross-tab
+ * storage events for the locale key only.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  activeLocale,
+  AVAILABLE_LOCALES,
+  clearStoredLocale,
+  writeStoredLocale,
+} from "../../src/common/localize.js";
+
+// The dev bundle ships only "en"; register a second locale so a stored
+// override is accepted and a cache flip is observable through the public API.
+const TEST_LOCALE = "xx-test";
+
+beforeEach(() => {
+  AVAILABLE_LOCALES.push(TEST_LOCALE);
+});
+
+afterEach(() => {
+  clearStoredLocale();
+  AVAILABLE_LOCALES.splice(AVAILABLE_LOCALES.indexOf(TEST_LOCALE), 1);
+});
+
+describe("activeLocale caching", () => {
+  it("invalidates on the same-tab stored-locale writers", () => {
+    clearStoredLocale();
+    const detected = activeLocale();
+    expect(activeLocale()).toBe(detected);
+
+    writeStoredLocale(TEST_LOCALE);
+    expect(activeLocale()).toBe(TEST_LOCALE);
+
+    clearStoredLocale();
+    expect(activeLocale()).toBe(detected);
+  });
+
+  it("invalidates on a cross-tab storage event for the locale key only", () => {
+    clearStoredLocale();
+    const detected = activeLocale();
+
+    // Another tab's write lands directly in storage; only the matching
+    // storage event busts the cache.
+    localStorage.setItem("esphome-locale", TEST_LOCALE);
+    expect(activeLocale()).toBe(detected);
+    window.dispatchEvent(new StorageEvent("storage", { key: "unrelated-key" }));
+    expect(activeLocale()).toBe(detected);
+    window.dispatchEvent(new StorageEvent("storage", { key: "esphome-locale" }));
+    expect(activeLocale()).toBe(TEST_LOCALE);
+
+    // key === null is a full storage clear.
+    localStorage.removeItem("esphome-locale");
+    window.dispatchEvent(new StorageEvent("storage", { key: null }));
+    expect(activeLocale()).toBe(detected);
+  });
+});

--- a/test/util/format-job-time.test.ts
+++ b/test/util/format-job-time.test.ts
@@ -63,6 +63,12 @@ describe("formatElapsed", () => {
   it("clamps negative deltas to zero", () => {
     expect(formatElapsed(-1000)).toBe("0s");
   });
+
+  it("forwards the language for locale-aware digits", () => {
+    expect(formatElapsed((4 * 60 + 32) * 1000, "en")).toBe("4m 32s");
+    // Arabic-Egypt shapes digits as Arabic-Indic numerals.
+    expect(formatElapsed(45 * 1000, "ar-EG")).toBe("\u0664\u0665s");
+  });
 });
 
 describe("formatAbsoluteTime", () => {

--- a/test/util/relative-time.test.ts
+++ b/test/util/relative-time.test.ts
@@ -142,23 +142,23 @@ describe("getNumberFormatter", () => {
 });
 
 describe("formatDuration", () => {
-  it("renders the compact ladder without seconds by default", () => {
+  it("renders the compact variant by default", () => {
     expect(formatDuration(45)).toBe("45s");
     expect(formatDuration(8 * 60 + 30)).toBe("8m");
     expect(formatDuration(3600)).toBe("1h");
     expect(formatDuration(3600 + 14 * 60)).toBe("1h 14m");
   });
 
-  it("keeps the finer unit with showSeconds, padding hour-range minutes", () => {
-    expect(formatDuration(45, { showSeconds: true })).toBe("45s");
-    expect(formatDuration(4 * 60 + 32, { showSeconds: true })).toBe("4m 32s");
-    expect(formatDuration(3600 + 5 * 60, { showSeconds: true })).toBe("1h 05m");
-    expect(formatDuration(3600, { showSeconds: true })).toBe("1h 00m");
+  it("keeps the finer unit in the counter variant, padding hour-range minutes", () => {
+    expect(formatDuration(45, { variant: "counter" })).toBe("45s");
+    expect(formatDuration(4 * 60 + 32, { variant: "counter" })).toBe("4m 32s");
+    expect(formatDuration(3600 + 5 * 60, { variant: "counter" })).toBe("1h 05m");
+    expect(formatDuration(3600, { variant: "counter" })).toBe("1h 00m");
   });
 
   it("clamps negative input to zero", () => {
     expect(formatDuration(-5)).toBe("0s");
-    expect(formatDuration(-5, { showSeconds: true })).toBe("0s");
+    expect(formatDuration(-5, { variant: "counter" })).toBe("0s");
   });
 });
 

--- a/test/util/relative-time.test.ts
+++ b/test/util/relative-time.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it } from "vitest";
 import {
   ageOf,
   formatCountdown,
+  formatDuration,
   formatSecondsAgo,
   getNumberFormatter,
   remainingOf,
@@ -129,6 +130,35 @@ describe("getNumberFormatter", () => {
 
   it("does not crash without a language argument", () => {
     expect(() => getNumberFormatter(undefined, 0)).not.toThrow();
+  });
+
+  it("keys on minimum integer digits", () => {
+    const plain = getNumberFormatter("en", 0);
+    const padded = getNumberFormatter("en", 0, 2);
+    expect(plain).not.toBe(padded);
+    expect(padded).toBe(getNumberFormatter("en", 0, 2));
+    expect(padded.format(5)).toBe("05");
+  });
+});
+
+describe("formatDuration", () => {
+  it("renders the compact ladder without seconds by default", () => {
+    expect(formatDuration(45)).toBe("45s");
+    expect(formatDuration(8 * 60 + 30)).toBe("8m");
+    expect(formatDuration(3600)).toBe("1h");
+    expect(formatDuration(3600 + 14 * 60)).toBe("1h 14m");
+  });
+
+  it("keeps the finer unit with showSeconds, padding hour-range minutes", () => {
+    expect(formatDuration(45, { showSeconds: true })).toBe("45s");
+    expect(formatDuration(4 * 60 + 32, { showSeconds: true })).toBe("4m 32s");
+    expect(formatDuration(3600 + 5 * 60, { showSeconds: true })).toBe("1h 05m");
+    expect(formatDuration(3600, { showSeconds: true })).toBe("1h 00m");
+  });
+
+  it("clamps negative input to zero", () => {
+    expect(formatDuration(-5)).toBe("0s");
+    expect(formatDuration(-5, { showSeconds: true })).toBe("0s");
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

`formatElapsed` (format-job-time.ts) and `formatCountdown` (relative-time.ts) each hand-rolled the same seconds/minutes/hours ladder one directory apart. This merges them onto a single `formatDuration(seconds, { variant: "counter" | "compact", language })` core next to the shared number-formatter cache; both existing entry points stay as thin wrappers so call sites keep their domain signatures (milliseconds in, null gating). The `counter` variant is the live ticking shape (seconds kept in the minute range, hour-range minutes zero-padded); `compact` is the static readout.

The one visible tweak is that `formatElapsed` now renders locale-aware digits like `formatCountdown` already did: it takes an optional `language` (the timer render sites pass `activeLocale()`, the same accessor the reachability rows use) and pads via `minimumIntegerDigits` instead of an ASCII `padStart`, so non-Latin numbering systems no longer get mixed digit sets. Latin-digit locales render byte-identical output.

Because the timer render sites resolve the locale at log-stream render rate, `activeLocale()` is now memoized (module-level cache, invalidated by the stored-locale writers plus `languagechange` and locale-key `storage` events); a test pins the invalidation contract.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1186

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
