### PR TITLE
Keep the tour bubble off the step's controls on small viewports

### DIFF
--- a/src/components/guided-tour/esphome-guided-tour.styles.ts
+++ b/src/components/guided-tour/esphome-guided-tour.styles.ts
@@ -31,6 +31,13 @@ export const guidedTourStyles = css`
 
   .bubble {
     position: absolute;
+    display: flex;
+    flex-direction: column;
+    /* Cap the bubble so placement can always fit it somewhere on a small
+       screen; the body scrolls instead of covering the step's control. The
+       caret sits outside the box, so overflow lives on .bubble-scroll. */
+    max-height: min(60vh, calc(100vh - 32px));
+    max-height: min(60dvh, calc(100dvh - 32px));
     background: var(--wa-color-surface-raised, #fff);
     color: var(--wa-color-text-normal);
     border-radius: var(--wa-border-radius-l);
@@ -38,6 +45,12 @@ export const guidedTourStyles = css`
     padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-m);
     pointer-events: auto;
     box-sizing: border-box;
+  }
+
+  .bubble-scroll {
+    overflow-y: auto;
+    min-height: 0;
+    overscroll-behavior: contain;
   }
 
   .recovery-bubble {
@@ -176,6 +189,12 @@ export const guidedTourStyles = css`
 
   .btn-next:hover {
     background: var(--esphome-primary-hover);
+  }
+
+  @media (max-width: 480px) {
+    .bubble {
+      padding: var(--wa-space-m) var(--wa-space-m) var(--wa-space-s);
+    }
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/components/guided-tour/esphome-guided-tour.styles.ts
+++ b/src/components/guided-tour/esphome-guided-tour.styles.ts
@@ -48,9 +48,17 @@ export const guidedTourStyles = css`
   }
 
   .bubble-scroll {
+    flex: 1 1 auto;
     overflow-y: auto;
     min-height: 0;
     overscroll-behavior: contain;
+  }
+
+  /* Only the body compresses when the bubble hits its max-height. */
+  .tour-header,
+  .hint,
+  .actions {
+    flex-shrink: 0;
   }
 
   .recovery-bubble {

--- a/src/components/guided-tour/esphome-guided-tour.ts
+++ b/src/components/guided-tour/esphome-guided-tour.ts
@@ -9,6 +9,7 @@ import { isTypingTarget } from "../../util/typing-target.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { guidedTourStyles } from "./esphome-guided-tour.styles.js";
 import { renderTourBubble, renderTourRecovery } from "./tour-bubble.js";
+import { TourBubbleFit } from "./tour-bubble-fit.js";
 import { TOUR_LAYOUT_RESTORE_EVENT } from "./tour-layout-controller.js";
 import { TourNavigatorController } from "./tour-navigator-controller.js";
 import { captureTourConfiguration, navigateToTourStep } from "./tour-route.js";
@@ -62,6 +63,7 @@ export class ESPHomeGuidedTour extends LitElement {
   @state() private _showAnchorRecovery = false;
 
   @query(".tour-popover") private _popover?: HTMLElement;
+  @query(".bubble") private _bubbleEl?: HTMLElement;
   @query(".btn-skip") private _skipButton?: HTMLElement;
   @query(".btn-pause") private _pauseButton?: HTMLElement;
 
@@ -83,6 +85,14 @@ export class ESPHomeGuidedTour extends LitElement {
     pauseRect: () => this._pauseButton?.getBoundingClientRect(),
     onSkip: () => this._skip(),
     onPause: () => this._pause(),
+  });
+  private readonly _bubbleFit = new TourBubbleFit(this, {
+    bubbleEl: () => this._bubbleEl,
+    frame: () => (this._active ? this._frame : null),
+    anchorEl: () => this._observedTarget,
+    stepIndex: () => this._stepIndex,
+    isActionStep: () => this._step.kind === "action",
+    onHeightChange: () => this._refresh(),
   });
   private readonly _navigator = new TourNavigatorController(this, {
     isNavigatorStep: () =>
@@ -153,6 +163,7 @@ export class ESPHomeGuidedTour extends LitElement {
     setTourActive(true);
     this._stepIndex = stepIndex;
     this._frame = null;
+    this._bubbleFit.reset();
     this._dialogReady = false;
     this._revealRequested = false;
     this._bindTourListeners();
@@ -384,10 +395,12 @@ export class ESPHomeGuidedTour extends LitElement {
       { x: tr.left, y: tr.top, w: tr.width, h: tr.height },
       ...this._highlightRects(),
     ]);
-    this._frame = computeTourFrame(rect, this._step.side, {
-      w: window.innerWidth,
-      h: window.innerHeight,
-    });
+    this._frame = computeTourFrame(
+      rect,
+      this._step.side,
+      { w: window.innerWidth, h: window.innerHeight },
+      { bubbleHeight: this._bubbleFit.measuredHeight }
+    );
     if (appearing && this._step.anchors.some((a) => DIALOG_ANCHORS.has(a))) {
       this._bouncePopover();
     }
@@ -438,6 +451,7 @@ export class ESPHomeGuidedTour extends LitElement {
     this._stepIndex = index;
     setTourPending(index);
     this._frame = null;
+    this._bubbleFit.reset();
     this._revealRequested = false;
     if (
       !navigateToTourStep(

--- a/src/components/guided-tour/esphome-guided-tour.ts
+++ b/src/components/guided-tour/esphome-guided-tour.ts
@@ -20,6 +20,7 @@ import {
 } from "./tour-anchor.js";
 import {
   computeTourFrame,
+  toRect,
   unionRects,
   type Rect,
   type TourFrame,
@@ -88,9 +89,8 @@ export class ESPHomeGuidedTour extends LitElement {
   });
   private readonly _bubbleFit = new TourBubbleFit(this, {
     bubbleEl: () => this._bubbleEl,
-    frame: () => (this._active ? this._frame : null),
+    frame: () => this._frame,
     anchorEl: () => this._observedTarget,
-    stepIndex: () => this._stepIndex,
     isActionStep: () => this._step.kind === "action",
     onHeightChange: () => this._refresh(),
   });
@@ -390,9 +390,8 @@ export class ESPHomeGuidedTour extends LitElement {
     // backdrop swallows scroll, so a target below the fold (or its bubble)
     // would otherwise be unreachable on a small screen.
     if (appearing) this._scrollTargetIntoView(target);
-    const tr = target.getBoundingClientRect();
     const rect = unionRects([
-      { x: tr.left, y: tr.top, w: tr.width, h: tr.height },
+      toRect(target.getBoundingClientRect()),
       ...this._highlightRects(),
     ]);
     this._frame = computeTourFrame(
@@ -414,7 +413,7 @@ export class ESPHomeGuidedTour extends LitElement {
       if (!el) continue;
       const r = el.getBoundingClientRect();
       if (r.width > 0 || r.height > 0) {
-        rects.push({ x: r.left, y: r.top, w: r.width, h: r.height });
+        rects.push(toRect(r));
       }
     }
     return rects;

--- a/src/components/guided-tour/tour-bubble-fit.ts
+++ b/src/components/guided-tour/tour-bubble-fit.ts
@@ -1,5 +1,5 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
-import { BUBBLE_WIDTH, rectsIntersect, toRect, type TourFrame } from "./tour-geometry.js";
+import { rectsIntersect, toRect, type TourFrame } from "./tour-geometry.js";
 
 export interface TourBubbleFitOptions {
   /** The rendered bubble element (undefined until the frame first paints). */
@@ -21,8 +21,8 @@ export interface TourBubbleFitOptions {
  * a height estimate; long localized copy on a phone can double it, letting
  * an accepted placement cover the very control the step points at. After a
  * step's first paint this measures the side-placement bubble and asks the
- * host to re-place once with the real height (a docked bubble renders at a
- * different width, so its height never feeds back into side placement). Once
+ * host to re-place once with the real height (docked frames skip the
+ * feedback — placement already gave up on the side candidates). Once
  * settled, if the bubble still overlaps the spotlight hole, the anchor is
  * scrolled toward the free half of the viewport — one check per placement
  * per step, so a scroll-triggered re-measure can't loop and steady-state
@@ -55,7 +55,7 @@ export class TourBubbleFit implements ReactiveController {
     const frame = this._options.frame();
     const bubble = this._options.bubbleEl();
     if (!frame || !bubble) return;
-    const sideBubble = frame.bubble.width === BUBBLE_WIDTH;
+    const sideBubble = frame.dock === undefined;
     const placement = frame.dock ?? frame.side;
     if (
       this._checkedPlacements.has(placement) &&

--- a/src/components/guided-tour/tour-bubble-fit.ts
+++ b/src/components/guided-tour/tour-bubble-fit.ts
@@ -56,7 +56,9 @@ export class TourBubbleFit implements ReactiveController {
     const bubble = this._options.bubbleEl();
     if (!frame || !bubble) return;
     const sideBubble = frame.dock === undefined;
-    const placement = frame.dock ?? frame.side;
+    // Dock names reuse side names; prefix so "top" side and "top" dock
+    // placements each get their own check.
+    const placement = frame.dock ? `dock:${frame.dock}` : frame.side;
     if (
       this._checkedPlacements.has(placement) &&
       (!sideBubble || this._sideHeight !== undefined)

--- a/src/components/guided-tour/tour-bubble-fit.ts
+++ b/src/components/guided-tour/tour-bubble-fit.ts
@@ -1,10 +1,5 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
-import {
-  BUBBLE_WIDTH,
-  rectsIntersect,
-  type Rect,
-  type TourFrame,
-} from "./tour-geometry.js";
+import { BUBBLE_WIDTH, rectsIntersect, toRect, type TourFrame } from "./tour-geometry.js";
 
 export interface TourBubbleFitOptions {
   /** The rendered bubble element (undefined until the frame first paints). */
@@ -13,7 +8,6 @@ export interface TourBubbleFitOptions {
   frame: () => TourFrame | null;
   /** The step's measured anchor — the control the user must reach. */
   anchorEl: () => Element | null;
-  stepIndex: () => number;
   isActionStep: () => boolean;
   /** Re-place the bubble with the newly measured height. */
   onHeightChange: () => void;
@@ -24,18 +18,19 @@ export interface TourBubbleFitOptions {
  * the anchor clear of it.
  *
  * Placement runs before the bubble paints, so `computeTourFrame` starts from
- * a height estimate; long localized copy on a phone can double it, letting an
- * accepted placement cover the very control the step points at. After each
- * render this measures the bubble (memoized per bubble width so a docked
- * re-layout never feeds back into side placement) and asks the host to
- * re-place once per height change. Once the height is settled, if the bubble
- * still overlaps the action anchor, the anchor is scrolled toward the free
- * half of the viewport — once per placement per step, so a scroll-triggered
- * re-measure can't loop.
+ * a height estimate; long localized copy on a phone can double it, letting
+ * an accepted placement cover the very control the step points at. After a
+ * step's first paint this measures the side-placement bubble and asks the
+ * host to re-place once with the real height (a docked bubble renders at a
+ * different width, so its height never feeds back into side placement). Once
+ * settled, if the bubble still overlaps the spotlight hole, the anchor is
+ * scrolled toward the free half of the viewport — one check per placement
+ * per step, so a scroll-triggered re-measure can't loop and steady-state
+ * renders skip the layout reads entirely.
  */
 export class TourBubbleFit implements ReactiveController {
-  private _heights = new Map<number, number>();
-  private _spentNudges = new Set<string>();
+  private _sideHeight?: number;
+  private _checkedPlacements = new Set<string>();
 
   constructor(
     host: ReactiveControllerHost,
@@ -47,50 +42,51 @@ export class TourBubbleFit implements ReactiveController {
   /** The measured side-placement bubble height, if any (else the caller's
    *  estimate stands). */
   get measuredHeight(): number | undefined {
-    return this._heights.get(BUBBLE_WIDTH);
+    return this._sideHeight;
   }
 
-  /** Forget measurements and spent nudges; call on step change. */
+  /** Forget the measurement and checked placements; call on step change. */
   reset(): void {
-    this._heights.clear();
-    this._spentNudges.clear();
+    this._sideHeight = undefined;
+    this._checkedPlacements.clear();
   }
 
   hostUpdated(): void {
     const frame = this._options.frame();
     const bubble = this._options.bubbleEl();
     if (!frame || !bubble) return;
+    const sideBubble = frame.bubble.width === BUBBLE_WIDTH;
+    const placement = frame.dock ?? frame.side;
+    if (
+      this._checkedPlacements.has(placement) &&
+      (!sideBubble || this._sideHeight !== undefined)
+    ) {
+      return;
+    }
     const height = bubble.offsetHeight;
     if (height === 0) return;
-    const width = frame.bubble.width;
-    const prev = this._heights.get(width);
-    if (prev === undefined || Math.abs(prev - height) > 1) {
-      this._heights.set(width, height);
-      if (width === BUBBLE_WIDTH) {
-        this._options.onHeightChange();
-        return;
-      }
+    if (
+      sideBubble &&
+      (this._sideHeight === undefined || Math.abs(this._sideHeight - height) > 1)
+    ) {
+      this._sideHeight = height;
+      this._options.onHeightChange();
+      return;
     }
+    this._checkedPlacements.add(placement);
     this._maybeNudgeAnchor(frame, bubble);
   }
 
   private _maybeNudgeAnchor(frame: TourFrame, bubble: HTMLElement): void {
     if (!this._options.isActionStep()) return;
-    const key = `${this._options.stepIndex()}:${frame.dock ?? frame.side}`;
-    if (this._spentNudges.has(key)) return;
     const anchor = this._options.anchorEl();
     if (!anchor || typeof anchor.scrollIntoView !== "function") return;
-    const b = bubble.getBoundingClientRect();
-    if (!rectsIntersect(toRect(b), toRect(anchor.getBoundingClientRect()))) return;
-    this._spentNudges.add(key);
-    const bubbleOnTop = b.top + b.height / 2 < window.innerHeight / 2;
+    const bubbleRect = bubble.getBoundingClientRect();
+    if (!rectsIntersect(toRect(bubbleRect), frame.hole)) return;
+    const bubbleOnTop = bubbleRect.top + bubbleRect.height / 2 < window.innerHeight / 2;
     anchor.scrollIntoView({
       block: bubbleOnTop ? "end" : "start",
       inline: "nearest",
     });
   }
-}
-
-function toRect(r: DOMRect): Rect {
-  return { x: r.left, y: r.top, w: r.width, h: r.height };
 }

--- a/src/components/guided-tour/tour-bubble-fit.ts
+++ b/src/components/guided-tour/tour-bubble-fit.ts
@@ -1,0 +1,96 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import {
+  BUBBLE_WIDTH,
+  rectsIntersect,
+  type Rect,
+  type TourFrame,
+} from "./tour-geometry.js";
+
+export interface TourBubbleFitOptions {
+  /** The rendered bubble element (undefined until the frame first paints). */
+  bubbleEl: () => HTMLElement | undefined;
+  /** The frame the bubble was placed from (null while inactive/unanchored). */
+  frame: () => TourFrame | null;
+  /** The step's measured anchor — the control the user must reach. */
+  anchorEl: () => Element | null;
+  stepIndex: () => number;
+  isActionStep: () => boolean;
+  /** Re-place the bubble with the newly measured height. */
+  onHeightChange: () => void;
+}
+
+/**
+ * Feed the bubble's real rendered height back into placement, then nudge
+ * the anchor clear of it.
+ *
+ * Placement runs before the bubble paints, so `computeTourFrame` starts from
+ * a height estimate; long localized copy on a phone can double it, letting an
+ * accepted placement cover the very control the step points at. After each
+ * render this measures the bubble (memoized per bubble width so a docked
+ * re-layout never feeds back into side placement) and asks the host to
+ * re-place once per height change. Once the height is settled, if the bubble
+ * still overlaps the action anchor, the anchor is scrolled toward the free
+ * half of the viewport — once per placement per step, so a scroll-triggered
+ * re-measure can't loop.
+ */
+export class TourBubbleFit implements ReactiveController {
+  private _heights = new Map<number, number>();
+  private _spentNudges = new Set<string>();
+
+  constructor(
+    host: ReactiveControllerHost,
+    private readonly _options: TourBubbleFitOptions
+  ) {
+    host.addController(this);
+  }
+
+  /** The measured side-placement bubble height, if any (else the caller's
+   *  estimate stands). */
+  get measuredHeight(): number | undefined {
+    return this._heights.get(BUBBLE_WIDTH);
+  }
+
+  /** Forget measurements and spent nudges; call on step change. */
+  reset(): void {
+    this._heights.clear();
+    this._spentNudges.clear();
+  }
+
+  hostUpdated(): void {
+    const frame = this._options.frame();
+    const bubble = this._options.bubbleEl();
+    if (!frame || !bubble) return;
+    const height = bubble.offsetHeight;
+    if (height === 0) return;
+    const width = frame.bubble.width;
+    const prev = this._heights.get(width);
+    if (prev === undefined || Math.abs(prev - height) > 1) {
+      this._heights.set(width, height);
+      if (width === BUBBLE_WIDTH) {
+        this._options.onHeightChange();
+        return;
+      }
+    }
+    this._maybeNudgeAnchor(frame, bubble);
+  }
+
+  private _maybeNudgeAnchor(frame: TourFrame, bubble: HTMLElement): void {
+    if (!this._options.isActionStep()) return;
+    const key = `${this._options.stepIndex()}:${frame.dock ?? frame.side}`;
+    if (this._spentNudges.has(key)) return;
+    const anchor = this._options.anchorEl();
+    if (!anchor || typeof anchor.scrollIntoView !== "function") return;
+    const b = bubble.getBoundingClientRect();
+    if (!rectsIntersect(toRect(b), toRect(anchor.getBoundingClientRect()))) return;
+    this._spentNudges.add(key);
+    const bubbleOnTop = b.top + b.height / 2 < window.innerHeight / 2;
+    anchor.scrollIntoView({
+      block: bubbleOnTop ? "end" : "start",
+      inline: "nearest",
+    });
+  }
+}
+
+function toRect(r: DOMRect): Rect {
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+}

--- a/src/components/guided-tour/tour-bubble-fit.ts
+++ b/src/components/guided-tour/tour-bubble-fit.ts
@@ -31,6 +31,7 @@ export interface TourBubbleFitOptions {
 export class TourBubbleFit implements ReactiveController {
   private _sideHeight?: number;
   private _checkedPlacements = new Set<string>();
+  private _viewport = "";
 
   constructor(
     host: ReactiveControllerHost,
@@ -55,6 +56,13 @@ export class TourBubbleFit implements ReactiveController {
     const frame = this._options.frame();
     const bubble = this._options.bubbleEl();
     if (!frame || !bubble) return;
+    // The rendered height depends on the viewport (60vh cap, narrow-screen
+    // padding); a resize invalidates the measurement and the checks.
+    const viewport = `${window.innerWidth}x${window.innerHeight}`;
+    if (viewport !== this._viewport) {
+      this._viewport = viewport;
+      this.reset();
+    }
     const sideBubble = frame.dock === undefined;
     // Dock names reuse side names; prefix so "top" side and "top" dock
     // placements each get their own check.

--- a/src/components/guided-tour/tour-bubble.ts
+++ b/src/components/guided-tour/tour-bubble.ts
@@ -63,7 +63,7 @@ export function renderTourBubble(p: TourBubbleProps): TemplateResult {
         <wa-icon library="mdi" name="close" aria-hidden="true"></wa-icon>
       </button>
       ${
-        p.frame.overlay
+        p.frame.dock
           ? nothing
           : html`<div
               class="caret"
@@ -81,8 +81,10 @@ export function renderTourBubble(p: TourBubbleProps): TemplateResult {
           })}
         </span>
       </div>
-      <h2>${p.localize(p.step.titleKey)}</h2>
-      <p>${p.localize(p.step.bodyKey)}</p>
+      <div class="bubble-scroll">
+        <h2>${p.localize(p.step.titleKey)}</h2>
+        <p>${p.localize(p.step.bodyKey)}</p>
+      </div>
       ${
         p.step.kind === "action"
           ? html`

--- a/src/components/guided-tour/tour-geometry.ts
+++ b/src/components/guided-tour/tour-geometry.ts
@@ -61,6 +61,11 @@ export function rectsIntersect(a: Rect, b: Rect): boolean {
   return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
 }
 
+/** A DOMRect as the module's plain `Rect`. */
+export function toRect(r: DOMRect): Rect {
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+}
+
 /** The bounding box of one or more rects. */
 export function unionRects(rects: Rect[]): Rect {
   const x = Math.min(...rects.map((r) => r.x));
@@ -139,9 +144,12 @@ function bubbleTop(bubble: Bubble, vp: Viewport, height: number): number {
   return bubble.bottom !== undefined ? vp.h - bubble.bottom - height : (bubble.top ?? 0);
 }
 
-/** Long localized copy reaches ~310px on phones; desktop copy is much wider. */
+/** Long localized copy reaches ~310px on phones; desktop copy is much wider.
+ *  Clamped to the CSS max-height cap (60vh, esphome-guided-tour.styles.ts) so
+ *  the estimate never exceeds what a rendered bubble can be. */
 function bubbleHeightEstimate(vp: Viewport): number {
-  return vp.w <= 600 || vp.h <= 600 ? COMPACT_BUBBLE_HEIGHT_EST : BUBBLE_HEIGHT_EST;
+  const base = vp.w <= 600 || vp.h <= 600 ? COMPACT_BUBBLE_HEIGHT_EST : BUBBLE_HEIGHT_EST;
+  return Math.min(base, vp.h * 0.6);
 }
 
 function bubbleCoversHole(
@@ -164,7 +172,7 @@ function bubbleFitsViewport(bubble: Bubble, vp: Viewport, height: number): boole
 /** Full-width-ish bubble pinned to the viewport edge farther from the hole. */
 function computeDockedBubble(hole: Box, vp: Viewport): { bubble: Bubble; dock: Dock } {
   const w = Math.min(vp.w - EDGE_MARGIN * 2, DOCKED_MAX_WIDTH);
-  const left = clamp((vp.w - w) / 2, EDGE_MARGIN, vp.w - w - EDGE_MARGIN);
+  const left = (vp.w - w) / 2;
   const dock: Dock = hole.y + hole.h / 2 >= vp.h / 2 ? "top" : "bottom";
   return {
     bubble:

--- a/src/components/guided-tour/tour-geometry.ts
+++ b/src/components/guided-tour/tour-geometry.ts
@@ -150,7 +150,7 @@ function bubbleTop(bubble: Bubble, vp: Viewport, height: number): number {
  *  rendered bubble can be. */
 function bubbleHeightEstimate(vp: Viewport): number {
   const base = vp.w <= 600 || vp.h <= 600 ? COMPACT_BUBBLE_HEIGHT_EST : BUBBLE_HEIGHT_EST;
-  return Math.min(base, vp.h * 0.6, vp.h - EDGE_MARGIN * 2);
+  return Math.max(1, Math.min(base, vp.h * 0.6, vp.h - EDGE_MARGIN * 2));
 }
 
 function bubbleCoversHole(
@@ -172,7 +172,7 @@ function bubbleFitsViewport(bubble: Bubble, vp: Viewport, height: number): boole
 
 /** Full-width-ish bubble pinned to the viewport edge farther from the hole. */
 function computeDockedBubble(hole: Box, vp: Viewport): { bubble: Bubble; dock: Dock } {
-  const w = Math.min(vp.w - EDGE_MARGIN * 2, DOCKED_MAX_WIDTH);
+  const w = Math.max(1, Math.min(vp.w - EDGE_MARGIN * 2, DOCKED_MAX_WIDTH));
   const left = (vp.w - w) / 2;
   const dock: Dock = hole.y + hole.h / 2 >= vp.h / 2 ? "top" : "bottom";
   return {

--- a/src/components/guided-tour/tour-geometry.ts
+++ b/src/components/guided-tour/tour-geometry.ts
@@ -26,23 +26,25 @@ export interface Bubble {
   width: number;
 }
 
+export type Dock = "top" | "bottom";
+
 export interface TourFrame {
   hole: Box;
   dim: { top: Box; bottom: Box; left: Box; right: Box };
   bubble: Bubble;
   side: Side;
-  /** Bubble overlaps the hole because no side both clears it and fits the
-   *  viewport (near-full-screen target); the caret is meaningless then. */
-  overlay?: boolean;
+  /** Set when no side both clears the hole and fits the viewport; the bubble
+   *  is docked to this viewport edge instead and the caret is meaningless. */
+  dock?: Dock;
 }
 
 export const SPOTLIGHT_PADDING = 6;
 export const BUBBLE_WIDTH = 300;
 export const BUBBLE_GAP = 16;
 const EDGE_MARGIN = 16;
-const BUBBLE_BOTTOM_RESERVE = 200;
 const BUBBLE_HEIGHT_EST = 220;
 const COMPACT_BUBBLE_HEIGHT_EST = 340;
+const DOCKED_MAX_WIDTH = 360;
 
 const SIDE_ORDER: Record<Side, Side[]> = {
   right: ["right", "left", "top", "bottom"],
@@ -53,6 +55,10 @@ const SIDE_ORDER: Record<Side, Side[]> = {
 
 export function clamp(value: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(Math.max(lo, hi), value));
+}
+
+export function rectsIntersect(a: Rect, b: Rect): boolean {
+  return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
 }
 
 /** The bounding box of one or more rects. */
@@ -92,7 +98,8 @@ function computeBubble(
   hole: Box,
   side: Side,
   vp: Viewport,
-  width = BUBBLE_WIDTH
+  width: number,
+  height: number
 ): Bubble {
   const right = hole.x + hole.w;
   let left: number;
@@ -122,14 +129,13 @@ function computeBubble(
   }
   return {
     left,
-    top: clamp(top ?? 0, EDGE_MARGIN, vp.h - BUBBLE_BOTTOM_RESERVE),
+    top: clamp(top ?? 0, EDGE_MARGIN, vp.h - height - EDGE_MARGIN),
     width,
   };
 }
 
-/** The bubble's estimated top edge in viewport coordinates. */
-function bubbleTop(bubble: Bubble, vp: Viewport): number {
-  const height = bubbleHeightEstimate(vp);
+/** The bubble's top edge in viewport coordinates. */
+function bubbleTop(bubble: Bubble, vp: Viewport, height: number): number {
   return bubble.bottom !== undefined ? vp.h - bubble.bottom - height : (bubble.top ?? 0);
 }
 
@@ -138,63 +144,65 @@ function bubbleHeightEstimate(vp: Viewport): number {
   return vp.w <= 600 || vp.h <= 600 ? COMPACT_BUBBLE_HEIGHT_EST : BUBBLE_HEIGHT_EST;
 }
 
-function bubbleCoversHole(bubble: Bubble, vp: Viewport, hole: Box): boolean {
-  const top = bubbleTop(bubble, vp);
-  const height = bubbleHeightEstimate(vp);
-  const b = {
-    l: bubble.left,
-    r: bubble.left + bubble.width,
-    t: top,
-    b: top + height,
-  };
-  return !(
-    b.r <= hole.x ||
-    b.l >= hole.x + hole.w ||
-    b.b <= hole.y ||
-    b.t >= hole.y + hole.h
-  );
+function bubbleCoversHole(
+  bubble: Bubble,
+  vp: Viewport,
+  hole: Box,
+  height: number
+): boolean {
+  const top = bubbleTop(bubble, vp, height);
+  return rectsIntersect({ x: bubble.left, y: top, w: bubble.width, h: height }, hole);
 }
 
-/** True when the estimated bubble sits fully within the viewport's vertical
- *  margins (horizontal placement is already clamped in `computeBubble`). */
-function bubbleFitsViewport(bubble: Bubble, vp: Viewport): boolean {
-  const top = bubbleTop(bubble, vp);
-  return top >= EDGE_MARGIN && top + bubbleHeightEstimate(vp) <= vp.h - EDGE_MARGIN;
+/** True when the bubble sits fully within the viewport's vertical margins
+ *  (horizontal placement is already clamped in `computeBubble`). */
+function bubbleFitsViewport(bubble: Bubble, vp: Viewport, height: number): boolean {
+  const top = bubbleTop(bubble, vp, height);
+  return top >= EDGE_MARGIN && top + height <= vp.h - EDGE_MARGIN;
+}
+
+/** Full-width-ish bubble pinned to the viewport edge farther from the hole. */
+function computeDockedBubble(hole: Box, vp: Viewport): { bubble: Bubble; dock: Dock } {
+  const w = Math.min(vp.w - EDGE_MARGIN * 2, DOCKED_MAX_WIDTH);
+  const left = clamp((vp.w - w) / 2, EDGE_MARGIN, vp.w - w - EDGE_MARGIN);
+  const dock: Dock = hole.y + hole.h / 2 >= vp.h / 2 ? "top" : "bottom";
+  return {
+    bubble:
+      dock === "top"
+        ? { left, top: EDGE_MARGIN, width: w }
+        : { left, bottom: EDGE_MARGIN, width: w },
+    dock,
+  };
 }
 
 export function computeTourFrame(
   rect: Rect,
   side: Side,
   vp: Viewport,
-  options: { pad?: number; bubbleWidth?: number } = {}
+  options: { pad?: number; bubbleWidth?: number; bubbleHeight?: number } = {}
 ): TourFrame {
   const hole = computeHole(rect, options.pad);
-  const width = options.bubbleWidth;
+  const width = options.bubbleWidth ?? BUBBLE_WIDTH;
+  const height = options.bubbleHeight ?? bubbleHeightEstimate(vp);
 
   const candidates = SIDE_ORDER[side].map((candidate) => ({
     candidate,
-    bubble: computeBubble(hole, candidate, vp, width),
+    bubble: computeBubble(hole, candidate, vp, width, height),
   }));
   // Prefer a side that neither covers the hole nor overflows the viewport.
-  const clear = candidates.filter(({ bubble }) => !bubbleCoversHole(bubble, vp, hole));
-  const fitting = clear.find(({ bubble }) => bubbleFitsViewport(bubble, vp));
+  const clear = candidates.filter(
+    ({ bubble }) => !bubbleCoversHole(bubble, vp, hole, height)
+  );
+  const fitting = clear.find(({ bubble }) => bubbleFitsViewport(bubble, vp, height));
   const dim = computeDim(hole, vp);
   if (fitting) {
     return { hole, dim, bubble: fitting.bubble, side: fitting.candidate };
   }
 
-  // A near-full-screen hole leaves no side that both clears it and stays on
-  // screen; pin the bubble inside the viewport over the hole instead.
-  const w = width ?? BUBBLE_WIDTH;
-  const overlay: Bubble = {
-    left: clamp(hole.x + (hole.w - w) / 2, EDGE_MARGIN, vp.w - w - EDGE_MARGIN),
-    top: clamp(
-      hole.y + BUBBLE_GAP,
-      EDGE_MARGIN,
-      Math.max(EDGE_MARGIN, vp.h - bubbleHeightEstimate(vp) - EDGE_MARGIN)
-    ),
-    width: w,
-  };
-  // `side` is only read for caret placement, which overlay frames skip.
-  return { hole, dim, bubble: overlay, side, overlay: true };
+  // No side both clears the hole and stays on screen (tall target on a small
+  // viewport); dock the bubble to the edge whose half the hole occupies less,
+  // keeping the spotlit control reachable instead of pinning over it.
+  const docked = computeDockedBubble(hole, vp);
+  // `side` is only read for caret placement, which docked frames skip.
+  return { hole, dim, bubble: docked.bubble, side, dock: docked.dock };
 }

--- a/src/components/guided-tour/tour-geometry.ts
+++ b/src/components/guided-tour/tour-geometry.ts
@@ -145,11 +145,12 @@ function bubbleTop(bubble: Bubble, vp: Viewport, height: number): number {
 }
 
 /** Long localized copy reaches ~310px on phones; desktop copy is much wider.
- *  Clamped to the CSS max-height cap (60vh, esphome-guided-tour.styles.ts) so
- *  the estimate never exceeds what a rendered bubble can be. */
+ *  Clamped to the bubble's CSS max-height (min(60vh, 100vh - 32px) in
+ *  esphome-guided-tour.styles.ts) so the estimate never exceeds what a
+ *  rendered bubble can be. */
 function bubbleHeightEstimate(vp: Viewport): number {
   const base = vp.w <= 600 || vp.h <= 600 ? COMPACT_BUBBLE_HEIGHT_EST : BUBBLE_HEIGHT_EST;
-  return Math.min(base, vp.h * 0.6);
+  return Math.min(base, vp.h * 0.6, vp.h - EDGE_MARGIN * 2);
 }
 
 function bubbleCoversHole(

--- a/src/components/guided-tour/tour-steps.ts
+++ b/src/components/guided-tour/tour-steps.ts
@@ -70,6 +70,9 @@ export const TOUR_STEPS: readonly TourStep[] = [
     // Creation is asynchronous; anchor churn advances only after the device
     // page mounts, so failures keep this step visible in the wizard.
     actionAnchors: [],
+    // The credential inputs the hint asks for; keeping them in the hole
+    // keeps the bubble (and the dim) off them on small viewports.
+    highlightAnchors: ["wifi-fields"],
     route: "dashboard",
     side: "top",
     kind: "action",

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -431,7 +431,7 @@ export class ESPHomeWizardStepSetup extends LitElement {
 
   private _renderWifiSection() {
     return html`
-      <section class="section">
+      <section class="section" ${tourAnchor("wifi-fields")}>
         <div>
           <h3 class="section-title">${this._localize("wizard.wifi_configuration")}</h3>
           <p class="section-subtitle">

--- a/test/guided-tour/tour-bubble-fit.test.ts
+++ b/test/guided-tour/tour-bubble-fit.test.ts
@@ -1,0 +1,172 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactiveControllerHost } from "lit";
+
+import { TourBubbleFit } from "../../src/components/guided-tour/tour-bubble-fit.js";
+import {
+  BUBBLE_WIDTH,
+  type TourFrame,
+} from "../../src/components/guided-tour/tour-geometry.js";
+
+const HOST = {
+  addController: () => {},
+  removeController: () => {},
+  requestUpdate: () => {},
+  updateComplete: Promise.resolve(true),
+} as unknown as ReactiveControllerHost;
+
+function sideFrame(): TourFrame {
+  return {
+    hole: { x: 400, y: 300, w: 120, h: 40 },
+    dim: {
+      top: { x: 0, y: 0, w: 0, h: 0 },
+      bottom: { x: 0, y: 0, w: 0, h: 0 },
+      left: { x: 0, y: 0, w: 0, h: 0 },
+      right: { x: 0, y: 0, w: 0, h: 0 },
+    },
+    bubble: { left: 536, top: 300, width: BUBBLE_WIDTH },
+    side: "right",
+  };
+}
+
+function dockedFrame(): TourFrame {
+  return { ...sideFrame(), bubble: { left: 16, top: 16, width: 343 }, dock: "top" };
+}
+
+function fakeBubble(height: number, rect?: Partial<DOMRect>): HTMLElement {
+  return {
+    offsetHeight: height,
+    getBoundingClientRect: () =>
+      ({ left: 16, top: 16, width: 343, height, ...rect }) as DOMRect,
+  } as HTMLElement;
+}
+
+function fakeAnchor(rect: Partial<DOMRect>): Element & { scrollIntoView: unknown } {
+  return {
+    getBoundingClientRect: () =>
+      ({ left: 0, top: 0, width: 0, height: 0, ...rect }) as DOMRect,
+    scrollIntoView: vi.fn(),
+  } as unknown as Element & { scrollIntoView: unknown };
+}
+
+interface Harness {
+  fit: TourBubbleFit;
+  onHeightChange: ReturnType<typeof vi.fn>;
+  set frame(f: TourFrame | null);
+  set bubble(b: HTMLElement | undefined);
+  set anchor(a: Element | null);
+}
+
+function makeFit(): Harness {
+  let frame: TourFrame | null = null;
+  let bubble: HTMLElement | undefined;
+  let anchor: Element | null = null;
+  const onHeightChange = vi.fn();
+  const fit = new TourBubbleFit(HOST, {
+    bubbleEl: () => bubble,
+    frame: () => frame,
+    anchorEl: () => anchor,
+    isActionStep: () => true,
+    onHeightChange,
+  });
+  return {
+    fit,
+    onHeightChange,
+    set frame(f: TourFrame | null) {
+      frame = f;
+    },
+    set bubble(b: HTMLElement | undefined) {
+      bubble = b;
+    },
+    set anchor(a: Element | null) {
+      anchor = a;
+    },
+  };
+}
+
+function setViewport(width: number, height: number): void {
+  Object.defineProperty(window, "innerWidth", { value: width, configurable: true });
+  Object.defineProperty(window, "innerHeight", { value: height, configurable: true });
+}
+
+beforeEach(() => {
+  setViewport(1280, 800);
+});
+
+describe("TourBubbleFit", () => {
+  it("feeds the side bubble's measured height back exactly once per height", () => {
+    const h = makeFit();
+    h.frame = sideFrame();
+    h.bubble = fakeBubble(420);
+    h.fit.hostUpdated();
+    expect(h.onHeightChange).toHaveBeenCalledTimes(1);
+    expect(h.fit.measuredHeight).toBe(420);
+    h.fit.hostUpdated();
+    expect(h.onHeightChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("never feeds a docked bubble's height back into placement", () => {
+    const h = makeFit();
+    h.frame = dockedFrame();
+    h.bubble = fakeBubble(420);
+    h.fit.hostUpdated();
+    expect(h.onHeightChange).not.toHaveBeenCalled();
+    expect(h.fit.measuredHeight).toBeUndefined();
+  });
+
+  it("nudges the anchor once when the bubble overlaps the hole", () => {
+    const h = makeFit();
+    const frame = dockedFrame();
+    frame.hole = { x: 20, y: 100, w: 200, h: 60 };
+    h.frame = frame;
+    h.bubble = fakeBubble(300);
+    const anchor = fakeAnchor({ left: 40, top: 120, width: 100, height: 30 });
+    h.anchor = anchor;
+    h.fit.hostUpdated();
+    expect(anchor.scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(anchor.scrollIntoView).toHaveBeenCalledWith({
+      block: "end",
+      inline: "nearest",
+    });
+    h.fit.hostUpdated();
+    expect(anchor.scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not scroll when the bubble clears the hole", () => {
+    const h = makeFit();
+    h.frame = dockedFrame();
+    h.bubble = fakeBubble(200, { top: 584 });
+    const anchor = fakeAnchor({ left: 40, top: 120, width: 100, height: 30 });
+    h.anchor = anchor;
+    h.fit.hostUpdated();
+    expect(anchor.scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("re-measures after the viewport changes", () => {
+    const h = makeFit();
+    h.frame = sideFrame();
+    h.bubble = fakeBubble(420);
+    h.fit.hostUpdated();
+    h.fit.hostUpdated();
+    expect(h.onHeightChange).toHaveBeenCalledTimes(1);
+    setViewport(375, 667);
+    h.bubble = fakeBubble(500);
+    h.fit.hostUpdated();
+    expect(h.onHeightChange).toHaveBeenCalledTimes(2);
+    expect(h.fit.measuredHeight).toBe(500);
+  });
+
+  it("forgets the measurement and spent checks on reset", () => {
+    const h = makeFit();
+    h.frame = sideFrame();
+    h.bubble = fakeBubble(420);
+    h.fit.hostUpdated();
+    expect(h.fit.measuredHeight).toBe(420);
+    h.fit.reset();
+    expect(h.fit.measuredHeight).toBeUndefined();
+    h.fit.hostUpdated();
+    expect(h.onHeightChange).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/guided-tour/tour-geometry.test.ts
+++ b/test/guided-tour/tour-geometry.test.ts
@@ -101,26 +101,25 @@ describe("computeTourFrame bubble placement", () => {
     // The wizard's Finish button, bottom-right of a centred dialog on a narrow
     // viewport: a "right" bubble clamps back over it (the block bug). It must
     // flip to a side that leaves the control clickable and stays on screen —
-    // "left" would spill below the fold here, so it lands "top".
+    // "left" clears it once the height-aware clamp lifts the bubble above the
+    // fold.
     const vp: Viewport = { w: 1033, h: 800 };
     const finishBtn: Rect = { x: 724, y: 590, w: 82, h: 34 };
     const frame = computeTourFrame(finishBtn, "right", vp);
-    expect(frame.side).toBe("top");
-    // Top-anchored bubble sits above the target hole — doesn't cover it.
-    expect(vp.h - (frame.bubble.bottom ?? 0)).toBeLessThanOrEqual(frame.hole.y);
+    expect(frame.side).toBe("left");
+    // Lifted so the estimated bubble bottom stays inside the viewport margin.
+    expect((frame.bubble.top ?? 0) + 220).toBeLessThanOrEqual(vp.h - 16);
+    expect(frame.bubble.left + frame.bubble.width).toBeLessThanOrEqual(frame.hole.x);
   });
 
-  it("overlays the bubble on a near-full-screen hole instead of going off screen", () => {
-    // A full-pane target (mobile editor pane): no side both clears the hole
-    // and fits the viewport, so the bubble pins inside the viewport over it.
-    const vp: Viewport = { w: 375, h: 812 };
-    const pane: Rect = { x: 0, y: 72, w: 375, h: 630 };
-    const frame = computeTourFrame(pane, "left", vp);
-    expect(frame.overlay).toBe(true);
-    expect(frame.bubble.top).toBeGreaterThanOrEqual(16);
-    expect((frame.bubble.top ?? 0) + 220).toBeLessThanOrEqual(vp.h);
-    expect(frame.bubble.left).toBeGreaterThanOrEqual(16);
-    expect(frame.bubble.left + frame.bubble.width).toBeLessThanOrEqual(vp.w - 16);
+  it("keeps a tall real bubble on screen by lifting its top-anchored placement", () => {
+    // The estimate-height clamp used to reserve a fixed 200px and reject the
+    // side; with the real height threaded through, the bubble lifts to fit.
+    const vp: Viewport = { w: 1280, h: 800 };
+    const target: Rect = { x: 400, y: 640, w: 120, h: 40 };
+    const frame = computeTourFrame(target, "right", vp, { bubbleHeight: 300 });
+    expect(frame.side).toBe("right");
+    expect(frame.bubble.top).toBe(vp.h - 300 - 16);
   });
 
   it("prefers a viewport-fitting side over one that overflows it (mobile, target near top)", () => {
@@ -140,5 +139,53 @@ describe("computeTourFrame bubble placement", () => {
     const { bubble } = computeTourFrame(rightEdge, "right", VP);
     expect(bubble.left).toBeLessThanOrEqual(VP.w - BUBBLE_WIDTH - 16);
     expect(bubble.left).toBeGreaterThanOrEqual(16);
+  });
+});
+
+describe("computeTourFrame docked fallback", () => {
+  it("docks opposite the hole instead of pinning over a near-full-screen target", () => {
+    // A full-pane target (mobile editor pane): no side both clears the hole
+    // and fits the viewport. The bubble docks to the edge whose half the hole
+    // occupies less, leaving the pane interactive.
+    const vp: Viewport = { w: 375, h: 812 };
+    const pane: Rect = { x: 0, y: 72, w: 375, h: 630 };
+    const frame = computeTourFrame(pane, "left", vp);
+    expect(frame.dock).toBe("bottom");
+    expect(frame.bubble.bottom).toBe(16);
+    expect(frame.bubble.width).toBe(vp.w - 32);
+    expect(frame.bubble.left).toBe(16);
+  });
+
+  it("docks to the top when a phone-height bubble can't clear a low control", () => {
+    // iPhone SE, the featured board card's Select button near the bottom: a
+    // real bubble taller than every gap must not pin over the button.
+    const vp: Viewport = { w: 375, h: 667 };
+    const selectBtn: Rect = { x: 243, y: 590, w: 116, h: 40 };
+    const frame = computeTourFrame(selectBtn, "top", vp, { bubbleHeight: 560 });
+    expect(frame.dock).toBe("top");
+    expect(frame.bubble.top).toBe(16);
+  });
+
+  it("docks clear of the wifi step's field-spanning hole on a phone", () => {
+    // The wifi step's hole is the credentials section plus the Finish button
+    // (union); a tall bubble has no side left, so it docks over the header
+    // instead of burying the inputs.
+    const vp: Viewport = { w: 375, h: 667 };
+    const fieldsAndButton: Rect = { x: 16, y: 210, w: 343, h: 420 };
+    const frame = computeTourFrame(fieldsAndButton, "top", vp, {
+      bubbleHeight: 400,
+    });
+    expect(frame.dock).toBe("top");
+    expect(frame.bubble.top).toBe(16);
+    expect(frame.bubble.bottom).toBeUndefined();
+  });
+
+  it("caps the docked bubble width and centers it on desktop", () => {
+    const vp: Viewport = { w: 1280, h: 800 };
+    const pane: Rect = { x: 40, y: 40, w: 1200, h: 720 };
+    const frame = computeTourFrame(pane, "left", vp);
+    expect(frame.dock).toBe("top");
+    expect(frame.bubble.width).toBe(360);
+    expect(frame.bubble.left).toBe((vp.w - 360) / 2);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

On an iPhone SE the quickstart tour bubble covered the controls its own hint pointed at; step 3's bubble sat over the featured board's Select button, and step 5's bubble buried the Wi-Fi SSID and password inputs.

Three fixes in the tour placement. The bubble's real rendered height now feeds back into `computeTourFrame` (a new `TourBubbleFit` controller measures after paint and re-places once), so a placement is no longer accepted off the fixed height estimate that a phone's narrow copy overruns. When no side both clears the hole and fits the viewport, the bubble docks to the viewport edge away from the hole instead of pinning over it, and the anchor is scrolled clear if it still overlaps. The wifi step's credential fields join the spotlight hole via a `wifi-fields` highlight anchor, so placement keeps the bubble (and the dim) off them. The bubble is also capped at 60vh with a scrolling body as a safety net.

Verified headless at 375x667, 1033x800 and 1280x800: the Select button, name field, and both Wi-Fi inputs are clear of the bubble on every step.

**Related issue or feature (if applicable):**

- fixes user report of the tour blocking board select and Wi-Fi entry on iPhone SE

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
