### PR TITLE
Open the running job from the menu and drawer Install/Update too

### DIFF
--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -18,7 +18,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 import { showPendingChanges, showUpdateAvailable } from "../../util/device-sync.js";
 import { EscapeController } from "../../util/escape-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
-import { updateActionTitle } from "../../util/update-tooltip.js";
+import { busyActionLabel, updateActionTitle } from "../../util/update-tooltip.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "./device-drawer-content.js";
@@ -376,24 +376,17 @@ export class ESPHomeDeviceDrawer extends LitElement {
                   )}
                 >
                   <wa-icon library="mdi" name="upload"></wa-icon>
-                  ${this._localize(
-                    this.busy
-                      ? "dashboard.table_action_view_progress"
-                      : "dashboard.drawer_update"
-                  )}
+                  ${busyActionLabel(this._localize, this.busy, "dashboard.drawer_update")}
                 </button>`
               : showPendingChanges(device)
                 ? html`<button
                     class="action action--accent"
                     @click=${() =>
                       this._emitAction(this.busy ? "show-progress" : "install-device")}
+                    title=${busyActionLabel(this._localize, this.busy, "dashboard.install")}
                   >
                     <wa-icon library="mdi" name="upload"></wa-icon>
-                    ${this._localize(
-                      this.busy
-                        ? "dashboard.table_action_view_progress"
-                        : "dashboard.install"
-                    )}
+                    ${busyActionLabel(this._localize, this.busy, "dashboard.install")}
                   </button>`
                 : nothing
           }

--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -18,7 +18,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 import { showPendingChanges, showUpdateAvailable } from "../../util/device-sync.js";
 import { EscapeController } from "../../util/escape-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
-import { updateButtonTitle } from "../../util/update-tooltip.js";
+import { updateActionTitle } from "../../util/update-tooltip.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "./device-drawer-content.js";
@@ -365,26 +365,35 @@ export class ESPHomeDeviceDrawer extends LitElement {
             showUpdateAvailable(device)
               ? html`<button
                   class="action action--accent"
-                  ?disabled=${this.busy}
-                  @click=${() => this._emitAction("update-device")}
-                  title=${updateButtonTitle(
+                  @click=${() =>
+                    this._emitAction(this.busy ? "show-progress" : "update-device")}
+                  title=${updateActionTitle(
                     this._localize,
+                    this.busy,
                     rt.deployed_version,
                     device.current_version,
                     "dashboard.drawer_update"
                   )}
                 >
                   <wa-icon library="mdi" name="upload"></wa-icon>
-                  ${this._localize("dashboard.drawer_update")}
+                  ${this._localize(
+                    this.busy
+                      ? "dashboard.table_action_view_progress"
+                      : "dashboard.drawer_update"
+                  )}
                 </button>`
               : showPendingChanges(device)
                 ? html`<button
                     class="action action--accent"
-                    ?disabled=${this.busy}
-                    @click=${() => this._emitAction("install-device")}
+                    @click=${() =>
+                      this._emitAction(this.busy ? "show-progress" : "install-device")}
                   >
                     <wa-icon library="mdi" name="upload"></wa-icon>
-                    ${this._localize("dashboard.install")}
+                    ${this._localize(
+                      this.busy
+                        ? "dashboard.table_action_view_progress"
+                        : "dashboard.install"
+                    )}
                   </button>`
                 : nothing
           }

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -432,6 +432,10 @@ export class ESPHomeDeviceTable extends LitElement {
           e.stopPropagation();
           this._forwardEvent("install-device", e.detail);
         }}
+        @show-progress=${(e: CustomEvent) => {
+          e.stopPropagation();
+          this._forwardEvent("show-progress", e.detail);
+        }}
         @show-api-key=${(e: CustomEvent) => {
           e.stopPropagation();
           this._forwardEvent("show-api-key", e.detail);

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -251,6 +251,10 @@ export function renderDrawer(host: ESPHomePageDashboard): TemplateResult {
         host._drawerOpen = false;
         host._openInstallMethod(e.detail);
       }}
+      @show-progress=${(e: CustomEvent<ConfiguredDevice>) => {
+        host._drawerOpen = false;
+        host._showJobProgress(e.detail);
+      }}
       @open-logs=${(e: CustomEvent) => {
         host._drawerOpen = false;
         host._openLogs(e.detail);
@@ -286,6 +290,8 @@ export function renderCardContextMenu(host: ESPHomePageDashboard): TemplateResul
         host._openCommand(e.detail, "validate")}
       @install-device=${(e: CustomEvent<ConfiguredDevice>) =>
         host._openInstallMethod(e.detail)}
+      @show-progress=${(e: CustomEvent<ConfiguredDevice>) =>
+        host._showJobProgress(e.detail)}
       @show-api-key=${(e: CustomEvent<ConfiguredDevice>) => host._showApiKey(e.detail)}
       @download-yaml=${(e: CustomEvent<ConfiguredDevice>) =>
         downloadYaml(e.detail, host._api, host._localize)}

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -9,7 +9,7 @@ import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../util/device-sort.js";
 import { getCompactEncryptionVisual } from "../../util/encryption-state.js";
 import { formatFileSize } from "../../util/format-file-size.js";
 import { renderLabelChips } from "../../util/label-chip-template.js";
-import { updateActionTitle } from "../../util/update-tooltip.js";
+import { busyActionLabel, updateActionTitle } from "../../util/update-tooltip.js";
 import { renderVisitWebUiLink } from "../../util/visit-web-ui-link.js";
 import { buildWebUiUrl } from "../../util/web-ui-url.js";
 
@@ -317,10 +317,10 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
            free side-effect. Mirrors the legacy dashboard. */
         const showUpdate = row.showUpdate;
         const showInstall = !showUpdate && row.showModified;
-        const installLabel = localize(
-          row.busy
-            ? "dashboard.table_action_view_progress"
-            : "dashboard.table_action_install"
+        const installLabel = busyActionLabel(
+          localize,
+          row.busy,
+          "dashboard.table_action_install"
         );
         const visitUrl = buildWebUiUrl(device);
         const showVisit = visitUrl !== "";
@@ -361,10 +361,10 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
             showUpdate
               ? html`<button
                   class="cell-action-btn cell-action-btn--accent cell-action-btn--install"
-                  aria-label=${localize(
-                    row.busy
-                      ? "dashboard.table_action_view_progress"
-                      : "dashboard.table_action_update"
+                  aria-label=${busyActionLabel(
+                    localize,
+                    row.busy,
+                    "dashboard.table_action_update"
                   )}
                   title=${updateActionTitle(
                     localize,

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -26,6 +26,7 @@ import { dropdownMenuStyles } from "../../styles/dropdown-menu.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { EscapeController } from "../../util/escape-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { busyActionLabel } from "../../util/update-tooltip.js";
 import { renderVisitWebUiLink } from "../../util/visit-web-ui-link.js";
 import { buildWebUiUrl } from "../../util/web-ui-url.js";
 
@@ -208,11 +209,7 @@ export class ESPHomeTableRowMenu extends LitElement {
           @click=${() => this._emit(this.busy ? "show-progress" : "install-device")}
         >
           <wa-icon library="mdi" name="upload"></wa-icon>
-          ${this._localize(
-            this.busy
-              ? "dashboard.table_action_view_progress"
-              : "dashboard.action_install"
-          )}
+          ${busyActionLabel(this._localize, this.busy, "dashboard.action_install")}
         </div>
         ${
           this.device?.runtime_state.queued_update

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -204,11 +204,15 @@ export class ESPHomeTableRowMenu extends LitElement {
           ${this._localize("dashboard.action_validate")}
         </div>
         <div
-          class="menu-item menu-item--install ${this.busy ? "menu-item--disabled" : ""}"
-          @click=${this.busy ? undefined : () => this._emit("install-device")}
+          class="menu-item menu-item--install"
+          @click=${() => this._emit(this.busy ? "show-progress" : "install-device")}
         >
           <wa-icon library="mdi" name="upload"></wa-icon>
-          ${this._localize("dashboard.action_install")}
+          ${this._localize(
+            this.busy
+              ? "dashboard.table_action_view_progress"
+              : "dashboard.action_install"
+          )}
         </div>
         ${
           this.device?.runtime_state.queued_update

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -29,7 +29,7 @@ import { labelsContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { labelChipStyles } from "../util/label-chip-template.js";
 import { registerMdiIcons } from "../util/register-icons.js";
-import { updateActionTitle } from "../util/update-tooltip.js";
+import { busyActionLabel, updateActionTitle } from "../util/update-tooltip.js";
 import { renderVisitWebUiLink } from "../util/visit-web-ui-link.js";
 import { navigateCards, onHostContextMenu } from "./device-card/keyboard-nav.js";
 import {
@@ -270,9 +270,7 @@ export class ESPHomeDeviceCard extends LitElement {
       return html`<button
         class="action-btn action-btn--accent action-btn--tile"
         @click=${() => this._emit(this.busy ? "show-progress" : "update-device")}
-        aria-label=${this._localize(
-          this.busy ? "dashboard.table_action_view_progress" : "dashboard.update"
-        )}
+        aria-label=${busyActionLabel(this._localize, this.busy, "dashboard.update")}
         title=${updateActionTitle(
           this._localize,
           this.busy,
@@ -285,9 +283,7 @@ export class ESPHomeDeviceCard extends LitElement {
       </button>`;
     }
     if (this.showModified) {
-      const label = this._localize(
-        this.busy ? "dashboard.table_action_view_progress" : "dashboard.install"
-      );
+      const label = busyActionLabel(this._localize, this.busy, "dashboard.install");
       return html`<button
         class="action-btn action-btn--accent action-btn--tile"
         @click=${() => this._emit(this.busy ? "show-progress" : "install-device")}

--- a/src/components/device/install-action.ts
+++ b/src/components/device/install-action.ts
@@ -1,6 +1,6 @@
 import { html, type TemplateResult } from "lit";
 import type { LocalizeFunc } from "../../common/localize.js";
-import { updateActionTitle } from "../../util/update-tooltip.js";
+import { busyActionLabel, updateActionTitle } from "../../util/update-tooltip.js";
 
 export interface InstallActionProps {
   localize: LocalizeFunc;
@@ -45,9 +45,7 @@ export function renderInstallAction(p: InstallActionProps): TemplateResult {
         )}
       >
         <wa-icon library="mdi" name="upload"></wa-icon>
-        ${p.localize(
-          p.busy ? "dashboard.table_action_view_progress" : "dashboard.update"
-        )}
+        ${busyActionLabel(p.localize, p.busy, "dashboard.update")}
       </button>
       <button
         type="button"
@@ -61,9 +59,7 @@ export function renderInstallAction(p: InstallActionProps): TemplateResult {
       </button>
     </div>`;
   }
-  const installLabel = p.localize(
-    p.busy ? "dashboard.table_action_view_progress" : "dashboard.install"
-  );
+  const installLabel = busyActionLabel(p.localize, p.busy, "dashboard.install");
   return html`<button
     type="button"
     class="install-fab ${p.showModified ? "" : "install-fab--muted"}"

--- a/src/util/update-tooltip.ts
+++ b/src/util/update-tooltip.ts
@@ -18,6 +18,19 @@ export function updateButtonTitle(
 }
 
 /**
+ * Visible label / aria-label for an install-or-update affordance: the
+ * view-progress string while a job runs (the click re-attaches to it),
+ * the idle key otherwise.
+ */
+export function busyActionLabel(
+  localize: LocalizeFunc,
+  busy: boolean,
+  idleKey: string
+): string {
+  return localize(busy ? "dashboard.table_action_view_progress" : idleKey);
+}
+
+/**
  * Title for an Update action button: the view-progress hint while a job
  * runs (the click re-attaches to it), the update tooltip otherwise.
  */

--- a/test/_dom.ts
+++ b/test/_dom.ts
@@ -53,6 +53,24 @@ export function renderInto(tpl: unknown): HTMLElement {
 export const identityLocalize = (key: string): string => key;
 
 /**
+ * Click ``target`` and return which of ``names`` fired on ``listenOn``,
+ * in order — the "emits A, not B" assertion is then a single
+ * ``toEqual(["A"])``.
+ */
+export function clickCollect(
+  listenOn: HTMLElement,
+  target: HTMLElement,
+  names: string[]
+): string[] {
+  const fired: string[] = [];
+  for (const name of names) {
+    listenOn.addEventListener(name, () => fired.push(name));
+  }
+  target.click();
+  return fired;
+}
+
+/**
  * Await the host's update *and* its nested ``<esphome-base-dialog>``'s.
  *
  * The base dialog binds its ``confirmOnEnter`` Enter listener in its own

--- a/test/_dom.ts
+++ b/test/_dom.ts
@@ -63,10 +63,15 @@ export function clickCollect(
   names: string[]
 ): string[] {
   const fired: string[] = [];
-  for (const name of names) {
-    listenOn.addEventListener(name, () => fired.push(name));
-  }
+  const handlers = names.map((name) => {
+    const handler = () => fired.push(name);
+    listenOn.addEventListener(name, handler);
+    return [name, handler] as const;
+  });
   target.click();
+  for (const [name, handler] of handlers) {
+    listenOn.removeEventListener(name, handler);
+  }
   return fired;
 }
 

--- a/test/components/dashboard/_device-drawer.ts
+++ b/test/components/dashboard/_device-drawer.ts
@@ -1,0 +1,31 @@
+import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
+import { ESPHomeDeviceDrawer } from "../../../src/components/dashboard/device-drawer.js";
+import { mount } from "../../_dom.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+
+/**
+ * Drawer-footer test harness (drawer opens by default).
+ *
+ * Callers still need their own ``vi.mock`` lines for the webawesome icon
+ * module and ``device-drawer-content.js`` (the body pulls in noisy
+ * ``<wa-button>`` children) — vi.mock is hoisted per test module.
+ */
+export async function mountDrawer(
+  props: Partial<ESPHomeDeviceDrawer>
+): Promise<ESPHomeDeviceDrawer> {
+  return mount(new ESPHomeDeviceDrawer(), { open: true, ...props });
+}
+
+/** The footer's Update-or-Install accent button. */
+export function footerAccent(el: ESPHomeDeviceDrawer): HTMLButtonElement {
+  return el.shadowRoot!.querySelector<HTMLButtonElement>(".footer .action--accent")!;
+}
+
+/** Device with an update available (both versions known). */
+export function updateAvailableDevice(): ConfiguredDevice {
+  return makeConfiguredDevice({
+    update_available: true,
+    runtime_state: { deployed_version: "2024.6.0" },
+    current_version: "2024.12.0",
+  });
+}

--- a/test/components/dashboard/device-drawer-busy-actions.test.ts
+++ b/test/components/dashboard/device-drawer-busy-actions.test.ts
@@ -8,44 +8,17 @@
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-// The drawer body renders children that pull in <wa-button> (form-associated,
-// noisy under happy-dom); the footer under test uses plain buttons, so stubbing
-// the body keeps the mount light and quiet.
+// Stub the drawer body; see _device-drawer.ts.
 vi.mock("../../../src/components/dashboard/device-drawer-content.js", () => ({}));
 
-import { ESPHomeDeviceDrawer } from "../../../src/components/dashboard/device-drawer.js";
-import { mount } from "../../_dom.js";
+import { clickCollect } from "../../_dom.js";
 import { makeConfiguredDevice } from "../../_make-configured-device.js";
-
-function accent(el: ESPHomeDeviceDrawer): HTMLButtonElement {
-  return el.shadowRoot!.querySelector<HTMLButtonElement>(".footer .action--accent")!;
-}
-
-function clickCollect(
-  el: ESPHomeDeviceDrawer,
-  btn: HTMLElement,
-  events: string[]
-): string[] {
-  const fired: string[] = [];
-  for (const name of events) {
-    el.addEventListener(name, () => fired.push(name));
-  }
-  btn.click();
-  return fired;
-}
+import { footerAccent, mountDrawer, updateAvailableDevice } from "./_device-drawer.js";
 
 describe("device-drawer busy footer actions", () => {
   it("busy Update stays enabled, reads view-progress, and emits show-progress", async () => {
-    const el = await mount(new ESPHomeDeviceDrawer(), {
-      open: true,
-      busy: true,
-      device: makeConfiguredDevice({
-        update_available: true,
-        runtime_state: { deployed_version: "2024.6.0" },
-        current_version: "2024.12.0",
-      }),
-    });
-    const btn = accent(el);
+    const el = await mountDrawer({ busy: true, device: updateAvailableDevice() });
+    const btn = footerAccent(el);
     expect(btn.disabled).toBe(false);
     expect(btn.textContent).toContain("dashboard.table_action_view_progress");
     expect(btn.title).toBe("dashboard.table_action_view_progress");
@@ -55,16 +28,8 @@ describe("device-drawer busy footer actions", () => {
   });
 
   it("idle Update emits update-device", async () => {
-    const el = await mount(new ESPHomeDeviceDrawer(), {
-      open: true,
-      busy: false,
-      device: makeConfiguredDevice({
-        update_available: true,
-        runtime_state: { deployed_version: "2024.6.0" },
-        current_version: "2024.12.0",
-      }),
-    });
-    const btn = accent(el);
+    const el = await mountDrawer({ busy: false, device: updateAvailableDevice() });
+    const btn = footerAccent(el);
     expect(btn.textContent).toContain("dashboard.drawer_update");
     expect(clickCollect(el, btn, ["show-progress", "update-device"])).toEqual([
       "update-device",
@@ -72,14 +37,14 @@ describe("device-drawer busy footer actions", () => {
   });
 
   it("busy Install stays enabled, reads view-progress, and emits show-progress", async () => {
-    const el = await mount(new ESPHomeDeviceDrawer(), {
-      open: true,
+    const el = await mountDrawer({
       busy: true,
       device: makeConfiguredDevice({ has_pending_changes: true }),
     });
-    const btn = accent(el);
+    const btn = footerAccent(el);
     expect(btn.disabled).toBe(false);
     expect(btn.textContent).toContain("dashboard.table_action_view_progress");
+    expect(btn.title).toBe("dashboard.table_action_view_progress");
     expect(clickCollect(el, btn, ["show-progress", "install-device"])).toEqual([
       "show-progress",
     ]);

--- a/test/components/dashboard/device-drawer-busy-actions.test.ts
+++ b/test/components/dashboard/device-drawer-busy-actions.test.ts
@@ -36,6 +36,18 @@ describe("device-drawer busy footer actions", () => {
     ]);
   });
 
+  it("idle Install emits install-device", async () => {
+    const el = await mountDrawer({
+      busy: false,
+      device: makeConfiguredDevice({ has_pending_changes: true }),
+    });
+    const btn = footerAccent(el);
+    expect(btn.textContent).toContain("dashboard.install");
+    expect(clickCollect(el, btn, ["show-progress", "install-device"])).toEqual([
+      "install-device",
+    ]);
+  });
+
   it("busy Install stays enabled, reads view-progress, and emits show-progress", async () => {
     const el = await mountDrawer({
       busy: true,

--- a/test/components/dashboard/device-drawer-busy-actions.test.ts
+++ b/test/components/dashboard/device-drawer-busy-actions.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * While a job runs, the drawer footer's Update/Install button stays
+ * clickable, reads view-progress, and emits show-progress instead of
+ * update-device / install-device. Edit keeps disabling.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+// The drawer body renders children that pull in <wa-button> (form-associated,
+// noisy under happy-dom); the footer under test uses plain buttons, so stubbing
+// the body keeps the mount light and quiet.
+vi.mock("../../../src/components/dashboard/device-drawer-content.js", () => ({}));
+
+import { ESPHomeDeviceDrawer } from "../../../src/components/dashboard/device-drawer.js";
+import { mount } from "../../_dom.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+
+function accent(el: ESPHomeDeviceDrawer): HTMLButtonElement {
+  return el.shadowRoot!.querySelector<HTMLButtonElement>(".footer .action--accent")!;
+}
+
+function clickCollect(
+  el: ESPHomeDeviceDrawer,
+  btn: HTMLElement,
+  events: string[]
+): string[] {
+  const fired: string[] = [];
+  for (const name of events) {
+    el.addEventListener(name, () => fired.push(name));
+  }
+  btn.click();
+  return fired;
+}
+
+describe("device-drawer busy footer actions", () => {
+  it("busy Update stays enabled, reads view-progress, and emits show-progress", async () => {
+    const el = await mount(new ESPHomeDeviceDrawer(), {
+      open: true,
+      busy: true,
+      device: makeConfiguredDevice({
+        update_available: true,
+        runtime_state: { deployed_version: "2024.6.0" },
+        current_version: "2024.12.0",
+      }),
+    });
+    const btn = accent(el);
+    expect(btn.disabled).toBe(false);
+    expect(btn.textContent).toContain("dashboard.table_action_view_progress");
+    expect(btn.title).toBe("dashboard.table_action_view_progress");
+    expect(clickCollect(el, btn, ["show-progress", "update-device"])).toEqual([
+      "show-progress",
+    ]);
+  });
+
+  it("idle Update emits update-device", async () => {
+    const el = await mount(new ESPHomeDeviceDrawer(), {
+      open: true,
+      busy: false,
+      device: makeConfiguredDevice({
+        update_available: true,
+        runtime_state: { deployed_version: "2024.6.0" },
+        current_version: "2024.12.0",
+      }),
+    });
+    const btn = accent(el);
+    expect(btn.textContent).toContain("dashboard.drawer_update");
+    expect(clickCollect(el, btn, ["show-progress", "update-device"])).toEqual([
+      "update-device",
+    ]);
+  });
+
+  it("busy Install stays enabled, reads view-progress, and emits show-progress", async () => {
+    const el = await mount(new ESPHomeDeviceDrawer(), {
+      open: true,
+      busy: true,
+      device: makeConfiguredDevice({ has_pending_changes: true }),
+    });
+    const btn = accent(el);
+    expect(btn.disabled).toBe(false);
+    expect(btn.textContent).toContain("dashboard.table_action_view_progress");
+    expect(clickCollect(el, btn, ["show-progress", "install-device"])).toEqual([
+      "show-progress",
+    ]);
+    // Edit keeps disabling: editing mid-job stays gated.
+    expect(
+      el.shadowRoot!.querySelector<HTMLButtonElement>(".footer .action--primary")!
+        .disabled
+    ).toBe(true);
+  });
+});

--- a/test/components/dashboard/device-drawer-update-title.test.ts
+++ b/test/components/dashboard/device-drawer-update-title.test.ts
@@ -2,42 +2,27 @@
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-// The drawer body renders children that pull in <wa-button> (form-associated,
-// noisy under happy-dom); the footer under test uses plain buttons, so stubbing
-// the body keeps the mount light and quiet.
+// Stub the drawer body; see _device-drawer.ts.
 vi.mock("../../../src/components/dashboard/device-drawer-content.js", () => ({}));
 
-import { ESPHomeDeviceDrawer } from "../../../src/components/dashboard/device-drawer.js";
-import { mount } from "../../_dom.js";
 import { makeConfiguredDevice } from "../../_make-configured-device.js";
-
-function footerAccentTitle(el: ESPHomeDeviceDrawer): string | null {
-  return el.shadowRoot!.querySelector<HTMLElement>(".footer .action--accent")!.title;
-}
+import { footerAccent, mountDrawer, updateAvailableDevice } from "./_device-drawer.js";
 
 describe("device-drawer footer Update title", () => {
   it("wires installed + target versions into the Update button title", async () => {
     // Identity localize keeps the key; the version key proves both versions
     // threaded through (helper branch logic is unit-tested in update-tooltip).
-    const el = await mount(new ESPHomeDeviceDrawer(), {
-      open: true,
-      device: makeConfiguredDevice({
-        update_available: true,
-        runtime_state: { deployed_version: "2024.6.0" },
-        current_version: "2024.12.0",
-      }),
-    });
-    expect(footerAccentTitle(el)).toBe("dashboard.update_available_version");
+    const el = await mountDrawer({ device: updateAvailableDevice() });
+    expect(footerAccent(el).title).toBe("dashboard.update_available_version");
   });
 
   it("falls back to the plain Update title when a version is missing", async () => {
-    const el = await mount(new ESPHomeDeviceDrawer(), {
-      open: true,
+    const el = await mountDrawer({
       device: makeConfiguredDevice({
         update_available: true,
         runtime_state: { deployed_version: "2024.6.0" },
       }),
     });
-    expect(footerAccentTitle(el)).toBe("dashboard.drawer_update");
+    expect(footerAccent(el).title).toBe("dashboard.drawer_update");
   });
 });

--- a/test/components/dashboard/table-row-menu-busy-install.test.ts
+++ b/test/components/dashboard/table-row-menu-busy-install.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * While a job runs, the menu's Install item stays clickable, reads
+ * view-progress, and emits show-progress instead of install-device.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomeTableRowMenu } from "../../../src/components/dashboard/table-row-menu.js";
+import { mount } from "../../_dom.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+
+function installItem(el: ESPHomeTableRowMenu): HTMLElement {
+  return el.shadowRoot!.querySelector<HTMLElement>(".menu-item--install")!;
+}
+
+describe("table-row-menu install item while busy", () => {
+  it("stays enabled, reads view-progress, and emits show-progress for its device", async () => {
+    const device = makeConfiguredDevice({});
+    const el = await mount(new ESPHomeTableRowMenu(), {
+      device,
+      position: { x: 10, y: 10 },
+      busy: true,
+    });
+    const item = installItem(el);
+    expect(item.classList.contains("menu-item--disabled")).toBe(false);
+    expect(item.textContent).toContain("dashboard.table_action_view_progress");
+
+    const progress = vi.fn();
+    const install = vi.fn();
+    el.addEventListener("show-progress", progress);
+    el.addEventListener("install-device", install);
+    item.click();
+    expect(progress).toHaveBeenCalledTimes(1);
+    expect(progress.mock.calls[0][0].detail).toBe(device);
+    expect(install).not.toHaveBeenCalled();
+  });
+
+  it("emits install-device when idle", async () => {
+    const el = await mount(new ESPHomeTableRowMenu(), {
+      device: makeConfiguredDevice({}),
+      position: { x: 10, y: 10 },
+      busy: false,
+    });
+    const item = installItem(el);
+    expect(item.textContent).toContain("dashboard.action_install");
+
+    const progress = vi.fn();
+    const install = vi.fn();
+    el.addEventListener("show-progress", progress);
+    el.addEventListener("install-device", install);
+    item.click();
+    expect(install).toHaveBeenCalledTimes(1);
+    expect(progress).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/dashboard/table-row-menu-busy-install.test.ts
+++ b/test/components/dashboard/table-row-menu-busy-install.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { ESPHomeTableRowMenu } from "../../../src/components/dashboard/table-row-menu.js";
-import { mount } from "../../_dom.js";
+import { clickCollect, mount } from "../../_dom.js";
 import { makeConfiguredDevice } from "../../_make-configured-device.js";
 
 function installItem(el: ESPHomeTableRowMenu): HTMLElement {
@@ -28,14 +28,14 @@ describe("table-row-menu install item while busy", () => {
     expect(item.classList.contains("menu-item--disabled")).toBe(false);
     expect(item.textContent).toContain("dashboard.table_action_view_progress");
 
-    const progress = vi.fn();
-    const install = vi.fn();
-    el.addEventListener("show-progress", progress);
-    el.addEventListener("install-device", install);
-    item.click();
-    expect(progress).toHaveBeenCalledTimes(1);
-    expect(progress.mock.calls[0][0].detail).toBe(device);
-    expect(install).not.toHaveBeenCalled();
+    // With several jobs running, the detail is what routes the click to
+    // THIS device's job.
+    const detail = vi.fn();
+    el.addEventListener("show-progress", (e) => detail((e as CustomEvent).detail));
+    expect(clickCollect(el, item, ["show-progress", "install-device"])).toEqual([
+      "show-progress",
+    ]);
+    expect(detail).toHaveBeenCalledWith(device);
   });
 
   it("emits install-device when idle", async () => {
@@ -46,13 +46,8 @@ describe("table-row-menu install item while busy", () => {
     });
     const item = installItem(el);
     expect(item.textContent).toContain("dashboard.action_install");
-
-    const progress = vi.fn();
-    const install = vi.fn();
-    el.addEventListener("show-progress", progress);
-    el.addEventListener("install-device", install);
-    item.click();
-    expect(install).toHaveBeenCalledTimes(1);
-    expect(progress).not.toHaveBeenCalled();
+    expect(clickCollect(el, item, ["show-progress", "install-device"])).toEqual([
+      "install-device",
+    ]);
   });
 });

--- a/test/components/device-card-busy-actions.test.ts
+++ b/test/components/device-card-busy-actions.test.ts
@@ -11,6 +11,7 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 
 import type { ESPHomeDeviceCard } from "../../src/components/device-card.js";
+import { clickCollect } from "../_dom.js";
 import { mountDeviceCard as mount } from "./_device-card.js";
 
 function accentButton(el: ESPHomeDeviceCard): HTMLButtonElement {
@@ -19,39 +20,36 @@ function accentButton(el: ESPHomeDeviceCard): HTMLButtonElement {
   return btn!;
 }
 
-function clickEmits(el: ESPHomeDeviceCard, events: string[]): string[] {
-  const fired: string[] = [];
-  for (const name of events) {
-    el.addEventListener(name, () => fired.push(name));
-  }
-  accentButton(el).click();
-  return fired;
-}
-
 describe("device-card busy update/install actions", () => {
   it("busy update button is enabled and emits show-progress", async () => {
     const el = await mount({ busy: true, showUpdate: true });
-    expect(accentButton(el).disabled).toBe(false);
-    expect(clickEmits(el, ["show-progress", "update-device"])).toEqual(["show-progress"]);
+    const btn = accentButton(el);
+    expect(btn.disabled).toBe(false);
+    expect(clickCollect(el, btn, ["show-progress", "update-device"])).toEqual([
+      "show-progress",
+    ]);
   });
 
   it("idle update button emits update-device", async () => {
     const el = await mount({ busy: false, showUpdate: true });
-    expect(clickEmits(el, ["show-progress", "update-device"])).toEqual(["update-device"]);
+    expect(
+      clickCollect(el, accentButton(el), ["show-progress", "update-device"])
+    ).toEqual(["update-device"]);
   });
 
   it("busy install button is enabled and emits show-progress", async () => {
     const el = await mount({ busy: true, showModified: true });
-    expect(accentButton(el).disabled).toBe(false);
-    expect(clickEmits(el, ["show-progress", "install-device"])).toEqual([
+    const btn = accentButton(el);
+    expect(btn.disabled).toBe(false);
+    expect(clickCollect(el, btn, ["show-progress", "install-device"])).toEqual([
       "show-progress",
     ]);
   });
 
   it("idle install button emits install-device", async () => {
     const el = await mount({ busy: false, showModified: true });
-    expect(clickEmits(el, ["show-progress", "install-device"])).toEqual([
-      "install-device",
-    ]);
+    expect(
+      clickCollect(el, accentButton(el), ["show-progress", "install-device"])
+    ).toEqual(["install-device"]);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #1191, covering the two surfaces it left out: the card/table popup menu's **Install** item and the drawer footer's **Update/Install** buttons still greyed out while a firmware job ran. They now behave like the card, table, and editor buttons:

- **Row/context menu** (`table-row-menu.ts`, backing both the table kebab and the card context menu): the Install item stays clickable while busy, its label flips to "View install progress", and it emits `show-progress` instead of `install-device`. Rename/duplicate/clean/archive/delete items keep disabling — those genuinely can't run mid-job.
- **Drawer footer** (`device-drawer.ts`): the Update/Install accent button stays enabled, flips its visible label to the view-progress string (the visible text is the accessible name — same WCAG 2.5.3 shape as #1191's editor fab), reuses `updateActionTitle` for the tooltip, and emits `show-progress`. The Edit button keeps disabling.
- Wiring: `show-progress` handlers added for the drawer and card context menu in `render-content.ts` (routing to the existing `_showJobProgress`), and the table's row-menu event forwarder learns `show-progress` alongside its siblings.

No new i18n keys. New tests pin both surfaces (busy → enabled + view-progress label + `show-progress` with the device as detail; idle → the original events; drawer Edit still disabled while busy).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1192

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
