### PR TITLE
Scroll the no-peers walkthrough inside the Build server section

### DIFF
--- a/src/components/remote-build-panel.ts
+++ b/src/components/remote-build-panel.ts
@@ -306,7 +306,9 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
       `;
     }
     const approved = this._peers.filter((p) => p.status === "approved");
-    if (approved.length === 0) return renderOnboarding(this);
+    if (approved.length === 0) {
+      return html`<div class="onboarding">${renderOnboarding(this)}</div>`;
+    }
     return html`
       <div class="cards">${renderPeersCard(this, approved)} ${renderQueueCard(this)}</div>
     `;

--- a/src/components/remote-build-panel/styles.ts
+++ b/src/components/remote-build-panel/styles.ts
@@ -30,6 +30,18 @@ export const remoteBuildPanelStyles = css`
     margin-right: var(--content-gutter, var(--wa-space-l));
   }
 
+  /* The no-peers walkthrough can outgrow the viewport-pinned section on
+     narrow screens; it scrolls as a unit inside the panel instead of
+     overflowing into the Device builder bar below. */
+  .onboarding {
+    display: flex;
+    flex-direction: column;
+    gap: var(--stack-gap);
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
   /* Solo (Device builder hidden): no accordion banner at all; the
      panel content provides its own top inset instead. */
   :host([solo]) .panel {

--- a/test/pages/dashboard-remote-panel.test.ts
+++ b/test/pages/dashboard-remote-panel.test.ts
@@ -121,6 +121,20 @@ describe("dashboard remote-compute stacks", () => {
     expect(gridIn(page)).toBeNull();
   });
 
+  it("the no-peers walkthrough scrolls as a unit inside the panel", async () => {
+    const page = await mountDashboard({ remote: true, peers: [] });
+    const panel = panelIn(page)!;
+    // Context-provided panel fields, seeded directly for a bare mount.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (panel as any)._remoteBuildEnabled = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (panel as any)._peers = [];
+    await panel.updateComplete;
+    const scroller = panel.shadowRoot?.querySelector(".onboarding");
+    expect(scroller).not.toBeNull();
+    expect(scroller?.querySelector(".steps")).not.toBeNull();
+  });
+
   it("swapping to the builder collapses the remote stack (accordion)", async () => {
     const page = await mountDashboard({ remote: true, devices: [] });
     builderHeaderIn(page)!.click();


### PR DESCRIPTION
# What does this implement/fix?

On narrow screens the Build server section's no-peers walkthrough outgrew the viewport-pinned section and overflowed into the Device builder bar below it (step 3 rendered underneath the bar). The walkthrough now scrolls as a unit inside the panel — same containment the paired view's peer and queue lists already have — so nothing escapes the section at any width. Verified live at 581px wide: the content scrolls inside the panel and the Device builder bar stays clear.

**Related issue or feature (if applicable):**

- follow-up to #1240, found while testing narrow layouts

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
