### PR TITLE
Show the version that actually builds in the remote sub-line

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -129,10 +129,6 @@ export class ESPHomeCommandDialog extends LitElement {
   @state()
   _pairings: Map<string, PairingSummary> | null = null;
 
-  @consume({ context: versionContext, subscribe: true })
-  @state()
-  _esphomeVersion = "";
-
   @consume({ context: desktopVersionContext, subscribe: true })
   @state()
   _desktopVersion = "";

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -129,6 +129,10 @@ export class ESPHomeCommandDialog extends LitElement {
   @state()
   _pairings: Map<string, PairingSummary> | null = null;
 
+  @consume({ context: versionContext, subscribe: true })
+  @state()
+  _esphomeVersion = "";
+
   @consume({ context: desktopVersionContext, subscribe: true })
   @state()
   _desktopVersion = "";
@@ -182,6 +186,7 @@ export class ESPHomeCommandDialog extends LitElement {
     source: JobSource;
     source_label: string;
     source_esphome_version: string;
+    source_pin_sha256: string;
   } | null = null;
 
   // True while "Build locally instead" override is mid-flight.
@@ -345,6 +350,7 @@ export class ESPHomeCommandDialog extends LitElement {
       source: job.source,
       source_label: job.source_label,
       source_esphome_version: job.source_esphome_version,
+      source_pin_sha256: job.source_pin_sha256,
     };
     // Reattaching to a still-running (or finished) build: restore the true
     // compile clock so the replayed buffer doesn't restart the timer from now.

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -192,6 +192,7 @@ function primeAndFollow(host: ESPHomeCommandDialog, job: FirmwareJob): void {
     source: job.source,
     source_label: job.source_label,
     source_esphome_version: job.source_esphome_version,
+    source_pin_sha256: job.source_pin_sha256,
   };
   followJob(host, job.job_id);
 }

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -3,8 +3,8 @@ import { type FirmwareJob, JobSource, JobStatus } from "../../api/types/firmware
 import { activeLocale } from "../../common/localize.js";
 import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
-import { isPinnableVersion } from "../../util/version-mismatch.js";
 import { formatElapsed } from "../../util/format-job-time.js";
+import { isPinnableVersion } from "../../util/version-mismatch.js";
 import type { ESPHomeCommandDialog } from "../command-dialog.js";
 import {
   renderOffloadHint,
@@ -44,10 +44,10 @@ export function renderRemoteBuilderSubLine(
   const pin = liveJob?.source_pin_sha256 ?? host._primedSource?.source_pin_sha256 ?? "";
   const buildsLocalVersion =
     receiverVersion !== "" &&
-    receiverVersion !== host._esphomeVersion &&
-    isPinnableVersion(host._esphomeVersion) &&
+    receiverVersion !== host._appVersion &&
+    isPinnableVersion(host._appVersion) &&
     (host._pairings?.get(pin)?.auto_provision_supported ?? false);
-  const version = buildsLocalVersion ? host._esphomeVersion : receiverVersion;
+  const version = buildsLocalVersion ? host._appVersion : receiverVersion;
   const display = version ? `${label} (${version})` : label;
   // Only allow override for in-flight install — switching mid-upload or
   // mid-compile is a power-user shape without a UI today.

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -3,6 +3,7 @@ import { type FirmwareJob, JobSource, JobStatus } from "../../api/types/firmware
 import { activeLocale } from "../../common/localize.js";
 import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
+import { isPinnableVersion } from "../../util/version-mismatch.js";
 import { formatElapsed } from "../../util/format-job-time.js";
 import type { ESPHomeCommandDialog } from "../command-dialog.js";
 import {
@@ -35,9 +36,18 @@ export function renderRemoteBuilderSubLine(
   if (source !== JobSource.REMOTE || !label) return nothing;
   // source_esphome_version is also a job-creation-time snapshot; empty when
   // the pairing hadn't completed a peer-link session yet. Render "<label>
-  // (<version>)" so the operator can spot version skew vs the offloader.
-  const version =
+  // (<version>)" with the version that actually builds the firmware: a
+  // receiver that auto-provisions a mismatch compiles with this
+  // dashboard's own esphome in a venv, not its installed one.
+  const receiverVersion =
     liveJob?.source_esphome_version ?? host._primedSource?.source_esphome_version ?? "";
+  const pin = liveJob?.source_pin_sha256 ?? host._primedSource?.source_pin_sha256 ?? "";
+  const buildsLocalVersion =
+    receiverVersion !== "" &&
+    receiverVersion !== host._esphomeVersion &&
+    isPinnableVersion(host._esphomeVersion) &&
+    (host._pairings?.get(pin)?.auto_provision_supported ?? false);
+  const version = buildsLocalVersion ? host._esphomeVersion : receiverVersion;
   const display = version ? `${label} (${version})` : label;
   // Only allow override for in-flight install — switching mid-upload or
   // mid-compile is a power-user shape without a UI today.

--- a/test/components/command-dialog-install-chain.test.ts
+++ b/test/components/command-dialog-install-chain.test.ts
@@ -107,6 +107,7 @@ describe("command-dialog install chain follow", () => {
       source: JobSource.REMOTE,
       source_label: "builder",
       source_esphome_version: "",
+      source_pin_sha256: "",
     };
 
     host._jobId = "c1";

--- a/test/components/command-dialog-remote-sub-line.test.ts
+++ b/test/components/command-dialog-remote-sub-line.test.ts
@@ -47,7 +47,7 @@ function makeHost(opts: { auto: boolean; localVersion?: string }): ESPHomeComman
       source_pin_sha256: PIN,
     },
     _pairings: new Map([[PIN, makePairing(opts.auto)]]),
-    _esphomeVersion: opts.localVersion ?? "2026.7.0b2",
+    _appVersion: opts.localVersion ?? "2026.7.0b2",
     _commandType: "compile",
     _switchingToLocal: false,
   } as unknown as ESPHomeCommandDialog;

--- a/test/components/command-dialog-remote-sub-line.test.ts
+++ b/test/components/command-dialog-remote-sub-line.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment happy-dom
+//
+// Pins the "Building on <receiver> (<version>)" sub-line: the version
+// shown is the one that actually builds — the receiver's installed
+// esphome normally, this dashboard's own when the receiver
+// auto-provisions a mismatch.
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { JobSource } from "../../src/api/types/firmware-jobs.js";
+import type { PairingSummary } from "../../src/api/types/remote-build.js";
+import type { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
+import { renderRemoteBuilderSubLine } from "../../src/components/command-dialog/renderers.js";
+import { identityLocalize, renderInto } from "../_dom.js";
+
+const PIN = "a".repeat(64);
+
+function makePairing(auto: boolean): PairingSummary {
+  return {
+    receiver_hostname: "esphome-builder-x.local",
+    receiver_port: 6055,
+    pin_sha256: PIN,
+    label: "builder",
+    paired_at: 1,
+    status: "approved",
+    connected: true,
+    connecting: false,
+    last_connect_error: "",
+    esphome_version: "2026.6.5",
+    enabled: true,
+    auto_provision_supported: auto,
+  };
+}
+
+function makeHost(opts: { auto: boolean; localVersion?: string }): ESPHomeCommandDialog {
+  return {
+    _localize: (key: string, values?: Record<string, unknown>) =>
+      values ? `${key}:${JSON.stringify(values)}` : key,
+    _jobId: "j1",
+    _jobs: new Map(),
+    _primedSource: {
+      source: JobSource.REMOTE,
+      source_label: "builder",
+      source_esphome_version: "2026.6.5",
+      source_pin_sha256: PIN,
+    },
+    _pairings: new Map([[PIN, makePairing(opts.auto)]]),
+    _esphomeVersion: opts.localVersion ?? "2026.7.0b2",
+    _commandType: "compile",
+    _switchingToLocal: false,
+  } as unknown as ESPHomeCommandDialog;
+}
+
+describe("renderRemoteBuilderSubLine version", () => {
+  it("shows the local version when the receiver auto-provisions the mismatch", () => {
+    const el = renderInto(renderRemoteBuilderSubLine(makeHost({ auto: true })));
+    expect(el.textContent).toContain("builder (2026.7.0b2)");
+  });
+
+  it("shows the receiver's version when it can't auto-provision", () => {
+    const el = renderInto(renderRemoteBuilderSubLine(makeHost({ auto: false })));
+    expect(el.textContent).toContain("builder (2026.6.5)");
+  });
+
+  it("shows the receiver's version for a dev local build (unprovisionable)", () => {
+    const el = renderInto(
+      renderRemoteBuilderSubLine(makeHost({ auto: true, localVersion: "2026.8.0-dev" }))
+    );
+    expect(el.textContent).toContain("builder (2026.6.5)");
+  });
+});

--- a/test/components/command-dialog-remote-sub-line.test.ts
+++ b/test/components/command-dialog-remote-sub-line.test.ts
@@ -13,7 +13,7 @@ import { JobSource } from "../../src/api/types/firmware-jobs.js";
 import type { PairingSummary } from "../../src/api/types/remote-build.js";
 import type { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
 import { renderRemoteBuilderSubLine } from "../../src/components/command-dialog/renderers.js";
-import { identityLocalize, renderInto } from "../_dom.js";
+import { renderInto } from "../_dom.js";
 
 const PIN = "a".repeat(64);
 


### PR DESCRIPTION
# What does this implement/fix?

The install dialog's "Building on (receiver) ((version))" sub-line showed the receiver's installed esphome (2026.6.5 in the field report) while the build actually ran this dashboard's own version in an auto-provisioned venv (2026.7.0b2). The sub-line now shows the version that actually compiles the firmware: when the job's pairing advertises `auto_provision_supported`, the receiver's version differs, and the local version is pinnable, it shows the local version; otherwise the receiver's installed one (including for dev local builds, which can't be provisioned). Works for both the live job and the primed snapshot before the first jobs-context update; no wire change, the job already carries `source_pin_sha256`.

Stacked on #1248 (uses its `auto_provision_supported` field and `isPinnableVersion` helper); retargets to main when that merges.

**Related issue or feature (if applicable):**

- follow-up to #1248, companion backend: esphome/device-builder#2083

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
