### PR TITLE
Open the running job from Update/Install instead of greying out

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -35,8 +35,10 @@ import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { configurationStem, downloadAnsiText } from "../util/download-text.js";
+import { LightDismissController } from "../util/light-dismiss-controller.js";
 import { dispatchShowLogsAfterInstall } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import { RunTimerController } from "../util/run-timer-controller.js";
 import {
   deriveFollowCommandType,
   detachStream,
@@ -48,8 +50,6 @@ import {
   stopCommand,
   toggleShowSecrets,
 } from "./command-dialog/commands.js";
-import { LightDismissController } from "../util/light-dismiss-controller.js";
-import { RunTimerController } from "../util/run-timer-controller.js";
 import {
   renderCompileTimer,
   renderOffloadHintSlot,

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -9,7 +9,7 @@ import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../util/device-sort.js";
 import { getCompactEncryptionVisual } from "../../util/encryption-state.js";
 import { formatFileSize } from "../../util/format-file-size.js";
 import { renderLabelChips } from "../../util/label-chip-template.js";
-import { installActionTitle } from "../../util/update-tooltip.js";
+import { updateActionTitle } from "../../util/update-tooltip.js";
 import { renderVisitWebUiLink } from "../../util/visit-web-ui-link.js";
 import { buildWebUiUrl } from "../../util/web-ui-url.js";
 
@@ -366,7 +366,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
                       ? "dashboard.table_action_view_progress"
                       : "dashboard.table_action_update"
                   )}
-                  title=${installActionTitle(
+                  title=${updateActionTitle(
                     localize,
                     row.busy,
                     device.runtime_state.deployed_version,

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -9,7 +9,7 @@ import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../util/device-sort.js";
 import { getCompactEncryptionVisual } from "../../util/encryption-state.js";
 import { formatFileSize } from "../../util/format-file-size.js";
 import { renderLabelChips } from "../../util/label-chip-template.js";
-import { updateButtonTitle } from "../../util/update-tooltip.js";
+import { installActionTitle } from "../../util/update-tooltip.js";
 import { renderVisitWebUiLink } from "../../util/visit-web-ui-link.js";
 import { buildWebUiUrl } from "../../util/web-ui-url.js";
 
@@ -317,6 +317,11 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
            free side-effect. Mirrors the legacy dashboard. */
         const showUpdate = row.showUpdate;
         const showInstall = !showUpdate && row.showModified;
+        const installLabel = localize(
+          row.busy
+            ? "dashboard.table_action_view_progress"
+            : "dashboard.table_action_install"
+        );
         const visitUrl = buildWebUiUrl(device);
         const showVisit = visitUrl !== "";
         // Priority order (highest → lowest, last to drop on narrow
@@ -339,16 +344,8 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
             showInstall
               ? html`<button
                   class="cell-action-btn cell-action-btn--accent cell-action-btn--install"
-                  aria-label=${localize(
-                    row.busy
-                      ? "dashboard.table_action_view_progress"
-                      : "dashboard.table_action_install"
-                  )}
-                  title=${localize(
-                    row.busy
-                      ? "dashboard.table_action_view_progress"
-                      : "dashboard.table_action_install"
-                  )}
+                  aria-label=${installLabel}
+                  title=${installLabel}
                   @click=${(e: Event) =>
                     dispatchRowEvent(
                       e,
@@ -369,16 +366,13 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
                       ? "dashboard.table_action_view_progress"
                       : "dashboard.table_action_update"
                   )}
-                  title=${
-                    row.busy
-                      ? localize("dashboard.table_action_view_progress")
-                      : updateButtonTitle(
-                          localize,
-                          device.runtime_state.deployed_version,
-                          device.current_version,
-                          "dashboard.table_action_update"
-                        )
-                  }
+                  title=${installActionTitle(
+                    localize,
+                    row.busy,
+                    device.runtime_state.deployed_version,
+                    device.current_version,
+                    "dashboard.table_action_update"
+                  )}
                   @click=${(e: Event) =>
                     dispatchRowEvent(
                       e,

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -339,10 +339,22 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
             showInstall
               ? html`<button
                   class="cell-action-btn cell-action-btn--accent cell-action-btn--install"
-                  aria-label=${localize("dashboard.table_action_install")}
-                  title=${localize("dashboard.table_action_install")}
-                  ?disabled=${row.busy}
-                  @click=${(e: Event) => dispatchRowEvent(e, "install-device", device)}
+                  aria-label=${localize(
+                    row.busy
+                      ? "dashboard.table_action_view_progress"
+                      : "dashboard.table_action_install"
+                  )}
+                  title=${localize(
+                    row.busy
+                      ? "dashboard.table_action_view_progress"
+                      : "dashboard.table_action_install"
+                  )}
+                  @click=${(e: Event) =>
+                    dispatchRowEvent(
+                      e,
+                      row.busy ? "show-progress" : "install-device",
+                      device
+                    )}
                 >
                   <wa-icon library="mdi" name="upload"></wa-icon>
                 </button>`
@@ -352,15 +364,27 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
             showUpdate
               ? html`<button
                   class="cell-action-btn cell-action-btn--accent cell-action-btn--install"
-                  aria-label=${localize("dashboard.table_action_update")}
-                  title=${updateButtonTitle(
-                    localize,
-                    device.runtime_state.deployed_version,
-                    device.current_version,
-                    "dashboard.table_action_update"
+                  aria-label=${localize(
+                    row.busy
+                      ? "dashboard.table_action_view_progress"
+                      : "dashboard.table_action_update"
                   )}
-                  ?disabled=${row.busy}
-                  @click=${(e: Event) => dispatchRowEvent(e, "update-device", device)}
+                  title=${
+                    row.busy
+                      ? localize("dashboard.table_action_view_progress")
+                      : updateButtonTitle(
+                          localize,
+                          device.runtime_state.deployed_version,
+                          device.current_version,
+                          "dashboard.table_action_update"
+                        )
+                  }
+                  @click=${(e: Event) =>
+                    dispatchRowEvent(
+                      e,
+                      row.busy ? "show-progress" : "update-device",
+                      device
+                    )}
                 >
                   <wa-icon library="mdi" name="upload"></wa-icon>
                 </button>`

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -29,7 +29,7 @@ import { labelsContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { labelChipStyles } from "../util/label-chip-template.js";
 import { registerMdiIcons } from "../util/register-icons.js";
-import { installActionTitle } from "../util/update-tooltip.js";
+import { updateActionTitle } from "../util/update-tooltip.js";
 import { renderVisitWebUiLink } from "../util/visit-web-ui-link.js";
 import { navigateCards, onHostContextMenu } from "./device-card/keyboard-nav.js";
 import {
@@ -273,7 +273,7 @@ export class ESPHomeDeviceCard extends LitElement {
         aria-label=${this._localize(
           this.busy ? "dashboard.table_action_view_progress" : "dashboard.update"
         )}
-        title=${installActionTitle(
+        title=${updateActionTitle(
           this._localize,
           this.busy,
           this.installedVersion,

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -29,7 +29,7 @@ import { labelsContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { labelChipStyles } from "../util/label-chip-template.js";
 import { registerMdiIcons } from "../util/register-icons.js";
-import { updateButtonTitle } from "../util/update-tooltip.js";
+import { installActionTitle } from "../util/update-tooltip.js";
 import { renderVisitWebUiLink } from "../util/visit-web-ui-link.js";
 import { navigateCards, onHostContextMenu } from "./device-card/keyboard-nav.js";
 import {
@@ -273,30 +273,26 @@ export class ESPHomeDeviceCard extends LitElement {
         aria-label=${this._localize(
           this.busy ? "dashboard.table_action_view_progress" : "dashboard.update"
         )}
-        title=${
-          this.busy
-            ? this._localize("dashboard.table_action_view_progress")
-            : updateButtonTitle(
-                this._localize,
-                this.installedVersion,
-                this.availableVersion,
-                "dashboard.update"
-              )
-        }
+        title=${installActionTitle(
+          this._localize,
+          this.busy,
+          this.installedVersion,
+          this.availableVersion,
+          "dashboard.update"
+        )}
       >
         <wa-icon library="mdi" name="upload"></wa-icon>
       </button>`;
     }
     if (this.showModified) {
+      const label = this._localize(
+        this.busy ? "dashboard.table_action_view_progress" : "dashboard.install"
+      );
       return html`<button
         class="action-btn action-btn--accent action-btn--tile"
         @click=${() => this._emit(this.busy ? "show-progress" : "install-device")}
-        aria-label=${this._localize(
-          this.busy ? "dashboard.table_action_view_progress" : "dashboard.install"
-        )}
-        title=${this._localize(
-          this.busy ? "dashboard.table_action_view_progress" : "dashboard.install"
-        )}
+        aria-label=${label}
+        title=${label}
       >
         <wa-icon library="mdi" name="upload"></wa-icon>
       </button>`;

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -269,15 +269,20 @@ export class ESPHomeDeviceCard extends LitElement {
     if (this.showUpdate) {
       return html`<button
         class="action-btn action-btn--accent action-btn--tile"
-        ?disabled=${this.busy}
-        @click=${() => this._emit("update-device")}
-        aria-label=${this._localize("dashboard.update")}
-        title=${updateButtonTitle(
-          this._localize,
-          this.installedVersion,
-          this.availableVersion,
-          "dashboard.update"
+        @click=${() => this._emit(this.busy ? "show-progress" : "update-device")}
+        aria-label=${this._localize(
+          this.busy ? "dashboard.table_action_view_progress" : "dashboard.update"
         )}
+        title=${
+          this.busy
+            ? this._localize("dashboard.table_action_view_progress")
+            : updateButtonTitle(
+                this._localize,
+                this.installedVersion,
+                this.availableVersion,
+                "dashboard.update"
+              )
+        }
       >
         <wa-icon library="mdi" name="upload"></wa-icon>
       </button>`;
@@ -285,10 +290,13 @@ export class ESPHomeDeviceCard extends LitElement {
     if (this.showModified) {
       return html`<button
         class="action-btn action-btn--accent action-btn--tile"
-        ?disabled=${this.busy}
-        @click=${() => this._emit("install-device")}
-        aria-label=${this._localize("dashboard.install")}
-        title=${this._localize("dashboard.install")}
+        @click=${() => this._emit(this.busy ? "show-progress" : "install-device")}
+        aria-label=${this._localize(
+          this.busy ? "dashboard.table_action_view_progress" : "dashboard.install"
+        )}
+        title=${this._localize(
+          this.busy ? "dashboard.table_action_view_progress" : "dashboard.install"
+        )}
       >
         <wa-icon library="mdi" name="upload"></wa-icon>
       </button>`;

--- a/src/components/device/install-action.ts
+++ b/src/components/device/install-action.ts
@@ -1,6 +1,6 @@
 import { html, type TemplateResult } from "lit";
 import type { LocalizeFunc } from "../../common/localize.js";
-import { installActionTitle } from "../../util/update-tooltip.js";
+import { updateActionTitle } from "../../util/update-tooltip.js";
 
 export interface InstallActionProps {
   localize: LocalizeFunc;
@@ -33,7 +33,10 @@ export function renderInstallAction(p: InstallActionProps): TemplateResult {
         type="button"
         class="install-fab install-split__main"
         @click=${p.onUpdate}
-        title=${installActionTitle(
+        aria-label=${p.localize(
+          p.busy ? "dashboard.table_action_view_progress" : "dashboard.update"
+        )}
+        title=${updateActionTitle(
           p.localize,
           p.busy,
           p.installedVersion,
@@ -56,13 +59,15 @@ export function renderInstallAction(p: InstallActionProps): TemplateResult {
       </button>
     </div>`;
   }
+  const installLabel = p.localize(
+    p.busy ? "dashboard.table_action_view_progress" : "dashboard.install"
+  );
   return html`<button
     type="button"
     class="install-fab ${p.showModified ? "" : "install-fab--muted"}"
     @click=${p.onInstall}
-    title=${p.localize(
-      p.busy ? "dashboard.table_action_view_progress" : "dashboard.install"
-    )}
+    aria-label=${installLabel}
+    title=${installLabel}
   >
     <wa-icon library="mdi" name="upload"></wa-icon>
     ${p.localize("dashboard.install")}

--- a/src/components/device/install-action.ts
+++ b/src/components/device/install-action.ts
@@ -27,15 +27,15 @@ export interface InstallActionProps {
  * the device-editor shadow root, so its `.install-fab` styles apply.
  */
 export function renderInstallAction(p: InstallActionProps): TemplateResult {
+  // The visible text is the accessible name (no aria-label), and it flips to
+  // view-progress while busy — one honest label for sighted, screen-reader,
+  // and voice-control users alike (WCAG 2.5.3 Label in Name).
   if (p.showUpdate) {
     return html`<div class="install-split">
       <button
         type="button"
         class="install-fab install-split__main"
         @click=${p.onUpdate}
-        aria-label=${p.localize(
-          p.busy ? "dashboard.table_action_view_progress" : "dashboard.update"
-        )}
         title=${updateActionTitle(
           p.localize,
           p.busy,
@@ -45,7 +45,9 @@ export function renderInstallAction(p: InstallActionProps): TemplateResult {
         )}
       >
         <wa-icon library="mdi" name="upload"></wa-icon>
-        ${p.localize("dashboard.update")}
+        ${p.localize(
+          p.busy ? "dashboard.table_action_view_progress" : "dashboard.update"
+        )}
       </button>
       <button
         type="button"
@@ -66,10 +68,9 @@ export function renderInstallAction(p: InstallActionProps): TemplateResult {
     type="button"
     class="install-fab ${p.showModified ? "" : "install-fab--muted"}"
     @click=${p.onInstall}
-    aria-label=${installLabel}
     title=${installLabel}
   >
     <wa-icon library="mdi" name="upload"></wa-icon>
-    ${p.localize("dashboard.install")}
+    ${installLabel}
   </button>`;
 }

--- a/src/components/device/install-action.ts
+++ b/src/components/device/install-action.ts
@@ -20,8 +20,11 @@ export interface InstallActionProps {
  * install-method picker (Web Serial / OTA / manual) so a re-flash or
  * replacement chip still has a path. Otherwise a plain Install opens the
  * picker — highlighted when there are pending changes, muted but still usable
- * when the config already matches the deployed firmware. Rendered into the
- * device-editor shadow root, so its `.install-fab` styles apply.
+ * when the config already matches the deployed firmware. While a job runs
+ * (`busy`) the main buttons stay clickable — the page routes the click to the
+ * running job's progress dialog — and only the caret disables, since picking
+ * a method for a *new* job is exactly what can't start mid-job. Rendered into
+ * the device-editor shadow root, so its `.install-fab` styles apply.
  */
 export function renderInstallAction(p: InstallActionProps): TemplateResult {
   if (p.showUpdate) {
@@ -29,14 +32,17 @@ export function renderInstallAction(p: InstallActionProps): TemplateResult {
       <button
         type="button"
         class="install-fab install-split__main"
-        ?disabled=${p.busy}
         @click=${p.onUpdate}
-        title=${updateButtonTitle(
-          p.localize,
-          p.installedVersion,
-          p.availableVersion,
-          "dashboard.update"
-        )}
+        title=${
+          p.busy
+            ? p.localize("dashboard.table_action_view_progress")
+            : updateButtonTitle(
+                p.localize,
+                p.installedVersion,
+                p.availableVersion,
+                "dashboard.update"
+              )
+        }
       >
         <wa-icon library="mdi" name="upload"></wa-icon>
         ${p.localize("dashboard.update")}
@@ -56,9 +62,10 @@ export function renderInstallAction(p: InstallActionProps): TemplateResult {
   return html`<button
     type="button"
     class="install-fab ${p.showModified ? "" : "install-fab--muted"}"
-    ?disabled=${p.busy}
     @click=${p.onInstall}
-    title=${p.localize("dashboard.install")}
+    title=${p.localize(
+      p.busy ? "dashboard.table_action_view_progress" : "dashboard.install"
+    )}
   >
     <wa-icon library="mdi" name="upload"></wa-icon>
     ${p.localize("dashboard.install")}

--- a/src/components/device/install-action.ts
+++ b/src/components/device/install-action.ts
@@ -1,6 +1,6 @@
 import { html, type TemplateResult } from "lit";
 import type { LocalizeFunc } from "../../common/localize.js";
-import { updateButtonTitle } from "../../util/update-tooltip.js";
+import { installActionTitle } from "../../util/update-tooltip.js";
 
 export interface InstallActionProps {
   localize: LocalizeFunc;
@@ -33,16 +33,13 @@ export function renderInstallAction(p: InstallActionProps): TemplateResult {
         type="button"
         class="install-fab install-split__main"
         @click=${p.onUpdate}
-        title=${
-          p.busy
-            ? p.localize("dashboard.table_action_view_progress")
-            : updateButtonTitle(
-                p.localize,
-                p.installedVersion,
-                p.availableVersion,
-                "dashboard.update"
-              )
-        }
+        title=${installActionTitle(
+          p.localize,
+          p.busy,
+          p.installedVersion,
+          p.availableVersion,
+          "dashboard.update"
+        )}
       >
         <wa-icon library="mdi" name="upload"></wa-icon>
         ${p.localize("dashboard.update")}

--- a/src/components/process-terminal/offload-hint.ts
+++ b/src/components/process-terminal/offload-hint.ts
@@ -1,6 +1,6 @@
 import { html, type TemplateResult } from "lit";
-import type { LocalizeFunc } from "../../common/localize.js";
 import { JobSource } from "../../api/types/firmware-jobs.js";
+import type { LocalizeFunc } from "../../common/localize.js";
 import { splitTemplate } from "../../util/template-split.js";
 
 /**

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -948,8 +948,11 @@ export class ESPHomePageDevice extends LitElement {
   };
 
   // Persist the editor buffer before building — install/compile build the
-  // on-disk file, so an unsaved edit would flash the previous version.
+  // on-disk file, so an unsaved edit would flash the previous version. A
+  // click while a job already runs re-attaches to it instead: no save (the
+  // edit stays in the buffer), no second job.
   private _installAfterSave = async (run: () => void): Promise<void> => {
+    if (this._showActiveJobProgress()) return;
     let saved: boolean;
     try {
       saved = await this._saveYaml();
@@ -962,14 +965,8 @@ export class ESPHomePageDevice extends LitElement {
     }
     if (saved) run();
   };
-  private _saveThenInstall = (): Promise<void> | undefined => {
-    if (this._showActiveJobProgress()) return;
-    return this._installAfterSave(this._installCtrl.onInstall);
-  };
-  private _saveThenUpdate = (): Promise<void> | undefined => {
-    if (this._showActiveJobProgress()) return;
-    return this._installAfterSave(this._installCtrl.onUpdate);
-  };
+  private _saveThenInstall = () => this._installAfterSave(this._installCtrl.onInstall);
+  private _saveThenUpdate = () => this._installAfterSave(this._installCtrl.onUpdate);
 
   /** Re-attach the command dialog to this device's running job, if any —
    *  the Update/Install buttons stay clickable mid-job and open the

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -41,6 +41,7 @@ import { withBase } from "../util/base-path.js";
 import { fetchBoard } from "../util/board-body-cache.js";
 import { showPendingChanges, showUpdateAvailable } from "../util/device-sync.js";
 import { deviceLayoutToPref, prefToDeviceLayout } from "../util/editor-layout.js";
+import { firmwareJobDisplayName } from "../util/firmware-job-display.js";
 import { consumeJustCreated } from "../util/just-created.js";
 import { navigate, setLeaveGuard } from "../util/navigation.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
@@ -961,8 +962,27 @@ export class ESPHomePageDevice extends LitElement {
     }
     if (saved) run();
   };
-  private _saveThenInstall = () => this._installAfterSave(this._installCtrl.onInstall);
-  private _saveThenUpdate = () => this._installAfterSave(this._installCtrl.onUpdate);
+  private _saveThenInstall = (): Promise<void> | undefined => {
+    if (this._showActiveJobProgress()) return;
+    return this._installAfterSave(this._installCtrl.onInstall);
+  };
+  private _saveThenUpdate = (): Promise<void> | undefined => {
+    if (this._showActiveJobProgress()) return;
+    return this._installAfterSave(this._installCtrl.onUpdate);
+  };
+
+  /** Re-attach the command dialog to this device's running job, if any —
+   *  the Update/Install buttons stay clickable mid-job and open the
+   *  in-progress stream instead of saving and starting another job. */
+  private _showActiveJobProgress(): boolean {
+    const job = this._activeJobs.get(this.id);
+    if (!job) return false;
+    this._commandDialog.followJob(
+      job,
+      firmwareJobDisplayName(job, this._devices, this._localize)
+    );
+    return true;
+  }
 
   /** Catch ``clean-build`` from the install dialog's post-failure
    *  hint and route it through this page's command-dialog —

--- a/src/util/update-tooltip.ts
+++ b/src/util/update-tooltip.ts
@@ -16,3 +16,19 @@ export function updateButtonTitle(
     ? localize("dashboard.update_available_version", { installed, target })
     : localize(fallbackKey);
 }
+
+/**
+ * Title for an Update action button: the view-progress hint while a job
+ * runs (the click re-attaches to it), the update tooltip otherwise.
+ */
+export function installActionTitle(
+  localize: LocalizeFunc,
+  busy: boolean,
+  installed: string,
+  target: string,
+  fallbackKey: string
+): string {
+  return busy
+    ? localize("dashboard.table_action_view_progress")
+    : updateButtonTitle(localize, installed, target, fallbackKey);
+}

--- a/src/util/update-tooltip.ts
+++ b/src/util/update-tooltip.ts
@@ -21,7 +21,7 @@ export function updateButtonTitle(
  * Title for an Update action button: the view-progress hint while a job
  * runs (the click re-attaches to it), the update tooltip otherwise.
  */
-export function installActionTitle(
+export function updateActionTitle(
   localize: LocalizeFunc,
   busy: boolean,
   installed: string,

--- a/test/components/_device-card.ts
+++ b/test/components/_device-card.ts
@@ -1,0 +1,19 @@
+import { ESPHomeDeviceCard } from "../../src/components/device-card.js";
+
+/**
+ * Mount a device card with the shared kitchen fixture defaults.
+ *
+ * Callers still need their own `vi.mock` lines for the webawesome
+ * icon/spinner modules — vi.mock is hoisted per test module.
+ */
+export async function mountDeviceCard(
+  props: Partial<ESPHomeDeviceCard>
+): Promise<ESPHomeDeviceCard> {
+  const el = new ESPHomeDeviceCard();
+  el.name = "kitchen";
+  el.configuration = "kitchen.yaml";
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}

--- a/test/components/dashboard/table-columns.test.ts
+++ b/test/components/dashboard/table-columns.test.ts
@@ -51,7 +51,11 @@ function renderActionsCell(rowOverrides: Partial<DeviceRow> = {}): TemplateResul
     busy: false,
     showUpdate: false,
     showModified: false,
-    _device: { web_port: null },
+    _device: {
+      web_port: null,
+      current_version: "",
+      runtime_state: { deployed_version: "" },
+    },
     ...rowOverrides,
   } as unknown as DeviceRow;
   const info = { row: { original: row } } as unknown as CellContext<DeviceRow, unknown>;

--- a/test/components/dashboard/table-columns.test.ts
+++ b/test/components/dashboard/table-columns.test.ts
@@ -94,6 +94,50 @@ describe("device table actions", () => {
   });
 });
 
+function clickInstallAction(container: HTMLElement): string[] {
+  const btn = container.querySelector<HTMLButtonElement>(".cell-action-btn--install");
+  expect(btn).not.toBeNull();
+  expect(btn!.disabled).toBe(false);
+  const fired: string[] = [];
+  for (const name of ["show-progress", "install-device", "update-device"]) {
+    container.addEventListener(name, () => fired.push(name));
+  }
+  btn!.click();
+  return fired;
+}
+
+describe("device table busy install/update actions", () => {
+  it("busy install button stays enabled and dispatches show-progress", () => {
+    const container = renderInto(renderActionsCell({ busy: true, showModified: true }));
+    expect(clickInstallAction(container)).toEqual(["show-progress"]);
+  });
+
+  it("busy update button stays enabled and dispatches show-progress", () => {
+    const container = renderInto(renderActionsCell({ busy: true, showUpdate: true }));
+    expect(clickInstallAction(container)).toEqual(["show-progress"]);
+  });
+
+  it("idle install button dispatches install-device", () => {
+    const container = renderInto(renderActionsCell({ busy: false, showModified: true }));
+    expect(clickInstallAction(container)).toEqual(["install-device"]);
+  });
+
+  it("idle update button dispatches update-device", () => {
+    const container = renderInto(
+      renderActionsCell({
+        busy: false,
+        showUpdate: true,
+        _device: {
+          web_port: null,
+          current_version: "2026.6.0",
+          runtime_state: { deployed_version: "2026.5.0" },
+        } as unknown as DeviceRow["_device"],
+      })
+    );
+    expect(clickInstallAction(container)).toEqual(["update-device"]);
+  });
+});
+
 function renderNameCell(rowOverrides: Partial<DeviceRow> = {}): TemplateResult {
   const col = columns.find((c) => "accessorKey" in c && c.accessorKey === "name");
   if (!col?.cell || typeof col.cell !== "function") {

--- a/test/components/dashboard/table-columns.test.ts
+++ b/test/components/dashboard/table-columns.test.ts
@@ -98,32 +98,50 @@ describe("device table actions", () => {
   });
 });
 
-function clickInstallAction(container: HTMLElement): string[] {
+function clickInstallAction(container: HTMLElement): {
+  fired: string[];
+  details: unknown[];
+} {
   const btn = container.querySelector<HTMLButtonElement>(".cell-action-btn--install");
   expect(btn).not.toBeNull();
   expect(btn!.disabled).toBe(false);
   const fired: string[] = [];
+  const details: unknown[] = [];
   for (const name of ["show-progress", "install-device", "update-device"]) {
-    container.addEventListener(name, () => fired.push(name));
+    container.addEventListener(name, (e) => {
+      fired.push(name);
+      details.push((e as CustomEvent).detail);
+    });
   }
   btn!.click();
-  return fired;
+  return { fired, details };
 }
 
 describe("device table busy install/update actions", () => {
-  it("busy install button stays enabled and dispatches show-progress", () => {
-    const container = renderInto(renderActionsCell({ busy: true, showModified: true }));
-    expect(clickInstallAction(container)).toEqual(["show-progress"]);
+  it("busy install button stays enabled and dispatches show-progress for its own device", () => {
+    const device = {
+      web_port: null,
+      current_version: "",
+      runtime_state: { deployed_version: "" },
+    } as unknown as DeviceRow["_device"];
+    const container = renderInto(
+      renderActionsCell({ busy: true, showModified: true, _device: device })
+    );
+    const { fired, details } = clickInstallAction(container);
+    expect(fired).toEqual(["show-progress"]);
+    // The event carries the row's own device, so with several jobs running
+    // the dashboard opens this row's job, not another device's.
+    expect(details[0]).toBe(device);
   });
 
   it("busy update button stays enabled and dispatches show-progress", () => {
     const container = renderInto(renderActionsCell({ busy: true, showUpdate: true }));
-    expect(clickInstallAction(container)).toEqual(["show-progress"]);
+    expect(clickInstallAction(container).fired).toEqual(["show-progress"]);
   });
 
   it("idle install button dispatches install-device", () => {
     const container = renderInto(renderActionsCell({ busy: false, showModified: true }));
-    expect(clickInstallAction(container)).toEqual(["install-device"]);
+    expect(clickInstallAction(container).fired).toEqual(["install-device"]);
   });
 
   it("idle update button dispatches update-device", () => {
@@ -138,7 +156,7 @@ describe("device table busy install/update actions", () => {
         } as unknown as DeviceRow["_device"],
       })
     );
-    expect(clickInstallAction(container)).toEqual(["update-device"]);
+    expect(clickInstallAction(container).fired).toEqual(["update-device"]);
   });
 });
 

--- a/test/components/device-card-busy-actions.test.ts
+++ b/test/components/device-card-busy-actions.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The update/install accent button stays clickable while a job runs and
+ * emits `show-progress` (re-attach to the running job) instead of
+ * `update-device` / `install-device`.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+
+import { ESPHomeDeviceCard } from "../../src/components/device-card.js";
+
+async function mount(props: Partial<ESPHomeDeviceCard>): Promise<ESPHomeDeviceCard> {
+  const el = new ESPHomeDeviceCard();
+  el.name = "kitchen";
+  el.configuration = "kitchen.yaml";
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function accentButton(el: ESPHomeDeviceCard): HTMLButtonElement {
+  const btn = el.shadowRoot!.querySelector<HTMLButtonElement>(".action-btn--accent");
+  expect(btn).not.toBeNull();
+  return btn!;
+}
+
+function clickEmits(el: ESPHomeDeviceCard, events: string[]): string[] {
+  const fired: string[] = [];
+  for (const name of events) {
+    el.addEventListener(name, () => fired.push(name));
+  }
+  accentButton(el).click();
+  return fired;
+}
+
+describe("device-card busy update/install actions", () => {
+  it("busy update button is enabled and emits show-progress", async () => {
+    const el = await mount({ busy: true, showUpdate: true });
+    expect(accentButton(el).disabled).toBe(false);
+    expect(clickEmits(el, ["show-progress", "update-device"])).toEqual(["show-progress"]);
+  });
+
+  it("idle update button emits update-device", async () => {
+    const el = await mount({ busy: false, showUpdate: true });
+    expect(clickEmits(el, ["show-progress", "update-device"])).toEqual(["update-device"]);
+  });
+
+  it("busy install button is enabled and emits show-progress", async () => {
+    const el = await mount({ busy: true, showModified: true });
+    expect(accentButton(el).disabled).toBe(false);
+    expect(clickEmits(el, ["show-progress", "install-device"])).toEqual([
+      "show-progress",
+    ]);
+  });
+
+  it("idle install button emits install-device", async () => {
+    const el = await mount({ busy: false, showModified: true });
+    expect(clickEmits(el, ["show-progress", "install-device"])).toEqual([
+      "install-device",
+    ]);
+  });
+});

--- a/test/components/device-card-busy-actions.test.ts
+++ b/test/components/device-card-busy-actions.test.ts
@@ -10,17 +10,8 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 
-import { ESPHomeDeviceCard } from "../../src/components/device-card.js";
-
-async function mount(props: Partial<ESPHomeDeviceCard>): Promise<ESPHomeDeviceCard> {
-  const el = new ESPHomeDeviceCard();
-  el.name = "kitchen";
-  el.configuration = "kitchen.yaml";
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
+import type { ESPHomeDeviceCard } from "../../src/components/device-card.js";
+import { mountDeviceCard as mount } from "./_device-card.js";
 
 function accentButton(el: ESPHomeDeviceCard): HTMLButtonElement {
   const btn = el.shadowRoot!.querySelector<HTMLButtonElement>(".action-btn--accent");

--- a/test/components/device-card-queued-indicator.test.ts
+++ b/test/components/device-card-queued-indicator.test.ts
@@ -11,17 +11,7 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 
 import { DeviceState } from "../../src/api/types/devices.js";
-import { ESPHomeDeviceCard } from "../../src/components/device-card.js";
-
-async function mount(props: Partial<ESPHomeDeviceCard>): Promise<ESPHomeDeviceCard> {
-  const el = new ESPHomeDeviceCard();
-  el.name = "kitchen";
-  el.configuration = "kitchen.yaml";
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
+import { mountDeviceCard as mount } from "./_device-card.js";
 
 describe("device-card queued-update indicator", () => {
   it("shows the clock and keeps the offline status badge", async () => {

--- a/test/components/device-card.test.ts
+++ b/test/components/device-card.test.ts
@@ -12,18 +12,8 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 
 import { JobType } from "../../src/api/types/firmware-jobs.js";
-import { ESPHomeDeviceCard } from "../../src/components/device-card.js";
 import { makeFirmwareJob } from "../_make-firmware-job.js";
-
-async function mount(props: Partial<ESPHomeDeviceCard>): Promise<ESPHomeDeviceCard> {
-  const el = new ESPHomeDeviceCard();
-  el.name = "kitchen";
-  el.configuration = "kitchen.yaml";
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
+import { mountDeviceCard as mount } from "./_device-card.js";
 
 describe("device-card encryption indicator uses the raw pending flag", () => {
   it("shows encryption-pending but hides the modified dot when the gate is off", async () => {

--- a/test/components/device/device-editor-footer.test.ts
+++ b/test/components/device/device-editor-footer.test.ts
@@ -84,4 +84,22 @@ describe("device-editor footer install action", () => {
     btn!.click(); // still usable (re-flash)
     expect(install).toHaveBeenCalledTimes(1);
   });
+
+  it("busy Update stays enabled and its accessible name flips to view-progress", async () => {
+    const el = await mount({ showUpdate: true, busy: true });
+    const main = q(el, ".install-split__main") as HTMLButtonElement;
+    expect(main.disabled).toBe(false);
+    expect(main.getAttribute("aria-label")).toBe("dashboard.table_action_view_progress");
+    expect(main.title).toBe("dashboard.table_action_view_progress");
+    // The caret can only start a *new* job, so it alone disables mid-job.
+    expect((q(el, ".install-split__caret") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("busy Install stays enabled and its accessible name flips to view-progress", async () => {
+    const el = await mount({ showModified: true, busy: true });
+    const btn = q(el, ".install-fab") as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    expect(btn.getAttribute("aria-label")).toBe("dashboard.table_action_view_progress");
+    expect(btn.title).toBe("dashboard.table_action_view_progress");
+  });
 });

--- a/test/components/device/device-editor-footer.test.ts
+++ b/test/components/device/device-editor-footer.test.ts
@@ -85,21 +85,27 @@ describe("device-editor footer install action", () => {
     expect(install).toHaveBeenCalledTimes(1);
   });
 
-  it("busy Update stays enabled and its accessible name flips to view-progress", async () => {
+  it("busy Update stays enabled and its visible label flips to view-progress", async () => {
+    // The visible text IS the accessible name (no aria-label), so the flip
+    // covers screen-reader and voice-control users alike (WCAG 2.5.3).
     const el = await mount({ showUpdate: true, busy: true });
     const main = q(el, ".install-split__main") as HTMLButtonElement;
     expect(main.disabled).toBe(false);
-    expect(main.getAttribute("aria-label")).toBe("dashboard.table_action_view_progress");
+    expect(main.textContent).toContain("dashboard.table_action_view_progress");
+    expect(main.textContent).not.toContain("dashboard.update");
+    expect(main.hasAttribute("aria-label")).toBe(false);
     expect(main.title).toBe("dashboard.table_action_view_progress");
     // The caret can only start a *new* job, so it alone disables mid-job.
     expect((q(el, ".install-split__caret") as HTMLButtonElement).disabled).toBe(true);
   });
 
-  it("busy Install stays enabled and its accessible name flips to view-progress", async () => {
+  it("busy Install stays enabled and its visible label flips to view-progress", async () => {
     const el = await mount({ showModified: true, busy: true });
     const btn = q(el, ".install-fab") as HTMLButtonElement;
     expect(btn.disabled).toBe(false);
-    expect(btn.getAttribute("aria-label")).toBe("dashboard.table_action_view_progress");
+    expect(btn.textContent).toContain("dashboard.table_action_view_progress");
+    expect(btn.textContent).not.toContain("dashboard.install");
+    expect(btn.hasAttribute("aria-label")).toBe(false);
     expect(btn.title).toBe("dashboard.table_action_view_progress");
   });
 });

--- a/test/pages/device.test.ts
+++ b/test/pages/device.test.ts
@@ -187,8 +187,8 @@ interface InstallView {
   _activeJobs: Map<string, FirmwareJob>;
   _commandDialog: { followJob(job: FirmwareJob, displayName: string): void };
   _saveYaml(): Promise<boolean>;
-  _saveThenInstall(): Promise<void> | undefined;
-  _saveThenUpdate(): Promise<void> | undefined;
+  _saveThenInstall(): Promise<void>;
+  _saveThenUpdate(): Promise<void>;
 }
 
 function makeInstallView(saveResult: boolean): {

--- a/test/pages/device.test.ts
+++ b/test/pages/device.test.ts
@@ -8,6 +8,7 @@ vi.mock("sonner-js", () => ({
 import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import type { EditorValidateResponse } from "../../src/api/types/editor.js";
+import type { FirmwareJob } from "../../src/api/types/firmware-jobs.js";
 import type { DeviceLayoutMode } from "../../src/components/device/device-editor.js";
 import { ESPHomePageDevice } from "../../src/pages/device.js";
 
@@ -181,10 +182,13 @@ describe("esphome-page-device save re-entrancy", () => {
 });
 
 interface InstallView {
+  id: string;
   _installCtrl: { onInstall: () => void; onUpdate: () => void };
+  _activeJobs: Map<string, FirmwareJob>;
+  _commandDialog: { followJob(job: FirmwareJob, displayName: string): void };
   _saveYaml(): Promise<boolean>;
-  _saveThenInstall(): Promise<void>;
-  _saveThenUpdate(): Promise<void>;
+  _saveThenInstall(): Promise<void> | undefined;
+  _saveThenUpdate(): Promise<void> | undefined;
 }
 
 function makeInstallView(saveResult: boolean): {
@@ -235,5 +239,48 @@ describe("esphome-page-device save before install", () => {
     await expect(page._saveThenInstall()).resolves.toBeUndefined();
     expect(onInstall).not.toHaveBeenCalled();
     expect(vi.mocked(toast.error)).toHaveBeenCalledTimes(1);
+  });
+});
+
+function makeBusyInstallView(): ReturnType<typeof makeInstallView> & {
+  followJob: ReturnType<typeof vi.fn>;
+  job: FirmwareJob;
+} {
+  const view = makeInstallView(true);
+  const job = { job_id: "job-1", configuration: "kitchen.yaml" } as FirmwareJob;
+  view.page.id = "kitchen.yaml";
+  view.page._activeJobs = new Map([["kitchen.yaml", job]]);
+  const followJob = vi.fn();
+  // _commandDialog is a @query getter on the prototype; shadow it.
+  Object.defineProperty(view.page, "_commandDialog", { value: { followJob } });
+  return { ...view, followJob, job };
+}
+
+describe("esphome-page-device install while a job is running", () => {
+  test("update re-attaches to the running job: no save, no new build", async () => {
+    const { page, onUpdate, saveYaml, followJob, job } = makeBusyInstallView();
+    await page._saveThenUpdate();
+    expect(followJob).toHaveBeenCalledTimes(1);
+    expect(followJob.mock.calls[0][0]).toBe(job);
+    expect(saveYaml).not.toHaveBeenCalled();
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  test("install re-attaches to the running job: no save, no new build", async () => {
+    const { page, onInstall, saveYaml, followJob, job } = makeBusyInstallView();
+    await page._saveThenInstall();
+    expect(followJob).toHaveBeenCalledTimes(1);
+    expect(followJob.mock.calls[0][0]).toBe(job);
+    expect(saveYaml).not.toHaveBeenCalled();
+    expect(onInstall).not.toHaveBeenCalled();
+  });
+
+  test("with no active job the save-then-install path runs unchanged", async () => {
+    const { page, onInstall, saveYaml, followJob } = makeBusyInstallView();
+    page._activeJobs = new Map();
+    await page._saveThenInstall();
+    expect(followJob).not.toHaveBeenCalled();
+    expect(saveYaml).toHaveBeenCalledTimes(1);
+    expect(onInstall).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/pages/device.test.ts
+++ b/test/pages/device.test.ts
@@ -248,8 +248,13 @@ function makeBusyInstallView(): ReturnType<typeof makeInstallView> & {
 } {
   const view = makeInstallView(true);
   const job = { job_id: "job-1", configuration: "kitchen.yaml" } as FirmwareJob;
+  const otherJob = { job_id: "job-2", configuration: "garage.yaml" } as FirmwareJob;
   view.page.id = "kitchen.yaml";
-  view.page._activeJobs = new Map([["kitchen.yaml", job]]);
+  // A second device's concurrent job proves the lookup keys on this page's id.
+  view.page._activeJobs = new Map([
+    ["garage.yaml", otherJob],
+    ["kitchen.yaml", job],
+  ]);
   const followJob = vi.fn();
   // _commandDialog is a @query getter on the prototype; shadow it.
   Object.defineProperty(view.page, "_commandDialog", { value: { followJob } });
@@ -278,6 +283,17 @@ describe("esphome-page-device install while a job is running", () => {
   test("with no active job the save-then-install path runs unchanged", async () => {
     const { page, onInstall, saveYaml, followJob } = makeBusyInstallView();
     page._activeJobs = new Map();
+    await page._saveThenInstall();
+    expect(followJob).not.toHaveBeenCalled();
+    expect(saveYaml).toHaveBeenCalledTimes(1);
+    expect(onInstall).toHaveBeenCalledTimes(1);
+  });
+
+  test("another device's running job doesn't hijack this page's install", async () => {
+    const { page, onInstall, saveYaml, followJob } = makeBusyInstallView();
+    page._activeJobs = new Map([
+      ["garage.yaml", { job_id: "job-2", configuration: "garage.yaml" } as FirmwareJob],
+    ]);
     await page._saveThenInstall();
     expect(followJob).not.toHaveBeenCalled();
     expect(saveYaml).toHaveBeenCalledTimes(1);

--- a/test/util/logs-launch.test.ts
+++ b/test/util/logs-launch.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ConfiguredDevice } from "../../src/api/types/devices.js";
-import { launchLogs, launchLogsWithMethod } from "../../src/util/logs-launch.js";
 import type { LogsLaunchHost } from "../../src/util/logs-launch.js";
+import { launchLogs, launchLogsWithMethod } from "../../src/util/logs-launch.js";
 import { withWebSerial } from "../_web-serial.js";
 
 function makeDevice(): ConfiguredDevice {


### PR DESCRIPTION
# What does this implement/fix?

While a firmware job runs for a device, the Update/Install buttons greyed out — on the editor page's Update/Install fab, the dashboard card's accent button, and the table row's install/update buttons — leaving no affordance beyond the small status chip to get back to the running job. These buttons now stay enabled and re-attach the command dialog to the in-progress job instead of starting a new one:

- **Editor page** (`src/pages/device.ts`): when `_activeJobs` holds a job for this configuration, `_saveThenInstall` / `_saveThenUpdate` open it via `commandDialog.followJob(...)` — no save, no new job, so unsaved edits stay in the buffer and the dirty guard is untouched. The install-method caret stays disabled: picking a method for a *new* job is exactly what can't start mid-job.
- **Device card** (`src/components/device-card.ts`): the accent button emits `show-progress` while busy (the same event the status chip uses), `update-device` / `install-device` otherwise; tooltip/aria-label flip to the existing "View install progress" string.
- **Table rows** (`src/components/dashboard/table-columns.ts`): same conditional dispatch through the already-handled row `show-progress` event.

No new i18n keys (`dashboard.table_action_view_progress` reused). A separate first commit restores prettier formatting on three files that had drifted on `main` (import order only) — the repo-wide pre-commit format check was failing before any change.

Verified live against a dev backend (compile running on a real config): the fab stays enabled with the view-progress tooltip, clicking opens the command dialog streaming the running job, the install-method picker stays closed, and `firmware/get_jobs` shows no second job created.

**Related issue or feature (if applicable):**

- no issue; requested directly (Update/Install greys out during an install — should open the in-progress job instead)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
