### PR TITLE
Add an opt-in Hide the Device builder option

### DIFF
--- a/src/api/types/system.ts
+++ b/src/api/types/system.ts
@@ -116,9 +116,8 @@ export interface UserPreferences {
    *  Wi-Fi step and device-creation entry points are hidden. */
   remote_compute_only: boolean;
   /** Hide the dashboard's Device builder section entirely; offered
-   *  only while ``remote_compute_only`` is on. Absent on pre-1.1
-   *  backends. */
-  hide_device_builder?: boolean;
+   *  only while ``remote_compute_only`` is on. */
+  hide_device_builder: boolean;
   /** Auto-commit config edits to a Git history. Default ``true``; the
    *  off switch is an expert-only Appearance toggle. */
   version_history_enabled: boolean;

--- a/src/api/types/system.ts
+++ b/src/api/types/system.ts
@@ -115,6 +115,10 @@ export interface UserPreferences {
   /** This install is only a remote build node: onboarding skips the
    *  Wi-Fi step and device-creation entry points are hidden. */
   remote_compute_only: boolean;
+  /** Hide the dashboard's Device builder section entirely; offered
+   *  only while ``remote_compute_only`` is on. Absent on pre-1.1
+   *  backends. */
+  hide_device_builder?: boolean;
   /** Auto-commit config edits to a Git history. Default ``true``; the
    *  off switch is an expert-only Appearance toggle. */
   version_history_enabled: boolean;

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -52,6 +52,7 @@ import {
   recentJobsContext,
   remoteBuildCleanupTtlContext,
   remoteBuildEnabledContext,
+  hideDeviceBuilderContext,
   remoteComputeOnlyContext,
   serverVersionContext,
   versionContext,
@@ -95,6 +96,7 @@ import {
   onSetOffloaderVersionMatchPolicy,
   onSetRemoteBuildCleanupTtl,
   onSetRemoteBuildEnabled,
+  onSetHideDeviceBuilder,
   onSetRemoteComputeOnly,
   onSetTheme,
   onSetVersionHistoryEnabled,
@@ -159,6 +161,9 @@ export class ESPHomeApp extends LitElement {
   @provide({ context: remoteComputeOnlyContext })
   @state()
   _remoteComputeOnly = false;
+  @provide({ context: hideDeviceBuilderContext })
+  @state()
+  _hideDeviceBuilder = false;
   // Default true until the subscribe snapshot delivers preferences, matching
   // the backend default so the expert toggle paints as on before first load.
   @provide({ context: versionHistoryEnabledContext })
@@ -593,6 +598,8 @@ export class ESPHomeApp extends LitElement {
         @set-expert-mode=${(e: CustomEvent<boolean>) => onSetExpertMode(this, e)}
         @set-remote-compute-only=${(e: CustomEvent<boolean>) =>
           onSetRemoteComputeOnly(this, e)}
+        @set-hide-device-builder=${(e: CustomEvent<boolean>) =>
+          onSetHideDeviceBuilder(this, e)}
         @set-version-history-enabled=${(e: CustomEvent<boolean>) =>
           onSetVersionHistoryEnabled(this, e)}
         @set-remote-build-enabled=${(e: CustomEvent<boolean>) =>

--- a/src/components/app-shell/data-load.ts
+++ b/src/components/app-shell/data-load.ts
@@ -11,6 +11,7 @@ export function applyPreferences(host: ESPHomeApp, prefs: UserPreferences): void
   host.applyTheme(prefs.theme);
   host._experienceLevel = prefs.experience_level;
   host._remoteComputeOnly = prefs.remote_compute_only;
+  host._hideDeviceBuilder = prefs.hide_device_builder ?? false;
   host._versionHistoryEnabled = prefs.version_history_enabled;
 }
 

--- a/src/components/app-shell/data-load.ts
+++ b/src/components/app-shell/data-load.ts
@@ -11,7 +11,7 @@ export function applyPreferences(host: ESPHomeApp, prefs: UserPreferences): void
   host.applyTheme(prefs.theme);
   host._experienceLevel = prefs.experience_level;
   host._remoteComputeOnly = prefs.remote_compute_only;
-  host._hideDeviceBuilder = prefs.hide_device_builder ?? false;
+  host._hideDeviceBuilder = prefs.hide_device_builder;
   host._versionHistoryEnabled = prefs.version_history_enabled;
 }
 

--- a/src/components/app-shell/settings-actions.ts
+++ b/src/components/app-shell/settings-actions.ts
@@ -103,6 +103,22 @@ export function onSetRemoteComputeOnly(host: ESPHomeApp, e: CustomEvent<boolean>
   });
 }
 
+export function onSetHideDeviceBuilder(host: ESPHomeApp, e: CustomEvent<boolean>): void {
+  void optimisticSetting(host, {
+    get: () => host._hideDeviceBuilder,
+    set: (v) => {
+      host._hideDeviceBuilder = v;
+    },
+    write: () => host._api.updatePreferences({ hide_device_builder: e.detail }),
+    value: e.detail,
+    toastKey: "settings.experience_save_failed",
+    warn: "Failed to save hide-device-builder:",
+    inFlight: (active) => {
+      host._prefsWritesInFlight += active ? 1 : -1;
+    },
+  });
+}
+
 // Expert Mode is just experience_level === EXPERT; the Appearance/command-palette
 // toggle re-points the level (off → BEGINNER) through the same write path.
 export function onSetExpertMode(host: ESPHomeApp, e: CustomEvent<boolean>): void {

--- a/src/components/app-shell/settings-actions.ts
+++ b/src/components/app-shell/settings-actions.ts
@@ -88,13 +88,23 @@ function setExperienceLevel(host: ESPHomeApp, level: ExperienceLevel): void {
 }
 
 export function onSetRemoteComputeOnly(host: ESPHomeApp, e: CustomEvent<boolean>): void {
+  // Turning the parent off also clears the hide sub-toggle: its control
+  // disappears with the parent, and a stale true would re-hide the
+  // builder without warning on the next enable. Tuple-valued so a
+  // failed write reverts both fields together.
+  const clearHide = !e.detail && host._hideDeviceBuilder;
   void optimisticSetting(host, {
-    get: () => host._remoteComputeOnly,
-    set: (v) => {
-      host._remoteComputeOnly = v;
+    get: () => [host._remoteComputeOnly, host._hideDeviceBuilder] as const,
+    set: ([remote, hide]) => {
+      host._remoteComputeOnly = remote;
+      host._hideDeviceBuilder = hide;
     },
-    write: () => host._api.updatePreferences({ remote_compute_only: e.detail }),
-    value: e.detail,
+    write: () =>
+      host._api.updatePreferences({
+        remote_compute_only: e.detail,
+        ...(clearHide ? { hide_device_builder: false } : {}),
+      }),
+    value: [e.detail, clearHide ? false : host._hideDeviceBuilder] as const,
     toastKey: "settings.experience_save_failed",
     warn: "Failed to save remote-compute-only:",
     inFlight: (active) => {

--- a/src/components/dashboard/render-stacks.ts
+++ b/src/components/dashboard/render-stacks.ts
@@ -13,6 +13,7 @@ export function renderRemoteStack(host: ESPHomePageDashboard): TemplateResult {
   return html`
     <esphome-remote-build-panel
       .collapsed=${host._stacks.remoteCollapsed}
+      .solo=${host._stacks.builderHidden}
       @toggle-collapsed=${host._stacks.swap}
     ></esphome-remote-build-panel>
   `;

--- a/src/components/remote-build-panel.ts
+++ b/src/components/remote-build-panel.ts
@@ -241,14 +241,17 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
   }
 
   private _renderBanner(pendingCount: number) {
+    const activeCount = this._buckets().active.length;
     // Solo: the banner is a plain heading — no chevron, not focusable,
-    // no accordion semantics.
+    // no accordion semantics. Badges stay off through the existing
+    // collapsed gate (a solo panel is never collapsed).
     if (this.solo) {
       return html`
-        <header class="banner stack-bar">${this._renderBannerContent(0, 0)}</header>
+        <header class="banner stack-bar">
+          ${this._renderBannerContent(pendingCount, activeCount)}
+        </header>
       `;
     }
-    const activeCount = this._buckets().active.length;
     return html`
       <button
         type="button"

--- a/src/components/remote-build-panel.ts
+++ b/src/components/remote-build-panel.ts
@@ -258,27 +258,27 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
             ${this._localize("remote_build_dashboard.tagline")}
           </span>
           ${
-          this.collapsed && pendingCount > 0
-            ? html`
-                <span class="banner-badge banner-badge--requests">
-                  ${this._localize("remote_build_dashboard.badge_requests", {
+            this.collapsed && pendingCount > 0
+              ? html`
+                  <span class="banner-badge banner-badge--requests">
+                    ${this._localize("remote_build_dashboard.badge_requests", {
                     count: pendingCount,
                   })}
-                </span>
-              `
-            : nothing
-        }
+                  </span>
+                `
+              : nothing
+          }
           ${
-          this.collapsed && activeCount > 0
-            ? html`
-                <span class="banner-badge">
-                  ${this._localize("remote_build_dashboard.badge_active", {
+            this.collapsed && activeCount > 0
+              ? html`
+                  <span class="banner-badge">
+                    ${this._localize("remote_build_dashboard.badge_active", {
                     count: activeCount,
                   })}
-                </span>
-              `
-            : nothing
-        }
+                  </span>
+                `
+              : nothing
+          }
         </span>
         <wa-icon
           class="stack-bar-chevron"

--- a/src/components/remote-build-panel.ts
+++ b/src/components/remote-build-panel.ts
@@ -262,8 +262,8 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
               ? html`
                   <span class="banner-badge banner-badge--requests">
                     ${this._localize("remote_build_dashboard.badge_requests", {
-                    count: pendingCount,
-                  })}
+                      count: pendingCount,
+                    })}
                   </span>
                 `
               : nothing
@@ -273,8 +273,8 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
               ? html`
                   <span class="banner-badge">
                     ${this._localize("remote_build_dashboard.badge_active", {
-                    count: activeCount,
-                  })}
+                      count: activeCount,
+                    })}
                   </span>
                 `
               : nothing

--- a/src/components/remote-build-panel.ts
+++ b/src/components/remote-build-panel.ts
@@ -81,8 +81,8 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
   @property({ type: Boolean, reflect: true }) collapsed = false;
 
   /** The Device builder section is hidden (hide_device_builder pref):
-   *  this panel is the whole dashboard, so the banner stops being an
-   *  accordion header — no chevron, clicks don't fire toggle-collapsed. */
+   *  this panel is the whole dashboard, so the accordion banner isn't
+   *  rendered at all. */
   @property({ type: Boolean, reflect: true }) solo = false;
 
   @consume({ context: localizeContext, subscribe: true })
@@ -183,7 +183,7 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
     const pending = this._peers?.filter((p) => p.status === "pending") ?? [];
     return html`
       <section class="panel" aria-label=${this._localize("remote_build_dashboard.title")}>
-        ${this._renderBanner(pending.length)}
+        ${this.solo ? nothing : this._renderBanner(pending.length)}
         ${
           this.collapsed
             ? nothing
@@ -242,16 +242,6 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
 
   private _renderBanner(pendingCount: number) {
     const activeCount = this._buckets().active.length;
-    // Solo: the banner is a plain heading — no chevron, not focusable,
-    // no accordion semantics. Badges stay off through the existing
-    // collapsed gate (a solo panel is never collapsed).
-    if (this.solo) {
-      return html`
-        <header class="banner stack-bar">
-          ${this._renderBannerContent(pendingCount, activeCount)}
-        </header>
-      `;
-    }
     return html`
       <button
         type="button"
@@ -259,28 +249,15 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
         aria-expanded=${this.collapsed ? "false" : "true"}
         @click=${this._onToggleCollapsed}
       >
-        ${this._renderBannerContent(pendingCount, activeCount)}
-        <wa-icon
-          class="stack-bar-chevron"
-          library="mdi"
-          name="chevron-down"
-          aria-hidden="true"
-        ></wa-icon>
-      </button>
-    `;
-  }
-
-  private _renderBannerContent(pendingCount: number, activeCount: number) {
-    return html`
-      <wa-icon library="mdi" name="server-network"></wa-icon>
-      <span class="stack-bar-main">
-        <span class="stack-bar-title">
-          ${this._localize("remote_build_dashboard.title")}
-        </span>
-        <span class="stack-bar-subtitle">
-          ${this._localize("remote_build_dashboard.tagline")}
-        </span>
-        ${
+        <wa-icon library="mdi" name="server-network"></wa-icon>
+        <span class="stack-bar-main">
+          <span class="stack-bar-title">
+            ${this._localize("remote_build_dashboard.title")}
+          </span>
+          <span class="stack-bar-subtitle">
+            ${this._localize("remote_build_dashboard.tagline")}
+          </span>
+          ${
           this.collapsed && pendingCount > 0
             ? html`
                 <span class="banner-badge banner-badge--requests">
@@ -291,7 +268,7 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
               `
             : nothing
         }
-        ${
+          ${
           this.collapsed && activeCount > 0
             ? html`
                 <span class="banner-badge">
@@ -302,7 +279,14 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
               `
             : nothing
         }
-      </span>
+        </span>
+        <wa-icon
+          class="stack-bar-chevron"
+          library="mdi"
+          name="chevron-down"
+          aria-hidden="true"
+        ></wa-icon>
+      </button>
     `;
   }
 

--- a/src/components/remote-build-panel.ts
+++ b/src/components/remote-build-panel.ts
@@ -80,6 +80,11 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
    *  the page can join the collapsed bar with the builder header below. */
   @property({ type: Boolean, reflect: true }) collapsed = false;
 
+  /** The Device builder section is hidden (hide_device_builder pref):
+   *  this panel is the whole dashboard, so the banner stops being an
+   *  accordion header — no chevron, clicks don't fire toggle-collapsed. */
+  @property({ type: Boolean, reflect: true }) solo = false;
+
   @consume({ context: localizeContext, subscribe: true })
   @state()
   _localize: LocalizeFunc = (key) => key;
@@ -236,6 +241,13 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
   }
 
   private _renderBanner(pendingCount: number) {
+    // Solo: the banner is a plain heading — no chevron, not focusable,
+    // no accordion semantics.
+    if (this.solo) {
+      return html`
+        <header class="banner stack-bar">${this._renderBannerContent(0, 0)}</header>
+      `;
+    }
     const activeCount = this._buckets().active.length;
     return html`
       <button
@@ -244,37 +256,7 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
         aria-expanded=${this.collapsed ? "false" : "true"}
         @click=${this._onToggleCollapsed}
       >
-        <wa-icon library="mdi" name="server-network"></wa-icon>
-        <span class="stack-bar-main">
-          <span class="stack-bar-title">
-            ${this._localize("remote_build_dashboard.title")}
-          </span>
-          <span class="stack-bar-subtitle">
-            ${this._localize("remote_build_dashboard.tagline")}
-          </span>
-          ${
-            this.collapsed && pendingCount > 0
-              ? html`
-                  <span class="banner-badge banner-badge--requests">
-                    ${this._localize("remote_build_dashboard.badge_requests", {
-                      count: pendingCount,
-                    })}
-                  </span>
-                `
-              : nothing
-          }
-          ${
-            this.collapsed && activeCount > 0
-              ? html`
-                  <span class="banner-badge">
-                    ${this._localize("remote_build_dashboard.badge_active", {
-                      count: activeCount,
-                    })}
-                  </span>
-                `
-              : nothing
-          }
-        </span>
+        ${this._renderBannerContent(pendingCount, activeCount)}
         <wa-icon
           class="stack-bar-chevron"
           library="mdi"
@@ -282,6 +264,42 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
           aria-hidden="true"
         ></wa-icon>
       </button>
+    `;
+  }
+
+  private _renderBannerContent(pendingCount: number, activeCount: number) {
+    return html`
+      <wa-icon library="mdi" name="server-network"></wa-icon>
+      <span class="stack-bar-main">
+        <span class="stack-bar-title">
+          ${this._localize("remote_build_dashboard.title")}
+        </span>
+        <span class="stack-bar-subtitle">
+          ${this._localize("remote_build_dashboard.tagline")}
+        </span>
+        ${
+          this.collapsed && pendingCount > 0
+            ? html`
+                <span class="banner-badge banner-badge--requests">
+                  ${this._localize("remote_build_dashboard.badge_requests", {
+                    count: pendingCount,
+                  })}
+                </span>
+              `
+            : nothing
+        }
+        ${
+          this.collapsed && activeCount > 0
+            ? html`
+                <span class="banner-badge">
+                  ${this._localize("remote_build_dashboard.badge_active", {
+                    count: activeCount,
+                  })}
+                </span>
+              `
+            : nothing
+        }
+      </span>
     `;
   }
 

--- a/src/components/remote-build-panel/styles.ts
+++ b/src/components/remote-build-panel/styles.ts
@@ -30,6 +30,16 @@ export const remoteBuildPanelStyles = css`
     margin-right: var(--content-gutter, var(--wa-space-l));
   }
 
+  /* Solo (Device builder hidden): the banner is a plain heading, not
+     an accordion header. */
+  :host([solo]) .banner {
+    cursor: default;
+  }
+
+  :host([solo]) .banner:hover {
+    background: transparent;
+  }
+
   .banner-badge {
     display: inline-flex;
     align-items: center;

--- a/src/components/remote-build-panel/styles.ts
+++ b/src/components/remote-build-panel/styles.ts
@@ -30,14 +30,10 @@ export const remoteBuildPanelStyles = css`
     margin-right: var(--content-gutter, var(--wa-space-l));
   }
 
-  /* Solo (Device builder hidden): the banner is a plain heading, not
-     an accordion header. */
-  :host([solo]) .banner {
-    cursor: default;
-  }
-
-  :host([solo]) .banner:hover {
-    background: transparent;
+  /* Solo (Device builder hidden): no accordion banner at all; the
+     panel content provides its own top inset instead. */
+  :host([solo]) .panel {
+    padding-top: var(--stack-gap);
   }
 
   .banner-badge {

--- a/src/components/settings-dialog/appearance-section.ts
+++ b/src/components/settings-dialog/appearance-section.ts
@@ -14,6 +14,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import {
   expertModeContext,
   localizeContext,
+  hideDeviceBuilderContext,
   remoteComputeOnlyContext,
   versionHistoryEnabledContext,
 } from "../../context/index.js";
@@ -76,6 +77,10 @@ export class ESPHomeSettingsAppearance extends LitElement {
   @consume({ context: remoteComputeOnlyContext, subscribe: true })
   @state()
   private _remoteComputeOnly = false;
+
+  @consume({ context: hideDeviceBuilderContext, subscribe: true })
+  @state()
+  private _hideDeviceBuilder = false;
 
   @consume({ context: versionHistoryEnabledContext, subscribe: true })
   @state()
@@ -161,6 +166,18 @@ export class ESPHomeSettingsAppearance extends LitElement {
           this._remoteFeaturesOpen = !this._remoteFeaturesOpen;
         }
       )}
+      ${
+        this._remoteComputeOnly
+          ? renderToggleRow(this._localize, {
+              titleId: "hide-device-builder-title",
+              titleKey: "settings.hide_device_builder",
+              descKey: "settings.hide_device_builder_desc",
+              checked: this._hideDeviceBuilder,
+              onToggle: this._onToggleHideDeviceBuilder,
+              rowClass: "expert-row",
+            })
+          : nothing
+      }
     `;
   }
 
@@ -231,6 +248,16 @@ export class ESPHomeSettingsAppearance extends LitElement {
     this.dispatchEvent(
       new CustomEvent("set-remote-compute-only", {
         detail: !this._remoteComputeOnly,
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private _onToggleHideDeviceBuilder() {
+    this.dispatchEvent(
+      new CustomEvent("set-hide-device-builder", {
+        detail: !this._hideDeviceBuilder,
         bubbles: true,
         composed: true,
       })

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -130,11 +130,9 @@ export const remoteComputeOnlyContext = createContext<boolean>(
 );
 
 /**
- * Context for hiding the dashboard's Device builder section entirely.
- *
- * Only honoured while ``remote_compute_only`` is on; the Appearance
- * toggle that sets it is likewise gated. A live guided tour overrides
- * the hide so its anchors stay visible.
+ * Context for the raw ``hide_device_builder`` preference. The gating
+ * policy (remote-compute only, tour override) lives in
+ * ``DashboardStacksController.builderHidden``.
  */
 export const hideDeviceBuilderContext = createContext<boolean>(
   Symbol("esphome-hide-device-builder")

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -130,6 +130,17 @@ export const remoteComputeOnlyContext = createContext<boolean>(
 );
 
 /**
+ * Context for hiding the dashboard's Device builder section entirely.
+ *
+ * Only honoured while ``remote_compute_only`` is on; the Appearance
+ * toggle that sets it is likewise gated. A live guided tour overrides
+ * the hide so its anchors stay visible.
+ */
+export const hideDeviceBuilderContext = createContext<boolean>(
+  Symbol("esphome-hide-device-builder")
+);
+
+/**
  * Context for whether Git version-history auto-commit is enabled.
  *
  * Default ``true``. Set from the ``subscribe_events`` ``initial_state``

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -16,6 +16,7 @@ export {
   experienceLevelContext,
   expertModeContext,
   firmwareJobsContext,
+  hideDeviceBuilderContext,
   importableDevicesContext,
   integrationDocsContext,
   isHaAddonContext,

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -234,8 +234,7 @@ export class ESPHomePageDashboard extends LitElement {
     remoteComputeReady: () => this._remoteComputeOnly && this._prefsLoaded,
     hasApprovedSender: () =>
       this._buildServerPeers?.some((p) => p.status === "approved") ?? false,
-    hideBuilder: () =>
-      this._hideDeviceBuilder && this._remoteComputeOnly && this._prefsLoaded,
+    hideBuilder: () => this._hideDeviceBuilder,
   });
 
   // Passed to runBulkUpdate for the NO_COMPATIBLE_PEER toast
@@ -713,11 +712,11 @@ export class ESPHomePageDashboard extends LitElement {
     return html`
       ${this._stacks.show ? renderRemoteStack(this) : ""}
       ${
-        this._stacks.show
-          ? this._stacks.builderHidden
-            ? ""
-            : renderBuilderStack(this, content)
-          : content()
+        this._stacks.builderHidden
+          ? ""
+          : this._stacks.show
+            ? renderBuilderStack(this, content)
+            : content()
       }
       ${renderDrawer(this)}
       ${

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -94,6 +94,7 @@ import {
   devicesContext,
   devicesLoadedContext,
   expertModeContext,
+  hideDeviceBuilderContext,
   importableDevicesContext,
   labelsContext,
   localizeContext,
@@ -214,6 +215,9 @@ export class ESPHomePageDashboard extends LitElement {
   @consume({ context: remoteComputeOnlyContext, subscribe: true })
   @state()
   _remoteComputeOnly = false;
+  @consume({ context: hideDeviceBuilderContext, subscribe: true })
+  @state()
+  _hideDeviceBuilder = false;
 
   // False until preferences load once; the remote stack's expanded-by-
   // default treatment waits for the real preference value.
@@ -230,6 +234,8 @@ export class ESPHomePageDashboard extends LitElement {
     remoteComputeReady: () => this._remoteComputeOnly && this._prefsLoaded,
     hasApprovedSender: () =>
       this._buildServerPeers?.some((p) => p.status === "approved") ?? false,
+    hideBuilder: () =>
+      this._hideDeviceBuilder && this._remoteComputeOnly && this._prefsLoaded,
   });
 
   // Passed to runBulkUpdate for the NO_COMPATIBLE_PEER toast
@@ -706,7 +712,13 @@ export class ESPHomePageDashboard extends LitElement {
   private _renderStacked(content: () => TemplateResult): TemplateResult {
     return html`
       ${this._stacks.show ? renderRemoteStack(this) : ""}
-      ${this._stacks.show ? renderBuilderStack(this, content) : content()}
+      ${
+        this._stacks.show
+          ? this._stacks.builderHidden
+            ? ""
+            : renderBuilderStack(this, content)
+          : content()
+      }
       ${renderDrawer(this)}
       ${
         this._stacks.show && this._stacks.builderCollapsed

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1268,6 +1268,8 @@
     "appearance": "Appearance",
     "experience_save_failed": "Failed to save your preference",
     "remote_compute_only": "Remote compute dashboard",
+    "hide_device_builder": "Hide the Device builder",
+    "hide_device_builder_desc": "Show only the Build server view. Device creation and the device list come back the moment this is turned off.",
     "remote_compute_only_desc": "Put this install's remote build server dashboard front and center. Nothing is removed; the device builder section just starts collapsed.",
     "remote_compute_features_title": "What the remote compute dashboard changes",
     "remote_compute_feature_dashboard": "Build server front and center",

--- a/src/util/dashboard-stacks-controller.ts
+++ b/src/util/dashboard-stacks-controller.ts
@@ -11,7 +11,7 @@ interface DashboardStacksInputs {
   remoteComputeReady(): boolean;
   /** A sender is approved to build here. */
   hasApprovedSender(): boolean;
-  /** The hide_device_builder preference (caller gates it on remote-compute). */
+  /** The raw hide_device_builder preference. */
   hideBuilder(): boolean;
 }
 
@@ -46,9 +46,14 @@ export class DashboardStacksController implements ReactiveController {
   }
 
   /** The Device builder section is gone entirely (Build server only).
-   *  A live tour overrides — its anchors must stay visible. */
+   *  Honoured only with the remote-compute pref on; a live tour
+   *  overrides — its anchors must stay visible. */
   get builderHidden(): boolean {
-    return !this._tourEngaged && this._inputs.hideBuilder();
+    return (
+      !this._tourEngaged &&
+      this._inputs.hideBuilder() &&
+      this._inputs.remoteComputeReady()
+    );
   }
 
   get expanded(): DashboardStack {
@@ -69,7 +74,6 @@ export class DashboardStacksController implements ReactiveController {
   /** Both headers share this: with two stacks and always-one-open, every
    *  header click means "show the other section". */
   swap = (): void => {
-    if (this.builderHidden) return;
     const stack: DashboardStack = this.expanded === "remote" ? "builder" : "remote";
     this._choice = stack;
     saveExpandedStack(stack);

--- a/src/util/dashboard-stacks-controller.ts
+++ b/src/util/dashboard-stacks-controller.ts
@@ -11,6 +11,8 @@ interface DashboardStacksInputs {
   remoteComputeReady(): boolean;
   /** A sender is approved to build here. */
   hasApprovedSender(): boolean;
+  /** The hide_device_builder preference (caller gates it on remote-compute). */
+  hideBuilder(): boolean;
 }
 
 /**
@@ -43,9 +45,16 @@ export class DashboardStacksController implements ReactiveController {
     return this._inputs.remoteComputeReady() || this._inputs.hasApprovedSender();
   }
 
+  /** The Device builder section is gone entirely (Build server only).
+   *  A live tour overrides — its anchors must stay visible. */
+  get builderHidden(): boolean {
+    return !this._tourEngaged && this._inputs.hideBuilder();
+  }
+
   get expanded(): DashboardStack {
     // A live tour anchors builder content; never hide it.
     if (this._tourEngaged) return "builder";
+    if (this.builderHidden) return "remote";
     return this._choice ?? (this._inputs.remoteComputeReady() ? "remote" : "builder");
   }
 
@@ -60,6 +69,7 @@ export class DashboardStacksController implements ReactiveController {
   /** Both headers share this: with two stacks and always-one-open, every
    *  header click means "show the other section". */
   swap = (): void => {
+    if (this.builderHidden) return;
     const stack: DashboardStack = this.expanded === "remote" ? "builder" : "remote";
     this._choice = stack;
     saveExpandedStack(stack);

--- a/test/components/app-shell/data-load.test.ts
+++ b/test/components/app-shell/data-load.test.ts
@@ -100,6 +100,7 @@ describe("loadPreferences (post-wizard context refresh)", () => {
     table_sort_direction: null,
     experience_level: ExperienceLevel.EXPERT,
     remote_compute_only: true,
+    hide_device_builder: false,
     version_history_enabled: true,
     onboarding_completed_version: 2,
   };

--- a/test/components/app-shell/events-initial-state-prefs.test.ts
+++ b/test/components/app-shell/events-initial-state-prefs.test.ts
@@ -25,6 +25,7 @@ function prefs(over: Partial<UserPreferences> = {}): UserPreferences {
     table_sort_direction: null,
     experience_level: ExperienceLevel.EXPERT,
     remote_compute_only: true,
+    hide_device_builder: false,
     version_history_enabled: true,
     onboarding_completed_version: 2,
     ...over,

--- a/test/components/app-shell/settings-actions.test.ts
+++ b/test/components/app-shell/settings-actions.test.ts
@@ -26,6 +26,7 @@ type PrefsHost = Pick<
   ESPHomeApp,
   | "_experienceLevel"
   | "_remoteComputeOnly"
+  | "_hideDeviceBuilder"
   | "_versionHistoryEnabled"
   | "_localize"
   | "_prefsWritesInFlight"
@@ -37,6 +38,7 @@ function makePrefsHost(
   return {
     _experienceLevel: null,
     _remoteComputeOnly: false,
+    _hideDeviceBuilder: false,
     _versionHistoryEnabled: true,
     _localize: identityLocalize as ESPHomeApp["_localize"],
     _prefsWritesInFlight: 0,
@@ -330,6 +332,54 @@ describe("onSetRemoteComputeOnly", () => {
     expect(host._remoteComputeOnly).toBe(false);
     expect(toastError).toHaveBeenCalledOnce();
     expect(warn).toHaveBeenCalled();
+  });
+
+  it("turning off also clears the hide sub-toggle in the same write", async () => {
+    const update = vi.fn(async () => ({}));
+    const host = makePrefsHost(update);
+    host._remoteComputeOnly = true;
+    host._hideDeviceBuilder = true;
+    onSetRemoteComputeOnly(
+      host as unknown as ESPHomeApp,
+      new CustomEvent("x", { detail: false })
+    );
+    expect(host._remoteComputeOnly).toBe(false);
+    expect(host._hideDeviceBuilder).toBe(false);
+    await flush();
+    expect(update).toHaveBeenCalledWith({
+      remote_compute_only: false,
+      hide_device_builder: false,
+    });
+  });
+
+  it("a failed cascade write reverts both fields together", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const host = makePrefsHost(
+      vi.fn(async () => {
+        throw new Error("no");
+      })
+    );
+    host._remoteComputeOnly = true;
+    host._hideDeviceBuilder = true;
+    onSetRemoteComputeOnly(
+      host as unknown as ESPHomeApp,
+      new CustomEvent("x", { detail: false })
+    );
+    await flush();
+    expect(host._remoteComputeOnly).toBe(true);
+    expect(host._hideDeviceBuilder).toBe(true);
+  });
+
+  it("turning on leaves the hide sub-toggle alone", async () => {
+    const update = vi.fn(async () => ({}));
+    const host = makePrefsHost(update);
+    onSetRemoteComputeOnly(
+      host as unknown as ESPHomeApp,
+      new CustomEvent("x", { detail: true })
+    );
+    await flush();
+    expect(update).toHaveBeenCalledWith({ remote_compute_only: true });
+    expect(host._hideDeviceBuilder).toBe(false);
   });
 });
 

--- a/test/components/app-shell/settings-actions.test.ts
+++ b/test/components/app-shell/settings-actions.test.ts
@@ -9,6 +9,7 @@ import {
   onSetOffloaderPairingEnabled,
   onSetOffloaderVersionMatchPolicy,
   onSetRemoteBuildEnabled,
+  onSetHideDeviceBuilder,
   onSetRemoteComputeOnly,
   onSetTheme,
   onSetVersionHistoryEnabled,
@@ -380,6 +381,43 @@ describe("onSetRemoteComputeOnly", () => {
     await flush();
     expect(update).toHaveBeenCalledWith({ remote_compute_only: true });
     expect(host._hideDeviceBuilder).toBe(false);
+  });
+});
+
+describe("onSetHideDeviceBuilder", () => {
+  beforeEach(() => toastError.mockClear());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("optimistically flips and persists the preference on success", async () => {
+    const update = vi.fn(async () => ({}));
+    const host = makePrefsHost(update);
+    onSetHideDeviceBuilder(
+      host as unknown as ESPHomeApp,
+      new CustomEvent("x", { detail: true })
+    );
+    expect(host._hideDeviceBuilder).toBe(true);
+    await flush();
+    expect(host._hideDeviceBuilder).toBe(true);
+    expect(update).toHaveBeenCalledWith({ hide_device_builder: true });
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("reverts, logs, and toasts on backend rejection", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const host = makePrefsHost(
+      vi.fn(async () => {
+        throw new Error("no");
+      })
+    );
+    onSetHideDeviceBuilder(
+      host as unknown as ESPHomeApp,
+      new CustomEvent("x", { detail: true })
+    );
+    expect(host._hideDeviceBuilder).toBe(true);
+    await flush();
+    expect(host._hideDeviceBuilder).toBe(false);
+    expect(toastError).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalled();
   });
 });
 

--- a/test/components/settings-dialog/appearance-hide-builder.test.ts
+++ b/test/components/settings-dialog/appearance-hide-builder.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The "Hide the Device builder" toggle is offered only while the
+ * remote-compute pref is on, and flipping it fires a bubbling,
+ * composed `set-hide-device-builder` event carrying the next value.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomeSettingsAppearance } from "../../../src/components/settings-dialog/appearance-section.js";
+
+async function mount(opts: {
+  remote?: boolean;
+  hide?: boolean;
+}): Promise<ESPHomeSettingsAppearance> {
+  const el = new ESPHomeSettingsAppearance();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._remoteComputeOnly = opts.remote ?? false;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._hideDeviceBuilder = opts.hide ?? false;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+const hideToggle = (el: ESPHomeSettingsAppearance) =>
+  el
+    .shadowRoot!.querySelector("#hide-device-builder-title")
+    ?.closest(".expert-row")
+    ?.querySelector<HTMLButtonElement>('button.toggle[role="switch"]') ?? null;
+
+describe("appearance hide-device-builder toggle", () => {
+  it("is absent while the remote-compute pref is off", async () => {
+    const el = await mount({ remote: false, hide: true });
+    expect(hideToggle(el)).toBeNull();
+  });
+
+  it("shows under the remote-compute pref and fires the next value", async () => {
+    const el = await mount({ remote: true, hide: false });
+    const toggle = hideToggle(el)!;
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+
+    const events: boolean[] = [];
+    el.addEventListener("set-hide-device-builder", (e) =>
+      events.push((e as CustomEvent<boolean>).detail)
+    );
+    toggle.click();
+    expect(events).toEqual([true]);
+  });
+
+  it("reflects the current value via aria-checked", async () => {
+    const el = await mount({ remote: true, hide: true });
+    expect(hideToggle(el)!.getAttribute("aria-checked")).toBe("true");
+  });
+});

--- a/test/components/settings-dialog/appearance-hide-builder.test.ts
+++ b/test/components/settings-dialog/appearance-hide-builder.test.ts
@@ -28,10 +28,9 @@ async function mount(opts: {
 }
 
 const hideToggle = (el: ESPHomeSettingsAppearance) =>
-  el
-    .shadowRoot!.querySelector("#hide-device-builder-title")
-    ?.closest(".expert-row")
-    ?.querySelector<HTMLButtonElement>('button.toggle[role="switch"]') ?? null;
+  el.shadowRoot!.querySelector<HTMLButtonElement>(
+    'button.toggle[aria-labelledby="hide-device-builder-title"]'
+  );
 
 describe("appearance hide-device-builder toggle", () => {
   it("is absent while the remote-compute pref is off", async () => {

--- a/test/pages/dashboard-remote-panel.test.ts
+++ b/test/pages/dashboard-remote-panel.test.ts
@@ -64,6 +64,7 @@ function makePeer(overrides: Partial<PeerSummary> = {}): PeerSummary {
 
 async function mountDashboard(opts: {
   remote?: boolean;
+  hideBuilder?: boolean;
   prefsLoaded?: boolean;
   devices?: ConfiguredDevice[];
   peers?: PeerSummary[] | null;
@@ -72,6 +73,8 @@ async function mountDashboard(opts: {
   // Context-provided fields, seeded directly for a bare mount.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (page as any)._remoteComputeOnly = opts.remote ?? false;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._hideDeviceBuilder = opts.hideBuilder ?? false;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (page as any)._prefsLoaded = opts.prefsLoaded ?? true;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -158,6 +161,49 @@ describe("dashboard remote-compute stacks", () => {
     await page.updateComplete;
     expect(panel.collapsed).toBe(true);
     expect(builderHeaderIn(page)?.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("hide_device_builder leaves only the expanded panel, banner inert", async () => {
+    const page = await mountDashboard({
+      remote: true,
+      hideBuilder: true,
+      devices: [makeConfiguredDevice()],
+    });
+    const panel = panelIn(page)!;
+    expect(panel.collapsed).toBe(false);
+    expect(panel.solo).toBe(true);
+    // No builder section, no grid, no FAB / select bar.
+    expect(builderHeaderIn(page)).toBeNull();
+    expect(gridIn(page)).toBeNull();
+    expect(page.shadowRoot?.querySelector("esphome-fab")).toBeNull();
+    // The banner is a heading, not an accordion header.
+    await panel.updateComplete;
+    expect(panel.shadowRoot?.querySelector("button.banner")).toBeNull();
+    expect(panel.shadowRoot?.querySelector("header.banner")).not.toBeNull();
+    expect(panel.shadowRoot?.querySelector(".stack-bar-chevron")).toBeNull();
+  });
+
+  it("hide_device_builder is ignored without the remote-compute pref", async () => {
+    const page = await mountDashboard({
+      remote: false,
+      hideBuilder: true,
+      peers: [makePeer()],
+    });
+    expect(builderHeaderIn(page)).not.toBeNull();
+    expect(panelIn(page)!.collapsed).toBe(true);
+  });
+
+  it("a live tour overrides hide_device_builder so its anchors exist", async () => {
+    setTourPending();
+    const page = await mountDashboard({ remote: true, hideBuilder: true });
+    setTourActive(true);
+    await page.updateComplete;
+    expect(builderHeaderIn(page)).not.toBeNull();
+    expect(panelIn(page)!.collapsed).toBe(true);
+    setTourActive(false);
+    await page.updateComplete;
+    expect(builderHeaderIn(page)).toBeNull();
+    expect(panelIn(page)!.collapsed).toBe(false);
   });
 
   it("a paused tour releases the forced builder section", async () => {

--- a/test/pages/dashboard-remote-panel.test.ts
+++ b/test/pages/dashboard-remote-panel.test.ts
@@ -163,7 +163,7 @@ describe("dashboard remote-compute stacks", () => {
     expect(builderHeaderIn(page)?.getAttribute("aria-expanded")).toBe("true");
   });
 
-  it("hide_device_builder leaves only the expanded panel, banner inert", async () => {
+  it("hide_device_builder leaves only the expanded panel, no banner", async () => {
     const page = await mountDashboard({
       remote: true,
       hideBuilder: true,
@@ -176,10 +176,9 @@ describe("dashboard remote-compute stacks", () => {
     expect(builderHeaderIn(page)).toBeNull();
     expect(gridIn(page)).toBeNull();
     expect(page.shadowRoot?.querySelector("esphome-fab")).toBeNull();
-    // The banner is a heading, not an accordion header.
+    // No accordion banner at all — the panel content is the page.
     await panel.updateComplete;
-    expect(panel.shadowRoot?.querySelector("button.banner")).toBeNull();
-    expect(panel.shadowRoot?.querySelector("header.banner")).not.toBeNull();
+    expect(panel.shadowRoot?.querySelector(".banner")).toBeNull();
     expect(panel.shadowRoot?.querySelector(".stack-bar-chevron")).toBeNull();
   });
 


### PR DESCRIPTION
# What does this implement/fix?

Adds an explicit "Hide the Device builder" option to Settings → Appearance, offered only while "Remote compute dashboard" is on. With it enabled the dashboard shows just the Build server content: no accordion at all — the Build server banner row isn't rendered either, since with nothing to swap to it was a dead header — and the Device builder section, grid, FAB and select bar don't render. Turning it off restores the accordion instantly, a live guided tour temporarily overrides the hide so its anchors stay visible, and turning "Remote compute dashboard" off clears this sub-toggle in the same preferences write so a later re-enable can't surprise-hide the builder.

The default is unchanged; nothing is hidden unless the user opts in with this second toggle. The preference rides `hide_device_builder` from esphome/device-builder#2077 (merged), always present per the lockstep deployment model.

**Related issue or feature (if applicable):**

- backend preference: esphome/device-builder#2077

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
