### PR TITLE
Wrap the pair-build-server row instead of squeezing the helper text

### DIFF
--- a/src/components/settings-dialog/offload-styles.ts
+++ b/src/components/settings-dialog/offload-styles.ts
@@ -44,9 +44,20 @@ export const offloaderAlertStyles = css`
 `;
 
 export const pairingRowStyles = css`
+  /* Wraps so a wide button label (German) drops below the helper text
+     instead of squeezing it to a word per line on narrow viewports. */
   .pair-build-server-row {
     align-items: center;
     gap: var(--wa-space-s);
+    flex-wrap: wrap;
+  }
+
+  .pair-build-server-row .row-label {
+    flex: 1 1 240px;
+  }
+
+  .pair-build-server-row .btn-pair-build-server {
+    margin-left: auto;
   }
 
   .btn-pair-build-server {


### PR DESCRIPTION
# What does this implement/fix?

The "Pair with another dashboard" row in Settings, Send builds keeps its helper text and the pair button on one line; the button never shrinks, so on a phone the text collapses to a word per line, and the wide German button label makes it unreadable.

The row now wraps; when there is no room for the helper text beside the button, the button drops below the full width text and stays right aligned. Desktop keeps the single line layout, and the wrap is container driven so a narrow HA addon sidebar benefits too.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#2066

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
