### PR TITLE
Guard the install seams against superseding a running build

### DIFF
--- a/src/components/dashboard/install.ts
+++ b/src/components/dashboard/install.ts
@@ -1,6 +1,6 @@
 import type { ConfiguredDevice } from "../../api/types/devices.js";
 import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
-import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
+import { followActiveJob } from "../../util/firmware-job-display.js";
 import { launchLogs } from "../../util/logs-launch.js";
 import { applyInstallMethod } from "../apply-install-method.js";
 import type { CommandType } from "../command-dialog.js";
@@ -28,8 +28,9 @@ export function onInstallMethodSelect(
     void openLogsWithMethod(host, device, method, port);
     return;
   }
-  // A job may have started while the picker sat open (second tab, a
-  // deferred queued update firing); enqueuing now would supersede it.
+  // A job may have started while the picker sat open; enqueuing now
+  // would supersede it. Covers the firmwareDialog methods too, which
+  // never reach openCommand's guard.
   if (showJobProgress(host, device)) return;
   applyInstallMethod(method, port, {
     device,
@@ -49,24 +50,18 @@ export function openCommand(
   host._commandDialog.openForDevice(device, type, { port, ...options });
 }
 
-/**
- * Re-attach the command dialog to the device's running job.
- *
- * Returns true when a job was open — the install seams bail on it,
- * since enqueuing would supersede: the backend cancels and restarts
- * the configuration's in-flight jobs.
- */
+/** Re-attach the command dialog to the device's running job; true when one existed. */
 export function showJobProgress(
   host: ESPHomePageDashboard,
   device: ConfiguredDevice
 ): boolean {
-  const job = host._activeJobs.get(device.configuration);
-  if (!job) return false;
-  host._commandDialog.followJob(
-    job,
-    firmwareJobDisplayName(job, host._devices, host._localize)
+  return followActiveJob(
+    host._activeJobs,
+    device.configuration,
+    host._commandDialog,
+    host._devices,
+    host._localize
   );
-  return true;
 }
 
 export function openLogs(

--- a/src/components/dashboard/install.ts
+++ b/src/components/dashboard/install.ts
@@ -10,6 +10,7 @@ export function openInstallMethod(
   host: ESPHomePageDashboard,
   device: ConfiguredDevice
 ): void {
+  if (showJobProgress(host, device)) return;
   host._installMethodDevice = device;
   host._installMethodMode = "install";
   host._installMethodOpen = true;
@@ -27,6 +28,9 @@ export function onInstallMethodSelect(
     void openLogsWithMethod(host, device, method, port);
     return;
   }
+  // A job may have started while the picker sat open (second tab, a
+  // deferred queued update firing); enqueuing now would supersede it.
+  if (showJobProgress(host, device)) return;
   applyInstallMethod(method, port, {
     device,
     firmwareDialog: host._firmwareDialog,
@@ -41,19 +45,28 @@ export function openCommand(
   port?: string,
   options?: { bootloader?: boolean }
 ): void {
+  if (type === "install" && showJobProgress(host, device)) return;
   host._commandDialog.openForDevice(device, type, { port, ...options });
 }
 
+/**
+ * Re-attach the command dialog to the device's running job.
+ *
+ * Returns true when a job was open — the install seams bail on it,
+ * since enqueuing would supersede: the backend cancels and restarts
+ * the configuration's in-flight jobs.
+ */
 export function showJobProgress(
   host: ESPHomePageDashboard,
   device: ConfiguredDevice
-): void {
+): boolean {
   const job = host._activeJobs.get(device.configuration);
-  if (!job) return;
+  if (!job) return false;
   host._commandDialog.followJob(
     job,
     firmwareJobDisplayName(job, host._devices, host._localize)
   );
+  return true;
 }
 
 export function openLogs(

--- a/src/components/device/device-install-controller.ts
+++ b/src/components/device/device-install-controller.ts
@@ -24,12 +24,7 @@ export interface DeviceInstallControllerHost extends ReactiveControllerHost {
   readonly logsDialog: ESPHomeLogsDialog | null;
   readonly api: ESPHomeAPI;
   readonly localize: LocalizeFunc;
-  /**
-   * Re-attach the command dialog to the device's running job; true when
-   * one was open. The install seams bail on it — enqueuing would
-   * supersede (the backend cancels and restarts the configuration's
-   * in-flight jobs).
-   */
+  /** Re-attach the command dialog to the device's running job; true when one existed. */
   openActiveJobProgress(): boolean;
 }
 
@@ -90,7 +85,6 @@ export class DeviceInstallController implements ReactiveController {
   onUpdate = () => {
     const device = this._host.device;
     if (!device) return;
-    if (this._host.openActiveJobProgress()) return;
     this._openCommand(device, "install");
   };
 
@@ -114,8 +108,9 @@ export class DeviceInstallController implements ReactiveController {
       void launchLogsWithMethod(this._logsHost(logsDialog), device, method, port);
       return;
     }
-    // A job may have started while the picker sat open (second tab, a
-    // deferred queued update firing); enqueuing now would supersede it.
+    // A job may have started while the picker sat open; enqueuing now
+    // would supersede it. Covers the firmwareDialog methods too, which
+    // never reach _openCommand's guard.
     if (this._host.openActiveJobProgress()) return;
     applyInstallMethod(method, port, {
       device,
@@ -134,6 +129,9 @@ export class DeviceInstallController implements ReactiveController {
     port?: string,
     options?: { bootloader?: boolean }
   ) {
+    // Mirrors the dashboard's openCommand: an install enqueued over a
+    // running job would supersede it (cancel + restart).
+    if (type === "install" && this._host.openActiveJobProgress()) return;
     this._host.commandDialog?.openForDevice(device, type, { port, ...options });
   }
 }

--- a/src/components/device/device-install-controller.ts
+++ b/src/components/device/device-install-controller.ts
@@ -24,6 +24,13 @@ export interface DeviceInstallControllerHost extends ReactiveControllerHost {
   readonly logsDialog: ESPHomeLogsDialog | null;
   readonly api: ESPHomeAPI;
   readonly localize: LocalizeFunc;
+  /**
+   * Re-attach the command dialog to the device's running job; true when
+   * one was open. The install seams bail on it — enqueuing would
+   * supersede (the backend cancels and restarts the configuration's
+   * in-flight jobs).
+   */
+  openActiveJobProgress(): boolean;
 }
 
 export class DeviceInstallController implements ReactiveController {
@@ -61,6 +68,7 @@ export class DeviceInstallController implements ReactiveController {
   /** "Install" entry point — opens the install-method picker. */
   onInstall = () => {
     if (!this._host.device) return;
+    if (this._host.openActiveJobProgress()) return;
     this.methodMode = "install";
     this.installMethodOpen = true;
     this._host.requestUpdate();
@@ -82,6 +90,7 @@ export class DeviceInstallController implements ReactiveController {
   onUpdate = () => {
     const device = this._host.device;
     if (!device) return;
+    if (this._host.openActiveJobProgress()) return;
     this._openCommand(device, "install");
   };
 
@@ -105,6 +114,9 @@ export class DeviceInstallController implements ReactiveController {
       void launchLogsWithMethod(this._logsHost(logsDialog), device, method, port);
       return;
     }
+    // A job may have started while the picker sat open (second tab, a
+    // deferred queued update firing); enqueuing now would supersede it.
+    if (this._host.openActiveJobProgress()) return;
     applyInstallMethod(method, port, {
       device,
       firmwareDialog: this._host.firmwareDialog,

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -41,7 +41,7 @@ import { withBase } from "../util/base-path.js";
 import { fetchBoard } from "../util/board-body-cache.js";
 import { showPendingChanges, showUpdateAvailable } from "../util/device-sync.js";
 import { deviceLayoutToPref, prefToDeviceLayout } from "../util/editor-layout.js";
-import { firmwareJobDisplayName } from "../util/firmware-job-display.js";
+import { followActiveJob } from "../util/firmware-job-display.js";
 import { consumeJustCreated } from "../util/just-created.js";
 import { navigate, setLeaveGuard } from "../util/navigation.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
@@ -969,17 +969,15 @@ export class ESPHomePageDevice extends LitElement {
   private _saveThenInstall = () => this._installAfterSave(this._installCtrl.onInstall);
   private _saveThenUpdate = () => this._installAfterSave(this._installCtrl.onUpdate);
 
-  /** Re-attach the command dialog to this device's running job, if any —
-   *  the Update/Install buttons stay clickable mid-job and open the
-   *  in-progress stream instead of saving and starting another job. */
+  /** Re-attach the command dialog to this device's running job; true when one existed. */
   private _showActiveJobProgress(): boolean {
-    const job = this._activeJobs.get(this.id);
-    if (!job) return false;
-    this._commandDialog.followJob(
-      job,
-      firmwareJobDisplayName(job, this._devices, this._localize)
+    return followActiveJob(
+      this._activeJobs,
+      this.id,
+      this._commandDialog,
+      this._devices,
+      this._localize
     );
-    return true;
   }
 
   /** Catch ``clean-build`` from the install dialog's post-failure

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -333,6 +333,7 @@ export class ESPHomePageDevice extends LitElement {
       get localize() {
         return page._localize;
       },
+      openActiveJobProgress: () => page._showActiveJobProgress(),
     });
   }
 

--- a/src/util/firmware-job-display.ts
+++ b/src/util/firmware-job-display.ts
@@ -92,3 +92,24 @@ export function firmwareJobDisplayName(
   const device = devices.find((d) => d.configuration === job.configuration);
   return device?.friendly_name || device?.name || job.configuration;
 }
+
+/**
+ * Re-attach *dialog* to the configuration's running job, if any.
+ *
+ * Returns true when an active job existed (the dialog now follows it) —
+ * the install seams bail on true, since enqueuing instead would
+ * supersede: the backend cancels and restarts the configuration's
+ * in-flight jobs ("one active job per device").
+ */
+export function followActiveJob(
+  activeJobs: Map<string, FirmwareJob>,
+  configuration: string,
+  dialog: { followJob(job: FirmwareJob, displayName: string): void },
+  devices: ConfiguredDevice[],
+  localize: LocalizeFunc
+): boolean {
+  const job = activeJobs.get(configuration);
+  if (!job) return false;
+  dialog.followJob(job, firmwareJobDisplayName(job, devices, localize));
+  return true;
+}

--- a/test/components/dashboard/install-busy-guard.test.ts
+++ b/test/components/dashboard/install-busy-guard.test.ts
@@ -1,9 +1,8 @@
 /**
  * @vitest-environment happy-dom
  *
- * The dashboard's install seams re-attach to a running job instead of
- * enqueuing over it — the backend supersedes on enqueue (cancels and
- * restarts the configuration's in-flight jobs) (#1194).
+ * Pins the dashboard install seams' busy guard: a running job re-attaches
+ * instead of enqueuing over it, including the mid-picker race (#1194).
  */
 import { describe, expect, it, vi } from "vitest";
 import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
@@ -13,7 +12,7 @@ import {
   openCommand,
   openInstallMethod,
 } from "../../../src/components/dashboard/install.js";
-import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
+import { makeDashboardHost } from "./_host.js";
 
 const device = {
   name: "kitchen",
@@ -21,38 +20,41 @@ const device = {
   configuration: "kitchen.yaml",
 } as ConfiguredDevice;
 
+interface HostInternals {
+  _activeJobs: Map<string, FirmwareJob>;
+  _installMethodOpen: boolean;
+}
+
 function makeHost(busyConfigs: string[] = []) {
   const followJob = vi.fn();
   const openForDevice = vi.fn();
-  const host = {
+  const host = makeDashboardHost({
     _activeJobs: new Map(
       busyConfigs.map((c) => [c, { job_id: "job-1", configuration: c } as FirmwareJob])
     ),
     _commandDialog: { followJob, openForDevice },
     _devices: [device],
-    _localize: (key: string) => key,
     _firmwareDialog: null,
-    _installMethodDevice: null as ConfiguredDevice | null,
-    _installMethodMode: "install" as const,
+    _installMethodDevice: null,
+    _installMethodMode: "install",
     _installMethodOpen: false,
-  };
+  });
   return {
-    host: host as unknown as ESPHomePageDashboard,
-    raw: host,
+    host,
+    internals: host as unknown as HostInternals,
     followJob,
     openForDevice,
   };
 }
 
-const selectOta = () =>
-  new CustomEvent("select-method", { detail: { method: "ota" as string } });
+const selectOta = () => new CustomEvent("select-method", { detail: { method: "ota" } });
 
 describe("dashboard install seam busy guard", () => {
   it("openInstallMethod re-attaches instead of opening the picker while busy", () => {
-    const { host, raw, followJob } = makeHost(["kitchen.yaml"]);
+    const { host, internals, followJob } = makeHost(["kitchen.yaml"]);
     openInstallMethod(host, device);
     expect(followJob).toHaveBeenCalledTimes(1);
-    expect(raw._installMethodOpen).toBe(false);
+    expect(internals._installMethodOpen).toBe(false);
   });
 
   it("openCommand(install) re-attaches instead of enqueuing while busy", () => {
@@ -71,11 +73,11 @@ describe("dashboard install seam busy guard", () => {
   });
 
   it("a job started while the picker sat open blocks the select from superseding", () => {
-    const { host, raw, followJob, openForDevice } = makeHost();
+    const { host, internals, followJob, openForDevice } = makeHost();
     openInstallMethod(host, device);
-    expect(raw._installMethodOpen).toBe(true);
+    expect(internals._installMethodOpen).toBe(true);
     // The race: a job starts (second tab, deferred update firing) mid-picker.
-    raw._activeJobs.set("kitchen.yaml", {
+    internals._activeJobs.set("kitchen.yaml", {
       job_id: "job-2",
       configuration: "kitchen.yaml",
     } as FirmwareJob);

--- a/test/components/dashboard/install-busy-guard.test.ts
+++ b/test/components/dashboard/install-busy-guard.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The dashboard's install seams re-attach to a running job instead of
+ * enqueuing over it — the backend supersedes on enqueue (cancels and
+ * restarts the configuration's in-flight jobs) (#1194).
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
+import type { FirmwareJob } from "../../../src/api/types/firmware-jobs.js";
+import {
+  onInstallMethodSelect,
+  openCommand,
+  openInstallMethod,
+} from "../../../src/components/dashboard/install.js";
+import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
+
+const device = {
+  name: "kitchen",
+  friendly_name: "Kitchen",
+  configuration: "kitchen.yaml",
+} as ConfiguredDevice;
+
+function makeHost(busyConfigs: string[] = []) {
+  const followJob = vi.fn();
+  const openForDevice = vi.fn();
+  const host = {
+    _activeJobs: new Map(
+      busyConfigs.map((c) => [c, { job_id: "job-1", configuration: c } as FirmwareJob])
+    ),
+    _commandDialog: { followJob, openForDevice },
+    _devices: [device],
+    _localize: (key: string) => key,
+    _firmwareDialog: null,
+    _installMethodDevice: null as ConfiguredDevice | null,
+    _installMethodMode: "install" as const,
+    _installMethodOpen: false,
+  };
+  return {
+    host: host as unknown as ESPHomePageDashboard,
+    raw: host,
+    followJob,
+    openForDevice,
+  };
+}
+
+const selectOta = () =>
+  new CustomEvent("select-method", { detail: { method: "ota" as string } });
+
+describe("dashboard install seam busy guard", () => {
+  it("openInstallMethod re-attaches instead of opening the picker while busy", () => {
+    const { host, raw, followJob } = makeHost(["kitchen.yaml"]);
+    openInstallMethod(host, device);
+    expect(followJob).toHaveBeenCalledTimes(1);
+    expect(raw._installMethodOpen).toBe(false);
+  });
+
+  it("openCommand(install) re-attaches instead of enqueuing while busy", () => {
+    const { host, followJob, openForDevice } = makeHost(["kitchen.yaml"]);
+    openCommand(host, device, "install");
+    expect(followJob).toHaveBeenCalledTimes(1);
+    expect(openForDevice).not.toHaveBeenCalled();
+  });
+
+  it("openCommand passes non-install commands through while busy", () => {
+    // Validate/clean never enqueue an install; they keep working mid-job.
+    const { host, followJob, openForDevice } = makeHost(["kitchen.yaml"]);
+    openCommand(host, device, "validate");
+    expect(followJob).not.toHaveBeenCalled();
+    expect(openForDevice).toHaveBeenCalledTimes(1);
+  });
+
+  it("a job started while the picker sat open blocks the select from superseding", () => {
+    const { host, raw, followJob, openForDevice } = makeHost();
+    openInstallMethod(host, device);
+    expect(raw._installMethodOpen).toBe(true);
+    // The race: a job starts (second tab, deferred update firing) mid-picker.
+    raw._activeJobs.set("kitchen.yaml", {
+      job_id: "job-2",
+      configuration: "kitchen.yaml",
+    } as FirmwareJob);
+    onInstallMethodSelect(host, selectOta());
+    expect(followJob).toHaveBeenCalledTimes(1);
+    expect(openForDevice).not.toHaveBeenCalled();
+  });
+
+  it("an idle select still enqueues the install", () => {
+    const { host, followJob, openForDevice } = makeHost();
+    openInstallMethod(host, device);
+    onInstallMethodSelect(host, selectOta());
+    expect(followJob).not.toHaveBeenCalled();
+    expect(openForDevice).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/components/device-install-controller.test.ts
+++ b/test/components/device-install-controller.test.ts
@@ -92,8 +92,7 @@ describe("DeviceInstallController.methodMode", () => {
   });
 });
 
-// Enqueuing over a running job supersedes it (the backend cancels and
-// restarts), so every install seam re-attaches to the job instead (#1194).
+// Pins the controller's install seams' busy guard (#1194).
 describe("DeviceInstallController busy seam guard", () => {
   function makeBusyParts(busy: boolean) {
     const openForDevice = vi.fn();

--- a/test/components/device-install-controller.test.ts
+++ b/test/components/device-install-controller.test.ts
@@ -22,7 +22,8 @@ type LogsDialogStub = {
 
 function makeHost(
   device: ConfiguredDevice | null,
-  logsDialog: LogsDialogStub | null = null
+  logsDialog: LogsDialogStub | null = null,
+  overrides: Partial<DeviceInstallControllerHost> = {}
 ): DeviceInstallControllerHost {
   return {
     device,
@@ -31,10 +32,12 @@ function makeHost(
     logsDialog: logsDialog as DeviceInstallControllerHost["logsDialog"],
     api: {} as ESPHomeAPI,
     localize: (key: string) => key,
+    openActiveJobProgress: () => false,
     addController: vi.fn(),
     removeController: vi.fn(),
     requestUpdate: vi.fn(),
     updateComplete: Promise.resolve(true),
+    ...overrides,
   };
 }
 
@@ -86,5 +89,61 @@ describe("DeviceInstallController.methodMode", () => {
     ctrl.onInstall();
     expect(ctrl.installMethodOpen).toBe(true);
     expect(ctrl.methodMode).toBe("install");
+  });
+});
+
+// Enqueuing over a running job supersedes it (the backend cancels and
+// restarts), so every install seam re-attaches to the job instead (#1194).
+describe("DeviceInstallController busy seam guard", () => {
+  function makeBusyParts(busy: boolean) {
+    const openForDevice = vi.fn();
+    const openActiveJobProgress = vi.fn(() => busy);
+    const host = makeHost(makeConfiguredDevice(), null, {
+      commandDialog: {
+        openForDevice,
+      } as unknown as DeviceInstallControllerHost["commandDialog"],
+      openActiveJobProgress,
+    });
+    return {
+      ctrl: new DeviceInstallController(host),
+      openForDevice,
+      openActiveJobProgress,
+    };
+  }
+
+  it("onInstall re-attaches instead of opening the picker while busy", () => {
+    const { ctrl, openActiveJobProgress } = makeBusyParts(true);
+    ctrl.onInstall();
+    expect(openActiveJobProgress).toHaveBeenCalledTimes(1);
+    expect(ctrl.installMethodOpen).toBe(false);
+  });
+
+  it("onUpdate re-attaches instead of enqueuing while busy", () => {
+    const { ctrl, openForDevice, openActiveJobProgress } = makeBusyParts(true);
+    ctrl.onUpdate();
+    expect(openActiveJobProgress).toHaveBeenCalledTimes(1);
+    expect(openForDevice).not.toHaveBeenCalled();
+  });
+
+  it("a job started while the picker sat open blocks the select from superseding", () => {
+    const { ctrl, openForDevice, openActiveJobProgress } = makeBusyParts(false);
+    ctrl.onInstall();
+    expect(ctrl.installMethodOpen).toBe(true);
+    // The race: a job starts (second tab, deferred update firing) mid-picker.
+    openActiveJobProgress.mockReturnValue(true);
+    ctrl.onInstallMethodSelect(
+      new CustomEvent("select-method", { detail: { method: "ota" } })
+    );
+    expect(ctrl.installMethodOpen).toBe(false);
+    expect(openForDevice).not.toHaveBeenCalled();
+  });
+
+  it("an idle select still enqueues the install", () => {
+    const { ctrl, openForDevice } = makeBusyParts(false);
+    ctrl.onInstall();
+    ctrl.onInstallMethodSelect(
+      new CustomEvent("select-method", { detail: { method: "ota" } })
+    );
+    expect(openForDevice).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The backend supersedes on enqueue — `firmware/install` for a configuration that's already building **cancels and restarts** that build ("one active job per device", device-builder `docs/API.md`). #1191/#1193 route busy clicks to the running job's dialog at each leaf, but the seams underneath had no check, leaving two ways to silently kill an in-flight build:

1. **The install-method picker race** (reachable today): open the picker while idle, a job starts meanwhile (second tab, a deferred queued update firing), then pick a method — the selection enqueues and supersedes the running build.
2. **Any future surface that forgets the leaf branch** — nothing downstream would catch it.

This mirrors the device page's existing `_installAfterSave` guard at every install seam:

- **Dashboard** (`src/components/dashboard/install.ts`): `openInstallMethod`, `openCommand` (install type only — validate/clean pass through), and `onInstallMethodSelect` (install mode) now bail to `showJobProgress` when the configuration has an active job. `showJobProgress` returns whether it attached, so the guards read as one line.
- **Device page** (`device-install-controller.ts`): the controller host gains an `openActiveJobProgress()` callback (wired to the page's existing `_showActiveJobProgress`); `onInstall`, `onUpdate`, and the install-mode `onInstallMethodSelect` guard on it. The picker-select guard matters here too — web-serial / web-flash / binary-download selections route through the firmware dialog and bypass `openCommand` entirely.

Behavior is invisible on the already-converted surfaces (their leaves route first); the guards only fire on the race and on unconverted callers. New tests cover both seams: busy → re-attach without opening the picker/enqueuing, the mid-picker race, non-install commands passing through, and idle paths unchanged.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1194

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
