### PR TITLE
Flag an existing ESPHome server during onboarding

### DIFF
--- a/src/api/types/remote-build.ts
+++ b/src/api/types/remote-build.ts
@@ -286,6 +286,12 @@ export interface RemoteBuildPeer {
    * list filters those out; the Pair button there pre-fills a `> 0` port.
    */
   remote_build_port: number;
+  /**
+   * `true` when the discovered peer is the HA add-on (`ha_addon` TXT
+   * key). The add-on advertises `friendly_name: "Home Assistant"`, so
+   * this is mainly for badging; absent/false for every other install.
+   */
+  ha_addon?: boolean;
 }
 
 /**

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -219,9 +219,6 @@ export class ESPHomeApp extends LitElement {
   // auto-popped — it's collected per-device in the create wizard, or on demand
   // via the kebab "Set up Wi-Fi" dialog.
   @state() _onboardingShouldShow = false;
-  // Whether the first-run wizard should ask the remote-compute use-case
-  // question (non-HA only). Seeded from the onboarding state's step list.
-  @state() _onboardingHasUseCase = false;
   @state() _authState: AuthState = "connecting";
   @state() _authError: string | null = null;
   @state() _rateLimitedUntil = 0;
@@ -636,7 +633,6 @@ export class ESPHomeApp extends LitElement {
       <esphome-feedback-dialog></esphome-feedback-dialog>
       <esphome-onboarding-wifi-dialog></esphome-onboarding-wifi-dialog>
       <esphome-onboarding-wizard-dialog
-        .hasUseCase=${this._onboardingHasUseCase}
         @onboarding-acknowledged=${this._onOnboardingAcknowledged}
         @open-guided-tour=${this._onOpenGuidedTour}
       ></esphome-onboarding-wizard-dialog>

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -639,8 +639,6 @@ export class ESPHomeApp extends LitElement {
         .hasUseCase=${this._onboardingHasUseCase}
         @onboarding-acknowledged=${this._onOnboardingAcknowledged}
         @open-guided-tour=${this._onOpenGuidedTour}
-        @open-settings=${(e: CustomEvent<{ section?: Section } | undefined>) =>
-          this._settingsDialog?.open(e.detail?.section)}
       ></esphome-onboarding-wizard-dialog>
       <esphome-guided-tour></esphome-guided-tour>
     `;

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -639,6 +639,8 @@ export class ESPHomeApp extends LitElement {
         .hasUseCase=${this._onboardingHasUseCase}
         @onboarding-acknowledged=${this._onOnboardingAcknowledged}
         @open-guided-tour=${this._onOpenGuidedTour}
+        @open-settings=${(e: CustomEvent<{ section?: Section } | undefined>) =>
+          this._settingsDialog?.open(e.detail?.section)}
       ></esphome-onboarding-wizard-dialog>
       <esphome-guided-tour></esphome-guided-tour>
     `;

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -40,6 +40,7 @@ import {
   firmwareJobsContext,
   importableDevicesContext,
   integrationDocsContext,
+  isHaAddonContext,
   isHaIngressContext,
   labelsContext,
   localizeContext,
@@ -137,6 +138,7 @@ export class ESPHomeApp extends LitElement {
   _desktopUpdateCapable = false;
   @provide({ context: darkModeContext }) @state() _darkMode = initialDarkMode();
   @provide({ context: isHaIngressContext }) @state() _isHaIngress = false;
+  @provide({ context: isHaAddonContext }) @state() _isHaAddon = false;
   @provide({ context: activeJobsContext }) @state() _activeJobs: Map<
     string,
     FirmwareJob
@@ -449,6 +451,7 @@ export class ESPHomeApp extends LitElement {
       this._desktopVersion = info.desktop_version ?? "";
       this._desktopUpdateCapable = info.desktop_update_capable ?? false;
       this._isHaIngress = info.ha_ingress;
+      this._isHaAddon = info.ha_addon;
       this._apiConnected = true;
       void this._api.ready.then(() => this._afterAuthenticated());
     };

--- a/src/components/app-shell/data-load.ts
+++ b/src/components/app-shell/data-load.ts
@@ -1,4 +1,4 @@
-import { OnboardingStepId, type UserPreferences } from "../../api/types/system.js";
+import type { UserPreferences } from "../../api/types/system.js";
 import {
   isExperienceChosen,
   shouldAutoShowOnboarding,
@@ -22,9 +22,6 @@ export async function loadOnboardingState(host: ESPHomeApp): Promise<void> {
   const keysPromise = fetchSecretKeys(host._api);
   try {
     const state = await host._api.getOnboardingState();
-    host._onboardingHasUseCase = state.steps.some(
-      (s) => s.id === OnboardingStepId.USE_CASE
-    );
     // Only the mandatory setup wizard auto-pops. Wi-Fi is collected when the
     // first Wi-Fi device needs it, never during onboarding.
     host._onboardingShouldShow =

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -13,6 +13,7 @@ import {
   localizeContext,
 } from "../../context/index.js";
 import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
+import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { withBase } from "../../util/base-path.js";
 import { EnterController } from "../../util/enter-controller.js";
@@ -115,6 +116,7 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     dialogActionButtonStyles,
     choiceCardStyles,
     onboardingWizardStyles,
+    fullscreenMobileDialog("esphome-base-dialog"),
   ];
 
   /** Ordered screens for the current environment. */

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -5,7 +5,7 @@ import { customElement, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { RemoteBuildPeer } from "../../api/types/remote-build.js";
 import { ExperienceLevel } from "../../api/types/system.js";
-import type { LocalizeFunc } from "../../common/localize.js";
+import { activeLocale, type LocalizeFunc } from "../../common/localize.js";
 import {
   apiContext,
   buildOffloadDiscoveredHostsContext,
@@ -274,7 +274,7 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     // Cap the named list so a busy network can't push the switch off-screen.
     const shown = names.slice(0, 3);
     const extra = names.length - shown.length;
-    const joined = new Intl.ListFormat(undefined, {
+    const joined = new Intl.ListFormat(activeLocale(), {
       type: extra > 0 ? "unit" : "conjunction",
     }).format(shown);
     const foundLabel =

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -19,8 +19,8 @@ import { withBase } from "../../util/base-path.js";
 import { EnterController } from "../../util/enter-controller.js";
 import { EXPERIENCE_OPTIONS } from "../../util/experience.js";
 import { formatApiError } from "../../util/format-api-error.js";
-import { trimTrailingDot } from "../../util/hostname.js";
 import { notifyWarning } from "../../util/notify.js";
+import { remoteBuildPeerName } from "../../util/remote-build-peer-name.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { closeOpenDialogs } from "../base-dialog.js";
 import { choiceCardStyles } from "./choice-card-styles.js";
@@ -269,13 +269,7 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
 
   private _renderExistingServer() {
     const names = this._discoveredHosts
-      ? [
-          ...new Set(
-            [...this._discoveredHosts.values()].map((peer) =>
-              trimTrailingDot(peer.friendly_name.trim() || peer.name)
-            )
-          ),
-        ]
+      ? [...new Set([...this._discoveredHosts.values()].map(remoteBuildPeerName))]
       : [];
     // Cap the named list so a busy network can't push the switch off-screen.
     const shown = names.slice(0, 3);

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -1,13 +1,7 @@
 import { consume } from "@lit/context";
-import {
-  mdiCodeBraces,
-  mdiCompassOutline,
-  mdiLaptop,
-  mdiServerNetwork,
-  mdiSprout,
-} from "@mdi/js";
+import { mdiCodeBraces, mdiCompassOutline, mdiServerNetwork, mdiSprout } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { RemoteBuildPeer } from "../../api/types/remote-build.js";
 import { ExperienceLevel } from "../../api/types/system.js";
@@ -34,13 +28,13 @@ import { onboardingWizardStyles } from "./onboarding-wizard-styles.js";
 import { type WizardScreen, wizardScreens } from "./wizard-screens.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "@home-assistant/webawesome/dist/components/switch/switch.js";
 
 export const RESET_ONBOARDING_PARAM = "resetOnboarding";
 
 registerMdiIcons({
   "code-braces": mdiCodeBraces,
   "compass-outline": mdiCompassOutline,
-  laptop: mdiLaptop,
   "server-network": mdiServerNetwork,
   sprout: mdiSprout,
 });
@@ -48,11 +42,12 @@ registerMdiIcons({
 /**
  * Mandatory first-run onboarding flow.
  *
- * A fresh install walks through Welcome and experience. Expert users on non-HA
- * installs also choose a use case. The choices are persisted before the final
- * tour offer appears, so "Maybe later" only skips the optional tour. Wi-Fi is
- * intentionally absent: the first Wi-Fi device that needs shared credentials
- * collects them.
+ * A fresh install walks through Welcome and experience. When another Device
+ * Builder is on the network (non-add-on installs), an orientation step follows
+ * with an opt-in "remote compute only" switch. The choices are persisted before
+ * the final tour offer appears, so "Maybe later" only skips the optional tour.
+ * Wi-Fi is intentionally absent: the first Wi-Fi device that needs shared
+ * credentials collects them.
  *
  * ``?resetOnboarding=1`` reopens a clean default run for frontend development.
  * It does not reset data before opening; completing the choices writes them
@@ -75,16 +70,11 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
   @state()
   private _isHaAddon = false;
 
-  /** Whether this install can ask expert users the remote-compute use-case
-   *  question (non-HA only). Seeded by the app shell from onboarding state. */
-  @property({ type: Boolean }) hasUseCase = false;
-
   @state() private _open = false;
   @state() private _saving = false;
   @state() private _error: string | null = null;
   @state() private _index = 0;
 
-  @state() private _useCaseChosen = true;
   @state() private _remoteCompute = false;
   @state() private _experience: ExperienceLevel | null = ExperienceLevel.BEGINNER;
   // Frozen when leaving Welcome so mDNS hosts arriving mid-flow can't
@@ -113,7 +103,6 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     this._saving = false;
     this._error = null;
     this._index = 0;
-    this._useCaseChosen = true;
     this._remoteCompute = false;
     this._experience = ExperienceLevel.BEGINNER;
     this._existingServerPinned = false;
@@ -130,19 +119,16 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
 
   /** Ordered screens for the current environment. */
   private get _screens(): WizardScreen[] {
-    // Live while still on Welcome (safe to grow the tail as hosts arrive);
-    // frozen to the pinned value once past it.
+    // existing_server sits after experience (index 1). While the user is still
+    // on Welcome or experience the tail can grow as mDNS hosts arrive; freeze it
+    // once they advance past experience so a late host can't shift the flow.
     const showExistingServer =
-      this._index === 0 ? this._computeShowExistingServer() : this._existingServerPinned;
-    return wizardScreens({
-      hasUseCase: this.hasUseCase,
-      isExpert: this._experience === ExperienceLevel.EXPERT,
-      showExistingServer,
-    });
+      this._index <= 1 ? this._computeShowExistingServer() : this._existingServerPinned;
+    return wizardScreens({ showExistingServer });
   }
 
-  /** Show the orientation screen only off the HA add-on, and only when another
-   *  Device Builder is on the network. */
+  /** Offer the orientation step only off the HA add-on, and only when another
+   *  Device Builder is on the network (nothing to build for otherwise). */
   private _computeShowExistingServer(): boolean {
     return !this._isHaAddon && !!this._discoveredHosts?.size;
   }
@@ -168,8 +154,6 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
         return true;
       case "existing_server":
         return true;
-      case "use_case":
-        return this._useCaseChosen;
       case "experience":
         return this._experience !== null;
       case "tour":
@@ -261,8 +245,6 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
         return this._renderWelcome();
       case "existing_server":
         return this._renderExistingServer();
-      case "use_case":
-        return this._renderUseCase();
       case "experience":
         return this._renderExperience();
       case "tour":
@@ -293,22 +275,47 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
           ),
         ]
       : [];
-    const joined = new Intl.ListFormat(undefined, { type: "conjunction" }).format(names);
+    // Cap the named list so a busy network can't push the switch off-screen.
+    const shown = names.slice(0, 3);
+    const extra = names.length - shown.length;
+    const joined = new Intl.ListFormat(undefined, {
+      type: extra > 0 ? "unit" : "conjunction",
+    }).format(shown);
+    const foundLabel =
+      extra > 0
+        ? this._localize("onboarding.wizard.existing_server.found_overflow", {
+            name: joined,
+            count: extra,
+          })
+        : this._localize("onboarding.wizard.existing_server.found", { name: joined });
     return html`
-      <div class="tour-offer">
+      <div class="existing-server">
         <wa-icon library="mdi" name="server-network" class="tour-offer-icon"></wa-icon>
-        ${
-          names.length
-            ? html`<p class="tour-ready">
-                ${this._localize("onboarding.wizard.existing_server.found", {
-                  name: joined,
-                })}
-              </p>`
-            : nothing
-        }
+        ${names.length ? html`<p class="tour-ready">${foundLabel}</p>` : nothing}
         <p class="intro">${this._localize("onboarding.wizard.existing_server.intro")}</p>
+        <label class="remote-toggle">
+          <span class="remote-toggle-text">
+            <span class="remote-toggle-title">
+              ${this._localize("onboarding.wizard.existing_server.remote_only_title")}
+            </span>
+            <span class="remote-toggle-desc">
+              ${this._localize("onboarding.wizard.existing_server.remote_only_desc")}
+            </span>
+          </span>
+          <wa-switch
+            ?checked=${this._remoteCompute}
+            ?disabled=${this._saving}
+            @change=${this._onToggleRemoteCompute}
+          ></wa-switch>
+        </label>
       </div>
     `;
+  }
+
+  private _onToggleRemoteCompute(event: Event) {
+    this._remoteCompute = (
+      event.target as HTMLInputElement & { checked: boolean }
+    ).checked;
   }
 
   private _renderTourOffer() {
@@ -332,40 +339,6 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
       </div>
     `;
   }
-  private _renderUseCase() {
-    const devices = this._useCaseChosen && !this._remoteCompute;
-    const remote = this._useCaseChosen && this._remoteCompute;
-    return html`
-      <p class="intro">${this._localize("onboarding.wizard.use_case.intro")}</p>
-      <div
-        class="choices"
-        role="radiogroup"
-        aria-label=${this._localize("onboarding.wizard.use_case.title")}
-        @keydown=${onChoiceGroupKeydown}
-      >
-        ${renderChoiceCard({
-          icon: "laptop",
-          title: this._localize("onboarding.wizard.use_case.devices_title"),
-          description: this._localize("onboarding.wizard.use_case.devices_desc"),
-          selected: devices,
-          tabbable: rovingTabbable(devices, this._useCaseChosen, 0),
-          badge: this._localize("onboarding.wizard.recommended"),
-          disabled: this._saving,
-          onSelect: () => this._chooseUseCase(false),
-        })}
-        ${renderChoiceCard({
-          icon: "server-network",
-          title: this._localize("onboarding.wizard.use_case.remote_title"),
-          description: this._localize("onboarding.wizard.use_case.remote_desc"),
-          selected: remote,
-          tabbable: rovingTabbable(remote, this._useCaseChosen, 1),
-          disabled: this._saving,
-          onSelect: () => this._chooseUseCase(true),
-        })}
-      </div>
-    `;
-  }
-
   private _renderExperience() {
     return html`
       <p class="intro">${this._localize("onboarding.wizard.experience.intro")}</p>
@@ -398,17 +371,8 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     `;
   }
 
-  private _chooseUseCase(remoteCompute: boolean) {
-    this._useCaseChosen = true;
-    this._remoteCompute = remoteCompute;
-  }
-
   private _chooseExperience(level: ExperienceLevel) {
     this._experience = level;
-    if (level === ExperienceLevel.BEGINNER) {
-      this._useCaseChosen = true;
-      this._remoteCompute = false;
-    }
   }
 
   private _onBack() {
@@ -420,20 +384,19 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     this._error = null;
     switch (this._screen) {
       case "welcome":
-        this._existingServerPinned = this._computeShowExistingServer();
-        this._index += 1;
-        return;
-      case "existing_server":
         this._index += 1;
         return;
       case "experience":
-        if (this.hasUseCase && this._experience === ExperienceLevel.EXPERT) {
+        // Freeze whether the orientation step follows, now that mDNS has had
+        // Welcome + this screen to report.
+        this._existingServerPinned = this._computeShowExistingServer();
+        if (this._existingServerPinned) {
           this._index += 1;
           return;
         }
         await this._completeSetup();
         return;
-      case "use_case":
+      case "existing_server":
         await this._completeSetup();
         return;
       case "tour":

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -9,15 +9,22 @@ import {
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../../api/index.js";
+import type { RemoteBuildPeer } from "../../api/types/remote-build.js";
 import { ExperienceLevel } from "../../api/types/system.js";
 import type { LocalizeFunc } from "../../common/localize.js";
-import { apiContext, localizeContext } from "../../context/index.js";
+import {
+  apiContext,
+  buildOffloadDiscoveredHostsContext,
+  isHaAddonContext,
+  localizeContext,
+} from "../../context/index.js";
 import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { withBase } from "../../util/base-path.js";
 import { EnterController } from "../../util/enter-controller.js";
 import { EXPERIENCE_OPTIONS } from "../../util/experience.js";
 import { formatApiError } from "../../util/format-api-error.js";
+import { trimTrailingDot } from "../../util/hostname.js";
 import { notifyWarning } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { closeOpenDialogs } from "../base-dialog.js";
@@ -60,6 +67,14 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
   @consume({ context: apiContext })
   private _api!: ESPHomeAPI;
 
+  @consume({ context: buildOffloadDiscoveredHostsContext, subscribe: true })
+  @state()
+  private _discoveredHosts: Map<string, RemoteBuildPeer> | null = null;
+
+  @consume({ context: isHaAddonContext, subscribe: true })
+  @state()
+  private _isHaAddon = false;
+
   /** Whether this install can ask expert users the remote-compute use-case
    *  question (non-HA only). Seeded by the app shell from onboarding state. */
   @property({ type: Boolean }) hasUseCase = false;
@@ -72,6 +87,9 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
   @state() private _useCaseChosen = true;
   @state() private _remoteCompute = false;
   @state() private _experience: ExperienceLevel | null = ExperienceLevel.BEGINNER;
+  // Frozen when leaving Welcome so mDNS hosts arriving mid-flow can't
+  // insert/remove the existing-server screen under the user.
+  @state() private _existingServerPinned = false;
 
   private _startTourAfterClose = false;
   private _enter = new EnterController(this, () => {
@@ -98,6 +116,7 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     this._useCaseChosen = true;
     this._remoteCompute = false;
     this._experience = ExperienceLevel.BEGINNER;
+    this._existingServerPinned = false;
     this._startTourAfterClose = false;
     this._enter.set(true);
   }
@@ -111,10 +130,21 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
 
   /** Ordered screens for the current environment. */
   private get _screens(): WizardScreen[] {
+    // Live while still on Welcome (safe to grow the tail as hosts arrive);
+    // frozen to the pinned value once past it.
+    const showExistingServer =
+      this._index === 0 ? this._computeShowExistingServer() : this._existingServerPinned;
     return wizardScreens({
       hasUseCase: this.hasUseCase,
       isExpert: this._experience === ExperienceLevel.EXPERT,
+      showExistingServer,
     });
+  }
+
+  /** Show the orientation screen only off the HA add-on, and only when another
+   *  Device Builder is on the network. */
+  private _computeShowExistingServer(): boolean {
+    return !this._isHaAddon && !!this._discoveredHosts?.size;
   }
 
   private get _screen(): WizardScreen {
@@ -135,6 +165,8 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     if (this._saving) return false;
     switch (this._screen) {
       case "welcome":
+        return true;
+      case "existing_server":
         return true;
       case "use_case":
         return this._useCaseChosen;
@@ -227,6 +259,8 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     switch (this._screen) {
       case "welcome":
         return this._renderWelcome();
+      case "existing_server":
+        return this._renderExistingServer();
       case "use_case":
         return this._renderUseCase();
       case "experience":
@@ -245,6 +279,30 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
           alt=""
         />
         <p class="intro">${this._localize("onboarding.wizard.welcome.intro")}</p>
+      </div>
+    `;
+  }
+
+  private _renderExistingServer() {
+    const names = this._discoveredHosts
+      ? [...this._discoveredHosts.values()].map((peer) =>
+          trimTrailingDot(peer.friendly_name.trim() || peer.name)
+        )
+      : [];
+    const joined = new Intl.ListFormat(undefined, { type: "conjunction" }).format(names);
+    return html`
+      <div class="tour-offer">
+        <wa-icon library="mdi" name="server-network" class="tour-offer-icon"></wa-icon>
+        ${
+          names.length
+            ? html`<p class="tour-ready">
+                ${this._localize("onboarding.wizard.existing_server.found", {
+                  name: joined,
+                })}
+              </p>`
+            : nothing
+        }
+        <p class="intro">${this._localize("onboarding.wizard.existing_server.intro")}</p>
       </div>
     `;
   }
@@ -358,6 +416,10 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     this._error = null;
     switch (this._screen) {
       case "welcome":
+        this._existingServerPinned = this._computeShowExistingServer();
+        this._index += 1;
+        return;
+      case "existing_server":
         this._index += 1;
         return;
       case "experience":

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -217,6 +217,40 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
       `;
     }
 
+    if (this._screen === "existing_server") {
+      return html`
+        <button
+          type="button"
+          class="btn btn--cancel"
+          ?disabled=${this._saving}
+          @click=${this._onBack}
+        >
+          ${this._localize("onboarding.wizard.back")}
+        </button>
+        <span class="spacer"></span>
+        <button
+          type="button"
+          class="btn btn--cancel"
+          ?disabled=${this._saving}
+          @click=${this._onContinue}
+        >
+          ${this._localize("onboarding.wizard.existing_server.not_now")}
+        </button>
+        <button
+          type="button"
+          class="btn btn--primary"
+          ?disabled=${this._saving}
+          @click=${this._setupBuildServer}
+        >
+          ${
+            this._saving
+              ? this._localize("onboarding.wizard.saving")
+              : this._localize("onboarding.wizard.existing_server.setup")
+          }
+        </button>
+      `;
+    }
+
     return html`
       ${
         this._index > 0
@@ -285,9 +319,13 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
 
   private _renderExistingServer() {
     const names = this._discoveredHosts
-      ? [...this._discoveredHosts.values()].map((peer) =>
-          trimTrailingDot(peer.friendly_name.trim() || peer.name)
-        )
+      ? [
+          ...new Set(
+            [...this._discoveredHosts.values()].map((peer) =>
+              trimTrailingDot(peer.friendly_name.trim() || peer.name)
+            )
+          ),
+        ]
       : [];
     const joined = new Intl.ListFormat(undefined, { type: "conjunction" }).format(names);
     return html`
@@ -450,6 +488,40 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     this._emitAcknowledged();
     this._saving = false;
     this._index += 1;
+  }
+
+  private async _setupBuildServer() {
+    if (this._saving) return;
+    this._saving = true;
+    this._error = null;
+    try {
+      await this._api.setRemoteBuildSettings({ enabled: true });
+    } catch (err) {
+      this._error = formatApiError(
+        err,
+        this._localize,
+        "onboarding.wizard.existing_server.setup_failed"
+      );
+      this._saving = false;
+      return;
+    }
+    if (!(await this._persistChoices())) return;
+    try {
+      await this._api.markOnboardingAcknowledged();
+    } catch (err) {
+      console.warn("Failed to mark onboarding acknowledged:", err);
+      notifyWarning(this._localize("onboarding.wizard.ack_failed"));
+    }
+    this._emitAcknowledged();
+    this._saving = false;
+    this._open = false;
+    this.dispatchEvent(
+      new CustomEvent("open-settings", {
+        detail: { section: "build_server" },
+        bubbles: true,
+        composed: true,
+      })
+    );
   }
 
   private async _persistChoices(): Promise<boolean> {

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -217,40 +217,6 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
       `;
     }
 
-    if (this._screen === "existing_server") {
-      return html`
-        <button
-          type="button"
-          class="btn btn--cancel"
-          ?disabled=${this._saving}
-          @click=${this._onBack}
-        >
-          ${this._localize("onboarding.wizard.back")}
-        </button>
-        <span class="spacer"></span>
-        <button
-          type="button"
-          class="btn btn--cancel"
-          ?disabled=${this._saving}
-          @click=${this._onContinue}
-        >
-          ${this._localize("onboarding.wizard.existing_server.not_now")}
-        </button>
-        <button
-          type="button"
-          class="btn btn--primary"
-          ?disabled=${this._saving}
-          @click=${this._setupBuildServer}
-        >
-          ${
-            this._saving
-              ? this._localize("onboarding.wizard.saving")
-              : this._localize("onboarding.wizard.existing_server.setup")
-          }
-        </button>
-      `;
-    }
-
     return html`
       ${
         this._index > 0
@@ -488,40 +454,6 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     this._emitAcknowledged();
     this._saving = false;
     this._index += 1;
-  }
-
-  private async _setupBuildServer() {
-    if (this._saving) return;
-    this._saving = true;
-    this._error = null;
-    try {
-      await this._api.setRemoteBuildSettings({ enabled: true });
-    } catch (err) {
-      this._error = formatApiError(
-        err,
-        this._localize,
-        "onboarding.wizard.existing_server.setup_failed"
-      );
-      this._saving = false;
-      return;
-    }
-    if (!(await this._persistChoices())) return;
-    try {
-      await this._api.markOnboardingAcknowledged();
-    } catch (err) {
-      console.warn("Failed to mark onboarding acknowledged:", err);
-      notifyWarning(this._localize("onboarding.wizard.ack_failed"));
-    }
-    this._emitAcknowledged();
-    this._saving = false;
-    this._open = false;
-    this.dispatchEvent(
-      new CustomEvent("open-settings", {
-        detail: { section: "build_server" },
-        bubbles: true,
-        composed: true,
-      })
-    );
   }
 
   private async _persistChoices(): Promise<boolean> {

--- a/src/components/onboarding/onboarding-wizard-styles.ts
+++ b/src/components/onboarding/onboarding-wizard-styles.ts
@@ -48,6 +48,53 @@ export const onboardingWizardStyles = css`
     gap: var(--wa-space-s);
   }
 
+  .existing-server {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: var(--wa-space-s);
+    justify-content: flex-start;
+  }
+
+  .existing-server .tour-offer-icon {
+    margin-top: var(--wa-space-s);
+  }
+
+  .remote-toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-m);
+    width: 100%;
+    text-align: left;
+    box-sizing: border-box;
+    margin-top: var(--wa-space-s);
+    padding: var(--wa-space-m);
+    border: 1px solid var(--wa-color-surface-border);
+    border-radius: var(--wa-border-radius-m);
+    cursor: pointer;
+  }
+
+  .remote-toggle-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1;
+  }
+
+  .remote-toggle-title {
+    font-size: var(--wa-font-size-s);
+    font-weight: var(--wa-font-weight-semibold);
+    color: var(--wa-color-text-normal);
+  }
+
+  .remote-toggle-desc {
+    font-size: var(--wa-font-size-xs);
+    color: var(--wa-color-text-quiet);
+    line-height: 1.4;
+  }
+
   .welcome-screen {
     gap: var(--wa-space-xl);
   }

--- a/src/components/onboarding/onboarding-wizard-styles.ts
+++ b/src/components/onboarding/onboarding-wizard-styles.ts
@@ -5,6 +5,12 @@ export const onboardingWizardStyles = css`
     --width: min(520px, calc(100vw - 24px));
   }
 
+  /* Let the longer step titles wrap instead of truncating (the base dialog
+     ellipsizes by default), so nothing is chopped on a narrow / mobile sheet. */
+  esphome-base-dialog::part(title-text) {
+    white-space: normal;
+  }
+
   esphome-base-dialog.mandatory::part(close-button) {
     display: none;
   }

--- a/src/components/onboarding/onboarding-wizard-styles.ts
+++ b/src/components/onboarding/onboarding-wizard-styles.ts
@@ -14,7 +14,7 @@ export const onboardingWizardStyles = css`
     flex-direction: column;
     gap: var(--wa-space-m);
     box-sizing: border-box;
-    height: 300px;
+    height: 380px;
     overflow-y: auto;
   }
 
@@ -142,9 +142,12 @@ export const onboardingWizardStyles = css`
     flex: 1;
   }
 
-  @media (max-width: 600px), (max-height: 600px) {
+  /* On phones the dialog goes full-screen (fullscreenMobileDialog), so the
+     body fills the sheet instead of a fixed height — the switch and its
+     description then have room without scrolling. */
+  @media (max-width: 600px) {
     .body {
-      height: min(390px, calc(100dvh - 190px));
+      height: 100%;
     }
   }
 `;

--- a/src/components/onboarding/wizard-screens.ts
+++ b/src/components/onboarding/wizard-screens.ts
@@ -1,24 +1,17 @@
-export type WizardScreen =
-  "welcome" | "existing_server" | "use_case" | "experience" | "tour";
+export type WizardScreen = "welcome" | "experience" | "existing_server" | "tour";
 
 /**
  * The ordered onboarding-wizard screens for the current environment.
  *
- * Welcome and experience are always mandatory. When another ESPHome server is
- * already on the network (non-add-on installs only), an orientation screen
- * follows Welcome. Expert users on non-HA installs also choose whether this
- * dashboard manages devices or acts as a remote build server. The optional-tour
- * offer always closes the flow. Wi-Fi is deliberately not part of onboarding.
+ * Welcome and experience are always mandatory. When another Device Builder is
+ * on the network (non-add-on installs only), an orientation step follows
+ * experience — it's the only place the remote-build-server choice is offered,
+ * since there's nothing to build for otherwise. The optional-tour offer always
+ * closes the flow. Wi-Fi is deliberately not part of onboarding.
  */
-export function wizardScreens(opts: {
-  hasUseCase: boolean;
-  isExpert: boolean;
-  showExistingServer: boolean;
-}): WizardScreen[] {
-  const screens: WizardScreen[] = ["welcome"];
+export function wizardScreens(opts: { showExistingServer: boolean }): WizardScreen[] {
+  const screens: WizardScreen[] = ["welcome", "experience"];
   if (opts.showExistingServer) screens.push("existing_server");
-  screens.push("experience");
-  if (opts.hasUseCase && opts.isExpert) screens.push("use_case");
   screens.push("tour");
   return screens;
 }

--- a/src/components/onboarding/wizard-screens.ts
+++ b/src/components/onboarding/wizard-screens.ts
@@ -1,18 +1,23 @@
-export type WizardScreen = "welcome" | "use_case" | "experience" | "tour";
+export type WizardScreen =
+  "welcome" | "existing_server" | "use_case" | "experience" | "tour";
 
 /**
  * The ordered onboarding-wizard screens for the current environment.
  *
- * Welcome and experience are always mandatory. Expert users on non-HA installs
- * also choose whether this dashboard manages devices or acts as a remote build
- * server. The optional-tour offer always closes the flow. Wi-Fi is deliberately
- * not part of onboarding.
+ * Welcome and experience are always mandatory. When another ESPHome server is
+ * already on the network (non-add-on installs only), an orientation screen
+ * follows Welcome. Expert users on non-HA installs also choose whether this
+ * dashboard manages devices or acts as a remote build server. The optional-tour
+ * offer always closes the flow. Wi-Fi is deliberately not part of onboarding.
  */
 export function wizardScreens(opts: {
   hasUseCase: boolean;
   isExpert: boolean;
+  showExistingServer: boolean;
 }): WizardScreen[] {
-  const screens: WizardScreen[] = ["welcome", "experience"];
+  const screens: WizardScreen[] = ["welcome"];
+  if (opts.showExistingServer) screens.push("existing_server");
+  screens.push("experience");
   if (opts.hasUseCase && opts.isExpert) screens.push("use_case");
   screens.push("tour");
   return screens;

--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -27,6 +27,7 @@ import {
 import { espHomeStyles } from "../../styles/shared.js";
 import { normalizeHostnameForCompare, trimTrailingDot } from "../../util/hostname.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { remoteBuildPeerName } from "../../util/remote-build-peer-name.js";
 import type { ESPHomeConfirmDialog } from "../confirm-dialog.js";
 import type { ESPHomeEditPairingEndpointDialog } from "../edit-pairing-endpoint-dialog.js";
 import type { ESPHomePairBuildServerDialog } from "../pair-build-server-dialog.js";
@@ -323,8 +324,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
           esphome: peer.esphome_version,
         })
       : nothing;
-    // Prefer the friendly_name label; fall back to the instance name.
-    const displayName = trimTrailingDot(peer.friendly_name.trim() || peer.name);
+    const displayName = remoteBuildPeerName(peer);
     return html`
       <div class="row peer-row">
         <div class="row-label">

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -70,6 +70,11 @@ export const devicesLoadedContext = createContext<boolean>(
 /** Context for whether the frontend is running inside HA ingress. */
 export const isHaIngressContext = createContext<boolean>(Symbol("esphome-is-ha-ingress"));
 
+/** Context for whether the backend is running as the HA add-on. Broader than
+ *  :member:`isHaIngressContext` (also true when the add-on is reached directly
+ *  on its exposed port, not just through Supervisor ingress). */
+export const isHaAddonContext = createContext<boolean>(Symbol("esphome-is-ha-addon"));
+
 /** Context for active firmware jobs, keyed by device configuration.
  *  Tracks the latest non-terminal job per device (used for the busy
  *  spinner on cards/tables). For the full multi-job view, see

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -18,6 +18,7 @@ export {
   firmwareJobsContext,
   importableDevicesContext,
   integrationDocsContext,
+  isHaAddonContext,
   isHaIngressContext,
   labelsContext,
   localizeContext,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1019,15 +1019,10 @@
       "existing_server": {
         "title": "You already have ESPHome Device Builder",
         "found": "Found on your network: {name}",
-        "intro": "This app is a full ESPHome Device Builder and is ready to build firmware for the others. To send builds here, open Send builds on your existing dashboard and pair it with this machine."
-      },
-      "use_case": {
-        "title": "How will you use this?",
-        "intro": "This helps tailor the dashboard to what you need.",
-        "devices_title": "I want to manage ESPHome devices on this system",
-        "devices_desc": "Create, configure, build, flash, and manage devices from this dashboard.",
-        "remote_title": "I want to use this system as a remote build server",
-        "remote_desc": "Build firmware for Device Builder dashboards running on other systems. Device creation is hidden."
+        "found_overflow": "Found on your network: {name}, and {count} more",
+        "intro": "This app is a full ESPHome Device Builder and is ready to build firmware for the others. To send builds here, open Send builds on your existing dashboard and pair it with this machine.",
+        "remote_only_title": "Only use this for remote compute",
+        "remote_only_desc": "Hide device creation and use this install purely as a remote build server for other dashboards."
       },
       "experience": {
         "title": "Choose your experience level",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1016,6 +1016,11 @@
         "title": "Welcome to ESPHome Device Builder",
         "intro": "We’ll help you tailor your ESPHome experience in a few quick steps."
       },
+      "existing_server": {
+        "title": "You already have ESPHome running",
+        "found": "Found on your network: {name}",
+        "intro": "This app is a complete ESPHome install of its own, not a remote for that one. You can create and manage your devices right here."
+      },
       "use_case": {
         "title": "How will you use this?",
         "intro": "This helps tailor the dashboard to what you need.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1020,7 +1020,7 @@
         "title": "You already have ESPHome Device Builder",
         "found": "Found on your network: {name}",
         "found_overflow": "Found on your network: {name}, and {count} more",
-        "intro": "This app is a full ESPHome Device Builder and is ready to build firmware for the others. To send builds here, open Send builds on your existing dashboard and pair it with this machine.",
+        "intro": "This app is a full ESPHome Device Builder and is ready to build firmware for the others. To send builds here, open Settings → Send builds on your existing dashboard and pair it with this machine.",
         "remote_only_title": "Only use this for remote compute",
         "remote_only_desc": "Hide device creation and use this install purely as a remote build server for other dashboards."
       },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1017,9 +1017,12 @@
         "intro": "We’ll help you tailor your ESPHome experience in a few quick steps."
       },
       "existing_server": {
-        "title": "You already have ESPHome running",
+        "title": "You already have ESPHome Device Builder",
         "found": "Found on your network: {name}",
-        "intro": "This app is a complete ESPHome install of its own, not a remote for that one. You can create and manage your devices right here."
+        "intro": "Your existing ESPHome Device Builder can offload its firmware compiles to this machine. Set it up as a build server, or just manage devices right here.",
+        "setup": "Set up build server",
+        "not_now": "Not now",
+        "setup_failed": "Couldn’t enable the build server; you can turn it on later in Settings."
       },
       "use_case": {
         "title": "How will you use this?",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1019,10 +1019,7 @@
       "existing_server": {
         "title": "You already have ESPHome Device Builder",
         "found": "Found on your network: {name}",
-        "intro": "Your existing ESPHome Device Builder can offload its firmware compiles to this machine. Set it up as a build server, or just manage devices right here.",
-        "setup": "Set up build server",
-        "not_now": "Not now",
-        "setup_failed": "Couldn’t enable the build server; you can turn it on later in Settings."
+        "intro": "This app is a full ESPHome Device Builder and is ready to build firmware for the others. To send builds here, open Send builds on your existing dashboard and pair it with this machine."
       },
       "use_case": {
         "title": "How will you use this?",

--- a/src/util/remote-build-peer-name.ts
+++ b/src/util/remote-build-peer-name.ts
@@ -1,0 +1,36 @@
+import { trimTrailingDot } from "./hostname.js";
+
+/**
+ * Home Assistant's Supervisor names the ESPHome add-on container
+ * `<repo-hash>-esphome`, with `-beta` / `-dev` suffixes for those channels.
+ * That's what the add-on advertises as its mDNS `friendly_name` (the container
+ * hostname), so we can recognise it and show a human label without waiting for
+ * the backend `ha_addon` signal — which, when present, is treated as an
+ * additive confirmation.
+ */
+const HA_ADDON_HOSTNAME = /^[0-9a-f]{8}-esphome(?:-(beta|dev))?$/i;
+
+interface DiscoveredPeer {
+  friendly_name?: string;
+  name: string;
+  ha_addon?: boolean;
+}
+
+/**
+ * Display label for a discovered remote-build peer.
+ *
+ * Maps the HA add-on's Supervisor-assigned hostname to
+ * `Home Assistant App` (plus `(Beta)` / `(Dev)` for those channels); otherwise
+ * prefers `friendly_name`, falling back to the mDNS instance `name`.
+ */
+export function remoteBuildPeerName(peer: DiscoveredPeer): string {
+  const base = trimTrailingDot((peer.friendly_name ?? "").trim() || peer.name);
+  const match = HA_ADDON_HOSTNAME.exec(base);
+  if (match) {
+    const flavor = match[1]?.toLowerCase();
+    if (flavor === "dev") return "Home Assistant App (Dev)";
+    if (flavor === "beta") return "Home Assistant App (Beta)";
+    return "Home Assistant App";
+  }
+  return peer.ha_addon ? "Home Assistant App" : base;
+}

--- a/test/components/app-shell/data-load.test.ts
+++ b/test/components/app-shell/data-load.test.ts
@@ -40,7 +40,6 @@ function state(
 function makeHost(state: OnboardingState) {
   return {
     _onboardingPending: false,
-    _onboardingHasUseCase: false,
     _onboardingShouldShow: false,
     _api: { getOnboardingState: vi.fn(async () => state) },
   };

--- a/test/components/onboarding/onboarding-existing-server.test.ts
+++ b/test/components/onboarding/onboarding-existing-server.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import type { LocalizeFunc } from "../../../src/common/localize.js";
+import { ESPHomeOnboardingWizardDialog } from "../../../src/components/onboarding/onboarding-wizard-dialog.js";
+
+interface WizardInternals {
+  _index: number;
+  _screen: string;
+  _screens: string[];
+  _isHaAddon: boolean;
+  _discoveredHosts: Map<string, { friendly_name: string; name: string }> | null;
+  _localize: LocalizeFunc;
+  _onContinue(): Promise<void>;
+}
+
+const internals = (wizard: ESPHomeOnboardingWizardDialog) =>
+  wizard as unknown as WizardInternals;
+
+const hosts = (...entries: Array<{ friendly_name?: string; name: string }>) =>
+  new Map(
+    entries.map((e, i) => [
+      `h${i}`,
+      { friendly_name: e.friendly_name ?? "", name: e.name },
+    ])
+  );
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("onboarding existing-server orientation", () => {
+  it("inserts the orientation screen after welcome off the add-on", async () => {
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    wizard.open();
+    const state = internals(wizard);
+    state._isHaAddon = false;
+    state._discoveredHosts = hosts({ name: "living-room" });
+
+    expect(state._screen).toBe("welcome");
+    await state._onContinue();
+    expect(state._screen).toBe("existing_server");
+  });
+
+  it("advances from the orientation screen to experience", async () => {
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    wizard.open();
+    const state = internals(wizard);
+    state._isHaAddon = false;
+    state._discoveredHosts = hosts({ name: "living-room" });
+
+    await state._onContinue(); // welcome -> existing_server
+    await state._onContinue(); // existing_server -> experience
+    expect(state._screen).toBe("experience");
+  });
+
+  it("skips the orientation screen on the HA add-on", async () => {
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    wizard.open();
+    const state = internals(wizard);
+    state._isHaAddon = true;
+    state._discoveredHosts = hosts({ name: "living-room" });
+
+    await state._onContinue();
+    expect(state._screen).toBe("experience");
+    expect(state._screens).not.toContain("existing_server");
+  });
+
+  it("skips the orientation screen when no server is on the network", async () => {
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    wizard.open();
+    const state = internals(wizard);
+    state._isHaAddon = false;
+    state._discoveredHosts = null;
+
+    await state._onContinue();
+    expect(state._screen).toBe("experience");
+  });
+
+  it("does not retro-insert the screen when a host arrives after welcome", async () => {
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    wizard.open();
+    const state = internals(wizard);
+    state._isHaAddon = false;
+    state._discoveredHosts = null;
+
+    await state._onContinue(); // leaves welcome with nothing detected
+    expect(state._screen).toBe("experience");
+
+    state._discoveredHosts = hosts({ name: "late-arrival" }); // mDNS lands late
+    expect(state._screen).toBe("experience");
+    expect(state._screens).not.toContain("existing_server");
+  });
+
+  it("names the discovered server, preferring its friendly name", async () => {
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    document.body.appendChild(wizard);
+    const state = internals(wizard);
+    state._localize = ((key, values) =>
+      values?.name !== undefined ? String(values.name) : key) as LocalizeFunc;
+    wizard.open();
+    state._isHaAddon = false;
+    state._discoveredHosts = hosts({ friendly_name: "Living Room", name: "living-room" });
+
+    await state._onContinue(); // welcome -> existing_server
+    await wizard.updateComplete;
+
+    expect(wizard.shadowRoot?.textContent).toContain("Living Room");
+  });
+});

--- a/test/components/onboarding/onboarding-existing-server.test.ts
+++ b/test/components/onboarding/onboarding-existing-server.test.ts
@@ -11,12 +11,19 @@ import { ESPHomeOnboardingWizardDialog } from "../../../src/components/onboardin
 
 interface WizardInternals {
   _index: number;
+  _open: boolean;
   _screen: string;
   _screens: string[];
   _isHaAddon: boolean;
   _discoveredHosts: Map<string, { friendly_name: string; name: string }> | null;
   _localize: LocalizeFunc;
+  _api: {
+    setRemoteBuildSettings: ReturnType<typeof vi.fn>;
+    updatePreferences: ReturnType<typeof vi.fn>;
+    markOnboardingAcknowledged: ReturnType<typeof vi.fn>;
+  };
   _onContinue(): Promise<void>;
+  _setupBuildServer(): Promise<void>;
 }
 
 const internals = (wizard: ESPHomeOnboardingWizardDialog) =>
@@ -95,6 +102,36 @@ describe("onboarding existing-server orientation", () => {
     state._discoveredHosts = hosts({ name: "late-arrival" }); // mDNS lands late
     expect(state._screen).toBe("experience");
     expect(state._screens).not.toContain("existing_server");
+  });
+
+  it("enables the receiver role and opens Build server settings", async () => {
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    const state = internals(wizard);
+    state._api = {
+      setRemoteBuildSettings: vi.fn().mockResolvedValue(undefined),
+      updatePreferences: vi.fn().mockResolvedValue(undefined),
+      markOnboardingAcknowledged: vi.fn().mockResolvedValue(undefined),
+    };
+    wizard.open();
+    state._isHaAddon = false;
+    state._discoveredHosts = hosts({ name: "living-room" });
+    await state._onContinue(); // welcome -> existing_server
+
+    const openSettings = vi.fn();
+    wizard.addEventListener("open-settings", openSettings);
+    const acknowledged = vi.fn();
+    wizard.addEventListener("onboarding-acknowledged", acknowledged);
+
+    await state._setupBuildServer();
+
+    expect(state._api.setRemoteBuildSettings).toHaveBeenCalledWith({ enabled: true });
+    expect(state._api.markOnboardingAcknowledged).toHaveBeenCalledOnce();
+    expect(acknowledged).toHaveBeenCalledOnce();
+    expect(openSettings).toHaveBeenCalledOnce();
+    expect((openSettings.mock.calls[0][0] as CustomEvent).detail).toEqual({
+      section: "build_server",
+    });
+    expect(state._open).toBe(false);
   });
 
   it("names the discovered server, preferring its friendly name", async () => {

--- a/test/components/onboarding/onboarding-existing-server.test.ts
+++ b/test/components/onboarding/onboarding-existing-server.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}));
 
 import type { LocalizeFunc } from "../../../src/common/localize.js";
 import { ESPHomeOnboardingWizardDialog } from "../../../src/components/onboarding/onboarding-wizard-dialog.js";
@@ -14,8 +15,13 @@ interface WizardInternals {
   _screen: string;
   _screens: string[];
   _isHaAddon: boolean;
+  _remoteCompute: boolean;
   _discoveredHosts: Map<string, { friendly_name: string; name: string }> | null;
   _localize: LocalizeFunc;
+  _api: {
+    updatePreferences: ReturnType<typeof vi.fn>;
+    markOnboardingAcknowledged: ReturnType<typeof vi.fn>;
+  };
   _onContinue(): Promise<void>;
 }
 
@@ -30,12 +36,19 @@ const hosts = (...entries: Array<{ friendly_name?: string; name: string }>) =>
     ])
   );
 
+const stubApi = (state: WizardInternals) => {
+  state._api = {
+    updatePreferences: vi.fn().mockResolvedValue(undefined),
+    markOnboardingAcknowledged: vi.fn().mockResolvedValue(undefined),
+  };
+};
+
 afterEach(() => {
   document.body.replaceChildren();
 });
 
 describe("onboarding existing-server orientation", () => {
-  it("inserts the orientation screen after welcome off the add-on", async () => {
+  it("offers the orientation step after experience when a server is detected", async () => {
     const wizard = new ESPHomeOnboardingWizardDialog();
     wizard.open();
     const state = internals(wizard);
@@ -43,58 +56,70 @@ describe("onboarding existing-server orientation", () => {
     state._discoveredHosts = hosts({ name: "living-room" });
 
     expect(state._screen).toBe("welcome");
-    await state._onContinue();
+    await state._onContinue(); // welcome -> experience
+    expect(state._screen).toBe("experience");
+    await state._onContinue(); // experience -> existing_server
     expect(state._screen).toBe("existing_server");
   });
 
-  it("advances from the orientation screen to experience", async () => {
-    const wizard = new ESPHomeOnboardingWizardDialog();
-    wizard.open();
-    const state = internals(wizard);
-    state._isHaAddon = false;
-    state._discoveredHosts = hosts({ name: "living-room" });
-
-    await state._onContinue(); // welcome -> existing_server
-    await state._onContinue(); // existing_server -> experience
-    expect(state._screen).toBe("experience");
-  });
-
-  it("skips the orientation screen on the HA add-on", async () => {
+  it("skips the orientation step on the HA add-on", async () => {
     const wizard = new ESPHomeOnboardingWizardDialog();
     wizard.open();
     const state = internals(wizard);
     state._isHaAddon = true;
     state._discoveredHosts = hosts({ name: "living-room" });
 
-    await state._onContinue();
+    await state._onContinue(); // welcome -> experience
     expect(state._screen).toBe("experience");
     expect(state._screens).not.toContain("existing_server");
   });
 
-  it("skips the orientation screen when no server is on the network", async () => {
+  it("skips the orientation step when no server is on the network", async () => {
     const wizard = new ESPHomeOnboardingWizardDialog();
     wizard.open();
     const state = internals(wizard);
     state._isHaAddon = false;
     state._discoveredHosts = null;
 
-    await state._onContinue();
+    await state._onContinue(); // welcome -> experience
     expect(state._screen).toBe("experience");
+    expect(state._screens).not.toContain("existing_server");
   });
 
-  it("does not retro-insert the screen when a host arrives after welcome", async () => {
+  it("freezes the flow when a host arrives after leaving experience", async () => {
     const wizard = new ESPHomeOnboardingWizardDialog();
     wizard.open();
     const state = internals(wizard);
+    stubApi(state);
     state._isHaAddon = false;
     state._discoveredHosts = null;
 
-    await state._onContinue(); // leaves welcome with nothing detected
-    expect(state._screen).toBe("experience");
+    await state._onContinue(); // welcome -> experience
+    await state._onContinue(); // experience -> tour (nothing detected)
+    expect(state._screen).toBe("tour");
 
     state._discoveredHosts = hosts({ name: "late-arrival" }); // mDNS lands late
-    expect(state._screen).toBe("experience");
+    expect(state._screen).toBe("tour");
     expect(state._screens).not.toContain("existing_server");
+  });
+
+  it("persists remote_compute_only when the switch is on", async () => {
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    wizard.open();
+    const state = internals(wizard);
+    stubApi(state);
+    state._isHaAddon = false;
+    state._discoveredHosts = hosts({ name: "living-room" });
+
+    await state._onContinue(); // welcome -> experience
+    await state._onContinue(); // experience -> existing_server
+    state._remoteCompute = true; // user flips the switch
+    await state._onContinue(); // existing_server -> tour (persists)
+
+    expect(state._screen).toBe("tour");
+    expect(state._api.updatePreferences).toHaveBeenCalledWith(
+      expect.objectContaining({ remote_compute_only: true })
+    );
   });
 
   it("names the discovered server, preferring its friendly name", async () => {
@@ -107,7 +132,8 @@ describe("onboarding existing-server orientation", () => {
     state._isHaAddon = false;
     state._discoveredHosts = hosts({ friendly_name: "Living Room", name: "living-room" });
 
-    await state._onContinue(); // welcome -> existing_server
+    await state._onContinue(); // welcome -> experience
+    await state._onContinue(); // experience -> existing_server
     await wizard.updateComplete;
 
     expect(wizard.shadowRoot?.textContent).toContain("Living Room");

--- a/test/components/onboarding/onboarding-existing-server.test.ts
+++ b/test/components/onboarding/onboarding-existing-server.test.ts
@@ -11,19 +11,12 @@ import { ESPHomeOnboardingWizardDialog } from "../../../src/components/onboardin
 
 interface WizardInternals {
   _index: number;
-  _open: boolean;
   _screen: string;
   _screens: string[];
   _isHaAddon: boolean;
   _discoveredHosts: Map<string, { friendly_name: string; name: string }> | null;
   _localize: LocalizeFunc;
-  _api: {
-    setRemoteBuildSettings: ReturnType<typeof vi.fn>;
-    updatePreferences: ReturnType<typeof vi.fn>;
-    markOnboardingAcknowledged: ReturnType<typeof vi.fn>;
-  };
   _onContinue(): Promise<void>;
-  _setupBuildServer(): Promise<void>;
 }
 
 const internals = (wizard: ESPHomeOnboardingWizardDialog) =>
@@ -102,36 +95,6 @@ describe("onboarding existing-server orientation", () => {
     state._discoveredHosts = hosts({ name: "late-arrival" }); // mDNS lands late
     expect(state._screen).toBe("experience");
     expect(state._screens).not.toContain("existing_server");
-  });
-
-  it("enables the receiver role and opens Build server settings", async () => {
-    const wizard = new ESPHomeOnboardingWizardDialog();
-    const state = internals(wizard);
-    state._api = {
-      setRemoteBuildSettings: vi.fn().mockResolvedValue(undefined),
-      updatePreferences: vi.fn().mockResolvedValue(undefined),
-      markOnboardingAcknowledged: vi.fn().mockResolvedValue(undefined),
-    };
-    wizard.open();
-    state._isHaAddon = false;
-    state._discoveredHosts = hosts({ name: "living-room" });
-    await state._onContinue(); // welcome -> existing_server
-
-    const openSettings = vi.fn();
-    wizard.addEventListener("open-settings", openSettings);
-    const acknowledged = vi.fn();
-    wizard.addEventListener("onboarding-acknowledged", acknowledged);
-
-    await state._setupBuildServer();
-
-    expect(state._api.setRemoteBuildSettings).toHaveBeenCalledWith({ enabled: true });
-    expect(state._api.markOnboardingAcknowledged).toHaveBeenCalledOnce();
-    expect(acknowledged).toHaveBeenCalledOnce();
-    expect(openSettings).toHaveBeenCalledOnce();
-    expect((openSettings.mock.calls[0][0] as CustomEvent).detail).toEqual({
-      section: "build_server",
-    });
-    expect(state._open).toBe(false);
   });
 
   it("names the discovered server, preferring its friendly name", async () => {

--- a/test/components/onboarding/onboarding-wizard-restart.test.ts
+++ b/test/components/onboarding/onboarding-wizard-restart.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}));
 
 import { ExperienceLevel } from "../../../src/api/types/system.js";
 import {
@@ -20,11 +21,12 @@ interface WizardInternals {
   _open: boolean;
   _index: number;
   _screen: string;
-  _useCaseChosen: boolean;
   _remoteCompute: boolean;
   _experience: ExperienceLevel;
+  _existingServerPinned: boolean;
+  _isHaAddon: boolean;
+  _discoveredHosts: Map<string, { friendly_name: string; name: string }> | null;
   _titleKey: string;
-  _chooseExperience(level: ExperienceLevel): void;
   _onContinue(): Promise<void>;
   _onRequestClose(event: Event): void;
   _startTour(): void;
@@ -49,14 +51,12 @@ describe("onboarding wizard reset query", () => {
       `/?keep=yes&${RESET_ONBOARDING_PARAM}=1#section`
     );
     const wizard = new ESPHomeOnboardingWizardDialog();
-    wizard.hasUseCase = true;
     document.body.appendChild(wizard);
     await wizard.updateComplete;
 
     const state = internals(wizard);
     expect(state._open).toBe(true);
     expect(state._screen).toBe("welcome");
-    expect(state._useCaseChosen).toBe(true);
     expect(state._remoteCompute).toBe(false);
     expect(state._experience).toBe(ExperienceLevel.BEGINNER);
     expect(window.location.search).toBe("?keep=yes");
@@ -67,7 +67,6 @@ describe("onboarding wizard reset query", () => {
 describe("mandatory onboarding flow", () => {
   it("vetoes close requests until the final tour offer", () => {
     const wizard = new ESPHomeOnboardingWizardDialog();
-    wizard.hasUseCase = true;
     wizard.open();
     const state = internals(wizard);
 
@@ -75,7 +74,7 @@ describe("mandatory onboarding flow", () => {
     state._onRequestClose(requiredClose);
     expect(requiredClose.defaultPrevented).toBe(true);
 
-    state._index = 2;
+    state._index = 2; // welcome, experience, tour
     const optionalClose = new Event("request-close", { cancelable: true });
     state._onRequestClose(optionalClose);
     expect(optionalClose.defaultPrevented).toBe(false);
@@ -84,10 +83,9 @@ describe("mandatory onboarding flow", () => {
 
   it("persists choices before presenting the tour offer", async () => {
     const wizard = new ESPHomeOnboardingWizardDialog();
-    wizard.hasUseCase = true;
     wizard.open();
     const state = internals(wizard);
-    state._index = 1;
+    state._index = 1; // experience
     state._api = {
       updatePreferences: vi.fn().mockResolvedValue(undefined),
       markOnboardingAcknowledged: vi.fn().mockResolvedValue(undefined),
@@ -95,7 +93,7 @@ describe("mandatory onboarding flow", () => {
     const acknowledged = vi.fn();
     wizard.addEventListener("onboarding-acknowledged", acknowledged);
 
-    await state._onContinue();
+    await state._onContinue(); // experience -> tour (nothing detected)
 
     expect(state._api.updatePreferences).toHaveBeenCalledWith({
       experience_level: ExperienceLevel.BEGINNER,
@@ -106,45 +104,11 @@ describe("mandatory onboarding flow", () => {
     expect(acknowledged).toHaveBeenCalledOnce();
   });
 
-  it("asks expert users for their use case before saving", async () => {
-    const wizard = new ESPHomeOnboardingWizardDialog();
-    wizard.hasUseCase = true;
-    wizard.open();
-    const state = internals(wizard);
-    state._experience = ExperienceLevel.EXPERT;
-    state._index = 1;
-    state._api = {
-      updatePreferences: vi.fn(),
-      markOnboardingAcknowledged: vi.fn(),
-    };
-
-    await state._onContinue();
-
-    expect(state._screen).toBe("use_case");
-    expect(state._api.updatePreferences).not.toHaveBeenCalled();
-  });
-
-  it("restores local-device mode when switching back to beginner", () => {
-    const wizard = new ESPHomeOnboardingWizardDialog();
-    wizard.hasUseCase = true;
-    wizard.open();
-    const state = internals(wizard);
-    state._experience = ExperienceLevel.EXPERT;
-    state._remoteCompute = true;
-    state._index = 1;
-
-    state._chooseExperience(ExperienceLevel.BEGINNER);
-
-    expect(state._remoteCompute).toBe(false);
-    expect(state._screen).toBe("experience");
-  });
-
   it("starts the guided tour only after the final dialog has closed", () => {
     const wizard = new ESPHomeOnboardingWizardDialog();
-    wizard.hasUseCase = true;
     wizard.open();
     const state = internals(wizard);
-    state._index = 2;
+    state._index = 2; // tour
     const openTour = vi.fn();
     wizard.addEventListener("open-guided-tour", openTour);
 
@@ -157,13 +121,17 @@ describe("mandatory onboarding flow", () => {
 
   it("ends remote-compute setup without offering an incompatible tour", () => {
     const wizard = new ESPHomeOnboardingWizardDialog();
-    wizard.hasUseCase = true;
     wizard.open();
     const state = internals(wizard);
-    state._experience = ExperienceLevel.EXPERT;
+    // A detected server with the remote-compute switch on lands on the remote
+    // variant of the tour offer.
+    state._isHaAddon = false;
+    state._discoveredHosts = new Map([["h", { friendly_name: "", name: "hass" }]]);
+    state._existingServerPinned = true;
     state._remoteCompute = true;
-    state._index = 3;
+    state._index = 3; // welcome, experience, existing_server, tour
 
+    expect(state._screen).toBe("tour");
     expect(state._titleKey).toBe("onboarding.wizard.tour.remote_title");
   });
 });

--- a/test/components/onboarding/wizard-screens.test.ts
+++ b/test/components/onboarding/wizard-screens.test.ts
@@ -3,32 +3,47 @@ import { wizardScreens } from "../../../src/components/onboarding/wizard-screens
 
 describe("wizardScreens", () => {
   it("asks non-HA expert users how they will use the dashboard", () => {
-    expect(wizardScreens({ hasUseCase: true, isExpert: true })).toEqual([
-      "welcome",
-      "experience",
-      "use_case",
-      "tour",
-    ]);
+    expect(
+      wizardScreens({ hasUseCase: true, isExpert: true, showExistingServer: false })
+    ).toEqual(["welcome", "experience", "use_case", "tour"]);
   });
 
   it("skips the use-case screen for beginners", () => {
-    expect(wizardScreens({ hasUseCase: true, isExpert: false })).toEqual([
-      "welcome",
-      "experience",
-      "tour",
-    ]);
+    expect(
+      wizardScreens({ hasUseCase: true, isExpert: false, showExistingServer: false })
+    ).toEqual(["welcome", "experience", "tour"]);
   });
 
   it("skips the use-case screen in the HA add-on", () => {
-    expect(wizardScreens({ hasUseCase: false, isExpert: true })).toEqual([
-      "welcome",
-      "experience",
-      "tour",
-    ]);
+    expect(
+      wizardScreens({ hasUseCase: false, isExpert: true, showExistingServer: false })
+    ).toEqual(["welcome", "experience", "tour"]);
+  });
+
+  it("inserts the existing-server screen directly after welcome", () => {
+    expect(
+      wizardScreens({ hasUseCase: false, isExpert: false, showExistingServer: true })
+    ).toEqual(["welcome", "existing_server", "experience", "tour"]);
+  });
+
+  it("keeps the existing-server screen alongside the use-case screen", () => {
+    expect(
+      wizardScreens({ hasUseCase: true, isExpert: true, showExistingServer: true })
+    ).toEqual(["welcome", "existing_server", "experience", "use_case", "tour"]);
+  });
+
+  it("omits the existing-server screen when none was detected", () => {
+    expect(
+      wizardScreens({ hasUseCase: true, isExpert: true, showExistingServer: false })
+    ).not.toContain("existing_server");
   });
 
   it("never includes Wi-Fi setup", () => {
-    expect(wizardScreens({ hasUseCase: true, isExpert: true })).not.toContain("wifi");
-    expect(wizardScreens({ hasUseCase: false, isExpert: false })).not.toContain("wifi");
+    expect(
+      wizardScreens({ hasUseCase: true, isExpert: true, showExistingServer: true })
+    ).not.toContain("wifi");
+    expect(
+      wizardScreens({ hasUseCase: false, isExpert: false, showExistingServer: false })
+    ).not.toContain("wifi");
   });
 });

--- a/test/components/onboarding/wizard-screens.test.ts
+++ b/test/components/onboarding/wizard-screens.test.ts
@@ -2,48 +2,25 @@ import { describe, expect, it } from "vitest";
 import { wizardScreens } from "../../../src/components/onboarding/wizard-screens.js";
 
 describe("wizardScreens", () => {
-  it("asks non-HA expert users how they will use the dashboard", () => {
-    expect(
-      wizardScreens({ hasUseCase: true, isExpert: true, showExistingServer: false })
-    ).toEqual(["welcome", "experience", "use_case", "tour"]);
+  it("is welcome, experience, tour with nothing detected", () => {
+    expect(wizardScreens({ showExistingServer: false })).toEqual([
+      "welcome",
+      "experience",
+      "tour",
+    ]);
   });
 
-  it("skips the use-case screen for beginners", () => {
-    expect(
-      wizardScreens({ hasUseCase: true, isExpert: false, showExistingServer: false })
-    ).toEqual(["welcome", "experience", "tour"]);
-  });
-
-  it("skips the use-case screen in the HA add-on", () => {
-    expect(
-      wizardScreens({ hasUseCase: false, isExpert: true, showExistingServer: false })
-    ).toEqual(["welcome", "experience", "tour"]);
-  });
-
-  it("inserts the existing-server screen directly after welcome", () => {
-    expect(
-      wizardScreens({ hasUseCase: false, isExpert: false, showExistingServer: true })
-    ).toEqual(["welcome", "existing_server", "experience", "tour"]);
-  });
-
-  it("keeps the existing-server screen alongside the use-case screen", () => {
-    expect(
-      wizardScreens({ hasUseCase: true, isExpert: true, showExistingServer: true })
-    ).toEqual(["welcome", "existing_server", "experience", "use_case", "tour"]);
-  });
-
-  it("omits the existing-server screen when none was detected", () => {
-    expect(
-      wizardScreens({ hasUseCase: true, isExpert: true, showExistingServer: false })
-    ).not.toContain("existing_server");
+  it("inserts the existing-server step after experience when detected", () => {
+    expect(wizardScreens({ showExistingServer: true })).toEqual([
+      "welcome",
+      "experience",
+      "existing_server",
+      "tour",
+    ]);
   });
 
   it("never includes Wi-Fi setup", () => {
-    expect(
-      wizardScreens({ hasUseCase: true, isExpert: true, showExistingServer: true })
-    ).not.toContain("wifi");
-    expect(
-      wizardScreens({ hasUseCase: false, isExpert: false, showExistingServer: false })
-    ).not.toContain("wifi");
+    expect(wizardScreens({ showExistingServer: true })).not.toContain("wifi");
+    expect(wizardScreens({ showExistingServer: false })).not.toContain("wifi");
   });
 });

--- a/test/util/remote-build-peer-name.test.ts
+++ b/test/util/remote-build-peer-name.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { remoteBuildPeerName } from "../../src/util/remote-build-peer-name.js";
+
+describe("remoteBuildPeerName", () => {
+  it("labels the HA add-on stable channel", () => {
+    expect(remoteBuildPeerName({ friendly_name: "5c53de3b-esphome", name: "x" })).toBe(
+      "Home Assistant App"
+    );
+  });
+
+  it("labels the HA add-on beta and dev channels", () => {
+    expect(
+      remoteBuildPeerName({ friendly_name: "5c53de3b-esphome-beta", name: "x" })
+    ).toBe("Home Assistant App (Beta)");
+    expect(
+      remoteBuildPeerName({ friendly_name: "5c53de3b-esphome-dev", name: "x" })
+    ).toBe("Home Assistant App (Dev)");
+  });
+
+  it("recognises any repo-hash prefix, not just one install", () => {
+    expect(
+      remoteBuildPeerName({ friendly_name: "a1b2c3d4-esphome-dev", name: "x" })
+    ).toBe("Home Assistant App (Dev)");
+  });
+
+  it("falls back to the ha_addon flag when the hostname isn't the add-on shape", () => {
+    expect(
+      remoteBuildPeerName({ friendly_name: "hass-box", name: "x", ha_addon: true })
+    ).toBe("Home Assistant App");
+  });
+
+  it("prefers the friendly name for an ordinary peer", () => {
+    expect(remoteBuildPeerName({ friendly_name: "Mac", name: "esphome-builder-x" })).toBe(
+      "Mac"
+    );
+  });
+
+  it("falls back to the instance name and trims a trailing dot", () => {
+    expect(remoteBuildPeerName({ friendly_name: "", name: "living-room.local." })).toBe(
+      "living-room.local"
+    );
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

**This only changes onboarding for someone who already has a second install.** If you have exactly one ESPHome Device Builder, the first-run flow — Welcome → experience level → tour — is exactly as it is today. The new step appears **only when another Device Builder is detected on the local network** (and only on non-HA-add-on installs, Desktop / standalone) — i.e. you're standing up a second one alongside an existing dashboard such as the Home Assistant add-on. In that case a single extra step is inserted after the experience step.

**Why:** a newbie who installs ESPHome Desktop (or standalone Docker/pip) alongside an existing Device Builder — typically the Home Assistant add-on — often assumes the new app is a *client* for the old one and gets lost. What they usually want is the reverse: run the beefier new machine as a build server that the existing dashboard offloads its firmware compiles to.

**The new step (shown only on detection)** names the Device Builder(s) found, clarifies this app is a full install that's already a build server, and tells the user to pair from the *other* dashboard (**Settings → Send builds**). An opt-in **"Only use this for remote compute"** switch lets them dedicate this install as a pure build server (`remote_compute_only`, off by default).

Details:

- **Detection-gated, non-add-on only.** Reuses the mDNS-discovered hosts the offloader already browses (`buildOffloadDiscoveredHostsContext`) — no new backend command or WS call. Gated on a new `isHaAddonContext` (seeded from the handshake's `ha_addon`), so the add-on never shows it.
- **Remote-build choice moved here.** The standalone expert "usage mode" step was removed; the remote-compute choice now lives on this detection-gated step as a switch, since "act as a build server for other dashboards" only makes sense when another dashboard is actually present.
- **HA add-on labeling.** Discovered add-on peers display **Home Assistant App** (with `(Beta)` / `(Dev)` channels), derived from the Supervisor container hostname (`<repo-hash>-esphome[-channel]`); a shared helper is also used by the Send-builds list.
- **Race-safe.** The screen set is pinned when leaving the experience step, so an mDNS host arriving a beat late can't insert/remove a screen mid-flow. The discovered-name list is capped ("and N more").
- **Mobile.** The onboarding dialog is a full-screen sheet on phones (matching the logs / settings dialogs); long step titles wrap instead of truncating.

**Backend companion:** esphome/device-builder#2071 adds an additive `ha_addon` mDNS TXT flag (the label is derived frontend-side from the container hostname, so this works without waiting on that deploy).

## Screenshot
<img width="506" height="511" alt="Screenshot 2026-07-14 at 12 22 12 PM" src="https://github.com/user-attachments/assets/5d1d9af2-a8db-4331-b5f6-ecff097e9548" />



**Related issue or feature (if applicable):**

- From an onboarding design discussion (no public issue).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
