### PR TITLE
Hide the card expand button when the description fits its clamp

### DIFF
--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -235,6 +235,13 @@ export class ESPHomeComponentCatalog extends LitElement {
     loadMoreFooterStyles,
   ];
 
+  protected firstUpdated() {
+    // A late web-font swap changes wrap heights without a resize or a
+    // render, stranding stale expand buttons; re-measure once fonts
+    // settle. Optional-chained: happy-dom has no document.fonts.
+    document.fonts?.ready.then(() => this._measureDescriptionOverflow());
+  }
+
   protected updated() {
     this._measureDescriptionOverflow();
 

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -23,11 +23,10 @@ import { isFeaturedId } from "../../util/featured-id.js";
 import { IntersectionController } from "../../util/intersection-controller.js";
 import { PagedListController } from "../../util/paged-list-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { ResizeController } from "../../util/resize-controller.js";
+import { setsEqual } from "../../util/set-equal.js";
 import { renderLoadMoreFooter } from "../shared/load-more-footer.js";
-import {
-  overflowingDescriptionIds,
-  sameIdSet,
-} from "./component-catalog/description-overflow.js";
+import { overflowingDescriptionIds } from "./component-catalog/description-overflow.js";
 import {
   ambiguousNameIds,
   availableFeaturedCount,
@@ -108,15 +107,22 @@ export class ESPHomeComponentCatalog extends LitElement {
 
   // Cards whose clamped description actually overflows — the only ones
   // where the expand button reveals anything. Rebuilt after every render
-  // and on host resize (wrap width changes truncation).
-  @state() _overflowingDescriptions: ReadonlySet<string> = new Set();
+  // and on host resize (wrap width changes truncation). The equality
+  // check makes the updated() -> measure -> state cycle converge:
+  // removing a button doesn't change the description's wrap width, so
+  // the second pass measures the same set and stops.
+  @state({
+    hasChanged: (next: ReadonlySet<string>, old?: ReadonlySet<string>) =>
+      !old || !setsEqual(next, old),
+  })
+  _overflowingDescriptions: ReadonlySet<string> = new Set();
 
   @query(".sentinel") private _sentinel?: HTMLElement | null;
 
   @queryAll(".component-description--clamp[data-component-id]")
   private _clampedDescriptions!: NodeListOf<HTMLElement>;
 
-  private _resizeObserver = new ResizeObserver(() => this._measureDescriptionOverflow());
+  private _resize = new ResizeController(this, () => this._measureDescriptionOverflow());
 
   private _intersection = new IntersectionController(this, () => this._list.loadMore());
 
@@ -228,16 +234,6 @@ export class ESPHomeComponentCatalog extends LitElement {
     componentCatalogStyles,
     loadMoreFooterStyles,
   ];
-
-  connectedCallback() {
-    super.connectedCallback();
-    this._resizeObserver.observe(this);
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this._resizeObserver.disconnect();
-  }
 
   protected updated() {
     this._measureDescriptionOverflow();
@@ -394,14 +390,13 @@ export class ESPHomeComponentCatalog extends LitElement {
     this._expandedId = this._expandedId === component.id ? null : component.id;
   }
 
-  // The set-equality guard makes the updated() -> state -> updated() cycle
-  // converge: removing a button doesn't change the description's wrap
-  // width, so the second pass measures the same set and stops.
+  // The catalog stays mounted (hidden) inside its dialog: a hidden
+  // subtree measures 0/0 for every paragraph, so skip rather than wipe
+  // the set on dialog close — the reopen's load() render re-measures.
+  // Feature-detected: happy-dom has no checkVisibility.
   private _measureDescriptionOverflow() {
-    const next = overflowingDescriptionIds(this._clampedDescriptions);
-    if (!sameIdSet(next, this._overflowingDescriptions)) {
-      this._overflowingDescriptions = next;
-    }
+    if (this.checkVisibility && !this.checkVisibility()) return;
+    this._overflowingDescriptions = overflowingDescriptionIds(this._clampedDescriptions);
   }
 
   _onImageError(id: string) {

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -8,7 +8,7 @@ import {
   mdiPlus,
 } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { customElement, property, query, queryAll, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry, FeaturedBundle } from "../../api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../api/types/components.js";
@@ -24,6 +24,10 @@ import { IntersectionController } from "../../util/intersection-controller.js";
 import { PagedListController } from "../../util/paged-list-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { renderLoadMoreFooter } from "../shared/load-more-footer.js";
+import {
+  overflowingDescriptionIds,
+  sameIdSet,
+} from "./component-catalog/description-overflow.js";
 import {
   ambiguousNameIds,
   availableFeaturedCount,
@@ -102,7 +106,17 @@ export class ESPHomeComponentCatalog extends LitElement {
   // card down to the placeholder.
   @state() _imageFailed: Set<string> = new Set();
 
+  // Cards whose clamped description actually overflows — the only ones
+  // where the expand button reveals anything. Rebuilt after every render
+  // and on host resize (wrap width changes truncation).
+  @state() _overflowingDescriptions: ReadonlySet<string> = new Set();
+
   @query(".sentinel") private _sentinel?: HTMLElement | null;
+
+  @queryAll(".component-description--clamp[data-component-id]")
+  private _clampedDescriptions!: NodeListOf<HTMLElement>;
+
+  private _resizeObserver = new ResizeObserver(() => this._measureDescriptionOverflow());
 
   private _intersection = new IntersectionController(this, () => this._list.loadMore());
 
@@ -215,7 +229,19 @@ export class ESPHomeComponentCatalog extends LitElement {
     loadMoreFooterStyles,
   ];
 
+  connectedCallback() {
+    super.connectedCallback();
+    this._resizeObserver.observe(this);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._resizeObserver.disconnect();
+  }
+
   protected updated() {
+    this._measureDescriptionOverflow();
+
     // The sidebar badge / auto-select read availableFeaturedCount over the
     // board's recommendations (fetch-independent), while the grid reads the
     // fetched featured cards; during prop settling (yaml/board/platform arrive
@@ -366,6 +392,16 @@ export class ESPHomeComponentCatalog extends LitElement {
 
   _onToggleExpand(component: ComponentCatalogEntry) {
     this._expandedId = this._expandedId === component.id ? null : component.id;
+  }
+
+  // The set-equality guard makes the updated() -> state -> updated() cycle
+  // converge: removing a button doesn't change the description's wrap
+  // width, so the second pass measures the same set and stops.
+  private _measureDescriptionOverflow() {
+    const next = overflowingDescriptionIds(this._clampedDescriptions);
+    if (!sameIdSet(next, this._overflowingDescriptions)) {
+      this._overflowingDescriptions = next;
+    }
   }
 
   _onImageError(id: string) {

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -21,6 +21,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 import { debounce } from "../../util/debounce.js";
 import { isFeaturedId } from "../../util/featured-id.js";
 import { IntersectionController } from "../../util/intersection-controller.js";
+import { isVisible } from "../../util/is-visible.js";
 import { PagedListController } from "../../util/paged-list-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { ResizeController } from "../../util/resize-controller.js";
@@ -400,10 +401,14 @@ export class ESPHomeComponentCatalog extends LitElement {
   // The catalog stays mounted (hidden) inside its dialog: a hidden
   // subtree measures 0/0 for every paragraph, so skip rather than wipe
   // the set on dialog close — the reopen's load() render re-measures.
-  // Feature-detected: happy-dom has no checkVisibility.
   private _measureDescriptionOverflow() {
-    if (this.checkVisibility && !this.checkVisibility()) return;
-    this._overflowingDescriptions = overflowingDescriptionIds(this._clampedDescriptions);
+    if (!isVisible(this)) return;
+    const next = overflowingDescriptionIds(this._clampedDescriptions);
+    // The expanded card's unclamped text is excluded from measurement;
+    // keep its id so collapsing doesn't flash the button out for a
+    // frame before the post-collapse measure re-adds it.
+    if (this._expandedId) next.add(this._expandedId);
+    this._overflowingDescriptions = next;
   }
 
   _onImageError(id: string) {

--- a/src/components/device/component-catalog/description-overflow.ts
+++ b/src/components/device/component-catalog/description-overflow.ts
@@ -4,24 +4,14 @@
  * Drives whether a card renders its expand button at all: a
  * description that fits (or is empty) has nothing to reveal, so
  * the button would only reflow the grid — dead UI.
- *
- * Pure over the injected predicate so tests can stub layout
- * (happy-dom reports 0 for scroll metrics).
  */
 export function overflowingDescriptionIds(
-  paragraphs: Iterable<HTMLElement>,
-  isOverflowing: (el: HTMLElement) => boolean = (el) => el.scrollHeight > el.clientHeight
+  paragraphs: Iterable<HTMLElement>
 ): Set<string> {
   const ids = new Set<string>();
   for (const el of paragraphs) {
     const id = el.dataset.componentId;
-    if (id && isOverflowing(el)) ids.add(id);
+    if (id && el.scrollHeight > el.clientHeight) ids.add(id);
   }
   return ids;
-}
-
-export function sameIdSet(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
-  if (a.size !== b.size) return false;
-  for (const id of a) if (!b.has(id)) return false;
-  return true;
 }

--- a/src/components/device/component-catalog/description-overflow.ts
+++ b/src/components/device/component-catalog/description-overflow.ts
@@ -1,0 +1,27 @@
+/**
+ * Which clamped description paragraphs actually overflow their
+ * line clamp, keyed by the card id stamped on data-component-id.
+ * Drives whether a card renders its expand button at all: a
+ * description that fits (or is empty) has nothing to reveal, so
+ * the button would only reflow the grid — dead UI.
+ *
+ * Pure over the injected predicate so tests can stub layout
+ * (happy-dom reports 0 for scroll metrics).
+ */
+export function overflowingDescriptionIds(
+  paragraphs: Iterable<HTMLElement>,
+  isOverflowing: (el: HTMLElement) => boolean = (el) => el.scrollHeight > el.clientHeight
+): Set<string> {
+  const ids = new Set<string>();
+  for (const el of paragraphs) {
+    const id = el.dataset.componentId;
+    if (id && isOverflowing(el)) ids.add(id);
+  }
+  return ids;
+}
+
+export function sameIdSet(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const id of a) if (!b.has(id)) return false;
+  return true;
+}

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -106,6 +106,11 @@ export function renderCard(
   showPlatform = false
 ): TemplateResult {
   const hasImage = !!component.image_url && !host._imageFailed.has(component.id);
+  // Expanding only unclamps the description (plus a full-row span), so the
+  // button is dead UI unless the clamped text actually overflows. An open
+  // card keeps its button regardless — the unclamped text no longer
+  // measures as overflowing, but it still needs a collapse affordance.
+  const expandable = expanded || host._overflowingDescriptions.has(component.id);
   // Skip the chip entirely when the label is empty (defensive against an
   // API regression yielding a whitespace category id) so we don't render
   // a blank pill.
@@ -167,20 +172,27 @@ export function renderCard(
               : nothing
           }
         </div>
-        <button
-          class="expand-button"
-          type="button"
-          aria-pressed=${expanded}
-          title=${localize("wizard.expand_board")}
-          @click=${() => host._onToggleExpand(component)}
-        >
-          <wa-icon
-            library="mdi"
-            name=${expanded ? "arrow-collapse-all" : "arrow-expand-all"}
-          ></wa-icon>
-        </button>
+        ${
+          expandable
+            ? html`<button
+                class="expand-button"
+                type="button"
+                aria-pressed=${expanded}
+                title=${localize("wizard.expand_board")}
+                @click=${() => host._onToggleExpand(component)}
+              >
+                <wa-icon
+                  library="mdi"
+                  name=${expanded ? "arrow-collapse-all" : "arrow-expand-all"}
+                ></wa-icon>
+              </button>`
+            : nothing
+        }
       </div>
-      <p class="component-description ${expanded ? "" : "component-description--clamp"}">
+      <p
+        class="component-description ${expanded ? "" : "component-description--clamp"}"
+        data-component-id=${component.id}
+      >
         ${renderMarkdown(component.description)}
       </p>
       <div class="card-footer">

--- a/src/components/labels/bulk-labels-dialog.ts
+++ b/src/components/labels/bulk-labels-dialog.ts
@@ -38,6 +38,7 @@ import { dialogChromeStyles } from "../../styles/dialog-chrome.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { labelChipStyles, renderLabelChip } from "../../util/label-chip-template.js";
 import { notifyError, notifyInfo, notifySuccess } from "../../util/notify.js";
+import { setsEqual } from "../../util/set-equal.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import "../base-dialog.js";
 import { labelsListStyles } from "./labels-list-styles.js";
@@ -50,12 +51,6 @@ registerMdiIcons({
 });
 
 export type TriState = "checked" | "unchecked" | "indeterminate";
-
-function _setsEqual<T>(a: Set<T>, b: Set<T>): boolean {
-  if (a.size !== b.size) return false;
-  for (const item of a) if (!b.has(item)) return false;
-  return true;
-}
 
 @customElement("esphome-bulk-labels-dialog")
 export class ESPHomeBulkLabelsDialog extends LitElement {
@@ -261,7 +256,7 @@ export class ESPHomeBulkLabelsDialog extends LitElement {
         if (change === "checked") after.add(labelId);
         else after.delete(labelId);
       }
-      if (_setsEqual(before, after)) return [];
+      if (setsEqual(before, after)) return [];
       return [{ configuration: device.configuration, labelIds: [...after] }];
     });
   }

--- a/src/util/file-drop-controller.ts
+++ b/src/util/file-drop-controller.ts
@@ -1,4 +1,5 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { isVisible } from "./is-visible.js";
 import { ACCEPTED_UPLOAD_EXTENSIONS } from "./upload-file-types.js";
 
 export interface FileDropControllerOptions {
@@ -124,8 +125,4 @@ export class FileDropController implements ReactiveController {
 function hasFiles(e: DragEvent): boolean {
   if (!e.dataTransfer) return false;
   return e.dataTransfer.types.includes("Files") || e.dataTransfer.files.length > 0;
-}
-
-function isVisible(el: HTMLElement): boolean {
-  return el.isConnected && (el.checkVisibility?.() ?? el.offsetParent !== null);
 }

--- a/src/util/is-visible.ts
+++ b/src/util/is-visible.ts
@@ -1,0 +1,9 @@
+/**
+ * Whether the element is rendered (connected, no display:none
+ * ancestor). offsetParent is the fallback for engines without
+ * checkVisibility; it is null for hidden elements, and non-null for
+ * rendered descendants of positioned containers like dialogs.
+ */
+export function isVisible(el: HTMLElement): boolean {
+  return el.isConnected && (el.checkVisibility?.() ?? el.offsetParent !== null);
+}

--- a/src/util/resize-controller.ts
+++ b/src/util/resize-controller.ts
@@ -1,0 +1,26 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+
+/**
+ * Reactive controller wrapping a ``ResizeObserver`` over the host
+ * element: ``onResize`` fires whenever the host's box changes.
+ * Observation follows the host's connect/disconnect lifecycle.
+ */
+export class ResizeController implements ReactiveController {
+  private _observer: ResizeObserver;
+
+  constructor(
+    private readonly _host: ReactiveControllerHost & Element,
+    onResize: () => void
+  ) {
+    this._observer = new ResizeObserver(onResize);
+    _host.addController(this);
+  }
+
+  hostConnected(): void {
+    this._observer.observe(this._host);
+  }
+
+  hostDisconnected(): void {
+    this._observer.disconnect();
+  }
+}

--- a/src/util/set-equal.ts
+++ b/src/util/set-equal.ts
@@ -1,0 +1,6 @@
+/** Same members, order-independent. */
+export function setsEqual<T>(a: ReadonlySet<T>, b: ReadonlySet<T>): boolean {
+  if (a.size !== b.size) return false;
+  for (const item of a) if (!b.has(item)) return false;
+  return true;
+}

--- a/test/components/device/component-catalog-renderers.test.ts
+++ b/test/components/device/component-catalog-renderers.test.ts
@@ -22,6 +22,7 @@ function clickFrom(target: Element): MouseEvent {
 function makeHost(): ESPHomeComponentCatalog {
   return {
     _imageFailed: new Set<string>(),
+    _overflowingDescriptions: new Set<string>(),
     _category: "all",
     board: { name: "Guition Smart Screen" },
     _localize: localize,
@@ -108,6 +109,40 @@ describe("renderCard", () => {
     render(renderCard(makeHost(), makeEntry({}), false, false, localize), container);
     expect(container.querySelector(".component-category-chip--recommended")).toBeNull();
     expect(container.querySelector(".component-category-chip")?.textContent).toBe("Bus");
+  });
+
+  it("omits the expand button when the description doesn't overflow its clamp", () => {
+    // Expanding only unclamps the description, so a fitting (or empty)
+    // description makes the button pure dead UI.
+    const container = document.createElement("div");
+    render(renderCard(makeHost(), makeEntry({}), false, false, localize), container);
+    expect(container.querySelector(".expand-button")).toBeNull();
+  });
+
+  it("shows the expand button when the clamped description overflows", () => {
+    const container = document.createElement("div");
+    const host = makeHost();
+    (host._overflowingDescriptions as Set<string>).add("spi");
+    render(renderCard(host, makeEntry({}), false, false, localize), container);
+    expect(container.querySelector(".expand-button")).not.toBeNull();
+  });
+
+  it("keeps the collapse button on an expanded card", () => {
+    // Once open, the unclamped text no longer measures as overflowing; the
+    // card still needs its collapse affordance.
+    const container = document.createElement("div");
+    render(renderCard(makeHost(), makeEntry({}), true, false, localize), container);
+    const button = container.querySelector(".expand-button");
+    expect(button).not.toBeNull();
+    expect(button?.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("stamps the component id on the description for overflow measurement", () => {
+    const container = document.createElement("div");
+    render(renderCard(makeHost(), makeEntry({}), false, false, localize), container);
+    const description = container.querySelector<HTMLElement>(".component-description");
+    expect(description?.dataset.componentId).toBe("spi");
+    expect(description?.classList.contains("component-description--clamp")).toBe(true);
   });
 });
 

--- a/test/components/device/component-catalog/description-overflow.test.ts
+++ b/test/components/device/component-catalog/description-overflow.test.ts
@@ -1,9 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, expect, it } from "vitest";
-import {
-  overflowingDescriptionIds,
-  sameIdSet,
-} from "../../../../src/components/device/component-catalog/description-overflow.js";
+import { overflowingDescriptionIds } from "../../../../src/components/device/component-catalog/description-overflow.js";
 
 function makeParagraph(id: string | null, overflow: boolean): HTMLElement {
   const p = document.createElement("p");
@@ -17,6 +14,8 @@ describe("overflowingDescriptionIds", () => {
   it("collects only the ids whose clamped text overflows", () => {
     const ids = overflowingDescriptionIds([
       makeParagraph("sensor.dht", true),
+      // Equal heights (an exactly-two-line description) count as fitting;
+      // an expand button that reveals nothing must not appear.
       makeParagraph("async_tcp", false),
       makeParagraph("debug", true),
     ]);
@@ -25,27 +24,5 @@ describe("overflowingDescriptionIds", () => {
 
   it("skips a paragraph without a component id", () => {
     expect(overflowingDescriptionIds([makeParagraph(null, true)])).toEqual(new Set());
-  });
-
-  it("treats equal heights as fitting", () => {
-    // happy-dom and an exactly-two-line description both land here; an
-    // expand button that reveals nothing must not appear.
-    expect(overflowingDescriptionIds([makeParagraph("spi", false)])).toEqual(new Set());
-  });
-
-  it("honors an injected overflow predicate", () => {
-    const ids = overflowingDescriptionIds([makeParagraph("spi", false)], () => true);
-    expect(ids).toEqual(new Set(["spi"]));
-  });
-});
-
-describe("sameIdSet", () => {
-  it("matches sets regardless of insertion order", () => {
-    expect(sameIdSet(new Set(["a", "b"]), new Set(["b", "a"]))).toBe(true);
-  });
-
-  it("rejects a size mismatch and a same-size membership mismatch", () => {
-    expect(sameIdSet(new Set(["a"]), new Set(["a", "b"]))).toBe(false);
-    expect(sameIdSet(new Set(["a", "c"]), new Set(["a", "b"]))).toBe(false);
   });
 });

--- a/test/components/device/component-catalog/description-overflow.test.ts
+++ b/test/components/device/component-catalog/description-overflow.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import {
+  overflowingDescriptionIds,
+  sameIdSet,
+} from "../../../../src/components/device/component-catalog/description-overflow.js";
+
+function makeParagraph(id: string | null, overflow: boolean): HTMLElement {
+  const p = document.createElement("p");
+  if (id !== null) p.dataset.componentId = id;
+  Object.defineProperty(p, "scrollHeight", { value: overflow ? 40 : 20 });
+  Object.defineProperty(p, "clientHeight", { value: 20 });
+  return p;
+}
+
+describe("overflowingDescriptionIds", () => {
+  it("collects only the ids whose clamped text overflows", () => {
+    const ids = overflowingDescriptionIds([
+      makeParagraph("sensor.dht", true),
+      makeParagraph("async_tcp", false),
+      makeParagraph("debug", true),
+    ]);
+    expect(ids).toEqual(new Set(["sensor.dht", "debug"]));
+  });
+
+  it("skips a paragraph without a component id", () => {
+    expect(overflowingDescriptionIds([makeParagraph(null, true)])).toEqual(new Set());
+  });
+
+  it("treats equal heights as fitting", () => {
+    // happy-dom and an exactly-two-line description both land here; an
+    // expand button that reveals nothing must not appear.
+    expect(overflowingDescriptionIds([makeParagraph("spi", false)])).toEqual(new Set());
+  });
+
+  it("honors an injected overflow predicate", () => {
+    const ids = overflowingDescriptionIds([makeParagraph("spi", false)], () => true);
+    expect(ids).toEqual(new Set(["spi"]));
+  });
+});
+
+describe("sameIdSet", () => {
+  it("matches sets regardless of insertion order", () => {
+    expect(sameIdSet(new Set(["a", "b"]), new Set(["b", "a"]))).toBe(true);
+  });
+
+  it("rejects a size mismatch and a same-size membership mismatch", () => {
+    expect(sameIdSet(new Set(["a"]), new Set(["a", "b"]))).toBe(false);
+    expect(sameIdSet(new Set(["a", "c"]), new Set(["a", "b"]))).toBe(false);
+  });
+});

--- a/test/components/device/component-catalog/render-card-platform-chip.test.ts
+++ b/test/components/device/component-catalog/render-card-platform-chip.test.ts
@@ -16,6 +16,7 @@ import { identityLocalize as localize, renderInto } from "../../../_dom.js";
 function host(category = "stepper"): unknown {
   return {
     _imageFailed: new Set<string>(),
+    _overflowingDescriptions: new Set<string>(),
     _category: category,
     _onAdd: () => {},
     _onToggleExpand: () => {},

--- a/test/util/is-visible.test.ts
+++ b/test/util/is-visible.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { isVisible } from "../../src/util/is-visible.js";
+
+function makeElement({
+  connected = true,
+  checkVisibility,
+  offsetParent = null,
+}: {
+  connected?: boolean;
+  checkVisibility?: () => boolean;
+  offsetParent?: Element | null;
+} = {}): HTMLElement {
+  const el = document.createElement("div");
+  if (connected) document.body.append(el);
+  if (checkVisibility) el.checkVisibility = checkVisibility;
+  else Object.defineProperty(el, "checkVisibility", { value: undefined });
+  Object.defineProperty(el, "offsetParent", { value: offsetParent });
+  return el;
+}
+
+describe("isVisible", () => {
+  it("rejects a disconnected element", () => {
+    expect(isVisible(makeElement({ connected: false }))).toBe(false);
+  });
+
+  it("trusts checkVisibility when the engine provides it", () => {
+    expect(isVisible(makeElement({ checkVisibility: () => true }))).toBe(true);
+    expect(
+      isVisible(
+        makeElement({ checkVisibility: () => false, offsetParent: document.body })
+      )
+    ).toBe(false);
+  });
+
+  it("falls back to offsetParent when checkVisibility is missing", () => {
+    expect(isVisible(makeElement({ offsetParent: document.body }))).toBe(true);
+    expect(isVisible(makeElement({ offsetParent: null }))).toBe(false);
+  });
+});

--- a/test/util/set-equal.test.ts
+++ b/test/util/set-equal.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { setsEqual } from "../../src/util/set-equal.js";
+
+describe("setsEqual", () => {
+  it("matches sets regardless of insertion order", () => {
+    expect(setsEqual(new Set(["a", "b"]), new Set(["b", "a"]))).toBe(true);
+    expect(setsEqual(new Set(), new Set())).toBe(true);
+  });
+
+  it("rejects a size mismatch and a same-size membership mismatch", () => {
+    expect(setsEqual(new Set(["a"]), new Set(["a", "b"]))).toBe(false);
+    expect(setsEqual(new Set(["a", "c"]), new Set(["a", "b"]))).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Every component card rendered an expand button, but expanding only unclamps the two line description and spans the card full row; for cards whose description is empty or already fits, the button just reflowed the grid with nothing to reveal, dead UI. The catalog host now measures which clamped descriptions actually overflow (rebuilt after each render and on host resize, since wrap width changes truncation) and renderCard only shows the button for those; an expanded card always keeps its collapse button. Covers both the Choose components and Add configuration dialogs, which share this renderer.

**Related issue or feature (if applicable):**

- reported directly with screenshots, no issue filed

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
