### PR TITLE
Suppress the slow-build offload hint on ESPHome Desktop

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -129,8 +129,6 @@ export class ESPHomeCommandDialog extends LitElement {
   @state()
   _pairings: Map<string, PairingSummary> | null = null;
 
-  // Suppress the offload hint on the Desktop app — the build machine already
-  // is the user's computer.
   @consume({ context: desktopVersionContext, subscribe: true })
   @state()
   _desktopVersion = "";

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -26,6 +26,7 @@ import {
   buildOffloadJobsContext,
   buildOffloadPairingsContext,
   darkModeContext,
+  desktopVersionContext,
   devicesContext,
   firmwareJobsContext,
   localizeContext,
@@ -127,6 +128,12 @@ export class ESPHomeCommandDialog extends LitElement {
   @consume({ context: buildOffloadPairingsContext, subscribe: true })
   @state()
   _pairings: Map<string, PairingSummary> | null = null;
+
+  // Suppress the offload hint on the Desktop app — the build machine already
+  // is the user's computer.
+  @consume({ context: desktopVersionContext, subscribe: true })
+  @state()
+  _desktopVersion = "";
 
   @consume({ context: versionContext, subscribe: true })
   @state()

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -204,6 +204,7 @@ function renderTimerDetail(
       elapsedMs: compile,
       source: resolveJobSource(host),
       pairings: host._pairings,
+      desktop: Boolean(host._desktopVersion),
     });
   return html`
     <div
@@ -254,6 +255,7 @@ export function renderOffloadHintSlot(
     elapsedMs: host._timer.compileElapsedMs ?? 0,
     source: resolveJobSource(host),
     pairings: host._pairings,
+    desktop: Boolean(host._desktopVersion),
   });
   return visible ? renderOffloadHint(host) : nothing;
 }

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -112,8 +112,6 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   @state()
   _pairings: Map<string, PairingSummary> | null = null;
 
-  // Suppress the offload hint on the Desktop app — the build machine already
-  // is the user's computer.
   @consume({ context: desktopVersionContext, subscribe: true })
   @state()
   _desktopVersion = "";

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -22,6 +22,7 @@ import {
   apiContext,
   buildOffloadPairingsContext,
   darkModeContext,
+  desktopVersionContext,
   firmwareJobsContext,
   localizeContext,
 } from "../context/index.js";
@@ -110,6 +111,12 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   @consume({ context: buildOffloadPairingsContext, subscribe: true })
   @state()
   _pairings: Map<string, PairingSummary> | null = null;
+
+  // Suppress the offload hint on the Desktop app — the build machine already
+  // is the user's computer.
+  @consume({ context: desktopVersionContext, subscribe: true })
+  @state()
+  _desktopVersion = "";
 
   @state() _open = false;
   @state() _step: InstallStep = "installing";

--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -173,6 +173,7 @@ export function renderOffloadHintSlot(
     elapsedMs: host._timer.compileElapsedMs ?? 0,
     source: host._jobSource,
     pairings: host._pairings,
+    desktop: Boolean(host._desktopVersion),
   });
   return visible ? renderOffloadHint(host) : nothing;
 }

--- a/src/components/process-terminal/offload-hint.ts
+++ b/src/components/process-terminal/offload-hint.ts
@@ -26,6 +26,7 @@ interface OffloadHintState {
   elapsedMs: number;
   source: JobSource;
   pairings: ReadonlyMap<string, unknown> | null;
+  desktop: boolean;
 }
 
 /**
@@ -34,9 +35,12 @@ interface OffloadHintState {
  * suppresses it. The "auto-route to remote build" toggle is *not* consulted —
  * it defaults on, so gating on it would hide this nudge from every default
  * dashboard; only an actual pairing means offload is set up. ``null`` pairings
- * (still loading) counts as "not set up".
+ * (still loading) counts as "not set up". The Desktop app is also suppressed:
+ * the build machine already is the user's computer, so there's likely no
+ * faster machine to offload to.
  */
 export function shouldShowOffloadHint(state: OffloadHintState): boolean {
+  if (state.desktop) return false;
   if (state.source !== JobSource.LOCAL) return false;
   if (state.elapsedMs < OFFLOAD_HINT_THRESHOLD_MS) return false;
   if ((state.pairings?.size ?? 0) > 0) return false;

--- a/test/components/process-terminal/offload-hint.test.ts
+++ b/test/components/process-terminal/offload-hint.test.ts
@@ -15,6 +15,7 @@ const base = {
   elapsedMs: OVER,
   source: JobSource.LOCAL,
   pairings: null,
+  desktop: false,
 };
 
 describe("shouldShowOffloadHint", () => {
@@ -31,6 +32,10 @@ describe("shouldShowOffloadHint", () => {
     expect(shouldShowOffloadHint({ ...base, source: JobSource.REMOTE_PENDING })).toBe(
       false
     );
+  });
+
+  it("stays hidden on the Desktop app (no faster machine to offload to)", () => {
+    expect(shouldShowOffloadHint({ ...base, desktop: true })).toBe(false);
   });
 
   it("stays hidden when a build server is paired", () => {


### PR DESCRIPTION
# What does this implement/fix?

When a local compile runs past five minutes, the dialogs nudge the user toward "send builds to a faster machine" (Settings → build offload). On ESPHome Desktop the build machine already *is* the user's computer — if their desktop is slow, there is likely no faster machine to offload to, so the nudge is noise.

`shouldShowOffloadHint` now takes a `desktop` flag and stays hidden when it's set. Both dialogs feed it from the handshake's `desktop_version` via the existing `desktopVersionContext`, so all three surfaces are covered through the one gate: the command dialog's inline suggestion slot, its timer-detail popover nudge, and the install dialog's suggestion slot. Non-desktop behaviour is unchanged.

**Related issue or feature (if applicable):**

- None (requested directly by maintainer)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
