### PR TITLE
Render per-option catalog descriptions in select menus

### DIFF
--- a/src/api/types/config-entries.ts
+++ b/src/api/types/config-entries.ts
@@ -12,6 +12,10 @@ export type ConfigPrimitive = string | number | boolean;
 export interface ConfigValueOption {
   label: string;
   value: string;
+  /** Prose explaining the choice, rendered as secondary text under the label.
+   *  Set when the catalog's per-value docs read as a sentence rather than a
+   *  label. */
+  description?: string;
   /** ESP32 variants that accept this value (lowercased, e.g. `esp32s3`); absent
    *  or empty means every variant. When the device resolves to an ESP32 variant
    *  the select filters to it; otherwise (non-ESP32 or unknown) all options

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { chipNameToVariant } from "../../../util/chip-variant.js";
 import { nearCanonicalOption } from "../../../util/config-validation.js";
+import { renderOptionStack } from "../../../util/option-stack.js";
 import { parseYamlBoolean, YamlRawValue } from "../../../util/yaml-serialize.js";
 import type { OptionsComboboxValueChange } from "../../options-combobox-event.js";
 import {
@@ -226,38 +227,24 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
         ${shownOptions.map((opt) => {
           const selected = opt.value.toLowerCase() === valueLower;
           const isDefault = defaultStr !== "" && opt.value.toLowerCase() === defaultLower;
-          if (!isDefault && !opt.description) {
+          // wa-select activates the first option when nothing is committed,
+          // so the default gets a muted note (like the pin menu's notes) —
+          // the honest "this applies if you leave it" signal.
+          const defaultNote = isDefault
+            ? ctx.localize("device.default_option_tag")
+            : undefined;
+          if (!defaultNote && !opt.description) {
             return html`<wa-option value=${opt.value} ?selected=${selected}
-              >${opt.label}</wa-option
+              >${renderOptionStack(opt.label)}</wa-option
             >`;
           }
-          // wa-select activates the first option when nothing is committed,
-          // so give the default a muted second line (like the pin menu's
-          // notes) — the honest "this applies if you leave it" signal.
-          // An option's catalog description stacks the same way.
           // `.label` keeps the closed control showing just the label.
           return html`<wa-option
             value=${opt.value}
             .label=${opt.label}
             ?selected=${selected}
           >
-            <span class="option-default-stack">
-              <span>${opt.label}</span>
-              ${
-                opt.description
-                  ? html`<small class="option-description-note"
-                      >${opt.description}</small
-                    >`
-                  : nothing
-              }
-              ${
-                isDefault
-                  ? html`<small class="option-default-note"
-                      >${ctx.localize("device.default_option_tag")}</small
-                    >`
-                  : nothing
-              }
-            </span>
+            ${renderOptionStack(opt.label, opt.description, defaultNote)}
           </wa-option>`;
         })}
       </wa-select>

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -226,7 +226,7 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
         ${shownOptions.map((opt) => {
           const selected = opt.value.toLowerCase() === valueLower;
           const isDefault = defaultStr !== "" && opt.value.toLowerCase() === defaultLower;
-          if (!isDefault) {
+          if (!isDefault && !opt.description) {
             return html`<wa-option value=${opt.value} ?selected=${selected}
               >${opt.label}</wa-option
             >`;
@@ -234,6 +234,7 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
           // wa-select activates the first option when nothing is committed,
           // so give the default a muted second line (like the pin menu's
           // notes) — the honest "this applies if you leave it" signal.
+          // An option's catalog description stacks the same way.
           // `.label` keeps the closed control showing just the label.
           return html`<wa-option
             value=${opt.value}
@@ -242,9 +243,20 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
           >
             <span class="option-default-stack">
               <span>${opt.label}</span>
-              <small class="option-default-note"
-                >${ctx.localize("device.default_option_tag")}</small
-              >
+              ${
+                opt.description
+                  ? html`<small class="option-description-note"
+                      >${opt.description}</small
+                    >`
+                  : nothing
+              }
+              ${
+                isDefault
+                  ? html`<small class="option-default-note"
+                      >${ctx.localize("device.default_option_tag")}</small
+                    >`
+                  : nothing
+              }
             </span>
           </wa-option>`;
         })}

--- a/src/components/options-combobox.ts
+++ b/src/components/options-combobox.ts
@@ -14,6 +14,7 @@ import { mdiChevronDown } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { inputStyles } from "../styles/inputs.js";
+import { renderOptionStack } from "../util/option-stack.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { buildOptionsComboboxChangeEvent } from "./options-combobox-event.js";
 import { optionsComboboxStyles } from "./options-combobox.styles.js";
@@ -154,27 +155,11 @@ export class ESPHomeOptionsCombobox extends LitElement {
                       @click=${() => this._select(opt)}
                       @mouseenter=${() => (this._active = i)}
                     >
-                      ${
-                        this._isDefault(opt) || opt.description
-                          ? html`<span class="option-default-stack">
-                              <span class="option-label">${opt.label}</span>
-                              ${
-                                opt.description
-                                  ? html`<small class="option-description-note"
-                                      >${opt.description}</small
-                                    >`
-                                  : nothing
-                              }
-                              ${
-                                this._isDefault(opt)
-                                  ? html`<small class="option-default-note"
-                                      >${this.defaultNote}</small
-                                    >`
-                                  : nothing
-                              }
-                            </span>`
-                          : html`<span class="option-label">${opt.label}</span>`
-                      }
+                      ${renderOptionStack(
+                        opt.label,
+                        opt.description,
+                        this._isDefault(opt) ? this.defaultNote : undefined
+                      )}
                     </div>`
                 )}
               </div>`

--- a/src/components/options-combobox.ts
+++ b/src/components/options-combobox.ts
@@ -26,6 +26,8 @@ registerMdiIcons({ "chevron-down": mdiChevronDown });
 export interface ComboboxOption {
   label: string;
   value: string;
+  /** Prose explaining the choice, rendered as a quiet second line. */
+  description?: string;
 }
 
 @customElement("esphome-options-combobox")
@@ -153,12 +155,23 @@ export class ESPHomeOptionsCombobox extends LitElement {
                       @mouseenter=${() => (this._active = i)}
                     >
                       ${
-                        this._isDefault(opt)
+                        this._isDefault(opt) || opt.description
                           ? html`<span class="option-default-stack">
                               <span class="option-label">${opt.label}</span>
-                              <small class="option-default-note"
-                                >${this.defaultNote}</small
-                              >
+                              ${
+                                opt.description
+                                  ? html`<small class="option-description-note"
+                                      >${opt.description}</small
+                                    >`
+                                  : nothing
+                              }
+                              ${
+                                this._isDefault(opt)
+                                  ? html`<small class="option-default-note"
+                                      >${this.defaultNote}</small
+                                    >`
+                                  : nothing
+                              }
                             </span>`
                           : html`<span class="option-label">${opt.label}</span>`
                       }
@@ -184,7 +197,10 @@ export class ESPHomeOptionsCombobox extends LitElement {
     const q = this._query.trim().toLowerCase();
     if (!q) return this.options;
     return this.options.filter(
-      (o) => o.value.toLowerCase().includes(q) || o.label.toLowerCase().includes(q)
+      (o) =>
+        o.value.toLowerCase().includes(q) ||
+        o.label.toLowerCase().includes(q) ||
+        o.description?.toLowerCase().includes(q)
     );
   }
 

--- a/src/styles/inputs.ts
+++ b/src/styles/inputs.ts
@@ -122,10 +122,11 @@ export const inputStyles = css`
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--esphome-error), transparent 80%);
   }
 
-  /* Default option in a select menu: a label with a quiet second line, so
-     the default stays identifiable even though wa-select activates the
-     first option when nothing is committed. Mirrors the pin menu's notes. */
-  .option-default-stack {
+  /* Option row in a select menu: the label plus quiet annotation lines —
+     the option's catalog description and/or the default tag (wa-select
+     activates the first option when nothing is committed, so the default
+     must stay identifiable). Mirrors the pin menu's notes. */
+  .option-stack {
     display: inline-flex;
     flex-direction: column;
     gap: 1px;
@@ -139,7 +140,7 @@ export const inputStyles = css`
   }
 
   /* Catalog prose for one option (quiet, non-italic so it reads as
-     content rather than the default-tag annotation above). */
+     content rather than the default-tag annotation). */
   .option-description-note {
     font-size: var(--wa-font-size-2xs);
     color: var(--wa-color-text-quiet);

--- a/src/styles/inputs.ts
+++ b/src/styles/inputs.ts
@@ -138,6 +138,15 @@ export const inputStyles = css`
     font-style: italic;
   }
 
+  /* Catalog prose for one option (quiet, non-italic so it reads as
+     content rather than the default-tag annotation above). */
+  .option-description-note {
+    font-size: var(--wa-font-size-2xs);
+    color: var(--wa-color-text-quiet);
+    max-width: 42ch;
+    white-space: normal;
+  }
+
   wa-select::part(listbox) {
     padding-block: 0;
   }

--- a/src/util/option-stack.ts
+++ b/src/util/option-stack.ts
@@ -1,0 +1,30 @@
+import { html, nothing } from "lit";
+
+/**
+ * Option-row content shared by wa-select menus and the options-combobox:
+ * the plain label, or a stacked label plus quiet annotation lines (the
+ * option's catalog description, the default tag). Styles live in
+ * `inputStyles` (`.option-stack` and friends), which both hosts import.
+ */
+export function renderOptionStack(
+  label: unknown,
+  description?: string,
+  defaultNote?: string
+) {
+  if (!description && !defaultNote) {
+    return html`<span class="option-label">${label}</span>`;
+  }
+  return html`<span class="option-stack">
+    <span class="option-label">${label}</span>
+    ${
+      description
+        ? html`<small class="option-description-note">${description}</small>`
+        : nothing
+    }
+    ${
+      defaultNote
+        ? html`<small class="option-default-note">${defaultNote}</small>`
+        : nothing
+    }
+  </span>`;
+}

--- a/test/components/device/config-entry-select-description.test.ts
+++ b/test/components/device/config-entry-select-description.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { ConfigValueOption } from "../../../src/api/types/config-entries.js";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { renderSelectField } from "../../../src/components/device/config-entry-renderers/primitives.js";
+import { makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
+
+// Options whose catalog docs read as prose ship a per-option
+// `description` (label stays the value, e.g. web_server auth `type`'s
+// basic/digest); the menu renders it as a quiet second line, stacking
+// with the default tag when the option is also the default.
+const OPTIONS: ConfigValueOption[] = [
+  {
+    value: "basic",
+    label: "basic",
+    description: "Sends the password in an easily reversible form.",
+  },
+  { value: "digest", label: "digest", description: "Sends only hashes. Recommended." },
+];
+
+const serialize = (tpl: unknown): string =>
+  JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+
+function renderFor(overrides: Record<string, unknown> = {}) {
+  const entry = makeEntry(ConfigEntryType.SELECT, { options: OPTIONS, ...overrides });
+  return renderSelectField(entry, ["type"], makeRenderCtx({}));
+}
+
+describe("renderSelectField — option descriptions", () => {
+  it("renders each described option with a quiet second line", () => {
+    const json = serialize(renderFor());
+    expect(json.match(/option-description-note/g)).toHaveLength(2);
+    expect(json).toContain("Sends only hashes. Recommended.");
+  });
+
+  it("stacks the description with the default tag on the default option", () => {
+    const json = serialize(renderFor({ default_value: "basic" }));
+    expect(json.match(/option-description-note/g)).toHaveLength(2);
+    expect(json.match(/option-default-note/g)).toHaveLength(1);
+  });
+
+  it("keeps undescribed options on the plain single-line shape", () => {
+    const plain = makeEntry(ConfigEntryType.SELECT, {
+      options: [{ value: "a", label: "a" }],
+    });
+    const json = serialize(renderSelectField(plain, ["type"], makeRenderCtx({})));
+    expect(json).not.toContain("option-description-note");
+    expect(json).not.toContain("option-default-stack");
+  });
+});

--- a/test/components/device/config-entry-select-description.test.ts
+++ b/test/components/device/config-entry-select-description.test.ts
@@ -4,10 +4,8 @@ import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { renderSelectField } from "../../../src/components/device/config-entry-renderers/primitives.js";
 import { makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
 
-// Options whose catalog docs read as prose ship a per-option
-// `description` (label stays the value, e.g. web_server auth `type`'s
-// basic/digest); the menu renders it as a quiet second line, stacking
-// with the default tag when the option is also the default.
+// Described options render a quiet second line; the default option
+// stacks both notes.
 const OPTIONS: ConfigValueOption[] = [
   {
     value: "basic",
@@ -44,6 +42,6 @@ describe("renderSelectField — option descriptions", () => {
     });
     const json = serialize(renderSelectField(plain, ["type"], makeRenderCtx({})));
     expect(json).not.toContain("option-description-note");
-    expect(json).not.toContain("option-default-stack");
+    expect(json).not.toContain("option-stack");
   });
 });

--- a/test/components/options-combobox.test.ts
+++ b/test/components/options-combobox.test.ts
@@ -214,6 +214,54 @@ describe("esphome-options-combobox", () => {
     expect(el.shadowRoot!.querySelector(".option-default-note")).toBeNull();
   });
 
+  test("renders an option's description as a quiet second line", async () => {
+    const el = await mount("");
+    el.options = [
+      { label: "basic", value: "basic", description: "Reversible on every request." },
+      { label: "digest", value: "digest" },
+    ];
+    await el.updateComplete;
+    await open(el);
+    const opts = options(el);
+    expect(opts[0].querySelector(".option-description-note")?.textContent?.trim()).toBe(
+      "Reversible on every request."
+    );
+    expect(opts[1].querySelector(".option-description-note")).toBeNull();
+  });
+
+  test("stacks the description with the default note on the default option", async () => {
+    const el = await mount("");
+    el.options = [
+      { label: "basic", value: "basic", description: "Reversible on every request." },
+    ];
+    el.defaultValue = "basic";
+    el.defaultNote = "default";
+    await el.updateComplete;
+    await open(el);
+    const opt = options(el)[0];
+    expect(opt.querySelector(".option-description-note")).not.toBeNull();
+    expect(opt.querySelector(".option-default-note")?.textContent?.trim()).toBe(
+      "default"
+    );
+  });
+
+  test("typing filters on description text too", async () => {
+    const el = await mount("");
+    el.options = [
+      { label: "basic", value: "basic", description: "Reversible on every request." },
+      { label: "digest", value: "digest", description: "Sends only hashes." },
+    ];
+    await el.updateComplete;
+    await open(el);
+    const field = input(el);
+    field.value = "hashes";
+    field.dispatchEvent(new InputEvent("input"));
+    await el.updateComplete;
+    const opts = options(el);
+    expect(opts).toHaveLength(1);
+    expect(opts[0].querySelector(".option-label")?.textContent?.trim()).toBe("digest");
+  });
+
   test("the change event is namespaced (no generic value-changed)", () => {
     expect(OPTIONS_COMBOBOX_CHANGE_EVENT).toBe("options-combobox-change");
   });


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#2055 (esphbot's blocking finding on the catalog sync: the `web_server.auth.type` dropdown rendered full sentences instead of `basic`/`digest`).

The backend now ships an optional `description` per `ConfigValueOption`: when a value's schema docs read as prose, the label stays the value and the prose moves to `description`. This PR renders it:

- `ConfigValueOption` gains `description?: string`.
- `renderSelectField`'s strict `wa-select` shows the description as a quiet second line inside the option, reusing the existing `option-default-stack` shape and stacking with the *default* tag when the option is also the default.
- `esphome-options-combobox` (the `allow_custom_value` path) renders the same second line, and the type-ahead filter now also matches description text (typing "hashes" finds `digest`).
- New `.option-description-note` style beside `option-default-note` in the shared input styles: same quiet size, non-italic so prose reads as content rather than the default-tag annotation, wrapped at `42ch` so long sentences don't stretch the menu.

Old catalogs without the field render exactly as before (the stack only appears when a description or default tag is present).

Verified live against the backend branch: `web_server.auth.type` shows `basic` / `digest` with their sentences beneath and `basic` tagged default; `switch.gpio restore_mode` shows each enum value with its prose, `ALWAYS_OFF` tagged default.

**Related issue or feature (if applicable):**

- companion to esphome/device-builder#2055 (fixes the finding in https://github.com/esphome/device-builder/pull/2051#pullrequestreview-4691189630)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
