### PR TITLE
Keep the section editor's advanced fields from jumping around the toggle

### DIFF
--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -315,10 +315,11 @@ export class ESPHomeConfigEntryForm extends LitElement {
    *  grow. */
   private _constraintClusters = new ConstraintClusterController(this);
 
-  /** gateAdvanced unit placement (key → prefilled) frozen while the section
-   *  is open, so a value landing mid-edit doesn't re-home the field above the
-   *  switch under the user's pointer (#1977). Cleared on close and on
-   *  ``entries`` change; the next closed render classifies live again. */
+  /** gateAdvanced unit placement (key → paints inline, else gated) frozen
+   *  while the section is open, so a value landing mid-edit doesn't re-home
+   *  the field above the switch under the user's pointer (#1977). Cleared on
+   *  close and on ``entries`` change; the next closed render classifies live
+   *  again. */
   private _openAdvancedPlacement: Map<string, boolean> = new Map();
 
   /** Viewport top of the advanced control at click time, consumed when the

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -577,7 +577,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
           if (row) {
             this._advancedControlAnchor = {
               top: row.getBoundingClientRect().top,
-              at: Date.now(),
+              at: performance.now(),
             };
           }
           this._emitAdvancedToggle(sw.checked);
@@ -596,7 +596,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
     const anchor = this._advancedControlAnchor;
     if (!anchor || !changed.has("showAdvanced")) return;
     this._advancedControlAnchor = undefined;
-    if (Date.now() - anchor.at > 2000) return;
+    if (performance.now() - anchor.at > 2000) return;
     const row = this.shadowRoot?.querySelector<HTMLElement>(".advanced-toggle-row");
     if (!row) return;
     const scroller = nearestScrollContainer(row);

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -475,8 +475,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
       // While the section is open both buckets are on screen, so live
       // reclassification only moves fields around mid-edit; freeze each
       // unit's placement at first sight and re-classify live once closed
-      // (under gateAdvanced ``open`` is exactly ``showAdvanced``).
-      if (!this.showAdvanced) this._openAdvancedPlacement.clear();
+      // (under gateAdvanced ``open`` is exactly ``showAdvanced``). The
+      // ``set`` is a memo-cache write, not reactive state — the units it
+      // keys on exist only inside this render plan; ``willUpdate`` owns
+      // every clear.
       gatedAdvanced = [];
       for (const item of advanced) {
         let inline: boolean;
@@ -570,7 +572,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
         ?disabled=${locked}
         .checked=${open}
         @change=${(e: Event) => {
-          const sw = e.currentTarget as HTMLInputElement & { checked: boolean };
+          const sw = e.currentTarget as HTMLElement & { checked: boolean };
           const row = sw.parentElement;
           if (row) {
             this._advancedControlAnchor = {
@@ -654,6 +656,11 @@ export class ESPHomeConfigEntryForm extends LitElement {
       // Re-seed disclosures for the new component; a key like "pin:pin-advanced"
       // recurs across sections, and the form instance is reused.
       this._seededNestedOpen.clear();
+    }
+    // Closing the advanced section drops the frozen placement so the next
+    // open re-freezes from the then-current YAML state.
+    if (changed.has("showAdvanced") && !this.showAdvanced) {
+      this._openAdvancedPlacement.clear();
     }
   }
 

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -569,7 +569,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
         ?disabled=${locked}
         .checked=${open}
         @change=${(e: Event) => {
-          const sw = e.target as HTMLInputElement & { checked: boolean };
+          const sw = e.currentTarget as HTMLInputElement & { checked: boolean };
           const row = sw.parentElement;
           if (row) {
             this._advancedControlAnchor = {
@@ -594,7 +594,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
     if (!anchor || !changed.has("showAdvanced")) return;
     this._advancedControlAnchor = undefined;
     if (Date.now() - anchor.at > 2000) return;
-    const row = this.shadowRoot?.querySelector(".advanced-toggle-row");
+    const row = this.shadowRoot?.querySelector<HTMLElement>(".advanced-toggle-row");
     if (!row) return;
     const scroller = nearestScrollContainer(row);
     if (scroller) scroller.scrollTop += row.getBoundingClientRect().top - anchor.top;

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -49,6 +49,7 @@ import {
   subscribePinRegistryModes,
 } from "../../util/pin-registry-modes-cache.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { nearestScrollContainer } from "../../util/scroll-container.js";
 import { SessionBlobCacheController } from "../../util/session-blob-cache-controller.js";
 import { looksLikeSubstitution, parseSubstitutions } from "../../util/substitutions.js";
 import {
@@ -314,6 +315,18 @@ export class ESPHomeConfigEntryForm extends LitElement {
    *  grow. */
   private _constraintClusters = new ConstraintClusterController(this);
 
+  /** gateAdvanced unit placement (key → prefilled) frozen while the section
+   *  is open, so a value landing mid-edit doesn't re-home the field above the
+   *  switch under the user's pointer (#1977). Cleared on close and on
+   *  ``entries`` change; the next closed render classifies live again. */
+  private _openAdvancedPlacement: Map<string, boolean> = new Map();
+
+  /** Viewport top of the advanced control at click time, consumed when the
+   *  host's ``showAdvanced`` round-trips back. Nested basic groups reveal
+   *  advanced children in place ABOVE the control, so toggling shifts it by
+   *  hundreds of px (#1977); the scroll is compensated to keep it put. */
+  private _advancedControlAnchor?: { top: number; at: number };
+
   static styles = [
     fieldRendererStyles,
     css`
@@ -458,9 +471,22 @@ export class ESPHomeConfigEntryForm extends LitElement {
         }
         return hasMaterialValue(item, this.values);
       };
+      // While the section is open both buckets are on screen, so live
+      // reclassification only moves fields around mid-edit; freeze each
+      // unit's placement at first sight and re-classify live once closed
+      // (under gateAdvanced ``open`` is exactly ``showAdvanced``).
+      if (!this.showAdvanced) this._openAdvancedPlacement.clear();
       gatedAdvanced = [];
       for (const item of advanced) {
-        (unitPrefilled(item) ? inlineAdvanced : gatedAdvanced).push(item);
+        let inline: boolean;
+        if (this.showAdvanced) {
+          const key = Array.isArray(item) ? item[0].key : item.key;
+          inline = this._openAdvancedPlacement.get(key) ?? unitPrefilled(item);
+          this._openAdvancedPlacement.set(key, inline);
+        } else {
+          inline = unitPrefilled(item);
+        }
+        (inline ? inlineAdvanced : gatedAdvanced).push(item);
       }
     }
     // gateAdvanced never force-opens on a pre-filled field (those already paint
@@ -542,14 +568,36 @@ export class ESPHomeConfigEntryForm extends LitElement {
         size="small"
         ?disabled=${locked}
         .checked=${open}
-        @change=${(e: Event) =>
-          this._emitAdvancedToggle(
-            (e.target as HTMLInputElement & { checked: boolean }).checked
-          )}
+        @change=${(e: Event) => {
+          const sw = e.target as HTMLInputElement & { checked: boolean };
+          const row = sw.parentElement;
+          if (row) {
+            this._advancedControlAnchor = {
+              top: row.getBoundingClientRect().top,
+              at: Date.now(),
+            };
+          }
+          this._emitAdvancedToggle(sw.checked);
+        }}
       >
         ${label}
       </wa-switch>
     </div>`;
+  }
+
+  /** Scroll-compensate the control back to its click-time viewport position
+   *  once the toggled ``showAdvanced`` re-render landed. The anchor expires
+   *  quickly so a host that declined the toggle can't leave a stale one to
+   *  fire on a later, unrelated ``showAdvanced`` change. */
+  private _restoreAdvancedControlAnchor(changed: PropertyValues): void {
+    const anchor = this._advancedControlAnchor;
+    if (!anchor || !changed.has("showAdvanced")) return;
+    this._advancedControlAnchor = undefined;
+    if (Date.now() - anchor.at > 2000) return;
+    const row = this.shadowRoot?.querySelector(".advanced-toggle-row");
+    if (!row) return;
+    const scroller = nearestScrollContainer(row);
+    if (scroller) scroller.scrollTop += row.getBoundingClientRect().top - anchor.top;
   }
 
   private _emitAdvancedToggle(show: boolean) {
@@ -600,6 +648,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
     if (changed.has("entries") && changed.get("entries") !== undefined) {
       this._pendingUnits.clear();
       this._editingMagnitudes.clear();
+      this._openAdvancedPlacement.clear();
       this._constraintClusters.reset();
       // Re-seed disclosures for the new component; a key like "pin:pin-advanced"
       // recurs across sections, and the form instance is reused.
@@ -628,6 +677,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
       this._emitAdvancedToggle(true);
     }
     this._maybeRevealForFocus();
+    this._restoreAdvancedControlAnchor(changed);
   }
 
   /** When the YAML cursor targets a hidden advanced field, ask the host

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -123,6 +123,10 @@ export interface ConfigEntryValueChange {
   value: unknown;
 }
 
+/** How long a clicked advanced-control anchor stays valid awaiting the
+ *  host's ``showAdvanced`` round-trip (normally one render, milliseconds). */
+export const ADVANCED_ANCHOR_TTL_MS = 2000;
+
 @customElement("esphome-config-entry-form")
 export class ESPHomeConfigEntryForm extends LitElement {
   @consume({ context: localizeContext, subscribe: true })
@@ -596,7 +600,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
     const anchor = this._advancedControlAnchor;
     if (!anchor || !changed.has("showAdvanced")) return;
     this._advancedControlAnchor = undefined;
-    if (performance.now() - anchor.at > 2000) return;
+    if (performance.now() - anchor.at > ADVANCED_ANCHOR_TTL_MS) return;
     const row = this.shadowRoot?.querySelector<HTMLElement>(".advanced-toggle-row");
     if (!row) return;
     const scroller = nearestScrollContainer(row);

--- a/src/util/scroll-container.ts
+++ b/src/util/scroll-container.ts
@@ -1,0 +1,17 @@
+/** Composed-tree parent: crosses shadow boundaries via the root's host. */
+export function composedParent(el: Element): Element | null {
+  if (el.parentElement) return el.parentElement;
+  const root = el.getRootNode();
+  return root instanceof ShadowRoot ? root.host : null;
+}
+
+/** Nearest composed-tree ancestor that actually scrolls vertically. */
+export function nearestScrollContainer(el: Element): Element | null {
+  for (let n = composedParent(el); n; n = composedParent(n)) {
+    if (n.scrollHeight > n.clientHeight) {
+      const overflowY = getComputedStyle(n).overflowY;
+      if (overflowY === "auto" || overflowY === "scroll") return n;
+    }
+  }
+  return null;
+}

--- a/src/util/scroll-container.ts
+++ b/src/util/scroll-container.ts
@@ -6,9 +6,9 @@ export function composedParent(el: Element): Element | null {
 }
 
 /** Nearest composed-tree ancestor that actually scrolls vertically. */
-export function nearestScrollContainer(el: Element): Element | null {
+export function nearestScrollContainer(el: Element): HTMLElement | null {
   for (let n = composedParent(el); n; n = composedParent(n)) {
-    if (n.scrollHeight > n.clientHeight) {
+    if (n instanceof HTMLElement && n.scrollHeight > n.clientHeight) {
       const overflowY = getComputedStyle(n).overflowY;
       if (overflowY === "auto" || overflowY === "scroll") return n;
     }

--- a/src/util/scroll-container.ts
+++ b/src/util/scroll-container.ts
@@ -1,5 +1,7 @@
-/** Composed-tree parent: crosses shadow boundaries via the root's host. */
+/** Flattened-tree parent: slotted nodes climb through their slot, shadow
+ *  roots through their host. */
 export function composedParent(el: Element): Element | null {
+  if (el.assignedSlot) return el.assignedSlot;
   if (el.parentElement) return el.parentElement;
   const root = el.getRootNode();
   return root instanceof ShadowRoot ? root.host : null;

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -16,7 +16,10 @@ vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}
 
 import type { ConfigEntry } from "../../../src/api/types/config-entries.js";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
-import { ESPHomeConfigEntryForm } from "../../../src/components/device/config-entry-form.js";
+import {
+  ADVANCED_ANCHOR_TTL_MS,
+  ESPHomeConfigEntryForm,
+} from "../../../src/components/device/config-entry-form.js";
 import { makeConfigEntry } from "../../util/_make-config-entry.js";
 
 const BASIC = makeConfigEntry({
@@ -676,6 +679,8 @@ describe("config-entry-form advanced-section", () => {
   // captured at click time and the scroll container compensated after the
   // ``showAdvanced`` re-render. wa-* controls can't mount under happy-dom,
   // so geometry is stubbed and each half is driven directly.
+  const ROW_TOP = 500;
+  const ROW_TOP_AFTER = 900; // re-render grew content above the control
   function anchoredControl(rowTop: number) {
     const form = new ESPHomeConfigEntryForm();
     const scroller = document.createElement("div");
@@ -698,30 +703,32 @@ describe("config-entry-form advanced-section", () => {
   }
 
   it("compensates the scroll container so the toggled control stays put", () => {
-    const { form, scroller, row, sw } = anchoredControl(500);
+    const { form, scroller, row, sw } = anchoredControl(ROW_TOP);
     sw.dispatchEvent(new Event("change"));
-    // The re-render grew content above the control by 400px.
-    row.getBoundingClientRect = () => ({ top: 900 }) as DOMRect;
+    row.getBoundingClientRect = () => ({ top: ROW_TOP_AFTER }) as DOMRect;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (form as any)._restoreAdvancedControlAnchor(new Map([["showAdvanced", false]]));
-    expect(scroller.scrollTop).toBe(400);
+    expect(scroller.scrollTop).toBe(ROW_TOP_AFTER - ROW_TOP);
     // Consumed: a second showAdvanced change must not re-scroll.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (form as any)._restoreAdvancedControlAnchor(new Map([["showAdvanced", true]]));
-    expect(scroller.scrollTop).toBe(400);
+    expect(scroller.scrollTop).toBe(ROW_TOP_AFTER - ROW_TOP);
   });
 
   it("holds the anchor for a showAdvanced change and ignores a stale one", () => {
-    const { form, scroller, row, sw } = anchoredControl(500);
+    const { form, scroller, row, sw } = anchoredControl(ROW_TOP);
     sw.dispatchEvent(new Event("change"));
-    row.getBoundingClientRect = () => ({ top: 900 }) as DOMRect;
+    row.getBoundingClientRect = () => ({ top: ROW_TOP_AFTER }) as DOMRect;
     // Unrelated update: no scroll, anchor kept for the real toggle render.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (form as any)._restoreAdvancedControlAnchor(new Map([["values", {}]]));
     expect(scroller.scrollTop).toBe(0);
     // Expired anchor: consumed without scrolling.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (form as any)._advancedControlAnchor = { top: 500, at: performance.now() - 3000 };
+    (form as any)._advancedControlAnchor = {
+      top: ROW_TOP,
+      at: performance.now() - ADVANCED_ANCHOR_TTL_MS - 1,
+    };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (form as any)._restoreAdvancedControlAnchor(new Map([["showAdvanced", false]]));
     expect(scroller.scrollTop).toBe(0);

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -721,7 +721,7 @@ describe("config-entry-form advanced-section", () => {
     expect(scroller.scrollTop).toBe(0);
     // Expired anchor: consumed without scrolling.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (form as any)._advancedControlAnchor = { top: 500, at: Date.now() - 3000 };
+    (form as any)._advancedControlAnchor = { top: 500, at: performance.now() - 3000 };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (form as any)._restoreAdvancedControlAnchor(new Map([["showAdvanced", false]]));
     expect(scroller.scrollTop).toBe(0);

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -57,6 +57,15 @@ function control(container: HTMLElement): HTMLElement | null {
   return container.querySelector<HTMLElement>(".advanced-toggle-row");
 }
 
+/** Stub the form's localizer so the control's "(N)" count is observable. */
+function stubCountLocalize(form: ESPHomeConfigEntryForm): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (form as any)._localize = (key: string, params?: { count?: number }) =>
+    key === "device.show_advanced_count"
+      ? `Show advanced settings (${params?.count})`
+      : key;
+}
+
 describe("config-entry-form advanced-section", () => {
   it("renders the control after basic fields, hides advanced until expanded", () => {
     const c = renderForm([BASIC, ADVANCED]);
@@ -248,11 +257,7 @@ describe("config-entry-form advanced-section", () => {
     form.advancedSection = true;
     form.gateAdvanced = true;
     form.showAdvanced = false;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (form as any)._localize = (key: string, params?: { count?: number }) =>
-      key === "device.show_advanced_count"
-        ? `Show advanced settings (${params?.count})`
-        : key;
+    stubCountLocalize(form);
     const container = document.createElement("div");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     render((form as any).render(), container);
@@ -319,11 +324,7 @@ describe("config-entry-form advanced-section", () => {
     form.advancedSection = true;
     form.gateAdvanced = true;
     form.showAdvanced = false;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (form as any)._localize = (key: string, params?: { count?: number }) =>
-      key === "device.show_advanced_count"
-        ? `Show advanced settings (${params?.count})`
-        : key;
+    stubCountLocalize(form);
     const container = document.createElement("div");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     render((form as any).render(), container);
@@ -364,12 +365,7 @@ describe("config-entry-form advanced-section", () => {
     form.advancedSection = true;
     form.gateAdvanced = true;
     form.showAdvanced = true;
-    // Default _localize returns the key; interpolate so the count is observable.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (form as any)._localize = (key: string, params?: { count?: number }) =>
-      key === "device.show_advanced_count"
-        ? `Show advanced settings (${params?.count})`
-        : key;
+    stubCountLocalize(form);
     const container = document.createElement("div");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     render((form as any).render(), container);
@@ -405,11 +401,7 @@ describe("config-entry-form advanced-section", () => {
     form.advancedSection = true;
     form.gateAdvanced = true;
     form.showAdvanced = true;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (form as any)._localize = (key: string, params?: { count?: number }) =>
-      key === "device.show_advanced_count"
-        ? `Show advanced settings (${params?.count})`
-        : key;
+    stubCountLocalize(form);
     const container = document.createElement("div");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     render((form as any).render(), container);
@@ -451,11 +443,7 @@ describe("config-entry-form advanced-section", () => {
     form.advancedSection = true;
     form.gateAdvanced = true;
     form.showAdvanced = true;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (form as any)._localize = (key: string, params?: { count?: number }) =>
-      key === "device.show_advanced_count"
-        ? `Show advanced settings (${params?.count})`
-        : key;
+    stubCountLocalize(form);
     const container = document.createElement("div");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     render((form as any).render(), container);
@@ -610,5 +598,68 @@ describe("config-entry-form advanced-section", () => {
     sw.checked = true;
     sw.dispatchEvent(new Event("change"));
     expect(detail).toEqual({ show: true });
+  });
+
+  // Placement freeze while open (#1977): a value landing mid-edit must not
+  // re-home the field above the switch; live classification resumes on close.
+  function gatedOpenForm(values: Record<string, unknown>) {
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [
+      makeConfigEntry({
+        key: "internal",
+        type: ConfigEntryType.STRING,
+        label: "Filled Adv",
+        advanced: true,
+      }),
+      makeConfigEntry({
+        key: "show_test_card",
+        type: ConfigEntryType.BOOLEAN,
+        label: "Test Card",
+        advanced: true,
+      }),
+      makeConfigEntry({
+        key: "command_retain",
+        type: ConfigEntryType.STRING,
+        label: "Empty Adv",
+        advanced: true,
+      }),
+    ];
+    form.values = values;
+    form.advancedSection = true;
+    form.gateAdvanced = true;
+    form.showAdvanced = true;
+    stubCountLocalize(form);
+    const container = document.createElement("div");
+    const paint = () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      render((form as any).render(), container);
+      return container.textContent ?? "";
+    };
+    return { form, paint };
+  }
+
+  it("keeps a field filled while the section is open below the control", () => {
+    const { form, paint } = gatedOpenForm({ internal: "x" });
+    let text = paint();
+    expect(text.indexOf("Filled Adv")).toBeLessThan(text.indexOf("Show advanced"));
+    expect(text.indexOf("Show advanced")).toBeLessThan(text.indexOf("Test Card"));
+    expect(text).toContain("Show advanced settings (2)");
+    form.values = { ...form.values, show_test_card: true };
+    text = paint();
+    expect(text.indexOf("Show advanced")).toBeLessThan(text.indexOf("Test Card"));
+    expect(text).toContain("Show advanced settings (2)");
+  });
+
+  it("re-homes a mid-open filled field inline once the toggle turns off", () => {
+    const { form, paint } = gatedOpenForm({});
+    paint();
+    form.values = { show_test_card: true };
+    paint();
+    form.showAdvanced = false;
+    const text = paint();
+    expect(text).toContain("Test Card");
+    expect(text.indexOf("Test Card")).toBeLessThan(text.indexOf("Show advanced"));
+    expect(text).toContain("Show advanced settings (2)");
+    expect(text).not.toContain("Empty Adv");
   });
 });

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -661,6 +661,14 @@ describe("config-entry-form advanced-section", () => {
     expect(text.indexOf("Test Card")).toBeLessThan(text.indexOf("Show advanced"));
     expect(text).toContain("Show advanced settings (2)");
     expect(text).not.toContain("Empty Adv");
+    // willUpdate's close-clear dropped the mid-open placement, so reopening
+    // re-freezes from the current values: the filled field is now inline.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any).willUpdate(new Map([["showAdvanced", true]]));
+    form.showAdvanced = true;
+    const reopened = paint();
+    expect(reopened.indexOf("Test Card")).toBeLessThan(reopened.indexOf("Show advanced"));
+    expect(reopened).toContain("Show advanced settings (2)");
   });
 
   // Toggle scroll anchor (#1977): flipping the control reveals nested

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -9,7 +9,7 @@
  * default, a real unlocked switch). The control emits ``advanced-toggle``.
  */
 import { render } from "lit";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}));
@@ -677,6 +677,7 @@ describe("config-entry-form advanced-section", () => {
       clientHeight: { value: 300 },
     });
     document.body.appendChild(scroller);
+    onTestFinished(() => scroller.remove());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     render((form as any)._renderAdvancedControl(false, 2, false), scroller);
     const row = scroller.querySelector<HTMLElement>(".advanced-toggle-row")!;

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -662,4 +662,59 @@ describe("config-entry-form advanced-section", () => {
     expect(text).toContain("Show advanced settings (2)");
     expect(text).not.toContain("Empty Adv");
   });
+
+  // Toggle scroll anchor (#1977): flipping the control reveals nested
+  // advanced children in place ABOVE it, so the row's viewport position is
+  // captured at click time and the scroll container compensated after the
+  // ``showAdvanced`` re-render. wa-* controls can't mount under happy-dom,
+  // so geometry is stubbed and each half is driven directly.
+  function anchoredControl(rowTop: number) {
+    const form = new ESPHomeConfigEntryForm();
+    const scroller = document.createElement("div");
+    scroller.style.overflowY = "auto";
+    Object.defineProperties(scroller, {
+      scrollHeight: { value: 1000 },
+      clientHeight: { value: 300 },
+    });
+    document.body.appendChild(scroller);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    render((form as any)._renderAdvancedControl(false, 2, false), scroller);
+    const row = scroller.querySelector<HTMLElement>(".advanced-toggle-row")!;
+    row.getBoundingClientRect = () => ({ top: rowTop }) as DOMRect;
+    // The restore path resolves the row through the form's shadow root;
+    // without a mount, point it at the rendered fragment.
+    Object.defineProperty(form, "shadowRoot", { value: scroller });
+    const sw = row.querySelector<HTMLElement>("wa-switch")!;
+    return { form, scroller, row, sw };
+  }
+
+  it("compensates the scroll container so the toggled control stays put", () => {
+    const { form, scroller, row, sw } = anchoredControl(500);
+    sw.dispatchEvent(new Event("change"));
+    // The re-render grew content above the control by 400px.
+    row.getBoundingClientRect = () => ({ top: 900 }) as DOMRect;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any)._restoreAdvancedControlAnchor(new Map([["showAdvanced", false]]));
+    expect(scroller.scrollTop).toBe(400);
+    // Consumed: a second showAdvanced change must not re-scroll.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any)._restoreAdvancedControlAnchor(new Map([["showAdvanced", true]]));
+    expect(scroller.scrollTop).toBe(400);
+  });
+
+  it("holds the anchor for a showAdvanced change and ignores a stale one", () => {
+    const { form, scroller, row, sw } = anchoredControl(500);
+    sw.dispatchEvent(new Event("change"));
+    row.getBoundingClientRect = () => ({ top: 900 }) as DOMRect;
+    // Unrelated update: no scroll, anchor kept for the real toggle render.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any)._restoreAdvancedControlAnchor(new Map([["values", {}]]));
+    expect(scroller.scrollTop).toBe(0);
+    // Expired anchor: consumed without scrolling.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any)._advancedControlAnchor = { top: 500, at: Date.now() - 3000 };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any)._restoreAdvancedControlAnchor(new Map([["showAdvanced", false]]));
+    expect(scroller.scrollTop).toBe(0);
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Two fixes for the structured editor's "Show advanced settings" section, both from the same report.

First, setting a value on an advanced field while the section was open instantly moved the field above the toggle and decremented the count, so the option looked like it vanished. The gate-advanced split re-reads the live values every render; the placement is now frozen per field while the section is open, and the live classification resumes when the toggle turns off. YAML-present advanced fields still paint inline while the section is closed.

Second, flipping the toggle shifted the switch under the pointer by hundreds of pixels, because nested basic groups (pin schemas, `display.dimensions`) reveal their advanced children in place above the control. The switch's viewport position is captured at click time and the scroll container is compensated after the re-render, so the control stays put in both directions. Verified headlessly with the reported `mipi_rgb` config: 566px of content inserts above the control on open and the switch now moves 0px.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1977

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
