### PR TITLE
Don't lose the guided tour's create-device click to a mid-dispatch refresh

### DIFF
--- a/src/components/guided-tour/esphome-guided-tour.ts
+++ b/src/components/guided-tour/esphome-guided-tour.ts
@@ -5,19 +5,16 @@ import { customElement, query, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext, remoteComputeOnlyContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import { isTypingTarget } from "../../util/typing-target.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { isTypingTarget } from "../../util/typing-target.js";
 import { guidedTourStyles } from "./esphome-guided-tour.styles.js";
-import { renderTourBubble, renderTourRecovery } from "./tour-bubble.js";
-import { TourBubbleFit } from "./tour-bubble-fit.js";
-import { TOUR_LAYOUT_RESTORE_EVENT } from "./tour-layout-controller.js";
-import { TourNavigatorController } from "./tour-navigator-controller.js";
-import { captureTourConfiguration, navigateToTourStep } from "./tour-route.js";
 import {
   TOUR_ANCHOR_EVENT,
   requestTourReveal,
   type TourAnchorEventDetail,
 } from "./tour-anchor.js";
+import { TourBubbleFit } from "./tour-bubble-fit.js";
+import { renderTourBubble, renderTourRecovery } from "./tour-bubble.js";
 import {
   computeTourFrame,
   toRect,
@@ -25,6 +22,9 @@ import {
   type Rect,
   type TourFrame,
 } from "./tour-geometry.js";
+import { TOUR_LAYOUT_RESTORE_EVENT } from "./tour-layout-controller.js";
+import { TourNavigatorController } from "./tour-navigator-controller.js";
+import { captureTourConfiguration, navigateToTourStep } from "./tour-route.js";
 import {
   clearTourConfiguration,
   clearTourPending,
@@ -279,17 +279,29 @@ export class ESPHomeGuidedTour extends LitElement {
     if ((this._step.actionAnchors?.length ?? 0) > 0) return false;
     const next = TOUR_STEPS[this._stepIndex + 1];
     if (!next) return false;
-    const currentPresent = this._step.anchors.some((a) => this._anchors.has(a));
-    const nextPresent = next.anchors.some((a) => this._anchors.has(a));
-    if (!currentPresent && nextPresent) {
-      const enteringDialog =
-        !this._step.anchors.some((anchor) => DIALOG_ANCHORS.has(anchor)) &&
-        next.anchors.some((anchor) => DIALOG_ANCHORS.has(anchor));
-      if (enteringDialog && !this._dialogReady) return false;
-      this._goToStep(this._stepIndex + 1);
-      return true;
+    const enteringDialog =
+      !this._step.anchors.some((anchor) => DIALOG_ANCHORS.has(anchor)) &&
+      next.anchors.some((anchor) => DIALOG_ANCHORS.has(anchor));
+    if (enteringDialog) {
+      // Anchor churn can't signal completion here: the page keeps this
+      // step's anchors registered behind the modal, and a hidden dialog
+      // keeps the next step's registered but sizeless. The dialog visibly
+      // showing the next anchor after its open animation is the signal.
+      if (!this._dialogReady) return false;
+      const sized = next.anchors.some((a) => {
+        const el = this._anchors.get(a);
+        if (!el) return false;
+        const r = el.getBoundingClientRect();
+        return r.width > 0 || r.height > 0;
+      });
+      if (!sized) return false;
+    } else {
+      const currentPresent = this._step.anchors.some((a) => this._anchors.has(a));
+      const nextPresent = next.anchors.some((a) => this._anchors.has(a));
+      if (currentPresent || !nextPresent) return false;
     }
-    return false;
+    this._goToStep(this._stepIndex + 1);
+    return true;
   }
 
   // Scroll/resize can fire many times per frame; coalesce the layout reads
@@ -354,13 +366,7 @@ export class ESPHomeGuidedTour extends LitElement {
     }
     const present = this._presentAnchorEls();
 
-    this._teardownClicks();
-    if (this._step.kind === "action") {
-      for (const el of this._actionAnchorEls()) {
-        el.addEventListener("click", this._onAnchorClick);
-        this._clickTargets.push(el);
-      }
-    }
+    this._syncClickTargets();
 
     const target =
       present.find((el) => {
@@ -439,6 +445,21 @@ export class ESPHomeGuidedTour extends LitElement {
       el.removeEventListener("click", this._onAnchorClick);
     }
     this._clickTargets = [];
+  }
+
+  private _syncClickTargets(): void {
+    // removeEventListener drops a listener from an in-flight dispatch even
+    // when it is re-added immediately, so a full teardown here would eat the
+    // very click _onAnchorClick waits for whenever that click's own handlers
+    // re-render an anchor. Only touch elements that actually changed.
+    const els = this._step.kind === "action" ? this._actionAnchorEls() : [];
+    for (const el of this._clickTargets) {
+      if (!els.includes(el)) el.removeEventListener("click", this._onAnchorClick);
+    }
+    for (const el of els) {
+      el.addEventListener("click", this._onAnchorClick);
+    }
+    this._clickTargets = els;
   }
 
   private _goToStep(index: number): void {

--- a/test/guided-tour/tour-pause.test.ts
+++ b/test/guided-tour/tour-pause.test.ts
@@ -19,8 +19,8 @@ import {
   getPendingTourStep,
   getTourConfiguration,
   isTourPending,
-  setTourConfiguration,
   setTourActive,
+  setTourConfiguration,
   setTourPending,
 } from "../../src/components/guided-tour/tour-session.js";
 import { TOUR_STEPS } from "../../src/components/guided-tour/tour-steps.js";
@@ -46,6 +46,21 @@ interface TourInternals {
 }
 
 const internals = (tour: ESPHomeGuidedTour) => tour as unknown as TourInternals;
+
+const sized = (el: HTMLElement): HTMLElement => {
+  el.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      bottom: 24,
+      right: 120,
+      width: 120,
+      height: 24,
+    }) as DOMRect;
+  return el;
+};
 
 afterEach(() => {
   vi.useRealTimers();
@@ -195,10 +210,46 @@ describe("guided-tour pause state", () => {
     state._active = true;
     state._stepIndex = 0;
     state._dialogReady = false;
-    state._anchors.set("create-method-basic", document.createElement("button"));
+    // The create button stays registered behind the modal.
+    state._anchors.set("create-device-fab", document.createElement("button"));
+    state._anchors.set("create-method-basic", sized(document.createElement("button")));
 
     expect(state._maybeAutoAdvance()).toBe(false);
     state._onDialogShown();
+    expect(state._stepIndex).toBe(1);
+  });
+
+  it("does not advance into a wizard that is not visibly open", () => {
+    const state = internals(new ESPHomeGuidedTour());
+    state._active = true;
+    state._stepIndex = 0;
+    state._dialogReady = true;
+    state._anchors.set("create-device-fab", document.createElement("button"));
+    // A hidden dialog keeps its anchors registered but sizeless.
+    state._anchors.set("create-method-basic", document.createElement("button"));
+
+    expect(state._maybeAutoAdvance()).toBe(false);
+    expect(state._stepIndex).toBe(0);
+  });
+
+  it("does not detach the click listener when a refresh leaves targets unchanged", () => {
+    const state = internals(new ESPHomeGuidedTour());
+    state._active = true;
+    state._stepIndex = 0;
+    const create = sized(document.createElement("button"));
+    document.body.appendChild(create);
+    state._anchors.set("create-device-fab", create);
+    state._refresh();
+
+    // Browsers skip a listener removed during dispatch even when re-added,
+    // so the mid-click refresh caused by the wizard opening must not detach
+    // _onAnchorClick while its click is still in flight.
+    const removeSpy = vi.spyOn(create, "removeEventListener");
+    state._refresh();
+    expect(removeSpy).not.toHaveBeenCalled();
+
+    create.click();
+    create.remove();
     expect(state._stepIndex).toBe(1);
   });
 


### PR DESCRIPTION
# What does this implement/fix?

Clicking "+ Create device" on the guided tour's first step sometimes opened the wizard without the tour advancing; it stayed on "Step 1 of 11" with the wizard open in front of it, and every later attempt behaved the same.

Two problems combined:

1. Opening the wizard resets it to the method screen. When a previous wizard session was dismissed on a later screen (the hidden dialog keeps its steps mounted), that reset re-renders tour anchors while the click is still dispatching, and the tour's refresh tore down and re-added its click listener. A listener removed during dispatch is skipped even when re-added immediately, so the tour never saw the click. The refresh now leaves listeners on unchanged targets alone.
2. The intended backstop, auto-advancing into the dialog once its open animation finishes, could never fire: it required the current step's anchors to be gone, and the create button stays registered behind the modal. It now advances once the dialog has shown and the next step's anchor is visibly sized; a hidden dialog keeps its anchors registered but sizeless, so it cannot fire early. The in-dialog steps keep the old churn rule.

This is also why the reporter only ever saw step 1 fail: inside the wizard each screen swap unmounts the previous anchor, so the churn backstop rescues a missed click there.

Reproduced with real mouse input against a live backend (wizard parked on the board step, tour started, create button clicked: wizard opened, tour stuck on step 1) and verified the same sequence now advances to step 2.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#2072

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
