### PR TITLE
Seed receiver settings and the jobs snapshot from initial_state

### DIFF
--- a/src/api/types/event-subscription.ts
+++ b/src/api/types/event-subscription.ts
@@ -222,6 +222,18 @@ export interface InitialStateEventData {
    *  reason as ``pairings`` / ``peers`` — absent controller,
    *  omitted field. */
   remote_jobs?: OffloaderRemoteJobSnapshotEntry[];
+  /** Receiver-side settings scalars (RAM-canonical on the backend's
+   *  ReceiverState). Gate the Build server panel's first paint —
+   *  disabled CTA vs live view — without a get_settings round-trip.
+   *  Optional: absent controller (or pre-1.1 backend), omitted
+   *  field. Live updates keep flowing through the existing
+   *  loadRemoteBuildSettings refreshes. */
+  remote_build_settings?: { enabled: boolean; cleanup_ttl_seconds: number };
+  /** Full firmware-jobs snapshot (active + retained history, the same
+   *  rows follow_jobs would replay) so the build queue paints in one
+   *  shot. Optional for the same reasons as above; follow_jobs stays
+   *  the live-update stream. */
+  firmware_jobs?: FirmwareJob[];
   /** Offloader-side master "Remote builds enabled" toggle (7b).
    *  When `false`, the backend's ``pick_build_path`` short-
    *  circuits every install to LOCAL; paired peer-link

--- a/src/api/types/event-subscription.ts
+++ b/src/api/types/event-subscription.ts
@@ -11,7 +11,12 @@ import {
 } from "./devices.js";
 import { JobStatus, type FirmwareJob } from "./firmware-jobs.js";
 import type { OffloaderAlertSnapshotEntry } from "./remote-build-events.js";
-import type { PairingSummary, PeerSummary, RemoteBuildPeer } from "./remote-build.js";
+import type {
+  PairingSummary,
+  PeerSummary,
+  RemoteBuildPeer,
+  RemoteBuildSettings,
+} from "./remote-build.js";
 import type { UserPreferences } from "./system.js";
 
 // ─── Event Subscription ─────────────────────────────────────
@@ -227,7 +232,7 @@ export interface InitialStateEventData {
    *  updates keep flowing through the loadRemoteBuildSettings
    *  refreshes. Optional for the same reason as `peers` — absent
    *  controller, omitted field. */
-  remote_build_settings?: { enabled: boolean; cleanup_ttl_seconds: number };
+  remote_build_settings?: Pick<RemoteBuildSettings, "enabled" | "cleanup_ttl_seconds">;
   /** Firmware-jobs snapshot: the same rows follow_jobs would replay
    *  (created_at order, output omitted), seeding the queue in one
    *  shot. Optional for the same reason as above; follow_jobs stays

--- a/src/api/types/event-subscription.ts
+++ b/src/api/types/event-subscription.ts
@@ -223,15 +223,14 @@ export interface InitialStateEventData {
    *  omitted field. */
   remote_jobs?: OffloaderRemoteJobSnapshotEntry[];
   /** Receiver-side settings scalars (RAM-canonical on the backend's
-   *  ReceiverState). Gate the Build server panel's first paint —
-   *  disabled CTA vs live view — without a get_settings round-trip.
-   *  Optional: absent controller (or pre-1.1 backend), omitted
-   *  field. Live updates keep flowing through the existing
-   *  loadRemoteBuildSettings refreshes. */
+   *  ReceiverState). Seed the Build server panel's first paint;
+   *  updates keep flowing through the loadRemoteBuildSettings
+   *  refreshes. Optional for the same reason as `peers` — absent
+   *  controller, omitted field. */
   remote_build_settings?: { enabled: boolean; cleanup_ttl_seconds: number };
-  /** Full firmware-jobs snapshot (active + retained history, the same
-   *  rows follow_jobs would replay) so the build queue paints in one
-   *  shot. Optional for the same reasons as above; follow_jobs stays
+  /** Firmware-jobs snapshot: the same rows follow_jobs would replay
+   *  (created_at order, output omitted), seeding the queue in one
+   *  shot. Optional for the same reason as above; follow_jobs stays
    *  the live-update stream. */
   firmware_jobs?: FirmwareJob[];
   /** Offloader-side master "Remote builds enabled" toggle (7b).

--- a/src/api/types/remote-build.ts
+++ b/src/api/types/remote-build.ts
@@ -317,7 +317,7 @@ export interface IdentityView {
   /**
    * mDNS-advertised pairing address: host is 'null' and addresses
    * '[]' without a registered advertiser, port is 'null' while the
-   * listener is down. All absent from pre-1.1 backends.
+   * listener is down.
    */
   listener_host?: string | null;
   listener_addresses?: string[];

--- a/src/components/app-shell/events.ts
+++ b/src/components/app-shell/events.ts
@@ -38,6 +38,7 @@ import {
 import { seededMap } from "../../util/snapshot.js";
 import type { ESPHomeApp } from "../app-shell.js";
 import { applyPreferences } from "./data-load.js";
+import { seedJobs } from "./jobs.js";
 
 // Merge a partial diff into the matching offloader pairing row keyed by pin_sha256.
 // _buildOffloadPairings === null = snapshot not seeded; missing row = event raced
@@ -67,6 +68,8 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
         pairings,
         offloader_alerts,
         remote_jobs,
+        remote_build_settings,
+        firmware_jobs,
         remote_builds_enabled,
         version_match_policy,
         include_local_in_pool,
@@ -111,6 +114,14 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
         }
         host._buildOffloadJobs = seeded;
       }
+      // Receiver settings scalars: same skip-while-write guard the
+      // loadRemoteBuildSettings refresh uses, so a reconnect snapshot
+      // can't revert an optimistic toggle mid-write.
+      if (remote_build_settings !== undefined && !host._remoteBuildSetInFlight) {
+        host._remoteBuildEnabled = remote_build_settings.enabled;
+        host._remoteBuildCleanupTtl = remote_build_settings.cleanup_ttl_seconds;
+      }
+      if (firmware_jobs !== undefined) seedJobs(host, firmware_jobs);
       // Skip re-applying offloader settings while a toggle write is in flight,
       // so a reconnect's snapshot can't revert the optimistic value mid-write.
       if (host._offloaderWritesInFlight === 0) {

--- a/src/components/app-shell/jobs.ts
+++ b/src/components/app-shell/jobs.ts
@@ -49,13 +49,16 @@ export function subscribeToFollowJobs(host: ESPHomeApp): void {
  * One-shot seed from the initial_state snapshot: a single map build
  * (one render) instead of one per follow_jobs replay frame. Terminal
  * jobs land in history only, and no recent-flash timers fire on a
- * page-load snapshot.
+ * page-load snapshot. Anything already tracked wins over the snapshot
+ * row — a follow_jobs frame that raced ahead of the initial_state
+ * push is newer than the frozen snapshot.
  */
 export function seedJobs(host: ESPHomeApp, jobs: FirmwareJob[]): void {
   const all = new Map<string, FirmwareJob>();
+  for (const job of jobs) all.set(job.job_id, job);
+  for (const [id, job] of host._firmwareJobs) all.set(id, job);
   const active = new Map<string, FirmwareJob>();
-  for (const job of jobs) {
-    all.set(job.job_id, job);
+  for (const job of all.values()) {
     if (isTerminalJobStatus(job.status)) continue;
     active.set(job.configuration, job);
     // Mirror under the new key so the soon-to-be-renamed card finds the job.

--- a/src/components/app-shell/jobs.ts
+++ b/src/components/app-shell/jobs.ts
@@ -45,6 +45,26 @@ export function subscribeToFollowJobs(host: ESPHomeApp): void {
   }
 }
 
+/**
+ * One-shot seed from the initial_state snapshot: a single map build
+ * (one render) instead of one per follow_jobs replay frame. Terminal
+ * jobs land in history only, and no recent-flash timers fire on a
+ * page-load snapshot.
+ */
+export function seedJobs(host: ESPHomeApp, jobs: FirmwareJob[]): void {
+  const all = new Map<string, FirmwareJob>();
+  const active = new Map<string, FirmwareJob>();
+  for (const job of jobs) {
+    all.set(job.job_id, job);
+    if (isTerminalJobStatus(job.status)) continue;
+    active.set(job.configuration, job);
+    // Mirror under the new key so the soon-to-be-renamed card finds the job.
+    for (const key of renameKeys(job)) active.set(key, job);
+  }
+  host._firmwareJobs = all;
+  host._activeJobs = active;
+}
+
 export function handleJobEvent(host: ESPHomeApp, event: string, data: unknown): void {
   switch (event) {
     case "snapshot":

--- a/test/components/app-shell/events-initial-state-panel.test.ts
+++ b/test/components/app-shell/events-initial-state-panel.test.ts
@@ -14,7 +14,11 @@ import { makeFirmwareJob } from "../../_make-firmware-job.js";
 
 type Host = { [key: string]: unknown } & Pick<
   ESPHomeApp,
-  "_remoteBuildEnabled" | "_remoteBuildCleanupTtl" | "_firmwareJobs" | "_activeJobs"
+  | "_remoteBuildEnabled"
+  | "_remoteBuildCleanupTtl"
+  | "_remoteBuildSetInFlight"
+  | "_firmwareJobs"
+  | "_activeJobs"
 >;
 
 function makeHost(): Host {
@@ -62,18 +66,41 @@ describe("handleEvent INITIAL_STATE panel seeds", () => {
   it("keeps the optimistic value while a settings write is in flight", () => {
     const host = makeHost();
     host._remoteBuildEnabled = true;
-    (host as Record<string, unknown>)._remoteBuildSetInFlight = true;
+    host._remoteBuildSetInFlight = true;
     dispatch(host, {
       remote_build_settings: { enabled: false, cleanup_ttl_seconds: 3600 },
     });
     expect(host._remoteBuildEnabled).toBe(true);
   });
 
-  it("leaves the defaults alone when the field is absent (old backend)", () => {
+  it("leaves the defaults alone when the receiver controller is absent", () => {
     const host = makeHost();
     dispatch(host, {});
     expect(host._remoteBuildEnabled).toBe(false);
     expect(host._remoteBuildCleanupTtl).toBeNull();
+  });
+
+  it("keeps a job a follow_jobs frame delivered ahead of the snapshot", () => {
+    const host = makeHost();
+    const raced = makeFirmwareJob({
+      job_id: "j-new",
+      configuration: "c.yaml",
+      job_type: JobType.COMPILE,
+      status: JobStatus.QUEUED,
+    });
+    host._firmwareJobs = new Map([[raced.job_id, raced]]);
+    host._activeJobs = new Map([[raced.configuration, raced]]);
+    const snapshotOnly = makeFirmwareJob({
+      job_id: "j-old",
+      configuration: "d.yaml",
+      job_type: JobType.COMPILE,
+      status: JobStatus.COMPLETED,
+    });
+    dispatch(host, { firmware_jobs: [snapshotOnly] });
+    // The frozen snapshot predates the raced frame; both survive.
+    expect(host._firmwareJobs.get("j-new")?.status).toBe(JobStatus.QUEUED);
+    expect(host._firmwareJobs.has("j-old")).toBe(true);
+    expect(host._activeJobs.get("c.yaml")?.job_id).toBe("j-new");
   });
 
   it("seeds the jobs snapshot in one shot, terminal jobs history-only", () => {

--- a/test/components/app-shell/events-initial-state-panel.test.ts
+++ b/test/components/app-shell/events-initial-state-panel.test.ts
@@ -1,12 +1,13 @@
-// Pins the initial_state seeds the Build server panel paints from:
-// receiver settings scalars (no disabled-CTA flash) and the one-shot
-// firmware-jobs snapshot (no per-frame queue accretion).
+// Pins what initial_state seeds for the Build server panel's first
+// paint: the receiver settings scalars (no disabled-CTA flash) and the
+// one-shot firmware-jobs snapshot (no per-frame queue buildup).
 
 import { describe, expect, it } from "vitest";
 import {
   DeviceEventType,
   type InitialStateEventData,
 } from "../../../src/api/types/event-subscription.js";
+import { CLEANUP_TTL_DEFAULT_SECONDS } from "../../../src/api/types/remote-build.js";
 import { JobStatus, JobType } from "../../../src/api/types/firmware-jobs.js";
 import type { ESPHomeApp } from "../../../src/components/app-shell.js";
 import { handleEvent } from "../../../src/components/app-shell/events.js";
@@ -24,7 +25,7 @@ type Host = { [key: string]: unknown } & Pick<
 function makeHost(): Host {
   return {
     _remoteBuildEnabled: false,
-    _remoteBuildCleanupTtl: null,
+    _remoteBuildCleanupTtl: CLEANUP_TTL_DEFAULT_SECONDS,
     _remoteBuildSetInFlight: false,
     _firmwareJobs: new Map(),
     _activeJobs: new Map(),
@@ -77,7 +78,7 @@ describe("handleEvent INITIAL_STATE panel seeds", () => {
     const host = makeHost();
     dispatch(host, {});
     expect(host._remoteBuildEnabled).toBe(false);
-    expect(host._remoteBuildCleanupTtl).toBeNull();
+    expect(host._remoteBuildCleanupTtl).toBe(CLEANUP_TTL_DEFAULT_SECONDS);
   });
 
   it("keeps a job a follow_jobs frame delivered ahead of the snapshot", () => {

--- a/test/components/app-shell/events-initial-state-panel.test.ts
+++ b/test/components/app-shell/events-initial-state-panel.test.ts
@@ -104,6 +104,20 @@ describe("handleEvent INITIAL_STATE panel seeds", () => {
     expect(host._activeJobs.get("c.yaml")?.job_id).toBe("j-new");
   });
 
+  it("mirrors a live RENAME job under its soon-to-be-renamed key", () => {
+    const host = makeHost();
+    const rename = makeFirmwareJob({
+      job_id: "j-ren",
+      configuration: "old.yaml",
+      job_type: JobType.RENAME,
+      status: JobStatus.RUNNING,
+      new_name: "brand-new",
+    });
+    dispatch(host, { firmware_jobs: [rename] });
+    expect(host._activeJobs.get("old.yaml")?.job_id).toBe("j-ren");
+    expect(host._activeJobs.get("brand-new.yaml")?.job_id).toBe("j-ren");
+  });
+
   it("seeds the jobs snapshot in one shot, terminal jobs history-only", () => {
     const host = makeHost();
     const running = makeFirmwareJob({

--- a/test/components/app-shell/events-initial-state-panel.test.ts
+++ b/test/components/app-shell/events-initial-state-panel.test.ts
@@ -1,0 +1,98 @@
+// Pins the initial_state seeds the Build server panel paints from:
+// receiver settings scalars (no disabled-CTA flash) and the one-shot
+// firmware-jobs snapshot (no per-frame queue accretion).
+
+import { describe, expect, it } from "vitest";
+import {
+  DeviceEventType,
+  type InitialStateEventData,
+} from "../../../src/api/types/event-subscription.js";
+import { JobStatus, JobType } from "../../../src/api/types/firmware-jobs.js";
+import type { ESPHomeApp } from "../../../src/components/app-shell.js";
+import { handleEvent } from "../../../src/components/app-shell/events.js";
+import { makeFirmwareJob } from "../../_make-firmware-job.js";
+
+type Host = { [key: string]: unknown } & Pick<
+  ESPHomeApp,
+  "_remoteBuildEnabled" | "_remoteBuildCleanupTtl" | "_firmwareJobs" | "_activeJobs"
+>;
+
+function makeHost(): Host {
+  return {
+    _remoteBuildEnabled: false,
+    _remoteBuildCleanupTtl: null,
+    _remoteBuildSetInFlight: false,
+    _firmwareJobs: new Map(),
+    _activeJobs: new Map(),
+    // Fields the INITIAL_STATE handler writes unconditionally.
+    _prefsLoaded: false,
+    _prefsWritesInFlight: 0,
+    _devices: [],
+    _importableDevices: [],
+    _devicesLoaded: false,
+    _buildServerPeers: null,
+    _buildOffloadDiscoveredHosts: null,
+    _buildOffloadPairings: null,
+    _offloaderWritesInFlight: 0,
+    _buildOffloadAlerts: null,
+    _offloaderRemoteBuildsEnabled: null,
+    _offloaderVersionMatchPolicy: null,
+    _offloaderIncludeLocalInPool: null,
+  } as unknown as Host;
+}
+
+function dispatch(host: Host, data: Partial<InitialStateEventData>): void {
+  handleEvent(host as unknown as ESPHomeApp, DeviceEventType.INITIAL_STATE, {
+    devices: [],
+    importable: [],
+    ...data,
+  } as InitialStateEventData);
+}
+
+describe("handleEvent INITIAL_STATE panel seeds", () => {
+  it("seeds the receiver settings scalars", () => {
+    const host = makeHost();
+    dispatch(host, {
+      remote_build_settings: { enabled: true, cleanup_ttl_seconds: 7200 },
+    });
+    expect(host._remoteBuildEnabled).toBe(true);
+    expect(host._remoteBuildCleanupTtl).toBe(7200);
+  });
+
+  it("keeps the optimistic value while a settings write is in flight", () => {
+    const host = makeHost();
+    host._remoteBuildEnabled = true;
+    (host as Record<string, unknown>)._remoteBuildSetInFlight = true;
+    dispatch(host, {
+      remote_build_settings: { enabled: false, cleanup_ttl_seconds: 3600 },
+    });
+    expect(host._remoteBuildEnabled).toBe(true);
+  });
+
+  it("leaves the defaults alone when the field is absent (old backend)", () => {
+    const host = makeHost();
+    dispatch(host, {});
+    expect(host._remoteBuildEnabled).toBe(false);
+    expect(host._remoteBuildCleanupTtl).toBeNull();
+  });
+
+  it("seeds the jobs snapshot in one shot, terminal jobs history-only", () => {
+    const host = makeHost();
+    const running = makeFirmwareJob({
+      job_id: "j-run",
+      configuration: "a.yaml",
+      job_type: JobType.COMPILE,
+      status: JobStatus.RUNNING,
+    });
+    const done = makeFirmwareJob({
+      job_id: "j-done",
+      configuration: "b.yaml",
+      job_type: JobType.COMPILE,
+      status: JobStatus.COMPLETED,
+    });
+    dispatch(host, { firmware_jobs: [running, done] });
+    expect([...host._firmwareJobs.keys()].sort()).toEqual(["j-done", "j-run"]);
+    expect(host._activeJobs.get("a.yaml")?.job_id).toBe("j-run");
+    expect(host._activeJobs.has("b.yaml")).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Loading a build-server install briefly flashed "Remote builds are disabled" and then built the queue history up row by row. Both came from post-connect round-trips: the receiver settings arrived via a separate `remote_build/get_settings` call, and the queue accreted from per-job `follow_jobs` replay frames (one map copy and render each).

The `initial_state` snapshot now carries both (companion backend PR), and the frontend seeds them in one shot: the receiver scalars apply behind the same skip-while-write guard the settings refresh uses, and a new `seedJobs` builds the jobs and active maps in a single render, terminal jobs history-only, no recent-flash timers on page load. `follow_jobs` stays the live-update stream; the fields are optional only because the corresponding controller can be down, matching the other snapshot keys.

**Related issue or feature (if applicable):**

- companion backend PR: esphome/device-builder#2078

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
