### PR TITLE
Coordinate cross-dialog navigation through an open-dialog registry

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -67,7 +67,6 @@ import { isExpert } from "../util/experience.js";
 import { notifyInfo } from "../util/notify.js";
 import { isRecentSerialActivity, markSerialActivity } from "../util/web-serial.js";
 import { onLoginSubmit } from "./app-shell/auth.js";
-import { closeOpenDialogs } from "./base-dialog.js";
 import {
   loadIntegrationDocs,
   loadLabels,
@@ -579,13 +578,8 @@ export class ESPHomeApp extends LitElement {
         @set-expert-mode=${(e: CustomEvent<boolean>) => onSetExpertMode(this, e)}
         @set-language=${(e: CustomEvent<Parameters<typeof onSetLanguage>[1]["detail"]>) =>
           onSetLanguage(this, e as Parameters<typeof onSetLanguage>[1])}
-        @open-settings=${(e: CustomEvent<{ section?: Section } | undefined>) => {
-          // Cross-dialog navigation: close whatever modal the event came
-          // from (firmware tasks, a terminal reopened over it, ...) so
-          // settings can't paint underneath a still-open sibling.
-          closeOpenDialogs(this._settingsDialog ?? undefined);
-          this._settingsDialog?.open(e.detail?.section);
-        }}
+        @open-settings=${(e: CustomEvent<{ section?: Section } | undefined>) =>
+          this._settingsDialog?.open(e.detail?.section)}
         @open-firmware-jobs=${() => this._firmwareJobsDialog?.open()}
         @open-reset-build-env=${() => this._firmwareJobsDialog?.openResetBuildEnv()}
         @open-feedback=${() => this._feedbackDialog?.open()}

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -67,6 +67,7 @@ import { isExpert } from "../util/experience.js";
 import { notifyInfo } from "../util/notify.js";
 import { isRecentSerialActivity, markSerialActivity } from "../util/web-serial.js";
 import { onLoginSubmit } from "./app-shell/auth.js";
+import { closeOpenDialogs } from "./base-dialog.js";
 import {
   loadIntegrationDocs,
   loadLabels,
@@ -579,10 +580,10 @@ export class ESPHomeApp extends LitElement {
         @set-language=${(e: CustomEvent<Parameters<typeof onSetLanguage>[1]["detail"]>) =>
           onSetLanguage(this, e as Parameters<typeof onSetLanguage>[1])}
         @open-settings=${(e: CustomEvent<{ section?: Section } | undefined>) => {
-          // Close the firmware-tasks dialog first — a build's offload link
-          // opens settings from a terminal reopened over it, and it would
-          // otherwise stay stacked on top and hide the settings dialog.
-          this._firmwareJobsDialog?.close();
+          // Cross-dialog navigation: close whatever modal the event came
+          // from (firmware tasks, a terminal reopened over it, ...) so
+          // settings can't paint underneath a still-open sibling.
+          closeOpenDialogs(this._settingsDialog ?? undefined);
           this._settingsDialog?.open(e.detail?.section);
         }}
         @open-firmware-jobs=${() => this._firmwareJobsDialog?.open()}

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -17,12 +17,9 @@ const openDialogs = new Set<ESPHomeBaseDialog>();
  * Request-close every open dialog except those inside *except*'s composed
  * tree.
  *
- * For when a control inside one modal navigates to another: two open
- * ``wa-dialog``s stack by paint order, so the newly opened one can end up
- * hidden underneath a still-open sibling. Each close is a
- * :meth:`ESPHomeBaseDialog.requestClose`, so busy gates and host
- * ``request-close`` vetoes still apply — a dialog that refuses to close
- * stays open, same as Escape.
+ * Each close is a :meth:`ESPHomeBaseDialog.requestClose`, so busy gates and
+ * host ``request-close`` vetoes still apply — a dialog that refuses to
+ * close stays open, same as Escape.
  */
 export function closeOpenDialogs(except?: Node): void {
   for (const dialog of [...openDialogs]) {
@@ -224,26 +221,21 @@ export class ESPHomeBaseDialog extends LitElement {
   }
 
   /**
-   * Ask the host for a close, honouring the same gates as Escape / the X
-   * button.
+   * Ask for a close through the exact Escape codepath.
    *
-   * Absorbed while ``busy``. Otherwise dispatches ``request-close``; a host
-   * that doesn't veto flips its flag and the reactive ``?open`` binding
-   * runs the actual hide (which re-fires ``request-close`` through
-   * ``wa-hide`` — hosts' handlers are idempotent flips). Poking the inner
-   * ``wa-dialog`` directly instead double-triggers its hide watcher (once
-   * for the property, once for the binding's attribute removal) and it
-   * re-opens itself, so the host flag is the only safe entry point.
+   * Delegates to the inner ``wa-dialog``'s ``requestClose()`` method (what
+   * its own Escape handler calls), so the one ``wa-hide`` → busy gate →
+   * host-veto → hide → ``after-hide`` sequence runs — both host shapes
+   * close (flag flipped from ``request-close`` or from ``after-hide``).
+   * Don't switch this to writing the ``open`` *property*: its watcher
+   * reverts and re-requests, double-triggering the hide.
    */
   requestClose(): void {
-    if (this.busy) return;
-    this.dispatchEvent(
-      new CustomEvent("request-close", {
-        cancelable: true,
-        bubbles: false,
-        composed: false,
-      })
-    );
+    this.shadowRoot
+      ?.querySelector<HTMLElement & { requestClose?: (source?: unknown) => void }>(
+        "wa-dialog"
+      )
+      ?.requestClose?.(this);
   }
 
   // Focus a consumer-marked ``[autofocus]`` control once the dialog has

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -8,6 +8,40 @@ import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { centeredMobileDialog } from "../styles/dialog-mobile.js";
 import { EnterController } from "../util/enter-controller.js";
 
+/** Wrappers currently open, maintained by the class below. Backs
+ *  cross-dialog navigation (``closeOpenDialogs``); dialogs not built on
+ *  the wrapper don't participate. */
+const openDialogs = new Set<ESPHomeBaseDialog>();
+
+/**
+ * Request-close every open dialog except those inside *except*'s composed
+ * tree.
+ *
+ * For when a control inside one modal navigates to another: two open
+ * ``wa-dialog``s stack by paint order, so the newly opened one can end up
+ * hidden underneath a still-open sibling. Each close is a
+ * :meth:`ESPHomeBaseDialog.requestClose`, so busy gates and host
+ * ``request-close`` vetoes still apply — a dialog that refuses to close
+ * stays open, same as Escape.
+ */
+export function closeOpenDialogs(except?: Node): void {
+  for (const dialog of [...openDialogs]) {
+    if (except && composedContains(except, dialog)) continue;
+    dialog.requestClose();
+  }
+}
+
+// Composed-tree containment: follows shadow boundaries via the host chain,
+// so a component passed as ``except`` shields the wrapper in its shadow DOM.
+function composedContains(ancestor: Node, node: Node): boolean {
+  let cur: Node | null = node;
+  while (cur) {
+    if (cur === ancestor) return true;
+    cur = cur.parentNode ?? (cur instanceof ShadowRoot ? cur.host : null);
+  }
+  return false;
+}
+
 /**
  * Thin shared wrapper around ``<wa-dialog>``.
  *
@@ -175,6 +209,41 @@ export class ESPHomeBaseDialog extends LitElement {
     if (changed.has("open") || changed.has("confirmOnEnter")) {
       this._enter.set(this.open && this.confirmOnEnter !== undefined);
     }
+    if (this.open) openDialogs.add(this);
+    else openDialogs.delete(this);
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (this.open) openDialogs.add(this);
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    openDialogs.delete(this);
+  }
+
+  /**
+   * Ask the host for a close, honouring the same gates as Escape / the X
+   * button.
+   *
+   * Absorbed while ``busy``. Otherwise dispatches ``request-close``; a host
+   * that doesn't veto flips its flag and the reactive ``?open`` binding
+   * runs the actual hide (which re-fires ``request-close`` through
+   * ``wa-hide`` — hosts' handlers are idempotent flips). Poking the inner
+   * ``wa-dialog`` directly instead double-triggers its hide watcher (once
+   * for the property, once for the binding's attribute removal) and it
+   * re-opens itself, so the host flag is the only safe entry point.
+   */
+  requestClose(): void {
+    if (this.busy) return;
+    this.dispatchEvent(
+      new CustomEvent("request-close", {
+        cancelable: true,
+        bubbles: false,
+        composed: false,
+      })
+    );
   }
 
   // Focus a consumer-marked ``[autofocus]`` control once the dialog has

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -18,6 +18,7 @@ import type { OffloaderAlertSnapshotEntry } from "../api/types/remote-build-even
 import type { LocalizeFunc } from "../common/localize.js";
 import { buildOffloadAlertsContext, localizeContext } from "../context/index.js";
 import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
+import { closeOpenDialogs } from "./base-dialog.js";
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -83,6 +84,10 @@ export class ESPHomeSettingsDialog extends LitElement {
   ];
 
   open(section: Section = "appearance") {
+    // Opening from inside another modal (a terminal's offload link, the
+    // firmware-tasks list): dismiss open siblings or this one can paint
+    // underneath them.
+    closeOpenDialogs(this);
     this._section = section;
     this._open = true;
   }

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -18,10 +18,10 @@ import type { OffloaderAlertSnapshotEntry } from "../api/types/remote-build-even
 import type { LocalizeFunc } from "../common/localize.js";
 import { buildOffloadAlertsContext, localizeContext } from "../context/index.js";
 import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
-import { closeOpenDialogs } from "./base-dialog.js";
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import { closeOpenDialogs } from "./base-dialog.js";
 import {
   SETTINGS_DIALOG_BREAKPOINT,
   settingsRowStyles,
@@ -30,7 +30,6 @@ import {
 import { SECTIONS, type Section, type SectionDef } from "./settings-dialog/types.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
-import "./base-dialog.js";
 import "./settings-dialog/appearance-section.js";
 import "./settings-dialog/build-offload-section.js";
 import "./settings-dialog/build-server-section.js";

--- a/test/components/base-dialog-close-open.test.ts
+++ b/test/components/base-dialog-close-open.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment happy-dom
 //
 // Pins the open-dialog registry behind closeOpenDialogs (issue #1185): open
-// wrappers get a request-close (so the host decides, same as Escape), the
-// except subtree is shielded across shadow boundaries, busy dialogs are
-// absorbed, and closed / disconnected wrappers are ignored.
+// wrappers are closed through the inner wa-dialog's Escape codepath, the
+// except subtree is shielded across shadow boundaries, the busy gate absorbs
+// the request, and closed / disconnected wrappers are ignored.
 import { describe, expect, it, vi } from "vitest";
 
 // wa-dialog runs form-validation lifecycle hooks happy-dom doesn't implement;
@@ -12,6 +12,31 @@ vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}
 
 import { closeOpenDialogs, ESPHomeBaseDialog } from "../../src/components/base-dialog.js";
 import { mount } from "../_dom.js";
+
+/* The real element registration is stubbed out above; register a stand-in
+   whose requestClose mimics the real one's entry point — fire the cancelable
+   wa-hide and record the outcome — so the wrapper's busy gate and
+   request-close re-emission are exercised for real. */
+class WaDialogStub extends HTMLElement {
+  requestCloseCalls = 0;
+  lastHidePrevented: boolean | null = null;
+
+  requestClose(): void {
+    this.requestCloseCalls++;
+    const ev = new CustomEvent("wa-hide", {
+      cancelable: true,
+      bubbles: true,
+      composed: true,
+    });
+    this.dispatchEvent(ev);
+    this.lastHidePrevented = ev.defaultPrevented;
+  }
+}
+customElements.define("wa-dialog", WaDialogStub);
+
+function innerStub(el: ESPHomeBaseDialog): WaDialogStub {
+  return el.shadowRoot!.querySelector("wa-dialog") as unknown as WaDialogStub;
+}
 
 function watchRequestClose(el: ESPHomeBaseDialog) {
   const spy = vi.fn();
@@ -24,32 +49,35 @@ describe("closeOpenDialogs", () => {
     const openEl = await mount(new ESPHomeBaseDialog(), { open: true });
     const closedEl = await mount(new ESPHomeBaseDialog(), { open: false });
     const openSpy = watchRequestClose(openEl);
-    const closedSpy = watchRequestClose(closedEl);
 
     closeOpenDialogs();
 
+    expect(innerStub(openEl).requestCloseCalls).toBe(1);
     expect(openSpy).toHaveBeenCalledTimes(1);
-    expect(closedSpy).not.toHaveBeenCalled();
+    expect(innerStub(openEl).lastHidePrevented).toBe(false);
+    expect(innerStub(closedEl).requestCloseCalls).toBe(0);
   });
 
   it("leaves the wrapper's own open flag to the host", async () => {
     const el = await mount(new ESPHomeBaseDialog(), { open: true });
     closeOpenDialogs();
-    // The host flips this from its request-close handler; the sweep only
-    // asks.
+    // The host flips this from its request-close/after-hide handlers; the
+    // sweep only asks.
     expect(el.open).toBe(true);
   });
 
-  it("absorbs the request while busy", async () => {
+  it("absorbs the close while busy, before any host veto", async () => {
     const el = await mount(new ESPHomeBaseDialog(), { open: true, busy: true });
     const spy = watchRequestClose(el);
+
     closeOpenDialogs();
+
+    expect(innerStub(el).lastHidePrevented).toBe(true);
     expect(spy).not.toHaveBeenCalled();
   });
 
   it("shields the except subtree across a shadow boundary", async () => {
     const swept = await mount(new ESPHomeBaseDialog(), { open: true });
-    const sweptSpy = watchRequestClose(swept);
 
     // Stands in for a settings-dialog component: the wrapper lives in its
     // shadow DOM, and the component element is what gets passed as except.
@@ -60,40 +88,37 @@ describe("closeOpenDialogs", () => {
     shielded.open = true;
     shadow.appendChild(shielded);
     await shielded.updateComplete;
-    const shieldedSpy = watchRequestClose(shielded);
 
     closeOpenDialogs(component);
 
-    expect(sweptSpy).toHaveBeenCalledTimes(1);
-    expect(shieldedSpy).not.toHaveBeenCalled();
+    expect(innerStub(swept).requestCloseCalls).toBe(1);
+    expect(innerStub(shielded).requestCloseCalls).toBe(0);
   });
 
   it("drops a dialog from the sweep once it closes", async () => {
     const el = await mount(new ESPHomeBaseDialog(), { open: true });
-    const spy = watchRequestClose(el);
     el.open = false;
     await el.updateComplete;
 
     closeOpenDialogs();
-    expect(spy).not.toHaveBeenCalled();
+    expect(innerStub(el).requestCloseCalls).toBe(0);
   });
 
   it("drops a dialog from the sweep once it disconnects", async () => {
     const el = await mount(new ESPHomeBaseDialog(), { open: true });
-    const spy = watchRequestClose(el);
+    const stub = innerStub(el);
     el.remove();
 
     closeOpenDialogs();
-    expect(spy).not.toHaveBeenCalled();
+    expect(stub.requestCloseCalls).toBe(0);
   });
 
   it("re-registers an open dialog that reconnects", async () => {
     const el = await mount(new ESPHomeBaseDialog(), { open: true });
-    const spy = watchRequestClose(el);
     el.remove();
     document.body.appendChild(el);
 
     closeOpenDialogs();
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(innerStub(el).requestCloseCalls).toBe(1);
   });
 });

--- a/test/components/base-dialog-close-open.test.ts
+++ b/test/components/base-dialog-close-open.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+//
+// Pins the open-dialog registry behind closeOpenDialogs (issue #1185): open
+// wrappers get a request-close (so the host decides, same as Escape), the
+// except subtree is shielded across shadow boundaries, busy dialogs are
+// absorbed, and closed / disconnected wrappers are ignored.
+import { describe, expect, it, vi } from "vitest";
+
+// wa-dialog runs form-validation lifecycle hooks happy-dom doesn't implement;
+// stub the import so the wrapper can render in the test.
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+
+import { closeOpenDialogs, ESPHomeBaseDialog } from "../../src/components/base-dialog.js";
+import { mount } from "../_dom.js";
+
+function watchRequestClose(el: ESPHomeBaseDialog) {
+  const spy = vi.fn();
+  el.addEventListener("request-close", spy);
+  return spy;
+}
+
+describe("closeOpenDialogs", () => {
+  it("requests close on every open dialog and skips closed ones", async () => {
+    const openEl = await mount(new ESPHomeBaseDialog(), { open: true });
+    const closedEl = await mount(new ESPHomeBaseDialog(), { open: false });
+    const openSpy = watchRequestClose(openEl);
+    const closedSpy = watchRequestClose(closedEl);
+
+    closeOpenDialogs();
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(closedSpy).not.toHaveBeenCalled();
+  });
+
+  it("leaves the wrapper's own open flag to the host", async () => {
+    const el = await mount(new ESPHomeBaseDialog(), { open: true });
+    closeOpenDialogs();
+    // The host flips this from its request-close handler; the sweep only
+    // asks.
+    expect(el.open).toBe(true);
+  });
+
+  it("absorbs the request while busy", async () => {
+    const el = await mount(new ESPHomeBaseDialog(), { open: true, busy: true });
+    const spy = watchRequestClose(el);
+    closeOpenDialogs();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("shields the except subtree across a shadow boundary", async () => {
+    const swept = await mount(new ESPHomeBaseDialog(), { open: true });
+    const sweptSpy = watchRequestClose(swept);
+
+    // Stands in for a settings-dialog component: the wrapper lives in its
+    // shadow DOM, and the component element is what gets passed as except.
+    const component = document.createElement("div");
+    const shadow = component.attachShadow({ mode: "open" });
+    document.body.appendChild(component);
+    const shielded = new ESPHomeBaseDialog();
+    shielded.open = true;
+    shadow.appendChild(shielded);
+    await shielded.updateComplete;
+    const shieldedSpy = watchRequestClose(shielded);
+
+    closeOpenDialogs(component);
+
+    expect(sweptSpy).toHaveBeenCalledTimes(1);
+    expect(shieldedSpy).not.toHaveBeenCalled();
+  });
+
+  it("drops a dialog from the sweep once it closes", async () => {
+    const el = await mount(new ESPHomeBaseDialog(), { open: true });
+    const spy = watchRequestClose(el);
+    el.open = false;
+    await el.updateComplete;
+
+    closeOpenDialogs();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("drops a dialog from the sweep once it disconnects", async () => {
+    const el = await mount(new ESPHomeBaseDialog(), { open: true });
+    const spy = watchRequestClose(el);
+    el.remove();
+
+    closeOpenDialogs();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("re-registers an open dialog that reconnects", async () => {
+    const el = await mount(new ESPHomeBaseDialog(), { open: true });
+    const spy = watchRequestClose(el);
+    el.remove();
+    document.body.appendChild(el);
+
+    closeOpenDialogs();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Opening modal B while modal A is still up can leave B painted underneath A, so cross-dialog navigation needs the initiating modal dismissed first. Today that is hand-wired per site: the app shell's `open-settings` handler closes the firmware-tasks dialog by name, and the next "open X from inside Y" path would need its own `.close()` call.

This replaces the hand-wiring with a small registry on `esphome-base-dialog`: every open wrapper registers itself, and `closeOpenDialogs(except?)` asks each one to close. The sweep lives in `settings-dialog.open()` itself, so every path that opens Settings gets exclusivity for free and the app-shell handler shrinks back to one line; a future destination dialog that grows the same stacking exposure adds the same one call to its own `open()`. The `except` check follows composed ancestry, so the settings dialog passing itself shields the wrapper inside its shadow root and re-opening Settings while it is already up cannot close it on itself.

Each swept close goes through the wrapper's new `requestClose()`, which delegates to the inner `wa-dialog`'s public `requestClose()` method, the exact codepath its own Escape handler uses. That means the one documented `wa-hide` → busy gate → host veto → hide → `after-hide` sequence runs: busy dialogs absorb the request, a vetoing host stays open exactly like Escape, and both host shapes close correctly whether they flip their flag from `request-close` or from `after-hide`. A doc comment pins why the `open` property is not the entry point (its watcher reverts and re-requests, double-triggering the hide).

Verified live against the original repro: Firmware tasks open, `open-settings` dispatched from inside the layout, jobs dialog closes and Settings opens on top at Send builds. Dialogs not built on the wrapper don't participate in the sweep.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1185

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
