### PR TITLE
Say list view, not table view, in the tour's dashboard step

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1074,7 +1074,7 @@
       },
       "dashboard": {
         "title": "Find it on your dashboard",
-        "body": "Your device lives here now. Switch between card and table views as your collection grows."
+        "body": "Your device lives here now. Switch between card and list views as your collection grows."
       },
       "done": {
         "title": "You’re all set",


### PR DESCRIPTION
# What does this implement/fix?

The view toggle on the dashboard is labelled "List view", but the guided tour's dashboard step said "Switch between card and table views". Align the tour copy with the toggle label, since that is the term users actually see on the control.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2016

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
