### PR TITLE
Batch the install dialog's log streaming like the command dialog

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -36,6 +36,7 @@ import { espHomeStyles } from "../styles/shared.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { configurationStem, downloadAnsiText } from "../util/download-text.js";
 import { LightDismissController } from "../util/light-dismiss-controller.js";
+import { LineBatcher } from "../util/line-batcher.js";
 import { dispatchShowLogsAfterInstall } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { RunTimerController } from "../util/run-timer-controller.js";
@@ -142,8 +143,9 @@ export class ESPHomeCommandDialog extends LitElement {
 
   // rAF batch buffer for streamed output — coalesce per-line writes
   // into one render per frame instead of one per line (#348).
-  private _pendingLines: string[] = [];
-  private _flushScheduled = 0;
+  private _lineBatch = new LineBatcher((batch) => {
+    this._lines = [...this._lines, ...batch];
+  });
 
   // Distinguishes user-stopped from backend-failed. Both flip _state to "error"
   // but only real failures get the reset-build-env hint.
@@ -463,31 +465,20 @@ export class ESPHomeCommandDialog extends LitElement {
   // Buffer a streamed line; flushed on the next animation frame.
   _enqueueLine(line: string): void {
     this._timer.noteLine(line);
-    this._pendingLines.push(line);
-    if (this._flushScheduled) return;
-    this._flushScheduled = requestAnimationFrame(() => {
-      this._flushScheduled = 0;
-      this._flushPendingLines();
-    });
+    this._lineBatch.enqueue(line);
   }
 
   // Drain pending lines into ``_lines`` now. Called from terminal
   // callbacks, detachStream, and _downloadOutput so consumers
   // don't race the rAF.
   _flushPendingLines(): void {
-    if (this._pendingLines.length === 0) return;
-    this._lines = [...this._lines, ...this._pendingLines];
-    this._pendingLines = [];
+    this._lineBatch.flush();
   }
 
   // Drop the pending batch and cancel any scheduled flush. Paired
   // with every ``_lines = []`` reset.
   _resetPendingLines(): void {
-    this._pendingLines = [];
-    if (this._flushScheduled) {
-      cancelAnimationFrame(this._flushScheduled);
-      this._flushScheduled = 0;
-    }
+    this._lineBatch.reset();
   }
 
   _downloadOutput = () => {

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -28,6 +28,7 @@ import {
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { initialDarkMode } from "../util/dark-mode.js";
+import { LineBatcher } from "../util/line-batcher.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { RunTimerController } from "../util/run-timer-controller.js";
 import type { DetectedChip } from "../util/web-serial.js";
@@ -153,6 +154,12 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   _jobId = "";
   _streamId = "";
 
+  // rAF batch buffer for streamed output — coalesce per-line writes into
+  // one render per frame instead of one per line (#1203).
+  private _lineBatch = new LineBatcher((batch) => {
+    this._logLines = [...this._logLines, ...batch];
+  });
+
   // Build compile clocks — drives the compiling-step elapsed readout + the
   // offload hint. The step-based runEnded backstop freezes the span when the
   // flow leaves compiling without a summary banner.
@@ -261,6 +268,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     });
     this._statusMessage = "";
     this._errorMessage = "";
+    this._lineBatch.reset();
     this._logLines = [];
     this._logsExpanded = false;
     this._flashPercent = 0;
@@ -285,6 +293,8 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   // stops working for a dismissed dialog, unless ``cancelJob: false`` —
   // then the job is released to finish in the background queue.
   _detachStream({ cancelJob = true }: { cancelJob?: boolean } = {}) {
+    // Land any buffered lines before teardown so nothing streamed is lost.
+    this._flushLogLines();
     // Tear down an in-flight USB-flasher hand-off (message listener + timers)
     // too, so closing or reusing the dialog can't leak it or let a stale
     // flasher tab mutate the next install's state. Pure teardown, no _fail.
@@ -334,10 +344,23 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   // Drop into red error state. detail is optional — render skips it entirely
   // when empty so a single-string call doesn't paint the same text twice.
   _fail(title: string, detail = "") {
+    // The expanded log must show every line up to the failure, not race the rAF.
+    this._flushLogLines();
     this._step = "error";
     this._statusMessage = title;
     this._errorMessage = detail;
     this._logsExpanded = true;
+  }
+
+  // Buffer a streamed line; flushed on the next animation frame.
+  _enqueueLogLine(line: string): void {
+    this._lineBatch.enqueue(line);
+  }
+
+  // Drain pending lines into ``_logLines`` now — terminal callbacks and
+  // teardown call this so consumers don't race the rAF.
+  _flushLogLines(): void {
+    this._lineBatch.flush();
   }
 
   // Close + navigate to /device/<configuration>. Same payload shape as

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -68,7 +68,7 @@ export async function startWebSerialInstall(
   // install showed no esptool logs at all, unlike the OTA / server-serial
   // paths which stream the backend job output (#346).
   const onLog = (line: string) => {
-    host._logLines = [...host._logLines, line];
+    host._enqueueLogLine(line);
   };
 
   // 1. Connect and detect chip
@@ -564,11 +564,12 @@ function waitForRunningJob(
       onOutput: (line) => {
         if (host._step === "queued") host._step = "compiling";
         host._timer.noteLine(line);
-        host._logLines = [...host._logLines, line];
+        host._enqueueLogLine(line);
       },
       onResult: () => {
         host._streamId = "";
         host._compileReject = null;
+        host._flushLogLines();
         resolve(true);
       },
       onError: () => {
@@ -605,13 +606,14 @@ export function compileAndWait(
             host._statusMessage = host._localize("firmware.status_compiling");
           }
           host._timer.noteLine(line);
-          host._logLines = [...host._logLines, line];
+          host._enqueueLogLine(line);
           if (isValidationFailureLine(line)) host._failedDuringValidate = true;
         },
         onResult: (data) => {
           host._streamId = "";
           host._jobId = "";
           host._compileReject = null;
+          host._flushLogLines();
           const result = data as unknown as {
             status: string;
             error?: string | null;

--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -236,6 +236,9 @@ export function renderStatusExtra(
 }
 
 function downloadInstallLogs(host: ESPHomeFirmwareInstallDialog): void {
+  // Land the pending rAF batch so a mid-stream download can't drop the
+  // last frame of lines (mirrors command-dialog's _downloadOutput).
+  host._flushLogLines();
   const stem = configurationStem(host._device?.configuration, "install");
   downloadAnsiText(host._logLines, `${stem}-install.txt`);
 }

--- a/src/util/line-batcher.ts
+++ b/src/util/line-batcher.ts
@@ -1,0 +1,40 @@
+/**
+ * rAF-batched sink for streamed log lines.
+ *
+ * Reactive log arrays must be reassigned (not mutated) for Lit change
+ * detection, so appending per line copies the whole array per line —
+ * O(n²) over a compile log. Buffer here and coalesce into one
+ * reassignment per animation frame instead (#348, #1203). Call
+ * ``flush()`` at terminal transitions so consumers don't race the rAF,
+ * and ``reset()`` alongside every log-array reset.
+ */
+export class LineBatcher {
+  private _pending: string[] = [];
+  private _scheduled = 0;
+
+  constructor(private readonly _append: (batch: string[]) => void) {}
+
+  enqueue(line: string): void {
+    this._pending.push(line);
+    if (this._scheduled) return;
+    this._scheduled = requestAnimationFrame(() => {
+      this._scheduled = 0;
+      this.flush();
+    });
+  }
+
+  flush(): void {
+    if (this._pending.length === 0) return;
+    const batch = this._pending;
+    this._pending = [];
+    this._append(batch);
+  }
+
+  reset(): void {
+    this._pending = [];
+    if (this._scheduled) {
+      cancelAnimationFrame(this._scheduled);
+      this._scheduled = 0;
+    }
+  }
+}

--- a/test/components/firmware-install-dialog-artifact-download.test.ts
+++ b/test/components/firmware-install-dialog-artifact-download.test.ts
@@ -74,6 +74,11 @@ function makeHost(getBinariesResults: FirmwareBinary[][]) {
     _binaries: [] as FirmwareBinary[],
     _downloadedFilename: "",
     _logLines: [] as string[],
+    // Synchronous stand-ins for the dialog's rAF-batched log sink.
+    _enqueueLogLine(line: string) {
+      this._logLines = [...this._logLines, line];
+    },
+    _flushLogLines() {},
     _failedDuringCompile: false,
     _jobId: "",
     _streamId: "",

--- a/test/components/firmware-install-dialog-download-binary.test.ts
+++ b/test/components/firmware-install-dialog-download-binary.test.ts
@@ -67,6 +67,11 @@ function makeHost(installer: Installer, binaries: FirmwareBinary[]) {
     _binaries: [] as FirmwareBinary[],
     _downloadedFilename: "",
     _logLines: [] as string[],
+    // Synchronous stand-ins for the dialog's rAF-batched log sink.
+    _enqueueLogLine(line: string) {
+      this._logLines = [...this._logLines, line];
+    },
+    _flushLogLines() {},
     _failedDuringCompile: false,
     _failedDuringValidate: false,
     _jobId: "",

--- a/test/components/firmware-install-dialog-log-batching.test.ts
+++ b/test/components/firmware-install-dialog-log-batching.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the dialog-level batching wiring with a REAL LineBatcher (the flow
+ * harnesses stub the sink): lines buffer until a flush point, and _fail /
+ * _detachStream land the pending batch synchronously.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("../../src/util/web-serial.js", () => ({
+  connectToPort: vi.fn(),
+  detectChip: vi.fn(),
+  disconnect: vi.fn(),
+  flashFirmware: vi.fn(),
+  resetAndDisconnect: vi.fn(),
+  SERIAL_ACTIVITY_WINDOW_MS: 6000,
+}));
+
+import { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
+import { identityLocalize } from "../_dom.js";
+
+function makeDialog(): ESPHomeFirmwareInstallDialog {
+  const dialog = new ESPHomeFirmwareInstallDialog();
+  Object.assign(dialog, { _localize: identityLocalize });
+  return dialog;
+}
+
+describe("install-dialog log batching wiring", () => {
+  it("buffers lines until the frame, and _fail lands them synchronously", () => {
+    const dialog = makeDialog();
+    dialog._enqueueLogLine("buffered line");
+    // Still pending — the rAF hasn't fired.
+    expect(dialog._logLines).toEqual([]);
+    dialog._fail("boom");
+    // The expanded error log must show every line, not race the rAF.
+    expect(dialog._logLines).toEqual(["buffered line"]);
+  });
+
+  it("_detachStream lands the pending batch before teardown", () => {
+    const dialog = makeDialog();
+    dialog._enqueueLogLine("last line");
+    dialog._detachStream();
+    expect(dialog._logLines).toEqual(["last line"]);
+  });
+});

--- a/test/components/firmware-install-dialog-log-batching.test.ts
+++ b/test/components/firmware-install-dialog-log-batching.test.ts
@@ -16,9 +16,16 @@ vi.mock("../../src/util/web-serial.js", () => ({
   resetAndDisconnect: vi.fn(),
   SERIAL_ACTIVITY_WINDOW_MS: 6000,
 }));
+const { downloadAnsiText } = vi.hoisted(() => ({ downloadAnsiText: vi.fn() }));
+vi.mock("../../src/util/download-text.js", () => ({
+  configurationStem: vi.fn(() => "device"),
+  downloadAnsiText,
+  triggerDownload: vi.fn(),
+}));
 
 import { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
-import { identityLocalize } from "../_dom.js";
+import { renderLogs } from "../../src/components/firmware-install-dialog/renderers.js";
+import { identityLocalize, renderInto } from "../_dom.js";
 
 function makeDialog(): ESPHomeFirmwareInstallDialog {
   const dialog = new ESPHomeFirmwareInstallDialog();
@@ -42,5 +49,19 @@ describe("install-dialog log batching wiring", () => {
     dialog._enqueueLogLine("last line");
     dialog._detachStream();
     expect(dialog._logLines).toEqual(["last line"]);
+  });
+
+  it("a mid-stream log download flushes before reading", () => {
+    const dialog = makeDialog();
+    Object.assign(dialog, { _logLines: ["landed line"] });
+    dialog._enqueueLogLine("buffered line");
+    const container = renderInto(renderLogs(dialog));
+    // Second .logs-toggle is the download button (first is the expander).
+    const buttons = container.querySelectorAll<HTMLElement>(".logs-toggle");
+    buttons[1].click();
+    expect(downloadAnsiText).toHaveBeenCalledWith(
+      ["landed line", "buffered line"],
+      "device-install.txt"
+    );
   });
 });

--- a/test/components/firmware-install-dialog-usb-flash.test.ts
+++ b/test/components/firmware-install-dialog-usb-flash.test.ts
@@ -42,6 +42,11 @@ function makeHost(opts: { compileOk: boolean; binaries?: FirmwareBinary[] }) {
     _statusMessage: "",
     _errorMessage: "",
     _logLines: [] as string[],
+    // Synchronous stand-ins for the dialog's rAF-batched log sink.
+    _enqueueLogLine(line: string) {
+      this._logLines = [...this._logLines, line];
+    },
+    _flushLogLines() {},
     _jobId: "",
     _streamId: "",
     _compileReject: null,

--- a/test/components/firmware-install-dialog-web-serial.test.ts
+++ b/test/components/firmware-install-dialog-web-serial.test.ts
@@ -58,6 +58,11 @@ function makeHost() {
     _statusMessage: "",
     _flashPercent: 0,
     _logLines: [] as string[],
+    // Synchronous stand-ins for the dialog's rAF-batched log sink.
+    _enqueueLogLine(line: string) {
+      this._logLines = [...this._logLines, line];
+    },
+    _flushLogLines() {},
     _open: true,
     _showLogsAfterInstall: false,
     _detected: null as unknown,

--- a/test/util/line-batcher.test.ts
+++ b/test/util/line-batcher.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the LineBatcher contract: one append per frame regardless of line
+ * count, flush drains immediately, reset drops pending lines and cancels
+ * the scheduled frame.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LineBatcher } from "../../src/util/line-batcher.js";
+
+function withManualRaf() {
+  const frames: FrameRequestCallback[] = [];
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    frames.push(cb);
+    return frames.length;
+  });
+  const cancelled: number[] = [];
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    cancelled.push(id);
+  });
+  return {
+    frames,
+    cancelled,
+    fire: () => {
+      const pending = frames.splice(0);
+      for (const cb of pending) cb(0);
+    },
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("LineBatcher", () => {
+  it("coalesces many enqueues into one append per frame", () => {
+    const raf = withManualRaf();
+    const append = vi.fn();
+    const batcher = new LineBatcher(append);
+    batcher.enqueue("a");
+    batcher.enqueue("b");
+    batcher.enqueue("c");
+    expect(append).not.toHaveBeenCalled();
+    expect(raf.frames).toHaveLength(1); // one frame scheduled, not three
+    raf.fire();
+    expect(append).toHaveBeenCalledTimes(1);
+    expect(append).toHaveBeenCalledWith(["a", "b", "c"]);
+  });
+
+  it("flush drains immediately and the later frame is a no-op", () => {
+    const raf = withManualRaf();
+    const append = vi.fn();
+    const batcher = new LineBatcher(append);
+    batcher.enqueue("a");
+    batcher.flush();
+    expect(append).toHaveBeenCalledWith(["a"]);
+    raf.fire();
+    expect(append).toHaveBeenCalledTimes(1); // nothing left to append
+  });
+
+  it("reset drops pending lines and cancels the scheduled frame", () => {
+    const raf = withManualRaf();
+    const append = vi.fn();
+    const batcher = new LineBatcher(append);
+    batcher.enqueue("a");
+    batcher.reset();
+    expect(raf.cancelled).toHaveLength(1);
+    raf.fire();
+    batcher.flush();
+    expect(append).not.toHaveBeenCalled();
+  });
+
+  it("keeps batching across frames", () => {
+    const raf = withManualRaf();
+    const lines: string[] = [];
+    const batcher = new LineBatcher((batch) => lines.push(...batch));
+    batcher.enqueue("a");
+    raf.fire();
+    batcher.enqueue("b");
+    batcher.enqueue("c");
+    raf.fire();
+    expect(lines).toEqual(["a", "b", "c"]);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The firmware-install dialog appended streamed log output one line at a time via `_logLines = [...prev, line]` — a full array copy per line, O(n²) over a compile log, at three sites (the web-serial esptool stream, `compileAndWait`, and #1201's `waitForRunningJob`). The command dialog already solved the identical problem with an rAF-coalesced buffer (#348).

Per the direction on #1203, this extracts that mechanism into a shared `LineBatcher` util (`src/util/line-batcher.ts`: `enqueue` schedules one flush per animation frame, `flush` drains immediately, `reset` drops pending lines and cancels the frame) and points both dialogs at it:

- **Command dialog**: `_enqueueLine` / `_flushPendingLines` / `_resetPendingLines` keep their exact API (callers in `commands.ts` and existing tests untouched) but delegate to the shared batcher.
- **Install dialog**: the three per-line copy sites now enqueue; flushes land at the terminal follow callbacks, `_fail` (the expanded error log must show every line, not race the rAF), and `_detachStream`; `_init` resets the pending batch alongside `_logLines`.

The four install-dialog test harnesses gained synchronous stand-ins for the sink so their assertions stay deterministic, and a new unit suite pins the `LineBatcher` contract (one append per frame, immediate flush, reset cancels the frame, batching across frames).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1203

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
