### PR TITLE
Bail to the YAML-only notice on unparseable numeric primitives

### DIFF
--- a/src/components/device/config-entry-renderers/primitives-numeric.ts
+++ b/src/components/device/config-entry-renderers/primitives-numeric.ts
@@ -52,7 +52,8 @@ export function renderNumberField(entry: ConfigEntry, path: string[], ctx: Rende
   // <input type="number"> and reads as unset — and an edit would write a bare
   // number over the original value. Bail visibly instead; a ${substitution}
   // stays editable as text, matching the validator's carve-out (#2056).
-  // Number(String(raw)) is the same numeric test validateEntry applies.
+  // Number(String(raw)) mirrors validateEntry's coercion, tightened to
+  // isFinite: Infinity also blanks in a number input, so it bails too.
   if (raw != null && !Number.isFinite(Number(String(raw)))) {
     return looksLikeSubstitution(String(raw))
       ? renderStringField(entry, "text", path, ctx)

--- a/src/components/device/config-entry-renderers/primitives-numeric.ts
+++ b/src/components/device/config-entry-renderers/primitives-numeric.ts
@@ -285,7 +285,7 @@ export function renderFloatWithUnitField(
     parsed.value === null &&
     editingText == null &&
     rawValue != null &&
-    rawValue !== ""
+    String(rawValue).trim() !== ""
   ) {
     return looksLikeSubstitution(String(rawValue))
       ? renderStringField(entry, "text", path, ctx)

--- a/src/components/device/config-entry-renderers/primitives-numeric.ts
+++ b/src/components/device/config-entry-renderers/primitives-numeric.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../util/float-with-unit.js";
 import { formatHexInt, parseHexInt } from "../../../util/hex-int.js";
 import { coerceIntFieldValue } from "../../../util/int-input.js";
+import { looksLikeSubstitution } from "../../../util/substitutions.js";
 import {
   parseTimePeriodScalar,
   serializeTimePeriod,
@@ -49,13 +50,13 @@ export function renderNumberField(entry: ConfigEntry, path: string[], ctx: Rende
   }
   // An unparseable primitive ("250 steps/s", a stray boolean) blanks inside
   // <input type="number"> and reads as unset — and an edit would write a bare
-  // number over the original value. Bail visibly instead (#2056).
-  if (
-    raw != null &&
-    raw !== "" &&
-    (typeof raw === "boolean" || !Number.isFinite(Number(raw)))
-  ) {
-    return renderYamlOnlyField(entry, path, ctx);
+  // number over the original value. Bail visibly instead; a ${substitution}
+  // stays editable as text, matching the validator's carve-out (#2056).
+  // Number(String(raw)) is the same numeric test validateEntry applies.
+  if (raw != null && !Number.isFinite(Number(String(raw)))) {
+    return looksLikeSubstitution(String(raw))
+      ? renderStringField(entry, "text", path, ctx)
+      : renderYamlOnlyField(entry, path, ctx);
   }
   // FLOAT keeps the native number spinner — floats don't take 0x… literals.
   const value = String(raw ?? "");
@@ -277,14 +278,17 @@ export function renderFloatWithUnitField(
   const editingText = ctx.getEditingMagnitude(path);
   // A present value the parser can't split ("21C", "inf") would render as an
   // empty magnitude + unit picker and read as unset. Bail visibly unless the
-  // user is mid-edit — the buffer legitimately holds partial input (#2056).
+  // user is mid-edit — the buffer legitimately holds partial input — with the
+  // same editable-text carve-out for a ${substitution} value (#2056).
   if (
     parsed.value === null &&
     editingText == null &&
     rawValue != null &&
     rawValue !== ""
   ) {
-    return renderYamlOnlyField(entry, path, ctx);
+    return looksLikeSubstitution(String(rawValue))
+      ? renderStringField(entry, "text", path, ctx)
+      : renderYamlOnlyField(entry, path, ctx);
   }
   const numberValue = editingText ?? (parsed.value === null ? "" : String(parsed.value));
   const unit = chooseDisplayUnit(

--- a/src/components/device/config-entry-renderers/primitives-numeric.ts
+++ b/src/components/device/config-entry-renderers/primitives-numeric.ts
@@ -26,6 +26,7 @@ import {
   renderLabel,
   renderStringField,
   renderYamlOnlyFallbackIfNonPrimitive,
+  renderYamlOnlyField,
   type RenderCtx,
 } from "../config-entry-renderers-shared.js";
 
@@ -45,6 +46,16 @@ export function renderNumberField(entry: ConfigEntry, path: string[], ctx: Rende
   }
   if (entry.type === ConfigEntryType.INTEGER) {
     return renderIntField(entry, path, ctx);
+  }
+  // An unparseable primitive ("250 steps/s", a stray boolean) blanks inside
+  // <input type="number"> and reads as unset — and an edit would write a bare
+  // number over the original value. Bail visibly instead (#2056).
+  if (
+    raw != null &&
+    raw !== "" &&
+    (typeof raw === "boolean" || !Number.isFinite(Number(raw)))
+  ) {
+    return renderYamlOnlyField(entry, path, ctx);
   }
   // FLOAT keeps the native number spinner — floats don't take 0x… literals.
   const value = String(raw ?? "");
@@ -264,6 +275,17 @@ export function renderFloatWithUnitField(
   // Edit buffer survives intermediate typing states ("-", "1e", "1.") that
   // the parser turns into null/"". Cleared on blur and on entries change.
   const editingText = ctx.getEditingMagnitude(path);
+  // A present value the parser can't split ("21C", "inf") would render as an
+  // empty magnitude + unit picker and read as unset. Bail visibly unless the
+  // user is mid-edit — the buffer legitimately holds partial input (#2056).
+  if (
+    parsed.value === null &&
+    editingText == null &&
+    rawValue != null &&
+    rawValue !== ""
+  ) {
+    return renderYamlOnlyField(entry, path, ctx);
+  }
   const numberValue = editingText ?? (parsed.value === null ? "" : String(parsed.value));
   const unit = chooseDisplayUnit(
     rawValue,

--- a/src/util/float-with-unit.ts
+++ b/src/util/float-with-unit.ts
@@ -20,8 +20,9 @@ export interface FloatWithUnit {
 // symbol (resistance: 'Ohm' / 'OHM' for Ω; temperature: '21C', '70F', '21° C'
 // for the degree forms). Keyed by the canonical base symbol (unit_options[0]);
 // each matched spelling is folded onto its symbol before matching, so
-// '5.6kOhm' lands on the kΩ option and '21C' on °C. ESPHome rejects plural
-// forms ('Ohms'), so the patterns are anchored to the singular. The
+// '5.6kOhm' lands on the kΩ option and '21C' on °C. Plurals follow upstream:
+// resistance rejects 'Ohms' so that pattern stays singular, while current /
+// voltage / data size accept 'amps' / 'Volts' / 'bytes' and fold them. The
 // temperature patterns are case-sensitive: ESPHome parses a trailing
 // lowercase 'c' as the centi metric prefix ('21c' is 0.21 °C), never a degree.
 // The full spelling inventory mirrors esphome/config_validation.py's

--- a/src/util/float-with-unit.ts
+++ b/src/util/float-with-unit.ts
@@ -16,14 +16,29 @@ export interface FloatWithUnit {
   unit: string;
 }
 
-// ESPHome accepts a textual spelling for some units whose unit_options carry a
-// non-ASCII symbol (resistance: 'Ohm' / 'OHM' for Ω). Keyed by the canonical
-// base symbol (unit_options[0]); the matched spelling is folded onto that
-// symbol before matching, so '5.6kOhm' lands on the kΩ option. Only the symbol
-// units a user cannot easily type need an entry. ESPHome rejects plural forms
-// ('Ohms'), so the patterns are anchored to the singular.
-const UNIT_SPELLING_ALIASES: Record<string, RegExp> = {
-  Ω: /ohm$/i,
+// ESPHome accepts textual spellings for some units whose unit_options carry a
+// symbol (resistance: 'Ohm' / 'OHM' for Ω; temperature: '21C', '70F', '21° C'
+// for the degree forms). Keyed by the canonical base symbol (unit_options[0]);
+// each matched spelling is folded onto its symbol before matching, so
+// '5.6kOhm' lands on the kΩ option and '21C' on °C. ESPHome rejects plural
+// forms ('Ohms'), so the patterns are anchored to the singular. The
+// temperature patterns are case-sensitive: ESPHome parses a trailing
+// lowercase 'c' as the centi metric prefix ('21c' is 0.21 °C), never a degree.
+// The full spelling inventory mirrors esphome/config_validation.py's
+// float_with_unit alternations and validate_bytes; symbol-only lists
+// (°/deg, dB/dBm, FPS/Hz, bar) already match case-insensitively without help.
+const UNIT_SPELLING_ALIASES: Record<string, readonly (readonly [RegExp, string])[]> = {
+  Ω: [[/ohm$/i, "Ω"]],
+  "°C": [
+    [/(?:°\s*C|(?<!°)C|°)$/, "°C"],
+    [/(?:°\s*F|(?<!°)F)$/, "°F"],
+    [/°\s*K$/, "K"],
+  ],
+  mireds: [[/Kelvin$/, "K"]],
+  A: [[/(?:amp|ampere)s?$/i, "A"]],
+  V: [[/volts?$/i, "V"]],
+  bps: [[/bits?\/s$/, "bps"]],
+  B: [[/(?:bytes?|[Bb]s|b)$/, "B"]],
 };
 
 /**
@@ -64,10 +79,13 @@ export function parseFloatWithUnit(
   const trimmed = raw === null || raw === undefined ? "" : String(raw).trim();
   if (trimmed === "") return { value: null, unit: fallbackUnit };
 
-  // Fold a textual unit spelling onto its symbol when this picker uses one,
-  // so '5.6kOhm' matches the kΩ option (see UNIT_SPELLING_ALIASES).
-  const aliasPattern = UNIT_SPELLING_ALIASES[fallbackUnit];
-  const text = aliasPattern ? trimmed.replace(aliasPattern, fallbackUnit) : trimmed;
+  // Fold textual unit spellings onto their symbols when this picker uses
+  // them, so '5.6kOhm' matches the kΩ option and '21C' matches °C (see
+  // UNIT_SPELLING_ALIASES).
+  let text = trimmed;
+  for (const [pattern, symbol] of UNIT_SPELLING_ALIASES[fallbackUnit] ?? []) {
+    text = text.replace(pattern, symbol);
+  }
   const lowerText = text.toLowerCase();
   let match: string | undefined;
   let bestScore = -1;

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -270,14 +270,33 @@ describe("renderNumberField / renderFloatWithUnitField — bail on unparseable p
     expect(rendersBailBranch(json)).toBe(true);
   });
 
+  it("renders both fields as editable text for a ${substitution} value", () => {
+    // The validator skips numeric checks for substitution refs; the
+    // renderer must keep them editable, not lock them behind the notice.
+    const floatCtx = makeCtx({ max_speed: "${speed}" }).ctx;
+    const floatJson = JSON.stringify(
+      renderNumberField(floatEntry(), ["max_speed"], floatCtx),
+      (k, v) => (k === "_$litType$" ? 0 : v)
+    );
+    expect(rendersBailBranch(floatJson)).toBe(false);
+    expect(floatJson).toContain("${speed}");
+
+    const unitCtx = makeCtx({ default_target_temperature: "${target}" }).ctx;
+    const unitJson = JSON.stringify(
+      renderFloatWithUnitField(withUnitEntry(), ["default_target_temperature"], unitCtx),
+      (k, v) => (k === "_$litType$" ? 0 : v)
+    );
+    expect(rendersBailBranch(unitJson)).toBe(false);
+    expect(unitJson).toContain("${target}");
+  });
+
   it("keeps the editable UI mid-edit even when the committed value is empty", () => {
-    const emitChange = vi.fn();
     const ctx = makeRenderCtx(
       { default_target_temperature: "1e" },
       {
         board: null,
         overrides: {
-          emitChange,
+          emitChange: vi.fn(),
           renderEntry: () => "<rendered>",
           getEditingMagnitude: () => "1e",
         },

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -18,6 +18,7 @@ import { renderMultiValueField } from "../../../src/components/device/config-ent
 import {
   renderBooleanField,
   renderFloatWithUnitField,
+  renderNumberField,
   renderTextareaField,
   renderTimePeriodField,
 } from "../../../src/components/device/config-entry-renderers/primitives.js";
@@ -201,6 +202,107 @@ describe("renderTimePeriodField / renderFloatWithUnitField — bail on non-primi
     const tpl = renderFloatWithUnitField(entry, ["frequency"], ctx);
     const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
     expect(rendersBailBranch(json)).toBe(false);
+  });
+});
+
+// <input type="number"> silently blanks a non-numeric .value, so an
+// unparseable primitive under a FLOAT field ("250 steps/s" before the
+// catalog carried the unit) read as unset, and the first keystroke wrote
+// a bare number over it. Same class in the with-unit renderer: a value
+// the parser can't split ("21C") rendered an empty magnitude + unit
+// picker. Both bail to the YAML-only notice (#2056).
+describe("renderNumberField / renderFloatWithUnitField — bail on unparseable primitive", () => {
+  const floatEntry = (): ConfigEntry =>
+    makeConfigEntry({
+      key: "max_speed",
+      type: ConfigEntryType.FLOAT,
+      label: "Max Speed",
+    });
+
+  const withUnitEntry = (): ConfigEntry =>
+    makeConfigEntry({
+      key: "default_target_temperature",
+      type: ConfigEntryType.FLOAT_WITH_UNIT,
+      label: "Default Target Temperature",
+      unit_options: ["°C", "°F", "K"],
+    });
+
+  it("bails on a unit-suffixed string under a FLOAT field", () => {
+    const { ctx } = makeCtx({ max_speed: "250 steps/s" });
+    const tpl = renderNumberField(floatEntry(), ["max_speed"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(true);
+  });
+
+  it("bails on a boolean under a FLOAT field", () => {
+    const { ctx } = makeCtx({ max_speed: true });
+    const tpl = renderNumberField(floatEntry(), ["max_speed"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(true);
+  });
+
+  it("renders the number input for a number and a numeric string", () => {
+    for (const value of [250, "250"]) {
+      const { ctx } = makeCtx({ max_speed: value });
+      const tpl = renderNumberField(floatEntry(), ["max_speed"], ctx);
+      const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+      expect(rendersBailBranch(json)).toBe(false);
+      expect(rendersEditableBranch(json)).toBe(true);
+    }
+  });
+
+  it("renders the number input when the value is unset", () => {
+    const { ctx } = makeCtx({});
+    const tpl = renderNumberField(floatEntry(), ["max_speed"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(false);
+    expect(rendersEditableBranch(json)).toBe(true);
+  });
+
+  it("bails on a malformed unit string under a float-with-unit field", () => {
+    const { ctx } = makeCtx({ default_target_temperature: "21C" });
+    const tpl = renderFloatWithUnitField(
+      withUnitEntry(),
+      ["default_target_temperature"],
+      ctx
+    );
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(true);
+  });
+
+  it("keeps the editable UI mid-edit even when the committed value is empty", () => {
+    const emitChange = vi.fn();
+    const ctx = makeRenderCtx(
+      { default_target_temperature: "1e" },
+      {
+        board: null,
+        overrides: {
+          emitChange,
+          renderEntry: () => "<rendered>",
+          getEditingMagnitude: () => "1e",
+        },
+      }
+    );
+    const tpl = renderFloatWithUnitField(
+      withUnitEntry(),
+      ["default_target_temperature"],
+      ctx
+    );
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(false);
+  });
+
+  it("renders the editable float-with-unit UI for a well-formed value and for unset", () => {
+    for (const values of [{ default_target_temperature: "21°C" }, {}]) {
+      const { ctx } = makeCtx(values);
+      const tpl = renderFloatWithUnitField(
+        withUnitEntry(),
+        ["default_target_temperature"],
+        ctx
+      );
+      const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+      expect(rendersBailBranch(json)).toBe(false);
+    }
   });
 });
 

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -323,7 +323,12 @@ describe("renderNumberField / renderFloatWithUnitField — bail on unparseable p
   });
 
   it("renders the editable float-with-unit UI for a well-formed value and for unset", () => {
-    for (const values of [{ default_target_temperature: "21°C" }, {}]) {
+    // A whitespace-only value is effectively unset, never a bail.
+    for (const values of [
+      { default_target_temperature: "21°C" },
+      { default_target_temperature: " " },
+      {},
+    ]) {
       const { ctx } = makeCtx(values);
       const tpl = renderFloatWithUnitField(
         withUnitEntry(),

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -260,7 +260,7 @@ describe("renderNumberField / renderFloatWithUnitField — bail on unparseable p
   });
 
   it("bails on a malformed unit string under a float-with-unit field", () => {
-    const { ctx } = makeCtx({ default_target_temperature: "21C" });
+    const { ctx } = makeCtx({ default_target_temperature: "21X" });
     const tpl = renderFloatWithUnitField(
       withUnitEntry(),
       ["default_target_temperature"],
@@ -268,6 +268,17 @@ describe("renderNumberField / renderFloatWithUnitField — bail on unparseable p
     );
     const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
     expect(rendersBailBranch(json)).toBe(true);
+  });
+
+  it("keeps a degree-less temperature spelling editable (21C is valid upstream)", () => {
+    const { ctx } = makeCtx({ default_target_temperature: "21C" });
+    const tpl = renderFloatWithUnitField(
+      withUnitEntry(),
+      ["default_target_temperature"],
+      ctx
+    );
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(false);
   });
 
   it("renders both fields as editable text for a ${substitution} value", () => {

--- a/test/util/float-with-unit.test.ts
+++ b/test/util/float-with-unit.test.ts
@@ -232,6 +232,69 @@ describe("parseFloatWithUnit", () => {
       });
     });
 
+    it("folds ESPHome's degree-less temperature spellings onto the ° options", () => {
+      // cv.temperature accepts '21C', '70F', and '21° C' and normalizes
+      // them, so they must edit as numbers rather than lock read-only.
+      expect(parseFloatWithUnit("21C", TEMPERATURE_UNITS)).toEqual({
+        value: 21,
+        unit: "°C",
+      });
+      expect(parseFloatWithUnit("21° C", TEMPERATURE_UNITS)).toEqual({
+        value: 21,
+        unit: "°C",
+      });
+      expect(parseFloatWithUnit("70F", TEMPERATURE_UNITS)).toEqual({
+        value: 70,
+        unit: "°F",
+      });
+      // A trailing lowercase 'c' is the centi metric prefix to ESPHome
+      // ('21c' parses as 0.21 °C), so it must NOT fold onto °C.
+      expect(parseFloatWithUnit("21c", TEMPERATURE_UNITS)).toEqual({
+        value: null,
+        unit: "°C",
+      });
+      // The remaining cv.temperature alternations: a bare degree is
+      // Celsius, and Kelvin also takes the degree forms.
+      expect(parseFloatWithUnit("21°", TEMPERATURE_UNITS)).toEqual({
+        value: 21,
+        unit: "°C",
+      });
+      expect(parseFloatWithUnit("294° K", TEMPERATURE_UNITS)).toEqual({
+        value: 294,
+        unit: "K",
+      });
+    });
+
+    it("folds the remaining ESPHome textual unit spellings onto their symbols", () => {
+      // Inventory from esphome/config_validation.py: current
+      // (amp/ampere), voltage (volt/Volts), bps (bit/s, bits/s),
+      // color temperature (Kelvin), data size (byte/b/Bs forms).
+      expect(parseFloatWithUnit("2 amps", ["A", "mA"])).toEqual({
+        value: 2,
+        unit: "A",
+      });
+      expect(parseFloatWithUnit("3.3volt", ["V", "mV"])).toEqual({
+        value: 3.3,
+        unit: "V",
+      });
+      expect(parseFloatWithUnit("9600bit/s", ["bps", "kbps"])).toEqual({
+        value: 9600,
+        unit: "bps",
+      });
+      expect(parseFloatWithUnit("6500Kelvin", ["mireds", "K"])).toEqual({
+        value: 6500,
+        unit: "K",
+      });
+      expect(parseFloatWithUnit("5Mbyte", ["B", "kB", "MB", "GB"])).toEqual({
+        value: 5,
+        unit: "MB",
+      });
+      expect(parseFloatWithUnit("512b", ["B", "kB", "MB", "GB"])).toEqual({
+        value: 512,
+        unit: "B",
+      });
+    });
+
     it("save round-trip normalises case-variant input to canonical", () => {
       // Round-trip via parse → serialize. The user's lowercase
       // ``Mhz`` becomes the canonical ``MHz`` on save — same shape


### PR DESCRIPTION
# What does this implement/fix?

A numeric field whose YAML value the renderer can't parse used to render as an empty input; `<input type="number">` silently blanks a non numeric value, so a float field holding `250 steps/s` read as unset and the first keystroke wrote a bare number over it. A malformed `float_with_unit` value such as `default_target_temperature: 21C` had the same problem, an empty magnitude plus unit picker. Both renderers now bail to the existing YAML only notice, the same treatment non primitive values already get; the mid edit buffer still renders the editable UI so partial input like `1e` is not interrupted. The catalog half (typing stepper `max_speed` as `float_with_unit`) lands in a backend companion PR.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2056

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
