### PR TITLE
Keep editor overlays above the find-and-replace bar

### DIFF
--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -172,7 +172,7 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
       flex: 1;
       min-height: 0;
       /* Contain CodeMirror's internal z-indexes (search panel: 300) so they
-         can't paint over the action rows hosts float above the editor. */
+         can't paint over action rows that host pages float above the editor. */
       isolation: isolate;
     }
 

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -171,6 +171,9 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
       position: relative;
       flex: 1;
       min-height: 0;
+      /* Contain CodeMirror's internal z-indexes (search panel: 300) so they
+         can't paint over the action rows hosts float above the editor. */
+      isolation: isolate;
     }
 
     .cm-wrap {


### PR DESCRIPTION
# What does this implement/fix?

The 3 dot menu next to Install opens upward and rendered behind the find and replace bar. CodeMirror's search panel ships with `z-index: 300` in the library base theme, and nothing between it and the card body creates a stacking context, so it outranked the floating action row's `z-index: 10` context and painted over the open menu.

The YAML editor host now sets `isolation: isolate`, which keeps CodeMirror's internal z-indexes contained inside the editor; the menu and the action row paint above the panel again. This also fixes the same occlusion on the Secrets page, where the floating Save button was covered by an open find bar.

Verified in the live editor with a headless hit test at the overlap point: before the change the top element there is `cm-search cm-panel` on both pages; after it is the menu item, and Save on Secrets. Bumping the action row's own z-index instead was rejected because the mobile navigator drawer overlays the editor at `z-index: 100` and would be poked through.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2070

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
