### PR TITLE
Give bundle cards the same expand affordance as component cards

### DIFF
--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -394,8 +394,8 @@ export class ESPHomeComponentCatalog extends LitElement {
     `;
   }
 
-  _onToggleExpand(component: ComponentCatalogEntry) {
-    this._expandedId = this._expandedId === component.id ? null : component.id;
+  _onToggleExpand(id: string) {
+    this._expandedId = this._expandedId === id ? null : id;
   }
 
   // The catalog stays mounted (hidden) inside its dialog: a hidden

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -22,6 +22,26 @@ export function shouldHandleCardClick(ev: MouseEvent): boolean {
 // recommendation explainer rides a wa-tooltip anchored to the chip.
 // An empty tooltip (board body not yet hydrated) renders the chip
 // alone, rather than naming a placeholder board.
+function renderExpandButton(
+  host: ESPHomeComponentCatalog,
+  id: string,
+  expanded: boolean,
+  localize: LocalizeFunc
+): TemplateResult {
+  return html`<button
+    class="expand-button"
+    type="button"
+    aria-pressed=${expanded}
+    title=${localize("wizard.expand_board")}
+    @click=${() => host._onToggleExpand(id)}
+  >
+    <wa-icon
+      library="mdi"
+      name=${expanded ? "arrow-collapse-all" : "arrow-expand-all"}
+    ></wa-icon>
+  </button>`;
+}
+
 function renderRecommendedChip(chipId: string, tooltip: string): TemplateResult {
   return html`<span
       id=${chipId}
@@ -40,9 +60,17 @@ export function renderBundleCard(
   const recommendedTooltip = host.board
     ? host._localize("device.recommended_chip_tooltip", { board: host.board.name })
     : "";
+  // Bundle ids are board-local tokens (rgb_buzzer_module) that could
+  // collide with a bare core-component id (debug, wifi) in the shared
+  // expanded/overflow namespaces; the prefix keeps them apart.
+  const expandKey = `bundle.${bundle.id}`;
+  const expanded = host._expandedId === expandKey;
+  const expandable = expanded || host._overflowingDescriptions.has(expandKey);
   return html`
     <article
-      class="component-card component-card--featured"
+      class="component-card component-card--featured ${
+        expanded ? "component-card--expanded" : ""
+      }"
       @click=${(ev: MouseEvent) => {
         if (shouldHandleCardClick(ev)) host._onAddBundle(bundle);
       }}
@@ -74,10 +102,20 @@ export function renderBundleCard(
           <wa-icon library="mdi" name="package-variant-closed"></wa-icon>
           ${host._localize("device.featured_bundle_badge")}
         </span>
+        ${
+          expandable
+            ? renderExpandButton(host, expandKey, expanded, host._localize)
+            : nothing
+        }
       </div>
       ${
         bundle.description
-          ? html`<p class="component-description component-description--clamp">
+          ? html`<p
+              class="component-description ${
+                expanded ? "" : "component-description--clamp"
+              }"
+              data-component-id=${expandKey}
+            >
               ${renderMarkdown(bundle.description)}
             </p>`
           : nothing
@@ -174,18 +212,7 @@ export function renderCard(
         </div>
         ${
           expandable
-            ? html`<button
-                class="expand-button"
-                type="button"
-                aria-pressed=${expanded}
-                title=${localize("wizard.expand_board")}
-                @click=${() => host._onToggleExpand(component)}
-              >
-                <wa-icon
-                  library="mdi"
-                  name=${expanded ? "arrow-collapse-all" : "arrow-expand-all"}
-                ></wa-icon>
-              </button>`
+            ? renderExpandButton(host, component.id, expanded, localize)
             : nothing
         }
       </div>

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -22,26 +22,6 @@ export function shouldHandleCardClick(ev: MouseEvent): boolean {
 // recommendation explainer rides a wa-tooltip anchored to the chip.
 // An empty tooltip (board body not yet hydrated) renders the chip
 // alone, rather than naming a placeholder board.
-function renderExpandButton(
-  host: ESPHomeComponentCatalog,
-  id: string,
-  expanded: boolean,
-  localize: LocalizeFunc
-): TemplateResult {
-  return html`<button
-    class="expand-button"
-    type="button"
-    aria-pressed=${expanded}
-    title=${localize("wizard.expand_board")}
-    @click=${() => host._onToggleExpand(id)}
-  >
-    <wa-icon
-      library="mdi"
-      name=${expanded ? "arrow-collapse-all" : "arrow-expand-all"}
-    ></wa-icon>
-  </button>`;
-}
-
 function renderRecommendedChip(chipId: string, tooltip: string): TemplateResult {
   return html`<span
       id=${chipId}
@@ -50,6 +30,22 @@ function renderRecommendedChip(chipId: string, tooltip: string): TemplateResult 
       >${categoryChipLabel("featured")}</span
     >
     ${tooltip ? html`<wa-tooltip for=${chipId}>${tooltip}</wa-tooltip>` : nothing}`;
+}
+
+function renderExpandButton(host: ESPHomeComponentCatalog, id: string): TemplateResult {
+  const expanded = host._expandedId === id;
+  return html`<button
+    class="expand-button"
+    type="button"
+    aria-pressed=${expanded}
+    title=${host._localize("wizard.expand_board")}
+    @click=${() => host._onToggleExpand(id)}
+  >
+    <wa-icon
+      library="mdi"
+      name=${expanded ? "arrow-collapse-all" : "arrow-expand-all"}
+    ></wa-icon>
+  </button>`;
 }
 
 export function renderBundleCard(
@@ -102,11 +98,7 @@ export function renderBundleCard(
           <wa-icon library="mdi" name="package-variant-closed"></wa-icon>
           ${host._localize("device.featured_bundle_badge")}
         </span>
-        ${
-          expandable
-            ? renderExpandButton(host, expandKey, expanded, host._localize)
-            : nothing
-        }
+        ${expandable ? renderExpandButton(host, expandKey) : nothing}
       </div>
       ${
         bundle.description
@@ -210,11 +202,7 @@ export function renderCard(
               : nothing
           }
         </div>
-        ${
-          expandable
-            ? renderExpandButton(host, component.id, expanded, localize)
-            : nothing
-        }
+        ${expandable ? renderExpandButton(host, component.id) : nothing}
       </div>
       <p
         class="component-description ${expanded ? "" : "component-description--clamp"}"

--- a/test/components/device/component-catalog-renderers.test.ts
+++ b/test/components/device/component-catalog-renderers.test.ts
@@ -23,6 +23,7 @@ function makeHost(): ESPHomeComponentCatalog {
   return {
     _imageFailed: new Set<string>(),
     _overflowingDescriptions: new Set<string>(),
+    _expandedId: null,
     _category: "all",
     board: { name: "Guition Smart Screen" },
     _localize: localize,
@@ -173,6 +174,51 @@ describe("renderBundleCard", () => {
     expect(container.querySelector("wa-tooltip")).toBeNull();
     // No tooltip to raise — the chip must not be a dead tab stop.
     expect(chip?.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("omits the expand button when the description doesn't overflow its clamp", () => {
+    const container = document.createElement("div");
+    render(renderBundleCard(makeHost(), makeBundle()), container);
+    expect(container.querySelector(".expand-button")).toBeNull();
+    // Prefixed key: a board-local bundle id must not collide with a
+    // bare core-component id in the shared overflow namespace.
+    expect(
+      container.querySelector<HTMLElement>(".component-description")?.dataset.componentId
+    ).toBe("bundle.rgb_buzzer_module");
+  });
+
+  it("shows the expand button when the clamped description overflows", () => {
+    const container = document.createElement("div");
+    const host = makeHost();
+    (host._overflowingDescriptions as Set<string>).add("bundle.rgb_buzzer_module");
+    render(renderBundleCard(host, makeBundle()), container);
+    expect(container.querySelector(".expand-button")).not.toBeNull();
+  });
+
+  it("unclamps the description and keeps the collapse button while expanded", () => {
+    const container = document.createElement("div");
+    const host = makeHost();
+    (host as unknown as { _expandedId: string })._expandedId = "bundle.rgb_buzzer_module";
+    render(renderBundleCard(host, makeBundle()), container);
+    expect(container.querySelector(".component-card--expanded")).not.toBeNull();
+    const description = container.querySelector(".component-description");
+    expect(description?.classList.contains("component-description--clamp")).toBe(false);
+    const button = container.querySelector(".expand-button");
+    expect(button?.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("toggles expansion under the prefixed bundle key", () => {
+    const container = document.createElement("div");
+    const host = makeHost();
+    const toggled: string[] = [];
+    (host as unknown as { _onToggleExpand: (id: string) => void })._onToggleExpand = (
+      id
+    ) => toggled.push(id);
+    render(renderBundleCard(host, makeBundle()), container);
+    (host._overflowingDescriptions as Set<string>).add("bundle.rgb_buzzer_module");
+    render(renderBundleCard(host, makeBundle()), container);
+    (container.querySelector(".expand-button") as HTMLButtonElement).click();
+    expect(toggled).toEqual(["bundle.rgb_buzzer_module"]);
   });
 });
 

--- a/test/components/device/component-catalog-renderers.test.ts
+++ b/test/components/device/component-catalog-renderers.test.ts
@@ -12,6 +12,7 @@ import {
   renderCard,
   shouldHandleCardClick,
 } from "../../../src/components/device/component-catalog/renderers.js";
+import { makeCatalogHost } from "./component-catalog/_host.js";
 
 function clickFrom(target: Element): MouseEvent {
   const ev = new MouseEvent("click", { bubbles: true });
@@ -20,18 +21,10 @@ function clickFrom(target: Element): MouseEvent {
 }
 
 function makeHost(): ESPHomeComponentCatalog {
-  return {
-    _imageFailed: new Set<string>(),
-    _overflowingDescriptions: new Set<string>(),
-    _expandedId: null,
-    _category: "all",
+  return makeCatalogHost({
     board: { name: "Guition Smart Screen" },
     _localize: localize,
-    _onAdd: () => {},
-    _onAddBundle: () => {},
-    _onToggleExpand: () => {},
-    _onImageError: () => {},
-  } as unknown as ESPHomeComponentCatalog;
+  });
 }
 
 function makeEntry(overrides: Partial<ComponentCatalogEntry>): ComponentCatalogEntry {
@@ -132,7 +125,9 @@ describe("renderCard", () => {
     // Once open, the unclamped text no longer measures as overflowing; the
     // card still needs its collapse affordance.
     const container = document.createElement("div");
-    render(renderCard(makeHost(), makeEntry({}), true, false, localize), container);
+    const host = makeHost();
+    host._expandedId = "spi";
+    render(renderCard(host, makeEntry({}), true, false, localize), container);
     const button = container.querySelector(".expand-button");
     expect(button).not.toBeNull();
     expect(button?.getAttribute("aria-pressed")).toBe("true");
@@ -180,8 +175,13 @@ describe("renderBundleCard", () => {
     const container = document.createElement("div");
     render(renderBundleCard(makeHost(), makeBundle()), container);
     expect(container.querySelector(".expand-button")).toBeNull();
-    // Prefixed key: a board-local bundle id must not collide with a
-    // bare core-component id in the shared overflow namespace.
+  });
+
+  it("stamps the prefixed key on the description for overflow measurement", () => {
+    // The prefix keeps the board-local bundle id apart from bare
+    // core-component ids in the shared expanded/overflow namespaces.
+    const container = document.createElement("div");
+    render(renderBundleCard(makeHost(), makeBundle()), container);
     expect(
       container.querySelector<HTMLElement>(".component-description")?.dataset.componentId
     ).toBe("bundle.rgb_buzzer_module");
@@ -198,7 +198,7 @@ describe("renderBundleCard", () => {
   it("unclamps the description and keeps the collapse button while expanded", () => {
     const container = document.createElement("div");
     const host = makeHost();
-    (host as unknown as { _expandedId: string })._expandedId = "bundle.rgb_buzzer_module";
+    host._expandedId = "bundle.rgb_buzzer_module";
     render(renderBundleCard(host, makeBundle()), container);
     expect(container.querySelector(".component-card--expanded")).not.toBeNull();
     const description = container.querySelector(".component-description");
@@ -209,12 +209,9 @@ describe("renderBundleCard", () => {
 
   it("toggles expansion under the prefixed bundle key", () => {
     const container = document.createElement("div");
-    const host = makeHost();
     const toggled: string[] = [];
-    (host as unknown as { _onToggleExpand: (id: string) => void })._onToggleExpand = (
-      id
-    ) => toggled.push(id);
-    render(renderBundleCard(host, makeBundle()), container);
+    const host = makeHost();
+    host._onToggleExpand = (id) => toggled.push(id);
     (host._overflowingDescriptions as Set<string>).add("bundle.rgb_buzzer_module");
     render(renderBundleCard(host, makeBundle()), container);
     (container.querySelector(".expand-button") as HTMLButtonElement).click();

--- a/test/components/device/component-catalog/_host.ts
+++ b/test/components/device/component-catalog/_host.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared catalog-host fake for the pure card render functions
+ * (renderCard / renderBundleCard). Carries every host member the
+ * renderers read, so a new member lands here once instead of in each
+ * suite's hand-rolled copy.
+ */
+import type { ESPHomeComponentCatalog } from "../../../../src/components/device/component-catalog.js";
+import { identityLocalize } from "../../../_dom.js";
+
+export function makeCatalogHost(
+  overrides: Record<string, unknown> = {}
+): ESPHomeComponentCatalog {
+  return {
+    _imageFailed: new Set<string>(),
+    _overflowingDescriptions: new Set<string>(),
+    _expandedId: null,
+    _category: "all",
+    board: null,
+    _localize: identityLocalize,
+    _onAdd: () => {},
+    _onAddBundle: () => {},
+    _onToggleExpand: () => {},
+    _onImageError: () => {},
+    ...overrides,
+  } as unknown as ESPHomeComponentCatalog;
+}

--- a/test/components/device/component-catalog/render-bundle-card.test.ts
+++ b/test/components/device/component-catalog/render-bundle-card.test.ts
@@ -8,17 +8,11 @@ import { describe, expect, it } from "vitest";
 
 import type { FeaturedBundle } from "../../../../src/api/types/boards.js";
 import { renderBundleCard } from "../../../../src/components/device/component-catalog/renderers.js";
-import { identityLocalize, renderInto } from "../../../_dom.js";
+import { renderInto } from "../../../_dom.js";
+import { makeCatalogHost } from "./_host.js";
 
 function host(failed: string[] = []): unknown {
-  return {
-    _imageFailed: new Set(failed),
-    _overflowingDescriptions: new Set<string>(),
-    _expandedId: null,
-    _onAddBundle: () => {},
-    _onImageError: () => {},
-    _localize: identityLocalize,
-  };
+  return makeCatalogHost({ _imageFailed: new Set(failed) });
 }
 
 function bundle(overrides: Partial<FeaturedBundle> = {}): FeaturedBundle {
@@ -56,14 +50,9 @@ describe("renderBundleCard image", () => {
 
   it("calls _onImageError with the bundle id when the img fires an error", () => {
     const failedIds: string[] = [];
-    const spyHost = {
-      _imageFailed: new Set<string>(),
-      _overflowingDescriptions: new Set<string>(),
-      _expandedId: null,
-      _onAddBundle: () => {},
+    const spyHost = makeCatalogHost({
       _onImageError: (id: string) => failedIds.push(id),
-      _localize: identityLocalize,
-    };
+    });
     const b = bundle({ image_url: "https://example.com/module.jpg" });
     const el = renderInto(renderBundleCard(spyHost as never, b));
     el.querySelector("img")!.dispatchEvent(new Event("error"));

--- a/test/components/device/component-catalog/render-bundle-card.test.ts
+++ b/test/components/device/component-catalog/render-bundle-card.test.ts
@@ -13,6 +13,8 @@ import { identityLocalize, renderInto } from "../../../_dom.js";
 function host(failed: string[] = []): unknown {
   return {
     _imageFailed: new Set(failed),
+    _overflowingDescriptions: new Set<string>(),
+    _expandedId: null,
     _onAddBundle: () => {},
     _onImageError: () => {},
     _localize: identityLocalize,
@@ -56,6 +58,8 @@ describe("renderBundleCard image", () => {
     const failedIds: string[] = [];
     const spyHost = {
       _imageFailed: new Set<string>(),
+      _overflowingDescriptions: new Set<string>(),
+      _expandedId: null,
       _onAddBundle: () => {},
       _onImageError: (id: string) => failedIds.push(id),
       _localize: identityLocalize,

--- a/test/components/device/component-catalog/render-card-platform-chip.test.ts
+++ b/test/components/device/component-catalog/render-card-platform-chip.test.ts
@@ -12,16 +12,10 @@ import {
 } from "../../../../src/api/types/components.js";
 import { renderCard } from "../../../../src/components/device/component-catalog/renderers.js";
 import { identityLocalize as localize, renderInto } from "../../../_dom.js";
+import { makeCatalogHost } from "./_host.js";
 
 function host(category = "stepper"): unknown {
-  return {
-    _imageFailed: new Set<string>(),
-    _overflowingDescriptions: new Set<string>(),
-    _category: category,
-    _onAdd: () => {},
-    _onToggleExpand: () => {},
-    _onImageError: () => {},
-  };
+  return makeCatalogHost({ _category: category });
 }
 
 function entry(id: string): ComponentCatalogEntry {


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #1227: bundle cards clamp their descriptions like component cards but had no expand button at all, so a truncated bundle description was unreadable; next to component cards that now expand exactly when truncated, the gap read as a bug. The expand button is a shared renderer used by both card kinds and bundle descriptions join the overflow measurement under a bundle. prefixed key, since board local bundle ids could collide with bare core component ids like debug in the shared expanded and overflow namespaces.

**Related issue or feature (if applicable):**

- follow up to #1227

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
