### PR TITLE
Focus the structured-editor field from URL deep links on load

### DIFF
--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -29,9 +29,8 @@ import { initialDarkMode } from "../util/dark-mode.js";
 import { editorSearchPhrases } from "../util/editor-search-phrases.js";
 import { ESPHOME_YAML_INDENT, esphomeYaml } from "../util/esphome-yaml-lang.js";
 import { idleCompletion } from "../util/idle-completion.js";
-import { getKeyPathWithListIndices } from "../util/yaml-ast.js";
 import { createYamlCompletionSource } from "../util/yaml-completion.js";
-import { cursorKeyPathAt } from "../util/yaml-cursor-paths.js";
+import { cursorKeyPathAt, indexedKeyPathAt } from "../util/yaml-cursor-paths.js";
 import { lineKeyToken, type YamlAutoFix } from "../util/yaml-error-analysis.js";
 import { createYamlHoverTooltip } from "../util/yaml-hover.js";
 import { indentOf } from "../util/yaml-line-walker.js";
@@ -507,17 +506,15 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
           ) {
             this._lastReportedCursorLine = line;
             this._lastReportedPathKey = pathKey;
-            // AST-only sibling of ``path`` carrying block-sequence list
-            // indices — what the automation editor needs to resolve a
-            // node inside a handler body. Empty (omitted) on lines only
-            // the indent walkers can anchor.
-            const indexedPath = getKeyPathWithListIndices(update.state, head);
             this.dispatchEvent(
               new CustomEvent("yaml-cursor-line", {
                 detail: {
                   line,
                   path,
-                  indexedPath: indexedPath.length ? indexedPath : undefined,
+                  // AST-only sibling of ``path`` carrying block-sequence
+                  // list indices — what the automation editor needs to
+                  // resolve a node inside a handler body.
+                  indexedPath: indexedKeyPathAt(update.state, head),
                 },
                 bubbles: true,
                 composed: true,

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -29,20 +29,12 @@ import { initialDarkMode } from "../util/dark-mode.js";
 import { editorSearchPhrases } from "../util/editor-search-phrases.js";
 import { ESPHOME_YAML_INDENT, esphomeYaml } from "../util/esphome-yaml-lang.js";
 import { idleCompletion } from "../util/idle-completion.js";
-import {
-  getKeyPath,
-  getKeyPathWithListIndices,
-  isInsideBlockScalar,
-} from "../util/yaml-ast.js";
+import { getKeyPathWithListIndices } from "../util/yaml-ast.js";
 import { createYamlCompletionSource } from "../util/yaml-completion.js";
+import { cursorKeyPathAt } from "../util/yaml-cursor-paths.js";
 import { lineKeyToken, type YamlAutoFix } from "../util/yaml-error-analysis.js";
 import { createYamlHoverTooltip } from "../util/yaml-hover.js";
-import {
-  blankLineContext,
-  fieldPathByIndent,
-  indentOf,
-  keyPathByIndent,
-} from "../util/yaml-line-walker.js";
+import { indentOf } from "../util/yaml-line-walker.js";
 import {
   createBackendYamlLinter,
   lintErrorLineGutter,
@@ -505,31 +497,9 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
           // moves with no edit.
           if (line === this._lastReportedCursorLine && !update.docChanged) return;
           // Resolve the caret's key path field-first (the page derives the
-          // form-relative path from it). The AST can't anchor an empty-value
-          // `key:` (Lezer leaves the Pair open) and yields nothing on a blank
-          // line, so prefer the indent walkers there: fieldPathByIndent gives
-          // the field path including the leaf key for an empty-value pair, else
-          // fall back to the AST, else the ancestor chain from a blank line.
-          // `skipListItems` keeps an anonymous `- ` dash from masquerading as a
-          // container key.
-          let path = fieldPathByIndent(update.state.doc, line - 1);
-          // Inside a block scalar (a `lambda: |-` body) a `key:`-looking
-          // content line is literal text, not a field; the regex can't tell,
-          // so defer to the AST there.
-          if (path && isInsideBlockScalar(update.state, head)) path = null;
-          if (!path) {
-            path = getKeyPath(update.state, head);
-            if (path.length === 0) {
-              const blank = blankLineContext(update.state.doc, head);
-              if (blank)
-                path = keyPathByIndent(
-                  update.state.doc,
-                  blank.lineIdx,
-                  blank.indent,
-                  true
-                );
-            }
-          }
+          // form-relative path from it). The indent-walker/AST fallback
+          // chain is shared with the URL deep-link load path.
+          const path = cursorKeyPathAt(update.state, head);
           const pathKey = JSON.stringify(path);
           if (
             line !== this._lastReportedCursorLine ||

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -47,7 +47,10 @@ import { navigate, setLeaveGuard } from "../util/navigation.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { UnsavedGuard } from "../util/unsaved-guard.js";
-import { resolveSectionForUrlLine } from "../util/url-line-resolver.js";
+import {
+  resolveSectionForUrlLine,
+  resolveUrlLineFocus,
+} from "../util/url-line-resolver.js";
 import { buildWebUiUrl } from "../util/web-ui-url.js";
 import {
   getLastValidatedResult,
@@ -675,9 +678,14 @@ export class ESPHomePageDevice extends LitElement {
     }
   }
 
+  /** ``true`` once the URL's ``?line=`` has been resolved against the
+   *  loaded YAML. ``_updateUrl`` round-trips and later ``_loadYaml``
+   *  calls (board swap) must not re-derive focus from a stale line. */
+  private _urlLineConsumed = false;
+
   /**
-   * Resolve a ``?line=N`` URL parameter to a concrete section
-   * once the YAML has loaded.
+   * Resolve a ``?line=N`` URL parameter to a concrete section and
+   * field focus once the YAML has loaded. Runs once per navigation.
    *
    * Direct-link arrivals from the dashboard's YAML hit list
    * carry only ``?line=N`` (not ``?section=``); the navigator's
@@ -686,16 +694,22 @@ export class ESPHomePageDevice extends LitElement {
    * the just-loaded YAML to find the section that contains line
    * N and pin both ``_selectedSection`` and ``_scrollToHighlight``
    * — the navigator's existing emit-on-update logic then fires
-   * the scroll-into-view dispatch in CodeMirror.
+   * the scroll-into-view dispatch in CodeMirror. The focus paths
+   * deep-target the line's field in the structured editor, the
+   * same as a live caret move onto it.
    */
   private _maybeResolveLineFromUrl() {
-    const resolved = resolveSectionForUrlLine(
+    if (this._urlLineConsumed) return;
+    this._urlLineConsumed = true;
+    const resolved = resolveUrlLineFocus(
       this._yaml,
       this._selectedFromLine,
       this._selectedSection
     );
     if (!resolved) return;
     this._selectedSection = resolved.sectionKey;
+    this._focusFieldPath = resolved.fieldPath;
+    this._focusYamlPath = resolved.yamlPath;
     // ``_highlightRange`` is what the editor reads to drive
     // scroll-into-view; the user-click path sets it via
     // ``_onYamlHighlight`` from the navigator's ``yaml-highlight``
@@ -926,7 +940,7 @@ export class ESPHomePageDevice extends LitElement {
       this._cacheLayout("both");
     }
     this._setHighlight({ fromLine: line, toLine: line }, true, true);
-    const resolved = resolveSectionForUrlLine(this._yaml, line, null);
+    const resolved = resolveSectionForUrlLine(this._yaml, line);
     if (resolved) {
       this._selectedSection = resolved.sectionKey;
     }

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -173,7 +173,14 @@ export class ESPHomePageDevice extends LitElement {
   private _selectedSection: string | null = this._readUrlParam("section", null);
 
   @state()
-  private _selectedFromLine?: number = this._readUrlLine();
+  private _selectedFromLine?: number;
+
+  /** One-shot ``?line=`` deep-link intent, consumed (cleared) by
+   *  ``_maybeResolveLineFromUrl`` once the YAML is loaded. Kept apart
+   *  from ``_selectedFromLine`` — that field is durable section-instance
+   *  state the URL round-trips, so parking the intent there would
+   *  re-derive focus on every later ``_loadYaml`` (board swap). */
+  private _pendingUrlLine?: number = this._readUrlLine();
 
   /** Instance-relative field path the YAML cursor is on, for the form to
    *  scroll into view; empty on a section header / non-field line. */
@@ -678,14 +685,8 @@ export class ESPHomePageDevice extends LitElement {
     }
   }
 
-  /** ``true`` once the URL's ``?line=`` has been resolved against the
-   *  loaded YAML. ``_updateUrl`` round-trips and later ``_loadYaml``
-   *  calls (board swap) must not re-derive focus from a stale line. */
-  private _urlLineConsumed = false;
-
   /**
-   * Resolve a ``?line=N`` URL parameter to a concrete section and
-   * field focus once the YAML has loaded. Runs once per navigation.
+   * Consume the one-shot ``?line=`` intent once the YAML has loaded.
    *
    * Direct-link arrivals from the dashboard's YAML hit list
    * carry only ``?line=N`` (not ``?section=``); the navigator's
@@ -695,19 +696,19 @@ export class ESPHomePageDevice extends LitElement {
    * N and pin both ``_selectedSection`` and ``_scrollToHighlight``
    * — the navigator's existing emit-on-update logic then fires
    * the scroll-into-view dispatch in CodeMirror. The focus paths
-   * deep-target the line's field in the structured editor, the
-   * same as a live caret move onto it.
+   * deep-target the line's field in the structured editor, and
+   * ``_selectedFromLine`` is pinned to the section's own start so
+   * the arrival is state-identical to a live caret move onto the
+   * line (instance disambiguation, same-section move checks).
    */
   private _maybeResolveLineFromUrl() {
-    if (this._urlLineConsumed) return;
-    this._urlLineConsumed = true;
-    const resolved = resolveUrlLineFocus(
-      this._yaml,
-      this._selectedFromLine,
-      this._selectedSection
-    );
+    if (this._pendingUrlLine === undefined || !this._yaml) return;
+    const line = this._pendingUrlLine;
+    this._pendingUrlLine = undefined;
+    const resolved = resolveUrlLineFocus(this._yaml, line, this._selectedSection);
     if (!resolved) return;
     this._selectedSection = resolved.sectionKey;
+    this._selectedFromLine = resolved.sectionFromLine;
     this._focusFieldPath = resolved.fieldPath;
     this._focusYamlPath = resolved.yamlPath;
     // ``_highlightRange`` is what the editor reads to drive

--- a/src/util/url-line-resolver.ts
+++ b/src/util/url-line-resolver.ts
@@ -21,6 +21,10 @@ import { sectionAtLine, sectionKeyOf } from "./yaml-sections.js";
 export interface ResolvedUrlLine {
   /** Section key (e.g. ``"esphome"``, ``"sensor.dht"``) the line falls within. */
   sectionKey: string;
+  /** First line of the section *instance* containing the URL line — what a
+   *  live caret move would pin as ``selectedFromLine`` (duplicate-key
+   *  sections resolve their instance by it). */
+  sectionFromLine: number;
   /**
    * Highlight range fed to the YAML editor.
    *
@@ -77,6 +81,7 @@ export function resolveSectionForUrlLine(
   if (!match) return null;
   return {
     sectionKey: sectionKeyOf(match),
+    sectionFromLine: match.fromLine,
     range: { fromLine: line, toLine: line },
   };
 }
@@ -95,11 +100,10 @@ export function resolveUrlLineFocus(
   line: number | undefined,
   currentSection: string | null
 ): ResolvedUrlLineFocus | null {
-  if (line === undefined) return null;
   const resolved = resolveSectionForUrlLine(yaml, line);
   if (!resolved) return null;
   if (currentSection !== null && currentSection !== resolved.sectionKey) return null;
-  const paths = pathsForYamlLine(yaml, line);
+  const paths = pathsForYamlLine(yaml, resolved.range.fromLine);
   return {
     ...resolved,
     fieldPath: paths ? formRelativePath(paths.path) : [],

--- a/src/util/url-line-resolver.ts
+++ b/src/util/url-line-resolver.ts
@@ -8,11 +8,14 @@
  * + scroll path keys off ``selectedSection``. Without this
  * resolver the editor mounts but never scrolls.
  *
- * Pure function so the device page's call site stays a thin
- * wrapper that just assigns the resolved values; behaviour is
+ * Pure functions so the device page's call sites stay thin
+ * wrappers that just assign the resolved values; behaviour is
  * unit-testable without spinning up Lit / CodeMirror.
  */
 
+import { formRelativePath } from "./backend-field-errors.js";
+import type { YamlPathSegment } from "./yaml-ast.js";
+import { pathsForYamlLine } from "./yaml-cursor-paths.js";
 import { sectionAtLine, sectionKeyOf } from "./yaml-sections.js";
 
 export interface ResolvedUrlLine {
@@ -32,6 +35,16 @@ export interface ResolvedUrlLine {
   range: { fromLine: number; toLine: number };
 }
 
+/** ``ResolvedUrlLine`` plus the focus paths a live caret on that line
+ *  would have produced. */
+export interface ResolvedUrlLineFocus extends ResolvedUrlLine {
+  /** Section-relative form field path; ``[]`` when the line names no field. */
+  fieldPath: string[];
+  /** Document-absolute indexed key path; ``undefined`` when the AST
+   *  couldn't anchor the line. */
+  yamlPath?: YamlPathSegment[];
+}
+
 /**
  * Resolve *line* (1-indexed) inside *yaml* to its containing
  * top-level section, or ``null`` when:
@@ -39,8 +52,6 @@ export interface ResolvedUrlLine {
  * - ``line`` is undefined (no ``?line=`` param);
  * - ``yaml`` is empty (still loading — caller should retry
  *   when the YAML lands);
- * - ``currentSection`` is already set (user already picked a
- *   section, don't overwrite their selection);
  * - the line falls outside any parsed section (line points at
  *   leading comments / blank lines before the first key).
  *
@@ -51,8 +62,7 @@ export interface ResolvedUrlLine {
  */
 export function resolveSectionForUrlLine(
   yaml: string,
-  line: number | undefined,
-  currentSection: string | null
+  line: number | undefined
 ): ResolvedUrlLine | null {
   if (line === undefined) return null;
   // ``line`` came from a URL param via ``Number(raw)`` so it
@@ -62,12 +72,37 @@ export function resolveSectionForUrlLine(
   // and throws on out-of-range; ``sectionAtLine`` likewise
   // expects a positive integer. Reject anything that isn't.
   if (!Number.isInteger(line) || line < 1) return null;
-  if (currentSection !== null) return null;
   if (!yaml) return null;
   const match = sectionAtLine(yaml, line);
   if (!match) return null;
   return {
     sectionKey: sectionKeyOf(match),
     range: { fromLine: line, toLine: line },
+  };
+}
+
+/**
+ * ``resolveSectionForUrlLine`` plus the deep-focus paths, for the
+ * once-per-navigation load path.
+ *
+ * With *currentSection* set (the URL carried ``?section=`` too), the
+ * line must resolve inside that same section or the whole result is
+ * ``null`` — focusing a field in a section the URL didn't select
+ * would flash an unrelated form.
+ */
+export function resolveUrlLineFocus(
+  yaml: string,
+  line: number | undefined,
+  currentSection: string | null
+): ResolvedUrlLineFocus | null {
+  if (line === undefined) return null;
+  const resolved = resolveSectionForUrlLine(yaml, line);
+  if (!resolved) return null;
+  if (currentSection !== null && currentSection !== resolved.sectionKey) return null;
+  const paths = pathsForYamlLine(yaml, line);
+  return {
+    ...resolved,
+    fieldPath: paths ? formRelativePath(paths.path) : [],
+    yamlPath: paths?.indexedPath,
   };
 }

--- a/src/util/yaml-cursor-paths.ts
+++ b/src/util/yaml-cursor-paths.ts
@@ -69,9 +69,10 @@ export function pathsForYamlLine(yaml: string, line: number): YamlLinePaths | nu
   if (line < 1 || line > state.doc.lines) return null;
   const pos = state.doc.line(line).to;
   // Runs once per navigation; parsing to the target line is single-digit
-  // ms. The path walks only read ancestors of ``pos``, so nothing past it
-  // is needed, and a partial tree (budget exhausted) still resolves.
-  ensureSyntaxTree(state, pos, 1000);
+  // ms, so the budget only bites on pathological files — where a partial
+  // tree fails soft (the indent walkers still anchor the key path). The
+  // path walks only read ancestors of ``pos``; nothing past it is needed.
+  ensureSyntaxTree(state, pos, 200);
   return {
     path: cursorKeyPathAt(state, pos),
     indexedPath: indexedKeyPathAt(state, pos),

--- a/src/util/yaml-cursor-paths.ts
+++ b/src/util/yaml-cursor-paths.ts
@@ -1,0 +1,69 @@
+/**
+ * Key-path derivation for a caret position, shared between the live
+ * editor's cursor listener and the URL deep-link load path.
+ *
+ * The fallback chain matters: the AST can't anchor an empty-value
+ * ``key:`` (Lezer leaves the Pair open) and yields nothing on a blank
+ * line, so the indent walkers cover those — except inside a block
+ * scalar, where a ``key:``-looking content line is literal text and
+ * only the AST can tell.
+ */
+
+import { ensureSyntaxTree } from "@codemirror/language";
+import { EditorState } from "@codemirror/state";
+import { esphomeYaml } from "./esphome-yaml-lang.js";
+import {
+  getKeyPath,
+  getKeyPathWithListIndices,
+  isInsideBlockScalar,
+  type YamlPathSegment,
+} from "./yaml-ast.js";
+import {
+  blankLineContext,
+  fieldPathByIndent,
+  keyPathByIndent,
+} from "./yaml-line-walker.js";
+
+/** Document-absolute key path at *pos*: indent walkers first (they
+ *  anchor empty-value pairs and blank lines the AST can't), then the
+ *  AST. ``[]`` when nothing anchors. */
+export function cursorKeyPathAt(state: EditorState, pos: number): string[] {
+  const line = state.doc.lineAt(pos);
+  let path = fieldPathByIndent(state.doc, line.number - 1);
+  if (path && isInsideBlockScalar(state, pos)) path = null;
+  if (!path) {
+    path = getKeyPath(state, pos);
+    if (path.length === 0) {
+      const blank = blankLineContext(state.doc, pos);
+      if (blank) path = keyPathByIndent(state.doc, blank.lineIdx, blank.indent, true);
+    }
+  }
+  return path;
+}
+
+/** The key path plus its indexed (AST-only) sibling, as carried by the
+ *  editor's ``yaml-cursor-line`` event. */
+export interface YamlLinePaths {
+  path: string[];
+  /** ``undefined`` on lines only the indent walkers can anchor. */
+  indexedPath?: YamlPathSegment[];
+}
+
+/**
+ * Derive the paths a caret at the end of *line* (1-indexed) would
+ * report, from a raw YAML string — for deep-link arrivals where no
+ * editor view exists yet. ``null`` when the line is out of range.
+ */
+export function pathsForYamlLine(yaml: string, line: number): YamlLinePaths | null {
+  const state = EditorState.create({ doc: yaml, extensions: [esphomeYaml()] });
+  if (line < 1 || line > state.doc.lines) return null;
+  // Runs once per navigation; a device YAML parses in single-digit ms.
+  // A null return (budget exhausted) still leaves a usable partial tree.
+  ensureSyntaxTree(state, state.doc.length, 1000);
+  const pos = state.doc.line(line).to;
+  const indexedPath = getKeyPathWithListIndices(state, pos);
+  return {
+    path: cursorKeyPathAt(state, pos),
+    indexedPath: indexedPath.length ? indexedPath : undefined,
+  };
+}

--- a/src/util/yaml-cursor-paths.ts
+++ b/src/util/yaml-cursor-paths.ts
@@ -41,11 +41,21 @@ export function cursorKeyPathAt(state: EditorState, pos: number): string[] {
   return path;
 }
 
+/** ``getKeyPathWithListIndices`` under the ``yaml-cursor-line`` event's
+ *  convention: ``undefined`` (omitted) on lines only the indent walkers
+ *  can anchor. */
+export function indexedKeyPathAt(
+  state: EditorState,
+  pos: number
+): YamlPathSegment[] | undefined {
+  const indexed = getKeyPathWithListIndices(state, pos);
+  return indexed.length ? indexed : undefined;
+}
+
 /** The key path plus its indexed (AST-only) sibling, as carried by the
  *  editor's ``yaml-cursor-line`` event. */
 export interface YamlLinePaths {
   path: string[];
-  /** ``undefined`` on lines only the indent walkers can anchor. */
   indexedPath?: YamlPathSegment[];
 }
 
@@ -57,13 +67,13 @@ export interface YamlLinePaths {
 export function pathsForYamlLine(yaml: string, line: number): YamlLinePaths | null {
   const state = EditorState.create({ doc: yaml, extensions: [esphomeYaml()] });
   if (line < 1 || line > state.doc.lines) return null;
-  // Runs once per navigation; a device YAML parses in single-digit ms.
-  // A null return (budget exhausted) still leaves a usable partial tree.
-  ensureSyntaxTree(state, state.doc.length, 1000);
   const pos = state.doc.line(line).to;
-  const indexedPath = getKeyPathWithListIndices(state, pos);
+  // Runs once per navigation; parsing to the target line is single-digit
+  // ms. The path walks only read ancestors of ``pos``, so nothing past it
+  // is needed, and a partial tree (budget exhausted) still resolves.
+  ensureSyntaxTree(state, pos, 1000);
   return {
     path: cursorKeyPathAt(state, pos),
-    indexedPath: indexedPath.length ? indexedPath : undefined,
+    indexedPath: indexedKeyPathAt(state, pos),
   };
 }

--- a/test/pages/device-url-line-focus.test.ts
+++ b/test/pages/device-url-line-focus.test.ts
@@ -49,7 +49,7 @@ function makePage(
   page.id = "kitchen.yaml";
   internals(page)._yaml = YAML;
   internals(page)._savedYaml = YAML;
-  internals(page)._selectedFromLine = opts.line;
+  internals(page)._pendingUrlLine = opts.line;
   internals(page)._selectedSection = opts.section ?? null;
   return page;
 }
@@ -69,6 +69,15 @@ describe("URL ?line= deep focus on load (#1212)", () => {
     expect(internals(page)._scrollToHighlight).toBe(true);
   });
 
+  it("pins _selectedFromLine to the section start, as a live caret move would", () => {
+    // Line 7 sits in the sensor item instance starting at line 5; the
+    // raw line stays in the highlight range only.
+    const page = makePage({ line: 7 });
+    internals(page)._maybeResolveLineFromUrl();
+    expect(internals(page)._selectedFromLine).toBe(5);
+    expect(internals(page)._highlightRange).toEqual({ fromLine: 7, toLine: 7 });
+  });
+
   it("a section+line arrival keeps the section and still derives focus", () => {
     const page = makePage({ line: 7, section: "sensor.aht10" });
     internals(page)._maybeResolveLineFromUrl();
@@ -85,14 +94,25 @@ describe("URL ?line= deep focus on load (#1212)", () => {
     expect(internals(page)._focusYamlPath).toBeUndefined();
   });
 
-  it("runs once per navigation — a later _loadYaml (board swap) can't re-derive", () => {
+  it("consumes the intent — a later _loadYaml (board swap) can't re-derive", () => {
     const page = makePage({ line: 2 });
     internals(page)._maybeResolveLineFromUrl();
+    expect(internals(page)._pendingUrlLine).toBeUndefined();
     internals(page)._focusFieldPath = undefined;
     internals(page)._focusYamlPath = undefined;
     internals(page)._maybeResolveLineFromUrl();
     expect(internals(page)._focusFieldPath).toBeUndefined();
     expect(internals(page)._focusYamlPath).toBeUndefined();
+  });
+
+  it("keeps the intent pending while the YAML hasn't loaded", () => {
+    const page = makePage({ line: 2 });
+    internals(page)._yaml = "";
+    internals(page)._maybeResolveLineFromUrl();
+    expect(internals(page)._pendingUrlLine).toBe(2);
+    internals(page)._yaml = YAML;
+    internals(page)._maybeResolveLineFromUrl();
+    expect(internals(page)._focusFieldPath).toEqual(["sda"]);
   });
 
   it("no line param is a no-op", () => {

--- a/test/pages/device-url-line-focus.test.ts
+++ b/test/pages/device-url-line-focus.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that a deep-link arrival (?line=N, optionally ?section=) derives the
+ * structured-editor focus from the loaded YAML once per navigation
+ * (esphome/device-builder-frontend#1212) — previously the load path only
+ * selected the section and the form always painted from the top.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("../../src/components/command-dialog.js", () => ({}));
+vi.mock("../../src/components/device/device-editor.js", () => ({}));
+vi.mock("../../src/components/device/device-navigator.js", () => ({}));
+vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
+vi.mock("../../src/components/install-method-dialog.js", () => ({}));
+vi.mock("../../src/components/logs-dialog.js", () => ({}));
+vi.mock("../../src/components/unsaved-changes-dialog.js", () => ({}));
+vi.mock("../../src/components/yaml-validation-dialog.js", () => ({}));
+vi.mock("../../src/components/device/device-install-controller.js", () => ({
+  DeviceInstallController: class {
+    constructor() {}
+  },
+}));
+
+import { ESPHomePageDevice } from "../../src/pages/device.js";
+
+const YAML = [
+  "i2c:",
+  "  sda: 1",
+  "  scl: 0",
+  "sensor:",
+  "  - platform: aht10",
+  "    temperature:",
+  "      name: Temperature",
+  "",
+].join("\n");
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const internals = (page: ESPHomePageDevice) => page as any;
+
+function makePage(
+  opts: { line?: number; section?: string | null } = {}
+): ESPHomePageDevice {
+  const page = new ESPHomePageDevice();
+  page.id = "kitchen.yaml";
+  internals(page)._yaml = YAML;
+  internals(page)._savedYaml = YAML;
+  internals(page)._selectedFromLine = opts.line;
+  internals(page)._selectedSection = opts.section ?? null;
+  return page;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("URL ?line= deep focus on load (#1212)", () => {
+  it("a line-only arrival selects the section and derives both focus paths", () => {
+    const page = makePage({ line: 2 });
+    internals(page)._maybeResolveLineFromUrl();
+    expect(internals(page)._selectedSection).toBe("i2c");
+    expect(internals(page)._focusFieldPath).toEqual(["sda"]);
+    expect(internals(page)._focusYamlPath).toEqual(["i2c", "sda"]);
+    expect(internals(page)._highlightRange).toEqual({ fromLine: 2, toLine: 2 });
+    expect(internals(page)._scrollToHighlight).toBe(true);
+  });
+
+  it("a section+line arrival keeps the section and still derives focus", () => {
+    const page = makePage({ line: 7, section: "sensor.aht10" });
+    internals(page)._maybeResolveLineFromUrl();
+    expect(internals(page)._selectedSection).toBe("sensor.aht10");
+    expect(internals(page)._focusFieldPath).toEqual(["temperature", "name"]);
+    expect(internals(page)._focusYamlPath).toEqual(["sensor", 0, "temperature", "name"]);
+  });
+
+  it("a section that disagrees with the line derives nothing", () => {
+    const page = makePage({ line: 2, section: "sensor.aht10" });
+    internals(page)._maybeResolveLineFromUrl();
+    expect(internals(page)._selectedSection).toBe("sensor.aht10");
+    expect(internals(page)._focusFieldPath).toBeUndefined();
+    expect(internals(page)._focusYamlPath).toBeUndefined();
+  });
+
+  it("runs once per navigation — a later _loadYaml (board swap) can't re-derive", () => {
+    const page = makePage({ line: 2 });
+    internals(page)._maybeResolveLineFromUrl();
+    internals(page)._focusFieldPath = undefined;
+    internals(page)._focusYamlPath = undefined;
+    internals(page)._maybeResolveLineFromUrl();
+    expect(internals(page)._focusFieldPath).toBeUndefined();
+    expect(internals(page)._focusYamlPath).toBeUndefined();
+  });
+
+  it("no line param is a no-op", () => {
+    const page = makePage({ section: "i2c" });
+    internals(page)._maybeResolveLineFromUrl();
+    expect(internals(page)._focusFieldPath).toBeUndefined();
+    expect(internals(page)._highlightRange).toBeNull();
+  });
+});

--- a/test/util/url-line-resolver.test.ts
+++ b/test/util/url-line-resolver.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveSectionForUrlLine } from "../../src/util/url-line-resolver.js";
+import {
+  resolveSectionForUrlLine,
+  resolveUrlLineFocus,
+} from "../../src/util/url-line-resolver.js";
 
 const SAMPLE_YAML = `esphome:
   name: kitchen
@@ -22,9 +25,20 @@ binary_sensor:
     name: Doorbell
 `;
 
+const SCRIPT_YAML = `esphome:
+  name: kitchen
+
+script:
+  - id: blink
+    mode: single
+    then:
+      - logger.log:
+          format: hi
+`;
+
 describe("resolveSectionForUrlLine", () => {
   it("returns null when line is undefined", () => {
-    expect(resolveSectionForUrlLine(SAMPLE_YAML, undefined, null)).toBeNull();
+    expect(resolveSectionForUrlLine(SAMPLE_YAML, undefined)).toBeNull();
   });
 
   it.each([NaN, 0, -1, -100, 1.5, 7.5])(
@@ -35,16 +49,12 @@ describe("resolveSectionForUrlLine", () => {
       // (fractional), or ``?line=-1`` would otherwise feed bad input
       // to ``sectionAtLine`` / CodeMirror's ``doc.line(n)`` which
       // throws. Validate at the boundary.
-      expect(resolveSectionForUrlLine(SAMPLE_YAML, badLine, null)).toBeNull();
+      expect(resolveSectionForUrlLine(SAMPLE_YAML, badLine)).toBeNull();
     }
   );
 
   it("returns null when YAML is empty (still loading)", () => {
-    expect(resolveSectionForUrlLine("", 5, null)).toBeNull();
-  });
-
-  it("returns null when a section is already selected (don't overwrite)", () => {
-    expect(resolveSectionForUrlLine(SAMPLE_YAML, 5, "esphome")).toBeNull();
+    expect(resolveSectionForUrlLine("", 5)).toBeNull();
   });
 
   it("resolves a line in the esphome block to esphome section + line-pinned range", () => {
@@ -52,7 +62,7 @@ describe("resolveSectionForUrlLine", () => {
     // containing section. Editor scrolls to ``range.fromLine``;
     // widening to section.fromLine→toLine would silently land
     // every hit inside a section on the section header.
-    const got = resolveSectionForUrlLine(SAMPLE_YAML, 2, null);
+    const got = resolveSectionForUrlLine(SAMPLE_YAML, 2);
     expect(got).not.toBeNull();
     expect(got!.sectionKey).toBe("esphome");
     expect(got!.range).toEqual({ fromLine: 2, toLine: 2 });
@@ -60,14 +70,14 @@ describe("resolveSectionForUrlLine", () => {
 
   it("resolves a line in the wifi block to wifi", () => {
     // Line 9 is ``  ssid: home_network`` inside the ``wifi:`` block.
-    const got = resolveSectionForUrlLine(SAMPLE_YAML, 9, null);
+    const got = resolveSectionForUrlLine(SAMPLE_YAML, 9);
     expect(got).not.toBeNull();
     expect(got!.sectionKey).toBe("wifi");
   });
 
   it("resolves a line inside binary_sensor to that platform-keyed section", () => {
     // Line 17 is ``  - platform: gpio`` inside binary_sensor.
-    const got = resolveSectionForUrlLine(SAMPLE_YAML, 17, null);
+    const got = resolveSectionForUrlLine(SAMPLE_YAML, 17);
     expect(got).not.toBeNull();
     expect(got!.sectionKey).toContain("binary_sensor");
   });
@@ -77,7 +87,7 @@ describe("resolveSectionForUrlLine", () => {
     // out-of-bounds line numbers (truncated YAML, malformed URL)
     // resolve to null rather than throwing or returning a stale
     // last-section match.
-    const got = resolveSectionForUrlLine(SAMPLE_YAML, 999, null);
+    const got = resolveSectionForUrlLine(SAMPLE_YAML, 999);
     expect(got).toBeNull();
   });
 
@@ -88,8 +98,8 @@ describe("resolveSectionForUrlLine", () => {
     // would have landed on the platform line. Pin that the URL
     // line drives the range so deep-link to line N actually
     // lands on line N.
-    const a = resolveSectionForUrlLine(SAMPLE_YAML, 18, null); // pin: GPIO2
-    const b = resolveSectionForUrlLine(SAMPLE_YAML, 19, null); // name: Doorbell
+    const a = resolveSectionForUrlLine(SAMPLE_YAML, 18); // pin: GPIO2
+    const b = resolveSectionForUrlLine(SAMPLE_YAML, 19); // name: Doorbell
     expect(a).not.toBeNull();
     expect(b).not.toBeNull();
     expect(a!.sectionKey).toBe(b!.sectionKey);
@@ -101,11 +111,63 @@ describe("resolveSectionForUrlLine", () => {
     // Single-line range invariant.
     const lines = SAMPLE_YAML.split("\n").length;
     for (let i = 1; i <= lines; i++) {
-      const got = resolveSectionForUrlLine(SAMPLE_YAML, i, null);
+      const got = resolveSectionForUrlLine(SAMPLE_YAML, i);
       if (got) {
         expect(got.range.toLine).toBe(got.range.fromLine);
         expect(got.range.fromLine).toBe(i);
       }
     }
+  });
+});
+
+describe("resolveUrlLineFocus", () => {
+  it("carries the section resolution plus both focus paths for a field line", () => {
+    // Line 9 is ``  ssid: home_network``.
+    const got = resolveUrlLineFocus(SAMPLE_YAML, 9, null);
+    expect(got).not.toBeNull();
+    expect(got!.sectionKey).toBe("wifi");
+    expect(got!.range).toEqual({ fromLine: 9, toLine: 9 });
+    expect(got!.fieldPath).toEqual(["ssid"]);
+    expect(got!.yamlPath).toEqual(["wifi", "ssid"]);
+  });
+
+  it("indexes list entries in yamlPath", () => {
+    // Line 18 is ``    pin: GPIO2`` inside binary_sensor's first item.
+    const got = resolveUrlLineFocus(SAMPLE_YAML, 18, null);
+    expect(got!.fieldPath).toEqual(["pin"]);
+    expect(got!.yamlPath).toEqual(["binary_sensor", 0, "pin"]);
+  });
+
+  it("a section header line yields an empty fieldPath", () => {
+    // Line 8 is ``wifi:`` — nothing to deep-target, section only.
+    const got = resolveUrlLineFocus(SAMPLE_YAML, 8, null);
+    expect(got!.sectionKey).toBe("wifi");
+    expect(got!.fieldPath).toEqual([]);
+  });
+
+  it("resolves a nested automation line to the per-item section with an indexed path", () => {
+    // Line 9 is ``          format: hi`` inside the script's action body.
+    const got = resolveUrlLineFocus(SCRIPT_YAML, 9, null);
+    expect(got).not.toBeNull();
+    expect(got!.sectionKey).toBe("automation:script:blink");
+    expect(got!.yamlPath).toEqual(["script", 0, "then", 0, "logger.log", "format"]);
+  });
+
+  it("returns the focus when the URL's section matches the line's section", () => {
+    const got = resolveUrlLineFocus(SAMPLE_YAML, 9, "wifi");
+    expect(got).not.toBeNull();
+    expect(got!.fieldPath).toEqual(["ssid"]);
+  });
+
+  it("returns null when the URL's section disagrees with the line", () => {
+    // A stale/hand-edited URL pairing ``section=esphome`` with a wifi
+    // line must not flash a same-named field in the wrong form.
+    expect(resolveUrlLineFocus(SAMPLE_YAML, 9, "esphome")).toBeNull();
+  });
+
+  it("propagates a null section resolution", () => {
+    expect(resolveUrlLineFocus(SAMPLE_YAML, undefined, null)).toBeNull();
+    expect(resolveUrlLineFocus("", 5, null)).toBeNull();
+    expect(resolveUrlLineFocus(SAMPLE_YAML, 999, null)).toBeNull();
   });
 });

--- a/test/util/url-line-resolver.test.ts
+++ b/test/util/url-line-resolver.test.ts
@@ -65,6 +65,7 @@ describe("resolveSectionForUrlLine", () => {
     const got = resolveSectionForUrlLine(SAMPLE_YAML, 2);
     expect(got).not.toBeNull();
     expect(got!.sectionKey).toBe("esphome");
+    expect(got!.sectionFromLine).toBe(1);
     expect(got!.range).toEqual({ fromLine: 2, toLine: 2 });
   });
 
@@ -150,6 +151,7 @@ describe("resolveUrlLineFocus", () => {
     const got = resolveUrlLineFocus(SCRIPT_YAML, 9, null);
     expect(got).not.toBeNull();
     expect(got!.sectionKey).toBe("automation:script:blink");
+    expect(got!.sectionFromLine).toBe(5);
     expect(got!.yamlPath).toEqual(["script", 0, "then", 0, "logger.log", "format"]);
   });
 

--- a/test/util/yaml-cursor-paths.test.ts
+++ b/test/util/yaml-cursor-paths.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { pathsForYamlLine } from "../../src/util/yaml-cursor-paths.js";
+
+const YAML = `esphome:
+  name: kitchen
+
+wifi:
+  ssid: home
+  password:
+
+sensor:
+  - platform: aht10
+    temperature:
+      name: Temperature
+    lambda: |-
+      id: looks_like_a_key
+`;
+
+describe("pathsForYamlLine", () => {
+  it("derives both paths for a populated field line", () => {
+    expect(pathsForYamlLine(YAML, 5)).toEqual({
+      path: ["wifi", "ssid"],
+      indexedPath: ["wifi", "ssid"],
+    });
+  });
+
+  it("indexes block-sequence items", () => {
+    expect(pathsForYamlLine(YAML, 11)!.indexedPath).toEqual([
+      "sensor",
+      0,
+      "temperature",
+      "name",
+    ]);
+  });
+
+  it("anchors an empty-value pair via the indent walker", () => {
+    // ``password:`` after a populated sibling — Lezer leaves the Pair
+    // open, so only the walker keeps the leaf key.
+    expect(pathsForYamlLine(YAML, 6)!.path).toEqual(["wifi", "password"]);
+  });
+
+  it("does not treat block-scalar content as fields", () => {
+    // ``id: looks_like_a_key`` inside the lambda body is literal text.
+    const got = pathsForYamlLine(YAML, 13)!;
+    expect(got.path).not.toContain("id");
+  });
+
+  it("resolves a blank indented line to its ancestor chain", () => {
+    const yaml = "esp32:\n  framework:\n    \nlogger:\n";
+    expect(pathsForYamlLine(yaml, 3)!.path).toEqual(["esp32", "framework"]);
+  });
+
+  it("returns null for an out-of-range line", () => {
+    expect(pathsForYamlLine(YAML, 0)).toBeNull();
+    expect(pathsForYamlLine(YAML, 999)).toBeNull();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

A pasted or restored device URL now deep targets the field in the structured editor, the same as clicking that line in the YAML pane. Previously `?line=` only highlighted the YAML pane and the structured side always painted from the top.

The editor's caret path derivation (the indent walker / AST fallback chain) moves to a shared `yaml-cursor-paths` module so the load path derives the same paths from the raw YAML string via a throwaway EditorState; no editor view needs to exist yet. `resolveUrlLineFocus` extends the existing URL line resolver with the two focus paths, gated on the line agreeing with an explicit `?section=` so a stale URL can't flash a field in the wrong form.

On the page, the `?line=` param becomes one shot intent (`_pendingUrlLine`) consumed once the YAML loads, so `_updateUrl` round trips and later reloads (board swap) can't re derive focus from a stale line, and an arrival that races the YAML load stays pending until it lands. After resolving, `_selectedFromLine` is pinned to the section instance's own start line, making a deep link arrival state identical to a live caret move (duplicate key sections resolve the right instance; the first same section interaction doesn't take the cross section branch).

Works for component sections (`_focusFieldPath` into the form's field scroll) and automation sections (`_focusYamlPath` into the script / api action / automation editors from #1210 and #1213). Verified live on the dev stack with line only URLs, matching `section=` + `line=` pairs, and the mismatch case.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1212

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
