### PR TITLE
Use a Desktop-appropriate build-offload intro in Settings

### DIFF
--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -18,6 +18,7 @@ import {
   buildOffloadDiscoveredHostsContext,
   buildOffloadJobsContext,
   buildOffloadPairingsContext,
+  desktopVersionContext,
   localizeContext,
   offloaderRemoteBuildsEnabledContext,
   offloaderVersionMatchPolicyContext,
@@ -78,6 +79,10 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
   @consume({ context: versionContext, subscribe: true })
   @state()
   private _appVersion = "";
+
+  @consume({ context: desktopVersionContext, subscribe: true })
+  @state()
+  private _desktopVersion = "";
 
   @consume({ context: buildOffloadDiscoveredHostsContext, subscribe: true })
   @state()
@@ -148,8 +153,12 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
   ];
 
   // Intro copy with "ESPHome Desktop" itself linked to the app's docs, so a
-  // reader learns how to get it inline rather than via a separate CTA.
+  // reader learns how to get it inline rather than via a separate CTA. On
+  // Desktop that link is self-referential, so a plain variant renders instead.
   private _renderPairedServersDesc() {
+    if (this._desktopVersion) {
+      return html`${this._localize("settings.paired_build_servers_desc_desktop")}`;
+    }
     const [before, after] = splitTemplate(
       this._localize("settings.paired_build_servers_desc"),
       "{desktop_link}"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1265,6 +1265,7 @@
     "pair_build_server_row_aria": "Pair with {name}",
     "paired_build_servers_heading": "Paired build servers",
     "paired_build_servers_desc": "Compiling firmware is CPU-heavy and can take a while on a low-power system. Pair a faster machine on your network, another dashboard or {desktop_link}, to cut compile times; flashing still happens here. Pending rows are waiting for the receiver's admin to accept.",
+    "paired_build_servers_desc_desktop": "Pair a faster machine on your network running another Device Builder to cut compile times; flashing still happens here. Pending rows are waiting for the receiver's admin to accept.",
     "esphome_desktop": "ESPHome Desktop",
     "paired_build_servers_loading": "Loading pairings…",
     "paired_build_servers_empty": "No build servers paired yet.",

--- a/test/components/build-offload-section/paired-servers-desc.test.ts
+++ b/test/components/build-offload-section/paired-servers-desc.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that ``_renderPairedServersDesc`` renders the plain Desktop intro
+ * variant (no install link) when ``desktop_version`` is set, and keeps the
+ * linked copy everywhere else.
+ */
+import { describe, expect, it } from "vitest";
+import { ESPHomeSettingsBuildOffload } from "../../../src/components/settings-dialog/build-offload-section.js";
+import { identityLocalize, renderInto } from "../../_dom.js";
+
+function renderDesc(desktopVersion: string): HTMLElement {
+  const fn = (
+    ESPHomeSettingsBuildOffload.prototype as unknown as Record<string, () => unknown>
+  )._renderPairedServersDesc;
+  return renderInto(
+    fn.call({ _localize: identityLocalize, _desktopVersion: desktopVersion })
+  );
+}
+
+describe("_renderPairedServersDesc", () => {
+  it("links the ESPHome Desktop docs in the default copy", () => {
+    const el = renderDesc("");
+    const link = el.querySelector("a.settings-inline-link");
+    expect(link).not.toBeNull();
+    expect(link!.textContent?.trim()).toBe("settings.esphome_desktop");
+    expect(el.textContent).toContain("settings.paired_build_servers_desc");
+  });
+
+  it("renders the plain Desktop variant with no link on Desktop", () => {
+    const el = renderDesc("1.2.3");
+    expect(el.querySelector("a")).toBeNull();
+    expect(el.textContent?.trim()).toBe("settings.paired_build_servers_desc_desktop");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

On ESPHome Desktop the Settings build offload intro still linked to installing ESPHome Desktop, the app the user is already running, and pitched offload at low-power systems. When the handshake carries `desktop_version`, the intro now renders a plain variant that suggests pairing a faster machine on your network running another Device Builder, with no install link; every other install keeps the current copy.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1219

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
