### PR TITLE
Hide the stack-bar taglines on phones

### DIFF
--- a/src/components/shared/stack-bar-styles.ts
+++ b/src/components/shared/stack-bar-styles.ts
@@ -84,10 +84,19 @@ export const stackBarStyles = css`
   }
 
   /* Quiet inline tagline after the title ("builds firmware for other
-     dashboards"); wraps under the title on narrow viewports. */
+     dashboards"). Hidden on phones — it wraps under the title there and
+     doubles each bar's height; the titles carry the meaning alone. The
+     870px cutoff matches the header's compact breakpoint the bars align
+     to (--esphome-header-logo-box). */
   .stack-bar-subtitle {
     font-size: var(--stack-bar-subtitle-size);
     color: var(--wa-color-text-quiet);
+  }
+
+  @media (max-width: 870px) {
+    .stack-bar-subtitle {
+      display: none;
+    }
   }
 
   .stack-bar-chevron {


### PR DESCRIPTION
# What does this implement/fix?

On phones the stack-bar taglines ("builds firmware for other dashboards", "create and manage your devices") wrap under their titles and double each accordion bar's height. They're hidden below 870px — the same compact breakpoint the app header the bars align to already uses — and the titles carry the meaning alone. One rule in the shared stack-bar fragment covers both bars.

**Related issue or feature (if applicable):**

- follow-up to #1240, found while testing narrow layouts

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
