### PR TITLE
Keep Edit clickable while a job runs

### DIFF
--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -355,7 +355,6 @@ export class ESPHomeDeviceDrawer extends LitElement {
         <div class="footer">
           <button
             class="action action--primary"
-            ?disabled=${this.busy}
             @click=${() => this._emitAction("edit-device")}
           >
             <wa-icon library="mdi" name="pencil"></wa-icon>

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -335,7 +335,6 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
             class="cell-action-btn cell-action-btn--accent cell-action-btn--edit"
             aria-label=${localize("dashboard.table_action_edit")}
             title=${localize("dashboard.table_action_edit")}
-            ?disabled=${row.busy}
             @click=${(e: Event) => dispatchRowEvent(e, "edit-device", device)}
           >
             <wa-icon library="mdi" name="pencil"></wa-icon>

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -224,7 +224,6 @@ export class ESPHomeDeviceCard extends LitElement {
                 <div class="device-actions" @click=${(e: Event) => e.stopPropagation()}>
                   <button
                     class="action-btn action-btn--primary"
-                    ?disabled=${this.busy}
                     @click=${() => this._emit("edit-device")}
                   >
                     <wa-icon library="mdi" name="pencil"></wa-icon>

--- a/test/components/dashboard/device-drawer-busy-actions.test.ts
+++ b/test/components/dashboard/device-drawer-busy-actions.test.ts
@@ -3,7 +3,8 @@
  *
  * While a job runs, the drawer footer's Update/Install button stays
  * clickable, reads view-progress, and emits show-progress instead of
- * update-device / install-device. Edit keeps disabling.
+ * update-device / install-device. Edit stays clickable too — the editor
+ * is designed for mid-job use (#1196).
  */
 import { describe, expect, it, vi } from "vitest";
 
@@ -60,10 +61,11 @@ describe("device-drawer busy footer actions", () => {
     expect(clickCollect(el, btn, ["show-progress", "install-device"])).toEqual([
       "show-progress",
     ]);
-    // Edit keeps disabling: editing mid-job stays gated.
+    // Edit stays clickable: it only navigates, and the editor handles
+    // mid-job use (#1196).
     expect(
       el.shadowRoot!.querySelector<HTMLButtonElement>(".footer .action--primary")!
         .disabled
-    ).toBe(true);
+    ).toBe(false);
   });
 });

--- a/test/components/dashboard/table-columns.test.ts
+++ b/test/components/dashboard/table-columns.test.ts
@@ -139,6 +139,14 @@ describe("device table busy install/update actions", () => {
     expect(clickInstallAction(container).fired).toEqual(["show-progress"]);
   });
 
+  it("busy row keeps Edit clickable", () => {
+    // Edit only navigates; the editor is designed for mid-job use (#1196).
+    const container = renderInto(renderActionsCell({ busy: true }));
+    expect(
+      container.querySelector<HTMLButtonElement>(".cell-action-btn--edit")!.disabled
+    ).toBe(false);
+  });
+
   it("idle install button dispatches install-device", () => {
     const container = renderInto(renderActionsCell({ busy: false, showModified: true }));
     expect(clickInstallAction(container).fired).toEqual(["install-device"]);

--- a/test/components/device-card-busy-actions.test.ts
+++ b/test/components/device-card-busy-actions.test.ts
@@ -52,4 +52,12 @@ describe("device-card busy update/install actions", () => {
       clickCollect(el, accentButton(el), ["show-progress", "install-device"])
     ).toEqual(["install-device"]);
   });
+
+  it("busy card keeps Edit clickable", async () => {
+    // Edit only navigates; the editor is designed for mid-job use (#1196).
+    const el = await mount({ busy: true, showUpdate: true });
+    const edit = el.shadowRoot!.querySelector<HTMLButtonElement>(".action-btn--primary")!;
+    expect(edit.disabled).toBe(false);
+    expect(clickCollect(el, edit, ["edit-device"])).toEqual(["edit-device"]);
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Removes the busy-while-building disable from the Edit buttons on the device card, the table row, and the drawer footer. Edit only navigates to the editor page, which is expressly designed for mid-job use (busy-routed Update/Install that re-attaches to the running job), so the gate prevented nothing real — it just blocked the most common "check the YAML while it builds" flow.

One correction to the issue text: the table row's Edit button *was* also busy-disabled (`table-columns.ts`), so all three surfaces are converted rather than two. Tests updated: the drawer suite's "Edit keeps disabling" pin is flipped, and the card/table busy suites now pin Edit as clickable.

Destructive/mutating actions (rename, duplicate, clean build files, archive, delete) keep their busy gates — those genuinely conflict with a running job.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1196

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
