### PR TITLE
Extract shared light-dismiss controller for hand-rolled popovers

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -212,7 +212,7 @@ export class ESPHomeCommandDialog extends LitElement {
 
   // The timer's detail popover: open flag here, dismissal shared. Escape is
   // capture-phase and claimed, so the hosting dialog doesn't also close.
-  _timerDetailOpen = false;
+  @state() _timerDetailOpen = false;
   private _timerDetailDismiss = new LightDismissController(
     this,
     () => this._closeTimerDetail(),
@@ -224,26 +224,20 @@ export class ESPHomeCommandDialog extends LitElement {
       onEscape: (e) => {
         e.preventDefault();
         e.stopPropagation();
-        this._closeTimerDetail();
       },
     }
   );
 
+  // Dismissal binds imperatively (not from willUpdate) so it works on a
+  // not-yet-connected host, where Lit defers updates.
   _toggleTimerDetail = () => {
-    if (this._timerDetailOpen) {
-      this._closeTimerDetail();
-      return;
-    }
-    this._timerDetailOpen = true;
-    this._timerDetailDismiss.set(true);
-    this.requestUpdate();
+    this._timerDetailOpen = !this._timerDetailOpen;
+    this._timerDetailDismiss.set(this._timerDetailOpen);
   };
 
   _closeTimerDetail() {
-    if (!this._timerDetailOpen) return;
     this._timerDetailOpen = false;
     this._timerDetailDismiss.set(false);
-    this.requestUpdate();
   }
 
   @query("esphome-process-terminal") _terminal?: ESPHomeProcessTerminal;

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -48,6 +48,7 @@ import {
   stopCommand,
   toggleShowSecrets,
 } from "./command-dialog/commands.js";
+import { LightDismissController } from "../util/light-dismiss-controller.js";
 import { RunTimerController } from "../util/run-timer-controller.js";
 import {
   renderCompileTimer,
@@ -198,7 +199,7 @@ export class ESPHomeCommandDialog extends LitElement {
   // started_at/completed_at for the total run time after an install's flash.
   _timerJobId = "";
 
-  // Build run/compile clocks + the timer's detail popover.
+  // Build run/compile clocks.
   _timer = new RunTimerController(this, {
     job: () => (this._timerJobId ? this._jobs.get(this._timerJobId) : undefined),
     jobId: () => this._timerJobId,
@@ -207,8 +208,43 @@ export class ESPHomeCommandDialog extends LitElement {
     // advance; stop once it freezes at completion.
     tick: () =>
       this._open && this._timer.totalRunElapsedMs !== null && !this._timer.isRunFrozen,
-    popoverWrapSelector: ".compile-timer-wrap",
   });
+
+  // The timer's detail popover: open flag here, dismissal shared. Escape is
+  // capture-phase and claimed, so the hosting dialog doesn't also close.
+  _timerDetailOpen = false;
+  private _timerDetailDismiss = new LightDismissController(
+    this,
+    () => this._closeTimerDetail(),
+    {
+      // The timer button toggles itself; only clicks outside the wrap close.
+      container: () => this.shadowRoot?.querySelector(".compile-timer-wrap"),
+      escapeTarget: document,
+      escapeCapture: true,
+      onEscape: (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        this._closeTimerDetail();
+      },
+    }
+  );
+
+  _toggleTimerDetail = () => {
+    if (this._timerDetailOpen) {
+      this._closeTimerDetail();
+      return;
+    }
+    this._timerDetailOpen = true;
+    this._timerDetailDismiss.set(true);
+    this.requestUpdate();
+  };
+
+  _closeTimerDetail() {
+    if (!this._timerDetailOpen) return;
+    this._timerDetailOpen = false;
+    this._timerDetailDismiss.set(false);
+    this.requestUpdate();
+  }
 
   @query("esphome-process-terminal") _terminal?: ESPHomeProcessTerminal;
 
@@ -264,6 +300,7 @@ export class ESPHomeCommandDialog extends LitElement {
     this._jobStatus = null;
     this._primedSource = null;
     this._timer.reset();
+    this._closeTimerDetail();
     this._failedDuringValidate = false;
     // Always start with secrets redacted on a fresh open — opt-in per session.
     this._showSecrets = false;
@@ -311,6 +348,7 @@ export class ESPHomeCommandDialog extends LitElement {
     // Reattaching to a still-running (or finished) build: restore the true
     // compile clock so the replayed buffer doesn't restart the timer from now.
     this._timer.attach(job);
+    this._closeTimerDetail();
     // Cancel any prior follow before starting a new one — without this,
     // every reopen layered fresh streams while previous ones still pumped
     // onOutput into _lines (lines duplicated per leaked subscription).
@@ -322,7 +360,7 @@ export class ESPHomeCommandDialog extends LitElement {
 
   public close = () => {
     void detachStream(this);
-    this._timer.closeDetail();
+    this._closeTimerDetail();
     this._open = false;
   };
 
@@ -477,7 +515,7 @@ export class ESPHomeCommandDialog extends LitElement {
 
   private _onDialogHide = () => {
     this._open = false;
-    this._timer.closeDetail();
+    this._closeTimerDetail();
     void detachStream(this);
   };
 

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -171,16 +171,16 @@ export function renderCompileTimer(
     <div class="compile-timer-wrap" slot="toolbar-left">
       <button
         class="compile-timer ${host._timer.isRunFrozen ? "" : "compile-timer--live"}"
-        aria-expanded=${host._timer.showDetail ? "true" : "false"}
+        aria-expanded=${host._timerDetailOpen ? "true" : "false"}
         aria-haspopup="dialog"
         aria-label="${formatElapsed(total)}. ${host._localize("command.run_elapsed_title")}"
         title=${host._localize("command.run_elapsed_title")}
-        @click=${host._timer.toggleDetail}
+        @click=${host._toggleTimerDetail}
       >
         <wa-icon library="mdi" name="timer-outline"></wa-icon>
         <span>${formatElapsed(total)}</span>
       </button>
-      ${host._timer.showDetail ? renderTimerDetail(host, total) : nothing}
+      ${host._timerDetailOpen ? renderTimerDetail(host, total) : nothing}
     </div>
   `;
 }

--- a/src/components/filters/filters-popover.ts
+++ b/src/components/filters/filters-popover.ts
@@ -59,7 +59,6 @@ export class ESPHomeFiltersPopover extends LitElement {
   private _dismiss = new LightDismissController(this, () => this._close(), {
     onEscape: (e) => {
       e.preventDefault();
-      this._close();
       // Focus usually sits on a row inside the popover; hand it back
       // to the trigger so keyboard flow doesn't dead-end.
       this._triggerEl?.focus();

--- a/src/components/filters/filters-popover.ts
+++ b/src/components/filters/filters-popover.ts
@@ -6,15 +6,16 @@
  * reached through ``this.children`` because slot assignment is empty
  * while the popover is closed.
  *
- * Popover / dismiss are hand-rolled (not ``wa-popover``) so the
- * document-level dismissal can't fight the modal dialogs that label
- * management opens after a ``request-popover-close``.
+ * Popover / dismiss are hand-rolled (not ``wa-popover``, dismissal via
+ * the shared :class:`LightDismissController`) so the document-level
+ * dismissal can't fight the modal dialogs that label management opens
+ * after a ``request-popover-close``.
  */
 import { mdiFilterVariant } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import { EscapeController } from "../../util/escape-controller.js";
+import { LightDismissController } from "../../util/light-dismiss-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { filterStyles } from "./filter-styles.js";
 import { filtersPopoverStyles } from "./filters-popover.styles.js";
@@ -55,23 +56,24 @@ export class ESPHomeFiltersPopover extends LitElement {
 
   @query(".facet-trigger") private _triggerEl?: HTMLButtonElement;
 
-  private _escape = new EscapeController(this, (e) => {
-    e.preventDefault();
-    this._close();
-    // Focus usually sits on a row inside the popover; hand it back
-    // to the trigger so keyboard flow doesn't dead-end.
-    this._triggerEl?.focus();
+  private _dismiss = new LightDismissController(this, () => this._close(), {
+    onEscape: (e) => {
+      e.preventDefault();
+      this._close();
+      // Focus usually sits on a row inside the popover; hand it back
+      // to the trigger so keyboard flow doesn't dead-end.
+      this._triggerEl?.focus();
+    },
   });
 
   static styles = [espHomeStyles, filterStyles, filtersPopoverStyles];
 
   protected willUpdate(changed: Map<string, unknown>) {
-    if (changed.has("_open")) this._escape.set(this._open);
+    if (changed.has("_open")) this._dismiss.set(this._open);
   }
 
   override connectedCallback() {
     super.connectedCallback();
-    document.addEventListener("click", this._onDocumentClick, true);
     window.addEventListener("resize", this._onResize);
     this.addEventListener("filter-section-toggle", this._onSectionToggle);
     this.addEventListener("request-popover-close", this._onRequestClose);
@@ -79,7 +81,6 @@ export class ESPHomeFiltersPopover extends LitElement {
 
   override disconnectedCallback() {
     super.disconnectedCallback();
-    document.removeEventListener("click", this._onDocumentClick, true);
     window.removeEventListener("resize", this._onResize);
     this.removeEventListener("filter-section-toggle", this._onSectionToggle);
     this.removeEventListener("request-popover-close", this._onRequestClose);
@@ -151,12 +152,6 @@ export class ESPHomeFiltersPopover extends LitElement {
   };
 
   private _onRequestClose = () => {
-    this._close();
-  };
-
-  private _onDocumentClick = (e: MouseEvent) => {
-    if (!this._open) return;
-    if (e.composedPath().includes(this)) return;
     this._close();
   };
 

--- a/src/components/mdi-icon-picker.ts
+++ b/src/components/mdi-icon-picker.ts
@@ -13,7 +13,7 @@ import { mdiClose, mdiMagnify, mdiPalette } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { inputStyles } from "../styles/inputs.js";
-import { EscapeController } from "../util/escape-controller.js";
+import { LightDismissController } from "../util/light-dismiss-controller.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { mdiIconPickerStyles } from "./mdi-icon-picker.styles.js";
 
@@ -119,18 +119,8 @@ export class ESPHomeMdiIconPicker extends LitElement {
 
   static styles = [inputStyles, mdiIconPickerStyles];
 
-  connectedCallback() {
-    super.connectedCallback();
-    document.addEventListener("click", this._onDocumentClick, true);
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    document.removeEventListener("click", this._onDocumentClick, true);
-  }
-
   protected willUpdate(changed: Map<string, unknown>) {
-    if (changed.has("_open")) this._escape.set(this._open);
+    if (changed.has("_open")) this._dismiss.set(this._open);
     // When the picker is mounted (or assigned a value) with an icon
     // already selected, kick off the catalog load so the trigger button
     // can render the SVG. Otherwise the form would open showing only a
@@ -143,22 +133,13 @@ export class ESPHomeMdiIconPicker extends LitElement {
   /* Esc binds to ``document`` (not ``window``) and the callback uses
      ``stopPropagation`` so a parent dialog wrapping the picker doesn't
      also close on the same keypress. */
-  private _escape = new EscapeController(
-    this,
-    (e) => {
+  private _dismiss = new LightDismissController(this, () => this._close(), {
+    escapeTarget: document,
+    onEscape: (e) => {
       e.stopPropagation();
       this._close();
     },
-    { target: document }
-  );
-
-  private _onDocumentClick = (e: Event) => {
-    if (!this._open) return;
-    const path = e.composedPath();
-    if (!path.includes(this)) {
-      this._close();
-    }
-  };
+  });
 
   private async _toggle() {
     if (this.disabled) return;

--- a/src/components/mdi-icon-picker.ts
+++ b/src/components/mdi-icon-picker.ts
@@ -135,10 +135,7 @@ export class ESPHomeMdiIconPicker extends LitElement {
      also close on the same keypress. */
   private _dismiss = new LightDismissController(this, () => this._close(), {
     escapeTarget: document,
-    onEscape: (e) => {
-      e.stopPropagation();
-      this._close();
-    },
+    onEscape: (e) => e.stopPropagation(),
   });
 
   private async _toggle() {

--- a/src/util/escape-controller.ts
+++ b/src/util/escape-controller.ts
@@ -7,6 +7,10 @@ export interface EscapeControllerOptions {
    *  swallow the same Escape. Accepts any ``EventTarget`` so tests can
    *  inject a stub. */
   target?: EventTarget;
+  /** Bind in the capture phase so the handler runs ahead of every
+   *  bubble-phase listener — e.g. a popover claiming Escape before its
+   *  hosting dialog sees the keypress. */
+  capture?: boolean;
 }
 
 /**
@@ -29,6 +33,7 @@ export interface EscapeControllerOptions {
 export class EscapeController implements ReactiveController {
   private _bound = false;
   private readonly _target: EventTarget;
+  private readonly _capture: boolean;
 
   constructor(
     host: ReactiveControllerHost,
@@ -36,6 +41,7 @@ export class EscapeController implements ReactiveController {
     options: EscapeControllerOptions = {}
   ) {
     this._target = options.target ?? window;
+    this._capture = options.capture ?? false;
     host.addController(this);
   }
 
@@ -46,9 +52,9 @@ export class EscapeController implements ReactiveController {
   set(active: boolean) {
     if (active === this._bound) return;
     if (active) {
-      this._target.addEventListener("keydown", this._handler);
+      this._target.addEventListener("keydown", this._handler, this._capture);
     } else {
-      this._target.removeEventListener("keydown", this._handler);
+      this._target.removeEventListener("keydown", this._handler, this._capture);
     }
     this._bound = active;
   }

--- a/src/util/light-dismiss-controller.ts
+++ b/src/util/light-dismiss-controller.ts
@@ -1,0 +1,75 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { EscapeController } from "./escape-controller.js";
+
+export interface LightDismissOptions {
+  /** Composed-path root treated as "inside" — clicks within it don't
+   *  dismiss. Defaults to the host element. A callback so it can resolve
+   *  a render-root node that only exists while the popover is open;
+   *  returning ``null``/``undefined`` makes every click dismiss. */
+  container?: () => Element | null | undefined;
+  /** Where the Escape listener binds; see ``EscapeControllerOptions``. */
+  escapeTarget?: EventTarget;
+  /** Bind Escape in the capture phase (claim it ahead of a hosting
+   *  dialog's own Escape handling). */
+  escapeCapture?: boolean;
+  /** Escape handling override. The default claims the event
+   *  (``preventDefault``) and dismisses; override for extras like
+   *  ``stopPropagation`` or returning focus to the trigger. */
+  onEscape?: (e: KeyboardEvent) => void;
+}
+
+/**
+ * Light dismissal for a hand-rolled popover: while active, a click
+ * outside the container or an Escape press invokes ``onDismiss``. The
+ * host owns the open flag and calls ``set(open)`` (typically from
+ * ``willUpdate``), mirroring :class:`EscapeController` — which handles
+ * the Escape half here.
+ *
+ * The click listener binds capture-phase on ``document`` so a
+ * ``stopPropagation`` inside the popover can't defeat dismissal, and it
+ * binds only while active, so the click that opened the popover (whose
+ * capture phase has already run by the time the host flips the flag)
+ * can't self-dismiss it.
+ */
+export class LightDismissController implements ReactiveController {
+  private _bound = false;
+  private readonly _escape: EscapeController;
+
+  constructor(
+    private readonly _host: ReactiveControllerHost & Element,
+    private readonly _onDismiss: () => void,
+    private readonly _options: LightDismissOptions = {}
+  ) {
+    this._escape = new EscapeController(
+      _host,
+      _options.onEscape ??
+        ((e) => {
+          e.preventDefault();
+          _onDismiss();
+        }),
+      { target: _options.escapeTarget, capture: _options.escapeCapture }
+    );
+    _host.addController(this);
+  }
+
+  hostDisconnected(): void {
+    this.set(false);
+  }
+
+  set(active: boolean): void {
+    this._escape.set(active);
+    if (active === this._bound) return;
+    if (active) {
+      document.addEventListener("click", this._onDocumentClick, true);
+    } else {
+      document.removeEventListener("click", this._onDocumentClick, true);
+    }
+    this._bound = active;
+  }
+
+  private _onDocumentClick = (e: MouseEvent): void => {
+    const container = this._options.container ? this._options.container() : this._host;
+    if (container && e.composedPath().includes(container)) return;
+    this._onDismiss();
+  };
+}

--- a/src/util/light-dismiss-controller.ts
+++ b/src/util/light-dismiss-controller.ts
@@ -12,9 +12,9 @@ export interface LightDismissOptions {
   /** Bind Escape in the capture phase (claim it ahead of a hosting
    *  dialog's own Escape handling). */
   escapeCapture?: boolean;
-  /** Escape handling override. The default claims the event
-   *  (``preventDefault``) and dismisses; override for extras like
-   *  ``stopPropagation`` or returning focus to the trigger. */
+  /** Pre-dismiss Escape hook: how to claim the event (default
+   *  ``preventDefault``) plus per-site extras like ``stopPropagation``
+   *  or returning focus to the trigger. Dismissal always follows. */
   onEscape?: (e: KeyboardEvent) => void;
 }
 
@@ -42,11 +42,11 @@ export class LightDismissController implements ReactiveController {
   ) {
     this._escape = new EscapeController(
       _host,
-      _options.onEscape ??
-        ((e) => {
-          e.preventDefault();
-          _onDismiss();
-        }),
+      (e) => {
+        if (_options.onEscape) _options.onEscape(e);
+        else e.preventDefault();
+        _onDismiss();
+      },
       { target: _options.escapeTarget, capture: _options.escapeCapture }
     );
     _host.addController(this);

--- a/src/util/run-timer-controller.ts
+++ b/src/util/run-timer-controller.ts
@@ -21,9 +21,6 @@ export interface RunTimerOptions {
   runEnded: () => boolean;
   /** Whether the 1s ticker should run (host visible and the run live). */
   tick: () => boolean;
-  /** Selector for the timer wrap in the host's render root; clicks inside it
-   *  don't dismiss the detail popover. */
-  popoverWrapSelector?: string;
 }
 
 /**
@@ -35,21 +32,18 @@ export interface RunTimerOptions {
  * progress gauge, mirrored to the cross-open store, and — on ``attach`` —
  * restored from the job's backend ``compile_started_at``/``compile_ended_at``
  * stamps first, so it survives reloads. A 1s ticker drives the live readouts
- * while ``tick()`` holds; it stops on freeze and on host disconnect. Also
- * owns the timer's detail popover open state with outside-click dismissal.
+ * while ``tick()`` holds; it stops on freeze and on host disconnect.
  */
 export class RunTimerController implements ReactiveController {
   /** Clock behind the live readouts; ticks each second while the run is live. */
   now = Date.now();
-  /** Whether the timer's detail popover is open. */
-  showDetail = false;
 
   private _compileStartedAt: number | null = null;
   private _compileEndedAt: number | null = null;
   private _tickHandle: ReturnType<typeof setInterval> | null = null;
 
   constructor(
-    private readonly _host: ReactiveControllerHost & Element,
+    private readonly _host: ReactiveControllerHost,
     private readonly _options: RunTimerOptions
   ) {
     _host.addController(this);
@@ -77,14 +71,12 @@ export class RunTimerController implements ReactiveController {
 
   hostDisconnected(): void {
     this._stopTicker();
-    this.closeDetail();
   }
 
   /** Reset for a fresh run (the host's open path). */
   reset(): void {
     this._compileStartedAt = null;
     this._compileEndedAt = null;
-    this.closeDetail();
   }
 
   /**
@@ -99,7 +91,6 @@ export class RunTimerController implements ReactiveController {
     this._compileStartedAt =
       parseIsoMs(job.compile_started_at) ?? timing?.startedAt ?? null;
     this._compileEndedAt = parseIsoMs(job.compile_ended_at) ?? timing?.endedAt ?? null;
-    this.closeDetail();
   }
 
   /** Latch the compile span off one streamed build-output line. */
@@ -156,30 +147,6 @@ export class RunTimerController implements ReactiveController {
     return parseIsoMs(this._options.job()?.completed_at) !== null;
   }
 
-  toggleDetail = (): void => {
-    if (this.showDetail) {
-      this.closeDetail();
-      return;
-    }
-    this.showDetail = true;
-    // Dismiss on the next click anywhere outside the timer (the toolbar, the
-    // log, elsewhere in the dialog). Capture-phase so it fires before other
-    // handlers; registered after this opening click so it doesn't self-close.
-    document.addEventListener("click", this._onOutsideClick, true);
-    // Escape closes just the popover — capture-phase and claimed, so the
-    // hosting dialog's own Escape handling doesn't also close the dialog.
-    document.addEventListener("keydown", this._onEscape, true);
-    this._host.requestUpdate();
-  };
-
-  closeDetail(): void {
-    if (!this.showDetail) return;
-    this.showDetail = false;
-    document.removeEventListener("click", this._onOutsideClick, true);
-    document.removeEventListener("keydown", this._onEscape, true);
-    this._host.requestUpdate();
-  }
-
   // Latch the compile start once, mirroring it to the cross-open timing store.
   private _markStarted(): void {
     if (this._compileStartedAt !== null) return;
@@ -197,22 +164,6 @@ export class RunTimerController implements ReactiveController {
     markCompileEnded(this._options.jobId(), now);
     this._host.requestUpdate();
   }
-
-  private _onOutsideClick = (e: MouseEvent): void => {
-    // The timer button toggles itself; only outside clicks close here.
-    const wrap = this._options.popoverWrapSelector
-      ? this._host.shadowRoot?.querySelector(this._options.popoverWrapSelector)
-      : null;
-    if (wrap && e.composedPath().includes(wrap)) return;
-    this.closeDetail();
-  };
-
-  private _onEscape = (e: KeyboardEvent): void => {
-    if (e.key !== "Escape") return;
-    e.preventDefault();
-    e.stopPropagation();
-    this.closeDetail();
-  };
 
   private _startTicker(): void {
     if (this._tickHandle !== null) return;

--- a/test/components/command-dialog-follow-restore.test.ts
+++ b/test/components/command-dialog-follow-restore.test.ts
@@ -28,6 +28,8 @@ interface Harness {
   _timerJobId: string;
   _commandType: CommandType;
   _timer: RunTimerController;
+  _timerDetailOpen: boolean;
+  _toggleTimerDetail: () => void;
   followJob: (job: FirmwareJob, displayName: string) => void;
 }
 
@@ -295,33 +297,33 @@ describe("command-dialog run timer visibility", () => {
 describe("command-dialog timer detail popover dismissal", () => {
   it("toggles open then closed", () => {
     const el = mount([]);
-    el._timer.toggleDetail();
-    expect(el._timer.showDetail).toBe(true);
-    el._timer.toggleDetail();
-    expect(el._timer.showDetail).toBe(false);
+    el._toggleTimerDetail();
+    expect(el._timerDetailOpen).toBe(true);
+    el._toggleTimerDetail();
+    expect(el._timerDetailOpen).toBe(false);
   });
 
   it("closes on a click outside the timer", () => {
     const el = mount([]);
-    el._timer.toggleDetail();
-    expect(el._timer.showDetail).toBe(true);
+    el._toggleTimerDetail();
+    expect(el._timerDetailOpen).toBe(true);
     // A document-level click whose composed path doesn't include the timer
     // wrap dismisses the popover.
     document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    expect(el._timer.showDetail).toBe(false);
+    expect(el._timerDetailOpen).toBe(false);
   });
 
   it("closes on Escape without letting it reach the hosting dialog", () => {
     const el = mount([]);
-    el._timer.toggleDetail();
-    expect(el._timer.showDetail).toBe(true);
+    el._toggleTimerDetail();
+    expect(el._timerDetailOpen).toBe(true);
     const esc = new KeyboardEvent("keydown", {
       key: "Escape",
       bubbles: true,
       cancelable: true,
     });
     document.dispatchEvent(esc);
-    expect(el._timer.showDetail).toBe(false);
+    expect(el._timerDetailOpen).toBe(false);
     // Claimed, so the dialog's own Escape handling doesn't also close it.
     expect(esc.defaultPrevented).toBe(true);
   });

--- a/test/util/light-dismiss-controller.test.ts
+++ b/test/util/light-dismiss-controller.test.ts
@@ -140,18 +140,23 @@ describe("LightDismissController Escape", () => {
     expect(esc.defaultPrevented).toBe(true);
   });
 
-  it("routes Escape through the onEscape override", () => {
+  it("runs the onEscape hook before dismissing", () => {
     const host = makeHost();
-    const onDismiss = vi.fn();
-    const onEscape = vi.fn();
+    const order: string[] = [];
+    const onDismiss = vi.fn(() => order.push("dismiss"));
+    const onEscape = vi.fn(() => order.push("hook"));
     const ctrl = track(new LightDismissController(host, onDismiss, { onEscape }));
     ctrl.set(true);
 
-    window.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })
-    );
-    expect(onEscape).toHaveBeenCalledTimes(1);
-    expect(onDismiss).not.toHaveBeenCalled();
+    const esc = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(esc);
+    expect(order).toEqual(["hook", "dismiss"]);
+    // The hook owns claiming; the controller adds no preventDefault of its own.
+    expect(esc.defaultPrevented).toBe(false);
   });
 });
 

--- a/test/util/light-dismiss-controller.test.ts
+++ b/test/util/light-dismiss-controller.test.ts
@@ -1,0 +1,185 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * LightDismissController: outside-click + Escape dismissal for hand-rolled
+ * popovers, active only while the host says so. The Escape half rides
+ * EscapeController, whose capture option is pinned here too (its own suite
+ * runs in plain Node, where event phases don't exist).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EscapeController } from "../../src/util/escape-controller.js";
+import { LightDismissController } from "../../src/util/light-dismiss-controller.js";
+
+type Host = import("lit").ReactiveControllerHost & HTMLElement;
+
+function makeHost(): Host {
+  const el = document.createElement("div");
+  Object.assign(el, {
+    addController: () => {},
+    removeController: () => {},
+    requestUpdate: () => {},
+    updateComplete: Promise.resolve(true),
+  });
+  document.body.appendChild(el);
+  return el as unknown as Host;
+}
+
+function clickOn(target: EventTarget) {
+  target.dispatchEvent(new MouseEvent("click", { bubbles: true, composed: true }));
+}
+
+/* Controllers bind to document/window; an active one left behind would
+   claim the next test's events (the Escape default preventDefaults, and
+   EscapeController skips claimed events). Deactivate every controller
+   made in the finished test. */
+const active: Array<{ set(a: boolean): void }> = [];
+
+function track<T extends { set(a: boolean): void }>(ctrl: T): T {
+  active.push(ctrl);
+  return ctrl;
+}
+
+afterEach(() => {
+  for (const ctrl of active.splice(0)) ctrl.set(false);
+  document.body.innerHTML = "";
+});
+
+describe("LightDismissController outside-click", () => {
+  it("dismisses on a click outside the host, not inside it", () => {
+    const host = makeHost();
+    const inner = document.createElement("button");
+    host.appendChild(inner);
+    const onDismiss = vi.fn();
+    const ctrl = track(new LightDismissController(host, onDismiss));
+    ctrl.set(true);
+
+    clickOn(inner);
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    clickOn(document.body);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the container callback as the inside boundary", () => {
+    const host = makeHost();
+    const wrap = document.createElement("div");
+    const outsideWrap = document.createElement("div");
+    host.appendChild(wrap);
+    host.appendChild(outsideWrap);
+    const onDismiss = vi.fn();
+    const ctrl = track(
+      new LightDismissController(host, onDismiss, { container: () => wrap })
+    );
+    ctrl.set(true);
+
+    clickOn(wrap);
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    // Inside the host but outside the container still dismisses.
+    clickOn(outsideWrap);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses on any click when the container resolves to nothing", () => {
+    const host = makeHost();
+    const onDismiss = vi.fn();
+    const ctrl = track(
+      new LightDismissController(host, onDismiss, { container: () => null })
+    );
+    ctrl.set(true);
+
+    clickOn(host);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("is inert until set(true) and after set(false) / hostDisconnected", () => {
+    const host = makeHost();
+    const onDismiss = vi.fn();
+    const ctrl = track(new LightDismissController(host, onDismiss));
+
+    clickOn(document.body);
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    ctrl.set(true);
+    ctrl.set(false);
+    clickOn(document.body);
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    ctrl.set(true);
+    ctrl.hostDisconnected();
+    clickOn(document.body);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("binds one listener across repeated set(true) calls", () => {
+    const host = makeHost();
+    const onDismiss = vi.fn();
+    const ctrl = track(new LightDismissController(host, onDismiss));
+    ctrl.set(true);
+    ctrl.set(true);
+
+    clickOn(document.body);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("LightDismissController Escape", () => {
+  it("claims Escape and dismisses by default", () => {
+    const host = makeHost();
+    const onDismiss = vi.fn();
+    const ctrl = track(new LightDismissController(host, onDismiss));
+    ctrl.set(true);
+
+    const esc = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(esc);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(esc.defaultPrevented).toBe(true);
+  });
+
+  it("routes Escape through the onEscape override", () => {
+    const host = makeHost();
+    const onDismiss = vi.fn();
+    const onEscape = vi.fn();
+    const ctrl = track(new LightDismissController(host, onDismiss, { onEscape }));
+    ctrl.set(true);
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })
+    );
+    expect(onEscape).toHaveBeenCalledTimes(1);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});
+
+describe("EscapeController capture option", () => {
+  it("runs ahead of a stopPropagation deeper in the tree when capturing", () => {
+    const child = document.createElement("div");
+    document.body.appendChild(child);
+    // A bubble-phase handler at the child swallows the event; only a
+    // capture-phase document listener sees it first.
+    child.addEventListener("keydown", (e) => e.stopPropagation());
+
+    const seen: string[] = [];
+    const host = makeHost();
+    const capturing = track(
+      new EscapeController(host, () => seen.push("capture"), {
+        target: document,
+        capture: true,
+      })
+    );
+    const bubbling = track(
+      new EscapeController(host, () => seen.push("bubble"), { target: document })
+    );
+    capturing.set(true);
+    bubbling.set(true);
+
+    child.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })
+    );
+    expect(seen).toEqual(["capture"]);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Three surfaces hand-rolled the same light-dismiss pattern for a popover: the command terminal's timer detail (bundled inside `RunTimerController`), the dashboard filters popover, and the MDI icon picker. Each carried its own document click listener plus its own Escape wiring, and the timer's copy re-implemented what `EscapeController` already generalizes.

This adds `LightDismissController` (`src/util/light-dismiss-controller.ts`): outside-click plus Escape, host owns the open flag and calls `set(open)`, mirroring the repo's `EscapeController`/`EnterController` shape. The Escape half delegates to `EscapeController`, which gains a one-line `capture` option so the timer popover can keep claiming Escape ahead of its hosting dialog. Each site keeps its exact dismissal semantics through the `container`/`escapeTarget`/`onEscape` options (filters returns focus to its trigger, the picker stops propagation without preventDefault, the timer claims and stops the event).

`RunTimerController` drops the popover surface entirely; the command dialog now owns the open flag and the firmware-install dialog no longer carries popover code it never used. The filters popover and icon picker also lose their always-bound document listeners; dismissal now binds only while open.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1187

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
