### PR TITLE
Make Retry wait out a foreign running build before re-flashing

### DIFF
--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -40,6 +40,7 @@ import {
   startDownload,
   startUsbFlash,
   startWebSerialInstall,
+  waitForRunningJob,
 } from "./firmware-install-dialog/install-flow.js";
 import {
   cardState,
@@ -392,10 +393,26 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   // build/flash, so a transient error (serial noise, the external flasher's
   // chip-init failing, a closed flasher tab) can be retried in place. Routes by
   // installer since web-flash hands off to the external tab again.
-  _retry = () => {
-    if (!this._device) return;
-    if (this._installer === "web-flash") this.installUsbFlash(this._device);
-    else this.installWebSerial(this._device);
+  _retry = async () => {
+    const device = this._device;
+    if (!device) return;
+    // A foreign build may have started while the error screen sat open;
+    // Retry bypasses the page-level seam guards, so re-running now would
+    // supersede it (#1202). Wait it out like the download flow instead.
+    const running = this._activeJobs.get(device.configuration);
+    if (running) {
+      this._step = "queued";
+      this._errorMessage = "";
+      this._statusMessage = this._localize("firmware.status_waiting_build");
+      const settled = await waitForRunningJob(
+        this,
+        running.job_id,
+        "firmware.install_failed"
+      );
+      if (!settled) return;
+    }
+    if (this._installer === "web-flash") this.installUsbFlash(device);
+    else this.installWebSerial(device);
   };
 
   _cancel = async () => {

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -403,9 +403,10 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     if (running) {
       this._step = "queued";
       this._errorMessage = "";
-      // Drop the failed run's log so the wait streams only the foreign
-      // build, not the old failure concatenated with it.
+      // Drop the failed run's log and clocks so the wait streams only the
+      // foreign build, not the old failure's lines or elapsed time.
       this._logLines = [];
+      this._timer.reset();
       this._statusMessage = this._localize("firmware.status_waiting_build");
       const settled = await waitForRunningJob(
         this,

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -403,6 +403,9 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     if (running) {
       this._step = "queued";
       this._errorMessage = "";
+      // Drop the failed run's log so the wait streams only the foreign
+      // build, not the old failure concatenated with it.
+      this._logLines = [];
       this._statusMessage = this._localize("firmware.status_waiting_build");
       const settled = await waitForRunningJob(
         this,

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -548,15 +548,17 @@ async function artifactsSettled(
  * Deliberately never sets ``host._jobId``: the dialog doesn't own this
  * job, so dismissing the download must not cancel it — teardown only
  * stops the follow stream. Resolves true on ANY terminal outcome (a
- * failed or cancelled build just means the download compiles fresh
+ * failed or cancelled build just means the caller compiles fresh
  * afterwards); false when the dialog was dismissed mid-wait, or on a
  * follow-stream error — a dead stream says nothing about the job, so
  * proceeding could still read torn artifacts or supersede it. The error
- * case fails the dialog; a retry re-reads the active-jobs map.
+ * case fails the dialog with *failKey*; a retry re-reads the active-jobs
+ * map.
  */
-function waitForRunningJob(
+export function waitForRunningJob(
   host: ESPHomeFirmwareInstallDialog,
-  jobId: string
+  jobId: string,
+  failKey = "firmware.download_failed"
 ): Promise<boolean> {
   return new Promise((resolve) => {
     host._compileReject = () => resolve(false);
@@ -574,7 +576,7 @@ function waitForRunningJob(
       onError: () => {
         host._streamId = "";
         host._compileReject = null;
-        host._fail(host._localize("firmware.download_failed"));
+        host._fail(host._localize(failKey));
         resolve(false);
       },
     });

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -546,7 +546,7 @@ async function artifactsSettled(
  * a terminal state.
  *
  * Deliberately never sets ``host._jobId``: the dialog doesn't own this
- * job, so dismissing the download must not cancel it — teardown only
+ * job, so dismissing the dialog must not cancel it — teardown only
  * stops the follow stream. Resolves true on ANY terminal outcome (a
  * failed or cancelled build just means the caller compiles fresh
  * afterwards); false when the dialog was dismissed mid-wait, or on a

--- a/test/components/firmware-install-dialog-retry-busy.test.ts
+++ b/test/components/firmware-install-dialog-retry-busy.test.ts
@@ -39,6 +39,7 @@ function makeDialog(busy: boolean) {
     _device: { configuration: "device.yaml" } as ConfiguredDevice,
     _installer: "web-serial",
     _step: "error",
+    _logLines: ["old failure line"],
     _localize: identityLocalize,
     _activeJobs: busy ? new Map([["device.yaml", runningJob]]) : new Map(),
     _api: { firmwareFollowJob: followJob },
@@ -58,6 +59,8 @@ describe("install-dialog Retry while a foreign build runs", () => {
     expect(installWebSerial).toHaveBeenCalledTimes(1);
     // Never claims the foreign job: dismissal must not cancel it.
     expect(dialog._jobId).toBe("");
+    // The failed run's log was dropped, not concatenated with the wait's.
+    expect(dialog._logLines).not.toContain("old failure line");
   });
 
   it("routes a web-flash retry through the USB flow after the wait", async () => {

--- a/test/components/firmware-install-dialog-retry-busy.test.ts
+++ b/test/components/firmware-install-dialog-retry-busy.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The error-screen Retry bypasses the page-level seam guards, so it waits
+ * out a foreign running build (never claiming it) before re-running the
+ * install flow (#1202).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("../../src/util/web-serial.js", () => ({
+  connectToPort: vi.fn(),
+  detectChip: vi.fn(),
+  disconnect: vi.fn(),
+  flashFirmware: vi.fn(),
+  resetAndDisconnect: vi.fn(),
+  SERIAL_ACTIVITY_WINDOW_MS: 6000,
+}));
+
+import type { ConfiguredDevice } from "../../src/api/types/devices.js";
+import type { FirmwareJob } from "../../src/api/types/firmware-jobs.js";
+import { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
+import { identityLocalize } from "../_dom.js";
+
+type FollowCbs = {
+  onResult?: (d: unknown) => void;
+  onError?: (e: string) => void;
+};
+
+const runningJob = { job_id: "foreign-1", configuration: "device.yaml" } as FirmwareJob;
+
+function makeDialog(busy: boolean) {
+  const dialog = new ESPHomeFirmwareInstallDialog();
+  const followJob = vi.fn((_id: string, cbs: FollowCbs) => {
+    cbs.onResult?.({ status: "completed" });
+    return "s1";
+  });
+  Object.assign(dialog, {
+    _device: { configuration: "device.yaml" } as ConfiguredDevice,
+    _installer: "web-serial",
+    _step: "error",
+    _localize: identityLocalize,
+    _activeJobs: busy ? new Map([["device.yaml", runningJob]]) : new Map(),
+    _api: { firmwareFollowJob: followJob },
+  });
+  const installWebSerial = vi.fn();
+  const installUsbFlash = vi.fn();
+  dialog.installWebSerial = installWebSerial;
+  dialog.installUsbFlash = installUsbFlash;
+  return { dialog, followJob, installWebSerial, installUsbFlash };
+}
+
+describe("install-dialog Retry while a foreign build runs", () => {
+  it("waits out the running job (without claiming it), then retries", async () => {
+    const { dialog, followJob, installWebSerial } = makeDialog(true);
+    await dialog._retry();
+    expect(followJob).toHaveBeenCalledWith("foreign-1", expect.anything());
+    expect(installWebSerial).toHaveBeenCalledTimes(1);
+    // Never claims the foreign job: dismissal must not cancel it.
+    expect(dialog._jobId).toBe("");
+  });
+
+  it("routes a web-flash retry through the USB flow after the wait", async () => {
+    const { dialog, installUsbFlash, installWebSerial } = makeDialog(true);
+    dialog._installer = "web-flash";
+    await dialog._retry();
+    expect(installUsbFlash).toHaveBeenCalledTimes(1);
+    expect(installWebSerial).not.toHaveBeenCalled();
+  });
+
+  it("fails with the install message and does not retry on a stream error", async () => {
+    const { dialog, followJob, installWebSerial } = makeDialog(true);
+    followJob.mockImplementationOnce((_id: string, cbs: FollowCbs) => {
+      cbs.onError?.("stream lost");
+      return "s1";
+    });
+    await dialog._retry();
+    expect(dialog._step).toBe("error");
+    expect(dialog._statusMessage).toBe("firmware.install_failed");
+    expect(installWebSerial).not.toHaveBeenCalled();
+  });
+
+  it("bails when dismissed mid-wait", async () => {
+    const { dialog, followJob, installWebSerial } = makeDialog(true);
+    followJob.mockImplementationOnce(() => "s1"); // never completes
+    const flow = dialog._retry();
+    expect(dialog._compileReject).not.toBeNull();
+    dialog._compileReject!(new Error("Install dialog dismissed"));
+    await flow;
+    expect(installWebSerial).not.toHaveBeenCalled();
+  });
+
+  it("retries immediately when nothing is running", async () => {
+    const { dialog, followJob, installWebSerial } = makeDialog(false);
+    await dialog._retry();
+    expect(followJob).not.toHaveBeenCalled();
+    expect(installWebSerial).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/components/firmware-install-dialog-retry-busy.test.ts
+++ b/test/components/firmware-install-dialog-retry-busy.test.ts
@@ -63,6 +63,13 @@ describe("install-dialog Retry while a foreign build runs", () => {
     expect(dialog._logLines).not.toContain("old failure line");
   });
 
+  it("resets the compile clocks before streaming the foreign build", async () => {
+    const { dialog } = makeDialog(true);
+    const reset = vi.spyOn(dialog._timer, "reset");
+    await dialog._retry();
+    expect(reset).toHaveBeenCalled();
+  });
+
   it("routes a web-flash retry through the USB flow after the wait", async () => {
     const { dialog, installUsbFlash, installWebSerial } = makeDialog(true);
     dialog._installer = "web-flash";


### PR DESCRIPTION
# What does this implement/fix?

The install dialog's error-screen **Retry** re-invokes `installWebSerial` / `installUsbFlash` directly on the dialog, bypassing the #1199 seam guards — so a build started while the error screen sat open (second tab, Update All, a deferred queued update firing) would be superseded (cancelled + restarted) by the retry's compile. It was the last caller that could reach `compileOrFail` while a foreign job runs.

Per the direction on #1202, Retry now **waits out the running build, then retries**: `_retry` reuses #1201's `waitForRunningJob` (now exported), flipping the dialog from the error screen to the queued/compiling view with the "Waiting for the current build to finish…" status and streaming the foreign job's output until it reaches a terminal state, then re-runs the install flow against the settled build dir. The waiter still never claims the job — dismissing the dialog mid-wait tears down only the follow stream and can't cancel a build it doesn't own.

The waiter's stream-error failure key is parameterized (`firmware.install_failed` for retry vs the existing `firmware.download_failed`), so a fail-closed stream error reads as an install failure in this context. No new i18n keys.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1202

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
