### PR TITLE
Pin the block-scalar cursor-path test to the exact resolved path

### DIFF
--- a/test/util/yaml-cursor-paths.test.ts
+++ b/test/util/yaml-cursor-paths.test.ts
@@ -40,9 +40,13 @@ describe("pathsForYamlLine", () => {
   });
 
   it("does not treat block-scalar content as fields", () => {
-    // ``id: looks_like_a_key`` inside the lambda body is literal text.
-    const got = pathsForYamlLine(YAML, 13)!;
-    expect(got.path).not.toContain("id");
+    // ``id: looks_like_a_key`` inside the lambda body is literal text;
+    // the AST attributes it to the enclosing ``lambda`` pair instead of
+    // letting the indent walker mint a phantom ``id`` field.
+    expect(pathsForYamlLine(YAML, 13)).toEqual({
+      path: ["sensor", "lambda"],
+      indexedPath: ["sensor", 0, "lambda"],
+    });
   });
 
   it("resolves a blank indented line to its ancestor chain", () => {


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #1215, which merged while this was in flight. The block scalar test in `test/util/yaml-cursor-paths.test.ts` asserted only that the derived path doesn't contain a phantom `id` field, which would also hold if the test accidentally targeted the `lambda: |-` line itself. Pin the exact resolved paths (`["sensor", "lambda"]` plus the indexed sibling) so the assertion can only pass on the scalar content line with the AST fallback doing its job.

Prompted by a Copilot review round on #1215; the other three comments in that round confused the test file's line numbers with the YAML fixture's own 1-indexed lines and needed no change.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
