### PR TITLE
Say builds use your version when the receiver auto-provisions

### DIFF
--- a/src/api/types/remote-build.ts
+++ b/src/api/types/remote-build.ts
@@ -178,6 +178,13 @@ export interface PairingSummary {
    * eligible).
    */
   enabled: boolean;
+  /**
+   * Receiver capability from the session handshake: a mismatched
+   * version is built in a venv provisioned with this offloader's
+   * own esphome, so the row shows informative copy instead of a
+   * skew warning.
+   */
+  auto_provision_supported: boolean;
 }
 
 /**

--- a/src/components/settings-dialog/build-offload-pairing-row.ts
+++ b/src/components/settings-dialog/build-offload-pairing-row.ts
@@ -4,7 +4,10 @@ import type { PairingSummary } from "../../api/types/remote-build.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import type { RemoteBuildJobState } from "../../context/index.js";
 import { trimTrailingDot } from "../../util/hostname.js";
-import { classifyVersionMismatch } from "../../util/version-mismatch.js";
+import {
+  classifyVersionMismatch,
+  isPinnableVersion,
+} from "../../util/version-mismatch.js";
 
 interface PillResult {
   pillClass: string;
@@ -179,6 +182,22 @@ function renderPeerVersion(
   // doesn't. Hidden until the first handshake fills in esphome_version.
   if (pairing.status !== "approved" || !pairing.esphome_version) return nothing;
   const kind = classifyVersionMismatch(appVersion, pairing.esphome_version);
+  // A mismatch the receiver can auto-provision isn't a caution: builds
+  // run with this dashboard's own version in a venv on the server.
+  if (
+    kind !== null &&
+    pairing.auto_provision_supported &&
+    isPinnableVersion(appVersion)
+  ) {
+    return html`
+      <span class="row-desc">
+        ${localize("settings.build_offload_pairing_version_auto_provision", {
+          peer: pairing.esphome_version,
+          local: appVersion,
+        })}
+      </span>
+    `;
+  }
   if (kind === null) {
     return html`
       <span class="row-desc">

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1388,6 +1388,7 @@
     "build_offload_pairing_last_error": "Last connection error: {detail}",
     "build_offload_pairing_enabled_aria": "Use {label} for remote builds",
     "build_offload_pairing_enabled_title": "Use this server when auto-routing installs",
+    "build_offload_pairing_version_auto_provision": "Build server runs ESPHome {peer}; your builds use {local} automatically",
     "build_offload_pairing_version_mismatch_patch": "Build server runs ESPHome {peer}; you're on {local}",
     "build_offload_pairing_version_mismatch_release": "Build server runs ESPHome {peer}; you're on {local}. YAML may not compile across this release gap.",
     "remote_build_submit_action": "Build remotely",

--- a/src/util/version-mismatch.ts
+++ b/src/util/version-mismatch.ts
@@ -28,6 +28,16 @@ export type VersionMismatchKind = "patch" | "release" | null;
  * Returns the mismatch classification for two ESPHome version
  * strings. See module docstring for the contract.
  */
+/**
+ * Whether *version* pins to a reproducible `pip install esphome==<v>` —
+ * a plain release or an a/b/rc pre-release, the shapes PyPI publishes.
+ * Twin of the backend's `is_pinnable_version`; the auto-provision copy
+ * only applies when the receiver could actually provision our version.
+ */
+export function isPinnableVersion(version: string): boolean {
+  return /^\d+(?:\.\d+)*(?:(?:a|b|rc)\d+)?$/.test(version);
+}
+
 export function classifyVersionMismatch(
   local: string,
   peer: string

--- a/src/util/version-mismatch.ts
+++ b/src/util/version-mismatch.ts
@@ -25,10 +25,6 @@ import type { PairingSummary, PeerStatus } from "../api/types/remote-build.js";
 export type VersionMismatchKind = "patch" | "release" | null;
 
 /**
- * Returns the mismatch classification for two ESPHome version
- * strings. See module docstring for the contract.
- */
-/**
  * Whether *version* pins to a reproducible `pip install esphome==<v>` —
  * a plain release or an a/b/rc pre-release, the shapes PyPI publishes.
  * Twin of the backend's `is_pinnable_version`; the auto-provision copy
@@ -38,6 +34,10 @@ export function isPinnableVersion(version: string): boolean {
   return /^\d+(?:\.\d+)*(?:(?:a|b|rc)\d+)?$/.test(version);
 }
 
+/**
+ * Returns the mismatch classification for two ESPHome version
+ * strings. See module docstring for the contract.
+ */
 export function classifyVersionMismatch(
   local: string,
   peer: string

--- a/test/components/app-shell/events-initial-state-pairings.test.ts
+++ b/test/components/app-shell/events-initial-state-pairings.test.ts
@@ -20,6 +20,7 @@ function makeSummary(pin: string, enabled: boolean): PairingSummary {
     last_connect_error: "",
     esphome_version: "",
     enabled,
+    auto_provision_supported: false,
   };
 }
 

--- a/test/components/app-shell/events-pairing-added.test.ts
+++ b/test/components/app-shell/events-pairing-added.test.ts
@@ -17,6 +17,7 @@ function makeSummary(pin: string): PairingSummary {
     last_connect_error: "",
     esphome_version: "",
     enabled: true,
+    auto_provision_supported: false,
   };
 }
 

--- a/test/components/app-shell/events-peer-link-opened.test.ts
+++ b/test/components/app-shell/events-peer-link-opened.test.ts
@@ -18,6 +18,7 @@ function makeSummary(pin: string, esphome_version: string): PairingSummary {
     last_connect_error: "boom",
     esphome_version,
     enabled: true,
+    auto_provision_supported: false,
   };
 }
 

--- a/test/components/app-shell/settings-actions.test.ts
+++ b/test/components/app-shell/settings-actions.test.ts
@@ -204,6 +204,7 @@ function makePairing(enabled: boolean): PairingSummary {
     last_connect_error: "",
     esphome_version: "",
     enabled,
+    auto_provision_supported: false,
   };
 }
 

--- a/test/components/settings-dialog/render-pairing-row.test.ts
+++ b/test/components/settings-dialog/render-pairing-row.test.ts
@@ -21,6 +21,7 @@ function makeSummary(esphome_version: string): PairingSummary {
     last_connect_error: "",
     esphome_version,
     enabled: true,
+    auto_provision_supported: false,
   };
 }
 
@@ -59,6 +60,16 @@ describe("renderPairingRow version line", () => {
   it("omits the version line before the first handshake (empty version)", () => {
     const text = renderedText(renderPairingRow(makeSummary(""), ctx()));
     expect(text).not.toContain("settings.remote_build_peer_version_line");
+  });
+
+  it("shows the auto-provision line instead of a warning when supported", () => {
+    const pairing = {
+      ...makeSummary("2026.5.0"),
+      auto_provision_supported: true,
+    };
+    const text = renderedText(renderPairingRow(pairing, ctx()));
+    expect(text).toContain("settings.build_offload_pairing_version_auto_provision");
+    expect(text).not.toContain("settings.build_offload_pairing_version_mismatch_release");
   });
 
   it("omits the version line on a mismatch (the mismatch note already states it)", () => {

--- a/test/util/bulk-update.test.ts
+++ b/test/util/bulk-update.test.ts
@@ -31,6 +31,7 @@ function pairing(overrides: Partial<PairingSummary>): PairingSummary {
     last_connect_error: "",
     esphome_version: "2026.5.0",
     enabled: true,
+    auto_provision_supported: false,
     ...overrides,
   };
 }

--- a/test/util/version-mismatch.test.ts
+++ b/test/util/version-mismatch.test.ts
@@ -3,6 +3,7 @@ import type { PairingSummary } from "../../src/api/types/remote-build.js";
 import {
   classifyNoCompatiblePeerReason,
   classifyVersionMismatch,
+  isPinnableVersion,
 } from "../../src/util/version-mismatch.js";
 
 function pairing(overrides: Partial<PairingSummary>): PairingSummary {
@@ -18,6 +19,7 @@ function pairing(overrides: Partial<PairingSummary>): PairingSummary {
     last_connect_error: "",
     esphome_version: "2026.5.0",
     enabled: true,
+    auto_provision_supported: false,
     ...overrides,
   };
 }
@@ -120,5 +122,16 @@ describe("classifyNoCompatiblePeerReason", () => {
     expect(
       classifyNoCompatiblePeerReason([pairing({ esphome_version: "2026.4.0" })], "")
     ).toBe("mixed");
+  });
+});
+
+describe("isPinnableVersion", () => {
+  it("accepts releases and a/b/rc pre-releases, rejects dev and local", () => {
+    expect(isPinnableVersion("2026.6.4")).toBe(true);
+    expect(isPinnableVersion("2026.7.0b2")).toBe(true);
+    expect(isPinnableVersion("2026.7.0rc1")).toBe(true);
+    expect(isPinnableVersion("2026.7.0-dev")).toBe(false);
+    expect(isPinnableVersion("1.0.0+local")).toBe(false);
+    expect(isPinnableVersion("")).toBe(false);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

After the first real auto-provisioned beta build, the Send-builds pairing row still warned "Build server runs ESPHome {peer}; you're on {local}" even though the receiver had just built with this dashboard's own version in a provisioned venv. When the pairing advertises `auto_provision_supported` and the local version is pinnable (release or a/b/rc pre-release, twin of the backend check), the row now says "Build server runs ESPHome {peer}; your builds use {local} automatically" instead of the caution. The warning stays for receivers that can't provision or for a dev local version.

`PairingSummary.auto_provision_supported` rides the companion backend PR; required field per the lockstep deployment model.

**Related issue or feature (if applicable):**

- companion backend PR: esphome/device-builder#2083

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
