### PR TITLE
Show the Recommended chip on bundle cards

### DIFF
--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -17,11 +17,29 @@ export function shouldHandleCardClick(ev: MouseEvent): boolean {
   return !target?.closest("a, button");
 }
 
+// Native title tooltips don't render inside the dialog's top layer
+// (Chromium suppresses them over showModal dialogs), so the
+// recommendation explainer rides a wa-tooltip anchored to the chip.
+// An empty tooltip (board body not yet hydrated) renders the chip
+// alone, rather than naming a placeholder board.
+function renderRecommendedChip(chipId: string, tooltip: string): TemplateResult {
+  return html`<span
+      id=${chipId}
+      class="component-category-chip component-category-chip--recommended"
+      tabindex=${tooltip ? "0" : "-1"}
+      >${categoryChipLabel("featured")}</span
+    >
+    ${tooltip ? html`<wa-tooltip for=${chipId}>${tooltip}</wa-tooltip>` : nothing}`;
+}
+
 export function renderBundleCard(
   host: ESPHomeComponentCatalog,
   bundle: FeaturedBundle
 ): TemplateResult {
   const hasImage = !!bundle.image_url && !host._imageFailed.has(bundle.id);
+  const recommendedTooltip = host.board
+    ? host._localize("device.recommended_chip_tooltip", { board: host.board.name })
+    : "";
   return html`
     <article
       class="component-card component-card--featured"
@@ -47,6 +65,10 @@ export function renderBundleCard(
         }
         <div class="component-card-header-text">
           <h3 class="component-title">${bundle.name}</h3>
+          ${renderRecommendedChip(
+            `recommended-chip-bundle-${bundle.id}`,
+            recommendedTooltip
+          )}
         </div>
         <span class="bundle-badge">
           <wa-icon library="mdi" name="package-variant-closed"></wa-icon>
@@ -95,11 +117,6 @@ export function renderCard(
   // Surfaced only when this card shares a name with another in the same
   // category; the category chip can't tell same-domain platforms apart.
   const platform = showPlatform ? platformLabel(component.id) : "";
-  // Native title tooltips don't render inside the dialog's top layer
-  // (Chromium suppresses them over showModal dialogs), so the
-  // recommendation explainer rides a wa-tooltip anchored to the chip.
-  // Empty until the board body has hydrated — the chip renders without
-  // a tooltip then, rather than naming a placeholder board.
   const recommendedTooltip =
     featured && host.board
       ? localize("device.recommended_chip_tooltip", { board: host.board.name })
@@ -133,19 +150,10 @@ export function renderCard(
           <h3 class="component-title">${component.name}</h3>
           ${
             featured
-              ? html`<span
-                    id=${`recommended-chip-${component.id}`}
-                    class="component-category-chip component-category-chip--recommended"
-                    tabindex=${recommendedTooltip ? "0" : "-1"}
-                    >${categoryChipLabel("featured")}</span
-                  >
-                  ${
-                    recommendedTooltip
-                      ? html`<wa-tooltip for=${`recommended-chip-${component.id}`}
-                          >${recommendedTooltip}</wa-tooltip
-                        >`
-                      : nothing
-                  }`
+              ? renderRecommendedChip(
+                  `recommended-chip-${component.id}`,
+                  recommendedTooltip
+                )
               : nothing
           }
           ${

--- a/test/components/device/component-catalog-renderers.test.ts
+++ b/test/components/device/component-catalog-renderers.test.ts
@@ -1,12 +1,14 @@
 // @vitest-environment happy-dom
 import { render } from "lit";
 import { describe, expect, it } from "vitest";
+import type { FeaturedBundle } from "../../../src/api/types/boards.js";
 import {
   ComponentCategory,
   type ComponentCatalogEntry,
 } from "../../../src/api/types/components.js";
 import type { ESPHomeComponentCatalog } from "../../../src/components/device/component-catalog.js";
 import {
+  renderBundleCard,
   renderCard,
   shouldHandleCardClick,
 } from "../../../src/components/device/component-catalog/renderers.js";
@@ -22,7 +24,9 @@ function makeHost(): ESPHomeComponentCatalog {
     _imageFailed: new Set<string>(),
     _category: "all",
     board: { name: "Guition Smart Screen" },
+    _localize: localize,
     _onAdd: () => {},
+    _onAddBundle: () => {},
     _onToggleExpand: () => {},
     _onImageError: () => {},
   } as unknown as ESPHomeComponentCatalog;
@@ -38,6 +42,15 @@ function makeEntry(overrides: Partial<ComponentCatalogEntry>): ComponentCatalogE
     image_url: "",
     ...overrides,
   } as ComponentCatalogEntry;
+}
+
+function makeBundle(): FeaturedBundle {
+  return {
+    id: "rgb_buzzer_module",
+    name: "RGB LED + Buzzer Module",
+    description: "The starter kit's RGB + Buzzer module.",
+    component_ids: ["rgb_leds", "buzzer_output"],
+  };
 }
 
 const localize = (key: string, values?: Record<string, string | number>) => {
@@ -95,6 +108,36 @@ describe("renderCard", () => {
     render(renderCard(makeHost(), makeEntry({}), false, false, localize), container);
     expect(container.querySelector(".component-category-chip--recommended")).toBeNull();
     expect(container.querySelector(".component-category-chip")?.textContent).toBe("Bus");
+  });
+});
+
+describe("renderBundleCard", () => {
+  it("marks the bundle with the Recommended chip beside the Bundle badge", () => {
+    const container = document.createElement("div");
+    render(renderBundleCard(makeHost(), makeBundle()), container);
+    const chip = container.querySelector(".component-category-chip--recommended");
+    expect(chip?.textContent?.trim()).toBe("Recommended");
+    // Focusable so keyboard users can raise the tooltip (focus trigger).
+    expect(chip?.getAttribute("tabindex")).toBe("0");
+    const tooltip = container.querySelector("wa-tooltip");
+    expect(tooltip?.getAttribute("for")).toBe(chip?.id);
+    expect(tooltip?.textContent?.trim()).toBe(
+      "Pre-configured for the Guition Smart Screen"
+    );
+    expect(container.querySelector(".bundle-badge")).not.toBeNull();
+    expect(container.querySelector(".component-card--featured")).not.toBeNull();
+  });
+
+  it("omits the tooltip until the board body has hydrated", () => {
+    const container = document.createElement("div");
+    const host = makeHost();
+    (host as unknown as { board: null }).board = null;
+    render(renderBundleCard(host, makeBundle()), container);
+    const chip = container.querySelector(".component-category-chip--recommended");
+    expect(chip).not.toBeNull();
+    expect(container.querySelector("wa-tooltip")).toBeNull();
+    // No tooltip to raise — the chip must not be a dead tab stop.
+    expect(chip?.getAttribute("tabindex")).toBe("-1");
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

#1221 added the Recommended chip and its "Pre-configured for the {board}" tooltip to featured cards in the Choose components dialog, but bundle cards were left with only the Bundle badge; they sit in the same Recommended category, so the missing chip reads as an inconsistency. The chip render is now a shared helper used by both card kinds, and bundle cards always carry it since every bundle is board recommended by definition.

**Related issue or feature (if applicable):**

- reported directly with screenshots, no issue filed

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
