### PR TITLE
Show the file's full match count when YAML search truncates to 5

### DIFF
--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -268,6 +268,10 @@ export interface YamlSearchHit {
   device_name: string;
   friendly_name: string;
   matches: YamlSearchMatch[];
+  /** Uncapped match count in the file's scanned window; greater than
+   *  `matches.length` when the per-file cap truncated the list. Absent
+   *  on backends that predate it — fall back to `matches.length`. */
+  total_matches?: number;
 }
 
 /** Response from devices/create. */

--- a/src/components/dashboard/render-toolbar.ts
+++ b/src/components/dashboard/render-toolbar.ts
@@ -175,7 +175,14 @@ export function renderYamlToolbar(host: ESPHomePageDashboard): TemplateResult {
   const hits = host._yamlSearch.hits;
   const matchCount =
     hits === null ? null : hits.reduce((sum, hit) => sum + hit.matches.length, 0);
-  const unit = host._localize("yaml_search.match_count", { count: matchCount ?? 0 });
+  const totalCount =
+    hits === null
+      ? null
+      : hits.reduce((sum, hit) => sum + (hit.total_matches ?? hit.matches.length), 0);
+  const unit =
+    totalCount !== null && totalCount > (matchCount ?? 0)
+      ? host._localize("yaml_search.match_count_of", { total: totalCount })
+      : host._localize("yaml_search.match_count", { count: matchCount ?? 0 });
   return html`
     <div class="toolbar">
       <div class="toolbar-row">${renderSearchInput(host)} ${renderViewToggle(host)}</div>

--- a/src/components/dashboard/render-yaml.ts
+++ b/src/components/dashboard/render-yaml.ts
@@ -122,7 +122,11 @@ function renderYamlHits(
       ${hits.map((hit) => {
         const blocks = buildYamlSnippetBlocks(hit.matches);
         const matchCount = hit.matches.length;
-        const countUnit = localize("yaml_search.match_count", { count: matchCount });
+        const totalCount = hit.total_matches ?? matchCount;
+        const countUnit =
+          totalCount > matchCount
+            ? localize("yaml_search.match_count_of", { total: totalCount })
+            : localize("yaml_search.match_count", { count: matchCount });
         const trailing = html`<span class="yaml-hit-group-count"
           >${matchCount} ${countUnit}</span
         >`;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1187,6 +1187,7 @@
     "searching": "Searching…",
     "no_matches": "No matches",
     "match_count": "{count, plural, one {match} other {matches}}",
+    "match_count_of": "of {total, plural, one {# match} other {# matches}}",
     "switch_to_yaml": "Search YAML content",
     "placeholder": "Search YAML content…",
     "no_match_yaml_preview": "{count, plural, one {Try YAML search — found # match across your configs} other {Try YAML search — found # matches across your configs}}"

--- a/test/components/dashboard/render-toolbar.test.ts
+++ b/test/components/dashboard/render-toolbar.test.ts
@@ -15,6 +15,7 @@ import {
   renderSearchInput,
   renderSelectBarOrFab,
   renderViewToggle,
+  renderYamlToolbar,
 } from "../../../src/components/dashboard/render-toolbar.js";
 import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
 import { renderInto } from "../../_dom.js";
@@ -81,6 +82,41 @@ describe("renderViewToggle Expert Mode gating", () => {
     const container = renderToggle(makeToggleHost(true));
     expect(container.querySelectorAll(".view-toggle-btn").length).toBe(3);
     expect(container.querySelector('wa-icon[name="code-braces"]')).not.toBeNull();
+  });
+});
+
+describe("renderYamlToolbar match count", () => {
+  function makeYamlHit(shown: number, total?: number) {
+    return {
+      configuration: "a.yaml",
+      device_name: "a",
+      friendly_name: "A",
+      matches: Array.from({ length: shown }, (_, i) => ({
+        line_number: i + 1,
+        line_text: "wifi:",
+        before: [],
+        after: [],
+      })),
+      ...(total === undefined ? {} : { total_matches: total }),
+    };
+  }
+
+  function countText(hits: unknown[]): string {
+    const host = makeHost({ _search: "wifi", _yamlSearch: { hits } });
+    const container = renderInto(renderYamlToolbar(host as ESPHomePageDashboard));
+    return container.querySelector(".device-count")?.textContent ?? "";
+  }
+
+  it("renders the 'of total' unit when the fleet total exceeds the shown sum", () => {
+    const text = countText([makeYamlHit(5, 23)]);
+    expect(text).toContain("5");
+    expect(text).toContain("yaml_search.match_count_of");
+  });
+
+  it("renders the plain unit when total_matches is absent (older backend)", () => {
+    const text = countText([makeYamlHit(5)]);
+    expect(text).toContain("yaml_search.match_count");
+    expect(text).not.toContain("match_count_of");
   });
 });
 

--- a/test/components/dashboard/render-yaml.test.ts
+++ b/test/components/dashboard/render-yaml.test.ts
@@ -48,3 +48,28 @@ describe("renderYamlMode hit header", () => {
     expect(anchor?.textContent?.trim()).toBe("Living Room");
   });
 });
+
+describe("renderYamlMode match count", () => {
+  function countText(hits: YamlSearchHit[]): string {
+    const container = renderInto(renderYamlMode(makeHost(hits)));
+    return container.querySelector(".yaml-hit-group-count")?.textContent ?? "";
+  }
+
+  it("renders the 'of total' unit when total_matches exceeds the shown list", () => {
+    const text = countText([{ ...makeHit(), total_matches: 23 }]);
+    expect(text).toContain("1");
+    expect(text).toContain("yaml_search.match_count_of");
+  });
+
+  it("renders the plain unit when total_matches is absent (older backend)", () => {
+    const text = countText([makeHit()]);
+    expect(text).toContain("yaml_search.match_count");
+    expect(text).not.toContain("match_count_of");
+  });
+
+  it("renders the plain unit when total_matches equals the shown count", () => {
+    const text = countText([{ ...makeHit(), total_matches: 1 }]);
+    expect(text).toContain("yaml_search.match_count");
+    expect(text).not.toContain("match_count_of");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

YAML search caps results at 5 matches per file, but the dashboard rendered a flat "5 matches" with no hint the list was truncated. The backend now reports each file's uncapped count as `total_matches` (esphome/device-builder#2025); this renders it — the per-device group header and the toolbar total read "5 of 23 matches" when the list is capped, and stay unchanged when it isn't. The field is optional, so older backends keep the current display.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2022

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
