### PR TITLE
Make RenderCtx.entries required

### DIFF
--- a/src/components/device/config-entry-renderers-types.ts
+++ b/src/components/device/config-entry-renderers-types.ts
@@ -49,12 +49,14 @@ export interface RenderCtx {
   reactiveConstraintKeys: Set<string>;
   /** The form's top-level config entries, for resolving a label of a key that
    *  isn't in a given cluster's members (a cardinality key that's also an
-   *  ``exclusive_group`` member is dropped from the cluster). Absent in
-   *  lightweight contexts; callers fall back to a narrower lookup. Also fed
-   *  to ``isEntryVisible`` as the ``siblings`` scope for the depends_on
-   *  default fallback — top-level only, matching every defaulted-dependency
-   *  gate in today's catalog; a context without it loses the fallback. */
-  entries?: ConfigEntry[];
+   *  ``exclusive_group`` member is dropped from the cluster), and fed to
+   *  ``isEntryVisible`` as the ``siblings`` scope for the depends_on default
+   *  fallback. Top-level is the *correct* sibling scope for every consumer:
+   *  the cluster / exclusive-group / banner renderers only ever run at the
+   *  top level (their paths are root-anchored), and nested leaves get their
+   *  per-level siblings from ``filterRenderable``'s own recursion. If those
+   *  renderers ever become nested-capable, rebase this alongside the paths. */
+  entries: ConfigEntry[];
   nestedOpenSections: Set<string>;
   getAt: (path: string[]) => unknown;
   errorAt: (path: string[]) => ValidationError | null;

--- a/src/components/device/config-entry-renderers/constraint-cluster.ts
+++ b/src/components/device/config-entry-renderers/constraint-cluster.ts
@@ -274,7 +274,7 @@ export function renderConstraintClusterField(cluster: ConstraintCluster, ctx: Re
   const message = ctx.localize(`device.constraint_${prompt.kind}`, {
     // Resolve labels against the full entry set so a cardinality key dropped
     // from members (also an exclusive_group member) still localizes.
-    keys: formatConstraintKeys(prompt.keys, ctx.entries ?? cluster.members, ctx),
+    keys: formatConstraintKeys(prompt.keys, ctx.entries, ctx),
   });
 
   const visibleMembers = cluster.members.filter(

--- a/test/components/device/_renderer-fixtures.ts
+++ b/test/components/device/_renderer-fixtures.ts
@@ -91,6 +91,7 @@ export function makeRenderCtx(
     requiredOnly: false,
     showAdvanced: false,
     presentComponents: new Set<string>(),
+    entries: [],
     nestedOpenSections: new Set<string>(),
     getAt: (path: string[]) => {
       let cur: unknown = values;

--- a/test/components/device/config-entry-form-constraint-cluster.test.ts
+++ b/test/components/device/config-entry-form-constraint-cluster.test.ts
@@ -53,7 +53,10 @@ const REQUIRED_GROUPS: RequiredGroup[] = [
   { kind: "exactly_one", keys: ["chipset", "bit0_high"] },
 ];
 
-function ctxFor(values: Record<string, unknown>): RenderCtx {
+function ctxFor(
+  values: Record<string, unknown>,
+  entries: ConfigEntry[] = ENTRIES
+): RenderCtx {
   return {
     localize: (key: string, params?: Record<string, unknown>) =>
       params ? `${key}|${params.keys}` : key,
@@ -61,6 +64,7 @@ function ctxFor(values: Record<string, unknown>): RenderCtx {
     getAt: (path: string[]) => values[path[0]],
     board: null,
     presentComponents: new Set<string>(),
+    entries,
     renderEntry: (entry: ConfigEntry) => `<entry:${entry.key}>`,
   } as unknown as RenderCtx;
 }
@@ -217,7 +221,10 @@ describe("renderConstraintClusterField (all-or-none box)", () => {
 
   it("boxes both members and warns when only one is set", () => {
     const out = serialize(
-      renderConstraintClusterField(cluster, ctxFor({ client_certificate: "/d.crt" }))
+      renderConstraintClusterField(
+        cluster,
+        ctxFor({ client_certificate: "/d.crt" }, MQTT_ENTRIES)
+      )
     );
     expect(out).toContain("nested-group");
     expect(out).toContain("unsatisfied");
@@ -236,7 +243,10 @@ describe("renderConstraintClusterField (all-or-none box)", () => {
     const out = serialize(
       renderConstraintClusterField(
         cluster,
-        ctxFor({ client_certificate: "/d.crt", client_certificate_key: "/d.key" })
+        ctxFor(
+          { client_certificate: "/d.crt", client_certificate_key: "/d.key" },
+          MQTT_ENTRIES
+        )
       )
     );
     expect(out).not.toContain("unsatisfied");

--- a/test/components/device/config-entry-form-constraint-cluster.test.ts
+++ b/test/components/device/config-entry-form-constraint-cluster.test.ts
@@ -171,6 +171,7 @@ function statefulCtx(initial: Record<string, unknown>) {
     },
     board: null,
     presentComponents: new Set<string>(),
+    entries: ENTRIES,
     renderEntry: (entry: ConfigEntry) => `<entry:${entry.key}>`,
     getClusterChoice: (id: string) => choice.get(id),
     setClusterChoice: (id: string, alt: string) => choice.set(id, alt),

--- a/test/components/device/config-entry-form-constraint-cluster.test.ts
+++ b/test/components/device/config-entry-form-constraint-cluster.test.ts
@@ -66,7 +66,7 @@ function ctxFor(
     presentComponents: new Set<string>(),
     entries,
     renderEntry: (entry: ConfigEntry) => `<entry:${entry.key}>`,
-  } as unknown as RenderCtx;
+  } satisfies Partial<RenderCtx> as unknown as RenderCtx;
 }
 
 const serialize = (tpl: unknown): string =>
@@ -179,7 +179,7 @@ function statefulCtx(initial: Record<string, unknown>) {
     setClusterStash: (id: string, key: string, v: unknown) =>
       stash.set(`${id} ${key}`, v),
     clearClusterStash: (id: string, key: string) => stash.delete(`${id} ${key}`),
-  } as unknown as RenderCtx;
+  } satisfies Partial<RenderCtx> as unknown as RenderCtx;
   return { ctx, values, stash, choice };
 }
 


### PR DESCRIPTION
# What does this implement/fix?

`RenderCtx.entries` was optional, but since #1217 it doubles as the `siblings` scope for `isEntryVisible`'s depends_on default fallback — a context built without it silently loses the fallback with no type error, and the label formatter fell back to a narrower lookup. Every production construction already sets it, so the optionality only ever *hid* omissions.

`entries` is now required. The dead absence fallback (`ctx.entries ?? cluster.members` in the cluster header's label resolution) goes with it, and the field's doc now pins why top-level is the correct sibling scope for every consumer: the cluster / exclusive-group / banner renderers only ever run at the top level (their paths are root-anchored — `buildFormRenderPlan` is never invoked with a nested list), and nested leaves get per-level siblings from `filterRenderable`'s own recursion. If those renderers ever become nested-capable, `entries` must be rebased alongside the paths.

The change proved its point immediately: the shared `makeRenderCtx` fixture and the constraint-cluster test's two hand-rolled ctxs (cast through `as unknown as RenderCtx`, so invisible to tsc) all omitted `entries` — exactly the silent degradation #1218 describes. They now supply the entry list they render.

No behaviour change in production paths.

**Related issue or feature (if applicable):**

- fixes #1218

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
