### PR TITLE
Deep-target nested automation fields from a YAML-pane click

### DIFF
--- a/src/components/device/automation-editor/automation-action-list.ts
+++ b/src/components/device/automation-editor/automation-action-list.ts
@@ -30,7 +30,11 @@ import { espHomeStyles } from "../../../styles/shared.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import "./automation-action-node.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
-import { type AutomationFocus, childFocus } from "./automation-focus.js";
+import {
+  type AutomationFocus,
+  childFocus,
+  focusTargetHasChanged,
+} from "./automation-focus.js";
 import "./catalog-picker-dialog.js";
 import type {
   CatalogPickedDetail,
@@ -84,7 +88,7 @@ export class ESPHomeAutomationActionList extends LitElement {
 
   /** Cursor focus target whose ``node`` head indexes this list; the
    *  matching row gets the sliced remainder. */
-  @property({ attribute: false })
+  @property({ attribute: false, hasChanged: focusTargetHasChanged })
   focusTarget: AutomationFocus | null = null;
 
   @query("esphome-catalog-picker-dialog")

--- a/src/components/device/automation-editor/automation-action-list.ts
+++ b/src/components/device/automation-editor/automation-action-list.ts
@@ -30,6 +30,7 @@ import { espHomeStyles } from "../../../styles/shared.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import "./automation-action-node.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
+import { type AutomationFocus, childFocus } from "./automation-focus.js";
 import "./catalog-picker-dialog.js";
 import type {
   CatalogPickedDetail,
@@ -80,6 +81,11 @@ export class ESPHomeAutomationActionList extends LitElement {
 
   @property({ type: Boolean, attribute: "hide-add" })
   hideAdd = false;
+
+  /** Cursor focus target whose ``node`` head indexes this list; the
+   *  matching row gets the sliced remainder. */
+  @property({ attribute: false })
+  focusTarget: AutomationFocus | null = null;
 
   @query("esphome-catalog-picker-dialog")
   private _picker!: ESPHomeCatalogPickerDialog;
@@ -136,6 +142,9 @@ export class ESPHomeAutomationActionList extends LitElement {
   private _renderRow(node: ActionNode, idx: number, isLast: boolean) {
     return html`<esphome-automation-action-node
       .value=${node}
+      .focusTarget=${
+        this.focusTarget?.node[0] === idx ? childFocus(this.focusTarget) : null
+      }
       .catalog=${this.catalog}
       .conditionCatalog=${this.conditionCatalog}
       .scripts=${this.scripts}

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -38,6 +38,7 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
+import { pathIsAdvanced } from "../../../util/config-entry-tree.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import "../config-entry-form.js";
@@ -45,6 +46,7 @@ import type { ConfigEntryValueChange } from "../config-entry-form.js";
 import "../config-entry-renderers/lambda-editor.js";
 import { lambdaBodyOf } from "../config-entry-renderers/lambda.js";
 import { literalLambdaToggleStyles } from "../config-entry-renderers/literal-lambda-toggle.js";
+import { fieldHighlightStyles } from "../field-highlight.styles.js";
 import "./automation-condition-tree.js";
 import {
   delayLambdaOf,
@@ -55,6 +57,12 @@ import {
   writeDelayParams,
 } from "./automation-delay-params.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
+import {
+  type AutomationFocus,
+  childFocus,
+  focusKey,
+  scrollFlashRow,
+} from "./automation-focus.js";
 import "./catalog-picker-dialog.js";
 import type {
   CatalogPickedDetail,
@@ -122,6 +130,12 @@ export class ESPHomeAutomationActionNode extends LitElement {
   @property({ type: Boolean })
   last = false;
 
+  /** Cursor focus target routed to this node: ``"conditions"`` head →
+   *  the boolean gate, a child-list key → that nested list, empty →
+   *  this node's params form or the row itself. */
+  @property({ attribute: false })
+  focusTarget: AutomationFocus | null = null;
+
   @query("esphome-catalog-picker-dialog")
   private _picker!: ESPHomeCatalogPickerDialog;
 
@@ -150,7 +164,15 @@ export class ESPHomeAutomationActionNode extends LitElement {
     inputStyles,
     automationEditorStyles,
     literalLambdaToggleStyles,
+    fieldHighlightStyles,
   ];
+
+  /** ``focusKey`` of the last target applied, so a same-valued object
+   *  re-sliced by the parent's render doesn't re-run the side effects. */
+  private _lastFocusKey?: string;
+
+  /** Row-level scroll already performed for the current target. */
+  private _focusScrolled = false;
 
   /**
    * The list reuses nodes by DOM position (plain actions.map, no keyed
@@ -161,14 +183,62 @@ export class ESPHomeAutomationActionNode extends LitElement {
    * on that would snap the card shut mid-edit.
    */
   protected willUpdate(changed: PropertyValues<this>): void {
-    if (!changed.has("value")) return;
-    const previous = changed.get("value") as ActionNode | undefined;
-    if (previous && previous.action_id !== this.value.action_id) {
-      this._collapsed = false;
-      this._showAdvanced = false;
-      this._delayLambdaStash = "";
-      this._delayLiteralStash = null;
+    if (changed.has("value")) {
+      const previous = changed.get("value") as ActionNode | undefined;
+      if (previous && previous.action_id !== this.value.action_id) {
+        this._collapsed = false;
+        this._showAdvanced = false;
+        this._delayLambdaStash = "";
+        this._delayLiteralStash = null;
+      }
     }
+    if (changed.has("focusTarget")) this._applyFocusTarget();
+  }
+
+  /** One-shot per distinct target: un-collapse so the body renders, and
+   *  reveal advanced params when the target field hides behind them. */
+  private _applyFocusTarget(): void {
+    const key = focusKey(this.focusTarget);
+    if (key === this._lastFocusKey) return;
+    this._lastFocusKey = key;
+    if (!key) return;
+    this._focusScrolled = false;
+    this._collapsed = false;
+    const t = this.focusTarget!;
+    if (t.node.length === 0 && t.field.length > 0) {
+      const def = this.catalog.find((a) => a.id === this.value.action_id);
+      if (def && pathIsAdvanced(def.config_entries, t.field)) {
+        this._showAdvanced = true;
+      }
+    }
+  }
+
+  protected updated(): void {
+    this._maybeScrollSelf();
+  }
+
+  /** Scroll + flash this row when the target terminates here — a
+   *  node-level target, or one the rendered surface can't forward
+   *  (no gate/child list/params form for the remaining path). */
+  private _maybeScrollSelf(): void {
+    const t = this.focusTarget;
+    if (!t || this._focusScrolled || !this._isTerminalFocus(t)) return;
+    this._focusScrolled = true;
+    const row = this.shadowRoot?.querySelector<HTMLElement>(".ae-row");
+    if (row) scrollFlashRow(row);
+  }
+
+  private _isTerminalFocus(t: AutomationFocus): boolean {
+    const def = this.catalog.find((a) => a.id === this.value.action_id);
+    const head = t.node[0];
+    if (head === "conditions") return !(def?.id === "if" || def?.id === "wait_until");
+    if (typeof head === "string") {
+      return !(def?.accepts_action_list ?? []).includes(head);
+    }
+    if (t.field.length === 0) return true;
+    // Field target with no catalog form to arm (bespoke delay widget,
+    // entry-less action) — degrade to the row flash.
+    return !def || def.id === "delay" || def.config_entries.length === 0;
   }
 
   protected render() {
@@ -315,6 +385,9 @@ export class ESPHomeAutomationActionNode extends LitElement {
       <esphome-automation-condition-tree
         no-header
         .conditions=${this.value.conditions ?? []}
+        .focusTarget=${
+          this.focusTarget?.node[0] === "conditions" ? childFocus(this.focusTarget) : null
+        }
         .catalog=${this.conditionCatalog}
         .devices=${this.devices}
         .board=${this.board}
@@ -358,6 +431,9 @@ export class ESPHomeAutomationActionNode extends LitElement {
           <esphome-automation-action-list
             no-header
             .actions=${this.value.children?.[key] ?? []}
+            .focusTarget=${
+              this.focusTarget?.node[0] === key ? childFocus(this.focusTarget) : null
+            }
             .catalog=${this.catalog}
             .conditionCatalog=${this.conditionCatalog}
             .scripts=${this.scripts}
@@ -399,12 +475,16 @@ export class ESPHomeAutomationActionNode extends LitElement {
     // The form owns the advanced section; an all-advanced action (no basic
     // fields) renders everything with no control, matching the old
     // force-open-no-toggle behaviour.
+    const t = this.focusTarget;
     return html`<esphome-config-entry-form
       .entries=${def.config_entries}
       .values=${this.value.params}
       .requiredGroups=${def.required_groups ?? NO_REQUIRED_GROUPS}
       .board=${this.board}
       .yaml=${this.yaml}
+      .focusFieldPath=${
+        t && t.node.length === 0 && t.field.length > 0 ? t.field : undefined
+      }
       ?disabled=${this.disabled}
       advanced-section
       ?show-advanced=${this._showAdvanced}

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -38,7 +38,6 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
-import { pathIsAdvanced } from "../../../util/config-entry-tree.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import "../config-entry-form.js";
@@ -46,6 +45,7 @@ import type { ConfigEntryValueChange } from "../config-entry-form.js";
 import "../config-entry-renderers/lambda-editor.js";
 import { lambdaBodyOf } from "../config-entry-renderers/lambda.js";
 import { literalLambdaToggleStyles } from "../config-entry-renderers/literal-lambda-toggle.js";
+import { scrollFlashRow } from "../field-highlight.js";
 import { fieldHighlightStyles } from "../field-highlight.styles.js";
 import "./automation-condition-tree.js";
 import {
@@ -60,8 +60,7 @@ import { automationEditorStyles } from "./automation-editor.styles.js";
 import {
   type AutomationFocus,
   childFocus,
-  focusKey,
-  scrollFlashRow,
+  focusTargetHasChanged,
 } from "./automation-focus.js";
 import "./catalog-picker-dialog.js";
 import type {
@@ -87,6 +86,21 @@ registerMdiIcons({
 // Stable identity for group-less defs — a fresh [] per render would
 // defeat Lit's property change detection on the form mount.
 const NO_REQUIRED_GROUPS: RequiredGroup[] = [];
+
+/** Only ``if`` and ``wait_until`` carry a separate boolean-gate
+ *  condition list distinct from a sub-action list. Detected by catalog
+ *  id rather than a flag on AutomationAction — the wire shape keeps the
+ *  gate implicit in the action's semantics. */
+function hasConditionGate(def: AutomationAction | undefined): boolean {
+  return def?.id === "if" || def?.id === "wait_until";
+}
+
+/** Whether the action's params render as a catalog-driven
+ *  ``<esphome-config-entry-form>`` (vs the bespoke delay widget or
+ *  nothing). */
+function rendersParamsForm(def: AutomationAction | undefined): def is AutomationAction {
+  return !!def && def.id !== "delay" && def.config_entries.length > 0;
+}
 
 @customElement("esphome-automation-action-node")
 export class ESPHomeAutomationActionNode extends LitElement {
@@ -133,7 +147,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
   /** Cursor focus target routed to this node: ``"conditions"`` head →
    *  the boolean gate, a child-list key → that nested list, empty →
    *  this node's params form or the row itself. */
-  @property({ attribute: false })
+  @property({ attribute: false, hasChanged: focusTargetHasChanged })
   focusTarget: AutomationFocus | null = null;
 
   @query("esphome-catalog-picker-dialog")
@@ -167,11 +181,8 @@ export class ESPHomeAutomationActionNode extends LitElement {
     fieldHighlightStyles,
   ];
 
-  /** ``focusKey`` of the last target applied, so a same-valued object
-   *  re-sliced by the parent's render doesn't re-run the side effects. */
-  private _lastFocusKey?: string;
-
-  /** Row-level scroll already performed for the current target. */
+  /** Row-level scroll spent on the current target (``hasChanged`` keys
+   *  the property by value, so a reset means a genuinely new target). */
   private _focusScrolled = false;
 
   /**
@@ -192,24 +203,10 @@ export class ESPHomeAutomationActionNode extends LitElement {
         this._delayLiteralStash = null;
       }
     }
-    if (changed.has("focusTarget")) this._applyFocusTarget();
-  }
-
-  /** One-shot per distinct target: un-collapse so the body renders, and
-   *  reveal advanced params when the target field hides behind them. */
-  private _applyFocusTarget(): void {
-    const key = focusKey(this.focusTarget);
-    if (key === this._lastFocusKey) return;
-    this._lastFocusKey = key;
-    if (!key) return;
-    this._focusScrolled = false;
-    this._collapsed = false;
-    const t = this.focusTarget!;
-    if (t.node.length === 0 && t.field.length > 0) {
-      const def = this.catalog.find((a) => a.id === this.value.action_id);
-      if (def && pathIsAdvanced(def.config_entries, t.field)) {
-        this._showAdvanced = true;
-      }
+    if (changed.has("focusTarget")) {
+      this._focusScrolled = false;
+      // A collapsed card doesn't render its body — the target couldn't mount.
+      if (this.focusTarget) this._collapsed = false;
     }
   }
 
@@ -219,11 +216,13 @@ export class ESPHomeAutomationActionNode extends LitElement {
 
   /** Scroll + flash this row when the target terminates here — a
    *  node-level target, or one the rendered surface can't forward
-   *  (no gate/child list/params form for the remaining path). */
+   *  (no gate/child list/params form for the remaining path). One
+   *  evaluation per target; forwarding layers pay nothing after it. */
   private _maybeScrollSelf(): void {
     const t = this.focusTarget;
-    if (!t || this._focusScrolled || !this._isTerminalFocus(t)) return;
+    if (!t || this._focusScrolled) return;
     this._focusScrolled = true;
+    if (!this._isTerminalFocus(t)) return;
     const row = this.shadowRoot?.querySelector<HTMLElement>(".ae-row");
     if (row) scrollFlashRow(row);
   }
@@ -231,14 +230,13 @@ export class ESPHomeAutomationActionNode extends LitElement {
   private _isTerminalFocus(t: AutomationFocus): boolean {
     const def = this.catalog.find((a) => a.id === this.value.action_id);
     const head = t.node[0];
-    if (head === "conditions") return !(def?.id === "if" || def?.id === "wait_until");
+    if (head === "conditions") return !hasConditionGate(def);
     if (typeof head === "string") {
       return !(def?.accepts_action_list ?? []).includes(head);
     }
     if (t.field.length === 0) return true;
-    // Field target with no catalog form to arm (bespoke delay widget,
-    // entry-less action) — degrade to the row flash.
-    return !def || def.id === "delay" || def.config_entries.length === 0;
+    // Field target with no catalog form to arm — degrade to the row flash.
+    return !rendersParamsForm(def);
   }
 
   protected render() {
@@ -373,13 +371,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
    * declare one (``if`` / ``wait_until``).
    */
   private _renderConditionGate(def: AutomationAction | undefined) {
-    // Only ``if`` and ``wait_until`` carry a separate boolean-gate
-    // condition list distinct from a sub-action list. Detect by
-    // checking the catalog's action id rather than re-introducing
-    // a flag on AutomationAction — the wire shape keeps the gate
-    // implicit in the action's semantics.
-    if (!def) return nothing;
-    if (def.id !== "if" && def.id !== "wait_until") return nothing;
+    if (!hasConditionGate(def)) return nothing;
     return html`<div class="ae-nested">
       <p class="ae-nested-label">${this._localize("device.automation_only_when")}</p>
       <esphome-automation-condition-tree
@@ -469,9 +461,8 @@ export class ESPHomeAutomationActionNode extends LitElement {
    * exact substitution.
    */
   private _renderActionParams(def: AutomationAction | undefined) {
-    if (!def) return nothing;
-    if (def.id === "delay") return this._renderDelayParams();
-    if (def.config_entries.length === 0) return nothing;
+    if (def?.id === "delay") return this._renderDelayParams();
+    if (!rendersParamsForm(def)) return nothing;
     // The form owns the advanced section; an all-advanced action (no basic
     // fields) renders everything with no control, matching the old
     // force-open-no-toggle behaviour.

--- a/src/components/device/automation-editor/automation-condition-tree.ts
+++ b/src/components/device/automation-editor/automation-condition-tree.ts
@@ -33,18 +33,17 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
-import { pathIsAdvanced } from "../../../util/config-entry-tree.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import "../config-entry-form.js";
 import type { ConfigEntryValueChange } from "../config-entry-form.js";
+import { scrollFlashRow } from "../field-highlight.js";
 import { fieldHighlightStyles } from "../field-highlight.styles.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import {
   type AutomationFocus,
   childFocus,
-  focusKey,
-  scrollFlashRow,
+  focusTargetHasChanged,
 } from "./automation-focus.js";
 import "./catalog-picker-dialog.js";
 import type {
@@ -112,7 +111,7 @@ export class ESPHomeAutomationConditionTree extends LitElement {
   /** Cursor focus target — ``node`` here is condition-list indices
    *  only: ``[idx]`` targets a row (or its params via ``field``),
    *  deeper indices recurse into a combinator's child tree. */
-  @property({ attribute: false })
+  @property({ attribute: false, hasChanged: focusTargetHasChanged })
   focusTarget: AutomationFocus | null = null;
 
   @query("esphome-catalog-picker-dialog")
@@ -137,29 +136,12 @@ export class ESPHomeAutomationConditionTree extends LitElement {
     fieldHighlightStyles,
   ];
 
-  /** ``focusKey`` of the last target applied — the parent re-slices a
-   *  fresh object per render, so key by value. */
-  private _lastFocusKey?: string;
-
-  /** Row-level scroll already performed for the current target. */
+  /** Row-level scroll spent on the current target (``hasChanged`` keys
+   *  the property by value, so a reset means a genuinely new target). */
   private _focusScrolled = false;
 
-  /** One-shot per distinct target: reveal a row's advanced params when
-   *  the target field hides behind them. */
   protected willUpdate(changed: PropertyValues<this>): void {
-    if (!changed.has("focusTarget")) return;
-    const key = focusKey(this.focusTarget);
-    if (key === this._lastFocusKey) return;
-    this._lastFocusKey = key;
-    if (!key) return;
-    this._focusScrolled = false;
-    const t = this.focusTarget!;
-    const idx = t.node[0];
-    if (typeof idx !== "number" || t.node.length > 1 || t.field.length === 0) return;
-    const def = this.catalog.find((c) => c.id === this.conditions[idx]?.condition_id);
-    if (def && pathIsAdvanced(def.config_entries, t.field)) {
-      this._setRowAdvanced(idx, true);
-    }
+    if (changed.has("focusTarget")) this._focusScrolled = false;
   }
 
   protected updated(): void {
@@ -390,6 +372,7 @@ export class ESPHomeAutomationConditionTree extends LitElement {
   private _maybeScrollRow(): void {
     const t = this.focusTarget;
     if (!t || this._focusScrolled) return;
+    this._focusScrolled = true;
     const idx = t.node[0];
     if (typeof idx !== "number") return;
     const def = this.catalog.find((c) => c.id === this.conditions[idx]?.condition_id);
@@ -398,7 +381,6 @@ export class ESPHomeAutomationConditionTree extends LitElement {
         ? !def?.accepts_condition_list
         : t.field.length === 0 || !def || def.config_entries.length === 0;
     if (!terminal) return;
-    this._focusScrolled = true;
     const row = this.shadowRoot?.querySelectorAll<HTMLElement>(".ae-row")[idx];
     if (row) scrollFlashRow(row);
   }

--- a/src/components/device/automation-editor/automation-condition-tree.ts
+++ b/src/components/device/automation-editor/automation-condition-tree.ts
@@ -19,7 +19,7 @@ import {
   mdiPencilOutline,
   mdiPlus,
 } from "@mdi/js";
-import { html, LitElement, nothing } from "lit";
+import { html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 
 import type {
@@ -33,11 +33,19 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
+import { pathIsAdvanced } from "../../../util/config-entry-tree.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import "../config-entry-form.js";
 import type { ConfigEntryValueChange } from "../config-entry-form.js";
+import { fieldHighlightStyles } from "../field-highlight.styles.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
+import {
+  type AutomationFocus,
+  childFocus,
+  focusKey,
+  scrollFlashRow,
+} from "./automation-focus.js";
 import "./catalog-picker-dialog.js";
 import type {
   CatalogPickedDetail,
@@ -101,6 +109,12 @@ export class ESPHomeAutomationConditionTree extends LitElement {
   @property({ attribute: false })
   devices: AvailableComponentInstance[] = [];
 
+  /** Cursor focus target — ``node`` here is condition-list indices
+   *  only: ``[idx]`` targets a row (or its params via ``field``),
+   *  deeper indices recurse into a combinator's child tree. */
+  @property({ attribute: false })
+  focusTarget: AutomationFocus | null = null;
+
   @query("esphome-catalog-picker-dialog")
   private _picker!: ESPHomeCatalogPickerDialog;
 
@@ -116,7 +130,41 @@ export class ESPHomeAutomationConditionTree extends LitElement {
    *  changes remap or drop entries so the flag follows its row. */
   @state() private _advancedIdxs: ReadonlySet<number> = new Set();
 
-  static styles = [espHomeStyles, inputStyles, automationEditorStyles];
+  static styles = [
+    espHomeStyles,
+    inputStyles,
+    automationEditorStyles,
+    fieldHighlightStyles,
+  ];
+
+  /** ``focusKey`` of the last target applied — the parent re-slices a
+   *  fresh object per render, so key by value. */
+  private _lastFocusKey?: string;
+
+  /** Row-level scroll already performed for the current target. */
+  private _focusScrolled = false;
+
+  /** One-shot per distinct target: reveal a row's advanced params when
+   *  the target field hides behind them. */
+  protected willUpdate(changed: PropertyValues<this>): void {
+    if (!changed.has("focusTarget")) return;
+    const key = focusKey(this.focusTarget);
+    if (key === this._lastFocusKey) return;
+    this._lastFocusKey = key;
+    if (!key) return;
+    this._focusScrolled = false;
+    const t = this.focusTarget!;
+    const idx = t.node[0];
+    if (typeof idx !== "number" || t.node.length > 1 || t.field.length === 0) return;
+    const def = this.catalog.find((c) => c.id === this.conditions[idx]?.condition_id);
+    if (def && pathIsAdvanced(def.config_entries, t.field)) {
+      this._setRowAdvanced(idx, true);
+    }
+  }
+
+  protected updated(): void {
+    this._maybeScrollRow();
+  }
 
   protected render() {
     return html`
@@ -155,6 +203,13 @@ export class ESPHomeAutomationConditionTree extends LitElement {
   private _renderNode(node: ConditionNode, idx: number) {
     const def = this.catalog.find((c) => c.id === node.condition_id);
     const lastIdx = this.conditions.length - 1;
+    const rowFocus = this.focusTarget?.node[0] === idx ? this.focusTarget : null;
+    const nestedFocus =
+      rowFocus && rowFocus.node.length > 1 ? childFocus(rowFocus) : null;
+    const fieldFocus =
+      rowFocus && rowFocus.node.length === 1 && rowFocus.field.length > 0
+        ? rowFocus.field
+        : undefined;
     return html`
       <div class="ae-row">
         <div class="ae-row-header">
@@ -209,6 +264,7 @@ export class ESPHomeAutomationConditionTree extends LitElement {
                   .requiredGroups=${def.required_groups ?? NO_REQUIRED_GROUPS}
                   .board=${this.board}
                   .yaml=${this.yaml}
+                  .focusFieldPath=${fieldFocus}
                   ?disabled=${this.disabled}
                   advanced-section
                   ?show-advanced=${this._advancedIdxs.has(idx)}
@@ -228,6 +284,7 @@ export class ESPHomeAutomationConditionTree extends LitElement {
                   <esphome-automation-condition-tree
                     no-header
                     .conditions=${node.children ?? []}
+                    .focusTarget=${nestedFocus}
                     .catalog=${this.catalog}
                     .devices=${this.devices}
                     .board=${this.board}
@@ -325,6 +382,25 @@ export class ESPHomeAutomationConditionTree extends LitElement {
       [...this._advancedIdxs].filter((i) => i !== idx).map((i) => (i > idx ? i - 1 : i))
     );
     this._emit(removeAt(this.conditions, idx));
+  }
+
+  /** Scroll + flash the targeted row when the target terminates on it —
+   *  a node-level target, or one this row can't forward (no params form
+   *  for a field target, no child tree for a deeper one). */
+  private _maybeScrollRow(): void {
+    const t = this.focusTarget;
+    if (!t || this._focusScrolled) return;
+    const idx = t.node[0];
+    if (typeof idx !== "number") return;
+    const def = this.catalog.find((c) => c.id === this.conditions[idx]?.condition_id);
+    const terminal =
+      t.node.length > 1
+        ? !def?.accepts_condition_list
+        : t.field.length === 0 || !def || def.config_entries.length === 0;
+    if (!terminal) return;
+    this._focusScrolled = true;
+    const row = this.shadowRoot?.querySelectorAll<HTMLElement>(".ae-row")[idx];
+    if (row) scrollFlashRow(row);
   }
 
   private _emit(conditions: ConditionNode[]) {

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -27,7 +27,7 @@
  * is outstanding.
  */
 import { consume } from "@lit/context";
-import { html, LitElement, nothing } from "lit";
+import { html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 
@@ -35,6 +35,7 @@ import type { ESPHomeAPI } from "../../../api/index.js";
 import type {
   AutomationLocation,
   AutomationTree,
+  AutomationTrigger,
   AvailableAutomations,
   AvailableComponentInstance,
   AvailableScript,
@@ -45,11 +46,19 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { apiContext, localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
+import { pathIsAdvanced } from "../../../util/config-entry-tree.js";
 import { formatApiError } from "../../../util/format-api-error.js";
 import { parseSubstitutions } from "../../../util/substitutions.js";
+import { triggerParamFormEntries } from "../../../util/trigger-param-form-entries.js";
 import { AutoApplyController } from "./auto-apply-controller.js";
 import type { ESPHomeAutomationActionList } from "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
+import {
+  type AutomationFocus,
+  automationRelativePath,
+  resolveAutomationFocus,
+  type YamlPathSegment,
+} from "./automation-focus.js";
 import { CatalogLoadController } from "./catalog-load-controller.js";
 import { loadIntervalComponent } from "./load-interval-component.js";
 import { ParseErrorController } from "./parse-error-controller.js";
@@ -107,6 +116,12 @@ export class ESPHomeAutomationEditor extends LitElement {
   addMode = false;
 
   @property() yaml = "";
+
+  /** Document-absolute indexed key path at the YAML cursor; resolved
+   *  against the hydrated tree to scroll/highlight the matching node
+   *  or field. Ignored when it doesn't land inside this automation. */
+  @property({ attribute: false })
+  focusYamlPath?: YamlPathSegment[];
 
   /** Action-list reference — used by the header-positioned Add
    *  button to open the catalog picker dialog that lives inside
@@ -177,6 +192,31 @@ export class ESPHomeAutomationEditor extends LitElement {
    *  read-only Target field can preview ${...} like the text fields do. */
   private _parseSubstitutions = memoizeOne(parseSubstitutions);
 
+  /** Cursor path → tree focus. Memoized on (value, location, path) so it
+   *  self-heals once the async hydrate lands the tree. */
+  private _resolveFocus = memoizeOne(
+    (
+      value: AutomationTree | null,
+      location: AutomationLocation | null,
+      path?: YamlPathSegment[]
+    ): AutomationFocus | null => {
+      if (!value || !path?.length) return null;
+      const rel = automationRelativePath(path, location);
+      return rel ? resolveAutomationFocus(value, rel) : null;
+    }
+  );
+
+  /** The catalog trigger currently in effect — shared by render and the
+   *  focus-driven advanced reveal. */
+  private _activeTrigger(automation: AutomationTree): AutomationTrigger | null {
+    const id = effectiveTriggerIdFor(
+      automation,
+      this.location,
+      this._available?.devices ?? []
+    );
+    return id ? (this._available?.triggers.find((t) => t.id === id) ?? null) : null;
+  }
+
   static styles = [espHomeStyles, inputStyles, automationEditorStyles];
 
   connectedCallback(): void {
@@ -193,6 +233,25 @@ export class ESPHomeAutomationEditor extends LitElement {
     // the page-level save guard hold a direct ref and call
     // flushPending() before its global save) is dispatched by the
     // shared engine's hostConnected.
+  }
+
+  /** Reveal hidden advanced trigger params when the cursor targets one,
+   *  so the form's scroll-to-field can reach it. */
+  protected willUpdate(changed: PropertyValues): void {
+    if (
+      this._showAdvanced ||
+      !(changed.has("focusYamlPath") || changed.has("value") || changed.has("_available"))
+    ) {
+      return;
+    }
+    const focus = this._resolveFocus(this.value, this.location, this.focusYamlPath);
+    if (!focus || focus.node.length > 0 || focus.field.length === 0) return;
+    const entries = triggerParamFormEntries(
+      this.location,
+      this._intervalComponent,
+      this._activeTrigger(this.value ?? emptyAutomationTree())
+    );
+    if (pathIsAdvanced(entries, focus.field)) this._showAdvanced = true;
   }
 
   protected updated(changed: Map<string, unknown>) {
@@ -376,9 +435,8 @@ export class ESPHomeAutomationEditor extends LitElement {
     const conditions = this._available?.conditions ?? [];
     const disabled = this._engine.deleting;
     const effectiveTriggerId = effectiveTriggerIdFor(automation, target, devices);
-    const activeTrigger = effectiveTriggerId
-      ? (triggers.find((t) => t.id === effectiveTriggerId) ?? null)
-      : null;
+    const activeTrigger = this._activeTrigger(automation);
+    const focus = this._resolveFocus(this.value, this.location, this.focusYamlPath);
     return html`
       ${renderAutomationHeader(
         this.location,
@@ -416,6 +474,7 @@ export class ESPHomeAutomationEditor extends LitElement {
               yaml: this.yaml,
               disabled,
               showAdvanced: this._showAdvanced,
+              focusFieldPath: focus && focus.node.length === 0 ? focus.field : undefined,
               onValueChange: this._onTriggerParamsValueChange,
               onAdvancedToggle: this._onAdvancedToggle,
             })}`
@@ -430,6 +489,7 @@ export class ESPHomeAutomationEditor extends LitElement {
         yaml: this.yaml,
         disabled,
         localize: this._localize,
+        focusTarget: focus && focus.node.length > 0 ? focus : null,
         onOpenPicker: () => this._actionList?.openPicker(),
         onActionsChange: this._onActionsChange,
       })}

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -27,7 +27,7 @@
  * is outstanding.
  */
 import { consume } from "@lit/context";
-import { html, LitElement, nothing, type PropertyValues } from "lit";
+import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 
@@ -35,7 +35,6 @@ import type { ESPHomeAPI } from "../../../api/index.js";
 import type {
   AutomationLocation,
   AutomationTree,
-  AutomationTrigger,
   AvailableAutomations,
   AvailableComponentInstance,
   AvailableScript,
@@ -46,10 +45,8 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { apiContext, localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
-import { pathIsAdvanced } from "../../../util/config-entry-tree.js";
 import { formatApiError } from "../../../util/format-api-error.js";
 import { parseSubstitutions } from "../../../util/substitutions.js";
-import { triggerParamFormEntries } from "../../../util/trigger-param-form-entries.js";
 import { AutoApplyController } from "./auto-apply-controller.js";
 import type { ESPHomeAutomationActionList } from "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
@@ -206,17 +203,6 @@ export class ESPHomeAutomationEditor extends LitElement {
     }
   );
 
-  /** The catalog trigger currently in effect — shared by render and the
-   *  focus-driven advanced reveal. */
-  private _activeTrigger(automation: AutomationTree): AutomationTrigger | null {
-    const id = effectiveTriggerIdFor(
-      automation,
-      this.location,
-      this._available?.devices ?? []
-    );
-    return id ? (this._available?.triggers.find((t) => t.id === id) ?? null) : null;
-  }
-
   static styles = [espHomeStyles, inputStyles, automationEditorStyles];
 
   connectedCallback(): void {
@@ -233,25 +219,6 @@ export class ESPHomeAutomationEditor extends LitElement {
     // the page-level save guard hold a direct ref and call
     // flushPending() before its global save) is dispatched by the
     // shared engine's hostConnected.
-  }
-
-  /** Reveal hidden advanced trigger params when the cursor targets one,
-   *  so the form's scroll-to-field can reach it. */
-  protected willUpdate(changed: PropertyValues): void {
-    if (
-      this._showAdvanced ||
-      !(changed.has("focusYamlPath") || changed.has("value") || changed.has("_available"))
-    ) {
-      return;
-    }
-    const focus = this._resolveFocus(this.value, this.location, this.focusYamlPath);
-    if (!focus || focus.node.length > 0 || focus.field.length === 0) return;
-    const entries = triggerParamFormEntries(
-      this.location,
-      this._intervalComponent,
-      this._activeTrigger(this.value ?? emptyAutomationTree())
-    );
-    if (pathIsAdvanced(entries, focus.field)) this._showAdvanced = true;
   }
 
   protected updated(changed: Map<string, unknown>) {
@@ -435,7 +402,9 @@ export class ESPHomeAutomationEditor extends LitElement {
     const conditions = this._available?.conditions ?? [];
     const disabled = this._engine.deleting;
     const effectiveTriggerId = effectiveTriggerIdFor(automation, target, devices);
-    const activeTrigger = this._activeTrigger(automation);
+    const activeTrigger = effectiveTriggerId
+      ? (triggers.find((t) => t.id === effectiveTriggerId) ?? null)
+      : null;
     const focus = this._resolveFocus(this.value, this.location, this.focusYamlPath);
     return html`
       ${renderAutomationHeader(

--- a/src/components/device/automation-editor/automation-focus.ts
+++ b/src/components/device/automation-editor/automation-focus.ts
@@ -17,8 +17,9 @@ import type {
   AutomationTree,
   ConditionNode,
 } from "../../../api/types/automations.js";
+import type { YamlPathSegment } from "../../../util/yaml-ast.js";
 
-export type YamlPathSegment = string | number;
+export type { YamlPathSegment };
 
 /** Tree coordinates for one focus target inside an automation. */
 export interface AutomationFocus {
@@ -103,16 +104,11 @@ export function focusKey(focus: AutomationFocus | null | undefined): string | un
   return focus ? JSON.stringify([focus.node, focus.field]) : undefined;
 }
 
-/** Scroll a node row into view with the shared one-shot cursor glow. */
-export function scrollFlashRow(row: HTMLElement): void {
-  row.scrollIntoView({ block: "center" });
-  if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
-  row.classList.remove("field--highlight");
-  void row.offsetWidth;
-  row.classList.add("field--highlight");
-  row.addEventListener("animationend", () => row.classList.remove("field--highlight"), {
-    once: true,
-  });
+/** ``@property`` comparator for ``focusTarget``: parents mint a fresh
+ *  (deep-equal) slice per render; only a value change should dirty the
+ *  subtree. */
+export function focusTargetHasChanged(a: unknown, b: unknown): boolean {
+  return focusKey(a as AutomationFocus | null) !== focusKey(b as AutomationFocus | null);
 }
 
 function actionListFocus(

--- a/src/components/device/automation-editor/automation-focus.ts
+++ b/src/components/device/automation-editor/automation-focus.ts
@@ -49,26 +49,13 @@ export function automationRelativePath(
   path: readonly YamlPathSegment[],
   location: AutomationLocation | null
 ): YamlPathSegment[] | null {
-  if (!location) return null;
-  switch (location.kind) {
-    case "device_on":
-    case "component_on": {
-      const at = path.indexOf(location.trigger);
-      if (at < 0) return null;
-      const rest = path.slice(at + 1);
-      if (location.index === undefined) return rest;
-      return rest[0] === location.index ? rest.slice(1) : null;
-    }
-    case "component_action": {
-      const at = path.indexOf(location.field);
-      return at < 0 ? null : path.slice(at + 1);
-    }
-    case "interval":
-      return path[0] === "interval" && path[1] === location.index ? path.slice(2) : null;
-    default:
-      // script / api_action / light_effect mount different editors.
-      return null;
-  }
+  const anchor = location && handlerAnchor(location);
+  if (!anchor) return null;
+  const at = path.indexOf(anchor.key);
+  if (at < 0) return null;
+  const rest = path.slice(at + 1);
+  if (anchor.index === undefined) return rest;
+  return rest[0] === anchor.index ? rest.slice(1) : null;
 }
 
 /**
@@ -83,14 +70,15 @@ export function resolveAutomationFocus(
   relPath: readonly YamlPathSegment[]
 ): AutomationFocus | null {
   if (relPath.length === 0) return null;
+  const inActions = (p: readonly YamlPathSegment[]) =>
+    listFocus(tree.actions, actionId, actionBodyFocus, p, [], null);
   const head = relPath[0];
-  if (head === "then") return actionListFocus(tree.actions, relPath.slice(1), [], null);
-  if (typeof head === "number") return actionListFocus(tree.actions, relPath, [], null);
+  if (head === "then") return inActions(relPath.slice(1));
+  if (typeof head === "number") return inActions(relPath);
   // Single-bare-action shortcut: the mapping mixes trigger params and
-  // action ids, so try the actions the decomposer pulled out first.
-  const bare = tree.actions.findIndex((a) => a.action_id === head);
-  if (bare >= 0) return actionBodyFocus(tree.actions[bare], relPath.slice(1), [bare]);
-  return { node: [], field: relPath.map(String) };
+  // action ids, so try the actions the decomposer pulled out before
+  // treating the segment as a trigger param.
+  return inActions(relPath) ?? { node: [], field: relPath.map(String) };
 }
 
 /** Focus slice for the next level down — peels the segment the current
@@ -111,12 +99,46 @@ export function focusTargetHasChanged(a: unknown, b: unknown): boolean {
   return focusKey(a as AutomationFocus | null) !== focusKey(b as AutomationFocus | null);
 }
 
-function actionListFocus(
-  nodes: ActionNode[],
+/** The list key anchoring a location's handler body in the YAML, plus
+ *  the entry index for list-shaped handlers. */
+function handlerAnchor(
+  location: AutomationLocation
+): { key: string; index?: number } | null {
+  switch (location.kind) {
+    case "device_on":
+    case "component_on":
+      return { key: location.trigger, index: location.index };
+    case "component_action":
+      return { key: location.field };
+    case "interval":
+      return { key: "interval", index: location.index };
+    default:
+      // script / api_action / light_effect mount different editors.
+      return null;
+  }
+}
+
+const actionId = (a: ActionNode): string => a.action_id;
+const conditionId = (c: ConditionNode): string => c.condition_id;
+
+/**
+ * One step through an id-keyed node list — the shape actions and
+ * conditions share. ``[n, <id>, …]`` is the list form, a bare string
+ * head the single-mapping (dict) form; *descend* continues into the
+ * matched node's body.
+ */
+function listFocus<T, F extends AutomationFocus | null>(
+  items: T[],
+  idOf: (item: T) => string,
+  descend: (
+    item: T,
+    path: readonly YamlPathSegment[],
+    at: YamlPathSegment[]
+  ) => AutomationFocus,
   path: readonly YamlPathSegment[],
   at: YamlPathSegment[],
-  fallback: AutomationFocus | null
-): AutomationFocus | null {
+  fallback: F
+): AutomationFocus | F {
   if (path.length === 0) return fallback;
   const head = path[0];
   if (typeof head === "number") {
@@ -125,16 +147,16 @@ function actionListFocus(
       // A hand-written multi-key item decomposes to several nodes and
       // shifts later indices, so fall back to an id search on mismatch.
       const idx =
-        nodes[head]?.action_id === wrapper
+        items[head] !== undefined && idOf(items[head]) === wrapper
           ? head
-          : nodes.findIndex((a) => a.action_id === wrapper);
-      if (idx >= 0) return actionBodyFocus(nodes[idx], path.slice(2), [...at, idx]);
+          : items.findIndex((item) => idOf(item) === wrapper);
+      if (idx >= 0) return descend(items[idx], path.slice(2), [...at, idx]);
     }
-    return nodes[head] ? { node: [...at, head], field: [] } : fallback;
+    return items[head] !== undefined ? { node: [...at, head], field: [] } : fallback;
   }
-  // A list-key body given a single mapping instead of a list.
-  const idx = nodes.findIndex((a) => a.action_id === head);
-  if (idx >= 0) return actionBodyFocus(nodes[idx], path.slice(1), [...at, idx]);
+  // Dict form: a single entry carried as a mapping, no list index.
+  const idx = items.findIndex((item) => idOf(item) === head);
+  if (idx >= 0) return descend(items[idx], path.slice(1), [...at, idx]);
   return fallback;
 }
 
@@ -148,50 +170,39 @@ function actionBodyFocus(
   const head = path[0];
   if (typeof head === "string") {
     if (CONDITION_GATE_KEYS.has(head)) {
-      return conditionListFocus(
+      return listFocus(
         a.conditions ?? [],
+        conditionId,
+        conditionBodyFocus,
         path.slice(1),
         [...at, "conditions"],
         here
       );
     }
     if (a.children && head in a.children) {
-      return (
-        actionListFocus(a.children[head], path.slice(1), [...at, head], here) ?? here
+      return listFocus(
+        a.children[head],
+        actionId,
+        actionBodyFocus,
+        path.slice(1),
+        [...at, head],
+        here
       );
     }
     if (a.conditions?.some((c) => c.condition_id === head)) {
       // ``wait_until``'s dict shorthand omits the gate key — the
       // segment is the condition id itself.
-      return conditionListFocus(a.conditions, path, [...at, "conditions"], here);
+      return listFocus(
+        a.conditions,
+        conditionId,
+        conditionBodyFocus,
+        path,
+        [...at, "conditions"],
+        here
+      );
     }
   }
   return { node: at, field: path.map(String) };
-}
-
-function conditionListFocus(
-  conds: ConditionNode[],
-  path: readonly YamlPathSegment[],
-  at: YamlPathSegment[],
-  fallback: AutomationFocus
-): AutomationFocus {
-  if (path.length === 0) return fallback;
-  const head = path[0];
-  if (typeof head === "number") {
-    const wrapper = path[1];
-    if (typeof wrapper === "string") {
-      const idx =
-        conds[head]?.condition_id === wrapper
-          ? head
-          : conds.findIndex((c) => c.condition_id === wrapper);
-      if (idx >= 0) return conditionBodyFocus(conds[idx], path.slice(2), [...at, idx]);
-    }
-    return conds[head] ? { node: [...at, head], field: [] } : fallback;
-  }
-  // Dict form: a single condition carried as a mapping, no list index.
-  const idx = conds.findIndex((c) => c.condition_id === head);
-  if (idx >= 0) return conditionBodyFocus(conds[idx], path.slice(1), [...at, idx]);
-  return fallback;
 }
 
 function conditionBodyFocus(
@@ -209,7 +220,7 @@ function conditionBodyFocus(
   ) {
     // Combinator (``and``/``or``/``not``…) — recurse; from here down the
     // node path is condition-list indices only.
-    return conditionListFocus(kids, path, at, here);
+    return listFocus(kids, conditionId, conditionBodyFocus, path, at, here);
   }
   return { node: at, field: path.map(String) };
 }

--- a/src/components/device/automation-editor/automation-focus.ts
+++ b/src/components/device/automation-editor/automation-focus.ts
@@ -179,7 +179,10 @@ function actionBodyFocus(
         here
       );
     }
-    if (a.children && head in a.children) {
+    // Own-property check, not `in`: the wire tree's `children` is a plain
+    // object, so a param key like ``constructor`` would match via the
+    // prototype and route into a non-array (see yaml-section-values.ts).
+    if (a.children && Object.prototype.hasOwnProperty.call(a.children, head)) {
       return listFocus(
         a.children[head],
         actionId,

--- a/src/components/device/automation-editor/automation-focus.ts
+++ b/src/components/device/automation-editor/automation-focus.ts
@@ -1,0 +1,219 @@
+/**
+ * YAML-cursor → automation-tree focus resolution.
+ *
+ * The YAML pane reports an indexed key path (``["binary_sensor", 0,
+ * "on_click", 0, "then", 0, "if", "condition", 0, "sensor.in_range",
+ * "above"]``); these helpers slice it down to the automation handler
+ * body and walk it against the backend-decomposed ``AutomationTree``
+ * so the editor can scroll/highlight the clicked node or field. The
+ * walk mirrors the backend's ``_decompose.py`` YAML shapes (explicit
+ * ``then:`` vs bare list vs single bare action, dict-form conditions,
+ * ``wait_until``'s gate-less shorthand) and fails soft: an unresolved
+ * tail degrades to the deepest resolved node.
+ */
+import type {
+  ActionNode,
+  AutomationLocation,
+  AutomationTree,
+  ConditionNode,
+} from "../../../api/types/automations.js";
+
+export type YamlPathSegment = string | number;
+
+/** Tree coordinates for one focus target inside an automation. */
+export interface AutomationFocus {
+  /** Path through the tree. ``[]`` = the trigger-params form. A number
+   *  indexes the current action/condition list; ``"conditions"`` enters
+   *  an ``ActionNode``'s boolean gate (reserved — YAML gate keys are
+   *  ``condition``/``all``/``any``, never a child-list key); any other
+   *  string is an ``accepts_action_list`` child key (``then``/``else``). */
+  node: YamlPathSegment[];
+  /** Params-form-relative field path; ``[]`` = highlight the node row. */
+  field: string[];
+}
+
+/** Action-body keys that introduce a condition gate rather than params. */
+const CONDITION_GATE_KEYS: ReadonlySet<string> = new Set(["condition", "all", "any"]);
+
+/**
+ * Slice a document-absolute indexed key path down to the handler body
+ * addressed by *location*.
+ *
+ * The prefix before the handler key isn't re-verified — the caller
+ * resolved *location* from the same cursor position, so they agree by
+ * construction. Returns ``null`` when the path doesn't reach the
+ * handler (or the location kind mounts a different editor).
+ */
+export function automationRelativePath(
+  path: readonly YamlPathSegment[],
+  location: AutomationLocation | null
+): YamlPathSegment[] | null {
+  if (!location) return null;
+  switch (location.kind) {
+    case "device_on":
+    case "component_on": {
+      const at = path.indexOf(location.trigger);
+      if (at < 0) return null;
+      const rest = path.slice(at + 1);
+      if (location.index === undefined) return rest;
+      return rest[0] === location.index ? rest.slice(1) : null;
+    }
+    case "component_action": {
+      const at = path.indexOf(location.field);
+      return at < 0 ? null : path.slice(at + 1);
+    }
+    case "interval":
+      return path[0] === "interval" && path[1] === location.index ? path.slice(2) : null;
+    default:
+      // script / api_action / light_effect mount different editors.
+      return null;
+  }
+}
+
+/**
+ * Walk a handler-relative path against the decomposed tree.
+ *
+ * Returns ``null`` only when nothing resolves at all (empty path, or a
+ * top-level list index into an empty tree); once inside the tree an
+ * unresolvable tail returns the deepest resolved node with ``field: []``.
+ */
+export function resolveAutomationFocus(
+  tree: AutomationTree,
+  relPath: readonly YamlPathSegment[]
+): AutomationFocus | null {
+  if (relPath.length === 0) return null;
+  const head = relPath[0];
+  if (head === "then") return actionListFocus(tree.actions, relPath.slice(1), [], null);
+  if (typeof head === "number") return actionListFocus(tree.actions, relPath, [], null);
+  // Single-bare-action shortcut: the mapping mixes trigger params and
+  // action ids, so try the actions the decomposer pulled out first.
+  const bare = tree.actions.findIndex((a) => a.action_id === head);
+  if (bare >= 0) return actionBodyFocus(tree.actions[bare], relPath.slice(1), [bare]);
+  return { node: [], field: relPath.map(String) };
+}
+
+/** Focus slice for the next level down — peels the segment the current
+ *  render layer consumed. */
+export function childFocus(focus: AutomationFocus): AutomationFocus {
+  return { node: focus.node.slice(1), field: focus.field };
+}
+
+/** Value key for dedupe — the parent re-slices a fresh object per render. */
+export function focusKey(focus: AutomationFocus | null | undefined): string | undefined {
+  return focus ? JSON.stringify([focus.node, focus.field]) : undefined;
+}
+
+/** Scroll a node row into view with the shared one-shot cursor glow. */
+export function scrollFlashRow(row: HTMLElement): void {
+  row.scrollIntoView({ block: "center" });
+  if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+  row.classList.remove("field--highlight");
+  void row.offsetWidth;
+  row.classList.add("field--highlight");
+  row.addEventListener("animationend", () => row.classList.remove("field--highlight"), {
+    once: true,
+  });
+}
+
+function actionListFocus(
+  nodes: ActionNode[],
+  path: readonly YamlPathSegment[],
+  at: YamlPathSegment[],
+  fallback: AutomationFocus | null
+): AutomationFocus | null {
+  if (path.length === 0) return fallback;
+  const head = path[0];
+  if (typeof head === "number") {
+    const wrapper = path[1];
+    if (typeof wrapper === "string") {
+      // A hand-written multi-key item decomposes to several nodes and
+      // shifts later indices, so fall back to an id search on mismatch.
+      const idx =
+        nodes[head]?.action_id === wrapper
+          ? head
+          : nodes.findIndex((a) => a.action_id === wrapper);
+      if (idx >= 0) return actionBodyFocus(nodes[idx], path.slice(2), [...at, idx]);
+    }
+    return nodes[head] ? { node: [...at, head], field: [] } : fallback;
+  }
+  // A list-key body given a single mapping instead of a list.
+  const idx = nodes.findIndex((a) => a.action_id === head);
+  if (idx >= 0) return actionBodyFocus(nodes[idx], path.slice(1), [...at, idx]);
+  return fallback;
+}
+
+function actionBodyFocus(
+  a: ActionNode,
+  path: readonly YamlPathSegment[],
+  at: YamlPathSegment[]
+): AutomationFocus {
+  const here: AutomationFocus = { node: at, field: [] };
+  if (path.length === 0) return here;
+  const head = path[0];
+  if (typeof head === "string") {
+    if (CONDITION_GATE_KEYS.has(head)) {
+      return conditionListFocus(
+        a.conditions ?? [],
+        path.slice(1),
+        [...at, "conditions"],
+        here
+      );
+    }
+    if (a.children && head in a.children) {
+      return (
+        actionListFocus(a.children[head], path.slice(1), [...at, head], here) ?? here
+      );
+    }
+    if (a.conditions?.some((c) => c.condition_id === head)) {
+      // ``wait_until``'s dict shorthand omits the gate key — the
+      // segment is the condition id itself.
+      return conditionListFocus(a.conditions, path, [...at, "conditions"], here);
+    }
+  }
+  return { node: at, field: path.map(String) };
+}
+
+function conditionListFocus(
+  conds: ConditionNode[],
+  path: readonly YamlPathSegment[],
+  at: YamlPathSegment[],
+  fallback: AutomationFocus
+): AutomationFocus {
+  if (path.length === 0) return fallback;
+  const head = path[0];
+  if (typeof head === "number") {
+    const wrapper = path[1];
+    if (typeof wrapper === "string") {
+      const idx =
+        conds[head]?.condition_id === wrapper
+          ? head
+          : conds.findIndex((c) => c.condition_id === wrapper);
+      if (idx >= 0) return conditionBodyFocus(conds[idx], path.slice(2), [...at, idx]);
+    }
+    return conds[head] ? { node: [...at, head], field: [] } : fallback;
+  }
+  // Dict form: a single condition carried as a mapping, no list index.
+  const idx = conds.findIndex((c) => c.condition_id === head);
+  if (idx >= 0) return conditionBodyFocus(conds[idx], path.slice(1), [...at, idx]);
+  return fallback;
+}
+
+function conditionBodyFocus(
+  c: ConditionNode,
+  path: readonly YamlPathSegment[],
+  at: YamlPathSegment[]
+): AutomationFocus {
+  const here: AutomationFocus = { node: at, field: [] };
+  if (path.length === 0) return here;
+  const kids = c.children ?? [];
+  const head = path[0];
+  if (
+    kids.length > 0 &&
+    (typeof head === "number" || kids.some((k) => k.condition_id === head))
+  ) {
+    // Combinator (``and``/``or``/``not``…) — recurse; from here down the
+    // node path is condition-list indices only.
+    return conditionListFocus(kids, path, at, here);
+  }
+  return { node: at, field: path.map(String) };
+}

--- a/src/components/device/automation-editor/render-automation-sections.ts
+++ b/src/components/device/automation-editor/render-automation-sections.ts
@@ -26,6 +26,7 @@ import { registerMdiIcons } from "../../../util/register-icons.js";
 import { triggerParamFormEntries } from "../../../util/trigger-param-form-entries.js";
 import "../config-entry-form.js";
 import "./automation-action-list.js";
+import type { AutomationFocus } from "./automation-focus.js";
 import "./automation-target-picker.js";
 import "./automation-trigger-picker.js";
 import { renderTargetField } from "./render-target-field.js";
@@ -105,6 +106,7 @@ export function renderTriggerParamsForm(opts: {
   yaml: string;
   disabled: boolean;
   showAdvanced: boolean;
+  focusFieldPath?: string[];
   onValueChange: (e: CustomEvent<{ path: string[]; value: unknown }>) => void;
   onAdvancedToggle: (e: CustomEvent<{ show: boolean }>) => void;
 }) {
@@ -126,6 +128,7 @@ export function renderTriggerParamsForm(opts: {
       .values=${opts.automation.trigger_params}
       .board=${opts.board}
       .yaml=${opts.yaml}
+      .focusFieldPath=${opts.focusFieldPath}
       ?disabled=${opts.disabled}
       advanced-section
       ?show-advanced=${opts.showAdvanced}
@@ -148,6 +151,7 @@ export function renderActionsSection(opts: {
   yaml: string;
   disabled: boolean;
   localize: LocalizeFunc;
+  focusTarget?: AutomationFocus | null;
   onOpenPicker: () => void;
   onActionsChange: (e: CustomEvent<{ actions: AutomationTree["actions"] }>) => void;
 }) {
@@ -171,6 +175,7 @@ export function renderActionsSection(opts: {
       <esphome-automation-action-list
         no-header
         hide-add
+        .focusTarget=${opts.focusTarget ?? null}
         .actions=${opts.automation.actions}
         .catalog=${opts.catalog}
         .conditionCatalog=${opts.conditionCatalog}

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -33,7 +33,7 @@ import type { ConfiguredDevice } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, devicesContext, localizeContext } from "../../context/index.js";
 import { floatRequiredFirst } from "../../util/config-entry-ordering.js";
-import { anyAdvancedEntry } from "../../util/config-entry-tree.js";
+import { anyAdvancedEntry, pathIsAdvanced } from "../../util/config-entry-tree.js";
 import {
   catalogEntryToProvider,
   type ComponentProvider,
@@ -256,6 +256,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
   /** Instance-relative field path to scroll into view, from the YAML cursor. */
   @property({ attribute: false })
   focusFieldPath?: string[];
+
+  /** ``focusFieldPath`` key already advanced-revealed — one-shot per
+   *  target so a later deliberate collapse sticks. */
+  private _focusRevealKey?: string;
 
   @state()
   private _nestedOpenSections: Set<string> = new Set();
@@ -614,6 +618,23 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // field paints inline, so nothing needs the section forced open — and flipping
     // showAdvanced would reveal every empty advanced field, the bug this guards.
     if (this.advancedSection && !this.showAdvanced && this._effectiveForceOpen()) {
+      this._emitAdvancedToggle(true);
+    }
+    this._maybeRevealForFocus();
+  }
+
+  /** When the YAML cursor targets a hidden advanced field, ask the host
+   *  to open the section (once per target) so the scroll can reach it. */
+  private _maybeRevealForFocus(): void {
+    if (!this.advancedSection || this.showAdvanced || !this.focusFieldPath?.length) {
+      return;
+    }
+    // Entries can land after the path (async catalog) — hold the shot.
+    if (this.entries.length === 0) return;
+    const key = fieldKeyAttr(this.focusFieldPath);
+    if (key === this._focusRevealKey) return;
+    this._focusRevealKey = key;
+    if (pathIsAdvanced(this.entries, this.focusFieldPath)) {
       this._emitAdvancedToggle(true);
     }
   }

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -106,6 +106,10 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
   @property({ attribute: false })
   focusFieldPath?: string[];
 
+  /** Indexed key path at the cursor, for automation deep-targeting. */
+  @property({ attribute: false })
+  focusYamlPath?: (string | number)[];
+
   /** The selected section's backend errors; forwarded to the section editor. */
   @property({ attribute: false })
   backendErrors: InstanceBackendErrors = NO_INSTANCE_ERRORS;
@@ -426,6 +430,7 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
         .platform=${this.board?.esphome.platform ?? ""}
         .location=${location}
         .yaml=${this.yaml}
+        .focusYamlPath=${this.focusYamlPath}
       ></esphome-automation-editor>`;
     }
     return html`<esphome-device-section-config

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -146,6 +146,10 @@ export class ESPHomeDeviceEditor extends LitElement {
   @property({ attribute: false })
   focusFieldPath?: string[];
 
+  /** Indexed key path at the cursor, for automation deep-targeting. */
+  @property({ attribute: false })
+  focusYamlPath?: (string | number)[];
+
   /** The selected section's backend errors; forwarded to the section editor. */
   @property({ attribute: false })
   backendErrors: InstanceBackendErrors = NO_INSTANCE_ERRORS;
@@ -346,6 +350,7 @@ export class ESPHomeDeviceEditor extends LitElement {
                 .selectedSection=${this.selectedSection}
                 .selectedFromLine=${this.selectedFromLine}
                 .focusFieldPath=${this.focusFieldPath}
+                .focusYamlPath=${this.focusYamlPath}
                 .backendErrors=${this.backendErrors}
                 .justCreated=${this.justCreated}
                 .yamlPaneVisible=${effectiveLayout !== "left"}

--- a/src/components/device/field-highlight.ts
+++ b/src/components/device/field-highlight.ts
@@ -1,0 +1,28 @@
+/** Behavior side of ``field-highlight.styles.ts``: the one-shot cursor
+ *  glow shared by the form's field scroll and the automation editors'
+ *  row scroll. */
+
+/** Class that runs the glow animation; defined in ``fieldHighlightStyles``. */
+export const FIELD_FLASH_CLASS = "field--highlight";
+
+/**
+ * Restart the one-shot glow on *el*.
+ *
+ * Skipped under reduced motion: the animation is disabled there, so
+ * adding the class only strands it (``animationend`` never fires).
+ */
+export function flashHighlight(el: HTMLElement): void {
+  if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+  el.classList.remove(FIELD_FLASH_CLASS);
+  void el.offsetWidth;
+  el.classList.add(FIELD_FLASH_CLASS);
+  el.addEventListener("animationend", () => el.classList.remove(FIELD_FLASH_CLASS), {
+    once: true,
+  });
+}
+
+/** Scroll a node row into view with the glow. */
+export function scrollFlashRow(row: HTMLElement): void {
+  row.scrollIntoView({ block: "center" });
+  flashHighlight(row);
+}

--- a/src/components/device/field-scroll-controller.ts
+++ b/src/components/device/field-scroll-controller.ts
@@ -1,13 +1,11 @@
 import type { PropertyValues } from "lit";
 import { fieldKeyAttr, parseFieldKey } from "./config-entry-renderers-shared.js";
+import { flashHighlight } from "./field-highlight.js";
 
 /** Renders to spend looking for a cursor-targeted field before giving up.
  *  entries + values land in separate renders, so one retry isn't enough;
  *  the cap stops an unbounded shadow-DOM walk for a never-rendered path. */
 const MAX_TRIES = 3;
-
-/** Class that runs the one-shot glow; defined in ``config-entry-form.styles``. */
-const FLASH_CLASS = "field--highlight";
 
 /** Don't re-pulse the same field within this window — moving the cursor
  *  around inside one field shouldn't keep re-flashing it. */
@@ -100,8 +98,13 @@ export class FieldScrollController {
   maybeScroll(changed: PropertyValues): void {
     const fp = this.host.focusFieldPath;
     const key = fp?.length ? fieldKeyAttr(fp) : undefined;
+    // showAdvanced counts: a focus-driven advanced reveal renders the
+    // target field a pass after the path landed.
     const relevant =
-      changed.has("focusFieldPath") || changed.has("entries") || changed.has("values");
+      changed.has("focusFieldPath") ||
+      changed.has("entries") ||
+      changed.has("values") ||
+      changed.has("showAdvanced");
     const { gate, scroll } = advanceScrollGate(
       {
         scrolledKey: this._scrolledKey,
@@ -146,29 +149,13 @@ export class FieldScrollController {
       // plus input — lands fully in view instead of clipped at the fold.
       target.scrollIntoView({ block: "center" });
       // Keyed on the matched prefix; debounced so it isn't re-pulsed on every
-      // cursor nudge. Skipped under reduced-motion: the animation is disabled
-      // there, so adding the class only strands it (animationend never fires).
+      // cursor nudge.
       const matchedKey = fieldKeyAttr(path.slice(0, len));
       const now = Date.now();
-      const reduceMotion = window.matchMedia?.(
-        "(prefers-reduced-motion: reduce)"
-      ).matches;
-      if (
-        !reduceMotion &&
-        (matchedKey !== this._lastFlashKey || now - this._lastFlashAt > FLASH_DEDUP_MS)
-      ) {
+      if (matchedKey !== this._lastFlashKey || now - this._lastFlashAt > FLASH_DEDUP_MS) {
         this._lastFlashKey = matchedKey;
         this._lastFlashAt = now;
-        target.classList.remove(FLASH_CLASS);
-        void target.offsetWidth;
-        target.classList.add(FLASH_CLASS);
-        // Drop the class once the one-shot glow ends so it isn't left on the
-        // element (and can't linger across a re-render).
-        target.addEventListener(
-          "animationend",
-          () => target.classList.remove(FLASH_CLASS),
-          { once: true }
-        );
+        flashHighlight(target);
       }
       if (len === path.length) this._scrolledKey = key;
       return;

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -29,7 +29,11 @@ import { initialDarkMode } from "../util/dark-mode.js";
 import { editorSearchPhrases } from "../util/editor-search-phrases.js";
 import { ESPHOME_YAML_INDENT, esphomeYaml } from "../util/esphome-yaml-lang.js";
 import { idleCompletion } from "../util/idle-completion.js";
-import { getKeyPath, isInsideBlockScalar } from "../util/yaml-ast.js";
+import {
+  getKeyPath,
+  getKeyPathWithListIndices,
+  isInsideBlockScalar,
+} from "../util/yaml-ast.js";
 import { createYamlCompletionSource } from "../util/yaml-completion.js";
 import { lineKeyToken, type YamlAutoFix } from "../util/yaml-error-analysis.js";
 import { createYamlHoverTooltip } from "../util/yaml-hover.js";
@@ -533,9 +537,18 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
           ) {
             this._lastReportedCursorLine = line;
             this._lastReportedPathKey = pathKey;
+            // AST-only sibling of ``path`` carrying block-sequence list
+            // indices — what the automation editor needs to resolve a
+            // node inside a handler body. Empty (omitted) on lines only
+            // the indent walkers can anchor.
+            const indexedPath = getKeyPathWithListIndices(update.state, head);
             this.dispatchEvent(
               new CustomEvent("yaml-cursor-line", {
-                detail: { line, path },
+                detail: {
+                  line,
+                  path,
+                  indexedPath: indexedPath.length ? indexedPath : undefined,
+                },
                 bubbles: true,
                 composed: true,
               })

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -177,6 +177,11 @@ export class ESPHomePageDevice extends LitElement {
   @state()
   private _focusFieldPath?: string[];
 
+  /** Document-absolute indexed key path at the cursor — the automation
+   *  editor resolves it against its tree to deep-target a nested node. */
+  @state()
+  private _focusYamlPath?: (string | number)[];
+
   /** Backend validation errors resolved onto section instances, refreshed
    *  on every lint pass. Feeds the navigator badges and the selected
    *  section's inline form errors. */
@@ -1092,6 +1097,7 @@ export class ESPHomePageDevice extends LitElement {
             .selectedSection=${this._selectedSection}
             .selectedFromLine=${this._selectedFromLine}
             .focusFieldPath=${this._focusFieldPath}
+            .focusYamlPath=${this._focusYamlPath}
             .backendErrors=${this._instanceBackendErrors(
               this._backendErrors,
               this._selectedSection,
@@ -1386,7 +1392,13 @@ export class ESPHomePageDevice extends LitElement {
    * `if` blocks in `yaml-editor.ts:_buildExtensions`'s
    * `updateListener`.
    */
-  private _onYamlCursorLine(e: CustomEvent<{ line: number; path?: string[] }>) {
+  private _onYamlCursorLine(
+    e: CustomEvent<{
+      line: number;
+      path?: string[];
+      indexedPath?: (string | number)[];
+    }>
+  ) {
     // The user is driving from the YAML pane now — drop any pending
     // form-field retry so it can't re-highlight after they've moved on.
     this._clearPendingFieldLine();
@@ -1407,6 +1419,7 @@ export class ESPHomePageDevice extends LitElement {
       // Same section: update the field target directly for intra-section
       // moves (the switch below would early-return and freeze it).
       this._focusFieldPath = rel;
+      this._focusYamlPath = e.detail.indexedPath;
       return;
     }
     // Cross-section: set the field path only when the switch actually
@@ -1416,6 +1429,7 @@ export class ESPHomePageDevice extends LitElement {
       this._selectedSection = sectionKey;
       this._selectedFromLine = match.fromLine;
       this._focusFieldPath = rel;
+      this._focusYamlPath = e.detail.indexedPath;
       // The navigator selection follows the caret; a block highlight
       // left on the previously clicked component would disagree with
       // it (#1885). The highlight is a navigator/form affordance —

--- a/src/util/yaml-ast.ts
+++ b/src/util/yaml-ast.ts
@@ -199,6 +199,10 @@ export function getKeyPath(state: EditorState, pos: number): string[] {
   return keys.reverse();
 }
 
+/** One segment of an indexed key path: a mapping key or a
+ *  block-sequence index. */
+export type YamlPathSegment = string | number;
+
 /**
  * Like ``getKeyPath``, but block-sequence items contribute their
  * numeric index, so a field inside ``esphome: areas: - id:`` yields
@@ -208,8 +212,8 @@ export function getKeyPath(state: EditorState, pos: number): string[] {
 export function getKeyPathWithListIndices(
   state: EditorState,
   pos: number
-): (string | number)[] {
-  const segs: (string | number)[] = [];
+): YamlPathSegment[] {
+  const segs: YamlPathSegment[] = [];
   for (let node = resolveAnchoredNode(state, pos); node; node = node.parent) {
     if (node.name === "Pair") {
       const k = getPairKey(state, node);

--- a/test/components/device/automation-editor/automation-focus-plumbing.test.ts
+++ b/test/components/device/automation-editor/automation-focus-plumbing.test.ts
@@ -41,7 +41,7 @@ import { ESPHomeAutomationActionNode } from "../../../../src/components/device/a
 import { ESPHomeAutomationConditionTree } from "../../../../src/components/device/automation-editor/automation-condition-tree.js";
 import { ESPHomeAutomationEditor } from "../../../../src/components/device/automation-editor/automation-editor.js";
 import type { AutomationFocus } from "../../../../src/components/device/automation-editor/automation-focus.js";
-import { flushMicrotasks } from "../../../_dom.js";
+import { flushMicrotasks, mount } from "../../../_dom.js";
 
 const entry = (key: string, advanced = false) =>
   ({ key, type: "string", label: key, advanced }) as unknown as ConfigEntry;
@@ -84,14 +84,7 @@ const inRange = (params: Record<string, unknown> = {}): ConditionNode => ({
   children: [],
 });
 
-async function settle(el: HTMLElement & { updateComplete: Promise<boolean> }) {
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
-
 afterEach(() => {
-  document.body.innerHTML = "";
   vi.restoreAllMocks();
 });
 
@@ -105,7 +98,7 @@ describe("action-list focus slicing", () => {
     list.catalog = [IF_DEF, LOG_DEF];
     list.conditionCatalog = [IN_RANGE_DEF];
     list.focusTarget = { node: [1, "conditions", 0], field: ["above"] };
-    await settle(list);
+    await mount(list);
 
     const rows = list.shadowRoot!.querySelectorAll("esphome-automation-action-node");
     expect((rows[0] as ESPHomeAutomationActionNode).focusTarget).toBeNull();
@@ -126,7 +119,7 @@ describe("action-node focus routing", () => {
     el.catalog = [IF_DEF, LOG_DEF];
     el.conditionCatalog = [IN_RANGE_DEF, OR_DEF];
     el.focusTarget = focusTarget;
-    await settle(el);
+    await mount(el);
     return el;
   }
 
@@ -160,7 +153,9 @@ describe("action-node focus routing", () => {
     expect(byLabel("action").focusTarget).toBeNull();
   });
 
-  it("arms the params form and reveals advanced for a hidden advanced field", async () => {
+  it("arms the params form's focusFieldPath for a field target", async () => {
+    // The advanced reveal itself is the form's job (one-shot
+    // advanced-toggle, pinned in config-entry-form-advanced-section).
     const el = await mountNode(
       { action_id: "logger.log", params: {}, children: {}, conditions: [] },
       { node: [], field: ["level"] }
@@ -168,8 +163,6 @@ describe("action-node focus routing", () => {
     const form = el.shadowRoot!.querySelector("esphome-config-entry-form");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((form as any).focusFieldPath).toEqual(["level"]);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((el as any)._showAdvanced).toBe(true);
   });
 
   it("un-collapses a collapsed card so the target can render", async () => {
@@ -209,7 +202,7 @@ describe("condition-tree focus routing", () => {
     tree.conditions = [inRange({ above: 20 }), inRange({ above: 30 })];
     tree.catalog = [IN_RANGE_DEF];
     tree.focusTarget = { node: [1], field: ["above"] };
-    await settle(tree);
+    await mount(tree);
 
     const forms = tree.shadowRoot!.querySelectorAll("esphome-config-entry-form");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -225,7 +218,7 @@ describe("condition-tree focus routing", () => {
     ];
     tree.catalog = [IN_RANGE_DEF, OR_DEF];
     tree.focusTarget = { node: [0, 1], field: ["below"] };
-    await settle(tree);
+    await mount(tree);
 
     const nested = tree.shadowRoot!.querySelector(
       "esphome-automation-condition-tree"
@@ -278,7 +271,7 @@ describe("automation-editor focus resolution", () => {
       "sensor.in_range",
       "above",
     ];
-    await settle(editor);
+    await mount(editor);
     await flushMicrotasks(5);
 
     const list = editor.shadowRoot!.querySelector(

--- a/test/components/device/automation-editor/automation-focus-plumbing.test.ts
+++ b/test/components/device/automation-editor/automation-focus-plumbing.test.ts
@@ -1,0 +1,292 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The focus target threads from the editor through list → node →
+ * condition tree, arming the right leaf form's ``focusFieldPath``,
+ * un-collapsing collapsed cards, revealing advanced params, and
+ * degrading to a row scroll when the target terminates on a node.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-target-picker.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-trigger-picker.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/catalog-picker-dialog.js",
+  () => ({})
+);
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+
+import type { ESPHomeAPI } from "../../../../src/api/index.js";
+import type {
+  ActionNode,
+  AutomationAction,
+  AutomationCondition,
+  AvailableAutomations,
+  ConditionNode,
+} from "../../../../src/api/types/automations.js";
+import type { ConfigEntry } from "../../../../src/api/types/config-entries.js";
+import { ESPHomeAutomationActionList } from "../../../../src/components/device/automation-editor/automation-action-list.js";
+import { ESPHomeAutomationActionNode } from "../../../../src/components/device/automation-editor/automation-action-node.js";
+import { ESPHomeAutomationConditionTree } from "../../../../src/components/device/automation-editor/automation-condition-tree.js";
+import { ESPHomeAutomationEditor } from "../../../../src/components/device/automation-editor/automation-editor.js";
+import type { AutomationFocus } from "../../../../src/components/device/automation-editor/automation-focus.js";
+import { flushMicrotasks } from "../../../_dom.js";
+
+const entry = (key: string, advanced = false) =>
+  ({ key, type: "string", label: key, advanced }) as unknown as ConfigEntry;
+
+const IF_DEF = {
+  id: "if",
+  name: "If",
+  description: "",
+  config_entries: [],
+  accepts_action_list: ["then", "else"],
+} as unknown as AutomationAction;
+
+const LOG_DEF = {
+  id: "logger.log",
+  name: "Log",
+  description: "",
+  config_entries: [entry("format"), entry("level", true)],
+  accepts_action_list: [],
+} as unknown as AutomationAction;
+
+const IN_RANGE_DEF = {
+  id: "sensor.in_range",
+  name: "In range",
+  description: "",
+  config_entries: [entry("above"), entry("below")],
+  accepts_condition_list: false,
+} as unknown as AutomationCondition;
+
+const OR_DEF = {
+  id: "or",
+  name: "Or",
+  description: "",
+  config_entries: [],
+  accepts_condition_list: true,
+} as unknown as AutomationCondition;
+
+const inRange = (params: Record<string, unknown> = {}): ConditionNode => ({
+  condition_id: "sensor.in_range",
+  params,
+  children: [],
+});
+
+async function settle(el: HTMLElement & { updateComplete: Promise<boolean> }) {
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("action-list focus slicing", () => {
+  it("hands the sliced target to the indexed row only", async () => {
+    const list = new ESPHomeAutomationActionList();
+    list.actions = [
+      { action_id: "logger.log", params: {}, children: {}, conditions: [] },
+      { action_id: "if", params: {}, children: {}, conditions: [inRange()] },
+    ];
+    list.catalog = [IF_DEF, LOG_DEF];
+    list.conditionCatalog = [IN_RANGE_DEF];
+    list.focusTarget = { node: [1, "conditions", 0], field: ["above"] };
+    await settle(list);
+
+    const rows = list.shadowRoot!.querySelectorAll("esphome-automation-action-node");
+    expect((rows[0] as ESPHomeAutomationActionNode).focusTarget).toBeNull();
+    expect((rows[1] as ESPHomeAutomationActionNode).focusTarget).toEqual({
+      node: ["conditions", 0],
+      field: ["above"],
+    });
+  });
+});
+
+describe("action-node focus routing", () => {
+  async function mountNode(
+    value: ActionNode,
+    focusTarget: AutomationFocus | null
+  ): Promise<ESPHomeAutomationActionNode> {
+    const el = new ESPHomeAutomationActionNode();
+    el.value = value;
+    el.catalog = [IF_DEF, LOG_DEF];
+    el.conditionCatalog = [IN_RANGE_DEF, OR_DEF];
+    el.focusTarget = focusTarget;
+    await settle(el);
+    return el;
+  }
+
+  it("routes a conditions head into the gate tree, sliced", async () => {
+    const el = await mountNode(
+      { action_id: "if", params: {}, children: {}, conditions: [inRange()] },
+      { node: ["conditions", 0], field: ["above"] }
+    );
+    const tree = el.shadowRoot!.querySelector(
+      "esphome-automation-condition-tree"
+    ) as ESPHomeAutomationConditionTree;
+    expect(tree.focusTarget).toEqual({ node: [0], field: ["above"] });
+  });
+
+  it("routes a child-list key into that nested list, sliced", async () => {
+    const el = await mountNode(
+      {
+        action_id: "if",
+        params: {},
+        children: { then: [], else: [] },
+        conditions: [],
+      },
+      { node: ["else", 0], field: [] }
+    );
+    const lists = el.shadowRoot!.querySelectorAll("esphome-automation-action-list");
+    const byLabel = (label: string) =>
+      [...lists].find((l) =>
+        l.parentElement?.textContent?.toLowerCase().includes(label)
+      ) as ESPHomeAutomationActionList;
+    expect(byLabel("else").focusTarget).toEqual({ node: [0], field: [] });
+    expect(byLabel("action").focusTarget).toBeNull();
+  });
+
+  it("arms the params form and reveals advanced for a hidden advanced field", async () => {
+    const el = await mountNode(
+      { action_id: "logger.log", params: {}, children: {}, conditions: [] },
+      { node: [], field: ["level"] }
+    );
+    const form = el.shadowRoot!.querySelector("esphome-config-entry-form");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((form as any).focusFieldPath).toEqual(["level"]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._showAdvanced).toBe(true);
+  });
+
+  it("un-collapses a collapsed card so the target can render", async () => {
+    const el = await mountNode(
+      { action_id: "logger.log", params: {}, children: {}, conditions: [] },
+      null
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._collapsed = true;
+    await el.updateComplete;
+    el.focusTarget = { node: [], field: ["format"] };
+    await el.updateComplete;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._collapsed).toBe(false);
+    expect(el.shadowRoot!.querySelector("esphome-config-entry-form")).not.toBeNull();
+  });
+
+  it("scrolls and flashes the row once for a node-level target", async () => {
+    const scrolled = vi
+      .spyOn(HTMLElement.prototype, "scrollIntoView")
+      .mockImplementation(() => {});
+    const el = await mountNode(
+      { action_id: "logger.log", params: {}, children: {}, conditions: [] },
+      { node: [], field: [] }
+    );
+    expect(scrolled).toHaveBeenCalledTimes(1);
+    // A re-render with the same target must not re-scroll.
+    el.focusTarget = { node: [], field: [] };
+    await el.updateComplete;
+    expect(scrolled).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("condition-tree focus routing", () => {
+  it("arms the targeted leaf form and leaves siblings alone", async () => {
+    const tree = new ESPHomeAutomationConditionTree();
+    tree.conditions = [inRange({ above: 20 }), inRange({ above: 30 })];
+    tree.catalog = [IN_RANGE_DEF];
+    tree.focusTarget = { node: [1], field: ["above"] };
+    await settle(tree);
+
+    const forms = tree.shadowRoot!.querySelectorAll("esphome-config-entry-form");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((forms[0] as any).focusFieldPath).toBeUndefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((forms[1] as any).focusFieldPath).toEqual(["above"]);
+  });
+
+  it("recurses a deeper target into the combinator's child tree", async () => {
+    const tree = new ESPHomeAutomationConditionTree();
+    tree.conditions = [
+      { condition_id: "or", params: {}, children: [inRange(), inRange()] },
+    ];
+    tree.catalog = [IN_RANGE_DEF, OR_DEF];
+    tree.focusTarget = { node: [0, 1], field: ["below"] };
+    await settle(tree);
+
+    const nested = tree.shadowRoot!.querySelector(
+      "esphome-automation-condition-tree"
+    ) as ESPHomeAutomationConditionTree;
+    expect(nested.focusTarget).toEqual({ node: [1], field: ["below"] });
+    const forms = nested.shadowRoot!.querySelectorAll("esphome-config-entry-form");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((forms[1] as any).focusFieldPath).toEqual(["below"]);
+  });
+});
+
+describe("automation-editor focus resolution", () => {
+  it("resolves the cursor path against its tree and hands it to the action list", async () => {
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue({
+        triggers: [],
+        actions: [IF_DEF, LOG_DEF],
+        conditions: [IN_RANGE_DEF],
+        scripts: [],
+        devices: [],
+      } as unknown as AvailableAutomations),
+      getAutomationBodies: vi.fn().mockResolvedValue({}),
+      parseDeviceAutomations: vi.fn().mockResolvedValue([]),
+    } as unknown as ESPHomeAPI;
+    const editor = new ESPHomeAutomationEditor();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor as any)._api = api;
+    editor.configuration = "device.yaml";
+    editor.location = {
+      kind: "component_on",
+      component_id: "button_module",
+      trigger: "on_click",
+      index: 0,
+    };
+    editor.value = {
+      trigger_id: null,
+      trigger_params: {},
+      actions: [{ action_id: "if", params: {}, children: {}, conditions: [inRange()] }],
+    };
+    editor.focusYamlPath = [
+      "binary_sensor",
+      0,
+      "on_click",
+      0,
+      "then",
+      0,
+      "if",
+      "condition",
+      0,
+      "sensor.in_range",
+      "above",
+    ];
+    await settle(editor);
+    await flushMicrotasks(5);
+
+    const list = editor.shadowRoot!.querySelector(
+      "esphome-automation-action-list"
+    ) as ESPHomeAutomationActionList;
+    expect(list.focusTarget).toEqual({
+      node: [0, "conditions", 0],
+      field: ["above"],
+    });
+  });
+});

--- a/test/components/device/automation-editor/automation-focus.test.ts
+++ b/test/components/device/automation-editor/automation-focus.test.ts
@@ -279,10 +279,13 @@ describe("resolveAutomationFocus", () => {
   });
 
   it("terminates at node level on a scalar shorthand", () => {
-    // ``- logger.log: warm`` — the cursor path ends at the action id.
-    expect(
-      resolveAutomationFocus(REPRO, ["then", 0, "if", "then", 0, "logger.log"])
-    ).toEqual({ node: [0, "then", 0], field: [] });
+    // ``- logger.log: warm`` — the cursor path ends at the action id key,
+    // never reaching the shorthand-mapped param.
+    const t = tree([action("logger.log", { params: { format: "warm" } })]);
+    expect(resolveAutomationFocus(t, ["then", 0, "logger.log"])).toEqual({
+      node: [0],
+      field: [],
+    });
   });
 
   it("falls back to an id search when a multi-key item shifted indices", () => {

--- a/test/components/device/automation-editor/automation-focus.test.ts
+++ b/test/components/device/automation-editor/automation-focus.test.ts
@@ -317,6 +317,15 @@ describe("resolveAutomationFocus", () => {
     expect(resolveAutomationFocus(tree([]), ["then", 5])).toBeNull();
   });
 
+  it("treats a prototype-named param key as a field, not a child list", () => {
+    // ``constructor`` is inherited by every plain object; ``in`` on the
+    // wire tree's children would route into Object.prototype and crash.
+    expect(resolveAutomationFocus(REPRO, ["then", 0, "if", "constructor", 0])).toEqual({
+      node: [0],
+      field: ["constructor", "0"],
+    });
+  });
+
   it("returns null on an empty relative path", () => {
     expect(resolveAutomationFocus(REPRO, [])).toBeNull();
   });

--- a/test/components/device/automation-editor/automation-focus.test.ts
+++ b/test/components/device/automation-editor/automation-focus.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Truth table for the YAML-cursor → automation-tree focus resolution:
+ * slicing a document-absolute path to the handler body, and walking it
+ * against the decomposed tree across every YAML shorthand shape.
+ */
+import { describe, expect, it } from "vitest";
+
+import type {
+  ActionNode,
+  AutomationTree,
+  ConditionNode,
+} from "../../../../src/api/types/automations.js";
+import {
+  automationRelativePath,
+  childFocus,
+  focusKey,
+  resolveAutomationFocus,
+} from "../../../../src/components/device/automation-editor/automation-focus.js";
+
+function action(id: string, extra: Partial<ActionNode> = {}): ActionNode {
+  return { action_id: id, params: {}, children: {}, conditions: [], ...extra };
+}
+
+function condition(id: string, extra: Partial<ConditionNode> = {}): ConditionNode {
+  return { condition_id: id, params: {}, children: [], ...extra };
+}
+
+function tree(actions: ActionNode[]): AutomationTree {
+  return { trigger_id: null, trigger_params: {}, actions };
+}
+
+// The apollo-starter-kit repro: on_click → then → if → two in_range
+// conditions → logger.log.
+const REPRO = tree([
+  action("if", {
+    conditions: [
+      condition("sensor.in_range", { params: { id: "t", above: 20 } }),
+      condition("sensor.in_range", { params: { id: "h", above: 20 } }),
+    ],
+    children: { then: [action("logger.log", { params: { format: "warm" } })] },
+  }),
+]);
+
+describe("automationRelativePath", () => {
+  it("slices past a component_on trigger with a list index", () => {
+    expect(
+      automationRelativePath(["binary_sensor", 0, "on_click", 0, "then", 0, "if"], {
+        kind: "component_on",
+        component_id: "button_module",
+        trigger: "on_click",
+        index: 0,
+      })
+    ).toEqual(["then", 0, "if"]);
+  });
+
+  it("slices a mapping-form trigger without an index", () => {
+    expect(
+      automationRelativePath(["binary_sensor", 0, "on_press", "min_length"], {
+        kind: "component_on",
+        component_id: "b",
+        trigger: "on_press",
+      })
+    ).toEqual(["min_length"]);
+  });
+
+  it("finds the trigger key under a sub-entity host", () => {
+    expect(
+      automationRelativePath(["sensor", 0, "temperature", "on_value", "then", 0], {
+        kind: "component_on",
+        component_id: "sensor",
+        trigger: "on_value",
+      })
+    ).toEqual(["then", 0]);
+  });
+
+  it("slices device_on with and without an index", () => {
+    const loc = { kind: "device_on", trigger: "on_boot" } as const;
+    expect(automationRelativePath(["esphome", "on_boot", "then", 0], loc)).toEqual([
+      "then",
+      0,
+    ]);
+    expect(
+      automationRelativePath(["esphome", "on_boot", 1, "priority"], {
+        ...loc,
+        index: 1,
+      })
+    ).toEqual(["priority"]);
+  });
+
+  it("slices component_action on its field key", () => {
+    expect(
+      automationRelativePath(["cover", 0, "open_action", 0, "logger.log"], {
+        kind: "component_action",
+        component_id: "cover_1",
+        field: "open_action",
+      })
+    ).toEqual([0, "logger.log"]);
+  });
+
+  it("slices interval by index", () => {
+    expect(
+      automationRelativePath(["interval", 2, "then", 0], { kind: "interval", index: 2 })
+    ).toEqual(["then", 0]);
+    expect(
+      automationRelativePath(["interval", 1, "then"], { kind: "interval", index: 2 })
+    ).toBeNull();
+  });
+
+  it("rejects a path outside the located handler", () => {
+    expect(
+      automationRelativePath(["binary_sensor", 0, "name"], {
+        kind: "component_on",
+        component_id: "b",
+        trigger: "on_click",
+        index: 0,
+      })
+    ).toBeNull();
+    // Wrong list entry of a list-shaped trigger.
+    expect(
+      automationRelativePath(["time", 0, "on_time", 1, "seconds"], {
+        kind: "component_on",
+        component_id: "time",
+        trigger: "on_time",
+        index: 0,
+      })
+    ).toBeNull();
+  });
+
+  it("returns null for kinds that mount other editors", () => {
+    expect(
+      automationRelativePath(["script", 0, "then"], { kind: "script", id: "s" })
+    ).toBeNull();
+    expect(
+      automationRelativePath(["api", "actions", 0], {
+        kind: "api_action",
+        action_name: "a",
+      })
+    ).toBeNull();
+  });
+});
+
+describe("resolveAutomationFocus", () => {
+  it("resolves the repro path to the first condition's above field", () => {
+    expect(
+      resolveAutomationFocus(REPRO, [
+        "then",
+        0,
+        "if",
+        "condition",
+        0,
+        "sensor.in_range",
+        "above",
+      ])
+    ).toEqual({ node: [0, "conditions", 0], field: ["above"] });
+  });
+
+  it("resolves the second condition by its list index", () => {
+    expect(
+      resolveAutomationFocus(REPRO, [
+        "then",
+        0,
+        "if",
+        "condition",
+        1,
+        "sensor.in_range",
+        "above",
+      ])
+    ).toEqual({ node: [0, "conditions", 1], field: ["above"] });
+  });
+
+  it("resolves a nested then-branch action to node level", () => {
+    expect(
+      resolveAutomationFocus(REPRO, ["then", 0, "if", "then", 0, "logger.log"])
+    ).toEqual({ node: [0, "then", 0], field: [] });
+  });
+
+  it("routes a non-action key to the trigger params form", () => {
+    expect(resolveAutomationFocus(REPRO, ["min_length"])).toEqual({
+      node: [],
+      field: ["min_length"],
+    });
+  });
+
+  it("resolves the bare action-list form without a then wrapper", () => {
+    expect(
+      resolveAutomationFocus(tree([action("light.turn_on")]), [
+        0,
+        "light.turn_on",
+        "brightness",
+      ])
+    ).toEqual({ node: [0], field: ["brightness"] });
+  });
+
+  it("resolves the single-bare-action shortcut mixed with trigger params", () => {
+    const t = tree([action("switch.toggle", { params: { id: "relay" } })]);
+    expect(resolveAutomationFocus(t, ["switch.toggle", "id"])).toEqual({
+      node: [0],
+      field: ["id"],
+    });
+    expect(resolveAutomationFocus(t, ["min_length"])).toEqual({
+      node: [],
+      field: ["min_length"],
+    });
+  });
+
+  it("resolves a dict-form condition with no list index", () => {
+    const t = tree([action("if", { conditions: [condition("api.connected")] })]);
+    expect(
+      resolveAutomationFocus(t, ["then", 0, "if", "condition", "api.connected"])
+    ).toEqual({ node: [0, "conditions", 0], field: [] });
+  });
+
+  it("recurses into a combinator's children by index", () => {
+    const t = tree([
+      action("if", {
+        conditions: [
+          condition("or", {
+            children: [
+              condition("sensor.in_range", { params: { above: 1 } }),
+              condition("sensor.in_range", { params: { below: 2 } }),
+            ],
+          }),
+        ],
+      }),
+    ]);
+    expect(
+      resolveAutomationFocus(t, [
+        "then",
+        0,
+        "if",
+        "condition",
+        0,
+        "or",
+        1,
+        "sensor.in_range",
+        "below",
+      ])
+    ).toEqual({ node: [0, "conditions", 0, 1], field: ["below"] });
+  });
+
+  it("resolves wait_until's gate-less dict shorthand and its timeout param", () => {
+    const t = tree([action("wait_until", { conditions: [condition("api.connected")] })]);
+    expect(resolveAutomationFocus(t, ["then", 0, "wait_until", "api.connected"])).toEqual(
+      {
+        node: [0, "conditions", 0],
+        field: [],
+      }
+    );
+    expect(resolveAutomationFocus(t, ["then", 0, "wait_until", "timeout"])).toEqual({
+      node: [0],
+      field: ["timeout"],
+    });
+  });
+
+  it("resolves if-inside-if through nested then/else lists", () => {
+    const inner = action("if", {
+      conditions: [condition("api.connected")],
+      children: { then: [action("logger.log")] },
+    });
+    const t = tree([
+      action("if", { children: { then: [inner], else: [action("delay")] } }),
+    ]);
+    expect(
+      resolveAutomationFocus(t, [
+        "then",
+        0,
+        "if",
+        "then",
+        0,
+        "if",
+        "condition",
+        "api.connected",
+      ])
+    ).toEqual({ node: [0, "then", 0, "conditions", 0], field: [] });
+    expect(resolveAutomationFocus(t, ["then", 0, "if", "else", 0, "delay"])).toEqual({
+      node: [0, "else", 0],
+      field: [],
+    });
+  });
+
+  it("terminates at node level on a scalar shorthand", () => {
+    // ``- logger.log: warm`` — the cursor path ends at the action id.
+    expect(
+      resolveAutomationFocus(REPRO, ["then", 0, "if", "then", 0, "logger.log"])
+    ).toEqual({ node: [0, "then", 0], field: [] });
+  });
+
+  it("falls back to an id search when a multi-key item shifted indices", () => {
+    const t = tree([action("logger.log"), action("switch.toggle")]);
+    // YAML item 1 is switch.toggle but a multi-key item 0 pushed it to
+    // node index 1 already; a mismatched index still finds it by id.
+    expect(resolveAutomationFocus(t, ["then", 0, "switch.toggle", "id"])).toEqual({
+      node: [1],
+      field: ["id"],
+    });
+  });
+
+  it("fails soft to the deepest resolved node", () => {
+    // Unknown child key under the if → the if node itself.
+    expect(
+      resolveAutomationFocus(REPRO, ["then", 0, "if", "bogus_list", 0, "x"])
+    ).toEqual({ node: [0], field: ["bogus_list", "0", "x"] });
+    // Out-of-range condition index with a known wrapper id → the id
+    // search lands on a same-id sibling rather than losing the target.
+    expect(
+      resolveAutomationFocus(REPRO, ["then", 0, "if", "condition", 9, "sensor.in_range"])
+    ).toEqual({ node: [0, "conditions", 0], field: [] });
+    // Out-of-range condition index with no wrapper → the enclosing action.
+    expect(resolveAutomationFocus(REPRO, ["then", 0, "if", "condition", 9])).toEqual({
+      node: [0],
+      field: [],
+    });
+    // Out-of-range action index with no wrapper → nothing to anchor.
+    expect(resolveAutomationFocus(tree([]), ["then", 5])).toBeNull();
+  });
+
+  it("returns null on an empty relative path", () => {
+    expect(resolveAutomationFocus(REPRO, [])).toBeNull();
+  });
+});
+
+describe("focus helpers", () => {
+  it("childFocus peels one node segment, keeping the field", () => {
+    expect(childFocus({ node: [0, "conditions", 1], field: ["above"] })).toEqual({
+      node: ["conditions", 1],
+      field: ["above"],
+    });
+  });
+
+  it("focusKey keys by value and maps null to undefined", () => {
+    const a = focusKey({ node: [0], field: ["x"] });
+    expect(a).toBe(focusKey({ node: [0], field: ["x"] }));
+    expect(a).not.toBe(focusKey({ node: [0], field: ["y"] }));
+    expect(focusKey(null)).toBeUndefined();
+  });
+});

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -538,6 +538,60 @@ describe("config-entry-form advanced-section", () => {
     expect(detail).toEqual({ show: true });
   });
 
+  it("asks the host to open the section once when the cursor targets a hidden advanced field", () => {
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [BASIC, ADVANCED];
+    form.values = {};
+    form.advancedSection = true;
+    form.showAdvanced = false;
+    form.focusFieldPath = ["reboot_timeout"];
+    let count = 0;
+    form.addEventListener("advanced-toggle", () => count++);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any).updated(new Map());
+    expect(count).toBe(1);
+    // One-shot: a host decline (or a deliberate re-collapse) sticks.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any).updated(new Map());
+    expect(count).toBe(1);
+  });
+
+  it("does not ask for a basic-field focus target", () => {
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [BASIC, ADVANCED];
+    form.values = {};
+    form.advancedSection = true;
+    form.showAdvanced = false;
+    form.focusFieldPath = ["name"];
+    let emitted = false;
+    form.addEventListener("advanced-toggle", () => {
+      emitted = true;
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any).updated(new Map());
+    expect(emitted).toBe(false);
+  });
+
+  it("holds the focus-reveal shot until entries land", () => {
+    // The path can arrive before the async catalog; the target must not be
+    // consumed against an empty schema.
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [];
+    form.values = {};
+    form.advancedSection = true;
+    form.showAdvanced = false;
+    form.focusFieldPath = ["reboot_timeout"];
+    let count = 0;
+    form.addEventListener("advanced-toggle", () => count++);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any).updated(new Map());
+    expect(count).toBe(0);
+    form.entries = [BASIC, ADVANCED];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any).updated(new Map());
+    expect(count).toBe(1);
+  });
+
   it("emits advanced-toggle when the control is clicked", () => {
     const form = new ESPHomeConfigEntryForm();
     form.entries = [BASIC, ADVANCED];

--- a/test/components/yaml-editor-cursor-line.test.ts
+++ b/test/components/yaml-editor-cursor-line.test.ts
@@ -17,6 +17,7 @@ import { ESPHomeYamlEditor } from "../../src/components/yaml-editor.js";
 interface CursorLineDetail {
   line: number;
   path: string[];
+  indexedPath?: (string | number)[];
 }
 
 async function mount(value: string): Promise<ESPHomeYamlEditor> {
@@ -186,6 +187,49 @@ describe("yaml-editor cursor-line emission (#946)", () => {
     view.dispatch({ changes: { from: at, insert: "G" } }); // no selection
     parseAll(view);
     expect(events).toHaveLength(0);
+  });
+
+  it("carries list indices on indexedPath for a nested automation line", async () => {
+    const el = await mount(
+      "binary_sensor:\n" +
+        "  - platform: gpio\n" +
+        "    on_click:\n" +
+        "      - then:\n" +
+        "          - if:\n" +
+        "              condition:\n" +
+        "                - sensor.in_range:\n" +
+        "                    above: 20\n"
+    );
+    const view = viewOf(el);
+    parseAll(view);
+    const events = record(el);
+
+    caretToLineEnd(view, 8); // the `above: 20` line
+    expect(events).toHaveLength(1);
+    expect(events[0].indexedPath).toEqual([
+      "binary_sensor",
+      0,
+      "on_click",
+      0,
+      "then",
+      0,
+      "if",
+      "condition",
+      0,
+      "sensor.in_range",
+      "above",
+    ]);
+  });
+
+  it("omits indexedPath on a line only the indent walkers anchor", async () => {
+    const el = await mount("esp32:\n  board: a\nhttp_request:\n  \n");
+    const view = viewOf(el);
+    parseAll(view);
+    const events = record(el);
+
+    caretToLineEnd(view, 4); // blank child line — no AST anchor
+    expect(events).toHaveLength(1);
+    expect(events[0].indexedPath).toBeUndefined();
   });
 
   it("still emits on an ordinary line change", async () => {

--- a/test/pages/device-cursor-highlight.test.ts
+++ b/test/pages/device-cursor-highlight.test.ts
@@ -58,9 +58,14 @@ function makePage(api: Partial<ESPHomeAPI> = {}): ESPHomePageDevice {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const internals = (page: ESPHomePageDevice) => page as any;
 
-function clickYamlLine(page: ESPHomePageDevice, line: number, path: string[] = []) {
+function clickYamlLine(
+  page: ESPHomePageDevice,
+  line: number,
+  path: string[] = [],
+  indexedPath?: (string | number)[]
+) {
   internals(page)._onYamlCursorLine(
-    new CustomEvent("yaml-cursor-line", { detail: { line, path } })
+    new CustomEvent("yaml-cursor-line", { detail: { line, path, indexedPath } })
   );
 }
 
@@ -161,6 +166,15 @@ describe("cursor-driven YAML highlight (#1885)", () => {
     expect(internals(page)._selectedSection).not.toBe("i2c");
     expect(internals(page)._highlightRange).toEqual({ fromLine: 2, toLine: 2 });
     expect(internals(page)._errorHighlight).toBe("active");
+  });
+
+  it("captures the indexed cursor path on cross- and same-section moves", () => {
+    const page = makePage();
+    clickYamlLine(page, 5, ["sensor"], ["sensor", 0, "platform"]); // cross-section
+    expect(internals(page)._focusYamlPath).toEqual(["sensor", 0, "platform"]);
+
+    clickYamlLine(page, 6, ["sensor", "temperature"], ["sensor", 0, "temperature"]);
+    expect(internals(page)._focusYamlPath).toEqual(["sensor", 0, "temperature"]);
   });
 
   it("an active error-jump highlight survives a hand edit", () => {


### PR DESCRIPTION
# What does this implement/fix?

Clicking a nested field inside an automation in the YAML pane (for example the `above: 20` of a `sensor.in_range` condition buried in an `on_click` handler) selected the automation section and opened the automation editor, but never scrolled to or highlighted the clicked target; the editor just showed the whole automation from the top. Component sections already deep target the exact field from the caret, so automations felt broken by comparison.

The cursor event now also carries the AST's indexed key path (list indices included, which the existing key-only path lacks), threaded as `focusYamlPath` down to the automation editor. A new pure module, `automation-focus.ts`, slices that path to the handler body and walks it against the backend-decomposed `AutomationTree`, mirroring the decomposer's YAML shapes: explicit `then:` versus bare action list versus the single-bare-action shortcut, dict-form conditions, combinator recursion, and `wait_until`'s gate-less shorthand. Each render layer then peels its segment of the resulting focus target; the action list routes to the row, the action node to its condition gate, nested `then`/`else` list or params form, and the condition tree to its leaf form, arming the existing `focusFieldPath`/`FieldScrollController` machinery for the final scroll and flash. Node-level targets (scalar shorthands like `logger.log: warm`, or an unresolvable tail) fail soft to a row scroll with the shared cursor glow, and a collapsed action card un-collapses so the target can render.

Two pieces landed on shared infrastructure rather than per site: `config-entry-form` now asks its host (one-shot `advanced-toggle` per focus target) to open the advanced section when the caret targets a hidden advanced field, and the one-shot glow kernel moved to `field-highlight.ts` where both `FieldScrollController` and the new row scroll consume it. The `focusTarget` properties compare by value so the per-render re-slices don't re-render the focused chain on every keystroke.

Deep-linking a pasted URL still lands at automation level (`resolveSectionForUrlLine` short-circuits when `section=` is already set), and `script:`/`api.actions:` bodies keep today's behaviour; both are follow-up candidates, the resolver already has the extension points.

**Related issue or feature (if applicable):**

- fixes: reported in chat while testing 1.4.x, no GitHub issue filed; repro is apollo-starter-kit.yaml, caret on a nested `above: 20` inside `binary_sensor[0].on_click`

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
