### PR TITLE
Say Recommended everywhere and make the chip stand out

### DIFF
--- a/src/api/types/components.ts
+++ b/src/api/types/components.ts
@@ -121,6 +121,10 @@ export interface ComponentCatalogEntry {
    *  parity, ...), range bounds (min/max_frequency in Hz) and required
    *  pins (require_tx / require_mosi / ...). Drives dep-add prefill. */
   bus_constraints?: Record<string, Record<string, unknown>>;
+  /** Real catalog category behind a `featured` entry (`bus` for a featured
+   *  `spi`), so the card can chip its type alongside its recommendation
+   *  status. Null/absent on regular entries. */
+  underlying_category?: ComponentCategory | null;
   /** Cross-field cardinality constraints over the top-level `config_entries`
    *  (from ESPHome's `cv.has_*_one_key` validators). Nested-scope constraints
    *  live on the owning `nested` entry's `required_groups`. */

--- a/src/components/device/component-card-category-label.ts
+++ b/src/components/device/component-card-category-label.ts
@@ -26,6 +26,10 @@ const ACRONYMS = new Set(["adc", "dac", "ota"]);
 
 export function categoryChipLabel(category: string): string {
   if (!category) return "";
+  // The synthetic board-recommendation category is the one id whose
+  // display word diverges from its wire id: every other surface
+  // (sidebar row, wizard copy) says "Recommended" (#1220).
+  if (category === "featured") return "Recommended";
   return category
     .split("_")
     .filter((word) => word.length > 0)

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -36,6 +36,7 @@ import { componentCatalogStyles } from "./component-catalog/styles.js";
 
 import "@home-assistant/webawesome/dist/components/badge/badge.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "@home-assistant/webawesome/dist/components/tooltip/tooltip.js";
 
 registerMdiIcons({
   "arrow-collapse-all": mdiArrowCollapseAll,

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -121,9 +121,14 @@ export function renderCard(
         <div class="component-card-header-text">
           <h3 class="component-title">${component.name}</h3>
           ${
-            categoryLabel
-              ? html`<span class="component-category-chip">${categoryLabel}</span>`
-              : nothing
+            featured
+              ? html`<span
+                  class="component-category-chip component-category-chip--recommended"
+                  >${localize("device.component_category_featured")}</span
+                >`
+              : categoryLabel
+                ? html`<span class="component-category-chip">${categoryLabel}</span>`
+                : nothing
           }
           ${
             platform

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -98,11 +98,12 @@ export function renderCard(
   // Native title tooltips don't render inside the dialog's top layer
   // (Chromium suppresses them over showModal dialogs), so the
   // recommendation explainer rides a wa-tooltip anchored to the chip.
-  const recommendedTooltip = featured
-    ? localize("device.recommended_chip_tooltip", {
-        board: host.board?.name || "board",
-      })
-    : "";
+  // Empty until the board body has hydrated — the chip renders without
+  // a tooltip then, rather than naming a placeholder board.
+  const recommendedTooltip =
+    featured && host.board
+      ? localize("device.recommended_chip_tooltip", { board: host.board.name })
+      : "";
   return html`
     <article
       class="component-card ${expanded ? "component-card--expanded" : ""} ${
@@ -138,9 +139,13 @@ export function renderCard(
                     tabindex="0"
                     >${categoryChipLabel("featured")}</span
                   >
-                  <wa-tooltip for=${`recommended-chip-${component.id}`}
-                    >${recommendedTooltip}</wa-tooltip
-                  >`
+                  ${
+                    recommendedTooltip
+                      ? html`<wa-tooltip for=${`recommended-chip-${component.id}`}
+                          >${recommendedTooltip}</wa-tooltip
+                        >`
+                      : nothing
+                  }`
               : nothing
           }
           ${

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -135,6 +135,7 @@ export function renderCard(
               ? html`<span
                     id=${`recommended-chip-${component.id}`}
                     class="component-category-chip component-category-chip--recommended"
+                    tabindex="0"
                     >${categoryChipLabel("featured")}</span
                   >
                   <wa-tooltip for=${`recommended-chip-${component.id}`}

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -136,7 +136,7 @@ export function renderCard(
               ? html`<span
                     id=${`recommended-chip-${component.id}`}
                     class="component-category-chip component-category-chip--recommended"
-                    tabindex="0"
+                    tabindex=${recommendedTooltip ? "0" : "-1"}
                     >${categoryChipLabel("featured")}</span
                   >
                   ${

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -95,6 +95,14 @@ export function renderCard(
   // Surfaced only when this card shares a name with another in the same
   // category; the category chip can't tell same-domain platforms apart.
   const platform = showPlatform ? platformLabel(component.id) : "";
+  // Native title tooltips don't render inside the dialog's top layer
+  // (Chromium suppresses them over showModal dialogs), so the
+  // recommendation explainer rides a wa-tooltip anchored to the chip.
+  const recommendedTooltip = featured
+    ? localize("device.recommended_chip_tooltip", {
+        board: host.board?.name || "board",
+      })
+    : "";
   return html`
     <article
       class="component-card ${expanded ? "component-card--expanded" : ""} ${
@@ -125,12 +133,13 @@ export function renderCard(
           ${
             featured
               ? html`<span
-                  class="component-category-chip component-category-chip--recommended"
-                  title=${localize("device.recommended_chip_tooltip", {
-                    board: host.board?.name || "board",
-                  })}
-                  >${localize("device.component_category_featured")}</span
-                >`
+                    id=${`recommended-chip-${component.id}`}
+                    class="component-category-chip component-category-chip--recommended"
+                    >${localize("device.component_category_featured")}</span
+                  >
+                  <wa-tooltip for=${`recommended-chip-${component.id}`}
+                    >${recommendedTooltip}</wa-tooltip
+                  >`
               : nothing
           }
           ${

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -88,7 +88,9 @@ export function renderCard(
   // API regression yielding a whitespace category id) so we don't render
   // a blank pill.
   const categoryLabel = shouldShowCategoryChip(host._category)
-    ? categoryChipLabel(component.category)
+    ? categoryChipLabel(
+        (featured ? component.underlying_category : component.category) ?? ""
+      )
     : "";
   // Surfaced only when this card shares a name with another in the same
   // category; the category chip can't tell same-domain platforms apart.
@@ -124,11 +126,17 @@ export function renderCard(
             featured
               ? html`<span
                   class="component-category-chip component-category-chip--recommended"
+                  title=${localize("device.recommended_chip_tooltip", {
+                    board: host.board?.name || "board",
+                  })}
                   >${localize("device.component_category_featured")}</span
                 >`
-              : categoryLabel
-                ? html`<span class="component-category-chip">${categoryLabel}</span>`
-                : nothing
+              : nothing
+          }
+          ${
+            categoryLabel
+              ? html`<span class="component-category-chip">${categoryLabel}</span>`
+              : nothing
           }
           ${
             platform

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -135,7 +135,7 @@ export function renderCard(
               ? html`<span
                     id=${`recommended-chip-${component.id}`}
                     class="component-category-chip component-category-chip--recommended"
-                    >${localize("device.component_category_featured")}</span
+                    >${categoryChipLabel("featured")}</span
                   >
                   <wa-tooltip for=${`recommended-chip-${component.id}`}
                     >${recommendedTooltip}</wa-tooltip

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -307,6 +307,13 @@ export const componentCatalogStyles = css`
     font-weight: var(--wa-font-weight-bold);
   }
 
+  /* Focusable (tabindex) so keyboard users can raise the explainer
+     tooltip; wa-tooltip's default trigger is hover+focus. */
+  .component-category-chip--recommended:focus-visible {
+    outline: none;
+    box-shadow: var(--esphome-focus-ring-tight);
+  }
+
   .component-description {
     margin: 0;
     font-size: var(--wa-font-size-2xs);

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -297,6 +297,16 @@ export const componentCatalogStyles = css`
     letter-spacing: 0.04em;
   }
 
+  /* Board-recommendation identity: same pill as its sibling chips so the
+     row reads as one family, recolored primary so it stands out from the
+     muted category chips (frontend #1220). */
+  .component-category-chip--recommended {
+    color: var(--esphome-primary);
+    background: var(--esphome-tint);
+    border-color: var(--esphome-primary);
+    font-weight: var(--wa-font-weight-bold);
+  }
+
   .component-description {
     margin: 0;
     font-size: var(--wa-font-size-2xs);

--- a/src/styles/apply-theme.ts
+++ b/src/styles/apply-theme.ts
@@ -40,6 +40,16 @@ function applyEspHomeTokens(): void {
   style.textContent = `
     :root {
       --esphome-svg-filter: none;
+
+      /* WebAwesome's stock tooltip is inverted (text-on-surface colors
+         swapped), which reads as a light bubble on our dark UI. Skin it
+         like the system's other floating surfaces (dropdown menus):
+         raised surface, hairline border, normal text. Mode-aware for
+         free — these tokens are remapped per .wa-light/.wa-dark below. */
+      --wa-tooltip-background-color: var(--wa-color-surface-raised);
+      --wa-tooltip-border-color: var(--wa-color-surface-border);
+      --wa-tooltip-content-color: var(--wa-color-text-normal);
+      --wa-tooltip-font-size: var(--wa-font-size-2xs);
     }
 
     /* Surfaces and text — remap WebAwesome's surface/text tokens to

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -689,6 +689,7 @@
     "component_categories": "Categories",
     "component_category_all": "All",
     "component_category_featured": "Recommended",
+    "recommended_chip_tooltip": "Pre-configured for the {board}",
     "search_components_placeholder": "Search components…",
     "no_components_found": "No components found",
     "components_load_error": "Could not load components. Check your connection and try again.",

--- a/test/components/device/component-card-category-label.test.ts
+++ b/test/components/device/component-card-category-label.test.ts
@@ -36,6 +36,12 @@ describe("categoryChipLabel", () => {
     expect(categoryChipLabel("audio_dac")).toBe("Audio DAC");
   });
 
+  it("maps the featured id to the Recommended display word", () => {
+    // The wire id stays ``featured`` but every user-facing surface
+    // says "Recommended" (#1220).
+    expect(categoryChipLabel("featured")).toBe("Recommended");
+  });
+
   it("returns an empty string for an empty id", () => {
     // Defensive: the catalog API contract guarantees a
     // non-empty ``category`` field, but if a future schema
@@ -92,6 +98,12 @@ describe("componentDialogTitle", () => {
         core: false,
       })
     ).toBe("ATM90E32 Power Sensor · Text Sensor");
+  });
+
+  it("says Recommended for a featured entry", () => {
+    expect(componentDialogTitle("SPI Bus (lcd_spi)", "featured", { core: false })).toBe(
+      "SPI Bus (lcd_spi) · Recommended"
+    );
   });
 
   it("keeps the bare name in the core-config flow", () => {

--- a/test/components/device/component-catalog-renderers.test.ts
+++ b/test/components/device/component-catalog-renderers.test.ts
@@ -58,7 +58,11 @@ describe("renderCard", () => {
     render(renderCard(makeHost(), entry, false, true, localize), container);
     const chip = container.querySelector(".component-category-chip--recommended");
     expect(chip?.textContent?.trim()).toBe("Recommended");
-    expect(chip?.getAttribute("title")).toBe(
+    // Native title tooltips don't render inside the dialog's top layer,
+    // so the explanation rides a wa-tooltip targeting the chip's id.
+    const tooltip = container.querySelector("wa-tooltip");
+    expect(tooltip?.getAttribute("for")).toBe(chip?.id);
+    expect(tooltip?.textContent?.trim()).toBe(
       "Pre-configured for the Guition Smart Screen"
     );
     const chips = [...container.querySelectorAll(".component-category-chip")].map((c) =>

--- a/test/components/device/component-catalog-renderers.test.ts
+++ b/test/components/device/component-catalog-renderers.test.ts
@@ -58,6 +58,8 @@ describe("renderCard", () => {
     render(renderCard(makeHost(), entry, false, true, localize), container);
     const chip = container.querySelector(".component-category-chip--recommended");
     expect(chip?.textContent?.trim()).toBe("Recommended");
+    // Focusable so keyboard users can raise the tooltip (focus trigger).
+    expect(chip?.getAttribute("tabindex")).toBe("0");
     // Native title tooltips don't render inside the dialog's top layer,
     // so the explanation rides a wa-tooltip targeting the chip's id.
     const tooltip = container.querySelector("wa-tooltip");

--- a/test/components/device/component-catalog-renderers.test.ts
+++ b/test/components/device/component-catalog-renderers.test.ts
@@ -74,6 +74,21 @@ describe("renderCard", () => {
     expect(container.querySelector(".component-card--featured")).not.toBeNull();
   });
 
+  it("omits the tooltip until the board body has hydrated", () => {
+    const container = document.createElement("div");
+    const host = makeHost();
+    (host as unknown as { board: null }).board = null;
+    const entry = makeEntry({
+      id: "featured.board.lcd_spi",
+      category: ComponentCategory.FEATURED,
+    });
+    render(renderCard(host, entry, false, true, localize), container);
+    expect(
+      container.querySelector(".component-category-chip--recommended")
+    ).not.toBeNull();
+    expect(container.querySelector("wa-tooltip")).toBeNull();
+  });
+
   it("keeps the muted category chip on a regular card", () => {
     const container = document.createElement("div");
     render(renderCard(makeHost(), makeEntry({}), false, false, localize), container);

--- a/test/components/device/component-catalog-renderers.test.ts
+++ b/test/components/device/component-catalog-renderers.test.ts
@@ -83,10 +83,11 @@ describe("renderCard", () => {
       category: ComponentCategory.FEATURED,
     });
     render(renderCard(host, entry, false, true, localize), container);
-    expect(
-      container.querySelector(".component-category-chip--recommended")
-    ).not.toBeNull();
+    const chip = container.querySelector(".component-category-chip--recommended");
+    expect(chip).not.toBeNull();
     expect(container.querySelector("wa-tooltip")).toBeNull();
+    // No tooltip to raise — the chip must not be a dead tab stop.
+    expect(chip?.getAttribute("tabindex")).toBe("-1");
   });
 
   it("keeps the muted category chip on a regular card", () => {

--- a/test/components/device/component-catalog-renderers.test.ts
+++ b/test/components/device/component-catalog-renderers.test.ts
@@ -21,6 +21,7 @@ function makeHost(): ESPHomeComponentCatalog {
   return {
     _imageFailed: new Set<string>(),
     _category: "all",
+    board: { name: "Guition Smart Screen" },
     _onAdd: () => {},
     _onToggleExpand: () => {},
     _onImageError: () => {},
@@ -39,19 +40,31 @@ function makeEntry(overrides: Partial<ComponentCatalogEntry>): ComponentCatalogE
   } as ComponentCatalogEntry;
 }
 
-const localize = (key: string) =>
-  key === "device.component_category_featured" ? "Recommended" : key;
+const localize = (key: string, values?: Record<string, string | number>) => {
+  if (key === "device.component_category_featured") return "Recommended";
+  if (key === "device.recommended_chip_tooltip")
+    return `Pre-configured for the ${values?.board}`;
+  return key;
+};
 
 describe("renderCard", () => {
-  it("marks a featured card with the prominent Recommended chip", () => {
+  it("marks a featured card with the Recommended chip plus its real category", () => {
     const container = document.createElement("div");
     const entry = makeEntry({
       id: "featured.board.lcd_spi",
       category: ComponentCategory.FEATURED,
+      underlying_category: ComponentCategory.BUS,
     });
     render(renderCard(makeHost(), entry, false, true, localize), container);
     const chip = container.querySelector(".component-category-chip--recommended");
     expect(chip?.textContent?.trim()).toBe("Recommended");
+    expect(chip?.getAttribute("title")).toBe(
+      "Pre-configured for the Guition Smart Screen"
+    );
+    const chips = [...container.querySelectorAll(".component-category-chip")].map((c) =>
+      c.textContent?.trim()
+    );
+    expect(chips).toEqual(["Recommended", "Bus"]);
     expect(container.querySelector(".component-card--featured")).not.toBeNull();
   });
 

--- a/test/components/device/component-catalog-renderers.test.ts
+++ b/test/components/device/component-catalog-renderers.test.ts
@@ -1,12 +1,67 @@
 // @vitest-environment happy-dom
+import { render } from "lit";
 import { describe, expect, it } from "vitest";
-import { shouldHandleCardClick } from "../../../src/components/device/component-catalog/renderers.js";
+import {
+  ComponentCategory,
+  type ComponentCatalogEntry,
+} from "../../../src/api/types/components.js";
+import type { ESPHomeComponentCatalog } from "../../../src/components/device/component-catalog.js";
+import {
+  renderCard,
+  shouldHandleCardClick,
+} from "../../../src/components/device/component-catalog/renderers.js";
 
 function clickFrom(target: Element): MouseEvent {
   const ev = new MouseEvent("click", { bubbles: true });
   Object.defineProperty(ev, "target", { value: target });
   return ev;
 }
+
+function makeHost(): ESPHomeComponentCatalog {
+  return {
+    _imageFailed: new Set<string>(),
+    _category: "all",
+    _onAdd: () => {},
+    _onToggleExpand: () => {},
+    _onImageError: () => {},
+  } as unknown as ESPHomeComponentCatalog;
+}
+
+function makeEntry(overrides: Partial<ComponentCatalogEntry>): ComponentCatalogEntry {
+  return {
+    id: "spi",
+    name: "SPI Bus",
+    description: "",
+    category: ComponentCategory.BUS,
+    docs_url: "",
+    image_url: "",
+    ...overrides,
+  } as ComponentCatalogEntry;
+}
+
+const localize = (key: string) =>
+  key === "device.component_category_featured" ? "Recommended" : key;
+
+describe("renderCard", () => {
+  it("marks a featured card with the prominent Recommended chip", () => {
+    const container = document.createElement("div");
+    const entry = makeEntry({
+      id: "featured.board.lcd_spi",
+      category: ComponentCategory.FEATURED,
+    });
+    render(renderCard(makeHost(), entry, false, true, localize), container);
+    const chip = container.querySelector(".component-category-chip--recommended");
+    expect(chip?.textContent?.trim()).toBe("Recommended");
+    expect(container.querySelector(".component-card--featured")).not.toBeNull();
+  });
+
+  it("keeps the muted category chip on a regular card", () => {
+    const container = document.createElement("div");
+    render(renderCard(makeHost(), makeEntry({}), false, false, localize), container);
+    expect(container.querySelector(".component-category-chip--recommended")).toBeNull();
+    expect(container.querySelector(".component-category-chip")?.textContent).toBe("Bus");
+  });
+});
 
 describe("shouldHandleCardClick", () => {
   it("adds when the click landed on a non-interactive part of the card", () => {


### PR DESCRIPTION
# What does this implement/fix?

The add component dialog said "Recommended" in the sidebar but "Featured" on the card chip and in the add form header, and the muted gray chip made a board recommendation hard to tell apart from the generic catalog entry it sits next to in search results (the SPI Bus pair from esphome/device-builder#1973).

`categoryChipLabel` now maps the wire id `featured` to the display word Recommended, which also fixes the add form header suffix through `componentDialogTitle`. The card chip for a recommendation keeps the same pill geometry as its sibling category chips but is recolored primary on tint with a primary border and bold weight, so the recommended card stands out at a glance while the row still reads as one family. The wire category id is untouched.

A recommended card also keeps its real category chip next to the Recommended pill (RECOMMENDED then BUS on the featured SPI card), read from the new `underlying_category` field the backend stamps on materialised featured entries (esphome/device-builder#1978); it degrades to the Recommended pill alone against an older backend. Hovering the Recommended pill explains why the card is there: "Pre-configured for the [board name]".

Verified live on the Guition ESP32-S3-4848S040 add component dialog: searching SPI shows "SPI Bus (lcd_spi)" with the highlighted RECOMMENDED pill and its BUS chip above the generic "SPI Bus" with the muted BUS chip alone, and the tooltip carries the full board name. Screenshots to follow.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1220

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
