### PR TITLE
Show the remote-compute explainer up front in onboarding

### DIFF
--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -317,15 +317,12 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
             @change=${this._onToggleRemoteCompute}
           ></wa-switch>
         </label>
-        ${
-          this._remoteCompute
-            ? html`
-                <div class="remote-feature-box">
-                  ${renderFeatureList(this._localize, REMOTE_COMPUTE_FEATURES)}
-                </div>
-              `
-            : nothing
-        }
+        <div class="remote-feature-box">
+          <p class="remote-feature-heading">
+            ${this._localize("settings.remote_compute_features_title")}
+          </p>
+          ${renderFeatureList(this._localize, REMOTE_COMPUTE_FEATURES)}
+        </div>
       </div>
     `;
   }

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -332,12 +332,13 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
       event.target as HTMLInputElement & { checked: boolean }
     ).checked;
     if (!this._remoteCompute) return;
-    // The explainer renders below the toggle, past the dialog's fold —
+    // The explainer sits below the toggle, often past the dialog's fold —
     // bring it into view so flipping the switch visibly does something.
     await this.updateComplete;
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     this.shadowRoot
       ?.querySelector(".remote-feature-box")
-      ?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      ?.scrollIntoView({ behavior: reduceMotion ? "auto" : "smooth", block: "nearest" });
   }
 
   private _renderTourOffer() {

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -335,7 +335,9 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     // The explainer sits below the toggle, often past the dialog's fold —
     // bring it into view so flipping the switch visibly does something.
     await this.updateComplete;
-    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const reduceMotion =
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     this.shadowRoot
       ?.querySelector(".remote-feature-box")
       ?.scrollIntoView({ behavior: reduceMotion ? "auto" : "smooth", block: "nearest" });

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -330,10 +330,17 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     `;
   }
 
-  private _onToggleRemoteCompute(event: Event) {
+  private async _onToggleRemoteCompute(event: Event) {
     this._remoteCompute = (
       event.target as HTMLInputElement & { checked: boolean }
     ).checked;
+    if (!this._remoteCompute) return;
+    // The explainer renders below the toggle, past the dialog's fold —
+    // bring it into view so flipping the switch visibly does something.
+    await this.updateComplete;
+    this.shadowRoot
+      ?.querySelector(".remote-feature-box")
+      ?.scrollIntoView({ behavior: "smooth", block: "nearest" });
   }
 
   private _renderTourOffer() {

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -335,6 +335,8 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     // The explainer sits below the toggle, often past the dialog's fold —
     // bring it into view so flipping the switch visibly does something.
     await this.updateComplete;
+    // A quick off-flip while the render was pending cancels the scroll.
+    if (!this._remoteCompute) return;
     const reduceMotion =
       typeof window.matchMedia === "function" &&
       window.matchMedia("(prefers-reduced-motion: reduce)").matches;

--- a/src/components/onboarding/onboarding-wizard-styles.ts
+++ b/src/components/onboarding/onboarding-wizard-styles.ts
@@ -111,6 +111,15 @@ export const onboardingWizardStyles = css`
     text-align: left;
   }
 
+  .remote-feature-heading {
+    margin: 0 0 var(--wa-space-2xs);
+    font-size: var(--wa-font-size-xs);
+    font-weight: var(--wa-font-weight-semibold);
+    color: var(--wa-color-text-quiet);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
   .welcome-screen {
     gap: var(--wa-space-xl);
   }

--- a/src/components/onboarding/onboarding-wizard-styles.ts
+++ b/src/components/onboarding/onboarding-wizard-styles.ts
@@ -24,6 +24,13 @@ export const onboardingWizardStyles = css`
     overflow-y: auto;
   }
 
+  /* The existing-server step carries the toggle plus the always-visible
+     explainer; give it enough height that the explainer isn't below the
+     fold on desktop (viewport-capped so short screens still fit). */
+  .body:has(.existing-server) {
+    height: min(560px, 72vh);
+  }
+
   .intro {
     font-size: var(--wa-font-size-s);
     color: var(--wa-color-text-quiet);

--- a/test/components/onboarding/onboarding-existing-server.test.ts
+++ b/test/components/onboarding/onboarding-existing-server.test.ts
@@ -23,6 +23,7 @@ interface WizardInternals {
     markOnboardingAcknowledged: ReturnType<typeof vi.fn>;
   };
   _onContinue(): Promise<void>;
+  _onToggleRemoteCompute(event: Event): Promise<void>;
 }
 
 const internals = (wizard: ESPHomeOnboardingWizardDialog) =>
@@ -120,6 +121,33 @@ describe("onboarding existing-server orientation", () => {
     expect(state._api.updatePreferences).toHaveBeenCalledWith(
       expect.objectContaining({ remote_compute_only: true })
     );
+  });
+
+  it("scrolls the explainer into view when the switch turns on", async () => {
+    const scrolled: string[] = [];
+    Element.prototype.scrollIntoView = function (this: Element) {
+      scrolled.push(this.className);
+    };
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    document.body.appendChild(wizard);
+    const state = internals(wizard);
+    wizard.open();
+    state._isHaAddon = false;
+    state._discoveredHosts = hosts({ name: "living-room" });
+
+    await state._onContinue(); // welcome -> experience
+    await state._onContinue(); // experience -> existing_server
+    await wizard.updateComplete;
+    await state._onToggleRemoteCompute({
+      target: { checked: true },
+    } as unknown as Event);
+    expect(scrolled).toEqual(["remote-feature-box"]);
+
+    // Turning it back off scrolls nothing (the box is gone).
+    await state._onToggleRemoteCompute({
+      target: { checked: false },
+    } as unknown as Event);
+    expect(scrolled).toEqual(["remote-feature-box"]);
   });
 
   it("names the discovered server, preferring its friendly name", async () => {

--- a/test/components/onboarding/onboarding-existing-server.test.ts
+++ b/test/components/onboarding/onboarding-existing-server.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment happy-dom
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
@@ -125,9 +125,15 @@ describe("onboarding existing-server orientation", () => {
 
   it("scrolls the explainer into view when the switch turns on", async () => {
     const scrolled: string[] = [];
+    // Not vi.spyOn — happy-dom may not define scrollIntoView at all;
+    // save/restore keeps the prototype clean for later tests either way.
+    const original = Element.prototype.scrollIntoView;
     Element.prototype.scrollIntoView = function (this: Element) {
       scrolled.push(this.className);
     };
+    onTestFinished(() => {
+      Element.prototype.scrollIntoView = original;
+    });
     const wizard = new ESPHomeOnboardingWizardDialog();
     document.body.appendChild(wizard);
     const state = internals(wizard);
@@ -146,7 +152,7 @@ describe("onboarding existing-server orientation", () => {
     } as unknown as Event);
     expect(scrolled).toEqual(["remote-feature-box"]);
 
-    // Turning it back off scrolls nothing (the box is gone).
+    // Turning it back off scrolls nothing (the box stays put).
     await state._onToggleRemoteCompute({
       target: { checked: false },
     } as unknown as Event);

--- a/test/components/onboarding/onboarding-existing-server.test.ts
+++ b/test/components/onboarding/onboarding-existing-server.test.ts
@@ -126,13 +126,18 @@ describe("onboarding existing-server orientation", () => {
   it("scrolls the explainer into view when the switch turns on", async () => {
     const scrolled: string[] = [];
     // Not vi.spyOn — happy-dom may not define scrollIntoView at all;
-    // save/restore keeps the prototype clean for later tests either way.
+    // restore the exact prototype shape (delete when it didn't exist).
+    const hadOwn = Object.prototype.hasOwnProperty.call(
+      Element.prototype,
+      "scrollIntoView"
+    );
     const original = Element.prototype.scrollIntoView;
     Element.prototype.scrollIntoView = function (this: Element) {
       scrolled.push(this.className);
     };
     onTestFinished(() => {
-      Element.prototype.scrollIntoView = original;
+      if (hadOwn) Element.prototype.scrollIntoView = original;
+      else delete (Element.prototype as Partial<Element>).scrollIntoView;
     });
     const wizard = new ESPHomeOnboardingWizardDialog();
     document.body.appendChild(wizard);
@@ -156,6 +161,15 @@ describe("onboarding existing-server orientation", () => {
     await state._onToggleRemoteCompute({
       target: { checked: false },
     } as unknown as Event);
+    expect(scrolled).toEqual(["remote-feature-box"]);
+
+    // An on-flip immediately reverted before the render lands scrolls
+    // nothing either.
+    const pending = state._onToggleRemoteCompute({
+      target: { checked: true },
+    } as unknown as Event);
+    state._remoteCompute = false;
+    await pending;
     expect(scrolled).toEqual(["remote-feature-box"]);
   });
 

--- a/test/components/onboarding/onboarding-existing-server.test.ts
+++ b/test/components/onboarding/onboarding-existing-server.test.ts
@@ -138,6 +138,9 @@ describe("onboarding existing-server orientation", () => {
     await state._onContinue(); // welcome -> experience
     await state._onContinue(); // experience -> existing_server
     await wizard.updateComplete;
+    // The explainer is visible before the switch is touched.
+    expect(wizard.shadowRoot?.querySelector(".remote-feature-box")).not.toBeNull();
+    expect(wizard.shadowRoot?.querySelector(".remote-feature-heading")).not.toBeNull();
     await state._onToggleRemoteCompute({
       target: { checked: true },
     } as unknown as Event);


### PR DESCRIPTION
# What does this implement/fix?

The remote-compute explainer in the onboarding existing-server step was invisible until after the switch was flipped, and even then rendered below the dialog's fold with nothing hinting it appeared. Two changes: the explainer now renders permanently below the switch with a "What the remote compute dashboard changes" heading, so the detail is discoverable before anyone commits to the toggle, and enabling the switch scrolls the box fully into view (instant instead of smooth under prefers-reduced-motion).

**Related issue or feature (if applicable):**

- follow-up to #1235 and #1240, found while re-running onboarding

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
