### PR TITLE
Warn when a bulk update will restart in-flight builds

### DIFF
--- a/src/components/update-all-dialog.ts
+++ b/src/components/update-all-dialog.ts
@@ -164,6 +164,24 @@ export class ESPHomeUpdateAllDialog extends LitElement {
     return this._matchedMemo(this._devices, this._selection);
   }
 
+  // Bulk update deliberately supersedes: the backend cancels and restarts a
+  // configuration's in-flight jobs on enqueue (#1195). Warn when it will
+  // actually happen. Memoized like the sibling tallies — _activeJobs churns
+  // on every job-progress event while the dialog sits open.
+  private _buildingCountMemo = memoizeOne(
+    (matched: ConfiguredDevice[], activeJobs: Map<string, FirmwareJob>) =>
+      matched.filter((d) => activeJobs.has(d.configuration)).length
+  );
+
+  private _renderSupersedeNote(matched: ConfiguredDevice[]) {
+    const building = this._buildingCountMemo(matched, this._activeJobs);
+    return building > 0
+      ? html`<div class="summary-note">
+          ${this._localize("update_all_dialog.supersede_note", { count: building })}
+        </div>`
+      : nothing;
+  }
+
   protected render() {
     // Keep one <esphome-base-dialog> so a close flips ?open reactively and
     // wa-dialog's exit animation plays on every path. Gate only the body +
@@ -196,21 +214,7 @@ export class ESPHomeUpdateAllDialog extends LitElement {
                   ${this._localize("update_all_dialog.count", {
                     count: matched.length,
                   })}
-                  ${(() => {
-                    // Bulk update deliberately supersedes: the backend cancels
-                    // and restarts a configuration's in-flight jobs on enqueue
-                    // (#1195). Say so when it will actually happen.
-                    const building = matched.filter((d) =>
-                      this._activeJobs.has(d.configuration)
-                    ).length;
-                    return building > 0
-                      ? html`<div class="summary-note">
-                          ${this._localize("update_all_dialog.supersede_note", {
-                            count: building,
-                          })}
-                        </div>`
-                      : nothing;
-                  })()}
+                  ${this._renderSupersedeNote(matched)}
                 </div>
                 <div class="actions">
                   <button class="btn btn--cancel" @click=${this.close}>

--- a/src/components/update-all-dialog.ts
+++ b/src/components/update-all-dialog.ts
@@ -4,9 +4,11 @@ import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import type { ESPHomeAPI } from "../api/index.js";
 import { DeviceState, type ConfiguredDevice } from "../api/types/devices.js";
+import type { FirmwareJob } from "../api/types/firmware-jobs.js";
 import type { PairingSummary } from "../api/types/remote-build.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
+  activeJobsContext,
   apiContext,
   buildOffloadPairingsContext,
   devicesContext,
@@ -70,6 +72,10 @@ export class ESPHomeUpdateAllDialog extends LitElement {
   @state()
   private _pairings: Map<string, PairingSummary> | null = null;
 
+  @consume({ context: activeJobsContext, subscribe: true })
+  @state()
+  private _activeJobs: Map<string, FirmwareJob> = new Map();
+
   @state()
   private _open = false;
 
@@ -108,6 +114,11 @@ export class ESPHomeUpdateAllDialog extends LitElement {
         padding: var(--wa-space-m) 0 0;
         font-size: var(--wa-font-size-s);
         color: var(--wa-color-text-quiet);
+      }
+
+      .summary-note {
+        margin-top: var(--wa-space-2xs);
+        color: var(--wa-color-warning-text-quiet);
       }
     `,
   ];
@@ -185,6 +196,21 @@ export class ESPHomeUpdateAllDialog extends LitElement {
                   ${this._localize("update_all_dialog.count", {
                     count: matched.length,
                   })}
+                  ${(() => {
+                    // Bulk update deliberately supersedes: the backend cancels
+                    // and restarts a configuration's in-flight jobs on enqueue
+                    // (#1195). Say so when it will actually happen.
+                    const building = matched.filter((d) =>
+                      this._activeJobs.has(d.configuration)
+                    ).length;
+                    return building > 0
+                      ? html`<div class="summary-note">
+                          ${this._localize("update_all_dialog.supersede_note", {
+                            count: building,
+                          })}
+                        </div>`
+                      : nothing;
+                  })()}
                 </div>
                 <div class="actions">
                   <button class="btn btn--cancel" @click=${this.close}>

--- a/src/components/update-all-dialog.ts
+++ b/src/components/update-all-dialog.ts
@@ -166,11 +166,17 @@ export class ESPHomeUpdateAllDialog extends LitElement {
 
   // Bulk update deliberately supersedes: the backend cancels and restarts a
   // configuration's in-flight jobs on enqueue (#1195). Warn when it will
-  // actually happen. Memoized like the sibling tallies — _activeJobs churns
-  // on every job-progress event while the dialog sits open.
+  // actually happen. Memoized like the sibling tallies, but _activeJobs is
+  // rebuilt on every job-progress event, so the memo misses on each tick
+  // while the dialog sits open — count with a plain loop, no allocation.
   private _buildingCountMemo = memoizeOne(
-    (matched: ConfiguredDevice[], activeJobs: Map<string, FirmwareJob>) =>
-      matched.filter((d) => activeJobs.has(d.configuration)).length
+    (matched: ConfiguredDevice[], activeJobs: Map<string, FirmwareJob>) => {
+      let building = 0;
+      for (const d of matched) {
+        if (activeJobs.has(d.configuration)) building += 1;
+      }
+      return building;
+    }
   );
 
   private _renderSupersedeNote(matched: ConfiguredDevice[]) {

--- a/src/components/update-all-dialog.ts
+++ b/src/components/update-all-dialog.ts
@@ -166,21 +166,14 @@ export class ESPHomeUpdateAllDialog extends LitElement {
 
   // Bulk update deliberately supersedes: the backend cancels and restarts a
   // configuration's in-flight jobs on enqueue (#1195). Warn when it will
-  // actually happen. Memoized like the sibling tallies, but _activeJobs is
-  // rebuilt on every job-progress event, so the memo misses on each tick
-  // while the dialog sits open — count with a plain loop, no allocation.
-  private _buildingCountMemo = memoizeOne(
-    (matched: ConfiguredDevice[], activeJobs: Map<string, FirmwareJob>) => {
-      let building = 0;
-      for (const d of matched) {
-        if (activeJobs.has(d.configuration)) building += 1;
-      }
-      return building;
-    }
-  );
-
+  // actually happen. Deliberately not memoized: the note only renders while
+  // jobs run, which is exactly when _activeJobs is rebuilt per progress
+  // event — a cache would always miss when it matters.
   private _renderSupersedeNote(matched: ConfiguredDevice[]) {
-    const building = this._buildingCountMemo(matched, this._activeJobs);
+    let building = 0;
+    for (const d of matched) {
+      if (this._activeJobs.has(d.configuration)) building += 1;
+    }
     return building > 0
       ? html`<div class="summary-note">
           ${this._localize("update_all_dialog.supersede_note", { count: building })}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1119,6 +1119,7 @@
   "update_all_dialog": {
     "title": "Update All",
     "count": "{count, plural, one {# device will be updated} other {# devices will be updated}}",
+    "supersede_note": "{count, plural, one {# device is building now — its build will restart} other {# devices are building now — their builds will restart}}",
     "confirm": "Update"
   },
   "yaml_search": {

--- a/test/components/update-all-dialog.test.ts
+++ b/test/components/update-all-dialog.test.ts
@@ -27,6 +27,7 @@ interface DialogInternals {
   _devices: ReturnType<typeof makeConfiguredDevice>[];
   _api: ESPHomeAPI;
   _selection: FacetSelection;
+  _activeJobs: Map<string, unknown>;
   _localize: (key: string, args?: { count?: number }) => string;
 }
 
@@ -139,5 +140,24 @@ describe("update-all-dialog", () => {
     await el.updateComplete;
     primaryButton(el).click();
     expect(firmwareInstallBulk).toHaveBeenCalledWith(["c.yaml"]);
+  });
+
+  it("warns how many matched devices are building (their builds restart)", async () => {
+    const { api } = fakeApi();
+    const el = await mount([onlineUpdatable, onlineCurrent, offlineUpdatable], api);
+    (el as unknown as DialogInternals)._activeJobs = new Map([["a.yaml", {}]]);
+    await el.updateComplete;
+    const note = el.shadowRoot!.querySelector(".summary-note");
+    expect(note).not.toBeNull();
+    expect(note!.textContent).toContain("update_all_dialog.supersede_note:1");
+  });
+
+  it("renders no supersede note when nothing matched is building", async () => {
+    const { api } = fakeApi();
+    const el = await mount([onlineUpdatable, onlineCurrent, offlineUpdatable], api);
+    // b.yaml is building but doesn't match the filter, so no note.
+    (el as unknown as DialogInternals)._activeJobs = new Map([["b.yaml", {}]]);
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector(".summary-note")).toBeNull();
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Per the decision on #1195: bulk update superseding in-flight builds is the intended fleet semantics ("update everything now"), so this documents it instead of filtering. The backend behavior is already specified in device-builder's `docs/API.md` ("One active job per device": queuing a new job cancels the configuration's queued/running jobs first); what was missing is any hint in the UI.

The Update All dialog now shows a warning line under the matched-device count when any matched device currently has an active job — "N devices are building now — their builds will restart" — driven by `activeJobsContext`, so the note appears only when a supersede will actually happen. New `update_all_dialog.supersede_note` i18n key; warning uses the `--wa-color-warning-text-quiet` token.

The select-bar's "Update selected" fires without a confirm step, so there's no natural place for the same note there; the semantics are now documented here and in the backend API docs.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1195

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
