### PR TITLE
Polish quickstart onboarding and guided tour

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -64,7 +64,6 @@ import {
   themeIsDark,
 } from "../util/dark-mode.js";
 import { isExpert } from "../util/experience.js";
-import { navigate } from "../util/navigation.js";
 import { notifyInfo } from "../util/notify.js";
 import { isRecentSerialActivity, markSerialActivity } from "../util/web-serial.js";
 import { onLoginSubmit } from "./app-shell/auth.js";
@@ -218,7 +217,6 @@ export class ESPHomeApp extends LitElement {
   // auto-popped — it's collected per-device in the create wizard, or on demand
   // via the kebab "Set up Wi-Fi" dialog.
   @state() _onboardingShouldShow = false;
-  @state() _onboardingSessionDismissed = false;
   // Whether the first-run wizard should ask the remote-compute use-case
   // question (non-HA only). Seeded from the onboarding state's step list.
   @state() _onboardingHasUseCase = false;
@@ -491,31 +489,16 @@ export class ESPHomeApp extends LitElement {
     }
   }
 
-  // Triggered by the onboarding dialog after a save or explicit decline.
-  // Refresh state so the badge reflects new data.
+  // The required choices have landed; refresh their contexts and completion
+  // state while the wizard presents its final, optional tour offer.
   _onOnboardingAcknowledged = () => {
     this._onboardingShouldShow = false;
     void loadOnboardingState(this);
-    void loadPreferences(this).then(() => this._maybeOfferTour());
+    void loadPreferences(this);
   };
-
-  private _maybeOfferTour(): void {
-    if (this._remoteComputeOnly || isExpert(this._experienceLevel)) return;
-
-    void navigate("/?tourStep=1");
-  }
 
   private _onOpenGuidedTour = () => {
     this._guidedTour?.start();
-  };
-
-  _onOnboardingDismissedSession = () => {
-    this._onboardingSessionDismissed = true;
-    this._onboardingShouldShow = false;
-    // Skip-Wi-Fi persists the experience pick without acknowledging; refresh
-    // prefs so the contexts (yaml-diff button, experience-gated UI) reflect it
-    // this session rather than waiting for the next reconnect.
-    void loadPreferences(this);
   };
 
   // Kebab "Set up / Change Wi-Fi credentials" — open the manual Wi-Fi dialog.
@@ -652,15 +635,14 @@ export class ESPHomeApp extends LitElement {
       <esphome-onboarding-wizard-dialog
         .hasUseCase=${this._onboardingHasUseCase}
         @onboarding-acknowledged=${this._onOnboardingAcknowledged}
-        @onboarding-dismissed-session=${this._onOnboardingDismissedSession}
+        @open-guided-tour=${this._onOpenGuidedTour}
       ></esphome-onboarding-wizard-dialog>
       <esphome-guided-tour></esphome-guided-tour>
     `;
   }
 
-  // Auto-pop the full first-run wizard for a fresh install. The standalone
-  // Wi-Fi dialog is mounted unconditionally (so the kebab "Set up Wi-Fi" can
-  // open it) but is never auto-popped — Wi-Fi is collected per-device now.
+  // Auto-pop the mandatory first-run wizard for a fresh install. The standalone
+  // Wi-Fi dialog remains available on demand but is never part of onboarding.
   protected willUpdate(changed: PropertyValues) {
     // Expert Mode is experience_level === EXPERT; keep the provided context in
     // sync so its consumers react when the level changes.

--- a/src/components/app-shell/data-load.ts
+++ b/src/components/app-shell/data-load.ts
@@ -25,14 +25,12 @@ export async function loadOnboardingState(host: ESPHomeApp): Promise<void> {
     host._onboardingHasUseCase = state.steps.some(
       (s) => s.id === OnboardingStepId.USE_CASE
     );
-    // Only the full first-run wizard (use-case + experience) auto-pops now;
-    // Wi-Fi is collected per-device in the create wizard, never auto-popped.
+    // Only the mandatory setup wizard auto-pops. Wi-Fi is collected when the
+    // first Wi-Fi device needs it, never during onboarding.
     host._onboardingShouldShow =
-      shouldAutoShowOnboarding(state, host._onboardingSessionDismissed) &&
-      !isExperienceChosen(state);
+      shouldAutoShowOnboarding(state) && !isExperienceChosen(state);
   } catch (err) {
-    // Non-critical — leave _onboardingShouldShow alone so a transient reload on
-    // a session-dismissed state can't re-open the wizard.
+    // Non-critical — leave the current visibility decision alone.
     console.warn("Failed to load onboarding state:", err);
   }
   host._onboardingPending = !hasSharedWifiSecret(await keysPromise);

--- a/src/components/dashboard/device-table-grid.ts
+++ b/src/components/dashboard/device-table-grid.ts
@@ -4,6 +4,8 @@ import { classMap } from "lit/directives/class-map.js";
 import { repeat } from "lit/directives/repeat.js";
 import type { ConfiguredDevice } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
+import { tourAnchor } from "../guided-tour/tour-anchor.js";
+import { getActiveTourConfiguration } from "../guided-tour/tour-session.js";
 
 export interface DeviceTableHeadProps {
   table: any;
@@ -110,6 +112,7 @@ export function renderDeviceTableHead(p: DeviceTableHeadProps): TemplateResult {
  * the host supplies.
  */
 export function renderDeviceTableBody(p: DeviceTableBodyProps): TemplateResult {
+  const tourConfiguration = getActiveTourConfiguration();
   return html`
     <tbody>
       ${
@@ -122,6 +125,9 @@ export function renderDeviceTableBody(p: DeviceTableBodyProps): TemplateResult {
               (row) => row.original.config,
               (row) => html`
                 <tr
+                  ${tourAnchor(
+                    row.original.config === tourConfiguration ? "tour-device" : undefined
+                  )}
                   role="row"
                   tabindex="0"
                   data-configuration=${row.original.config}

--- a/src/components/dashboard/device-table-tour.ts
+++ b/src/components/dashboard/device-table-tour.ts
@@ -35,9 +35,10 @@ export class TourTablePageController {
     if (this._pendingRequest === request) return;
     this._pendingRequest = request;
     queueMicrotask(() => {
+      if (this._pendingRequest !== request) return;
+      this._pendingRequest = null;
       if (getActiveTourConfiguration() !== configuration) return;
       this._setPageIndex(pageIndex);
-      this._pendingRequest = null;
     });
   }
 }

--- a/src/components/dashboard/device-table-tour.ts
+++ b/src/components/dashboard/device-table-tour.ts
@@ -1,0 +1,53 @@
+import { getActiveTourConfiguration } from "../guided-tour/tour-session.js";
+import { ALL_PAGE_SIZE } from "./pagination.js";
+
+interface TourRow {
+  original: { config: string };
+}
+
+export class TourTablePageController {
+  private _pendingRequest: string | null = null;
+
+  constructor(private readonly _setPageIndex: (pageIndex: number) => void) {}
+
+  ensureTargetPage(
+    rows: readonly TourRow[],
+    configuredPageSize: number,
+    effectivePageSize: number,
+    effectivePageIndex: number
+  ): void {
+    const configuration = getActiveTourConfiguration();
+    if (!configuration || configuredPageSize === ALL_PAGE_SIZE) {
+      this._pendingRequest = null;
+      return;
+    }
+    const rowIndex = rows.findIndex((row) => row.original.config === configuration);
+    if (rowIndex < 0) {
+      this._pendingRequest = null;
+      return;
+    }
+    const pageIndex = Math.floor(rowIndex / effectivePageSize);
+    if (pageIndex === effectivePageIndex) {
+      this._pendingRequest = null;
+      return;
+    }
+    const request = `${configuration}:${pageIndex}`;
+    if (this._pendingRequest === request) return;
+    this._pendingRequest = request;
+    queueMicrotask(() => {
+      if (getActiveTourConfiguration() !== configuration) return;
+      this._setPageIndex(pageIndex);
+      this._pendingRequest = null;
+    });
+  }
+}
+
+export function scrollTableConfigurationIntoView(
+  root: ShadowRoot | null,
+  configuration: string
+): void {
+  const row = root?.querySelector<HTMLElement>(
+    `tr[data-configuration="${CSS.escape(configuration)}"]`
+  );
+  row?.scrollIntoView({ behavior: "instant", block: "center" });
+}

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -42,7 +42,13 @@ import { matchesDeviceRow } from "../../util/device-search.js";
 import { showPendingChanges, showUpdateAvailable } from "../../util/device-sync.js";
 import { labelChipStyles, resolveLabelIds } from "../../util/label-chip-template.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { TourActivityController } from "../guided-tour/tour-activity-controller.js";
+import { getActiveTourConfiguration } from "../guided-tour/tour-session.js";
 import { renderDeviceTableBody, renderDeviceTableHead } from "./device-table-grid.js";
+import {
+  scrollTableConfigurationIntoView,
+  TourTablePageController,
+} from "./device-table-tour.js";
 import { tableCellStyles } from "./table-cell-styles.js";
 import type { ToggleableColumn } from "./table-column-toggle.js";
 import { createDeviceColumns, type DeviceRow } from "./table-columns.js";
@@ -76,14 +82,11 @@ registerMdiIcons({
   upload: mdiUpload,
 });
 
-// ─── Cached row-model factories (created once, reused forever) ───
-
 const coreRowModel = getCoreRowModel<DeviceRow>();
 const sortedRowModel = getSortedRowModel<DeviceRow>();
 const filteredRowModel = getFilteredRowModel<DeviceRow>();
 const paginatedRowModel = getPaginationRowModel<DeviceRow>();
 
-// Columns hidden by default unless the user explicitly enables them via preferences.
 const DEFAULT_HIDDEN_COLUMNS: VisibilityState = {
   comment: false,
   area: false,
@@ -96,6 +99,8 @@ const DEFAULT_HIDDEN_COLUMNS: VisibilityState = {
 
 @customElement("esphome-device-table")
 export class ESPHomeDeviceTable extends LitElement {
+  private _tourActivity = new TourActivityController(this);
+
   @consume({ context: localizeContext, subscribe: true })
   @state()
   private _localize: LocalizeFunc = (key) => key;
@@ -154,6 +159,10 @@ export class ESPHomeDeviceTable extends LitElement {
 
   @state()
   private _contextMenuDevice: ConfiguredDevice | null = null;
+
+  private _tourPage = new TourTablePageController((pageIndex) => {
+    this._pageIndex = pageIndex;
+  });
 
   @state()
   private _contextMenuPos: { x: number; y: number } | null = null;
@@ -223,6 +232,7 @@ export class ESPHomeDeviceTable extends LitElement {
     _columnId: string,
     filterValue: unknown
   ): boolean => {
+    if (row.original.config === getActiveTourConfiguration()) return true;
     // Full-text matching lives in util/device-search.ts so the
     // dashboard's select-all scoping helper matches the same rows
     // this filter makes visible (single source of truth).
@@ -306,8 +316,6 @@ export class ESPHomeDeviceTable extends LitElement {
 
   static styles = [espHomeStyles, tableCellStyles, tableLayoutStyles, labelChipStyles];
 
-  // ─── Render ───
-
   protected render() {
     const effectivePageSize = effectiveTablePageSize(this._pageSize, this._rows.length);
     const effectivePageIndex = this._pageSize === ALL_PAGE_SIZE ? 0 : this._pageIndex;
@@ -330,6 +338,12 @@ export class ESPHomeDeviceTable extends LitElement {
       globalFilterFn: this._globalFilterFn,
     });
 
+    this._tourPage.ensureTargetPage(
+      table.getSortedRowModel().rows,
+      this._pageSize,
+      effectivePageSize,
+      effectivePageIndex
+    );
     const rows = table.getRowModel().rows;
     this._visibleConfigs = table.getFilteredRowModel().rows.map((r) => r.original.config);
     const pgState = table.getState().pagination;
@@ -516,23 +530,9 @@ export class ESPHomeDeviceTable extends LitElement {
     );
   }
 
-  /** Scroll the row matching *configuration* into view.
-   *
-   *  Exposed so the dashboard can highlight a freshly-adopted device
-   *  without reaching across the table's shadow-DOM boundary —
-   *  ``shadowRoot.querySelector`` from the dashboard can't see rows
-   *  rendered in this component's shadow root. No-op when the row
-   *  isn't on the current page. ``behavior: "instant"`` dodges
-   *  Chrome mobile's smooth-scroll abort and lands the row at the
-   *  intended position — the highlight pulse handles transition
-   *  feedback. */
+  /** Scroll a configuration row without crossing its shadow-DOM boundary. */
   public scrollConfigurationIntoView(configuration: string): void {
-    const root = this.shadowRoot;
-    if (!root) return;
-    const row = root.querySelector<HTMLElement>(
-      `tr[data-configuration="${CSS.escape(configuration)}"]`
-    );
-    row?.scrollIntoView({ behavior: "instant", block: "center" });
+    scrollTableConfigurationIntoView(this.shadowRoot, configuration);
   }
 
   private _onRowKeydown(e: KeyboardEvent, device: ConfiguredDevice) {

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -5,6 +5,8 @@ import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
 import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../util/device-sort.js";
 import { showPendingChanges, showUpdateAvailable } from "../../util/device-sync.js";
 import { buildWebUiUrl } from "../../util/web-ui-url.js";
+import { tourAnchor } from "../guided-tour/tour-anchor.js";
+import { getActiveTourConfiguration } from "../guided-tour/tour-session.js";
 import { downloadYaml, editDevice } from "./actions.js";
 import { renderFacets } from "./render-facets.js";
 import {
@@ -14,6 +16,21 @@ import {
   renderSearchInput,
   renderViewToggle,
 } from "./render-toolbar.js";
+
+function includeTourDevice(
+  devices: ConfiguredDevice[],
+  allDevices: ConfiguredDevice[]
+): ConfiguredDevice[] {
+  const configuration = getActiveTourConfiguration();
+  if (
+    !configuration ||
+    devices.some((device) => device.configuration === configuration)
+  ) {
+    return devices;
+  }
+  const target = allDevices.find((device) => device.configuration === configuration);
+  return target ? [...devices, target] : devices;
+}
 
 export function renderDiscoveredSection(
   host: ESPHomePageDashboard
@@ -96,14 +113,19 @@ export function renderCardGrid(
   host: ESPHomePageDashboard,
   filtered: ConfiguredDevice[]
 ): TemplateResult {
+  const tourConfiguration = getActiveTourConfiguration();
+  const visibleDevices = includeTourDevice(filtered, host._devices);
   return html`
     <div class="devices-grid devices-grid--configured">
       ${host._devices.length === 0 ? renderAddDeviceCard(host) : ""}
-      ${filtered.map((device) => {
+      ${visibleDevices.map((device) => {
         const webUrl = buildWebUiUrl(device);
         const rt = device.runtime_state;
         return html`
           <esphome-device-card
+            ${tourAnchor(
+              device.configuration === tourConfiguration ? "tour-device" : undefined
+            )}
             data-configuration=${device.configuration}
             .name=${device.friendly_name || device.name}
             .configuration=${device.configuration}
@@ -148,7 +170,10 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
   // Sorted input so the no-column-sort default matches the card grid's
   // collator order instead of the backend's path order (#1917); an active
   // column sort still re-sorts on top.
-  const filteredDevices = host._applyFacetFilters(host._sortedDevices);
+  const filteredDevices = includeTourDevice(
+    host._applyFacetFilters(host._sortedDevices),
+    host._sortedDevices
+  );
   return html`
     <esphome-device-table
       .devices=${filteredDevices}
@@ -211,6 +236,7 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
         host._hideDeviceCreation
           ? ""
           : html`<button
+              ${tourAnchor("create-device-fab")}
               slot="actions"
               class="table-create-btn"
               @click=${() => host._createDialog.open()}

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -2,7 +2,11 @@ import type { SortingState, VisibilityState } from "@tanstack/lit-table";
 import { html, type TemplateResult } from "lit";
 import type { AdoptableDevice, ConfiguredDevice } from "../../api/types/devices.js";
 import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
-import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../util/device-sort.js";
+import {
+  DEVICE_SORT_COLLATOR,
+  deviceSortKey,
+  sortDevices,
+} from "../../util/device-sort.js";
 import { showPendingChanges, showUpdateAvailable } from "../../util/device-sync.js";
 import { buildWebUiUrl } from "../../util/web-ui-url.js";
 import { tourAnchor } from "../guided-tour/tour-anchor.js";
@@ -29,7 +33,7 @@ function includeTourDevice(
     return devices;
   }
   const target = allDevices.find((device) => device.configuration === configuration);
-  return target ? [...devices, target] : devices;
+  return target ? sortDevices([...devices, target]) : devices;
 }
 
 export function renderDiscoveredSection(

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -39,6 +39,7 @@ import {
   tourAnchor,
   type TourRevealEventDetail,
 } from "../guided-tour/tour-anchor.js";
+import { TOUR_LAYOUT_CHANGE_EVENT } from "../guided-tour/tour-layout-controller.js";
 import type { ESPHomeYamlEditor, HighlightRange } from "../yaml-editor.js";
 import { renderEditorToolbar } from "./device-editor-toolbar.js";
 import { deviceEditorStyles } from "./device-editor.styles.js";
@@ -139,7 +140,15 @@ export class ESPHomeDeviceEditor extends LitElement {
   private _onTourReveal = (event: Event): void => {
     const { id } = (event as CustomEvent<TourRevealEventDetail>).detail;
     const next = layoutRevealingAnchor(id, this.layout, this._isMobile);
-    if (next) this._setLayout(next);
+    if (next) {
+      this.dispatchEvent(
+        new CustomEvent(TOUR_LAYOUT_CHANGE_EVENT, {
+          detail: next,
+          bubbles: true,
+          composed: true,
+        })
+      );
+    }
   };
 
   @property({ attribute: false })

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -480,7 +480,12 @@ export class ESPHomeDeviceNavigator extends LitElement {
                     filtering,
                     selectedLine: this._selectedLine,
                     hoveredLine: this._hoveredLine,
-                    tourAnchorId: i === 0 && this.tourAnchorId ? "nav-core" : undefined,
+                    tourAnchorId:
+                      i === 0 && this.tourAnchorId
+                        ? this.classList.contains("drawer-nav")
+                          ? "nav-mobile-core"
+                          : "nav-core"
+                        : undefined,
                     // Omitted when empty (the steady state) so rows skip
                     // the per-render key construction entirely.
                     errorCount: this.errorCounts.size

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -480,6 +480,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
                     filtering,
                     selectedLine: this._selectedLine,
                     hoveredLine: this._hoveredLine,
+                    tourAnchorId: i === 0 && this.tourAnchorId ? "nav-core" : undefined,
                     // Omitted when empty (the steady state) so rows skip
                     // the per-render key construction entirely.
                     errorCount: this.errorCounts.size

--- a/src/components/device/navigator-render.ts
+++ b/src/components/device/navigator-render.ts
@@ -211,8 +211,8 @@ export function renderNavSection(v: NavSectionView): TemplateResult | typeof not
       tabindex=${ifDefined(v.filtering ? undefined : "0")}
       aria-expanded=${ifDefined(v.filtering ? undefined : v.open ? "true" : "false")}
       ${tourAnchor(v.tourAnchorId)}
-      @click=${v.filtering ? nothing : v.onToggle}
-      @keydown=${v.filtering ? nothing : onSectionKeydown}
+      @click=${v.filtering ? undefined : v.onToggle}
+      @keydown=${v.filtering ? undefined : onSectionKeydown}
     >
       <div class="nav-content-label">
         <wa-icon library="mdi" name=${v.icon}></wa-icon>

--- a/src/components/device/navigator-render.ts
+++ b/src/components/device/navigator-render.ts
@@ -191,6 +191,12 @@ function renderNavAction(action: NavAction): TemplateResult {
   </div>`;
 }
 
+function onSectionKeydown(event: KeyboardEvent): void {
+  if (event.key !== "Enter" && event.key !== " ") return;
+  event.preventDefault();
+  (event.currentTarget as HTMLElement).click();
+}
+
 /**
  * One section block: header (collapsible when not filtering), its rows,
  * and the "+ Add X" actions. Returns ``nothing`` while filtering when the
@@ -201,16 +207,12 @@ export function renderNavSection(v: NavSectionView): TemplateResult | typeof not
   return html`
     <div
       class="nav-content"
-      role="button"
-      tabindex="0"
-      aria-expanded=${v.open ? "true" : "false"}
+      role=${ifDefined(v.filtering ? undefined : "button")}
+      tabindex=${ifDefined(v.filtering ? undefined : "0")}
+      aria-expanded=${ifDefined(v.filtering ? undefined : v.open ? "true" : "false")}
       ${tourAnchor(v.tourAnchorId)}
-      @click=${() => v.onToggle()}
-      @keydown=${(event: KeyboardEvent) => {
-        if (event.key !== "Enter" && event.key !== " ") return;
-        event.preventDefault();
-        (event.currentTarget as HTMLElement).click();
-      }}
+      @click=${v.filtering ? nothing : v.onToggle}
+      @keydown=${v.filtering ? nothing : onSectionKeydown}
     >
       <div class="nav-content-label">
         <wa-icon library="mdi" name=${v.icon}></wa-icon>

--- a/src/components/device/navigator-render.ts
+++ b/src/components/device/navigator-render.ts
@@ -203,6 +203,7 @@ export function renderNavSection(v: NavSectionView): TemplateResult | typeof not
       class="nav-content"
       role="button"
       tabindex="0"
+      aria-expanded=${v.open ? "true" : "false"}
       ${tourAnchor(v.tourAnchorId)}
       @click=${() => v.onToggle()}
       @keydown=${(event: KeyboardEvent) => {

--- a/src/components/device/navigator-render.ts
+++ b/src/components/device/navigator-render.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { withBase } from "../../util/base-path.js";
+import { tourAnchor } from "../guided-tour/tour-anchor.js";
 import type { YamlSection } from "../../util/yaml-sections.js";
 import type { NavGroup } from "./navigator-groups.js";
 import { type NavRow, prettyDomain } from "./navigator-labels.js";
@@ -24,6 +25,7 @@ export interface NavSectionView {
   filtering: boolean;
   selectedLine: number | null;
   hoveredLine: number | null;
+  tourAnchorId?: string;
   /** Backend validation errors attributed to a row's section instance. */
   errorCount?: (item: YamlSection) => number;
   /** Localized accessible label for an error badge carrying count errors. */
@@ -194,7 +196,18 @@ function renderNavAction(action: NavAction): TemplateResult {
 export function renderNavSection(v: NavSectionView): TemplateResult | typeof nothing {
   if (v.filtering && v.rows.length === 0) return nothing;
   return html`
-    <div class="nav-content" @click=${() => v.onToggle()}>
+    <div
+      class="nav-content"
+      role="button"
+      tabindex="0"
+      ${tourAnchor(v.tourAnchorId)}
+      @click=${() => v.onToggle()}
+      @keydown=${(event: KeyboardEvent) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        (event.currentTarget as HTMLElement).click();
+      }}
+    >
       <div class="nav-content-label">
         <wa-icon library="mdi" name=${v.icon}></wa-icon>
         <p>${v.label}</p>

--- a/src/components/device/navigator-render.ts
+++ b/src/components/device/navigator-render.ts
@@ -82,6 +82,9 @@ function renderNavRow(row: NavRow, v: NavSectionView, showIcon: boolean): Templa
       class="nav-item ${
         v.selectedLine === item.fromLine ? "nav-item--selected" : ""
       } ${v.hoveredLine === item.fromLine ? "nav-item--hovered" : ""}"
+      ${tourAnchor(
+        item.key === "esphome" && v.tourAnchorId ? `${v.tourAnchorId}-item` : undefined
+      )}
       @mouseenter=${() => v.onItemEnter(item)}
       @mouseleave=${() => v.onItemLeave()}
       @click=${() => v.onItemClick(item)}

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -29,6 +29,7 @@ import {
   importableDevicesContext,
   localizeContext,
   onboardingPendingContext,
+  remoteComputeOnlyContext,
 } from "../context/index.js";
 import { dropdownMenuStyles } from "../styles/dropdown-menu.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -107,6 +108,10 @@ export class ESPHomeHeaderActions extends OverflowMenuElement {
   @consume({ context: onboardingPendingContext, subscribe: true })
   @state()
   private _onboardingPending = false;
+
+  @consume({ context: remoteComputeOnlyContext, subscribe: true })
+  @state()
+  private _remoteComputeOnly = false;
 
   /** Adoptable / ignored discoveries. Subscribed here so the
    *  kebab can gate the "Show ignored discoveries" entry on the
@@ -335,18 +340,22 @@ export class ESPHomeHeaderActions extends OverflowMenuElement {
                   <span class="menu-item-label">${this._localize("layout.search")}</span>
                   <kbd class="menu-item-shortcut">${searchShortcut}</kbd>
                 </div>
-                <div
-                  class="menu-item"
-                  role="menuitem"
-                  tabindex="0"
-                  @click=${this._openGuidedTour}
-                  @keydown=${this._onItemKeydown}
-                >
-                  <wa-icon library="mdi" name="compass-outline"></wa-icon>
-                  <span class="menu-item-label"
-                    >${this._localize("layout.guided_tour")}</span
-                  >
-                </div>
+                ${
+                  this._remoteComputeOnly
+                    ? nothing
+                    : html`<div
+                        class="menu-item"
+                        role="menuitem"
+                        tabindex="0"
+                        @click=${this._openGuidedTour}
+                        @keydown=${this._onItemKeydown}
+                      >
+                        <wa-icon library="mdi" name="compass-outline"></wa-icon>
+                        <span class="menu-item-label"
+                          >${this._localize("layout.guided_tour")}</span
+                        >
+                      </div>`
+                }
                 <div class="menu-divider" role="separator"></div>
                 <div
                   class="menu-item"

--- a/src/components/guided-tour/esphome-guided-tour.styles.ts
+++ b/src/components/guided-tour/esphome-guided-tour.styles.ts
@@ -40,7 +40,53 @@ export const guidedTourStyles = css`
     box-sizing: border-box;
   }
 
+  .recovery-bubble {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: min(320px, calc(100vw - 32px));
+    transform: translate(-50%, -50%);
+  }
+
+  .btn-step-close {
+    position: absolute;
+    top: var(--wa-space-s);
+    right: var(--wa-space-s);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    color: var(--wa-color-text-quiet);
+  }
+
+  .btn-step-close:hover,
+  .btn-step-close.hovered {
+    color: var(--wa-color-text-normal);
+    background: var(--wa-color-surface-lowered);
+  }
+
+  .btn-step-close wa-icon {
+    font-size: 18px;
+  }
+
+  .tour-header {
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-s);
+    padding: 0 var(--wa-space-xl) var(--wa-space-s) 0;
+    border-bottom: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+  }
+
+  .tour-name {
+    font-size: var(--wa-font-size-xs);
+    font-weight: var(--wa-font-weight-bold);
+    color: var(--wa-color-text-normal);
+  }
+
   .step-label {
+    margin-left: auto;
     font-size: 11px;
     font-weight: var(--wa-font-weight-bold);
     letter-spacing: 0.07em;
@@ -49,7 +95,7 @@ export const guidedTourStyles = css`
   }
 
   .bubble h2 {
-    margin: var(--wa-space-2xs) 0 0;
+    margin: var(--wa-space-xs) 0 0;
     font-size: var(--wa-font-size-m);
     font-weight: var(--wa-font-weight-bold);
   }

--- a/src/components/guided-tour/esphome-guided-tour.ts
+++ b/src/components/guided-tour/esphome-guided-tour.ts
@@ -116,12 +116,9 @@ export class ESPHomeGuidedTour extends LitElement {
     super.disconnectedCallback();
     window.removeEventListener(TOUR_ANCHOR_EVENT, this._onAnchorEvent);
     window.removeEventListener("popstate", this._onPopState);
-    this._unbindTourListeners();
-    this._teardownClicks();
-    this._observeTarget(null);
+    this._deactivate();
     this._resizeObserver?.disconnect();
     this._resizeObserver = undefined;
-    setTourActive(false);
   }
 
   start(stepIndex = 0): void {

--- a/src/components/guided-tour/esphome-guided-tour.ts
+++ b/src/components/guided-tour/esphome-guided-tour.ts
@@ -1,14 +1,17 @@
 import { consume } from "@lit/context";
+import { mdiClose } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
-import { styleMap } from "lit/directives/style-map.js";
 import type { LocalizeFunc } from "../../common/localize.js";
-import { localizeContext } from "../../context/index.js";
+import { localizeContext, remoteComputeOnlyContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { stripBase } from "../../util/base-path.js";
 import { navigate } from "../../util/navigation.js";
 import { isTypingTarget } from "../../util/typing-target.js";
+import { registerMdiIcons } from "../../util/register-icons.js";
 import { guidedTourStyles } from "./esphome-guided-tour.styles.js";
+import { renderTourBubble, renderTourRecovery } from "./tour-bubble.js";
+import { TOUR_LAYOUT_RESTORE_EVENT } from "./tour-layout-controller.js";
 import {
   TOUR_ANCHOR_EVENT,
   requestTourReveal,
@@ -20,9 +23,19 @@ import {
   type Rect,
   type TourFrame,
 } from "./tour-geometry.js";
-import { clearTourSuggestedName, setTourSuggestedName } from "./tour-session.js";
+import {
+  clearTourConfiguration,
+  clearTourPending,
+  clearTourSuggestedName,
+  getPendingTourStep,
+  getTourConfiguration,
+  setTourConfiguration,
+  setTourActive,
+  setTourPending,
+  setTourSuggestedName,
+} from "./tour-session.js";
 import { TourSkipAffordance } from "./tour-skip-affordance.js";
-import { renderTourSpotlightBackdrop, tourSpotlightStyles } from "./tour-spotlight.js";
+import { tourSpotlightStyles } from "./tour-spotlight.js";
 import {
   DIALOG_ANCHORS,
   STARTER_DEVICE_NAME,
@@ -30,18 +43,28 @@ import {
   type TourStep,
 } from "./tour-steps.js";
 
+import "@home-assistant/webawesome/dist/components/icon/icon.js";
+
+registerMdiIcons({ close: mdiClose });
+
 @customElement("esphome-guided-tour")
 export class ESPHomeGuidedTour extends LitElement {
   @consume({ context: localizeContext, subscribe: true })
   @state()
   private _localize: LocalizeFunc = (key) => key;
 
+  @consume({ context: remoteComputeOnlyContext, subscribe: true })
+  @state()
+  private _remoteComputeOnly = false;
+
   @state() private _active = false;
   @state() private _stepIndex = 0;
   @state() private _frame: TourFrame | null = null;
+  @state() private _showAnchorRecovery = false;
 
   @query(".tour-popover") private _popover?: HTMLElement;
   @query(".btn-skip") private _skipButton?: HTMLElement;
+  @query(".btn-pause") private _pauseButton?: HTMLElement;
 
   private readonly _anchors = new Map<string, Element>();
 
@@ -51,12 +74,16 @@ export class ESPHomeGuidedTour extends LitElement {
   private _revealRequested = false;
   private _reflowScheduled = false;
   private _tourListenersBound = false;
+  private _anchorRecoveryTimer?: number;
+  private _dialogReady = false;
 
   private readonly _skipAffordance = new TourSkipAffordance(this, {
     isDialogStep: () =>
       this._active && this._step.anchors.some((a) => DIALOG_ANCHORS.has(a)),
     skipRect: () => this._skipButton?.getBoundingClientRect(),
+    pauseRect: () => this._pauseButton?.getBoundingClientRect(),
     onSkip: () => this._skip(),
+    onPause: () => this._pause(),
   });
 
   private _observeTarget(el: Element | null): void {
@@ -89,17 +116,45 @@ export class ESPHomeGuidedTour extends LitElement {
     this._observeTarget(null);
     this._resizeObserver?.disconnect();
     this._resizeObserver = undefined;
+    setTourActive(false);
   }
 
   start(stepIndex = 0): void {
+    if (this._remoteComputeOnly) {
+      clearTourConfiguration();
+      clearTourPending();
+      return;
+    }
+    this._start(stepIndex, false);
+  }
+
+  private _start(requestedStep: number, resuming: boolean): void {
+    let stepIndex =
+      Number.isInteger(requestedStep) &&
+      requestedStep >= 0 &&
+      requestedStep < TOUR_STEPS.length
+        ? requestedStep
+        : 0;
+    if (
+      resuming &&
+      TOUR_STEPS[stepIndex].anchors.some((anchor) => DIALOG_ANCHORS.has(anchor))
+    ) {
+      stepIndex = 0;
+    }
+    if (!resuming || stepIndex === 0) clearTourConfiguration();
+    if (resuming && TOUR_STEPS[stepIndex].route === "device" && !getTourConfiguration()) {
+      stepIndex = 0;
+    }
+    setTourPending(stepIndex);
     setTourSuggestedName(STARTER_DEVICE_NAME);
     this._active = true;
+    setTourActive(true);
     this._stepIndex = stepIndex;
     this._frame = null;
+    this._dialogReady = false;
     this._revealRequested = false;
     this._bindTourListeners();
-    if (this._step.route === "dashboard" && this._onDeviceRoute()) void navigate("/");
-    this._scheduleMeasure();
+    if (!this._navigateToCurrentStep(resuming)) this._scheduleMeasure();
   }
 
   private _bindTourListeners(): void {
@@ -122,6 +177,10 @@ export class ESPHomeGuidedTour extends LitElement {
 
   protected firstUpdated(): void {
     this._consumeTourStepParam();
+    const pendingStep = getPendingTourStep();
+    if (!this._remoteComputeOnly && !this._active && pendingStep !== null) {
+      this._start(pendingStep, true);
+    }
   }
 
   private _onPopState = (): void => {
@@ -129,7 +188,10 @@ export class ESPHomeGuidedTour extends LitElement {
   };
 
   private _onDialogShown = (): void => {
-    if (this._active && this._step.anchors.some((a) => DIALOG_ANCHORS.has(a))) {
+    if (!this._active) return;
+    this._dialogReady = true;
+    if (this._maybeAutoAdvance()) return;
+    if (this._step.anchors.some((a) => DIALOG_ANCHORS.has(a))) {
       // The dialog's open animation is a transform (no layout-box change), so
       // the target ResizeObserver never fires; re-measure now that it settled.
       this._refresh();
@@ -161,6 +223,48 @@ export class ESPHomeGuidedTour extends LitElement {
     return stripBase(window.location.pathname).startsWith("/device/");
   }
 
+  private _onDashboardRoute(): boolean {
+    const path = stripBase(window.location.pathname);
+    return path === "" || path === "/";
+  }
+
+  /** Returns true when measurement must wait for an async route transition. */
+  private _navigateToCurrentStep(resuming: boolean): boolean {
+    let target: string | null = null;
+    if (this._step.route === "dashboard" && !this._onDashboardRoute()) {
+      target = "/";
+    } else if (resuming && this._step.route === "device" && !this._onDeviceRoute()) {
+      const configuration = getTourConfiguration();
+      if (configuration) target = `/device/${encodeURIComponent(configuration)}`;
+    }
+    if (target === null) return false;
+
+    void navigate(target).then(() => {
+      if (!this._active) return;
+      const arrived =
+        this._step.route === "dashboard"
+          ? this._onDashboardRoute()
+          : this._onDeviceRoute();
+      if (!arrived) {
+        this._pause();
+        return;
+      }
+      this._scheduleMeasure();
+    });
+    return true;
+  }
+
+  private _captureDeviceConfiguration(): void {
+    if (!this._active || !this._onDeviceRoute()) return;
+    const encoded = stripBase(window.location.pathname).slice("/device/".length);
+    if (!encoded) return;
+    try {
+      setTourConfiguration(decodeURIComponent(encoded));
+    } catch {
+      setTourConfiguration(encoded);
+    }
+  }
+
   private _onAnchorEvent = (event: Event): void => {
     const { id, el, action } = (event as CustomEvent<TourAnchorEventDetail>).detail;
     if (action === "register") {
@@ -170,6 +274,7 @@ export class ESPHomeGuidedTour extends LitElement {
     }
     // Anchors register from all over the app; only react while touring.
     if (!this._active) return;
+    this._captureDeviceConfiguration();
     if (this._maybeAutoAdvance()) return;
     this._refresh();
   };
@@ -181,6 +286,10 @@ export class ESPHomeGuidedTour extends LitElement {
     const currentPresent = this._step.anchors.some((a) => this._anchors.has(a));
     const nextPresent = next.anchors.some((a) => this._anchors.has(a));
     if (!currentPresent && nextPresent) {
+      const enteringDialog =
+        !this._step.anchors.some((anchor) => DIALOG_ANCHORS.has(anchor)) &&
+        next.anchors.some((anchor) => DIALOG_ANCHORS.has(anchor));
+      if (enteringDialog && !this._dialogReady) return false;
       this._goToStep(this._stepIndex + 1);
       return true;
     }
@@ -204,7 +313,7 @@ export class ESPHomeGuidedTour extends LitElement {
     if (event.key === "Escape") {
       event.preventDefault();
       event.stopPropagation();
-      this._skip();
+      this._pause();
       return;
     }
 
@@ -230,8 +339,18 @@ export class ESPHomeGuidedTour extends LitElement {
     return els;
   }
 
+  private _actionAnchorEls(): Element[] {
+    const els: Element[] = [];
+    for (const id of this._step.actionAnchors ?? this._step.anchors) {
+      const el = this._anchors.get(id);
+      if (el) els.push(el);
+    }
+    return els;
+  }
+
   private _refresh(): void {
     if (!this._active) {
+      this._clearAnchorRecovery();
       this._teardownClicks();
       this._observeTarget(null);
       this._frame = null;
@@ -241,7 +360,7 @@ export class ESPHomeGuidedTour extends LitElement {
 
     this._teardownClicks();
     if (this._step.kind === "action") {
-      for (const el of present) {
+      for (const el of this._actionAnchorEls()) {
         el.addEventListener("click", this._onAnchorClick);
         this._clickTargets.push(el);
       }
@@ -265,9 +384,11 @@ export class ESPHomeGuidedTour extends LitElement {
         if (presentId) requestTourReveal(presentId);
       }
       if (this._frame !== null) this._frame = null;
+      this._scheduleAnchorRecovery();
       return;
     }
 
+    this._clearAnchorRecovery();
     const appearing = this._frame === null;
     // On first paint of a step, pull an off-screen target into view — the dim
     // backdrop swallows scroll, so a target below the fold (or its bubble)
@@ -325,16 +446,15 @@ export class ESPHomeGuidedTour extends LitElement {
 
   private _goToStep(index: number): void {
     this._teardownClicks();
+    this._clearAnchorRecovery();
     // Consecutive dialog steps keep the affordance active; clear any hover
     // carried across so the cursor can't stay stuck until the next move.
     this._skipAffordance.reset();
     this._stepIndex = index;
+    setTourPending(index);
     this._frame = null;
     this._revealRequested = false;
-    if (this._step.route === "dashboard" && this._onDeviceRoute()) {
-      void navigate("/");
-    }
-    this._scheduleMeasure();
+    if (!this._navigateToCurrentStep(false)) this._scheduleMeasure();
   }
 
   private _next(): void {
@@ -349,15 +469,29 @@ export class ESPHomeGuidedTour extends LitElement {
     this._finish();
   };
 
-  private _finish(): void {
+  private _pause = (): void => {
+    this._deactivate();
+    this.dispatchEvent(new CustomEvent("tour-paused", { bubbles: true, composed: true }));
+  };
+
+  private _deactivate(): void {
+    this._clearAnchorRecovery();
     this._active = false;
+    setTourActive(false);
     this._frame = null;
     this._unbindTourListeners();
     this._skipAffordance.reset();
     this._teardownClicks();
     this._observeTarget(null);
     clearTourSuggestedName();
+    window.dispatchEvent(new Event(TOUR_LAYOUT_RESTORE_EVENT));
     this._hidePopover();
+  }
+
+  private _finish(): void {
+    clearTourConfiguration();
+    clearTourPending();
+    this._deactivate();
     this.dispatchEvent(
       new CustomEvent("tour-finished", { bubbles: true, composed: true })
     );
@@ -373,6 +507,22 @@ export class ESPHomeGuidedTour extends LitElement {
       }
       this._refresh();
     });
+  }
+
+  private _scheduleAnchorRecovery(): void {
+    if (this._anchorRecoveryTimer !== undefined || this._showAnchorRecovery) return;
+    this._anchorRecoveryTimer = window.setTimeout(() => {
+      this._anchorRecoveryTimer = undefined;
+      if (this._active && this._frame === null) this._showAnchorRecovery = true;
+    }, 800);
+  }
+
+  private _clearAnchorRecovery(): void {
+    if (this._anchorRecoveryTimer !== undefined) {
+      clearTimeout(this._anchorRecoveryTimer);
+      this._anchorRecoveryTimer = undefined;
+    }
+    this._showAnchorRecovery = false;
   }
 
   private _showPopover(): void {
@@ -393,6 +543,12 @@ export class ESPHomeGuidedTour extends LitElement {
   }
 
   protected updated(): void {
+    if (this._remoteComputeOnly) {
+      clearTourConfiguration();
+      clearTourPending();
+      if (this._active) this._deactivate();
+      return;
+    }
     const onDialogStep =
       this._active && this._step.anchors.some((a) => DIALOG_ANCHORS.has(a));
     this._skipAffordance.setActive(onDialogStep);
@@ -405,98 +561,25 @@ export class ESPHomeGuidedTour extends LitElement {
 
   protected render() {
     return html`<div class="tour-popover" popover="manual">
-      ${this._active && this._frame ? this._renderSpotlight(this._frame) : nothing}
+      ${
+        this._active && this._frame
+          ? renderTourBubble({
+              frame: this._frame,
+              step: this._step,
+              stepIndex: this._stepIndex,
+              totalSteps: TOUR_STEPS.length,
+              localize: this._localize,
+              skipHover: this._skipAffordance.hover,
+              pauseHover: this._skipAffordance.pauseHover,
+              onPause: this._pause,
+              onSkip: this._skip,
+              onNext: () => this._next(),
+            })
+          : this._active && this._showAnchorRecovery
+            ? renderTourRecovery(this._localize, this._pause, this._skip)
+            : nothing
+      }
     </div>`;
-  }
-
-  private _caretStyle(frame: TourFrame, side: TourStep["side"]): Record<string, string> {
-    const { hole, bubble } = frame;
-    const OUT = "-6px";
-
-    if (side === "left" || side === "right") {
-      const pos = this._caretPos(hole.y, hole.h, bubble.top ?? 0);
-      return side === "right" ? { left: OUT, top: pos } : { right: OUT, top: pos };
-    }
-    const pos = this._caretPos(hole.x, hole.w, bubble.left);
-    return side === "top" ? { bottom: OUT, left: pos } : { top: OUT, left: pos };
-  }
-
-  private _caretPos(start: number, size: number, bubbleStart: number): string {
-    const overlapStart = Math.max(0, start - bubbleStart);
-    const overlapEnd = start + size - bubbleStart;
-    return `clamp(12px, calc((${overlapStart}px + min(100%, ${overlapEnd}px)) / 2 - 6px), calc(100% - 20px))`;
-  }
-
-  private _renderSpotlight(frame: TourFrame) {
-    const { bubble } = frame;
-    const step = this._step;
-    const bubbleStyle: Record<string, string> = {
-      left: `${bubble.left}px`,
-      width: `${bubble.width}px`,
-      ...(bubble.bottom !== undefined
-        ? { bottom: `${bubble.bottom}px` }
-        : { top: `${bubble.top ?? 0}px` }),
-    };
-    return html`
-      ${renderTourSpotlightBackdrop(frame)}
-      <div
-        class="bubble"
-        role="dialog"
-        aria-live="polite"
-        aria-label=${this._localize(step.titleKey)}
-        style=${styleMap(bubbleStyle)}
-      >
-        ${
-          frame.overlay
-            ? nothing
-            : html`<div
-                class="caret"
-                style=${styleMap(this._caretStyle(frame, frame.side))}
-                aria-hidden="true"
-              ></div>`
-        }
-        <div class="step-label">
-          ${this._localize("tour.step_counter", {
-            current: this._stepIndex + 1,
-            total: TOUR_STEPS.length,
-          })}
-        </div>
-        <h2>${this._localize(step.titleKey)}</h2>
-        <p>${this._localize(step.bodyKey)}</p>
-        ${
-          step.kind === "action"
-            ? html`
-                <div class="hint">
-                  <span class="hint-dot" aria-hidden="true"></span>
-                  ${this._localize(step.hintKey ?? "tour.continue")}
-                </div>
-                <div class="actions action-only">
-                  <button
-                    type="button"
-                    class="btn btn-skip ${this._skipAffordance.hover ? "hovered" : ""}"
-                    @click=${this._skip}
-                  >
-                    ${this._localize("tour.skip")}
-                  </button>
-                </div>
-              `
-            : html`
-                <div class="actions">
-                  <button type="button" class="btn btn-skip" @click=${this._skip}>
-                    ${this._localize("tour.skip")}
-                  </button>
-                  <button type="button" class="btn btn-next" @click=${() => this._next()}>
-                    ${
-                      this._stepIndex >= TOUR_STEPS.length - 1
-                        ? this._localize("tour.finish")
-                        : this._localize("tour.next")
-                    }
-                  </button>
-                </div>
-              `
-        }
-      </div>
-    `;
   }
 }
 

--- a/src/components/guided-tour/esphome-guided-tour.ts
+++ b/src/components/guided-tour/esphome-guided-tour.ts
@@ -5,13 +5,13 @@ import { customElement, query, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext, remoteComputeOnlyContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import { stripBase } from "../../util/base-path.js";
-import { navigate } from "../../util/navigation.js";
 import { isTypingTarget } from "../../util/typing-target.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { guidedTourStyles } from "./esphome-guided-tour.styles.js";
 import { renderTourBubble, renderTourRecovery } from "./tour-bubble.js";
 import { TOUR_LAYOUT_RESTORE_EVENT } from "./tour-layout-controller.js";
+import { TourNavigatorController } from "./tour-navigator-controller.js";
+import { captureTourConfiguration, navigateToTourStep } from "./tour-route.js";
 import {
   TOUR_ANCHOR_EVENT,
   requestTourReveal,
@@ -29,7 +29,6 @@ import {
   clearTourSuggestedName,
   getPendingTourStep,
   getTourConfiguration,
-  setTourConfiguration,
   setTourActive,
   setTourPending,
   setTourSuggestedName,
@@ -84,6 +83,12 @@ export class ESPHomeGuidedTour extends LitElement {
     pauseRect: () => this._pauseButton?.getBoundingClientRect(),
     onSkip: () => this._skip(),
     onPause: () => this._pause(),
+  });
+  private readonly _navigator = new TourNavigatorController(this, {
+    isNavigatorStep: () =>
+      this._step.actionAnchors?.some((id) => id.endsWith("core-item")) ?? false,
+    onCoreSelected: () => this._goToStep(this._stepIndex + 1),
+    onReflow: () => this._refresh(),
   });
 
   private _observeTarget(el: Element | null): void {
@@ -154,7 +159,20 @@ export class ESPHomeGuidedTour extends LitElement {
     this._dialogReady = false;
     this._revealRequested = false;
     this._bindTourListeners();
-    if (!this._navigateToCurrentStep(resuming)) this._scheduleMeasure();
+    if (
+      !navigateToTourStep(
+        this._step,
+        resuming,
+        () => {
+          if (this._active) this._scheduleMeasure();
+        },
+        () => {
+          if (this._active) this._pause();
+        }
+      )
+    ) {
+      this._scheduleMeasure();
+    }
   }
 
   private _bindTourListeners(): void {
@@ -164,6 +182,7 @@ export class ESPHomeGuidedTour extends LitElement {
     window.addEventListener("scroll", this._onReflow, true);
     window.addEventListener("keydown", this._onKeydown, true);
     window.addEventListener("wa-after-show", this._onDialogShown);
+    this._navigator.setActive(true);
   }
 
   private _unbindTourListeners(): void {
@@ -173,6 +192,7 @@ export class ESPHomeGuidedTour extends LitElement {
     window.removeEventListener("scroll", this._onReflow, true);
     window.removeEventListener("keydown", this._onKeydown, true);
     window.removeEventListener("wa-after-show", this._onDialogShown);
+    this._navigator.setActive(false);
   }
 
   protected firstUpdated(): void {
@@ -219,52 +239,6 @@ export class ESPHomeGuidedTour extends LitElement {
     return TOUR_STEPS[this._stepIndex];
   }
 
-  private _onDeviceRoute(): boolean {
-    return stripBase(window.location.pathname).startsWith("/device/");
-  }
-
-  private _onDashboardRoute(): boolean {
-    const path = stripBase(window.location.pathname);
-    return path === "" || path === "/";
-  }
-
-  /** Returns true when measurement must wait for an async route transition. */
-  private _navigateToCurrentStep(resuming: boolean): boolean {
-    let target: string | null = null;
-    if (this._step.route === "dashboard" && !this._onDashboardRoute()) {
-      target = "/";
-    } else if (resuming && this._step.route === "device" && !this._onDeviceRoute()) {
-      const configuration = getTourConfiguration();
-      if (configuration) target = `/device/${encodeURIComponent(configuration)}`;
-    }
-    if (target === null) return false;
-
-    void navigate(target).then(() => {
-      if (!this._active) return;
-      const arrived =
-        this._step.route === "dashboard"
-          ? this._onDashboardRoute()
-          : this._onDeviceRoute();
-      if (!arrived) {
-        this._pause();
-        return;
-      }
-      this._scheduleMeasure();
-    });
-    return true;
-  }
-
-  private _captureDeviceConfiguration(): void {
-    if (!this._active || !this._onDeviceRoute()) return;
-    const encoded = stripBase(window.location.pathname).slice("/device/".length);
-    if (!encoded) return;
-    try {
-      setTourConfiguration(decodeURIComponent(encoded));
-    } catch {
-      setTourConfiguration(encoded);
-    }
-  }
-
   private _onAnchorEvent = (event: Event): void => {
     const { id, el, action } = (event as CustomEvent<TourAnchorEventDetail>).detail;
     if (action === "register") {
@@ -274,13 +248,27 @@ export class ESPHomeGuidedTour extends LitElement {
     }
     // Anchors register from all over the app; only react while touring.
     if (!this._active) return;
-    this._captureDeviceConfiguration();
+    captureTourConfiguration(this._active);
+    if (action === "register" && this._step.anchors.includes(id)) {
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) {
+        requestAnimationFrame(() => {
+          if (this._active && this._step.anchors.includes(id)) this._refresh();
+        });
+      }
+    }
+    if (action === "register" && id === "nav-mobile-core") {
+      this._navigator.anchorRegistered(id, el);
+    }
     if (this._maybeAutoAdvance()) return;
     this._refresh();
   };
 
   private _maybeAutoAdvance(): boolean {
     if (this._step.kind !== "action") return false;
+    // Explicit action anchors must receive their click; visual-anchor churn
+    // (for example opening the mobile navigator drawer) is not completion.
+    if ((this._step.actionAnchors?.length ?? 0) > 0) return false;
     const next = TOUR_STEPS[this._stepIndex + 1];
     if (!next) return false;
     const currentPresent = this._step.anchors.some((a) => this._anchors.has(a));
@@ -454,7 +442,20 @@ export class ESPHomeGuidedTour extends LitElement {
     setTourPending(index);
     this._frame = null;
     this._revealRequested = false;
-    if (!this._navigateToCurrentStep(false)) this._scheduleMeasure();
+    if (
+      !navigateToTourStep(
+        this._step,
+        false,
+        () => {
+          if (this._active) this._scheduleMeasure();
+        },
+        () => {
+          if (this._active) this._pause();
+        }
+      )
+    ) {
+      this._scheduleMeasure();
+    }
   }
 
   private _next(): void {

--- a/src/components/guided-tour/tour-activity-controller.ts
+++ b/src/components/guided-tour/tour-activity-controller.ts
@@ -1,0 +1,20 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { TOUR_ACTIVE_CHANGE_EVENT } from "./tour-session.js";
+
+export class TourActivityController implements ReactiveController {
+  constructor(private readonly _host: ReactiveControllerHost) {
+    _host.addController(this);
+  }
+
+  hostConnected(): void {
+    window.addEventListener(TOUR_ACTIVE_CHANGE_EVENT, this._onChange);
+  }
+
+  hostDisconnected(): void {
+    window.removeEventListener(TOUR_ACTIVE_CHANGE_EVENT, this._onChange);
+  }
+
+  private _onChange = (): void => {
+    this._host.requestUpdate();
+  };
+}

--- a/src/components/guided-tour/tour-bubble.ts
+++ b/src/components/guided-tour/tour-bubble.ts
@@ -1,0 +1,146 @@
+import { html, nothing, type TemplateResult } from "lit";
+import { styleMap } from "lit/directives/style-map.js";
+import type { LocalizeFunc } from "../../common/localize.js";
+import type { TourFrame } from "./tour-geometry.js";
+import { renderTourSpotlightBackdrop } from "./tour-spotlight.js";
+import type { TourStep } from "./tour-steps.js";
+
+interface TourBubbleProps {
+  frame: TourFrame;
+  step: TourStep;
+  stepIndex: number;
+  totalSteps: number;
+  localize: LocalizeFunc;
+  skipHover: boolean;
+  pauseHover: boolean;
+  onPause: () => void;
+  onSkip: () => void;
+  onNext: () => void;
+}
+
+function caretPosition(start: number, size: number, bubbleStart: number): string {
+  const overlapStart = Math.max(0, start - bubbleStart);
+  const overlapEnd = start + size - bubbleStart;
+  return `clamp(12px, calc((${overlapStart}px + min(100%, ${overlapEnd}px)) / 2 - 6px), calc(100% - 20px))`;
+}
+
+function caretStyle(frame: TourFrame): Record<string, string> {
+  const { hole, bubble, side } = frame;
+  const outside = "-6px";
+  if (side === "left" || side === "right") {
+    const top = caretPosition(hole.y, hole.h, bubble.top ?? 0);
+    return side === "right" ? { left: outside, top } : { right: outside, top };
+  }
+  const left = caretPosition(hole.x, hole.w, bubble.left);
+  return side === "top" ? { bottom: outside, left } : { top: outside, left };
+}
+
+export function renderTourBubble(p: TourBubbleProps): TemplateResult {
+  const { bubble } = p.frame;
+  const bubbleStyle: Record<string, string> = {
+    left: `${bubble.left}px`,
+    width: `${bubble.width}px`,
+    ...(bubble.bottom !== undefined
+      ? { bottom: `${bubble.bottom}px` }
+      : { top: `${bubble.top ?? 0}px` }),
+  };
+  return html`
+    ${renderTourSpotlightBackdrop(p.frame)}
+    <div
+      class="bubble"
+      role="dialog"
+      aria-live="polite"
+      aria-label=${p.localize(p.step.titleKey)}
+      style=${styleMap(bubbleStyle)}
+    >
+      <button
+        type="button"
+        class="btn btn-step-close btn-pause ${p.pauseHover ? "hovered" : ""}"
+        aria-label=${p.localize("tour.pause")}
+        title=${p.localize("tour.pause")}
+        @click=${p.onPause}
+      >
+        <wa-icon library="mdi" name="close" aria-hidden="true"></wa-icon>
+      </button>
+      ${
+        p.frame.overlay
+          ? nothing
+          : html`<div
+              class="caret"
+              style=${styleMap(caretStyle(p.frame))}
+              aria-hidden="true"
+            ></div>`
+      }
+
+      <div class="tour-header">
+        <span class="tour-name">${p.localize("tour.header")}</span>
+        <span class="step-label">
+          ${p.localize("tour.step_counter", {
+            current: p.stepIndex + 1,
+            total: p.totalSteps,
+          })}
+        </span>
+      </div>
+      <h2>${p.localize(p.step.titleKey)}</h2>
+      <p>${p.localize(p.step.bodyKey)}</p>
+      ${
+        p.step.kind === "action"
+          ? html`
+              <div class="hint">
+                <span class="hint-dot" aria-hidden="true"></span>
+                ${p.localize(p.step.hintKey ?? "tour.continue")}
+              </div>
+              <div class="actions action-only">
+                <button
+                  type="button"
+                  class="btn btn-skip ${p.skipHover ? "hovered" : ""}"
+                  @click=${p.onSkip}
+                >
+                  ${p.localize("tour.skip")}
+                </button>
+              </div>
+            `
+          : html`
+              <div class="actions">
+                <button type="button" class="btn btn-skip" @click=${p.onSkip}>
+                  ${p.localize("tour.skip")}
+                </button>
+                <button type="button" class="btn btn-next" @click=${p.onNext}>
+                  ${
+                    p.stepIndex >= p.totalSteps - 1
+                      ? p.localize("tour.finish")
+                      : p.localize(p.step.nextLabelKey ?? "tour.next")
+                  }
+                </button>
+              </div>
+            `
+      }
+    </div>
+  `;
+}
+
+export function renderTourRecovery(
+  localize: LocalizeFunc,
+  onPause: () => void,
+  onSkip: () => void
+): TemplateResult {
+  return html`
+    <div
+      class="bubble recovery-bubble"
+      role="dialog"
+      aria-live="polite"
+      aria-label=${localize("tour.unavailable_title")}
+    >
+      <h2>${localize("tour.unavailable_title")}</h2>
+      <p>${localize("tour.unavailable_body")}</p>
+      <div class="actions">
+        <button type="button" class="btn btn-skip" @click=${onSkip}>
+          ${localize("tour.skip")}
+        </button>
+        <button type="button" class="btn btn-next btn-pause" @click=${onPause}>
+          ${localize("tour.pause")}
+        </button>
+      </div>
+    </div>
+  `;
+}

--- a/src/components/guided-tour/tour-geometry.ts
+++ b/src/components/guided-tour/tour-geometry.ts
@@ -19,10 +19,6 @@ export interface Box {
   h: number;
 }
 
-export interface Ring extends Box {
-  radius: number;
-}
-
 export interface Bubble {
   left: number;
   top?: number;
@@ -32,7 +28,6 @@ export interface Bubble {
 
 export interface TourFrame {
   hole: Box;
-  ring: Ring;
   dim: { top: Box; bottom: Box; left: Box; right: Box };
   bubble: Bubble;
   side: Side;
@@ -44,7 +39,6 @@ export interface TourFrame {
 export const SPOTLIGHT_PADDING = 6;
 export const BUBBLE_WIDTH = 300;
 export const BUBBLE_GAP = 16;
-const RING_MAX_RADIUS = 14;
 const EDGE_MARGIN = 16;
 const BUBBLE_BOTTOM_RESERVE = 200;
 const BUBBLE_HEIGHT_EST = 220;
@@ -169,7 +163,6 @@ export function computeTourFrame(
   options: { pad?: number; bubbleWidth?: number } = {}
 ): TourFrame {
   const hole = computeHole(rect, options.pad);
-  const ring: Ring = { ...hole, radius: Math.min(hole.h / 2, RING_MAX_RADIUS) };
   const width = options.bubbleWidth;
 
   const candidates = SIDE_ORDER[side].map((candidate) => ({
@@ -181,7 +174,7 @@ export function computeTourFrame(
   const fitting = clear.find(({ bubble }) => bubbleFitsViewport(bubble, vp));
   const dim = computeDim(hole, vp);
   if (fitting) {
-    return { hole, ring, dim, bubble: fitting.bubble, side: fitting.candidate };
+    return { hole, dim, bubble: fitting.bubble, side: fitting.candidate };
   }
 
   // A near-full-screen hole leaves no side that both clears it and stays on
@@ -197,5 +190,5 @@ export function computeTourFrame(
     width: w,
   };
   // `side` is only read for caret placement, which overlay frames skip.
-  return { hole, ring, dim, bubble: overlay, side, overlay: true };
+  return { hole, dim, bubble: overlay, side, overlay: true };
 }

--- a/src/components/guided-tour/tour-geometry.ts
+++ b/src/components/guided-tour/tour-geometry.ts
@@ -42,6 +42,7 @@ export const BUBBLE_GAP = 16;
 const EDGE_MARGIN = 16;
 const BUBBLE_BOTTOM_RESERVE = 200;
 const BUBBLE_HEIGHT_EST = 220;
+const COMPACT_BUBBLE_HEIGHT_EST = 340;
 
 const SIDE_ORDER: Record<Side, Side[]> = {
   right: ["right", "left", "top", "bottom"],
@@ -128,18 +129,23 @@ function computeBubble(
 
 /** The bubble's estimated top edge in viewport coordinates. */
 function bubbleTop(bubble: Bubble, vp: Viewport): number {
-  return bubble.bottom !== undefined
-    ? vp.h - bubble.bottom - BUBBLE_HEIGHT_EST
-    : (bubble.top ?? 0);
+  const height = bubbleHeightEstimate(vp);
+  return bubble.bottom !== undefined ? vp.h - bubble.bottom - height : (bubble.top ?? 0);
+}
+
+/** Long localized copy reaches ~310px on phones; desktop copy is much wider. */
+function bubbleHeightEstimate(vp: Viewport): number {
+  return vp.w <= 600 || vp.h <= 600 ? COMPACT_BUBBLE_HEIGHT_EST : BUBBLE_HEIGHT_EST;
 }
 
 function bubbleCoversHole(bubble: Bubble, vp: Viewport, hole: Box): boolean {
   const top = bubbleTop(bubble, vp);
+  const height = bubbleHeightEstimate(vp);
   const b = {
     l: bubble.left,
     r: bubble.left + bubble.width,
     t: top,
-    b: top + BUBBLE_HEIGHT_EST,
+    b: top + height,
   };
   return !(
     b.r <= hole.x ||
@@ -153,7 +159,7 @@ function bubbleCoversHole(bubble: Bubble, vp: Viewport, hole: Box): boolean {
  *  margins (horizontal placement is already clamped in `computeBubble`). */
 function bubbleFitsViewport(bubble: Bubble, vp: Viewport): boolean {
   const top = bubbleTop(bubble, vp);
-  return top >= EDGE_MARGIN && top + BUBBLE_HEIGHT_EST <= vp.h - EDGE_MARGIN;
+  return top >= EDGE_MARGIN && top + bubbleHeightEstimate(vp) <= vp.h - EDGE_MARGIN;
 }
 
 export function computeTourFrame(
@@ -185,7 +191,7 @@ export function computeTourFrame(
     top: clamp(
       hole.y + BUBBLE_GAP,
       EDGE_MARGIN,
-      Math.max(EDGE_MARGIN, vp.h - BUBBLE_HEIGHT_EST - EDGE_MARGIN)
+      Math.max(EDGE_MARGIN, vp.h - bubbleHeightEstimate(vp) - EDGE_MARGIN)
     ),
     width: w,
   };

--- a/src/components/guided-tour/tour-layout-controller.ts
+++ b/src/components/guided-tour/tour-layout-controller.ts
@@ -1,0 +1,44 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+
+export const TOUR_LAYOUT_CHANGE_EVENT = "esphome-tour-layout-change";
+export const TOUR_LAYOUT_RESTORE_EVENT = "esphome-tour-layout-restore";
+
+export class TourLayoutController<T> implements ReactiveController {
+  private _previous: T | null = null;
+
+  constructor(
+    host: ReactiveControllerHost,
+    private readonly _getLayout: () => T,
+    private readonly _setLayout: (layout: T) => void
+  ) {
+    host.addController(this);
+  }
+
+  hostConnected(): void {
+    window.addEventListener(TOUR_LAYOUT_CHANGE_EVENT, this._onChange);
+    window.addEventListener(TOUR_LAYOUT_RESTORE_EVENT, this._onRestore);
+    window.addEventListener("layout-change", this._onUserChange);
+  }
+
+  hostDisconnected(): void {
+    window.removeEventListener(TOUR_LAYOUT_CHANGE_EVENT, this._onChange);
+    window.removeEventListener(TOUR_LAYOUT_RESTORE_EVENT, this._onRestore);
+    window.removeEventListener("layout-change", this._onUserChange);
+    this._previous = null;
+  }
+
+  private _onChange = (event: Event): void => {
+    if (this._previous === null) this._previous = this._getLayout();
+    this._setLayout((event as CustomEvent<T>).detail);
+  };
+
+  private _onRestore = (): void => {
+    if (this._previous === null) return;
+    this._setLayout(this._previous);
+    this._previous = null;
+  };
+
+  private _onUserChange = (): void => {
+    this._previous = null;
+  };
+}

--- a/src/components/guided-tour/tour-navigator-controller.ts
+++ b/src/components/guided-tour/tour-navigator-controller.ts
@@ -1,0 +1,45 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+
+interface TourNavigatorOptions {
+  isNavigatorStep: () => boolean;
+  onCoreSelected: () => void;
+  onReflow: () => void;
+}
+
+export class TourNavigatorController implements ReactiveController {
+  private _active = false;
+
+  constructor(
+    host: ReactiveControllerHost,
+    private readonly _options: TourNavigatorOptions
+  ) {
+    host.addController(this);
+  }
+
+  setActive(active: boolean): void {
+    if (active === this._active) return;
+    this._active = active;
+    if (active) window.addEventListener("section-select", this._onSectionSelect);
+    else window.removeEventListener("section-select", this._onSectionSelect);
+  }
+
+  anchorRegistered(id: string, element: Element): void {
+    if (!this._active || id !== "nav-mobile-core") return;
+    const root = element.getRootNode();
+    const drawer = root instanceof ShadowRoot ? root.host.parentElement : null;
+    drawer?.addEventListener("transitionend", this._options.onReflow, {
+      once: true,
+    });
+  }
+
+  hostDisconnected(): void {
+    this.setActive(false);
+  }
+
+  private _onSectionSelect = (event: Event): void => {
+    const { sectionKey } = (event as CustomEvent<{ sectionKey: string | null }>).detail;
+    if (this._options.isNavigatorStep() && sectionKey === "esphome") {
+      this._options.onCoreSelected();
+    }
+  };
+}

--- a/src/components/guided-tour/tour-route.ts
+++ b/src/components/guided-tour/tour-route.ts
@@ -27,11 +27,18 @@ export function navigateToTourStep(
   }
   if (target === null) return false;
 
-  void navigate(target).then(() => {
+  void (async () => {
+    try {
+      await navigate(target);
+    } catch (err) {
+      console.warn("Guided tour navigation failed:", err);
+      onCancelled();
+      return;
+    }
     const arrived = step.route === "dashboard" ? onDashboardRoute() : onTourDeviceRoute();
     if (arrived) onArrived();
     else onCancelled();
-  });
+  })();
   return true;
 }
 

--- a/src/components/guided-tour/tour-route.ts
+++ b/src/components/guided-tour/tour-route.ts
@@ -1,0 +1,47 @@
+import { stripBase } from "../../util/base-path.js";
+import { navigate } from "../../util/navigation.js";
+import { getTourConfiguration, setTourConfiguration } from "./tour-session.js";
+import type { TourStep } from "./tour-steps.js";
+
+export function onTourDeviceRoute(): boolean {
+  return stripBase(window.location.pathname).startsWith("/device/");
+}
+
+function onDashboardRoute(): boolean {
+  const path = stripBase(window.location.pathname);
+  return path === "" || path === "/";
+}
+
+export function navigateToTourStep(
+  step: TourStep,
+  resuming: boolean,
+  onArrived: () => void,
+  onCancelled: () => void
+): boolean {
+  let target: string | null = null;
+  if (step.route === "dashboard" && !onDashboardRoute()) {
+    target = "/";
+  } else if (resuming && step.route === "device" && !onTourDeviceRoute()) {
+    const configuration = getTourConfiguration();
+    if (configuration) target = `/device/${encodeURIComponent(configuration)}`;
+  }
+  if (target === null) return false;
+
+  void navigate(target).then(() => {
+    const arrived = step.route === "dashboard" ? onDashboardRoute() : onTourDeviceRoute();
+    if (arrived) onArrived();
+    else onCancelled();
+  });
+  return true;
+}
+
+export function captureTourConfiguration(active: boolean): void {
+  if (!active || !onTourDeviceRoute()) return;
+  const encoded = stripBase(window.location.pathname).slice("/device/".length);
+  if (!encoded) return;
+  try {
+    setTourConfiguration(decodeURIComponent(encoded));
+  } catch {
+    setTourConfiguration(encoded);
+  }
+}

--- a/src/components/guided-tour/tour-session.ts
+++ b/src/components/guided-tour/tour-session.ts
@@ -91,6 +91,10 @@ export function setTourActive(active: boolean): void {
   window.dispatchEvent(new Event(TOUR_ACTIVE_CHANGE_EVENT));
 }
 
+export function isTourActive(): boolean {
+  return tourActive;
+}
+
 export function getActiveTourConfiguration(): string | null {
   return tourActive ? getTourConfiguration() : null;
 }

--- a/src/components/guided-tour/tour-session.ts
+++ b/src/components/guided-tour/tour-session.ts
@@ -1,4 +1,8 @@
 const SUGGESTED_NAME_KEY = "esphome.tour-suggested-name";
+const TOUR_PENDING_KEY = "esphome.quickstart-tour-pending";
+const TOUR_CONFIGURATION_KEY = "esphome.quickstart-tour-configuration";
+export const TOUR_ACTIVE_CHANGE_EVENT = "esphome-tour-active-change";
+let tourActive = false;
 
 export function setTourSuggestedName(name: string): void {
   try {
@@ -23,4 +27,70 @@ export function clearTourSuggestedName(): void {
   } catch {
     // Nothing to clear when storage is unavailable — the set failed too.
   }
+}
+
+export function setTourPending(stepIndex = 0): void {
+  try {
+    localStorage.setItem(TOUR_PENDING_KEY, String(stepIndex));
+  } catch {
+    // Persistence is best-effort when browser storage is unavailable.
+  }
+}
+
+export function getPendingTourStep(): number | null {
+  try {
+    const raw = localStorage.getItem(TOUR_PENDING_KEY);
+    if (raw === null) return null;
+    if (raw === "true") return 0;
+    const step = Number(raw);
+    return Number.isInteger(step) && step >= 0 ? step : 0;
+  } catch {
+    return null;
+  }
+}
+
+export function isTourPending(): boolean {
+  return getPendingTourStep() !== null;
+}
+
+export function clearTourPending(): void {
+  try {
+    localStorage.removeItem(TOUR_PENDING_KEY);
+  } catch {
+    // Persistence is best-effort when browser storage is unavailable.
+  }
+}
+
+export function setTourConfiguration(configuration: string): void {
+  try {
+    localStorage.setItem(TOUR_CONFIGURATION_KEY, configuration);
+  } catch {
+    // Persistence is best-effort when browser storage is unavailable.
+  }
+}
+
+export function getTourConfiguration(): string | null {
+  try {
+    return localStorage.getItem(TOUR_CONFIGURATION_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function clearTourConfiguration(): void {
+  try {
+    localStorage.removeItem(TOUR_CONFIGURATION_KEY);
+  } catch {
+    // Persistence is best-effort when browser storage is unavailable.
+  }
+}
+
+export function setTourActive(active: boolean): void {
+  if (tourActive === active) return;
+  tourActive = active;
+  window.dispatchEvent(new Event(TOUR_ACTIVE_CHANGE_EVENT));
+}
+
+export function getActiveTourConfiguration(): string | null {
+  return tourActive ? getTourConfiguration() : null;
 }

--- a/src/components/guided-tour/tour-skip-affordance.ts
+++ b/src/components/guided-tour/tour-skip-affordance.ts
@@ -5,23 +5,26 @@ export interface TourSkipAffordanceOptions {
   isDialogStep: () => boolean;
   /** The Skip button's current viewport rect (undefined when not rendered). */
   skipRect: () => DOMRect | undefined;
+  /** The Close-for-now button's viewport rect. */
+  pauseRect: () => DOMRect | undefined;
   onSkip: () => void;
+  onPause: () => void;
 }
 
 /**
- * Skip-button hit-testing for dialog-anchored tour steps.
+ * Skip/close-button hit-testing for dialog-anchored tour steps.
  *
  * While a modal ``wa-dialog`` is open the tour popover paints above it but
  * is not hit-testable — the dialog owns the pointer — so the bubble's Skip
- * button receives neither real clicks nor ``:hover``. This controller
- * reproduces both from window-level events: a capturing click inside the
- * button's rect skips the tour, and pointer moves drive a hover flag plus
+ * buttons receive neither real clicks nor ``:hover``. This controller
+ * reproduces both from window-level events: a capturing click inside either
+ * button rect invokes its action, and pointer moves drive hover state plus
  * the pointer cursor. The cursor must live on ``document.documentElement``
  * (no element the tour controls is under the pointer), so the mutation is
  * confined here with teardown on both ``hostDisconnected`` and ``reset``.
  */
 export class TourSkipAffordance implements ReactiveController {
-  private _hover = false;
+  private _hover: "skip" | "pause" | null = null;
   private _prevCursor: string | null = null;
   private _listening = false;
 
@@ -34,7 +37,11 @@ export class TourSkipAffordance implements ReactiveController {
 
   /** True while the pointer is over the Skip button's rect. */
   get hover(): boolean {
-    return this._hover;
+    return this._hover === "skip";
+  }
+
+  get pauseHover(): boolean {
+    return this._hover === "pause";
   }
 
   /**
@@ -61,30 +68,37 @@ export class TourSkipAffordance implements ReactiveController {
 
   /** Clear the hover state and restore the document cursor. */
   reset(): void {
-    if (!this._hover) return;
-    this._hover = false;
+    if (this._hover === null) return;
+    this._hover = null;
     this._setCursor(false);
     this._host.requestUpdate();
   }
 
   private _onCaptureClick = (event: MouseEvent): void => {
     if (!this._options.isDialogStep()) return;
-    if (!this._hit(event)) return;
+    const target = this._hit(event);
+    if (target === null) return;
     event.preventDefault();
     event.stopPropagation();
-    this._options.onSkip();
+    if (target === "skip") this._options.onSkip();
+    else this._options.onPause();
   };
 
   private _onPointerMove = (event: PointerEvent): void => {
-    const over = this._options.isDialogStep() && this._hit(event);
-    if (over === this._hover) return;
-    this._hover = over;
-    this._setCursor(over);
+    const target = this._options.isDialogStep() ? this._hit(event) : null;
+    if (target === this._hover) return;
+    this._hover = target;
+    this._setCursor(target !== null);
     this._host.requestUpdate();
   };
 
-  private _hit(event: MouseEvent): boolean {
-    const r = this._options.skipRect();
+  private _hit(event: MouseEvent): "skip" | "pause" | null {
+    if (this._inside(event, this._options.skipRect())) return "skip";
+    if (this._inside(event, this._options.pauseRect())) return "pause";
+    return null;
+  }
+
+  private _inside(event: MouseEvent, r: DOMRect | undefined): boolean {
     return (
       !!r &&
       r.width > 0 &&

--- a/src/components/guided-tour/tour-spotlight.ts
+++ b/src/components/guided-tour/tour-spotlight.ts
@@ -17,14 +17,6 @@ export const tourSpotlightStyles = css`
     background: rgb(0 0 0 / 55%);
     pointer-events: auto;
   }
-
-  .tour-ring {
-    position: absolute;
-    box-sizing: border-box;
-    border: 2px solid var(--esphome-primary);
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 55%);
-    pointer-events: none;
-  }
 `;
 
 export function renderTourSpotlightBackdrop(frame: TourFrame): TemplateResult {
@@ -37,13 +29,5 @@ export function renderTourSpotlightBackdrop(frame: TourFrame): TemplateResult {
           aria-hidden="true"
         ></div>`
     )}
-    <div
-      class="tour-ring"
-      style=${styleMap({
-        ...boxStyle(frame.ring),
-        borderRadius: `${frame.ring.radius}px`,
-      })}
-      aria-hidden="true"
-    ></div>
   `;
 }

--- a/src/components/guided-tour/tour-steps.ts
+++ b/src/components/guided-tour/tour-steps.ts
@@ -6,6 +6,8 @@ export type TourRoute = "dashboard" | "device";
 
 export interface TourStep {
   anchors: string[];
+  /** Optional click targets when the visual spotlight covers a larger region. */
+  actionAnchors?: string[];
   /** Extra anchors merged into the spotlight hole (not click targets) so the
    *  bubble also keeps clear of context the step talks about. */
   highlightAnchors?: string[];
@@ -15,12 +17,14 @@ export interface TourStep {
   titleKey: string;
   bodyKey: string;
   hintKey?: string;
+  nextLabelKey?: string;
 }
 
 export const DIALOG_ANCHORS: ReadonlySet<string> = new Set([
   "create-method-basic",
   "board-featured",
   "name-finish",
+  "wifi-tour-continue",
 ]);
 
 export const TOUR_STEPS: readonly TourStep[] = [
@@ -45,7 +49,7 @@ export const TOUR_STEPS: readonly TourStep[] = [
   {
     anchors: ["board-featured"],
     route: "dashboard",
-    side: "right",
+    side: "top",
     kind: "action",
     titleKey: "tour.steps.board.title",
     bodyKey: "tour.steps.board.body",
@@ -55,20 +59,34 @@ export const TOUR_STEPS: readonly TourStep[] = [
     anchors: ["name-finish"],
     highlightAnchors: ["name-field"],
     route: "dashboard",
-    side: "right",
+    side: "top",
     kind: "action",
     titleKey: "tour.steps.name.title",
     bodyKey: "tour.steps.name.body",
     hintKey: "tour.steps.name.hint",
   },
   {
+    anchors: ["wifi-tour-continue"],
+    // Creation is asynchronous; anchor churn advances only after the device
+    // page mounts, so failures keep this step visible in the wizard.
+    actionAnchors: [],
+    route: "dashboard",
+    side: "top",
+    kind: "action",
+    titleKey: "tour.steps.wifi.title",
+    bodyKey: "tour.steps.wifi.body",
+    hintKey: "tour.steps.wifi.hint",
+  },
+  {
     // The open navigator when visible, else the toggle that reveals it.
     anchors: ["nav", "nav-toggle"],
+    actionAnchors: ["nav-core"],
     route: "device",
     side: "right",
-    kind: "info",
+    kind: "action",
     titleKey: "tour.steps.navigator.title",
     bodyKey: "tour.steps.navigator.body",
+    hintKey: "tour.steps.navigator.hint",
   },
   {
     anchors: ["central"],
@@ -77,6 +95,7 @@ export const TOUR_STEPS: readonly TourStep[] = [
     kind: "info",
     titleKey: "tour.steps.central.title",
     bodyKey: "tour.steps.central.body",
+    nextLabelKey: "tour.got_it",
   },
   {
     anchors: ["yaml"],
@@ -85,6 +104,7 @@ export const TOUR_STEPS: readonly TourStep[] = [
     kind: "info",
     titleKey: "tour.steps.yaml.title",
     bodyKey: "tour.steps.yaml.body",
+    nextLabelKey: "tour.got_it",
   },
   {
     anchors: ["layout-toggle"],
@@ -93,6 +113,7 @@ export const TOUR_STEPS: readonly TourStep[] = [
     kind: "info",
     titleKey: "tour.steps.layout.title",
     bodyKey: "tour.steps.layout.body",
+    nextLabelKey: "tour.got_it",
   },
   {
     anchors: ["install"],
@@ -101,21 +122,14 @@ export const TOUR_STEPS: readonly TourStep[] = [
     kind: "info",
     titleKey: "tour.steps.install.title",
     bodyKey: "tour.steps.install.body",
+    nextLabelKey: "tour.got_it",
   },
   {
-    anchors: ["view-toggle"],
+    anchors: ["tour-device"],
     route: "dashboard",
     side: "bottom",
     kind: "info",
     titleKey: "tour.steps.dashboard.title",
     bodyKey: "tour.steps.dashboard.body",
-  },
-  {
-    anchors: ["create-device-fab", "add-device-card"],
-    route: "dashboard",
-    side: "top",
-    kind: "info",
-    titleKey: "tour.steps.done.title",
-    bodyKey: "tour.steps.done.body",
   },
 ];

--- a/src/components/guided-tour/tour-steps.ts
+++ b/src/components/guided-tour/tour-steps.ts
@@ -79,8 +79,14 @@ export const TOUR_STEPS: readonly TourStep[] = [
   },
   {
     // The open navigator when visible, else the toggle that reveals it.
-    anchors: ["nav", "nav-toggle"],
-    actionAnchors: ["nav-core"],
+    anchors: [
+      "nav-mobile-core-item",
+      "nav-core-item",
+      "nav-mobile-core",
+      "nav",
+      "nav-toggle",
+    ],
+    actionAnchors: ["nav-mobile-core-item", "nav-core-item"],
     route: "device",
     side: "right",
     kind: "action",

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -41,10 +41,11 @@ registerMdiIcons({
 /**
  * Mandatory first-run onboarding flow.
  *
- * A fresh install walks through Welcome, use case (non-HA only), and
- * experience. The choices are persisted before the final tour offer appears,
- * so "Maybe later" only skips the optional tour. Wi-Fi is intentionally absent:
- * the first Wi-Fi device that needs shared credentials collects them.
+ * A fresh install walks through Welcome and experience. Expert users on non-HA
+ * installs also choose a use case. The choices are persisted before the final
+ * tour offer appears, so "Maybe later" only skips the optional tour. Wi-Fi is
+ * intentionally absent: the first Wi-Fi device that needs shared credentials
+ * collects them.
  *
  * ``?resetOnboarding=1`` reopens a clean default run for frontend development.
  * It does not reset data before opening; completing the choices writes them

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -75,7 +75,8 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
   private _startTourAfterClose = false;
   private _enter = new EnterController(this, () => {
     if (this._isTourOffer) {
-      this._startTour();
+      if (this._remoteCompute) this._maybeLater();
+      else this._startTour();
       return;
     }
     if (this._canContinue) void this._onContinue();
@@ -120,6 +121,12 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     return this._screen === "tour";
   }
 
+  private get _titleKey(): string {
+    return this._isTourOffer && this._remoteCompute
+      ? "onboarding.wizard.tour.remote_title"
+      : `onboarding.wizard.${this._screen}.title`;
+  }
+
   private get _canContinue(): boolean {
     if (this._saving) return false;
     switch (this._screen) {
@@ -140,7 +147,7 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
         class=${this._isTourOffer ? "" : "mandatory"}
         ?open=${this._open}
         ?busy=${this._saving}
-        .label=${this._localize(`onboarding.wizard.${this._screen}.title`)}
+        .label=${this._localize(this._titleKey)}
         @request-close=${this._onRequestClose}
         @after-hide=${this._onAfterHide}
       >
@@ -155,6 +162,14 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
 
   private _renderActions() {
     if (this._isTourOffer) {
+      if (this._remoteCompute) {
+        return html`
+          <span class="spacer"></span>
+          <button type="button" class="btn btn--primary" @click=${this._maybeLater}>
+            ${this._localize("onboarding.wizard.done")}
+          </button>
+        `;
+      }
       return html`
         <button type="button" class="btn btn--cancel" @click=${this._maybeLater}>
           ${this._localize("onboarding.wizard.dismiss")}
@@ -231,6 +246,17 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
   }
 
   private _renderTourOffer() {
+    if (this._remoteCompute) {
+      return html`
+        <div class="tour-offer">
+          <wa-icon library="mdi" name="server-network" class="tour-offer-icon"></wa-icon>
+          <p class="tour-ready">
+            ${this._localize("onboarding.wizard.tour.remote_ready")}
+          </p>
+          <p class="intro">${this._localize("onboarding.wizard.tour.remote_intro")}</p>
+        </div>
+      `;
+    }
     return html`
       <div class="tour-offer">
         <wa-icon library="mdi" name="compass-outline" class="tour-offer-icon"></wa-icon>

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -1,8 +1,8 @@
 import { consume } from "@lit/context";
 import {
-  mdiChip,
   mdiCodeBraces,
   mdiCompassOutline,
+  mdiLaptop,
   mdiServerNetwork,
   mdiSprout,
 } from "@mdi/js";
@@ -31,9 +31,9 @@ import "@home-assistant/webawesome/dist/components/icon/icon.js";
 export const RESET_ONBOARDING_PARAM = "resetOnboarding";
 
 registerMdiIcons({
-  chip: mdiChip,
   "code-braces": mdiCodeBraces,
   "compass-outline": mdiCompassOutline,
+  laptop: mdiLaptop,
   "server-network": mdiServerNetwork,
   sprout: mdiSprout,
 });
@@ -278,7 +278,7 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
         @keydown=${onChoiceGroupKeydown}
       >
         ${renderChoiceCard({
-          icon: "chip",
+          icon: "laptop",
           title: this._localize("onboarding.wizard.use_case.devices_title"),
           description: this._localize("onboarding.wizard.use_case.devices_desc"),
           selected: devices,

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -59,8 +59,8 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
   @consume({ context: apiContext })
   private _api!: ESPHomeAPI;
 
-  /** Whether this install asks the remote-compute use-case question
-   *  (non-HA only). Seeded by the app shell from the onboarding state. */
+  /** Whether this install can ask expert users the remote-compute use-case
+   *  question (non-HA only). Seeded by the app shell from onboarding state. */
   @property({ type: Boolean }) hasUseCase = false;
 
   @state() private _open = false;
@@ -110,7 +110,10 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
 
   /** Ordered screens for the current environment. */
   private get _screens(): WizardScreen[] {
-    return wizardScreens({ hasUseCase: this.hasUseCase });
+    return wizardScreens({
+      hasUseCase: this.hasUseCase,
+      isExpert: this._experience === ExperienceLevel.EXPERT,
+    });
   }
 
   private get _screen(): WizardScreen {
@@ -325,9 +328,7 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
                 ? this._localize("onboarding.wizard.recommended")
                 : undefined,
             disabled: this._saving,
-            onSelect: () => {
-              this._experience = level;
-            },
+            onSelect: () => this._chooseExperience(level),
           })
         )}
       </div>
@@ -339,6 +340,14 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     this._remoteCompute = remoteCompute;
   }
 
+  private _chooseExperience(level: ExperienceLevel) {
+    this._experience = level;
+    if (level === ExperienceLevel.BEGINNER) {
+      this._useCaseChosen = true;
+      this._remoteCompute = false;
+    }
+  }
+
   private _onBack() {
     this._error = null;
     if (this._index > 0) this._index -= 1;
@@ -348,10 +357,16 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     this._error = null;
     switch (this._screen) {
       case "welcome":
-      case "use_case":
         this._index += 1;
         return;
       case "experience":
+        if (this.hasUseCase && this._experience === ExperienceLevel.EXPERT) {
+          this._index += 1;
+          return;
+        }
+        await this._completeSetup();
+        return;
+      case "use_case":
         await this._completeSetup();
         return;
       case "tour":

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -2,7 +2,7 @@ import { consume } from "@lit/context";
 import {
   mdiChip,
   mdiCodeBraces,
-  mdiCursorDefaultClickOutline,
+  mdiCompassOutline,
   mdiServerNetwork,
   mdiSprout,
 } from "@mdi/js";
@@ -14,37 +14,41 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { withBase } from "../../util/base-path.js";
 import { EnterController } from "../../util/enter-controller.js";
 import { EXPERIENCE_OPTIONS } from "../../util/experience.js";
 import { formatApiError } from "../../util/format-api-error.js";
 import { notifyWarning } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { closeOpenDialogs } from "../base-dialog.js";
 import { choiceCardStyles } from "./choice-card-styles.js";
 import { onChoiceGroupKeydown, renderChoiceCard, rovingTabbable } from "./choice-card.js";
 import { onboardingWizardStyles } from "./onboarding-wizard-styles.js";
 import { type WizardScreen, wizardScreens } from "./wizard-screens.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
-import "../base-dialog.js";
+
+export const RESET_ONBOARDING_PARAM = "resetOnboarding";
 
 registerMdiIcons({
   chip: mdiChip,
+  "code-braces": mdiCodeBraces,
+  "compass-outline": mdiCompassOutline,
   "server-network": mdiServerNetwork,
   sprout: mdiSprout,
-  "cursor-default-click-outline": mdiCursorDefaultClickOutline,
-  "code-braces": mdiCodeBraces,
 });
 
 /**
- * First-run onboarding wizard.
+ * Mandatory first-run onboarding flow.
  *
- * Auto-popped by the app shell for a fresh install. Walks a short stepped
- * flow whose shape depends on the environment: non-HA installs lead with the
- * remote-compute use-case question, then everyone picks an experience level.
- * Both are persisted via ``updatePreferences``. The final step emits
- * ``onboarding-acknowledged`` so the app shell reloads preferences into
- * context and the flow does not auto-pop again. Wi-Fi is collected per-device
- * in the create wizard, not here.
+ * A fresh install walks through Welcome, use case (non-HA only), and
+ * experience. The choices are persisted before the final tour offer appears,
+ * so "Maybe later" only skips the optional tour. Wi-Fi is intentionally absent:
+ * the first Wi-Fi device that needs shared credentials collects them.
+ *
+ * ``?resetOnboarding=1`` reopens a clean default run for frontend development.
+ * It does not reset data before opening; completing the choices writes them
+ * through the same API path as first-run onboarding.
  */
 @customElement("esphome-onboarding-wizard-dialog")
 export class ESPHomeOnboardingWizardDialog extends LitElement {
@@ -64,19 +68,27 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
   @state() private _error: string | null = null;
   @state() private _index = 0;
 
-  // Both screens open with the recommended option pre-selected so a new
-  // user can click straight through: build-and-manage on the use-case
-  // screen, beginner on the experience screen.
   @state() private _useCaseChosen = true;
   @state() private _remoteCompute = false;
   @state() private _experience: ExperienceLevel | null = ExperienceLevel.BEGINNER;
 
-  private _exitedExplicitly = false;
+  private _startTourAfterClose = false;
   private _enter = new EnterController(this, () => {
+    if (this._isTourOffer) {
+      this._startTour();
+      return;
+    }
     if (this._canContinue) void this._onContinue();
   });
 
+  connectedCallback(): void {
+    super.connectedCallback();
+    this._consumeResetParam();
+  }
+
   open() {
+    if (this._open) return;
+    closeOpenDialogs(this);
     this._open = true;
     this._saving = false;
     this._error = null;
@@ -84,12 +96,8 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     this._useCaseChosen = true;
     this._remoteCompute = false;
     this._experience = ExperienceLevel.BEGINNER;
-    this._exitedExplicitly = false;
+    this._startTourAfterClose = false;
     this._enter.set(true);
-  }
-
-  close() {
-    this._open = false;
   }
 
   static styles = [
@@ -108,23 +116,28 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     return this._screens[this._index];
   }
 
-  private get _isLast(): boolean {
-    return this._index === this._screens.length - 1;
+  private get _isTourOffer(): boolean {
+    return this._screen === "tour";
   }
 
   private get _canContinue(): boolean {
     if (this._saving) return false;
     switch (this._screen) {
+      case "welcome":
+        return true;
       case "use_case":
         return this._useCaseChosen;
       case "experience":
         return this._experience !== null;
+      case "tour":
+        return false;
     }
   }
 
   protected render() {
     return html`
       <esphome-base-dialog
+        class=${this._isTourOffer ? "" : "mandatory"}
         ?open=${this._open}
         ?busy=${this._saving}
         .label=${this._localize(`onboarding.wizard.${this._screen}.title`)}
@@ -133,70 +146,100 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
       >
         <div class="body">
           ${this._renderSteps()} ${this._renderScreen()}
-          ${
-            this._error ? html`<p class="error" role="alert">${this._error}</p>` : nothing
-          }
+          ${this._error ? html`<p class="error" role="alert">${this._error}</p>` : nothing}
         </div>
-        <div slot="footer" class="actions">
-          ${
-            this._index > 0
-              ? html`<button
-                  type="button"
-                  class="btn btn--cancel"
-                  ?disabled=${this._saving}
-                  @click=${this._onBack}
-                >
-                  ${this._localize("onboarding.wizard.back")}
-                </button>`
-              : html`<button
-                  type="button"
-                  class="btn btn--cancel"
-                  ?disabled=${this._saving}
-                  @click=${this._dismissForSession}
-                >
-                  ${this._localize("onboarding.wizard.dismiss")}
-                </button>`
-          }
-          <span class="spacer"></span>
-          <button
-            type="button"
-            class="btn btn--primary"
-            ?disabled=${!this._canContinue}
-            @click=${this._onContinue}
-          >
-            ${
-              this._saving
-                ? this._localize("onboarding.wizard.saving")
-                : this._isLast
-                  ? this._localize("onboarding.wizard.finish")
-                  : this._localize("onboarding.wizard.continue")
-            }
-          </button>
-        </div>
+        <div slot="footer" class="actions">${this._renderActions()}</div>
       </esphome-base-dialog>
     `;
   }
 
+  private _renderActions() {
+    if (this._isTourOffer) {
+      return html`
+        <button type="button" class="btn btn--cancel" @click=${this._maybeLater}>
+          ${this._localize("onboarding.wizard.dismiss")}
+        </button>
+        <span class="spacer"></span>
+        <button type="button" class="btn btn--primary" @click=${this._startTour}>
+          ${this._localize("onboarding.wizard.start_tour")}
+        </button>
+      `;
+    }
+
+    return html`
+      ${
+        this._index > 0
+          ? html`<button
+              type="button"
+              class="btn btn--cancel"
+              ?disabled=${this._saving}
+              @click=${this._onBack}
+            >
+              ${this._localize("onboarding.wizard.back")}
+            </button>`
+          : nothing
+      }
+      <span class="spacer"></span>
+      <button
+        type="button"
+        class="btn btn--primary"
+        ?disabled=${!this._canContinue}
+        @click=${this._onContinue}
+      >
+        ${
+          this._saving
+            ? this._localize("onboarding.wizard.saving")
+            : this._localize("onboarding.wizard.continue")
+        }
+      </button>
+    `;
+  }
+
   private _renderSteps() {
-    // Purely decorative progress dots; the step itself is announced via the
-    // dialog label, so keep these out of the accessibility tree.
     return html`<div class="steps" aria-hidden="true">
       ${this._screens.map(
-        (_s, i) =>
-          html`<span class="step-dot ${i === this._index ? "active" : ""}"></span>`
+        (_screen, index) =>
+          html`<span class="step-dot ${index === this._index ? "active" : ""}"></span>`
       )}
     </div>`;
   }
 
   private _renderScreen() {
     switch (this._screen) {
+      case "welcome":
+        return this._renderWelcome();
       case "use_case":
         return this._renderUseCase();
       case "experience":
         return this._renderExperience();
+      case "tour":
+        return this._renderTourOffer();
     }
   }
 
+  private _renderWelcome() {
+    return html`
+      <div class="welcome-screen">
+        <img
+          class="welcome-logo"
+          src=${withBase("/assets/logo/esphome-favicon.svg")}
+          alt=""
+        />
+        <p class="intro">${this._localize("onboarding.wizard.welcome.intro")}</p>
+      </div>
+    `;
+  }
+
+  private _renderTourOffer() {
+    return html`
+      <div class="tour-offer">
+        <wa-icon library="mdi" name="compass-outline" class="tour-offer-icon"></wa-icon>
+        <p class="tour-ready">${this._localize("onboarding.wizard.tour.ready")}</p>
+        <p class="intro">${this._localize("onboarding.wizard.tour.intro")}</p>
+        <p class="intro">${this._localize("onboarding.wizard.tour.later")}</p>
+      </div>
+    `;
+  }
   private _renderUseCase() {
     const devices = this._useCaseChosen && !this._remoteCompute;
     const remote = this._useCaseChosen && this._remoteCompute;
@@ -240,7 +283,7 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
         aria-label=${this._localize("onboarding.wizard.experience.title")}
         @keydown=${onChoiceGroupKeydown}
       >
-        ${EXPERIENCE_OPTIONS.map(([level, icon], i) =>
+        ${EXPERIENCE_OPTIONS.map(([level, icon], index) =>
           renderChoiceCard({
             icon,
             title: this._localize(`onboarding.wizard.experience.${level}_title`),
@@ -249,7 +292,7 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
             tabbable: rovingTabbable(
               this._experience === level,
               this._experience !== null,
-              i
+              index
             ),
             badge:
               level === ExperienceLevel.BEGINNER
@@ -278,28 +321,33 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
   private async _onContinue() {
     this._error = null;
     switch (this._screen) {
+      case "welcome":
       case "use_case":
         this._index += 1;
         return;
       case "experience":
-        if (this._isLast) {
-          await this._finish();
-        } else {
-          this._index += 1;
-        }
+        await this._completeSetup();
+        return;
+      case "tour":
         return;
     }
   }
 
-  private async _finish() {
+  private async _completeSetup() {
     if (this._saving) return;
     this._saving = true;
-    this._error = null;
-    await this._acknowledgeAndClose();
+    if (!(await this._persistChoices())) return;
+    try {
+      await this._api.markOnboardingAcknowledged();
+    } catch (err) {
+      console.warn("Failed to mark onboarding acknowledged:", err);
+      notifyWarning(this._localize("onboarding.wizard.ack_failed"));
+    }
+    this._emitAcknowledged();
+    this._saving = false;
+    this._index += 1;
   }
 
-  /** Persist the experience / remote-compute picks; returns false and shows an
-   *  inline error on failure. */
   private async _persistChoices(): Promise<boolean> {
     try {
       await this._api.updatePreferences({
@@ -318,46 +366,50 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     }
   }
 
-  private async _acknowledgeAndClose() {
-    // Persist the picks BEFORE acknowledging, so a failed write can't leave
-    // the wizard marked done with experience / remote-compute unset (which
-    // would never re-pop). The app shell refreshes its context from these
-    // prefs on the onboarding-acknowledged event.
-    if (!(await this._persistChoices())) return;
-    try {
-      await this._api.markOnboardingAcknowledged();
-    } catch (err) {
-      // Prefs already landed; a failed ack only re-pops the wizard next load.
-      console.warn("Failed to mark onboarding acknowledged:", err);
-      notifyWarning(this._localize("onboarding.wizard.ack_failed"));
-    }
-    this._exitedExplicitly = true;
-    this._emitAcknowledged();
-    this.close();
-    this._saving = false;
-  }
-
-  private _onAfterHide() {
-    this._enter.set(false);
-    if (!this._exitedExplicitly) this._dismissForSession();
-  }
-
-  private _onRequestClose = (): void => {
+  private _maybeLater = () => {
     this._open = false;
   };
 
-  private _dismissForSession = () => {
-    this._exitedExplicitly = true;
-    this.dispatchEvent(
-      new CustomEvent("onboarding-dismissed-session", { bubbles: true, composed: true })
-    );
-    this.close();
+  private _startTour = () => {
+    this._startTourAfterClose = true;
+    this._open = false;
   };
+
+  private _onRequestClose = (event: Event): void => {
+    if (!this._isTourOffer) {
+      event.preventDefault();
+      return;
+    }
+    this._open = false;
+  };
+
+  private _onAfterHide() {
+    this._enter.set(false);
+    this._open = false;
+    if (!this._startTourAfterClose) return;
+    this._startTourAfterClose = false;
+    this.dispatchEvent(
+      new CustomEvent("open-guided-tour", { bubbles: true, composed: true })
+    );
+  }
 
   private _emitAcknowledged() {
     this.dispatchEvent(
       new CustomEvent("onboarding-acknowledged", { bubbles: true, composed: true })
     );
+  }
+
+  private _consumeResetParam(): void {
+    if (typeof __DEV__ === "undefined" || !__DEV__) return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get(RESET_ONBOARDING_PARAM) !== "1") return;
+
+    params.delete(RESET_ONBOARDING_PARAM);
+    const query = params.toString();
+    const cleaned =
+      window.location.pathname + (query ? `?${query}` : "") + window.location.hash;
+    window.history.replaceState(window.history.state, "", cleaned);
+    this.open();
   }
 }
 

--- a/src/components/onboarding/onboarding-wizard-styles.ts
+++ b/src/components/onboarding/onboarding-wizard-styles.ts
@@ -5,10 +5,17 @@ export const onboardingWizardStyles = css`
     --width: 520px;
   }
 
+  esphome-base-dialog.mandatory::part(close-button) {
+    display: none;
+  }
+
   .body {
     display: flex;
     flex-direction: column;
     gap: var(--wa-space-m);
+    box-sizing: border-box;
+    height: 300px;
+    overflow-y: auto;
   }
 
   .intro {
@@ -23,6 +30,38 @@ export const onboardingWizardStyles = css`
     vertical-align: -3px;
     margin-right: var(--wa-space-2xs);
     color: var(--esphome-primary);
+  }
+
+  .welcome-logo {
+    width: 64px;
+    height: 64px;
+  }
+
+  .welcome-screen,
+  .tour-offer {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    gap: var(--wa-space-s);
+  }
+
+  .welcome-screen {
+    gap: var(--wa-space-xl);
+  }
+
+  .tour-offer-icon {
+    font-size: 48px;
+    color: var(--esphome-primary);
+  }
+
+  .tour-ready {
+    margin: 0;
+    font-size: var(--wa-font-size-m);
+    font-weight: var(--wa-font-weight-bold);
+    color: var(--wa-color-text-normal);
   }
 
   /* Step dots show progress through the wizard without numbering, which

--- a/src/components/onboarding/onboarding-wizard-styles.ts
+++ b/src/components/onboarding/onboarding-wizard-styles.ts
@@ -2,7 +2,7 @@ import { css } from "lit";
 
 export const onboardingWizardStyles = css`
   esphome-base-dialog {
-    --width: 520px;
+    --width: min(520px, calc(100vw - 24px));
   }
 
   esphome-base-dialog.mandatory::part(close-button) {
@@ -93,5 +93,11 @@ export const onboardingWizardStyles = css`
 
   .actions .spacer {
     flex: 1;
+  }
+
+  @media (max-width: 600px), (max-height: 600px) {
+    .body {
+      height: min(390px, calc(100dvh - 190px));
+    }
   }
 `;

--- a/src/components/onboarding/wizard-screens.ts
+++ b/src/components/onboarding/wizard-screens.ts
@@ -3,13 +3,17 @@ export type WizardScreen = "welcome" | "use_case" | "experience" | "tour";
 /**
  * The ordered onboarding-wizard screens for the current environment.
  *
- * Welcome and experience are always mandatory. The use-case screen only
- * appears on non-HA installs, and the optional-tour offer always closes the
- * flow. Wi-Fi is deliberately not part of onboarding.
+ * Welcome and experience are always mandatory. Expert users on non-HA installs
+ * also choose whether this dashboard manages devices or acts as a remote build
+ * server. The optional-tour offer always closes the flow. Wi-Fi is deliberately
+ * not part of onboarding.
  */
-export function wizardScreens(opts: { hasUseCase: boolean }): WizardScreen[] {
-  const screens: WizardScreen[] = ["welcome"];
-  if (opts.hasUseCase) screens.push("use_case");
-  screens.push("experience", "tour");
+export function wizardScreens(opts: {
+  hasUseCase: boolean;
+  isExpert: boolean;
+}): WizardScreen[] {
+  const screens: WizardScreen[] = ["welcome", "experience"];
+  if (opts.hasUseCase && opts.isExpert) screens.push("use_case");
+  screens.push("tour");
   return screens;
 }

--- a/src/components/onboarding/wizard-screens.ts
+++ b/src/components/onboarding/wizard-screens.ts
@@ -1,16 +1,15 @@
-export type WizardScreen = "use_case" | "experience";
+export type WizardScreen = "welcome" | "use_case" | "experience" | "tour";
 
 /**
- * The ordered onboarding-wizard screens for a given environment.
+ * The ordered onboarding-wizard screens for the current environment.
  *
- * The use-case screen only appears on non-HA installs (`hasUseCase`); the
- * experience screen is always present. Wi-Fi is no longer an onboarding step —
- * it's collected per-device in the create wizard. Pure so the branch logic is
- * unit-testable without the component.
+ * Welcome and experience are always mandatory. The use-case screen only
+ * appears on non-HA installs, and the optional-tour offer always closes the
+ * flow. Wi-Fi is deliberately not part of onboarding.
  */
 export function wizardScreens(opts: { hasUseCase: boolean }): WizardScreen[] {
-  const screens: WizardScreen[] = [];
+  const screens: WizardScreen[] = ["welcome"];
   if (opts.hasUseCase) screens.push("use_case");
-  screens.push("experience");
+  screens.push("experience", "tour");
   return screens;
 }

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -345,17 +345,15 @@ export class ESPHomeWizardStepSetup extends LitElement {
         </button>
         <div class="actions-right">
           ${
-            this._stage === "wifi"
+            this._stage === "wifi" && this._wifiConfigured
               ? html`<button
-                  class="btn ${this._wifiConfigured ? "btn-primary" : "btn-secondary"} skip-wifi"
+                  class="btn btn-primary wifi-confirm"
                   type="button"
                   ${tourAnchor("wifi-tour-continue")}
                   ?disabled=${this.submitting}
-                  @click=${this._onSkipWifi}
+                  @click=${this._onUseSavedWifi}
                 >
-                  ${this._localize(
-                    this._wifiConfigured ? "wizard.wifi_use_saved" : "wizard.wifi_skip"
-                  )}
+                  ${this._localize("wizard.wifi_use_saved")}
                 </button>`
               : nothing
           }
@@ -365,7 +363,9 @@ export class ESPHomeWizardStepSetup extends LitElement {
               : html`<button
                   class="btn btn-primary"
                   type="button"
-                  ${tourAnchor(this._stage === "name" ? "name-finish" : undefined)}
+                  ${tourAnchor(
+                    this._stage === "name" ? "name-finish" : "wifi-tour-continue"
+                  )}
                   ?disabled=${!this._canAdvance() || this.submitting}
                   aria-busy=${this.submitting || nothing}
                   @click=${this._onNext}
@@ -512,7 +512,7 @@ export class ESPHomeWizardStepSetup extends LitElement {
     this._finish(this._wifiSsid, this._wifiPassword);
   }
 
-  private _onSkipWifi = () => {
+  private _onUseSavedWifi = () => {
     if (this.submitting) return;
     this._finish("", "");
   };

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -15,7 +15,7 @@ import { tourAnchor } from "../guided-tour/tour-anchor.js";
 import {
   clearTourSuggestedName,
   getTourSuggestedName,
-  isTourPending,
+  isTourActive,
 } from "../guided-tour/tour-session.js";
 import { wifiFieldsStyles } from "../onboarding/wifi-fields-styles.js";
 import { isWifiPasswordTooShort, renderWifiFields } from "../onboarding/wifi-fields.js";
@@ -55,7 +55,7 @@ export class ESPHomeWizardStepSetup extends LitElement {
    *  learn that saved credentials are reused without revealing their values. */
   private get _collectWifi(): boolean {
     return (
-      Boolean(this.board?.requires_wifi) && (!this._wifiConfigured || isTourPending())
+      Boolean(this.board?.requires_wifi) && (!this._wifiConfigured || isTourActive())
     );
   }
 

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -15,6 +15,7 @@ import { tourAnchor } from "../guided-tour/tour-anchor.js";
 import {
   clearTourSuggestedName,
   getTourSuggestedName,
+  isTourPending,
 } from "../guided-tour/tour-session.js";
 import { wifiFieldsStyles } from "../onboarding/wifi-fields-styles.js";
 import { isWifiPasswordTooShort, renderWifiFields } from "../onboarding/wifi-fields.js";
@@ -50,10 +51,12 @@ export class ESPHomeWizardStepSetup extends LitElement {
   @state()
   private _wifiConfigured = false;
 
-  /** Collect Wi-Fi only when the board needs it and no shared secret exists
-   *  yet; every other board skips the step. */
+  /** Show Wi-Fi when credentials are needed, or during the quickstart so users
+   *  learn that saved credentials are reused without revealing their values. */
   private get _collectWifi(): boolean {
-    return Boolean(this.board?.requires_wifi) && !this._wifiConfigured;
+    return (
+      Boolean(this.board?.requires_wifi) && (!this._wifiConfigured || isTourPending())
+    );
   }
 
   @state()
@@ -84,6 +87,7 @@ export class ESPHomeWizardStepSetup extends LitElement {
 
   private _canAdvance(): boolean {
     if (this._stage === "name") return !!this._deviceName.trim();
+    if (this._wifiConfigured) return true;
     // The Wi-Fi stage only appears when Wi-Fi is required, so an SSID is
     // mandatory; a too-short WPA passphrase is also rejected.
     return !!this._wifiSsid.trim() && !isWifiPasswordTooShort(this._wifiPassword);
@@ -219,6 +223,16 @@ export class ESPHomeWizardStepSetup extends LitElement {
         gap: var(--wa-space-s);
       }
 
+      .wifi-saved {
+        padding: var(--wa-space-m);
+        border-radius: var(--wa-border-radius-m);
+        background: var(--wa-color-surface-lowered);
+      }
+
+      .wifi-saved .section-title {
+        margin-bottom: var(--wa-space-2xs);
+      }
+
       .btn {
         display: inline-flex;
         align-items: center;
@@ -330,21 +344,40 @@ export class ESPHomeWizardStepSetup extends LitElement {
           ${this._localize("wizard.back")}
         </button>
         <div class="actions-right">
-          <button
-            class="btn btn-primary"
-            type="button"
-            ${tourAnchor("name-finish")}
-            ?disabled=${!this._canAdvance() || this.submitting}
-            aria-busy=${this.submitting || nothing}
-            @click=${this._onNext}
-          >
-            ${this.submitting ? html`<wa-spinner></wa-spinner>` : nothing}
-            ${
-              this._stage === "name" && this._collectWifi
-                ? this._localize("wizard.next")
-                : this._localize("wizard.finish_setup")
-            }
-          </button>
+          ${
+            this._stage === "wifi"
+              ? html`<button
+                  class="btn ${this._wifiConfigured ? "btn-primary" : "btn-secondary"} skip-wifi"
+                  type="button"
+                  ${tourAnchor("wifi-tour-continue")}
+                  ?disabled=${this.submitting}
+                  @click=${this._onSkipWifi}
+                >
+                  ${this._localize(
+                    this._wifiConfigured ? "wizard.wifi_use_saved" : "wizard.wifi_skip"
+                  )}
+                </button>`
+              : nothing
+          }
+          ${
+            this._stage === "wifi" && this._wifiConfigured
+              ? nothing
+              : html`<button
+                  class="btn btn-primary"
+                  type="button"
+                  ${tourAnchor(this._stage === "name" ? "name-finish" : undefined)}
+                  ?disabled=${!this._canAdvance() || this.submitting}
+                  aria-busy=${this.submitting || nothing}
+                  @click=${this._onNext}
+                >
+                  ${this.submitting ? html`<wa-spinner></wa-spinner>` : nothing}
+                  ${
+                    this._stage === "name" && this._collectWifi
+                      ? this._localize("wizard.next")
+                      : this._localize("wizard.finish_setup")
+                  }
+                </button>`
+          }
         </div>
       </div>
     `;
@@ -401,21 +434,38 @@ export class ESPHomeWizardStepSetup extends LitElement {
       <section class="section">
         <div>
           <h3 class="section-title">${this._localize("wizard.wifi_configuration")}</h3>
-          <p class="section-subtitle">${this._localize("wizard.wifi_required_desc")}</p>
+          <p class="section-subtitle">
+            ${this._localize(
+              this._wifiConfigured
+                ? "wizard.wifi_saved_desc"
+                : "wizard.wifi_required_desc"
+            )}
+          </p>
         </div>
 
-        ${renderWifiFields({
-          localize: this._localize,
-          ssid: this._wifiSsid,
-          password: this._wifiPassword,
-          disabled: false,
-          onSsidInput: (v) => {
-            this._wifiSsid = v;
-          },
-          onPasswordInput: (v) => {
-            this._wifiPassword = v;
-          },
-        })}
+        ${
+          this._wifiConfigured
+            ? html`<div class="wifi-saved" role="status">
+                <h4 class="section-title">
+                  ${this._localize("wizard.wifi_saved_title")}
+                </h4>
+                <p class="section-subtitle">
+                  ${this._localize("wizard.wifi_saved_reuse")}
+                </p>
+              </div>`
+            : renderWifiFields({
+                localize: this._localize,
+                ssid: this._wifiSsid,
+                password: this._wifiPassword,
+                disabled: false,
+                onSsidInput: (v) => {
+                  this._wifiSsid = v;
+                },
+                onPasswordInput: (v) => {
+                  this._wifiPassword = v;
+                },
+              })
+        }
       </section>
     `;
   }
@@ -453,10 +503,19 @@ export class ESPHomeWizardStepSetup extends LitElement {
       this._finish("", "");
       return;
     }
+    if (this._wifiConfigured) {
+      this._finish("", "");
+      return;
+    }
     // Pass the typed credentials through; the backend writes them to
     // secrets.yaml and emits !secret rather than inlining bare values.
     this._finish(this._wifiSsid, this._wifiPassword);
   }
+
+  private _onSkipWifi = () => {
+    if (this.submitting) return;
+    this._finish("", "");
+  };
 
   private _finish(wifiSsid: string, wifiPassword: string) {
     this.dispatchEvent(

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -78,6 +78,7 @@ import {
 } from "../components/dashboard/skeletons.js";
 import { dashboardStyles } from "../components/dashboard/styles.js";
 import { yamlModeStyles } from "../components/dashboard/yaml-mode-styles.js";
+import { TourActivityController } from "../components/guided-tour/tour-activity-controller.js";
 import { YamlSearchController } from "../components/yaml-search-controller.js";
 import {
   activeJobsContext,
@@ -169,6 +170,8 @@ registerMdiIcons({
 
 @customElement("esphome-page-dashboard")
 export class ESPHomePageDashboard extends LitElement {
+  private _tourActivity = new TourActivityController(this);
+
   @consume({ context: localizeContext, subscribe: true })
   @state()
   _localize: LocalizeFunc = (key) => key;

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -18,6 +18,7 @@ import { notifyError, notifySuccess } from "../util/notify.js";
 import { DeviceInstallController } from "../components/device/device-install-controller.js";
 import type { ESPHomeDeviceSectionConfig } from "../components/device/device-section-config.js";
 import type { ESPHomeFirmwareInstallDialog } from "../components/firmware-install-dialog.js";
+import { TourLayoutController } from "../components/guided-tour/tour-layout-controller.js";
 import { tourAnchor } from "../components/guided-tour/tour-anchor.js";
 import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";
 import type { ESPHomeUnsavedChangesDialog } from "../components/unsaved-changes-dialog.js";
@@ -131,6 +132,14 @@ export class ESPHomePageDevice extends LitElement {
 
   @state()
   private _layout: DeviceLayoutMode = "both";
+
+  private _tourLayout = new TourLayoutController(
+    this,
+    () => this._layout,
+    (layout: DeviceLayoutMode) => {
+      this._layout = layout;
+    }
+  );
 
   @state()
   private _openSections = new Set<number>(this._readUrlSections());

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1002,11 +1002,15 @@
     "wizard": {
       "back": "Back",
       "continue": "Continue",
-      "finish": "Finish",
       "dismiss": "Maybe later",
       "recommended": "RECOMMENDED",
+      "start_tour": "Start guided tour",
       "saving": "Saving…",
       "ack_failed": "Saved your choices, but the wizard couldn't be marked as completed — it may reappear next time.",
+      "welcome": {
+        "title": "Welcome to ESPHome Device Builder",
+        "intro": "We’ll help you tailor your ESPHome experience in a few quick steps."
+      },
       "use_case": {
         "title": "How will you use this?",
         "intro": "This helps tailor the dashboard to what you need.",
@@ -1022,6 +1026,12 @@
         "beginner_desc": "Start with a simple, guided interface.",
         "expert_title": "Expert",
         "expert_desc": "Unlock the diff viewer, navigator search, and YAML search."
+      },
+      "tour": {
+        "title": "You’re ready to build",
+        "ready": "Everything is set up and ready to use.",
+        "intro": "Take a guided tour to see how to create, configure, and install your first device.",
+        "later": "You can always start the tour later from the menu in the top-right corner."
       }
     }
   },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -547,7 +547,12 @@
     "full_setup_desc": "Adds this device's onboard components (relays, sensors, and more) so it's ready to use. You can change them afterwards in the editor.",
     "full_setup_partial": "{count, plural, one {Couldn't add recommended component {names}} other {Couldn't add recommended components {names}{extra, plural, =0 {} other { and # more}}}}; finish in the editor.",
     "wifi_configuration": "Wi-Fi Configuration",
-    "wifi_required_desc": "This board connects over Wi-Fi. Enter your network so the device can come online.",
+    "wifi_required_desc": "This board connects over Wi-Fi. Enter your network once and Device Builder will securely reuse it for future Wi-Fi devices.",
+    "wifi_saved_title": "Wi-Fi credentials already saved",
+    "wifi_saved_desc": "This board uses the shared Wi-Fi credentials already stored by Device Builder.",
+    "wifi_saved_reuse": "The saved values stay hidden and will be reused automatically.",
+    "wifi_skip": "Skip for now",
+    "wifi_use_saved": "Use saved credentials",
     "other_boards": "Other boards",
     "starter_kit": "Featured",
     "expand_board": "Expand details",
@@ -1003,6 +1008,7 @@
       "back": "Back",
       "continue": "Continue",
       "dismiss": "Maybe later",
+      "done": "Done",
       "recommended": "RECOMMENDED",
       "start_tour": "Start guided tour",
       "saving": "Saving…",
@@ -1030,15 +1036,23 @@
       "tour": {
         "title": "You’re ready to build",
         "ready": "Everything is set up and ready to use.",
-        "intro": "Take a guided tour to see how to create, configure, and install your first device.",
-        "later": "You can always start the tour later from the menu in the top-right corner."
+        "intro": "Take a guided tour to see how to create, configure, and install your first device. It takes about 5 minutes.",
+        "later": "You can always start the tour later from the menu in the top-right corner.",
+        "remote_title": "Setup complete",
+        "remote_ready": "Your remote build server is ready.",
+        "remote_intro": "This dashboard is configured to receive build jobs from other Device Builder installations."
       }
     }
   },
   "tour": {
+    "header": "Quickstart tour",
     "step_counter": "Step {current} of {total}",
     "skip": "Skip tour",
+    "pause": "Close for now",
+    "unavailable_title": "This tour step isn’t available",
+    "unavailable_body": "The highlighted control could not be shown. Close for now and try again later, or skip the tour.",
     "next": "Next",
+    "got_it": "Got it!",
     "finish": "Finish",
     "continue": "Continue",
     "steps": {
@@ -1049,30 +1063,36 @@
       },
       "method": {
         "title": "Choose how to start",
-        "body": "“Create new project” walks you through a starter kit or any ESP board.",
+        "body": "“Create new project” guides you through choosing and configuring your board step by step.",
         "hint": "Click “Create new project”"
       },
       "board": {
         "title": "Pick a board",
-        "body": "Starter kits come pre-configured and are ideal for your first device. Select the featured kit.",
-        "hint": "Click “Select” on the starter kit"
+        "body": "You can configure any board from the catalog. For this tour, we’ll use the featured Starter Kit as an example; the same workflow applies to other supported boards.",
+        "hint": "Click “Select” on the featured Starter Kit"
       },
       "name": {
-        "title": "Name it, then finish",
-        "body": "We’ve suggested a name and generated a working config. Finish to open it.",
-        "hint": "Click “Finish setup”"
+        "title": "Name your device",
+        "body": "We’ve suggested a name and generated a working configuration. Keep it or choose a name of your own.",
+        "hint": "Continue when the name looks right"
+      },
+      "wifi": {
+        "title": "Wi-Fi for your devices",
+        "body": "Device Builder stores Wi-Fi credentials once and reuses them for future devices. For this quickstart, continue without changing them.",
+        "hint": "Continue without changing Wi-Fi"
       },
       "navigator": {
         "title": "Your device navigator",
-        "body": "Browse and edit core configuration, components, and automations. No YAML required."
+        "body": "Core Configuration contains essentials such as Wi-Fi, device identity, and hardware settings. Components add sensors and features; Automations define behavior.",
+        "hint": "Open Core Configuration to continue"
       },
       "central": {
         "title": "The main editor",
         "body": "Select a section in the navigator to open it here. Configure your board, components, and automations visually; every change updates the YAML on the right."
       },
       "yaml": {
-        "title": "Live YAML, kept in sync",
-        "body": "Everything you do is mirrored here. Try changing fields in the visual editor and watch the YAML update."
+        "title": "Your configuration in YAML",
+        "body": "YAML is the text version of your device configuration—the source ESPHome uses to build the firmware. It stays in sync with the visual editor. We show it by default, but you can hide it and configure everything visually if you prefer."
       },
       "layout": {
         "title": "Switch your view",
@@ -1083,12 +1103,8 @@
         "body": "Flash firmware to your device over USB or the network. Your edits are saved automatically first — that’s the whole loop: configure and install."
       },
       "dashboard": {
-        "title": "Find it on your dashboard",
-        "body": "Your device lives here now. Switch between card and list views as your collection grows."
-      },
-      "done": {
-        "title": "You’re all set",
-        "body": "That’s the full loop: create, configure, and install. Add your next device whenever you like."
+        "title": "Your device is ready",
+        "body": "Your device has been added to the dashboard. From here you can monitor its status, edit its configuration, install updates, and return to it whenever you need."
       }
     }
   },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1084,7 +1084,7 @@
       "navigator": {
         "title": "Your device navigator",
         "body": "Core Configuration contains essentials such as Wi-Fi, device identity, and hardware settings. Components add sensors and features; Automations define behavior.",
-        "hint": "Open Core Configuration to continue"
+        "hint": "Expand Core Configuration, then open ESPHome Core"
       },
       "central": {
         "title": "The main editor",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1020,10 +1020,10 @@
       "use_case": {
         "title": "How will you use this?",
         "intro": "This helps tailor the dashboard to what you need.",
-        "devices_title": "Build and manage devices",
-        "devices_desc": "Create, configure, and flash ESPHome devices from this dashboard.",
-        "remote_title": "Remote compute only",
-        "remote_desc": "Use this installation only as a remote build server for other dashboards. Device creation stays hidden."
+        "devices_title": "I want to manage ESPHome devices on this system",
+        "devices_desc": "Create, configure, build, flash, and manage devices from this dashboard.",
+        "remote_title": "I want to use this system as a remote build server",
+        "remote_desc": "Build firmware for Device Builder dashboards running on other systems. Device creation is hidden."
       },
       "experience": {
         "title": "Choose your experience level",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -551,7 +551,6 @@
     "wifi_saved_title": "Wi-Fi credentials already saved",
     "wifi_saved_desc": "This board uses the shared Wi-Fi credentials already stored by Device Builder.",
     "wifi_saved_reuse": "The saved values stay hidden and will be reused automatically.",
-    "wifi_skip": "Skip for now",
     "wifi_use_saved": "Use saved credentials",
     "other_boards": "Other boards",
     "starter_kit": "Featured",
@@ -1077,9 +1076,9 @@
         "hint": "Continue when the name looks right"
       },
       "wifi": {
-        "title": "Wi-Fi for your devices",
-        "body": "Device Builder stores Wi-Fi credentials once and reuses them for future devices. For this quickstart, continue without changing them.",
-        "hint": "Continue without changing Wi-Fi"
+        "title": "Connect your device",
+        "body": "Enter your Wi-Fi details, or confirm the saved credentials. Device Builder stores them securely for future devices.",
+        "hint": "Enter or confirm Wi-Fi to continue"
       },
       "navigator": {
         "title": "Your device navigator",

--- a/src/types/webpack-env.d.ts
+++ b/src/types/webpack-env.d.ts
@@ -24,3 +24,6 @@ interface ImportMeta {
     }
   ): WebpackModuleContext;
 }
+
+/** Replaced by rspack's DefinePlugin; true only for the dev-server bundle. */
+declare const __DEV__: boolean;

--- a/src/util/onboarding-gate.ts
+++ b/src/util/onboarding-gate.ts
@@ -28,23 +28,13 @@ export function isExperienceChosen(state: OnboardingState): boolean {
 /**
  * True when the first-run wizard should auto-pop on load.
  *
- * Three conditions must hold simultaneously:
+ * Two conditions must hold simultaneously:
  *
  * 1. The user is behind the current onboarding version (a future
  *    bump re-prompts users who completed an earlier flow).
  * 2. *Something is actually pending.* A version bump alone isn't a
  *    reason to interrupt a user who already finished onboarding.
- * 3. The user hasn't already session-dismissed the dialog (the
- *    "Maybe later" / X / Escape paths set this so a refresh
- *    doesn't re-pop the dialog they just closed).
  */
-export function shouldAutoShowOnboarding(
-  state: OnboardingState,
-  sessionDismissed: boolean
-): boolean {
-  return (
-    state.completed_version < state.current_version &&
-    isOnboardingPending(state) &&
-    !sessionDismissed
-  );
+export function shouldAutoShowOnboarding(state: OnboardingState): boolean {
+  return state.completed_version < state.current_version && isOnboardingPending(state);
 }

--- a/test/components/app-shell/data-load.test.ts
+++ b/test/components/app-shell/data-load.test.ts
@@ -42,7 +42,6 @@ function makeHost(state: OnboardingState) {
     _onboardingPending: false,
     _onboardingHasUseCase: false,
     _onboardingShouldShow: false,
-    _onboardingSessionDismissed: false,
     _api: { getOnboardingState: vi.fn(async () => state) },
   };
 }
@@ -63,15 +62,6 @@ describe("loadOnboardingState routing", () => {
     const host = makeHost(
       state([{ id: OnboardingStepId.EXPERIENCE_LEVEL, status: DONE }])
     );
-    await loadOnboardingState(host as unknown as ESPHomeApp);
-    expect(host._onboardingShouldShow).toBe(false);
-  });
-
-  it("respects a session dismissal", async () => {
-    const host = makeHost(
-      state([{ id: OnboardingStepId.EXPERIENCE_LEVEL, status: PENDING }])
-    );
-    host._onboardingSessionDismissed = true;
     await loadOnboardingState(host as unknown as ESPHomeApp);
     expect(host._onboardingShouldShow).toBe(false);
   });

--- a/test/components/dashboard/device-table-tour.test.ts
+++ b/test/components/dashboard/device-table-tour.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TourTablePageController } from "../../../src/components/dashboard/device-table-tour.js";
+import {
+  clearTourConfiguration,
+  setTourActive,
+  setTourConfiguration,
+} from "../../../src/components/guided-tour/tour-session.js";
+
+afterEach(() => {
+  setTourActive(false);
+  clearTourConfiguration();
+});
+
+describe("TourTablePageController", () => {
+  it("allows the same page request after a cancelled microtask", async () => {
+    const setPageIndex = vi.fn();
+    const controller = new TourTablePageController(setPageIndex);
+    const rows = Array.from({ length: 30 }, (_, index) => ({
+      original: { config: `demo-${index}.yaml` },
+    }));
+    setTourConfiguration("demo-20.yaml");
+    setTourActive(true);
+
+    controller.ensureTargetPage(rows, 10, 10, 0);
+    setTourActive(false);
+    await Promise.resolve();
+    expect(setPageIndex).not.toHaveBeenCalled();
+
+    setTourActive(true);
+    controller.ensureTargetPage(rows, 10, 10, 0);
+    await Promise.resolve();
+    expect(setPageIndex).toHaveBeenCalledWith(2);
+  });
+});

--- a/test/components/dashboard/device-table.test.ts
+++ b/test/components/dashboard/device-table.test.ts
@@ -5,7 +5,7 @@
  * real row-count size (floored at 1), and the mounted table renders
  * every row on one page while a normal size paginates (discussion #3682).
  */
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
@@ -15,10 +15,20 @@ vi.mock("../../../src/components/dashboard/table-row-menu.js", () => ({}));
 import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
 import { ESPHomeDeviceTable } from "../../../src/components/dashboard/device-table.js";
 import {
+  clearTourConfiguration,
+  setTourActive,
+  setTourConfiguration,
+} from "../../../src/components/guided-tour/tour-session.js";
+import {
   ALL_PAGE_SIZE,
   effectiveTablePageSize,
 } from "../../../src/components/dashboard/pagination.js";
 import { makeConfiguredDevice } from "../../_make-configured-device.js";
+
+afterEach(() => {
+  setTourActive(false);
+  clearTourConfiguration();
+});
 
 describe("effectiveTablePageSize", () => {
   it("passes a normal page size through unchanged", () => {
@@ -74,6 +84,38 @@ describe("device-table All rendering", () => {
     const el = await mount(30, ALL_PAGE_SIZE);
     expect(rowCount(el)).toBe(30);
     expect(pageSizeAttr(el)).toBe("0");
+  });
+
+  it("moves to the page containing the quickstart target", async () => {
+    const el = await mount(30, 10);
+    setTourConfiguration("demo-20.yaml");
+    setTourActive(true);
+    el.requestUpdate();
+
+    await el.updateComplete;
+    await el.updateComplete;
+
+    expect(
+      el
+        .shadowRoot!.querySelector("tbody tr[data-configuration]")
+        ?.getAttribute("data-configuration")
+    ).toBe("demo-20.yaml");
+  });
+
+  it("finds the quickstart target through sorting and search filters", async () => {
+    const el = await mount(30, 10);
+    el.initialSorting = [{ id: "name", desc: true }];
+    el.search = "does-not-match";
+    setTourConfiguration("demo-0.yaml");
+    setTourActive(true);
+    el.requestUpdate();
+
+    await el.updateComplete;
+    await el.updateComplete;
+
+    expect(
+      el.shadowRoot!.querySelector('tbody tr[data-configuration="demo-0.yaml"]')
+    ).not.toBeNull();
   });
 });
 

--- a/test/components/dashboard/render-card-grid.test.ts
+++ b/test/components/dashboard/render-card-grid.test.ts
@@ -6,7 +6,7 @@
  * flow onto <esphome-device-card>, and the update indicator stays
  * gated on a live mDNS source.
  */
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
@@ -14,9 +14,19 @@ vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
 import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
 import { DeviceState } from "../../../src/api/types/devices.js";
 import { renderCardGrid } from "../../../src/components/dashboard/render-content.js";
+import {
+  clearTourConfiguration,
+  setTourActive,
+  setTourConfiguration,
+} from "../../../src/components/guided-tour/tour-session.js";
 import { renderInto } from "../../_dom.js";
 import { makeConfiguredDevice } from "../../_make-configured-device.js";
 import { makeDashboardHost } from "./_host.js";
+
+afterEach(() => {
+  setTourActive(false);
+  clearTourConfiguration();
+});
 
 function makeHost(devices: ConfiguredDevice[]) {
   return makeDashboardHost({
@@ -69,5 +79,27 @@ describe("renderCardGrid", () => {
     const card = renderCard(device);
     expect(card.hasAttribute("show-update")).toBe(false);
     expect(card.hasAttribute("queued-update")).toBe(false);
+  });
+
+  it("keeps the tour target in canonical device order", () => {
+    const zulu = makeConfiguredDevice({
+      name: "zulu",
+      friendly_name: "Zulu",
+      configuration: "zulu.yaml",
+    });
+    const alpha = makeConfiguredDevice({
+      name: "alpha",
+      friendly_name: "Alpha",
+      configuration: "alpha.yaml",
+    });
+    setTourConfiguration(alpha.configuration);
+    setTourActive(true);
+
+    const container = renderInto(renderCardGrid(makeHost([zulu, alpha]), [zulu]));
+    const configurations = [...container.querySelectorAll("esphome-device-card")].map(
+      (card) => card.getAttribute("data-configuration")
+    );
+
+    expect(configurations).toEqual(["alpha.yaml", "zulu.yaml"]);
   });
 });

--- a/test/components/device/device-navigator-filter.test.ts
+++ b/test/components/device/device-navigator-filter.test.ts
@@ -91,6 +91,15 @@ describe("device-navigator search filtering", () => {
     expect(rowSubtitles(nav)).toEqual(["Living Temp"]);
   });
 
+  it("renders forced-open filtered headers as non-interactive", async () => {
+    const nav = await mountNavigator("living");
+    const header = sectionHeaders(nav)[0];
+
+    expect(header.hasAttribute("role")).toBe(false);
+    expect(header.hasAttribute("tabindex")).toBe(false);
+    expect(header.hasAttribute("aria-expanded")).toBe(false);
+  });
+
   it("matches on the id even when the displayed name differs", async () => {
     // "Living Temp" (name) has a space; only the id "living_temp" matches.
     const nav = await mountNavigator("living_temp");

--- a/test/components/device/device-navigator-overview.test.ts
+++ b/test/components/device/device-navigator-overview.test.ts
@@ -38,4 +38,18 @@ describe("device-navigator section header icons", () => {
       SECTION_ICON.automations,
     ]);
   });
+
+  it("reports whether each keyboard-operable section is expanded", async () => {
+    const nav = await mountNavigator();
+    const firstHeader = nav.shadowRoot!.querySelector<HTMLElement>(".nav-content")!;
+    expect(firstHeader.getAttribute("role")).toBe("button");
+    expect(firstHeader.getAttribute("aria-expanded")).toBe("false");
+
+    nav.openSections = new Set([0]);
+    await nav.updateComplete;
+
+    expect(
+      nav.shadowRoot!.querySelector(".nav-content")?.getAttribute("aria-expanded")
+    ).toBe("true");
+  });
 });

--- a/test/components/onboarding/onboarding-wizard-restart.test.ts
+++ b/test/components/onboarding/onboarding-wizard-restart.test.ts
@@ -24,6 +24,7 @@ interface WizardInternals {
   _remoteCompute: boolean;
   _experience: ExperienceLevel;
   _titleKey: string;
+  _chooseExperience(level: ExperienceLevel): void;
   _onContinue(): Promise<void>;
   _onRequestClose(event: Event): void;
   _startTour(): void;
@@ -74,7 +75,7 @@ describe("mandatory onboarding flow", () => {
     state._onRequestClose(requiredClose);
     expect(requiredClose.defaultPrevented).toBe(true);
 
-    state._index = 3;
+    state._index = 2;
     const optionalClose = new Event("request-close", { cancelable: true });
     state._onRequestClose(optionalClose);
     expect(optionalClose.defaultPrevented).toBe(false);
@@ -86,7 +87,7 @@ describe("mandatory onboarding flow", () => {
     wizard.hasUseCase = true;
     wizard.open();
     const state = internals(wizard);
-    state._index = 2;
+    state._index = 1;
     state._api = {
       updatePreferences: vi.fn().mockResolvedValue(undefined),
       markOnboardingAcknowledged: vi.fn().mockResolvedValue(undefined),
@@ -105,12 +106,45 @@ describe("mandatory onboarding flow", () => {
     expect(acknowledged).toHaveBeenCalledOnce();
   });
 
+  it("asks expert users for their use case before saving", async () => {
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    wizard.hasUseCase = true;
+    wizard.open();
+    const state = internals(wizard);
+    state._experience = ExperienceLevel.EXPERT;
+    state._index = 1;
+    state._api = {
+      updatePreferences: vi.fn(),
+      markOnboardingAcknowledged: vi.fn(),
+    };
+
+    await state._onContinue();
+
+    expect(state._screen).toBe("use_case");
+    expect(state._api.updatePreferences).not.toHaveBeenCalled();
+  });
+
+  it("restores local-device mode when switching back to beginner", () => {
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    wizard.hasUseCase = true;
+    wizard.open();
+    const state = internals(wizard);
+    state._experience = ExperienceLevel.EXPERT;
+    state._remoteCompute = true;
+    state._index = 1;
+
+    state._chooseExperience(ExperienceLevel.BEGINNER);
+
+    expect(state._remoteCompute).toBe(false);
+    expect(state._screen).toBe("experience");
+  });
+
   it("starts the guided tour only after the final dialog has closed", () => {
     const wizard = new ESPHomeOnboardingWizardDialog();
     wizard.hasUseCase = true;
     wizard.open();
     const state = internals(wizard);
-    state._index = 3;
+    state._index = 2;
     const openTour = vi.fn();
     wizard.addEventListener("open-guided-tour", openTour);
 
@@ -126,6 +160,7 @@ describe("mandatory onboarding flow", () => {
     wizard.hasUseCase = true;
     wizard.open();
     const state = internals(wizard);
+    state._experience = ExperienceLevel.EXPERT;
     state._remoteCompute = true;
     state._index = 3;
 

--- a/test/components/onboarding/onboarding-wizard-restart.test.ts
+++ b/test/components/onboarding/onboarding-wizard-restart.test.ts
@@ -23,6 +23,7 @@ interface WizardInternals {
   _useCaseChosen: boolean;
   _remoteCompute: boolean;
   _experience: ExperienceLevel;
+  _titleKey: string;
   _onContinue(): Promise<void>;
   _onRequestClose(event: Event): void;
   _startTour(): void;
@@ -118,5 +119,16 @@ describe("mandatory onboarding flow", () => {
 
     state._onAfterHide();
     expect(openTour).toHaveBeenCalledOnce();
+  });
+
+  it("ends remote-compute setup without offering an incompatible tour", () => {
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    wizard.hasUseCase = true;
+    wizard.open();
+    const state = internals(wizard);
+    state._remoteCompute = true;
+    state._index = 3;
+
+    expect(state._titleKey).toBe("onboarding.wizard.tour.remote_title");
   });
 });

--- a/test/components/onboarding/onboarding-wizard-restart.test.ts
+++ b/test/components/onboarding/onboarding-wizard-restart.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ExperienceLevel } from "../../../src/api/types/system.js";
+import {
+  ESPHomeOnboardingWizardDialog,
+  RESET_ONBOARDING_PARAM,
+} from "../../../src/components/onboarding/onboarding-wizard-dialog.js";
+
+interface WizardInternals {
+  _api: {
+    updatePreferences: ReturnType<typeof vi.fn>;
+    markOnboardingAcknowledged: ReturnType<typeof vi.fn>;
+  };
+  _open: boolean;
+  _index: number;
+  _screen: string;
+  _useCaseChosen: boolean;
+  _remoteCompute: boolean;
+  _experience: ExperienceLevel;
+  _onContinue(): Promise<void>;
+  _onRequestClose(event: Event): void;
+  _startTour(): void;
+  _onAfterHide(): void;
+}
+
+const internals = (wizard: ESPHomeOnboardingWizardDialog) =>
+  wizard as unknown as WizardInternals;
+
+afterEach(() => {
+  document.body.replaceChildren();
+  window.history.replaceState(null, "", "/");
+  delete (globalThis as { __DEV__?: boolean }).__DEV__;
+});
+
+describe("onboarding wizard reset query", () => {
+  it("opens a clean default run and consumes only its query parameter", async () => {
+    (globalThis as { __DEV__?: boolean }).__DEV__ = true;
+    window.history.replaceState(
+      null,
+      "",
+      `/?keep=yes&${RESET_ONBOARDING_PARAM}=1#section`
+    );
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    wizard.hasUseCase = true;
+    document.body.appendChild(wizard);
+    await wizard.updateComplete;
+
+    const state = internals(wizard);
+    expect(state._open).toBe(true);
+    expect(state._screen).toBe("welcome");
+    expect(state._useCaseChosen).toBe(true);
+    expect(state._remoteCompute).toBe(false);
+    expect(state._experience).toBe(ExperienceLevel.BEGINNER);
+    expect(window.location.search).toBe("?keep=yes");
+    expect(window.location.hash).toBe("#section");
+  });
+});
+
+describe("mandatory onboarding flow", () => {
+  it("vetoes close requests until the final tour offer", () => {
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    wizard.hasUseCase = true;
+    wizard.open();
+    const state = internals(wizard);
+
+    const requiredClose = new Event("request-close", { cancelable: true });
+    state._onRequestClose(requiredClose);
+    expect(requiredClose.defaultPrevented).toBe(true);
+
+    state._index = 3;
+    const optionalClose = new Event("request-close", { cancelable: true });
+    state._onRequestClose(optionalClose);
+    expect(optionalClose.defaultPrevented).toBe(false);
+    expect(state._open).toBe(false);
+  });
+
+  it("persists choices before presenting the tour offer", async () => {
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    wizard.hasUseCase = true;
+    wizard.open();
+    const state = internals(wizard);
+    state._index = 2;
+    state._api = {
+      updatePreferences: vi.fn().mockResolvedValue(undefined),
+      markOnboardingAcknowledged: vi.fn().mockResolvedValue(undefined),
+    };
+    const acknowledged = vi.fn();
+    wizard.addEventListener("onboarding-acknowledged", acknowledged);
+
+    await state._onContinue();
+
+    expect(state._api.updatePreferences).toHaveBeenCalledWith({
+      experience_level: ExperienceLevel.BEGINNER,
+      remote_compute_only: false,
+    });
+    expect(state._api.markOnboardingAcknowledged).toHaveBeenCalledOnce();
+    expect(state._screen).toBe("tour");
+    expect(acknowledged).toHaveBeenCalledOnce();
+  });
+
+  it("starts the guided tour only after the final dialog has closed", () => {
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    wizard.hasUseCase = true;
+    wizard.open();
+    const state = internals(wizard);
+    state._index = 3;
+    const openTour = vi.fn();
+    wizard.addEventListener("open-guided-tour", openTour);
+
+    state._startTour();
+    expect(openTour).not.toHaveBeenCalled();
+
+    state._onAfterHide();
+    expect(openTour).toHaveBeenCalledOnce();
+  });
+});

--- a/test/components/onboarding/wizard-screens.test.ts
+++ b/test/components/onboarding/wizard-screens.test.ts
@@ -2,17 +2,25 @@ import { describe, expect, it } from "vitest";
 import { wizardScreens } from "../../../src/components/onboarding/wizard-screens.js";
 
 describe("wizardScreens", () => {
-  it("non-HA: welcome, use case, experience, then tour offer", () => {
-    expect(wizardScreens({ hasUseCase: true })).toEqual([
+  it("asks non-HA expert users how they will use the dashboard", () => {
+    expect(wizardScreens({ hasUseCase: true, isExpert: true })).toEqual([
       "welcome",
+      "experience",
       "use_case",
+      "tour",
+    ]);
+  });
+
+  it("skips the use-case screen for beginners", () => {
+    expect(wizardScreens({ hasUseCase: true, isExpert: false })).toEqual([
+      "welcome",
       "experience",
       "tour",
     ]);
   });
 
-  it("HA add-on: skips the use-case screen", () => {
-    expect(wizardScreens({ hasUseCase: false })).toEqual([
+  it("skips the use-case screen in the HA add-on", () => {
+    expect(wizardScreens({ hasUseCase: false, isExpert: true })).toEqual([
       "welcome",
       "experience",
       "tour",
@@ -20,7 +28,7 @@ describe("wizardScreens", () => {
   });
 
   it("never includes Wi-Fi setup", () => {
-    expect(wizardScreens({ hasUseCase: true })).not.toContain("wifi");
-    expect(wizardScreens({ hasUseCase: false })).not.toContain("wifi");
+    expect(wizardScreens({ hasUseCase: true, isExpert: true })).not.toContain("wifi");
+    expect(wizardScreens({ hasUseCase: false, isExpert: false })).not.toContain("wifi");
   });
 });

--- a/test/components/onboarding/wizard-screens.test.ts
+++ b/test/components/onboarding/wizard-screens.test.ts
@@ -2,11 +2,25 @@ import { describe, expect, it } from "vitest";
 import { wizardScreens } from "../../../src/components/onboarding/wizard-screens.js";
 
 describe("wizardScreens", () => {
-  it("non-HA: use-case then experience (Wi-Fi is collected per-device)", () => {
-    expect(wizardScreens({ hasUseCase: true })).toEqual(["use_case", "experience"]);
+  it("non-HA: welcome, use case, experience, then tour offer", () => {
+    expect(wizardScreens({ hasUseCase: true })).toEqual([
+      "welcome",
+      "use_case",
+      "experience",
+      "tour",
+    ]);
   });
 
-  it("HA add-on: experience only (no use-case screen)", () => {
-    expect(wizardScreens({ hasUseCase: false })).toEqual(["experience"]);
+  it("HA add-on: skips the use-case screen", () => {
+    expect(wizardScreens({ hasUseCase: false })).toEqual([
+      "welcome",
+      "experience",
+      "tour",
+    ]);
+  });
+
+  it("never includes Wi-Fi setup", () => {
+    expect(wizardScreens({ hasUseCase: true })).not.toContain("wifi");
+    expect(wizardScreens({ hasUseCase: false })).not.toContain("wifi");
   });
 });

--- a/test/components/wizard/wizard-step-setup.test.ts
+++ b/test/components/wizard/wizard-step-setup.test.ts
@@ -99,17 +99,14 @@ describe("wizard-step-setup", () => {
     expect(stage(el)).toBe("wifi");
   });
 
-  it("offers Skip for now on the Wi-Fi stage", async () => {
+  it("does not offer an unusable skip path before Wi-Fi is configured", async () => {
     const el = await mount(wifiBoard());
     await setName(el, "kitchen");
     pressEnter();
     await el.updateComplete;
+
     expect(stage(el)).toBe("wifi");
-    const skip = el.shadowRoot!.querySelector<HTMLButtonElement>(".skip-wifi")!;
-    const onFinish = vi.fn();
-    el.addEventListener("finish-setup", onFinish as EventListener);
-    skip.click();
-    expect((onFinish.mock.calls[0][0] as CustomEvent).detail.wifiSsid).toBe("");
+    expect(el.shadowRoot!.querySelector(".wifi-confirm")).toBeNull();
   });
 
   it("requires an SSID to finish a Wi-Fi-only board", async () => {
@@ -186,8 +183,30 @@ describe("wizard-step-setup", () => {
     expect(stage(el)).toBe("wifi");
     expect(el.shadowRoot!.querySelector(".wifi-saved")).not.toBeNull();
     expect(el.shadowRoot!.querySelector("#onboarding-ssid")).toBeNull();
-    expect(el.shadowRoot!.querySelector(".skip-wifi")?.textContent).toContain(
+    expect(el.shadowRoot!.querySelector(".wifi-confirm")?.textContent).toContain(
       "wizard.wifi_use_saved"
+    );
+  });
+
+  it("collects missing Wi-Fi during the tour instead of offering skip", async () => {
+    setTourActive(true);
+    const el = await mount(wifiBoard());
+    await setName(el, "kitchen");
+    pressEnter();
+    await el.updateComplete;
+
+    expect(stage(el)).toBe("wifi");
+    expect(el.shadowRoot!.querySelector(".wifi-confirm")).toBeNull();
+    expect(
+      el.shadowRoot!.querySelector(".actions-right .btn-primary")?.textContent
+    ).toContain("wizard.finish_setup");
+
+    await setSsid(el, "tour-network");
+    const onFinish = vi.fn();
+    el.addEventListener("finish-setup", onFinish as EventListener);
+    pressEnter();
+    expect((onFinish.mock.calls[0][0] as CustomEvent).detail.wifiSsid).toBe(
+      "tour-network"
     );
   });
 

--- a/test/components/wizard/wizard-step-setup.test.ts
+++ b/test/components/wizard/wizard-step-setup.test.ts
@@ -8,6 +8,10 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
+import {
+  clearTourPending,
+  setTourPending,
+} from "../../../src/components/guided-tour/tour-session.js";
 import { ESPHomeWizardStepSetup } from "../../../src/components/wizard/wizard-step-setup.js";
 import { fetchSecretKeys } from "../../../src/util/secrets-cache.js";
 import { pressEnter } from "../../_press-enter.js";
@@ -26,6 +30,7 @@ vi.mock("../../../src/util/secrets-cache.js", async (importOriginal) => ({
 }));
 
 beforeEach(() => {
+  clearTourPending();
   vi.mocked(fetchSecretKeys).mockResolvedValue([]);
 });
 
@@ -92,13 +97,17 @@ describe("wizard-step-setup", () => {
     expect(stage(el)).toBe("wifi");
   });
 
-  it("never shows a skip link on the Wi-Fi stage", async () => {
+  it("offers Skip for now on the Wi-Fi stage", async () => {
     const el = await mount(wifiBoard());
     await setName(el, "kitchen");
     pressEnter();
     await el.updateComplete;
     expect(stage(el)).toBe("wifi");
-    expect(el.shadowRoot!.querySelector(".skip-wifi")).toBeNull();
+    const skip = el.shadowRoot!.querySelector<HTMLButtonElement>(".skip-wifi")!;
+    const onFinish = vi.fn();
+    el.addEventListener("finish-setup", onFinish as EventListener);
+    skip.click();
+    expect((onFinish.mock.calls[0][0] as CustomEvent).detail.wifiSsid).toBe("");
   });
 
   it("requires an SSID to finish a Wi-Fi-only board", async () => {
@@ -162,6 +171,21 @@ describe("wizard-step-setup", () => {
     const detail = (onFinish.mock.calls[0][0] as CustomEvent).detail;
     expect(detail.wifiSsid).toBe("");
     expect(detail.wifiPassword).toBe("");
+  });
+
+  it("shows saved Wi-Fi during the tour without revealing its values", async () => {
+    setTourPending();
+    const el = await mount(wifiBoard(), ["wifi_ssid", "wifi_password"]);
+    await setName(el, "kitchen");
+    pressEnter();
+    await el.updateComplete;
+
+    expect(stage(el)).toBe("wifi");
+    expect(el.shadowRoot!.querySelector(".wifi-saved")).not.toBeNull();
+    expect(el.shadowRoot!.querySelector("#onboarding-ssid")).toBeNull();
+    expect(el.shadowRoot!.querySelector(".skip-wifi")?.textContent).toContain(
+      "wizard.wifi_use_saved"
+    );
   });
 
   it("passes a typed SSID through unchanged for the backend to persist", async () => {

--- a/test/components/wizard/wizard-step-setup.test.ts
+++ b/test/components/wizard/wizard-step-setup.test.ts
@@ -10,6 +10,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
 import {
   clearTourPending,
+  setTourActive,
   setTourPending,
 } from "../../../src/components/guided-tour/tour-session.js";
 import { ESPHomeWizardStepSetup } from "../../../src/components/wizard/wizard-step-setup.js";
@@ -31,6 +32,7 @@ vi.mock("../../../src/util/secrets-cache.js", async (importOriginal) => ({
 
 beforeEach(() => {
   clearTourPending();
+  setTourActive(false);
   vi.mocked(fetchSecretKeys).mockResolvedValue([]);
 });
 
@@ -175,6 +177,7 @@ describe("wizard-step-setup", () => {
 
   it("shows saved Wi-Fi during the tour without revealing its values", async () => {
     setTourPending();
+    setTourActive(true);
     const el = await mount(wifiBoard(), ["wifi_ssid", "wifi_password"]);
     await setName(el, "kitchen");
     pressEnter();
@@ -186,6 +189,19 @@ describe("wizard-step-setup", () => {
     expect(el.shadowRoot!.querySelector(".skip-wifi")?.textContent).toContain(
       "wizard.wifi_use_saved"
     );
+  });
+
+  it("does not show saved Wi-Fi while the tour is paused", async () => {
+    setTourPending();
+    const el = await mount(wifiBoard(), ["wifi_ssid", "wifi_password"]);
+    await setName(el, "kitchen");
+    const onFinish = vi.fn();
+    el.addEventListener("finish-setup", onFinish as EventListener);
+
+    pressEnter();
+
+    expect(onFinish).toHaveBeenCalledOnce();
+    expect(stage(el)).toBe("name");
   });
 
   it("passes a typed SSID through unchanged for the backend to persist", async () => {

--- a/test/guided-tour/tour-activity-controller.test.ts
+++ b/test/guided-tour/tour-activity-controller.test.ts
@@ -1,0 +1,27 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type { ReactiveControllerHost } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import { TourActivityController } from "../../src/components/guided-tour/tour-activity-controller.js";
+import { setTourActive } from "../../src/components/guided-tour/tour-session.js";
+
+describe("TourActivityController", () => {
+  it("requests a render whenever tour activity changes", () => {
+    const requestUpdate = vi.fn();
+    const host = {
+      addController() {},
+      removeController() {},
+      requestUpdate,
+      updateComplete: Promise.resolve(true),
+    } as unknown as ReactiveControllerHost;
+    const controller = new TourActivityController(host);
+    controller.hostConnected();
+
+    setTourActive(true);
+    setTourActive(false);
+
+    expect(requestUpdate).toHaveBeenCalledTimes(2);
+    controller.hostDisconnected();
+  });
+});

--- a/test/guided-tour/tour-geometry.test.ts
+++ b/test/guided-tour/tour-geometry.test.ts
@@ -76,14 +76,6 @@ describe("computeTourFrame dim panels", () => {
   });
 });
 
-describe("computeTourFrame ring", () => {
-  it("matches the hole and caps the corner radius at half its height", () => {
-    const { hole, ring } = computeTourFrame(TARGET, "right", VP);
-    expect({ x: ring.x, y: ring.y, w: ring.w, h: ring.h }).toEqual(hole);
-    expect(ring.radius).toBe(Math.min(hole.h / 2, 14));
-  });
-});
-
 describe("computeTourFrame bubble placement", () => {
   it("places a right-side bubble just past the hole, top-anchored", () => {
     const { hole, bubble } = computeTourFrame(TARGET, "right", VP);

--- a/test/guided-tour/tour-layout-controller.test.ts
+++ b/test/guided-tour/tour-layout-controller.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  TOUR_LAYOUT_CHANGE_EVENT,
+  TOUR_LAYOUT_RESTORE_EVENT,
+  TourLayoutController,
+} from "../../src/components/guided-tour/tour-layout-controller.js";
+
+let controller: ReactiveController | undefined;
+const host = {
+  addController(value: ReactiveController) {
+    controller = value;
+  },
+  removeController() {},
+  requestUpdate() {},
+  updateComplete: Promise.resolve(true),
+} as unknown as ReactiveControllerHost;
+
+afterEach(() => {
+  controller?.hostDisconnected?.();
+  controller = undefined;
+});
+
+describe("TourLayoutController", () => {
+  it("restores the layout that was active before the tour override", () => {
+    let layout = "right";
+    new TourLayoutController(
+      host,
+      () => layout,
+      (value) => {
+        layout = value;
+      }
+    );
+    controller?.hostConnected?.();
+
+    window.dispatchEvent(new CustomEvent(TOUR_LAYOUT_CHANGE_EVENT, { detail: "both" }));
+    expect(layout).toBe("both");
+
+    window.dispatchEvent(new Event(TOUR_LAYOUT_RESTORE_EVENT));
+    expect(layout).toBe("right");
+  });
+
+  it("does not undo a layout the user explicitly selected during the tour", () => {
+    let layout = "right";
+    new TourLayoutController(
+      host,
+      () => layout,
+      (value) => {
+        layout = value;
+      }
+    );
+    controller?.hostConnected?.();
+    window.dispatchEvent(new CustomEvent(TOUR_LAYOUT_CHANGE_EVENT, { detail: "both" }));
+
+    layout = "left";
+    window.dispatchEvent(new Event("layout-change"));
+    window.dispatchEvent(new Event(TOUR_LAYOUT_RESTORE_EVENT));
+
+    expect(layout).toBe("left");
+  });
+});

--- a/test/guided-tour/tour-pause.test.ts
+++ b/test/guided-tour/tour-pause.test.ts
@@ -157,6 +157,24 @@ describe("guided-tour pause state", () => {
     expect(isTourPending()).toBe(true);
   });
 
+  it("pauses when guarded navigation rejects", async () => {
+    const error = new Error("guard failed");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.mocked(navigate).mockRejectedValueOnce(error);
+    setTourPending();
+    window.history.replaceState(null, "", "/secrets");
+    const state = internals(new ESPHomeGuidedTour());
+
+    state.firstUpdated();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(state._active).toBe(false);
+    expect(isTourPending()).toBe(true);
+    expect(warn).toHaveBeenCalledWith("Guided tour navigation failed:", error);
+    warn.mockRestore();
+  });
+
   it("remeasures a dialog anchor after its opening transition", () => {
     const state = internals(new ESPHomeGuidedTour());
     state._active = true;

--- a/test/guided-tour/tour-pause.test.ts
+++ b/test/guided-tour/tour-pause.test.ts
@@ -11,6 +11,7 @@ vi.mock("../../src/util/navigation.js", () => ({
 }));
 
 import { ESPHomeGuidedTour } from "../../src/components/guided-tour/esphome-guided-tour.js";
+import { captureTourConfiguration } from "../../src/components/guided-tour/tour-route.js";
 import {
   clearTourConfiguration,
   clearTourPending,
@@ -37,7 +38,6 @@ interface TourInternals {
   _refresh(): void;
   _onDialogShown(): void;
   _maybeAutoAdvance(): boolean;
-  _captureDeviceConfiguration(): void;
   _onKeydown(event: KeyboardEvent): void;
   _next(): void;
   _pause(): void;
@@ -171,15 +171,30 @@ describe("guided-tour pause state", () => {
     expect(state._stepIndex).toBe(1);
   });
 
-  it("advances the navigator step only from Core Configuration", () => {
+  it("advances the navigator step only from ESPHome Core", () => {
     const state = internals(new ESPHomeGuidedTour());
     state._stepIndex = TOUR_STEPS.findIndex((step) => step.anchors.includes("nav"));
     const navigator = document.createElement("section");
     const core = document.createElement("button");
     state._anchors.set("nav", navigator);
-    state._anchors.set("nav-core", core);
+    state._anchors.set("nav-core-item", core);
 
     expect(state._actionAnchorEls()).toEqual([core]);
+  });
+
+  it("advances from the semantic ESPHome Core selection event", () => {
+    const tour = new ESPHomeGuidedTour();
+    const state = internals(tour);
+    const navigatorIndex = TOUR_STEPS.findIndex((step) => step.anchors.includes("nav"));
+    tour.start(navigatorIndex);
+
+    window.dispatchEvent(
+      new CustomEvent("section-select", {
+        detail: { sectionKey: "esphome" },
+      })
+    );
+
+    expect(state._stepIndex).toBe(navigatorIndex + 1);
   });
 
   it("waits for successful creation before leaving the Wi-Fi step", () => {
@@ -197,7 +212,7 @@ describe("guided-tour pause state", () => {
     state._active = true;
     window.history.replaceState(null, "", "/device/my%20tour.yaml");
 
-    state._captureDeviceConfiguration();
+    captureTourConfiguration(state._active);
 
     expect(getTourConfiguration()).toBe("my tour.yaml");
   });

--- a/test/guided-tour/tour-pause.test.ts
+++ b/test/guided-tour/tour-pause.test.ts
@@ -82,6 +82,19 @@ describe("guided-tour pause state", () => {
     expect(isTourPending()).toBe(false);
   });
 
+  it("can start again after a completed tour", () => {
+    const tour = new ESPHomeGuidedTour();
+    const state = internals(tour);
+    tour.start();
+    state._finish();
+
+    tour.start();
+
+    expect(state._active).toBe(true);
+    expect(state._stepIndex).toBe(0);
+    expect(getPendingTourStep()).toBe(0);
+  });
+
   it("does not start in remote-compute-only mode", () => {
     setTourPending();
     const tour = new ESPHomeGuidedTour();

--- a/test/guided-tour/tour-pause.test.ts
+++ b/test/guided-tour/tour-pause.test.ts
@@ -1,0 +1,233 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("../../src/util/navigation.js", () => ({
+  navigate: vi.fn(async (url: string) => {
+    window.history.pushState(null, "", url);
+  }),
+}));
+
+import { ESPHomeGuidedTour } from "../../src/components/guided-tour/esphome-guided-tour.js";
+import {
+  clearTourConfiguration,
+  clearTourPending,
+  getActiveTourConfiguration,
+  getPendingTourStep,
+  getTourConfiguration,
+  isTourPending,
+  setTourConfiguration,
+  setTourActive,
+  setTourPending,
+} from "../../src/components/guided-tour/tour-session.js";
+import { TOUR_STEPS } from "../../src/components/guided-tour/tour-steps.js";
+import { navigate } from "../../src/util/navigation.js";
+
+interface TourInternals {
+  _active: boolean;
+  _remoteComputeOnly: boolean;
+  _showAnchorRecovery: boolean;
+  _dialogReady: boolean;
+  _stepIndex: number;
+  _anchors: Map<string, Element>;
+  _actionAnchorEls(): Element[];
+  _bouncePopover(): void;
+  _refresh(): void;
+  _onDialogShown(): void;
+  _maybeAutoAdvance(): boolean;
+  _captureDeviceConfiguration(): void;
+  _onKeydown(event: KeyboardEvent): void;
+  _next(): void;
+  _pause(): void;
+  _finish(): void;
+  firstUpdated(): void;
+}
+
+const internals = (tour: ESPHomeGuidedTour) => tour as unknown as TourInternals;
+
+afterEach(() => {
+  vi.useRealTimers();
+  clearTourConfiguration();
+  clearTourPending();
+  setTourActive(false);
+  window.history.replaceState(null, "", "/");
+  vi.clearAllMocks();
+});
+
+describe("guided-tour pause state", () => {
+  it("keeps the tour pending when closed for now", () => {
+    const tour = new ESPHomeGuidedTour();
+    const state = internals(tour);
+    tour.start();
+    setTourConfiguration("paused.yaml");
+
+    state._pause();
+
+    expect(state._active).toBe(false);
+    expect(isTourPending()).toBe(true);
+    expect(getPendingTourStep()).toBe(0);
+    expect(getTourConfiguration()).toBe("paused.yaml");
+    expect(getActiveTourConfiguration()).toBeNull();
+  });
+
+  it("clears pending state when the tour is skipped or finished", () => {
+    const tour = new ESPHomeGuidedTour();
+    const state = internals(tour);
+    tour.start();
+
+    state._finish();
+
+    expect(isTourPending()).toBe(false);
+  });
+
+  it("does not start in remote-compute-only mode", () => {
+    setTourPending();
+    const tour = new ESPHomeGuidedTour();
+    const state = internals(tour);
+    state._remoteComputeOnly = true;
+
+    tour.start();
+
+    expect(state._active).toBe(false);
+    expect(isTourPending()).toBe(false);
+  });
+
+  it("reopens a pending tour on the next load", () => {
+    setTourPending();
+    const state = internals(new ESPHomeGuidedTour());
+
+    state.firstUpdated();
+
+    expect(state._active).toBe(true);
+  });
+
+  it("resumes the saved device step and route", async () => {
+    const yamlIndex = TOUR_STEPS.findIndex((step) => step.anchors.includes("yaml"));
+    setTourPending(yamlIndex);
+    setTourConfiguration("my device.yaml");
+    const state = internals(new ESPHomeGuidedTour());
+
+    state.firstUpdated();
+    await Promise.resolve();
+
+    expect(state._stepIndex).toBe(yamlIndex);
+    expect(navigate).toHaveBeenCalledWith("/device/my%20device.yaml");
+  });
+
+  it("restarts dialog-only action chains from the dashboard", async () => {
+    const boardIndex = TOUR_STEPS.findIndex((step) =>
+      step.anchors.includes("board-featured")
+    );
+    setTourPending(boardIndex);
+    window.history.replaceState(null, "", "/secrets");
+    const state = internals(new ESPHomeGuidedTour());
+
+    state.firstUpdated();
+    await Promise.resolve();
+
+    expect(state._stepIndex).toBe(0);
+    expect(navigate).toHaveBeenCalledWith("/");
+  });
+
+  it("pauses when a guarded route transition is cancelled", async () => {
+    vi.mocked(navigate).mockImplementationOnce(async () => {});
+    setTourPending();
+    window.history.replaceState(null, "", "/secrets");
+    const state = internals(new ESPHomeGuidedTour());
+
+    state.firstUpdated();
+    await Promise.resolve();
+
+    expect(state._active).toBe(false);
+    expect(isTourPending()).toBe(true);
+  });
+
+  it("remeasures a dialog anchor after its opening transition", () => {
+    const state = internals(new ESPHomeGuidedTour());
+    state._active = true;
+    state._stepIndex = TOUR_STEPS.findIndex((step) =>
+      step.anchors.includes("create-method-basic")
+    );
+    state._bouncePopover = vi.fn();
+    state._refresh = vi.fn();
+
+    state._onDialogShown();
+
+    expect(state._bouncePopover).toHaveBeenCalledOnce();
+    expect(state._refresh).toHaveBeenCalledOnce();
+  });
+
+  it("waits for the opening animation before showing the first dialog step", () => {
+    const state = internals(new ESPHomeGuidedTour());
+    state._active = true;
+    state._stepIndex = 0;
+    state._dialogReady = false;
+    state._anchors.set("create-method-basic", document.createElement("button"));
+
+    expect(state._maybeAutoAdvance()).toBe(false);
+    state._onDialogShown();
+    expect(state._stepIndex).toBe(1);
+  });
+
+  it("advances the navigator step only from Core Configuration", () => {
+    const state = internals(new ESPHomeGuidedTour());
+    state._stepIndex = TOUR_STEPS.findIndex((step) => step.anchors.includes("nav"));
+    const navigator = document.createElement("section");
+    const core = document.createElement("button");
+    state._anchors.set("nav", navigator);
+    state._anchors.set("nav-core", core);
+
+    expect(state._actionAnchorEls()).toEqual([core]);
+  });
+
+  it("waits for successful creation before leaving the Wi-Fi step", () => {
+    const state = internals(new ESPHomeGuidedTour());
+    state._stepIndex = TOUR_STEPS.findIndex((step) =>
+      step.anchors.includes("wifi-tour-continue")
+    );
+    state._anchors.set("wifi-tour-continue", document.createElement("button"));
+
+    expect(state._actionAnchorEls()).toEqual([]);
+  });
+
+  it("remembers the created configuration for the dashboard spotlight", () => {
+    const state = internals(new ESPHomeGuidedTour());
+    state._active = true;
+    window.history.replaceState(null, "", "/device/my%20tour.yaml");
+
+    state._captureDeviceConfiguration();
+
+    expect(getTourConfiguration()).toBe("my tour.yaml");
+  });
+
+  it("does not steal Enter from a focused tour button", () => {
+    const state = internals(new ESPHomeGuidedTour());
+    state._active = true;
+    state._stepIndex = TOUR_STEPS.findIndex((step) => step.anchors.includes("central"));
+    state._next = vi.fn();
+    const event = {
+      key: "Enter",
+      composedPath: () => [document.createElement("button")],
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as KeyboardEvent;
+
+    state._onKeydown(event);
+
+    expect(state._next).not.toHaveBeenCalled();
+  });
+
+  it("shows recovery controls when an anchor never appears", () => {
+    vi.useFakeTimers();
+    const state = internals(new ESPHomeGuidedTour());
+    state._active = true;
+    state._stepIndex = 0;
+
+    state._refresh();
+    vi.advanceTimersByTime(800);
+
+    expect(state._showAnchorRecovery).toBe(true);
+  });
+});

--- a/test/guided-tour/tour-skip-affordance.test.ts
+++ b/test/guided-tour/tour-skip-affordance.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type { ReactiveControllerHost } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TourSkipAffordance } from "../../src/components/guided-tour/tour-skip-affordance.js";
+
+const host = {
+  addController() {},
+  removeController() {},
+  requestUpdate() {},
+  updateComplete: Promise.resolve(true),
+} as unknown as ReactiveControllerHost;
+
+const rect = (left: number): DOMRect =>
+  ({ left, right: left + 20, top: 10, bottom: 30, width: 20, height: 20 }) as DOMRect;
+
+afterEach(() => {
+  document.documentElement.style.cursor = "";
+});
+
+describe("TourSkipAffordance", () => {
+  it("routes captured dialog clicks to Skip and Close for now separately", () => {
+    const onSkip = vi.fn();
+    const onPause = vi.fn();
+    const controller = new TourSkipAffordance(host, {
+      isDialogStep: () => true,
+      skipRect: () => rect(10),
+      pauseRect: () => rect(50),
+      onSkip,
+      onPause,
+    });
+    controller.setActive(true);
+
+    window.dispatchEvent(
+      new MouseEvent("click", { clientX: 15, clientY: 15, bubbles: true })
+    );
+    window.dispatchEvent(
+      new MouseEvent("click", { clientX: 55, clientY: 15, bubbles: true })
+    );
+
+    expect(onSkip).toHaveBeenCalledOnce();
+    expect(onPause).toHaveBeenCalledOnce();
+    controller.setActive(false);
+  });
+});

--- a/test/guided-tour/tour-spotlight.test.ts
+++ b/test/guided-tour/tour-spotlight.test.ts
@@ -5,7 +5,6 @@ import { findTemplatesByAnchor } from "../_lit-template-walker.js";
 
 const FRAME: TourFrame = {
   hole: { x: 100, y: 80, w: 200, h: 120 },
-  ring: { x: 100, y: 80, w: 200, h: 120, radius: 14 },
   dim: {
     top: { x: 0, y: 0, w: 800, h: 80 },
     bottom: { x: 0, y: 200, w: 800, h: 400 },
@@ -17,10 +16,9 @@ const FRAME: TourFrame = {
 };
 
 describe("renderTourSpotlightBackdrop", () => {
-  it("renders four dim panels around a visible target ring", () => {
+  it("renders four dim panels around the target cutout", () => {
     const result = renderTourSpotlightBackdrop(FRAME);
 
     expect(findTemplatesByAnchor(result, 'class="tour-dim"')).toHaveLength(4);
-    expect(findTemplatesByAnchor(result, 'class="tour-ring"')).toHaveLength(1);
   });
 });

--- a/test/util/onboarding-gate.test.ts
+++ b/test/util/onboarding-gate.test.ts
@@ -70,10 +70,7 @@ describe("isExperienceChosen", () => {
 describe("shouldAutoShowOnboarding", () => {
   it("pops for a fresh-install user behind current with pending step", () => {
     expect(
-      shouldAutoShowOnboarding(
-        stateWith([experience(OnboardingStepStatus.PENDING)]),
-        false
-      )
+      shouldAutoShowOnboarding(stateWith([experience(OnboardingStepStatus.PENDING)]))
     ).toBe(true);
   });
 
@@ -82,10 +79,7 @@ describe("shouldAutoShowOnboarding", () => {
       "(completed_version=0 + step DONE must not interrupt)",
     () => {
       expect(
-        shouldAutoShowOnboarding(
-          stateWith([experience(OnboardingStepStatus.DONE)]),
-          false
-        )
+        shouldAutoShowOnboarding(stateWith([experience(OnboardingStepStatus.DONE)]))
       ).toBe(false);
     }
   );
@@ -93,8 +87,7 @@ describe("shouldAutoShowOnboarding", () => {
   it("does NOT pop when user is up to date even with pending step", () => {
     expect(
       shouldAutoShowOnboarding(
-        stateWith([experience(OnboardingStepStatus.PENDING)], 1, 1),
-        false
+        stateWith([experience(OnboardingStepStatus.PENDING)], 1, 1)
       )
     ).toBe(false);
   });
@@ -102,22 +95,12 @@ describe("shouldAutoShowOnboarding", () => {
   it("does NOT pop when user is ahead of current (rolled back from a future build)", () => {
     expect(
       shouldAutoShowOnboarding(
-        stateWith([experience(OnboardingStepStatus.PENDING)], 1, 2),
-        false
-      )
-    ).toBe(false);
-  });
-
-  it("respects session-dismissal even with pending work", () => {
-    expect(
-      shouldAutoShowOnboarding(
-        stateWith([experience(OnboardingStepStatus.PENDING)]),
-        true
+        stateWith([experience(OnboardingStepStatus.PENDING)], 1, 2)
       )
     ).toBe(false);
   });
 
   it("does NOT pop when behind current but step list is empty", () => {
-    expect(shouldAutoShowOnboarding(stateWith([], 2, 0), false)).toBe(false);
+    expect(shouldAutoShowOnboarding(stateWith([], 2, 0))).toBe(false);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Polishes the onboarding and Quickstart tour merged in #1045 while preserving the later viewport, reveal, typing-target, listener-lifecycle, and file-size improvements.

The follow-up adds the approved desktop-first Welcome → experience → optional tour flow, with an additional use-case choice for Expert users on non-HA installs. It also adds contextual Wi-Fi review, action-driven coachmarks, Close-for-now pause/resume, clearer board, navigator, and YAML guidance, and a final spotlight on the created device in card or list view.

Responsive behavior was audited in Chromium at desktop, tablet portrait/landscape, phone portrait, small-phone portrait, and phone landscape sizes. Mobile adapts the navigator step to the drawer/Core-item flow; short landscape onboarding intentionally keeps an accessible internal scroll region.

**Related issue or feature (if applicable):**

- follow-up to #1045

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).