### PR TITLE
Move logs-dialog's capped log batching onto LineBatcher

### DIFF
--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -21,6 +21,7 @@ import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { configurationStem, downloadAnsiText } from "../util/download-text.js";
+import { LineBatcher } from "../util/line-batcher.js";
 import { notifyError } from "../util/notify.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { logsDialogStyles } from "./logs-dialog.styles.js";
@@ -116,9 +117,11 @@ export class ESPHomeLogsDialog extends LitElement {
   // rAF batch buffer: coalesce per-line appends into one render per frame
   // instead of one per line (mirrors command-dialog, #348). A fast serial
   // stream would otherwise schedule a full re-render of the whole list per
-  // line and freeze the tab.
-  private _pendingLines: string[] = [];
-  private _flushScheduled = 0;
+  // line and freeze the tab. maxLines bounds the pending buffer while the
+  // tab is hidden; _appendCapped bounds the visible one.
+  private _lineBatch = new LineBatcher((batch) => this._appendCapped(batch), {
+    maxLines: MAX_LOG_LINES,
+  });
 
   @state()
   private _open = false;
@@ -521,18 +524,7 @@ export class ESPHomeLogsDialog extends LitElement {
   // Buffer a streamed line; flushed on the next animation frame. The serial
   // reader (streamSerialToDialog) and the OTA stream both feed through here.
   _enqueueLine(line: string): void {
-    this._pendingLines.push(line);
-    // rAF doesn't fire while the tab is hidden, so a flood can pile up here
-    // unflushed. Trim with headroom (so we slice once per MAX_LOG_LINES pushes,
-    // not every push) to keep the pending buffer bounded too.
-    if (this._pendingLines.length > 2 * MAX_LOG_LINES) {
-      this._pendingLines = this._pendingLines.slice(-MAX_LOG_LINES);
-    }
-    if (this._flushScheduled) return;
-    this._flushScheduled = requestAnimationFrame(() => {
-      this._flushScheduled = 0;
-      this._flushPendingLines();
-    });
+    this._lineBatch.enqueue(line);
   }
 
   // Append to the visible buffer, trimmed to the newest MAX_LOG_LINES. The
@@ -547,19 +539,13 @@ export class ESPHomeLogsDialog extends LitElement {
   // MAX_LOG_LINES. Called from teardown / clear / download so consumers
   // don't race the rAF.
   _flushPendingLines(): void {
-    if (this._pendingLines.length === 0) return;
-    this._appendCapped(this._pendingLines);
-    this._pendingLines = [];
+    this._lineBatch.flush();
   }
 
   // Drop the pending batch and cancel any scheduled flush. Paired with every
   // ``_lines = []`` reset.
   _resetPendingLines(): void {
-    this._pendingLines = [];
-    if (this._flushScheduled) {
-      cancelAnimationFrame(this._flushScheduled);
-      this._flushScheduled = 0;
-    }
+    this._lineBatch.reset();
   }
 
   // Reset Device button (Web Serial only). Pulses RTS (wired to EN on the

--- a/src/util/line-batcher.ts
+++ b/src/util/line-batcher.ts
@@ -7,15 +7,30 @@
  * reassignment per animation frame instead (#348, #1203). Call
  * ``flush()`` at terminal transitions so consumers don't race the rAF,
  * and ``reset()`` alongside every log-array reset.
+ *
+ * ``maxLines`` bounds only the PENDING buffer — rAF doesn't fire while
+ * the tab is hidden, so a flood can pile up unflushed. Capping the
+ * merged visible buffer is the append callback's job (it owns that
+ * array; see logs-dialog's ``_appendCapped``).
  */
 export class LineBatcher {
   private _pending: string[] = [];
   private _scheduled = 0;
+  private readonly _maxLines?: number;
 
-  constructor(private readonly _append: (batch: string[]) => void) {}
+  constructor(
+    private readonly _append: (batch: string[]) => void,
+    opts: { maxLines?: number } = {}
+  ) {
+    this._maxLines = opts.maxLines;
+  }
 
   enqueue(line: string): void {
     this._pending.push(line);
+    // Trim with headroom — one slice per maxLines pushes, not every push.
+    if (this._maxLines !== undefined && this._pending.length > 2 * this._maxLines) {
+      this._pending = this._pending.slice(-this._maxLines);
+    }
     if (this._scheduled) return;
     this._scheduled = requestAnimationFrame(() => {
       this._scheduled = 0;

--- a/test/components/logs-dialog-batching.test.ts
+++ b/test/components/logs-dialog-batching.test.ts
@@ -57,7 +57,8 @@ describe("logs-dialog line batching + cap", () => {
     // pending buffer must not grow without bound during a flood.
     const d = new ESPHomeLogsDialog();
     for (let i = 0; i < 12000; i++) d._enqueueLine(String(i));
-    const pending = (d as unknown as { _pendingLines: string[] })._pendingLines;
+    const pending = (d as unknown as { _lineBatch: { _pending: string[] } })._lineBatch
+      ._pending;
     expect(d._lines).toHaveLength(0); // nothing flushed without a frame
     expect(pending.length).toBeLessThanOrEqual(10000); // 2 * MAX_LOG_LINES
     expect(pending[pending.length - 1]).toBe("11999"); // newest retained

--- a/test/util/line-batcher.test.ts
+++ b/test/util/line-batcher.test.ts
@@ -79,4 +79,19 @@ describe("LineBatcher", () => {
     raf.fire();
     expect(lines).toEqual(["a", "b", "c"]);
   });
+
+  it("maxLines bounds the pending buffer when frames never fire (hidden tab)", () => {
+    const raf = withManualRaf();
+    const append = vi.fn();
+    const batcher = new LineBatcher(append, { maxLines: 100 });
+    for (let i = 0; i < 250; i++) batcher.enqueue(String(i));
+    raf.fire();
+    expect(append).toHaveBeenCalledTimes(1);
+    const batch = append.mock.calls[0][0] as string[];
+    // Trimmed once at 201 pushes (headroom = 2 × maxLines) down to the
+    // newest 100, then grew again: 101..249 survive, 0..100 dropped.
+    expect(batch).toHaveLength(149);
+    expect(batch[0]).toBe("101");
+    expect(batch[batch.length - 1]).toBe("249");
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Converts the last hand-rolled copy of the rAF log-batching pattern — the logs dialog's — onto the shared `LineBatcher` util that #1205 extracted for the command and install dialogs.

The logs dialog's variant differed in one way: it's capped. That splits into two caps with different owners, and the conversion respects the split:

- **Pending-buffer bound** (rAF doesn't fire in hidden tabs, so a flood piles up unflushed): moved into `LineBatcher` as an optional `maxLines`, with the same 2× headroom trim the dialog hand-rolled (one slice per `maxLines` pushes, not per push). The other two dialogs pass no cap and are unchanged.
- **Visible-buffer cap** (newest `MAX_LOG_LINES` after merge): stays in the dialog's `_appendCapped` append callback — it owns that array, and the direct recovery-path append (`setSerialOpenFailed`) uses it too.

The dialog's `_enqueueLine` / `_flushPendingLines` / `_resetPendingLines` keep their exact API and delegate, so the serial/OTA stream callers and existing tests are untouched (one test's internal `_pendingLines` peek repointed at the batcher). New unit case pins the `maxLines` headroom-trim behavior at the util level; the existing logs-dialog batching suite (coalescing, both caps, recovery append, reset) passes unchanged.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1206

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
