### PR TITLE
Fall back to the dependency's default when resolving depends_on visibility

### DIFF
--- a/src/components/device/add-component-form-filter.ts
+++ b/src/components/device/add-component-form-filter.ts
@@ -75,7 +75,8 @@ export function addFormNeedsUserInput(
       values,
       opts.presentComponents,
       opts.targetPlatform ?? null,
-      opts.rootValues
+      opts.rootValues,
+      entries
     );
   if (planNeedsUserInput(plan, isVisible)) return true;
   // Pure-cardinality groups with no cluster box surface a banner only when

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -404,7 +404,14 @@ export class ESPHomeConfigEntryForm extends LitElement {
       cluster.members.some(
         (m) =>
           getIn(this.values, [m.key]) !== undefined ||
-          isEntryVisible(m, this.values, this.presentComponents, targetPlatform)
+          isEntryVisible(
+            m,
+            this.values,
+            this.presentComponents,
+            targetPlatform,
+            undefined,
+            this.entries
+          )
       );
     const renderedClusterKeys = new Set(
       plan.clusters.filter(clusterRenders).map((c) => c.members[0].key)

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -205,7 +205,8 @@ export function filterRenderable(
         values,
         opts.presentComponents,
         opts.targetPlatform,
-        opts.rootValues
+        opts.rootValues,
+        entries
       )
     ) {
       continue;

--- a/src/components/device/config-entry-renderers-types.ts
+++ b/src/components/device/config-entry-renderers-types.ts
@@ -50,7 +50,10 @@ export interface RenderCtx {
   /** The form's top-level config entries, for resolving a label of a key that
    *  isn't in a given cluster's members (a cardinality key that's also an
    *  ``exclusive_group`` member is dropped from the cluster). Absent in
-   *  lightweight contexts; callers fall back to a narrower lookup. */
+   *  lightweight contexts; callers fall back to a narrower lookup. Also fed
+   *  to ``isEntryVisible`` as the ``siblings`` scope for the depends_on
+   *  default fallback — top-level only, matching every defaulted-dependency
+   *  gate in today's catalog; a context without it loses the fallback. */
   entries?: ConfigEntry[];
   nestedOpenSections: Set<string>;
   getAt: (path: string[]) => unknown;

--- a/src/components/device/config-entry-renderers/constraint-banners.ts
+++ b/src/components/device/config-entry-renderers/constraint-banners.ts
@@ -53,7 +53,14 @@ export function collectUnsatisfiedConstraints(
       return (
         entry !== undefined &&
         (getIn(values, [k]) !== undefined ||
-          isEntryVisible(entry, values, presentComponents, targetPlatform))
+          isEntryVisible(
+            entry,
+            values,
+            presentComponents,
+            targetPlatform,
+            undefined,
+            entries
+          ))
       );
     });
   for (const group of requiredGroups) {

--- a/src/components/device/config-entry-renderers/constraint-cluster.ts
+++ b/src/components/device/config-entry-renderers/constraint-cluster.ts
@@ -181,7 +181,14 @@ export function renderConstraintRadioField(cluster: ConstraintCluster, ctx: Rend
   const targetPlatform = ctx.board?.esphome.platform ?? null;
   const isRenderable = (m: ConfigEntry): boolean =>
     ctx.getAt([m.key]) !== undefined ||
-    isEntryVisible(m, values, ctx.presentComponents, targetPlatform);
+    isEntryVisible(
+      m,
+      values,
+      ctx.presentComponents,
+      targetPlatform,
+      undefined,
+      ctx.entries
+    );
 
   // Gate alternatives on renderability (a board / platform / depends_on can hide
   // a side at runtime) and fall back to the static box when fewer than two real
@@ -273,7 +280,14 @@ export function renderConstraintClusterField(cluster: ConstraintCluster, ctx: Re
   const visibleMembers = cluster.members.filter(
     (m) =>
       ctx.getAt([m.key]) !== undefined ||
-      isEntryVisible(m, values, ctx.presentComponents, targetPlatform)
+      isEntryVisible(
+        m,
+        values,
+        ctx.presentComponents,
+        targetPlatform,
+        undefined,
+        ctx.entries
+      )
   );
   // All members gated off (depends_on / platform / hidden): skip the box rather
   // than render an empty bordered card with just a header.

--- a/src/components/device/config-entry-renderers/exclusive-group.ts
+++ b/src/components/device/config-entry-renderers/exclusive-group.ts
@@ -54,7 +54,14 @@ export function renderExclusiveGroupField(members: ConfigEntry[], ctx: RenderCtx
   const options = members.filter(
     (m) =>
       ctx.getAt([m.key]) !== undefined ||
-      isEntryVisible(m, rootValues, ctx.presentComponents, targetPlatform)
+      isEntryVisible(
+        m,
+        rootValues,
+        ctx.presentComponents,
+        targetPlatform,
+        undefined,
+        ctx.entries
+      )
   );
 
   // Every *rendered* option board-locked → the choice is fixed; render the

--- a/src/components/device/deprecation-notice.ts
+++ b/src/components/device/deprecation-notice.ts
@@ -110,7 +110,11 @@ export class ESPHomeDeprecationNotice extends LitElement {
       // A schema-gated deprecated key that doesn't apply to the current
       // values (wrong `type`) is a different problem than a migration.
       const entry = this.entries.find((e) => e.key === option.key);
-      if (entry && !isEntryVisible(entry, this.values)) continue;
+      if (
+        entry &&
+        !isEntryVisible(entry, this.values, undefined, undefined, undefined, this.entries)
+      )
+        continue;
       const changes = option.migrate(this.values[option.key]);
       if (changes) out.push({ option, changes });
     }

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -106,9 +106,7 @@ export function isEntryVisible(
   let depValue = Object.prototype.hasOwnProperty.call(values, entry.depends_on)
     ? values[entry.depends_on]
     : rootValues?.[entry.depends_on];
-  if (depValue == null) {
-    depValue = siblings?.find((s) => s.key === entry.depends_on)?.default_value;
-  }
+  depValue ??= siblings?.find((s) => s.key === entry.depends_on)?.default_value;
   if (entry.depends_on_value !== null && entry.depends_on_value !== undefined) {
     return depValue === entry.depends_on_value;
   }

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -65,6 +65,13 @@ export function platformSupported(
  * root-vs-sibling scope marker would remove the reliance on name
  * uniqueness.)
  *
+ * When the dependency resolves to nothing in either scope, its
+ * ``default_value`` (looked up in `siblings`, the schema list `entry`
+ * belongs to) stands in — YAML omits fields sitting at their default, so
+ * an absent ``spi.type`` still means ``single`` and must keep
+ * ``miso_pin``/``mosi_pin`` visible (#1972). Omit `siblings` and an
+ * unresolved dependency hides the entry as before.
+ *
  * Used by both ``filterRenderable`` (deciding what to paint) and
  * ``validateEntries`` (deciding what to validate). Keeping the
  * predicate in one place means a hidden-by-platform field can't be
@@ -76,7 +83,8 @@ export function isEntryVisible(
   values: Record<string, unknown>,
   presentComponents?: ReadonlySet<string>,
   targetPlatform?: string | null,
-  rootValues?: Record<string, unknown>
+  rootValues?: Record<string, unknown>,
+  siblings?: readonly ConfigEntry[]
 ): boolean {
   if (entry.hidden && !isValuePresent(values[entry.key])) return false;
 
@@ -95,9 +103,12 @@ export function isEntryVisible(
   // check order below is immaterial. Resolve the dependency in the
   // local scope first, then fall back to the component root so a
   // nested entry can gate on a top-level field.
-  const depValue = Object.prototype.hasOwnProperty.call(values, entry.depends_on)
+  let depValue = Object.prototype.hasOwnProperty.call(values, entry.depends_on)
     ? values[entry.depends_on]
     : rootValues?.[entry.depends_on];
+  if (depValue == null) {
+    depValue = siblings?.find((s) => s.key === entry.depends_on)?.default_value;
+  }
   if (entry.depends_on_value !== null && entry.depends_on_value !== undefined) {
     return depValue === entry.depends_on_value;
   }
@@ -366,7 +377,16 @@ function _validateEntriesRecursive(
   for (const entry of entries) {
     // Skip hidden entries and those whose visibility predicates fail —
     // we don't want to require fields the user can't even see.
-    if (!isEntryVisible(entry, values, presentComponents, targetPlatform, rootValues))
+    if (
+      !isEntryVisible(
+        entry,
+        values,
+        presentComponents,
+        targetPlatform,
+        rootValues,
+        entries
+      )
+    )
       continue;
 
     if (entry.type === ConfigEntryType.NESTED) {

--- a/test/components/device/config-entry-render-filter.test.ts
+++ b/test/components/device/config-entry-render-filter.test.ts
@@ -416,6 +416,29 @@ describe("filterRenderable", () => {
     ).toEqual(["mode", "advanced_opt"]);
   });
 
+  it("keeps depends_on fields visible when the dependency sits at its default (#1972)", () => {
+    // spi: `type` defaults to "single" and is omitted from YAML, so
+    // miso_pin/mosi_pin must render without the user re-selecting "single".
+    const entries = [
+      makeEntry({ key: "type", default_value: "single" }),
+      makeEntry({
+        key: "miso_pin",
+        depends_on: "type",
+        depends_on_value_any: ["single"],
+      }),
+      makeEntry({
+        key: "data_pins",
+        depends_on: "type",
+        depends_on_value_any: ["quad", "octal"],
+      }),
+    ];
+    expect(
+      filterRenderable(entries, {}, { requiredOnly: false, showAdvanced: false }).map(
+        (e) => e.key
+      )
+    ).toEqual(["type", "miso_pin"]);
+  });
+
   it("respects depends_on_value_any subset gating", () => {
     // Typed-schema shape (ethernet): one entry per unique field, gated
     // on the set of variants carrying it.

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -104,6 +104,53 @@ describe("isEntryVisible depends_on resolution", () => {
   });
 });
 
+describe("isEntryVisible depends_on default fallback", () => {
+  // The spi shape from #1972: `type` defaults to "single" and YAML omits
+  // defaulted fields, so miso_pin/mosi_pin must stay visible with `type` unset.
+  const type = makeEntry({ key: "type", default_value: "single" });
+  const misoPin = makeEntry({
+    key: "miso_pin",
+    depends_on: "type",
+    depends_on_value_any: ["single"],
+  });
+  const dataPins = makeEntry({
+    key: "data_pins",
+    depends_on: "type",
+    depends_on_value_any: ["quad", "octal"],
+  });
+  const siblings = [type, misoPin, dataPins];
+
+  it("an unset dependency reads as its sibling's default_value", () => {
+    expect(isEntryVisible(misoPin, {}, undefined, undefined, undefined, siblings)).toBe(
+      true
+    );
+    expect(isEntryVisible(dataPins, {}, undefined, undefined, undefined, siblings)).toBe(
+      false
+    );
+  });
+
+  it("an explicit value beats the default", () => {
+    const values = { type: "quad" };
+    expect(
+      isEntryVisible(misoPin, values, undefined, undefined, undefined, siblings)
+    ).toBe(false);
+    expect(
+      isEntryVisible(dataPins, values, undefined, undefined, undefined, siblings)
+    ).toBe(true);
+  });
+
+  it("without siblings an unset dependency hides the entry as before", () => {
+    expect(isEntryVisible(misoPin, {})).toBe(false);
+  });
+
+  it("a dependency without a default_value still hides the entry", () => {
+    const noDefault = [makeEntry({ key: "type" }), misoPin];
+    expect(isEntryVisible(misoPin, {}, undefined, undefined, undefined, noDefault)).toBe(
+      false
+    );
+  });
+});
+
 describe("nearCanonicalOption", () => {
   const opt = (value: string, label = value): ConfigValueOption => ({ label, value });
   const units = [opt("L"), opt("L/s"), opt("m³")];


### PR DESCRIPTION
# What does this implement/fix?

Adding an SPI bus with default settings writes `miso_pin`/`mosi_pin` to YAML but the structured editor doesn't show the fields until the user re-selects `single` in the Type dropdown — the value it was already displaying.

The cause is how `depends_on` gates resolve: `miso_pin`/`mosi_pin` are gated on `type == single`, `type` defaults to `single`, and YAML omits fields sitting at their default. `isEntryVisible` compared the gate against the raw value map, so an absent `type` read as `undefined` and failed the gate, even though every renderer already displays the default for an unset field.

`isEntryVisible` now falls back to the dependency's `default_value` (looked up in the sibling schema list callers already have in hand) when the dependency is unset in both the local and root scopes. All call sites — render filter, form clusters, exclusive groups, constraint banners/clusters, deprecation notice, and `validateEntries` — pass their entry list through, so paint and validation stay in lockstep. An explicit value still beats the default, and omitting the sibling list keeps the old behaviour.

A catalog scan shows 34 gates broken the same way (`spi` miso/mosi/interface, `sn74hc595` clock/data pins, `esp32_hosted` SDIO pins, `sensor.ads1118`, `output.modbus_controller`, `climate.haier`, `packet_transport`, …) — all fixed by this one fallback. Zero `depends_on_value_not` gates in the catalog have a defaulted dependency, so the fallback can only reveal fields the default legitimately satisfies, never newly hide one.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1972

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
