### PR TITLE
Extend YAML-cursor deep focus to the script and api-action editors

### DIFF
--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -49,7 +49,7 @@ import { automationEditorStyles } from "./automation-editor.styles.js";
 import {
   actionsFocus,
   createFocusResolver,
-  entryFieldFocus,
+  paramFocus,
   type YamlPathSegment,
 } from "./automation-focus.js";
 import "./callable-params-editor.js";
@@ -208,12 +208,11 @@ export class ESPHomeApiActionEditor extends LitElement {
     const conditions = this._available?.conditions ?? [];
     const disabled = this._engine.deleting;
     const focus = this._resolveFocus(this.value, this.location, this.focusYamlPath);
-    const entryField = entryFieldFocus(focus);
     return html`
       ${this._renderHeader()} ${this._renderActionNameField(disabled)}
       <esphome-callable-params-editor
         .value=${(automation.trigger_params.variables ?? {}) as Record<string, string>}
-        .focusParam=${entryField?.[0] === "variables" ? (entryField[1] ?? "") : null}
+        .focusParam=${paramFocus(focus, "variables")}
         ?disabled=${disabled}
         .fieldLabel=${this._localize("device.api_action_variables")}
         .description=${this._localize("device.api_action_variables_description")}

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -46,6 +46,7 @@ import { registerMdiIcons } from "../../../util/register-icons.js";
 import { AutoApplyController } from "./auto-apply-controller.js";
 import "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
+import { createFocusResolver, type YamlPathSegment } from "./automation-focus.js";
 import "./callable-params-editor.js";
 import { CatalogLoadController } from "./catalog-load-controller.js";
 import { ParseErrorController } from "./parse-error-controller.js";
@@ -98,6 +99,13 @@ export class ESPHomeApiActionEditor extends LitElement {
   addMode = false;
 
   @property() yaml = "";
+
+  /** Indexed key path at the YAML cursor; resolved against the
+   *  hydrated tree to scroll/highlight the matching action node. */
+  @property({ attribute: false })
+  focusYamlPath?: YamlPathSegment[];
+
+  private _resolveFocus = createFocusResolver();
 
   /** Scoped catalog response — drives the action / condition / script
    *  / device pickers inside the action list. */
@@ -194,6 +202,7 @@ export class ESPHomeApiActionEditor extends LitElement {
     const actions = this._available?.actions ?? [];
     const conditions = this._available?.conditions ?? [];
     const disabled = this._engine.deleting;
+    const focus = this._resolveFocus(this.value, this.location, this.focusYamlPath);
     return html`
       ${this._renderHeader()} ${this._renderActionNameField(disabled)}
       <esphome-callable-params-editor
@@ -212,6 +221,7 @@ export class ESPHomeApiActionEditor extends LitElement {
         </p>
         <esphome-automation-action-list
           no-header
+          .focusTarget=${focus && focus.node.length > 0 ? focus : null}
           .actions=${automation.actions}
           .catalog=${actions}
           .conditionCatalog=${conditions}

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -46,7 +46,11 @@ import { registerMdiIcons } from "../../../util/register-icons.js";
 import { AutoApplyController } from "./auto-apply-controller.js";
 import "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
-import { createFocusResolver, type YamlPathSegment } from "./automation-focus.js";
+import {
+  actionsFocus,
+  createFocusResolver,
+  type YamlPathSegment,
+} from "./automation-focus.js";
 import "./callable-params-editor.js";
 import { CatalogLoadController } from "./catalog-load-controller.js";
 import { ParseErrorController } from "./parse-error-controller.js";
@@ -221,7 +225,7 @@ export class ESPHomeApiActionEditor extends LitElement {
         </p>
         <esphome-automation-action-list
           no-header
-          .focusTarget=${focus && focus.node.length > 0 ? focus : null}
+          .focusTarget=${actionsFocus(focus)}
           .actions=${automation.actions}
           .catalog=${actions}
           .conditionCatalog=${conditions}

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -43,12 +43,16 @@ import { normalizeEspHomeId } from "../../../util/esphome-id.js";
 import { formatApiError } from "../../../util/format-api-error.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
+import { scrollFlashRow } from "../field-highlight.js";
+import { fieldHighlightStyles } from "../field-highlight.styles.js";
 import { AutoApplyController } from "./auto-apply-controller.js";
 import "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import {
   actionsFocus,
   createFocusResolver,
+  entryFieldFocus,
+  focusKey,
   paramFocus,
   type YamlPathSegment,
 } from "./automation-focus.js";
@@ -149,14 +153,23 @@ export class ESPHomeApiActionEditor extends LitElement {
     return this._engine.inFlightWrite;
   }
 
-  static styles = [espHomeStyles, inputStyles, automationEditorStyles];
+  static styles = [
+    espHomeStyles,
+    inputStyles,
+    automationEditorStyles,
+    fieldHighlightStyles,
+  ];
 
   connectedCallback(): void {
     super.connectedCallback();
     void this._load();
   }
 
+  /** ``focusKey`` already name-flashed — one-shot per target. */
+  private _nameFlashKey?: string;
+
   protected updated(changed: Map<string, unknown>) {
+    this._maybeFlashName();
     if (changed.has("configuration")) {
       void this._loadAvailable();
     }
@@ -304,6 +317,24 @@ export class ESPHomeApiActionEditor extends LitElement {
           this._onActionNameChange((e.target as HTMLInputElement).value)}
       />
     </div>`;
+  }
+
+  /** The action name lives in a bespoke input, outside any form — flash
+   *  its field when the cursor targets ``action:`` (or legacy
+   *  ``service:``). */
+  private _maybeFlashName(): void {
+    const focus = this._resolveFocus(this.value, this.location, this.focusYamlPath);
+    const head = entryFieldFocus(focus)?.[0];
+    if (head !== "action" && head !== "service") return;
+    const key = focusKey(focus);
+    if (key === this._nameFlashKey) return;
+    const field = this.shadowRoot
+      ?.querySelector("#api-action-name")
+      ?.closest<HTMLElement>(".field");
+    // Hold the shot while the loading spinner still owns the render.
+    if (!field) return;
+    this._nameFlashKey = key;
+    scrollFlashRow(field);
   }
 
   private async _load() {

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -49,6 +49,7 @@ import { automationEditorStyles } from "./automation-editor.styles.js";
 import {
   actionsFocus,
   createFocusResolver,
+  entryFieldFocus,
   type YamlPathSegment,
 } from "./automation-focus.js";
 import "./callable-params-editor.js";
@@ -207,10 +208,12 @@ export class ESPHomeApiActionEditor extends LitElement {
     const conditions = this._available?.conditions ?? [];
     const disabled = this._engine.deleting;
     const focus = this._resolveFocus(this.value, this.location, this.focusYamlPath);
+    const entryField = entryFieldFocus(focus);
     return html`
       ${this._renderHeader()} ${this._renderActionNameField(disabled)}
       <esphome-callable-params-editor
         .value=${(automation.trigger_params.variables ?? {}) as Record<string, string>}
+        .focusParam=${entryField?.[0] === "variables" ? (entryField[1] ?? "") : null}
         ?disabled=${disabled}
         .fieldLabel=${this._localize("device.api_action_variables")}
         .description=${this._localize("device.api_action_variables_description")}

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -50,12 +50,7 @@ import { parseSubstitutions } from "../../../util/substitutions.js";
 import { AutoApplyController } from "./auto-apply-controller.js";
 import type { ESPHomeAutomationActionList } from "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
-import {
-  type AutomationFocus,
-  automationRelativePath,
-  resolveAutomationFocus,
-  type YamlPathSegment,
-} from "./automation-focus.js";
+import { createFocusResolver, type YamlPathSegment } from "./automation-focus.js";
 import { CatalogLoadController } from "./catalog-load-controller.js";
 import { loadIntervalComponent } from "./load-interval-component.js";
 import { ParseErrorController } from "./parse-error-controller.js";
@@ -189,19 +184,7 @@ export class ESPHomeAutomationEditor extends LitElement {
    *  read-only Target field can preview ${...} like the text fields do. */
   private _parseSubstitutions = memoizeOne(parseSubstitutions);
 
-  /** Cursor path → tree focus. Memoized on (value, location, path) so it
-   *  self-heals once the async hydrate lands the tree. */
-  private _resolveFocus = memoizeOne(
-    (
-      value: AutomationTree | null,
-      location: AutomationLocation | null,
-      path?: YamlPathSegment[]
-    ): AutomationFocus | null => {
-      if (!value || !path?.length) return null;
-      const rel = automationRelativePath(path, location);
-      return rel ? resolveAutomationFocus(value, rel) : null;
-    }
-  );
+  private _resolveFocus = createFocusResolver();
 
   static styles = [espHomeStyles, inputStyles, automationEditorStyles];
 

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -50,7 +50,12 @@ import { parseSubstitutions } from "../../../util/substitutions.js";
 import { AutoApplyController } from "./auto-apply-controller.js";
 import type { ESPHomeAutomationActionList } from "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
-import { createFocusResolver, type YamlPathSegment } from "./automation-focus.js";
+import {
+  actionsFocus,
+  createFocusResolver,
+  entryFieldFocus,
+  type YamlPathSegment,
+} from "./automation-focus.js";
 import { CatalogLoadController } from "./catalog-load-controller.js";
 import { loadIntervalComponent } from "./load-interval-component.js";
 import { ParseErrorController } from "./parse-error-controller.js";
@@ -426,7 +431,7 @@ export class ESPHomeAutomationEditor extends LitElement {
               yaml: this.yaml,
               disabled,
               showAdvanced: this._showAdvanced,
-              focusFieldPath: focus && focus.node.length === 0 ? focus.field : undefined,
+              focusFieldPath: entryFieldFocus(focus),
               onValueChange: this._onTriggerParamsValueChange,
               onAdvancedToggle: this._onAdvancedToggle,
             })}`
@@ -441,7 +446,7 @@ export class ESPHomeAutomationEditor extends LitElement {
         yaml: this.yaml,
         disabled,
         localize: this._localize,
-        focusTarget: focus && focus.node.length > 0 ? focus : null,
+        focusTarget: actionsFocus(focus),
         onOpenPicker: () => this._actionList?.openPicker(),
         onActionsChange: this._onActionsChange,
       })}

--- a/src/components/device/automation-editor/automation-focus.ts
+++ b/src/components/device/automation-editor/automation-focus.ts
@@ -107,6 +107,14 @@ export function entryFieldFocus(focus: AutomationFocus | null): string[] | undef
   return focus && focus.node.length === 0 ? focus.field : undefined;
 }
 
+/** Entry-field focus routed to a callable-params block (``parameters``
+ *  / ``variables``): the targeted name, ``""`` for the block itself,
+ *  ``null`` when the focus points elsewhere. */
+export function paramFocus(focus: AutomationFocus | null, key: string): string | null {
+  const field = entryFieldFocus(focus);
+  return field?.[0] === key ? (field[1] ?? "") : null;
+}
+
 /** Value key for dedupe — the parent re-slices a fresh object per render. */
 export function focusKey(focus: AutomationFocus | null | undefined): string | undefined {
   return focus ? JSON.stringify([focus.node, focus.field]) : undefined;

--- a/src/components/device/automation-editor/automation-focus.ts
+++ b/src/components/device/automation-editor/automation-focus.ts
@@ -53,11 +53,11 @@ export function automationRelativePath(
 ): YamlPathSegment[] | null {
   const anchor = location && handlerAnchor(location);
   if (!anchor) return null;
-  const at = path.indexOf(anchor.keys[0]);
-  if (at < 0) return null;
-  for (let i = 1; i < anchor.keys.length; i++) {
-    if (path[at + i] !== anchor.keys[i]) return null;
+  let at = path.indexOf(anchor.keys[0]);
+  while (at >= 0 && !anchor.keys.every((k, i) => path[at + i] === k)) {
+    at = path.indexOf(anchor.keys[0], at + 1);
   }
+  if (at < 0) return null;
   const rest = path.slice(at + anchor.keys.length);
   if (anchor.index === undefined) return rest;
   if (anchor.index === "any") {

--- a/src/components/device/automation-editor/automation-focus.ts
+++ b/src/components/device/automation-editor/automation-focus.ts
@@ -11,6 +11,8 @@
  * ``wait_until``'s gate-less shorthand) and fails soft: an unresolved
  * tail degrades to the deepest resolved node.
  */
+import memoizeOne from "memoize-one";
+
 import type {
   ActionNode,
   AutomationLocation,
@@ -51,10 +53,16 @@ export function automationRelativePath(
 ): YamlPathSegment[] | null {
   const anchor = location && handlerAnchor(location);
   if (!anchor) return null;
-  const at = path.indexOf(anchor.key);
+  const at = path.indexOf(anchor.keys[0]);
   if (at < 0) return null;
-  const rest = path.slice(at + 1);
+  for (let i = 1; i < anchor.keys.length; i++) {
+    if (path[at + i] !== anchor.keys[i]) return null;
+  }
+  const rest = path.slice(at + anchor.keys.length);
   if (anchor.index === undefined) return rest;
+  if (anchor.index === "any") {
+    return typeof rest[0] === "number" ? rest.slice(1) : null;
+  }
   return rest[0] === anchor.index ? rest.slice(1) : null;
 }
 
@@ -99,21 +107,53 @@ export function focusTargetHasChanged(a: unknown, b: unknown): boolean {
   return focusKey(a as AutomationFocus | null) !== focusKey(b as AutomationFocus | null);
 }
 
-/** The list key anchoring a location's handler body in the YAML, plus
- *  the entry index for list-shaped handlers. */
+/** Memoized cursor-path → focus resolver, one per editor instance —
+ *  keyed on (value, location, path) so it self-heals once the async
+ *  hydrate lands the tree. */
+export function createFocusResolver(): (
+  value: AutomationTree | null,
+  location: AutomationLocation | null,
+  path?: YamlPathSegment[]
+) => AutomationFocus | null {
+  return memoizeOne(
+    (
+      value: AutomationTree | null,
+      location: AutomationLocation | null,
+      path?: YamlPathSegment[]
+    ): AutomationFocus | null => {
+      if (!value || !path?.length) return null;
+      const rel = automationRelativePath(path, location);
+      return rel ? resolveAutomationFocus(value, rel) : null;
+    }
+  );
+}
+
+/**
+ * The key sequence anchoring a location's handler body in the YAML,
+ * plus the entry-index policy for list-shaped handlers.
+ *
+ * ``"any"`` consumes whatever entry index the cursor path carries:
+ * script / api-action locations identify their entry by id, not
+ * index, and the caret that produced the path is the same one that
+ * resolved the location, so they agree by construction.
+ */
 function handlerAnchor(
   location: AutomationLocation
-): { key: string; index?: number } | null {
+): { keys: string[]; index?: number | "any" } | null {
   switch (location.kind) {
     case "device_on":
     case "component_on":
-      return { key: location.trigger, index: location.index };
+      return { keys: [location.trigger], index: location.index };
     case "component_action":
-      return { key: location.field };
+      return { keys: [location.field] };
     case "interval":
-      return { key: "interval", index: location.index };
+      return { keys: ["interval"], index: location.index };
+    case "script":
+      return { keys: ["script"], index: "any" };
+    case "api_action":
+      return { keys: ["api", "actions"], index: "any" };
     default:
-      // script / api_action / light_effect mount different editors.
+      // light_effect mounts a different editor.
       return null;
   }
 }

--- a/src/components/device/automation-editor/automation-focus.ts
+++ b/src/components/device/automation-editor/automation-focus.ts
@@ -95,6 +95,18 @@ export function childFocus(focus: AutomationFocus): AutomationFocus {
   return { node: focus.node.slice(1), field: focus.field };
 }
 
+/** The editor-level routing rule: a non-empty ``node`` path belongs to
+ *  the actions list. */
+export function actionsFocus(focus: AutomationFocus | null): AutomationFocus | null {
+  return focus && focus.node.length > 0 ? focus : null;
+}
+
+/** The counterpart: an empty ``node`` path targets the editor's
+ *  entry-params form. */
+export function entryFieldFocus(focus: AutomationFocus | null): string[] | undefined {
+  return focus && focus.node.length === 0 ? focus.field : undefined;
+}
+
 /** Value key for dedupe — the parent re-slices a fresh object per render. */
 export function focusKey(focus: AutomationFocus | null | undefined): string | undefined {
   return focus ? JSON.stringify([focus.node, focus.field]) : undefined;
@@ -107,25 +119,21 @@ export function focusTargetHasChanged(a: unknown, b: unknown): boolean {
   return focusKey(a as AutomationFocus | null) !== focusKey(b as AutomationFocus | null);
 }
 
-/** Memoized cursor-path → focus resolver, one per editor instance —
- *  keyed on (value, location, path) so it self-heals once the async
- *  hydrate lands the tree. */
-export function createFocusResolver(): (
+function resolveFocus(
   value: AutomationTree | null,
   location: AutomationLocation | null,
   path?: YamlPathSegment[]
-) => AutomationFocus | null {
-  return memoizeOne(
-    (
-      value: AutomationTree | null,
-      location: AutomationLocation | null,
-      path?: YamlPathSegment[]
-    ): AutomationFocus | null => {
-      if (!value || !path?.length) return null;
-      const rel = automationRelativePath(path, location);
-      return rel ? resolveAutomationFocus(value, rel) : null;
-    }
-  );
+): AutomationFocus | null {
+  if (!value || !path?.length) return null;
+  const rel = automationRelativePath(path, location);
+  return rel ? resolveAutomationFocus(value, rel) : null;
+}
+
+/** Memoized cursor-path → focus resolver, one per editor instance —
+ *  keyed on (value, location, path) so it self-heals once the async
+ *  hydrate lands the tree. */
+export function createFocusResolver(): typeof resolveFocus {
+  return memoizeOne(resolveFocus);
 }
 
 /**

--- a/src/components/device/automation-editor/callable-params-editor.ts
+++ b/src/components/device/automation-editor/callable-params-editor.ts
@@ -192,20 +192,22 @@ export class ESPHomeCallableParamsEditor extends LitElement {
 
   private _maybeScrollToParam(): void {
     if (this.focusParam === null || this._focusScrolled) return;
-    const idx = this._params.findIndex((p) => p.name === this.focusParam);
-    if (idx >= 0) {
-      const row =
-        this.shadowRoot?.querySelectorAll<HTMLElement>(".script-param-row")[idx];
-      // The wire sync above may have just filled ``_params``; the rows
-      // render next pass — hold the shot rather than mis-flash.
-      if (!row) return;
+    if (this.focusParam === "") {
+      // Block-level target — checked first so it can't alias an
+      // in-progress unnamed draft row.
       this._focusScrolled = true;
-      scrollFlashRow(row);
+      const block = this.shadowRoot?.querySelector<HTMLElement>(".field");
+      if (block) scrollFlashRow(block);
       return;
     }
+    const idx = this._params.findIndex((p) => p.name === this.focusParam);
+    if (idx < 0) return;
+    const row = this.shadowRoot?.querySelectorAll<HTMLElement>(".script-param-row")[idx];
+    // The wire sync above may have just filled ``_params``; the rows
+    // render next pass — hold the shot rather than mis-flash.
+    if (!row) return;
     this._focusScrolled = true;
-    const block = this.shadowRoot?.querySelector<HTMLElement>(".field");
-    if (block) scrollFlashRow(block);
+    scrollFlashRow(row);
   }
 
   private _readFromWire(): ParameterDecl[] {

--- a/src/components/device/automation-editor/callable-params-editor.ts
+++ b/src/components/device/automation-editor/callable-params-editor.ts
@@ -15,7 +15,7 @@
  */
 import { consume } from "@lit/context";
 import { mdiClose, mdiPlus } from "@mdi/js";
-import { html, LitElement, nothing } from "lit";
+import { html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import type { LocalizeFunc } from "../../../common/localize.js";
@@ -25,6 +25,8 @@ import { espHomeStyles } from "../../../styles/shared.js";
 import { normalizeEspHomeId } from "../../../util/esphome-id.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
+import { scrollFlashRow } from "../field-highlight.js";
+import { fieldHighlightStyles } from "../field-highlight.styles.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -71,6 +73,11 @@ export class ESPHomeCallableParamsEditor extends LitElement {
   /** Localized text input placeholder for the name column. */
   @property() namePlaceholder = "";
 
+  /** Cursor-targeted parameter name; ``""`` targets the block itself.
+   *  The matching row (or the whole field) scrolls in with the shared
+   *  cursor glow. */
+  @property() focusParam: string | null = null;
+
   /**
    * Working list mirroring ``value`` plus any in-progress unnamed
    * rows. Projected back to the wire map on each change; unnamed
@@ -78,22 +85,36 @@ export class ESPHomeCallableParamsEditor extends LitElement {
    */
   @state() private _params: ParameterDecl[] = [];
 
-  static styles = [espHomeStyles, inputStyles, automationEditorStyles];
+  static styles = [
+    espHomeStyles,
+    inputStyles,
+    automationEditorStyles,
+    fieldHighlightStyles,
+  ];
+
+  /** Row scroll spent on the current target. */
+  private _focusScrolled = false;
+
+  protected willUpdate(changed: PropertyValues<this>): void {
+    if (changed.has("focusParam")) this._focusScrolled = false;
+  }
 
   protected updated(changed: Map<string, unknown>) {
-    if (!changed.has("value")) return;
-    // Sync from outside (hydrate / parent re-render). Don't disturb
-    // local empty-name rows when the wire matches what we already
-    // have for named entries — the user is mid-edit on an unnamed
-    // row and we shouldn't drop it.
-    const fromWire = this._readFromWire();
-    const localNamed = this._params.filter((p) => p.name);
-    const matches =
-      localNamed.length === fromWire.length &&
-      localNamed.every(
-        (p, i) => p.name === fromWire[i].name && p.type === fromWire[i].type
-      );
-    if (!matches) this._params = fromWire;
+    if (changed.has("value")) {
+      // Sync from outside (hydrate / parent re-render). Don't disturb
+      // local empty-name rows when the wire matches what we already
+      // have for named entries — the user is mid-edit on an unnamed
+      // row and we shouldn't drop it.
+      const fromWire = this._readFromWire();
+      const localNamed = this._params.filter((p) => p.name);
+      const matches =
+        localNamed.length === fromWire.length &&
+        localNamed.every(
+          (p, i) => p.name === fromWire[i].name && p.type === fromWire[i].type
+        );
+      if (!matches) this._params = fromWire;
+    }
+    this._maybeScrollToParam();
   }
 
   protected render() {
@@ -167,6 +188,24 @@ export class ESPHomeCallableParamsEditor extends LitElement {
         <wa-icon library="mdi" name="close"></wa-icon>
       </button>
     </div>`;
+  }
+
+  private _maybeScrollToParam(): void {
+    if (this.focusParam === null || this._focusScrolled) return;
+    const idx = this._params.findIndex((p) => p.name === this.focusParam);
+    if (idx >= 0) {
+      const row =
+        this.shadowRoot?.querySelectorAll<HTMLElement>(".script-param-row")[idx];
+      // The wire sync above may have just filled ``_params``; the rows
+      // render next pass — hold the shot rather than mis-flash.
+      if (!row) return;
+      this._focusScrolled = true;
+      scrollFlashRow(row);
+      return;
+    }
+    this._focusScrolled = true;
+    const block = this.shadowRoot?.querySelector<HTMLElement>(".field");
+    if (block) scrollFlashRow(block);
   }
 
   private _readFromWire(): ParameterDecl[] {

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -52,6 +52,11 @@ import { AutoApplyController } from "./auto-apply-controller.js";
 import "./automation-action-list.js";
 import type { ESPHomeAutomationActionList } from "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
+import {
+  type AutomationFocus,
+  createFocusResolver,
+  type YamlPathSegment,
+} from "./automation-focus.js";
 import "./callable-params-editor.js";
 import { CatalogLoadController } from "./catalog-load-controller.js";
 import { ParseErrorController } from "./parse-error-controller.js";
@@ -102,11 +107,18 @@ export class ESPHomeScriptEditor extends LitElement {
 
   @property() yaml = "";
 
+  /** Indexed key path at the YAML cursor; resolved against the
+   *  hydrated tree to scroll/highlight the matching node or field. */
+  @property({ attribute: false })
+  focusYamlPath?: YamlPathSegment[];
+
   /** Action-list reference — used by the header-positioned Add
    *  button to open the catalog picker dialog that lives inside
    *  the action-list component. */
   @query("esphome-automation-action-list")
   private _actionList?: ESPHomeAutomationActionList;
+
+  private _resolveFocus = createFocusResolver();
 
   @state() private _available: AvailableAutomations | null = null;
   @state() private _loading = true;
@@ -288,8 +300,9 @@ export class ESPHomeScriptEditor extends LitElement {
     const actions = this._available?.actions ?? [];
     const conditions = this._available?.conditions ?? [];
     const disabled = this._engine.deleting;
+    const focus = this._resolveFocus(this.value, this.location, this.focusYamlPath);
     return html`
-      ${this._renderHeader()} ${this._renderConfigForm(automation, disabled)}
+      ${this._renderHeader()} ${this._renderConfigForm(automation, disabled, focus)}
       ${this._showAdvanced ? this._renderParametersField(automation, disabled) : nothing}
       <div class="field">
         <div class="ae-actions-header">
@@ -312,6 +325,7 @@ export class ESPHomeScriptEditor extends LitElement {
         <esphome-automation-action-list
           no-header
           hide-add
+          .focusTarget=${focus && focus.node.length > 0 ? focus : null}
           .actions=${automation.actions}
           .catalog=${actions}
           .conditionCatalog=${conditions}
@@ -388,7 +402,11 @@ export class ESPHomeScriptEditor extends LitElement {
    * and ``then`` is the actions block, rendered by the action-list
    * below the form.
    */
-  private _renderConfigForm(automation: AutomationTree, disabled: boolean) {
+  private _renderConfigForm(
+    automation: AutomationTree,
+    disabled: boolean,
+    focus: AutomationFocus | null
+  ) {
     const comp = this._scriptComponent;
     if (!comp) return nothing;
     const entries = comp.config_entries.filter(
@@ -405,6 +423,7 @@ export class ESPHomeScriptEditor extends LitElement {
         .values=${automation.trigger_params}
         .board=${this.board}
         .yaml=${this.yaml}
+        .focusFieldPath=${focus && focus.node.length === 0 ? focus.field : undefined}
         ?disabled=${disabled}
         advanced-section
         ?force-advanced-control=${hasParameters}

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -53,8 +53,10 @@ import "./automation-action-list.js";
 import type { ESPHomeAutomationActionList } from "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import {
+  actionsFocus,
   type AutomationFocus,
   createFocusResolver,
+  entryFieldFocus,
   type YamlPathSegment,
 } from "./automation-focus.js";
 import "./callable-params-editor.js";
@@ -325,7 +327,7 @@ export class ESPHomeScriptEditor extends LitElement {
         <esphome-automation-action-list
           no-header
           hide-add
-          .focusTarget=${focus && focus.node.length > 0 ? focus : null}
+          .focusTarget=${actionsFocus(focus)}
           .actions=${automation.actions}
           .catalog=${actions}
           .conditionCatalog=${conditions}
@@ -423,7 +425,7 @@ export class ESPHomeScriptEditor extends LitElement {
         .values=${automation.trigger_params}
         .board=${this.board}
         .yaml=${this.yaml}
-        .focusFieldPath=${focus && focus.node.length === 0 ? focus.field : undefined}
+        .focusFieldPath=${entryFieldFocus(focus)}
         ?disabled=${disabled}
         advanced-section
         ?force-advanced-control=${hasParameters}

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -58,6 +58,7 @@ import {
   createFocusResolver,
   entryFieldFocus,
   focusKey,
+  paramFocus,
   type YamlPathSegment,
 } from "./automation-focus.js";
 import "./callable-params-editor.js";
@@ -129,13 +130,12 @@ export class ESPHomeScriptEditor extends LitElement {
 
   /** The Parameters block hides behind the advanced toggle; reveal it
    *  when the cursor targets a parameter so the row can render. */
-  protected willUpdate(changed: PropertyValues): void {
-    if (!changed.has("focusYamlPath") && !changed.has("value")) return;
+  protected willUpdate(): void {
     const focus = this._resolveFocus(this.value, this.location, this.focusYamlPath);
     const key = focusKey(focus);
     if (key === this._paramsRevealKey) return;
     this._paramsRevealKey = key;
-    if (entryFieldFocus(focus)?.[0] === "parameters") this._showAdvanced = true;
+    if (paramFocus(focus, "parameters") !== null) this._showAdvanced = true;
   }
 
   @state() private _available: AvailableAutomations | null = null;
@@ -445,7 +445,9 @@ export class ESPHomeScriptEditor extends LitElement {
         .values=${automation.trigger_params}
         .board=${this.board}
         .yaml=${this.yaml}
-        .focusFieldPath=${entryFieldFocus(focus)}
+        .focusFieldPath=${
+          paramFocus(focus, "parameters") === null ? entryFieldFocus(focus) : undefined
+        }
         ?disabled=${disabled}
         advanced-section
         ?force-advanced-control=${hasParameters}
@@ -516,10 +518,9 @@ export class ESPHomeScriptEditor extends LitElement {
     focus: AutomationFocus | null
   ) {
     const value = (automation.trigger_params.parameters ?? {}) as Record<string, string>;
-    const entryField = entryFieldFocus(focus);
     return html`<esphome-callable-params-editor
       .value=${value}
-      .focusParam=${entryField?.[0] === "parameters" ? (entryField[1] ?? "") : null}
+      .focusParam=${paramFocus(focus, "parameters")}
       ?disabled=${disabled}
       .fieldLabel=${this._localize("device.automation_script_parameters")}
       .description=${this._localize("device.script_parameters_description")}

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -22,7 +22,7 @@
  */
 import { consume } from "@lit/context";
 import { mdiDelete, mdiOpenInNew, mdiScriptTextOutline } from "@mdi/js";
-import { html, LitElement, nothing } from "lit";
+import { html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 
 import type { ESPHomeAPI } from "../../../api/index.js";
@@ -57,6 +57,7 @@ import {
   type AutomationFocus,
   createFocusResolver,
   entryFieldFocus,
+  focusKey,
   type YamlPathSegment,
 } from "./automation-focus.js";
 import "./callable-params-editor.js";
@@ -121,6 +122,21 @@ export class ESPHomeScriptEditor extends LitElement {
   private _actionList?: ESPHomeAutomationActionList;
 
   private _resolveFocus = createFocusResolver();
+
+  /** ``focusKey`` already advanced-revealed — one-shot per target so a
+   *  later deliberate collapse sticks. */
+  private _paramsRevealKey?: string;
+
+  /** The Parameters block hides behind the advanced toggle; reveal it
+   *  when the cursor targets a parameter so the row can render. */
+  protected willUpdate(changed: PropertyValues): void {
+    if (!changed.has("focusYamlPath") && !changed.has("value")) return;
+    const focus = this._resolveFocus(this.value, this.location, this.focusYamlPath);
+    const key = focusKey(focus);
+    if (key === this._paramsRevealKey) return;
+    this._paramsRevealKey = key;
+    if (entryFieldFocus(focus)?.[0] === "parameters") this._showAdvanced = true;
+  }
 
   @state() private _available: AvailableAutomations | null = null;
   @state() private _loading = true;
@@ -305,7 +321,11 @@ export class ESPHomeScriptEditor extends LitElement {
     const focus = this._resolveFocus(this.value, this.location, this.focusYamlPath);
     return html`
       ${this._renderHeader()} ${this._renderConfigForm(automation, disabled, focus)}
-      ${this._showAdvanced ? this._renderParametersField(automation, disabled) : nothing}
+      ${
+        this._showAdvanced
+          ? this._renderParametersField(automation, disabled, focus)
+          : nothing
+      }
       <div class="field">
         <div class="ae-actions-header">
           <label class="field-label">
@@ -490,10 +510,16 @@ export class ESPHomeScriptEditor extends LitElement {
    * lives in the shared ``<esphome-callable-params-editor>``; we
    * just wire the wire-shape in and out of it here.
    */
-  private _renderParametersField(automation: AutomationTree, disabled: boolean) {
+  private _renderParametersField(
+    automation: AutomationTree,
+    disabled: boolean,
+    focus: AutomationFocus | null
+  ) {
     const value = (automation.trigger_params.parameters ?? {}) as Record<string, string>;
+    const entryField = entryFieldFocus(focus);
     return html`<esphome-callable-params-editor
       .value=${value}
+      .focusParam=${entryField?.[0] === "parameters" ? (entryField[1] ?? "") : null}
       ?disabled=${disabled}
       .fieldLabel=${this._localize("device.automation_script_parameters")}
       .description=${this._localize("device.script_parameters_description")}

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -22,7 +22,7 @@
  */
 import { consume } from "@lit/context";
 import { mdiDelete, mdiOpenInNew, mdiScriptTextOutline } from "@mdi/js";
-import { html, LitElement, nothing, type PropertyValues } from "lit";
+import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 
 import type { ESPHomeAPI } from "../../../api/index.js";

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -8,6 +8,7 @@ import {
 } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
+import memoizeOne from "memoize-one";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry, SlimBoard } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -402,9 +403,13 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
    * key into a typed location here so the editors don't have to
    * know about navigator routing.
    */
+  /** Key → location, memoized: a fresh object per render would defeat
+   *  the editors' focus-resolver memoization on every parent render. */
+  private _locationForKey = memoizeOne(locationFromSectionKey);
+
   private _renderSelectedSection() {
     const key = this.selectedSection!;
-    const location = key.startsWith("automation:") ? locationFromSectionKey(key) : null;
+    const location = key.startsWith("automation:") ? this._locationForKey(key) : null;
     if (location?.kind === "script") {
       return html`<esphome-script-editor
         .configuration=${this.configuration}

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -412,6 +412,7 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
         .platform=${this.board?.esphome.platform ?? ""}
         .location=${location}
         .yaml=${this.yaml}
+        .focusYamlPath=${this.focusYamlPath}
       ></esphome-script-editor>`;
     }
     if (location?.kind === "api_action") {
@@ -421,6 +422,7 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
         .platform=${this.board?.esphome.platform ?? ""}
         .location=${location}
         .yaml=${this.yaml}
+        .focusYamlPath=${this.focusYamlPath}
       ></esphome-api-action-editor>`;
     }
     if (location) {

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -381,6 +381,10 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
    * is to teach the user that the navigator is where you manage
    * these things, rather than handing them an add-button right here.
    */
+  /** Key → location, memoized: a fresh object per render would defeat
+   *  the editors' focus-resolver memoization on every parent render. */
+  private _locationForKey = memoizeOne(locationFromSectionKey);
+
   /**
    * Route an automation / script section key into the right
    * structured editor; everything else lands in the regular
@@ -403,10 +407,6 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
    * key into a typed location here so the editors don't have to
    * know about navigator routing.
    */
-  /** Key → location, memoized: a fresh object per render would defeat
-   *  the editors' focus-resolver memoization on every parent render. */
-  private _locationForKey = memoizeOne(locationFromSectionKey);
-
   private _renderSelectedSection() {
     const key = this.selectedSection!;
     const location = key.startsWith("automation:") ? this._locationForKey(key) : null;

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -373,14 +373,6 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
     `;
   }
 
-  /**
-   * Render one of the three numbered "next steps" panels in the
-   * unselected content pane (Core / Components / Automations). Each
-   * has a heading, a longer description, and a CTA that expands the
-   * matching section in the device navigator on the left — the goal
-   * is to teach the user that the navigator is where you manage
-   * these things, rather than handing them an add-button right here.
-   */
   /** Key → location, memoized: a fresh object per render would defeat
    *  the editors' focus-resolver memoization on every parent render. */
   private _locationForKey = memoizeOne(locationFromSectionKey);
@@ -453,6 +445,14 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
     ></esphome-device-section-config>`;
   }
 
+  /**
+   * Render one of the three numbered "next steps" panels in the
+   * unselected content pane (Core / Components / Automations). Each
+   * has a heading, a longer description, and a CTA that expands the
+   * matching section in the device navigator on the left — the goal
+   * is to teach the user that the navigator is where you manage
+   * these things, rather than handing them an add-button right here.
+   */
   private _renderStepSection(opts: {
     title: string;
     desc: string;

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -39,6 +39,9 @@ import {
 import { TriggerCatalogController } from "./trigger-catalog-controller.js";
 import { isYamlOnlySection } from "./yaml-only-sections.js";
 
+import { scrollFlashRow } from "./field-highlight.js";
+import { fieldHighlightStyles } from "./field-highlight.styles.js";
+
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 import "../confirm-dialog.js";
@@ -241,6 +244,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     inputStyles,
     dangerBannerStyles,
     deviceSectionConfigStyles,
+    fieldHighlightStyles,
   ];
 
   willUpdate(changedProperties: Map<string, unknown>) {
@@ -309,6 +313,28 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
 
   updated() {
     this._triggerCatalog.ensure();
+    this._maybeFlashApiActionsList();
+  }
+
+  /** ``focusFieldPath`` key already flashed — one-shot per target. */
+  private _apiListFlashKey?: string;
+
+  /** ``api.actions`` / ``services`` are hidden from the form — the
+   *  manage-list below it owns them, so a caret on those keys lands
+   *  there instead of on a field that no longer renders. */
+  private _maybeFlashApiActionsList(): void {
+    if (this.sectionKey !== "api") return;
+    const head = this.focusFieldPath?.[0];
+    if (head !== "actions" && head !== "services") return;
+    const key = JSON.stringify(this.focusFieldPath);
+    if (key === this._apiListFlashKey) return;
+    const list = this.shadowRoot?.querySelector<HTMLElement>(
+      "esphome-section-automation-list"
+    );
+    // The list renders once the section config loads — hold the shot.
+    if (!list) return;
+    this._apiListFlashKey = key;
+    scrollFlashRow(list);
   }
 
   connectedCallback() {

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1588,6 +1588,11 @@ export class ESPHomePageDevice extends LitElement {
       }
       this._selectedSection = sectionKey;
       this._selectedFromLine = fromLine;
+      // A navigator click carries no field intent — a stale cursor path
+      // would scroll/flash a target in the newly mounted editor that the
+      // user never pointed at.
+      this._focusFieldPath = undefined;
+      this._focusYamlPath = undefined;
       this._drawerOpen = false;
       this._updateUrl();
     });

--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -40,6 +40,9 @@ export function pathIsAdvanced(entries: ConfigEntry[], path: string[]): boolean 
     if (isIndexSegment(key)) continue;
     const entry = level.find((e) => e.key === key);
     if (!entry) return false;
+    // A hidden entry never renders, so opening the advanced section
+    // can't show it — don't reveal for one.
+    if (entry.hidden) return false;
     if (entry.advanced) advanced = true;
     level = entry.config_entries ?? [];
   }

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -232,14 +232,21 @@ export function sectionAtLine(yaml: string, line: number): YamlSection | null {
   );
   const autoHit = smallestContainingSection(autos, line);
   if (autoHit) return autoHit;
+  // ``script:`` / ``interval:`` blocks are wholly owned by their
+  // per-item automation editors — the block's own component form is a
+  // dead end, so any block-level hit routes to the first item.
+  const firstOwnedItem = (key: string) =>
+    AUTOMATION_KEYS.has(key) ? (autos.find((s) => s.parentKey === key) ?? null) : null;
   const tops = parseYamlTopLevelSections(yaml);
   const topHit = smallestContainingSection(tops, line);
-  if (topHit) return topHit;
+  if (topHit) return firstOwnedItem(topHit.key) ?? topHit;
   // A bare top-level sequence (usb_uart:, sensor:, …) expands into per-item
   // ranges that start at the first dash, so the header line itself is covered
   // by nothing. When the click lands exactly on such a header, select the
   // section's first instance instead of leaving the selection unchanged.
-  return _firstItemForListHeader(tops, yaml, line);
+  const headerHit = _firstItemForListHeader(tops, yaml, line);
+  if (headerHit) return firstOwnedItem(headerHit.key) ?? headerHit;
+  return null;
 }
 
 /**

--- a/test/components/device/automation-editor/api-action-editor-mount.test.ts
+++ b/test/components/device/automation-editor/api-action-editor-mount.test.ts
@@ -46,12 +46,14 @@ const loggerBodies = () => ({
 
 async function mountEditor(
   api: ESPHomeAPI,
-  configuration?: string
+  configuration?: string,
+  props: object = {}
 ): Promise<ESPHomeApiActionEditor> {
   const editor = new ESPHomeApiActionEditor();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (editor as any)._api = api;
   if (configuration !== undefined) editor.configuration = configuration;
+  Object.assign(editor, props);
   document.body.appendChild(editor);
   await editor.updateComplete;
   await flushMicrotasks(30);
@@ -95,20 +97,15 @@ describe("api-action-editor action-catalog hydration (#1286)", () => {
     const getAutomationBodies = vi.fn().mockResolvedValue(loggerBodies());
     const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
 
-    const editor = new ESPHomeApiActionEditor();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (editor as any)._api = api;
-    editor.configuration = "device.yaml";
-    editor.location = { kind: "api_action", action_name: "ring_bell" };
-    editor.value = {
-      trigger_id: null,
-      trigger_params: {},
-      actions: [{ action_id: "logger.log", params: {}, children: {}, conditions: [] }],
-    };
-    editor.focusYamlPath = ["api", "actions", 0, "then", 0, "logger.log", "format"];
-    document.body.appendChild(editor);
-    await editor.updateComplete;
-    await flushMicrotasks(30);
+    const editor = await mountEditor(api, "device.yaml", {
+      location: { kind: "api_action", action_name: "ring_bell" },
+      value: {
+        trigger_id: null,
+        trigger_params: {},
+        actions: [{ action_id: "logger.log", params: {}, children: {}, conditions: [] }],
+      },
+      focusYamlPath: ["api", "actions", 0, "then", 0, "logger.log", "format"],
+    });
 
     const list = editor.shadowRoot!.querySelector("esphome-automation-action-list");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/components/device/automation-editor/api-action-editor-mount.test.ts
+++ b/test/components/device/automation-editor/api-action-editor-mount.test.ts
@@ -89,4 +89,29 @@ describe("api-action-editor action-catalog hydration (#1286)", () => {
     expect(getAvailableAutomations).not.toHaveBeenCalled();
     expect(getAutomationBodies).not.toHaveBeenCalled();
   });
+
+  it("resolves a cursor path into the action list's focus target", async () => {
+    const getAvailableAutomations = vi.fn().mockResolvedValue(slimWithLoggerAction());
+    const getAutomationBodies = vi.fn().mockResolvedValue(loggerBodies());
+    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
+
+    const editor = new ESPHomeApiActionEditor();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor as any)._api = api;
+    editor.configuration = "device.yaml";
+    editor.location = { kind: "api_action", action_name: "ring_bell" };
+    editor.value = {
+      trigger_id: null,
+      trigger_params: {},
+      actions: [{ action_id: "logger.log", params: {}, children: {}, conditions: [] }],
+    };
+    editor.focusYamlPath = ["api", "actions", 0, "then", 0, "logger.log", "format"];
+    document.body.appendChild(editor);
+    await editor.updateComplete;
+    await flushMicrotasks(30);
+
+    const list = editor.shadowRoot!.querySelector("esphome-automation-action-list");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((list as any).focusTarget).toEqual({ node: [0], field: ["format"] });
+  });
 });

--- a/test/components/device/automation-editor/api-action-editor-mount.test.ts
+++ b/test/components/device/automation-editor/api-action-editor-mount.test.ts
@@ -112,6 +112,26 @@ describe("api-action-editor action-catalog hydration (#1286)", () => {
     expect((list as any).focusTarget).toEqual({ node: [0], field: ["format"] });
   });
 
+  it("flashes the name field for an action-key cursor path", async () => {
+    const scrolled = vi
+      .spyOn(HTMLElement.prototype, "scrollIntoView")
+      .mockImplementation(() => {});
+    const getAvailableAutomations = vi.fn().mockResolvedValue(slimWithLoggerAction());
+    const getAutomationBodies = vi.fn().mockResolvedValue({});
+    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
+
+    const editor = await mountEditor(api, "device.yaml", {
+      location: { kind: "api_action", action_name: "ring_bell" },
+      value: { trigger_id: null, trigger_params: {}, actions: [] },
+      focusYamlPath: ["api", "actions", 0, "action"],
+    });
+
+    expect(scrolled).toHaveBeenCalledTimes(1);
+    const field = editor.shadowRoot!.querySelector("#api-action-name")!.closest(".field");
+    expect(scrolled.mock.instances[0]).toBe(field);
+    vi.restoreAllMocks();
+  });
+
   it("routes a variables cursor path to the params editor", async () => {
     const getAvailableAutomations = vi.fn().mockResolvedValue(slimWithLoggerAction());
     const getAutomationBodies = vi.fn().mockResolvedValue({});

--- a/test/components/device/automation-editor/api-action-editor-mount.test.ts
+++ b/test/components/device/automation-editor/api-action-editor-mount.test.ts
@@ -111,4 +111,24 @@ describe("api-action-editor action-catalog hydration (#1286)", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((list as any).focusTarget).toEqual({ node: [0], field: ["format"] });
   });
+
+  it("routes a variables cursor path to the params editor", async () => {
+    const getAvailableAutomations = vi.fn().mockResolvedValue(slimWithLoggerAction());
+    const getAutomationBodies = vi.fn().mockResolvedValue({});
+    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
+
+    const editor = await mountEditor(api, "device.yaml", {
+      location: { kind: "api_action", action_name: "ring_bell" },
+      value: {
+        trigger_id: null,
+        trigger_params: { variables: { times: "int" } },
+        actions: [],
+      },
+      focusYamlPath: ["api", "actions", 0, "variables", "times"],
+    });
+
+    const params = editor.shadowRoot!.querySelector("esphome-callable-params-editor");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((params as any).focusParam).toBe("times");
+  });
 });

--- a/test/components/device/automation-editor/automation-focus.test.ts
+++ b/test/components/device/automation-editor/automation-focus.test.ts
@@ -126,14 +126,38 @@ describe("automationRelativePath", () => {
     ).toBeNull();
   });
 
+  it("slices a script entry, trusting the path's entry index", () => {
+    const loc = { kind: "script", id: "s2" } as const;
+    expect(automationRelativePath(["script", 1, "then", 0, "delay"], loc)).toEqual([
+      "then",
+      0,
+      "delay",
+    ]);
+    expect(automationRelativePath(["script", 0, "mode"], loc)).toEqual(["mode"]);
+    // A script block is always a list; a keyed shape never anchors.
+    expect(automationRelativePath(["script", "then"], loc)).toBeNull();
+  });
+
+  it("slices an api action under the two-key anchor", () => {
+    const loc = { kind: "api_action", action_name: "ring" } as const;
+    expect(
+      automationRelativePath(["api", "actions", 1, "then", 0, "logger.log"], loc)
+    ).toEqual(["then", 0, "logger.log"]);
+    expect(automationRelativePath(["api", "actions", 0, "variables", "x"], loc)).toEqual([
+      "variables",
+      "x",
+    ]);
+    // A different api child block never anchors, nor does the bare list key.
+    expect(automationRelativePath(["api", "encryption", "key"], loc)).toBeNull();
+    expect(automationRelativePath(["api", "actions"], loc)).toBeNull();
+  });
+
   it("returns null for kinds that mount other editors", () => {
     expect(
-      automationRelativePath(["script", 0, "then"], { kind: "script", id: "s" })
-    ).toBeNull();
-    expect(
-      automationRelativePath(["api", "actions", 0], {
-        kind: "api_action",
-        action_name: "a",
+      automationRelativePath(["light", 0, "effects", 0, "name"], {
+        kind: "light_effect",
+        component_id: "l1",
+        index: 0,
       })
     ).toBeNull();
   });

--- a/test/components/device/automation-editor/automation-focus.test.ts
+++ b/test/components/device/automation-editor/automation-focus.test.ts
@@ -152,6 +152,17 @@ describe("automationRelativePath", () => {
     expect(automationRelativePath(["api", "actions"], loc)).toBeNull();
   });
 
+  it("scans past a lone first-key occurrence to the full anchor sequence", () => {
+    // A param key equal to the anchor's first key must not block a later
+    // full-sequence match.
+    expect(
+      automationRelativePath(["api", "x", "api", "actions", 0, "then", 0], {
+        kind: "api_action",
+        action_name: "ring",
+      })
+    ).toEqual(["then", 0]);
+  });
+
   it("returns null for kinds that mount other editors", () => {
     expect(
       automationRelativePath(["light", 0, "effects", 0, "name"], {

--- a/test/components/device/automation-editor/callable-params-editor-focus.test.ts
+++ b/test/components/device/automation-editor/callable-params-editor-focus.test.ts
@@ -34,8 +34,10 @@ describe("callable-params-editor focus", () => {
     const rows = el.shadowRoot!.querySelectorAll(".script-param-row");
     expect(scrolled.mock.instances[0]).toBe(rows[1]);
 
-    // Same target re-rendered: no re-scroll.
-    el.focusParam = "loud";
+    // A real re-render with the target unchanged must not re-scroll —
+    // the one-shot guard, not Lit's string dedupe, is what holds it.
+    el.value = { ...el.value };
+    await el.updateComplete;
     await el.updateComplete;
     expect(scrolled).toHaveBeenCalledTimes(1);
   });

--- a/test/components/device/automation-editor/callable-params-editor-focus.test.ts
+++ b/test/components/device/automation-editor/callable-params-editor-focus.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The cursor-targeted parameter row scrolls in with the shared glow,
+ * once per target; an unknown or block-level target flashes the field.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+
+import { ESPHomeCallableParamsEditor } from "../../../../src/components/device/automation-editor/callable-params-editor.js";
+import { mount } from "../../../_dom.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function spyScroll() {
+  return vi.spyOn(HTMLElement.prototype, "scrollIntoView").mockImplementation(() => {});
+}
+
+describe("callable-params-editor focus", () => {
+  it("scrolls the matching row once per target", async () => {
+    const scrolled = spyScroll();
+    const el = await mount(new ESPHomeCallableParamsEditor(), {
+      value: { times: "int", loud: "bool" },
+      focusParam: "loud",
+    });
+    // The wire sync lands in updated(); settle a second pass.
+    await el.updateComplete;
+    expect(scrolled).toHaveBeenCalledTimes(1);
+    const rows = el.shadowRoot!.querySelectorAll(".script-param-row");
+    expect(scrolled.mock.instances[0]).toBe(rows[1]);
+
+    // Same target re-rendered: no re-scroll.
+    el.focusParam = "loud";
+    await el.updateComplete;
+    expect(scrolled).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the whole field for a block-level target", async () => {
+    const scrolled = spyScroll();
+    const el = await mount(new ESPHomeCallableParamsEditor(), {
+      value: { times: "int" },
+      focusParam: "",
+    });
+    await el.updateComplete;
+    expect(scrolled).toHaveBeenCalledTimes(1);
+    expect(scrolled.mock.instances[0]).toBe(el.shadowRoot!.querySelector(".field"));
+  });
+
+  it("does nothing without a target", async () => {
+    const scrolled = spyScroll();
+    await mount(new ESPHomeCallableParamsEditor(), { value: { times: "int" } });
+    expect(scrolled).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/device/automation-editor/script-editor-mount.test.ts
+++ b/test/components/device/automation-editor/script-editor-mount.test.ts
@@ -49,12 +49,14 @@ const loggerBodies = () => ({
 
 async function mountEditor(
   api: ESPHomeAPI,
-  configuration?: string
+  configuration?: string,
+  props: object = {}
 ): Promise<ESPHomeScriptEditor> {
   const editor = new ESPHomeScriptEditor();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (editor as any)._api = api;
   if (configuration !== undefined) editor.configuration = configuration;
+  Object.assign(editor, props);
   document.body.appendChild(editor);
   await editor.updateComplete;
   await flushMicrotasks(30);
@@ -98,20 +100,15 @@ describe("script-editor action-catalog hydration (#1286)", () => {
     const getAutomationBodies = vi.fn().mockResolvedValue(loggerBodies());
     const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
 
-    const editor = new ESPHomeScriptEditor();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (editor as any)._api = api;
-    editor.configuration = "device.yaml";
-    editor.location = { kind: "script", id: "my_script" };
-    editor.value = {
-      trigger_id: null,
-      trigger_params: { id: "my_script" },
-      actions: [{ action_id: "logger.log", params: {}, children: {}, conditions: [] }],
-    };
-    editor.focusYamlPath = ["script", 0, "then", 0, "logger.log", "format"];
-    document.body.appendChild(editor);
-    await editor.updateComplete;
-    await flushMicrotasks(30);
+    const editor = await mountEditor(api, "device.yaml", {
+      location: { kind: "script", id: "my_script" },
+      value: {
+        trigger_id: null,
+        trigger_params: { id: "my_script" },
+        actions: [{ action_id: "logger.log", params: {}, children: {}, conditions: [] }],
+      },
+      focusYamlPath: ["script", 0, "then", 0, "logger.log", "format"],
+    });
 
     const list = editor.shadowRoot!.querySelector("esphome-automation-action-list");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -123,23 +120,17 @@ describe("script-editor action-catalog hydration (#1286)", () => {
     const getAutomationBodies = vi.fn().mockResolvedValue({});
     const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
 
-    const editor = new ESPHomeScriptEditor();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (editor as any)._api = api;
-    editor.configuration = "device.yaml";
-    editor.location = { kind: "script", id: "my_script" };
-    editor.value = { trigger_id: null, trigger_params: { id: "my_script" }, actions: [] };
-    editor.focusYamlPath = ["script", 0, "mode"];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (editor as any)._scriptComponent = {
-      config_entries: [
-        { key: "id", type: "string", label: "ID" },
-        { key: "mode", type: "enum", label: "Mode" },
-      ],
-    };
-    document.body.appendChild(editor);
-    await editor.updateComplete;
-    await flushMicrotasks(30);
+    const editor = await mountEditor(api, "device.yaml", {
+      location: { kind: "script", id: "my_script" },
+      value: { trigger_id: null, trigger_params: { id: "my_script" }, actions: [] },
+      focusYamlPath: ["script", 0, "mode"],
+      _scriptComponent: {
+        config_entries: [
+          { key: "id", type: "string", label: "ID" },
+          { key: "mode", type: "enum", label: "Mode" },
+        ],
+      },
+    });
 
     const form = editor.shadowRoot!.querySelector("esphome-config-entry-form");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/components/device/automation-editor/script-editor-mount.test.ts
+++ b/test/components/device/automation-editor/script-editor-mount.test.ts
@@ -92,4 +92,57 @@ describe("script-editor action-catalog hydration (#1286)", () => {
     expect(getAvailableAutomations).not.toHaveBeenCalled();
     expect(getAutomationBodies).not.toHaveBeenCalled();
   });
+
+  it("resolves a cursor path into the action list's focus target", async () => {
+    const getAvailableAutomations = vi.fn().mockResolvedValue(slimWithLoggerAction());
+    const getAutomationBodies = vi.fn().mockResolvedValue(loggerBodies());
+    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
+
+    const editor = new ESPHomeScriptEditor();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor as any)._api = api;
+    editor.configuration = "device.yaml";
+    editor.location = { kind: "script", id: "my_script" };
+    editor.value = {
+      trigger_id: null,
+      trigger_params: { id: "my_script" },
+      actions: [{ action_id: "logger.log", params: {}, children: {}, conditions: [] }],
+    };
+    editor.focusYamlPath = ["script", 0, "then", 0, "logger.log", "format"];
+    document.body.appendChild(editor);
+    await editor.updateComplete;
+    await flushMicrotasks(30);
+
+    const list = editor.shadowRoot!.querySelector("esphome-automation-action-list");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((list as any).focusTarget).toEqual({ node: [0], field: ["format"] });
+  });
+
+  it("routes an entry-param cursor path to the config form", async () => {
+    const getAvailableAutomations = vi.fn().mockResolvedValue(slimWithLoggerAction());
+    const getAutomationBodies = vi.fn().mockResolvedValue({});
+    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
+
+    const editor = new ESPHomeScriptEditor();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor as any)._api = api;
+    editor.configuration = "device.yaml";
+    editor.location = { kind: "script", id: "my_script" };
+    editor.value = { trigger_id: null, trigger_params: { id: "my_script" }, actions: [] };
+    editor.focusYamlPath = ["script", 0, "mode"];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor as any)._scriptComponent = {
+      config_entries: [
+        { key: "id", type: "string", label: "ID" },
+        { key: "mode", type: "enum", label: "Mode" },
+      ],
+    };
+    document.body.appendChild(editor);
+    await editor.updateComplete;
+    await flushMicrotasks(30);
+
+    const form = editor.shadowRoot!.querySelector("esphome-config-entry-form");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((form as any).focusFieldPath).toEqual(["mode"]);
+  });
 });

--- a/test/components/device/automation-editor/script-editor-mount.test.ts
+++ b/test/components/device/automation-editor/script-editor-mount.test.ts
@@ -136,4 +136,26 @@ describe("script-editor action-catalog hydration (#1286)", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((form as any).focusFieldPath).toEqual(["mode"]);
   });
+
+  it("reveals the advanced-gated parameters block for a parameter target", async () => {
+    const getAvailableAutomations = vi.fn().mockResolvedValue(slimWithLoggerAction());
+    const getAutomationBodies = vi.fn().mockResolvedValue({});
+    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
+
+    const editor = await mountEditor(api, "device.yaml", {
+      location: { kind: "script", id: "my_script" },
+      value: {
+        trigger_id: null,
+        trigger_params: { id: "my_script", parameters: { pin: "int" } },
+        actions: [],
+      },
+      focusYamlPath: ["script", 0, "parameters", "pin"],
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((editor as any)._showAdvanced).toBe(true);
+    const params = editor.shadowRoot!.querySelector("esphome-callable-params-editor");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((params as any).focusParam).toBe("pin");
+  });
 });

--- a/test/pages/device-cursor-highlight.test.ts
+++ b/test/pages/device-cursor-highlight.test.ts
@@ -168,6 +168,21 @@ describe("cursor-driven YAML highlight (#1885)", () => {
     expect(internals(page)._errorHighlight).toBe("active");
   });
 
+  it("clears the field focus on a navigator-driven section switch", () => {
+    // A navigator click carries no field intent; a stale cursor path would
+    // scroll/flash an unrelated target in the newly mounted editor.
+    const page = makePage();
+    clickYamlLine(page, 2, ["i2c", "sda"], ["i2c", "sda"]);
+    expect(internals(page)._focusYamlPath).toEqual(["i2c", "sda"]);
+
+    internals(page)._onSectionSelect(
+      new CustomEvent("section-select", { detail: { sectionKey: "sensor", fromLine: 4 } })
+    );
+
+    expect(internals(page)._focusFieldPath).toBeUndefined();
+    expect(internals(page)._focusYamlPath).toBeUndefined();
+  });
+
   it("captures the indexed cursor path on cross- and same-section moves", () => {
     const page = makePage();
     clickYamlLine(page, 5, ["sensor"], ["sensor", 0, "platform"]); // cross-section

--- a/test/util/config-entry-tree.test.ts
+++ b/test/util/config-entry-tree.test.ts
@@ -31,6 +31,18 @@ describe("pathIsAdvanced", () => {
     expect(pathIsAdvanced(entries, ["hide_timestamp"])).toBe(true);
   });
 
+  it("is false for a hidden entry — revealing advanced can't show it", () => {
+    const hidden = {
+      key: "actions",
+      type: ConfigEntryType.NESTED,
+      label: "Actions",
+      advanced: true,
+      hidden: true,
+    } as ConfigEntry;
+    expect(pathIsAdvanced([...entries, hidden], ["actions"])).toBe(false);
+    expect(pathIsAdvanced([...entries, hidden], ["actions", "then"])).toBe(false);
+  });
+
   it("is false for a plain leaf", () => {
     expect(pathIsAdvanced(entries, ["name"])).toBe(false);
   });

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -348,6 +348,28 @@ sensor:
     expect(sectionAtLine(yaml, 7)?.key).toBe("logger");
   });
 
+  it("routes the script/interval block key line to the first item", () => {
+    // The block's own component form is a dead end — every item is
+    // owned by its automation editor.
+    const y = `script:
+  - id: morning_alarm
+    then:
+      - logger.log: hi
+interval:
+  - interval: 5s
+    then:
+      - logger.log: tick
+`;
+    expect(sectionAtLine(y, 1)?.key).toBe("automation:script:morning_alarm");
+    expect(sectionAtLine(y, 5)?.key).toBe("automation:interval:0");
+    // Inside an item stays on that item.
+    expect(sectionAtLine(y, 2)?.key).toBe("automation:script:morning_alarm");
+  });
+
+  it("keeps the block section for an empty script block", () => {
+    expect(sectionAtLine("script:\nlogger:\n", 1)?.key).toBe("script");
+  });
+
   it("hits the parent line of a flat-dict section", () => {
     expect(sectionAtLine(yaml, 2)?.key).toBe("esphome");
   });


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #1210: clicking a nested field inside a `script:` entry or an `api: actions:` entry in the YAML pane opened the right editor but never scrolled to or highlighted the target, even though both editors mount the same action list that already routes a focus target.

`handlerAnchor` grows a key sequence form with an any index policy: script and api action locations identify their entry by id rather than list index, and the caret that produced the cursor path is the same one that resolved the location, so the path's entry index is trusted (`script` anchors on `["script"]`, api actions on `["api", "actions"]`). A shared `createFocusResolver` replaces the automation editor's inline memoization and arms both new editors; the script editor routes entry params (id, mode, max_runs) to its config form and actions to its list, and the api action editor routes actions to its list. The name and variables surfaces stay bespoke with no field sink, which is fine, they sit at the top of a short editor and the payoff of this feature is deep targeting long nested action lists.

Two hardening pieces rode along from the review pass: `device-board-info` memoizes `locationFromSectionKey` so a fresh location object per render stops defeating the editors' focus resolver memoization, and a navigator driven section switch now clears the cursor field focus. Before, a stale cursor path could scroll and flash a target in the newly mounted editor that the user never pointed at, and the any index anchor would have widened what a stale path could match.

Verified live on the dev stack: a click on a `format:` nested under a script's `if → then → logger.log` flashes that field, a click on an api action's `level:` flashes it, and a click on a script's `mode:` lands on the config form field.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1211

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
