### PR TITLE
Give the remote-compute switch an accessible name

### DIFF
--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -301,6 +301,7 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
           <wa-switch
             ?checked=${this._remoteCompute}
             ?disabled=${this._saving}
+            aria-label=${this._localize("onboarding.wizard.existing_server.remote_only_title")}
             @change=${this._onToggleRemoteCompute}
           ></wa-switch>
         </label>


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #1235 (a late Copilot review comment). The remote-compute `<wa-switch>` on the onboarding existing-server step was only labelled by a wrapping `<label>`, which doesn't reliably name a custom element for screen readers. Set `aria-label` directly on the switch (its title, "Only use this for remote compute"), matching the other `wa-switch` usages in the codebase.

The other Copilot comment (checking `RemoteBuildPeer.hostname` for the add-on pattern) needs no change: the Supervisor container hostname lands in `friendly_name` — which the helper already checks — while `hostname` is the SRV target (`esphome-builder-<id>.local`), which never carries the `-esphome[-channel]` suffix.

**Related issue or feature (if applicable):**

- Follow-up to esphome/device-builder-frontend#1235 (no public issue).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
