### PR TITLE
Make Download wait for the running build instead of superseding it

### DIFF
--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -99,9 +99,9 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   _jobs: Map<string, FirmwareJob> = new Map();
 
   // Active job per configuration — the download flow waits for a running
-  // build instead of reading artifacts it's rewriting (#1200).
+  // build instead of reading artifacts it's rewriting (#1200). Not @state:
+  // read imperatively at download start, never in render.
   @consume({ context: activeJobsContext, subscribe: true })
-  @state()
   _activeJobs: Map<string, FirmwareJob> = new Map();
 
   // Suppress the "set up a build server" hint once a build server is paired.

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -18,6 +18,7 @@ import { type FirmwareBinary, JobSource } from "../api/types/firmware-jobs.js";
 import type { PairingSummary } from "../api/types/remote-build.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
+  activeJobsContext,
   apiContext,
   buildOffloadPairingsContext,
   darkModeContext,
@@ -96,6 +97,12 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   @consume({ context: firmwareJobsContext, subscribe: true })
   @state()
   _jobs: Map<string, FirmwareJob> = new Map();
+
+  // Active job per configuration — the download flow waits for a running
+  // build instead of reading artifacts it's rewriting (#1200).
+  @consume({ context: activeJobsContext, subscribe: true })
+  @state()
+  _activeJobs: Map<string, FirmwareJob> = new Map();
 
   // Suppress the "set up a build server" hint once a build server is paired.
   @consume({ context: buildOffloadPairingsContext, subscribe: true })

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -526,7 +526,8 @@ export function handOffToFlasher(host: ESPHomeFirmwareInstallDialog): void {
  * read and would be superseded (cancelled + restarted) by a fresh
  * compile (#1200).
  *
- * True to proceed; false when the dialog was dismissed mid-wait.
+ * True to proceed; false when the wait didn't complete (dialog dismissed,
+ * or the follow stream errored and the dialog already shows the failure).
  */
 async function artifactsSettled(
   host: ESPHomeFirmwareInstallDialog,
@@ -548,7 +549,10 @@ async function artifactsSettled(
  * job, so dismissing the download must not cancel it — teardown only
  * stops the follow stream. Resolves true on ANY terminal outcome (a
  * failed or cancelled build just means the download compiles fresh
- * afterwards), false when the dialog was dismissed mid-wait.
+ * afterwards); false when the dialog was dismissed mid-wait, or on a
+ * follow-stream error — a dead stream says nothing about the job, so
+ * proceeding could still read torn artifacts or supersede it. The error
+ * case fails the dialog; a retry re-reads the active-jobs map.
  */
 function waitForRunningJob(
   host: ESPHomeFirmwareInstallDialog,
@@ -570,7 +574,8 @@ function waitForRunningJob(
       onError: () => {
         host._streamId = "";
         host._compileReject = null;
-        resolve(true);
+        host._fail(host._localize("firmware.download_failed"));
+        resolve(false);
       },
     });
   });

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -350,15 +350,7 @@ export async function startArtifactDownload(
   const device = host._device;
   if (!device) return;
 
-  // A running build is rewriting the artifacts this download would read,
-  // and compiling now would supersede it (cancel + restart). Follow it to
-  // a terminal state first, then continue to fresh artifacts (#1200).
-  const running = host._activeJobs.get(device.configuration);
-  if (running) {
-    host._statusMessage = host._localize("firmware.status_waiting_build");
-    if (!(await waitForRunningJob(host, running.job_id))) return;
-    host._statusMessage = host._localize("firmware.status_downloading");
-  }
+  if (!(await artifactsSettled(host, device.configuration))) return;
 
   let binaries = await fetchBinaries(host, device.configuration);
   if (!binaries) return;
@@ -382,12 +374,15 @@ export async function startArtifactDownload(
 
 // Fetch one binary and hand it to the browser. Shared by the auto-select
 // paths and the picker; leaves _binaries intact for "download another format".
+// Re-settles at select time: the picker (or download-ready's "another
+// format") can sit open while a new build starts rewriting the file.
 export async function downloadSelectedBinary(
   host: ESPHomeFirmwareInstallDialog,
   file: string
 ): Promise<void> {
   const device = host._device;
   if (!device) return;
+  if (!(await artifactsSettled(host, device.configuration))) return;
   host._statusMessage = host._localize("firmware.status_downloading");
   // Distinct from the compile steps: the byte fetch isn't cancelable, so the
   // footer must not offer Stop (see renderFooter).
@@ -523,6 +518,26 @@ export function handOffToFlasher(host: ESPHomeFirmwareInstallDialog): void {
   // after a lost/never-ready tab recompiles, which is incremental and cheap.
   host._usbFirmware = null;
   host._usbFlashTeardown = teardown;
+}
+
+/**
+ * Wait out any running job for *configuration* before touching its
+ * artifacts — a running build both rewrites the files a download would
+ * read and would be superseded (cancelled + restarted) by a fresh
+ * compile (#1200).
+ *
+ * True to proceed; false when the dialog was dismissed mid-wait.
+ */
+async function artifactsSettled(
+  host: ESPHomeFirmwareInstallDialog,
+  configuration: string
+): Promise<boolean> {
+  const running = host._activeJobs.get(configuration);
+  if (!running) return true;
+  host._statusMessage = host._localize("firmware.status_waiting_build");
+  if (!(await waitForRunningJob(host, running.job_id))) return false;
+  host._statusMessage = host._localize("firmware.status_downloading");
+  return true;
 }
 
 /**

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -350,6 +350,16 @@ export async function startArtifactDownload(
   const device = host._device;
   if (!device) return;
 
+  // A running build is rewriting the artifacts this download would read,
+  // and compiling now would supersede it (cancel + restart). Follow it to
+  // a terminal state first, then continue to fresh artifacts (#1200).
+  const running = host._activeJobs.get(device.configuration);
+  if (running) {
+    host._statusMessage = host._localize("firmware.status_waiting_build");
+    if (!(await waitForRunningJob(host, running.job_id))) return;
+    host._statusMessage = host._localize("firmware.status_downloading");
+  }
+
   let binaries = await fetchBinaries(host, device.configuration);
   if (!binaries) return;
   if (binaries.length === 0) {
@@ -513,6 +523,42 @@ export function handOffToFlasher(host: ESPHomeFirmwareInstallDialog): void {
   // after a lost/never-ready tab recompiles, which is incremental and cheap.
   host._usbFirmware = null;
   host._usbFlashTeardown = teardown;
+}
+
+/**
+ * Stream an already-running job into the dialog and wait for it to reach
+ * a terminal state.
+ *
+ * Deliberately never sets ``host._jobId``: the dialog doesn't own this
+ * job, so dismissing the download must not cancel it — teardown only
+ * stops the follow stream. Resolves true on ANY terminal outcome (a
+ * failed or cancelled build just means the download compiles fresh
+ * afterwards), false when the dialog was dismissed mid-wait.
+ */
+function waitForRunningJob(
+  host: ESPHomeFirmwareInstallDialog,
+  jobId: string
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    host._compileReject = () => resolve(false);
+    host._streamId = host._api.firmwareFollowJob(jobId, {
+      onOutput: (line) => {
+        if (host._step === "queued") host._step = "compiling";
+        host._timer.noteLine(line);
+        host._logLines = [...host._logLines, line];
+      },
+      onResult: () => {
+        host._streamId = "";
+        host._compileReject = null;
+        resolve(true);
+      },
+      onError: () => {
+        host._streamId = "";
+        host._compileReject = null;
+        resolve(true);
+      },
+    });
+  });
 }
 
 export function compileAndWait(

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -454,6 +454,7 @@
     "status_verifying": "Verifying chip…",
     "status_compiling": "Compiling firmware…",
     "status_queued": "Waiting for server…",
+    "status_waiting_build": "Waiting for the current build to finish…",
     "status_installing": "Compiling and installing firmware…",
     "status_downloading": "Downloading firmware…",
     "status_flashing": "Flashing firmware to device…",

--- a/test/components/firmware-install-dialog-artifact-download.test.ts
+++ b/test/components/firmware-install-dialog-artifact-download.test.ts
@@ -106,6 +106,8 @@ describe("download flow (startArtifactDownload)", () => {
     const { host, api } = makeHost([[FACTORY]]);
     await run(host);
     expect(api.firmwareCompile).not.toHaveBeenCalled();
+    // With no active job there's nothing to wait on either.
+    expect(api.firmwareFollowJob).not.toHaveBeenCalled();
     expect(api.firmwareDownloadUrl).toHaveBeenCalledWith(
       "device.yaml",
       "firmware.factory.bin"
@@ -211,11 +213,21 @@ describe("download waits for a running build (#1200)", () => {
     expect(api.firmwareDownloadUrl).not.toHaveBeenCalled();
   });
 
-  it("skips the wait entirely when no job is running", async () => {
-    const { host, api } = makeHost([[FACTORY]]);
-    await run(host);
-    // followJob is only reached via compileAndWait, which didn't run.
+  it("re-waits at picker-select time for a build that started meanwhile", async () => {
+    const { host, api } = makeHost([[FACTORY, OTA, ELF]]);
+    await run(host); // lands on choose-binary, no job running
     expect(api.firmwareFollowJob).not.toHaveBeenCalled();
+    // The race: a build starts while the picker sits open.
+    host._activeJobs.set("device.yaml", runningJob);
+    await downloadSelectedBinary(
+      host as unknown as ESPHomeFirmwareInstallDialog,
+      "firmware.ota.bin"
+    );
+    expect(api.firmwareFollowJob).toHaveBeenCalledWith("running-1", expect.anything());
+    expect(api.firmwareDownloadUrl).toHaveBeenCalledWith(
+      "device.yaml",
+      "firmware.ota.bin"
+    );
     expect(host._step).toBe("download-ready");
   });
 });

--- a/test/components/firmware-install-dialog-artifact-download.test.ts
+++ b/test/components/firmware-install-dialog-artifact-download.test.ts
@@ -3,7 +3,8 @@
  * the device's existing build artefacts (firmware images + the ELF) so the
  * user can pick one, and compiles ONLY when nothing is built yet — an existing
  * build is served as-is, with no recompile, so the ELF's debug symbols keep
- * matching the firmware currently flashed on the device.
+ * matching the firmware currently flashed on the device. A running build is
+ * followed to completion first, without claiming it (#1200).
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -74,6 +75,8 @@ function makeHost(getBinariesResults: FirmwareBinary[][]) {
     _jobSource: JobSource.LOCAL,
     _jobSourceLabel: "",
     _compileReject: null as null | ((e: unknown) => void),
+    _activeJobs: new Map<string, unknown>(),
+    _timer: { noteLine: vi.fn() },
     _localize: identityLocalize,
     _fail: vi.fn(),
   };
@@ -156,5 +159,63 @@ describe("download flow (startArtifactDownload)", () => {
     expect(host._step).toBe("error");
     expect(host._statusMessage).toBe("firmware.no_binaries_remote");
     expect(api.firmwareDownloadUrl).not.toHaveBeenCalled();
+  });
+});
+
+describe("download waits for a running build (#1200)", () => {
+  const runningJob = { job_id: "running-1", configuration: "device.yaml" };
+
+  it("follows the running job to completion, then serves fresh artefacts", async () => {
+    const { host, api } = makeHost([[FACTORY]]);
+    host._activeJobs.set("device.yaml", runningJob);
+    await run(host);
+    // Waited on the running job (not a new compile), then downloaded.
+    expect(api.firmwareFollowJob).toHaveBeenCalledWith("running-1", expect.anything());
+    expect(api.firmwareCompile).not.toHaveBeenCalled();
+    expect(api.firmwareDownloadUrl).toHaveBeenCalledWith(
+      "device.yaml",
+      "firmware.factory.bin"
+    );
+    // The dialog never claims the job it waited on: dismissing the download
+    // must not cancel a build it doesn't own.
+    expect(host._jobId).toBe("");
+  });
+
+  it("continues to its own compile when the awaited job ends non-completed", async () => {
+    const { host, api } = makeHost([[], [FACTORY]]);
+    host._activeJobs.set("device.yaml", runningJob);
+    api.firmwareFollowJob.mockImplementationOnce(
+      (_id: string, cbs: { onResult: (d: unknown) => void }) => {
+        cbs.onResult({ status: JobStatus.CANCELLED });
+        return "s1";
+      }
+    );
+    await run(host);
+    // The wait resolves regardless of outcome; the empty build dir then
+    // triggers the download's own (no-longer-superseding) compile.
+    expect(api.firmwareCompile).toHaveBeenCalledTimes(1);
+    expect(host._step).toBe("download-ready");
+  });
+
+  it("bails without touching the backend when dismissed mid-wait", async () => {
+    const { host, api } = makeHost([[FACTORY]]);
+    host._activeJobs.set("device.yaml", runningJob);
+    // A follow that never completes: the user closes the dialog instead.
+    api.firmwareFollowJob.mockImplementationOnce(() => "s1");
+    const flow = run(host);
+    expect(host._compileReject).not.toBeNull();
+    host._compileReject!(new Error("Install dialog dismissed"));
+    await flow;
+    expect(api.firmwareGetBinaries).not.toHaveBeenCalled();
+    expect(api.firmwareCompile).not.toHaveBeenCalled();
+    expect(api.firmwareDownloadUrl).not.toHaveBeenCalled();
+  });
+
+  it("skips the wait entirely when no job is running", async () => {
+    const { host, api } = makeHost([[FACTORY]]);
+    await run(host);
+    // followJob is only reached via compileAndWait, which didn't run.
+    expect(api.firmwareFollowJob).not.toHaveBeenCalled();
+    expect(host._step).toBe("download-ready");
   });
 });

--- a/test/components/firmware-install-dialog-artifact-download.test.ts
+++ b/test/components/firmware-install-dialog-artifact-download.test.ts
@@ -39,6 +39,11 @@ const ELF: FirmwareBinary = {
   description: "Debug symbols for the ESP stack trace decoder.",
 };
 
+type FollowCbs = {
+  onResult?: (d: unknown) => void;
+  onError?: (e: string) => void;
+};
+
 // get_binaries can return a different list on each call (empty before a
 // compile, populated after), so accept a queue of results.
 function makeHost(getBinariesResults: FirmwareBinary[][]) {
@@ -50,8 +55,8 @@ function makeHost(getBinariesResults: FirmwareBinary[][]) {
     firmwareCompile: vi
       .fn()
       .mockResolvedValue({ job_id: "j1", source: JobSource.LOCAL, source_label: "" }),
-    firmwareFollowJob: vi.fn((_id: string, cbs: { onResult: (d: unknown) => void }) => {
-      cbs.onResult({ status: JobStatus.COMPLETED });
+    firmwareFollowJob: vi.fn((_id: string, cbs: FollowCbs) => {
+      cbs.onResult?.({ status: JobStatus.COMPLETED });
       return "s1";
     }),
     firmwareGetBinaries,
@@ -186,17 +191,31 @@ describe("download waits for a running build (#1200)", () => {
   it("continues to its own compile when the awaited job ends non-completed", async () => {
     const { host, api } = makeHost([[], [FACTORY]]);
     host._activeJobs.set("device.yaml", runningJob);
-    api.firmwareFollowJob.mockImplementationOnce(
-      (_id: string, cbs: { onResult: (d: unknown) => void }) => {
-        cbs.onResult({ status: JobStatus.CANCELLED });
-        return "s1";
-      }
-    );
+    api.firmwareFollowJob.mockImplementationOnce((_id: string, cbs: FollowCbs) => {
+      cbs.onResult?.({ status: JobStatus.CANCELLED });
+      return "s1";
+    });
     await run(host);
     // The wait resolves regardless of outcome; the empty build dir then
     // triggers the download's own (no-longer-superseding) compile.
     expect(api.firmwareCompile).toHaveBeenCalledTimes(1);
     expect(host._step).toBe("download-ready");
+  });
+
+  it("fails closed when the follow stream errors mid-wait", async () => {
+    // A dead stream says nothing about the job: proceeding could still read
+    // torn artifacts or supersede it, so the flow fails instead.
+    const { host, api } = makeHost([[FACTORY]]);
+    host._activeJobs.set("device.yaml", runningJob);
+    api.firmwareFollowJob.mockImplementationOnce((_id: string, cbs: FollowCbs) => {
+      cbs.onError?.("stream lost");
+      return "s1";
+    });
+    await run(host);
+    expect(host._step).toBe("error");
+    expect(host._statusMessage).toBe("firmware.download_failed");
+    expect(api.firmwareGetBinaries).not.toHaveBeenCalled();
+    expect(api.firmwareCompile).not.toHaveBeenCalled();
   });
 
   it("bails without touching the backend when dismissed mid-wait", async () => {

--- a/test/components/firmware-install-dialog-download-binary.test.ts
+++ b/test/components/firmware-install-dialog-download-binary.test.ts
@@ -74,6 +74,8 @@ function makeHost(installer: Installer, binaries: FirmwareBinary[]) {
     _jobSource: JobSource.LOCAL,
     _jobSourceLabel: "",
     _compileReject: null as null | ((e: unknown) => void),
+    _activeJobs: new Map<string, unknown>(),
+    _timer: { noteLine: vi.fn() },
     _localize: identityLocalize,
     _fail: vi.fn(),
   };


### PR DESCRIPTION
# What does this implement/fix?

The three-dot **Download** was the last unguarded supersede path (#1200): with the device mid-build it either downloaded artifacts the running compile was actively rewriting (torn/stale files), or — when the build dir was empty — enqueued a compile that superseded (cancelled + restarted) the running job.

Per the direction on the issue, Download now **waits for the running build and then shows the download screen**: `startArtifactDownload` looks up the configuration's active job (the dialog now consumes `activeJobsContext`), streams it into the dialog with a "Waiting for the current build to finish…" status while the log/timer UI runs, and continues to fresh artifacts once it reaches a terminal state.

Two deliberate details:

- **The waiter never claims the job** — `_jobId` stays empty, so dismissing the download dialog tears down only the follow stream; the dialog's dismiss path cancels `_jobId`, and it must not cancel a build it doesn't own. Pinned by a test.
- **Any terminal outcome unblocks the download** — a failed or cancelled awaited build just means the flow falls through to its own (no-longer-superseding) compile, exactly like the empty-build-dir case.

Issue item 2 (the optional `openForDevice` backstop guard) was deliberately declined — Download-path guard only.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1200

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
