### PR TITLE
Add a crash report button to the log viewer

### DIFF
--- a/src/api/types/protocol.ts
+++ b/src/api/types/protocol.ts
@@ -51,6 +51,10 @@ export interface ServerInfoMessage {
    * ESPHOME_DESKTOP_BIN; gates the "Check for updates" menu item. Older
    * desktop apps set desktop_version but not this. */
   desktop_update_capable?: boolean;
+  /** True when the backend runs inside a container (/.dockerenv probe).
+   * With ha_addon and desktop_version, distinguishes the bug-report
+   * form's installation kinds (add-on / Docker / pip). */
+  in_docker?: boolean;
 }
 
 export type ServerMessage = ResultMessage | ErrorMessage | EventMessage;

--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -163,6 +163,12 @@ export class ESPHomeCrashReportDialog extends LitElement {
         margin: 0 0 var(--wa-space-s);
       }
 
+      .describe-required {
+        font-size: var(--wa-font-size-s);
+        color: var(--wa-color-warning-fill-loud, orange);
+        margin: 0 0 var(--wa-space-s);
+      }
+
       .describe-label {
         display: block;
         font-size: var(--wa-font-size-s);
@@ -404,6 +410,13 @@ export class ESPHomeCrashReportDialog extends LitElement {
         )}
       </ul>
       <p class="hint">${this._localize("crash_report.hint")}</p>
+      ${
+        described
+          ? nothing
+          : html`<p class="describe-required" role="status">
+              ${this._localize("crash_report.describe_required")}
+            </p>`
+      }
       <div class="actions">
         <button class="btn btn--cancel" @click=${() => (this._dialog.open = false)}>
           ${this._localize("layout.cancel")}
@@ -411,10 +424,10 @@ export class ESPHomeCrashReportDialog extends LitElement {
         <button
           class="btn btn--confirm"
           ?disabled=${!described}
-          title=${described ? nothing : this._localize("crash_report.describe_required")}
           @click=${this._openIssue}
         >
-          ${this._localize("crash_report.open_issue")}
+          <wa-icon library="mdi" name="download"></wa-icon>
+          ${this._localize("crash_report.download_and_open")}
         </button>
       </div>
     `;

--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -197,6 +197,8 @@ export class ESPHomeCrashReportDialog extends LitElement {
         margin: 0 0 var(--wa-space-m);
       }
 
+      /* Primary-CTA colour only; shape and the disabled state come from
+         modalDialogStyles' shared .btn / .btn:disabled. */
       .btn--confirm {
         background: var(--esphome-primary);
         color: var(--esphome-on-primary);
@@ -204,11 +206,6 @@ export class ESPHomeCrashReportDialog extends LitElement {
 
       .btn--confirm:hover:not(:disabled) {
         background: var(--esphome-primary-hover);
-      }
-
-      .btn--confirm:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
       }
     `,
   ];

--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -1,6 +1,6 @@
 import { consume } from "@lit/context";
 import { mdiAlertCircleOutline, mdiClipboardTextOutline, mdiDownload } from "@mdi/js";
-import { LitElement, css, html, nothing } from "lit";
+import { LitElement, css, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { ConfiguredDevice } from "../api/types/devices.js";
@@ -15,13 +15,13 @@ import {
 } from "../context/index.js";
 import { modalDialogStyles } from "../styles/modal-dialog.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { stripAnsi } from "../util/ansi-escapes.js";
 import { copyToClipboard } from "../util/copy-to-clipboard.js";
 import {
   type CrashReport,
   type CrashScrape,
   buildFullReport,
   buildIssueUrl,
+  distillValidatedConfig,
   scrapeCrashData,
 } from "../util/crash-report.js";
 import { DialogOpenController } from "../util/dialog-open-controller.js";
@@ -37,12 +37,6 @@ registerMdiIcons({
   "clipboard-text-outline": mdiClipboardTextOutline,
   download: mdiDownload,
 });
-
-// esphome CLI log noise interleaved with the YAML dump on the merged
-// validate stream.
-const CLI_LOG_LINE_RE = /^(INFO|WARNING|ERROR|DEBUG|CRITICAL|VERBOSE)\b/;
-
-type Phase = "collecting" | "ready" | "copy-failed";
 
 /**
  * "Report this crash" flow: scrape the log buffer handed over by the
@@ -78,22 +72,22 @@ export class ESPHomeCrashReportDialog extends LitElement {
   private readonly _dialog = new DialogOpenController(this);
 
   @state()
-  private _phase: Phase = "collecting";
+  private _scrape: CrashScrape = scrapeCrashData([]);
+
+  // null = validate still in flight (collecting phase); "" = config
+  // unavailable (validation failed or empty); else the sanitized YAML.
+  @state()
+  private _configYaml: string | null = null;
 
   @state()
-  private _scrape: CrashScrape | null = null;
-
-  @state()
-  private _configYaml = "";
-
-  @state()
-  private _configFailed = false;
+  private _copyFailed = false;
 
   private _configuration = "";
   private _name = "";
-  // Bumped per open(); an in-flight validate stream from a previous
-  // open must not populate this session's config.
+  // Bumped per open(); a validate stream from a previous open must not
+  // populate this session's config.
   private _session = 0;
+  private _validateStreamId = "";
 
   static styles = [
     espHomeStyles,
@@ -160,12 +154,12 @@ export class ESPHomeCrashReportDialog extends LitElement {
 
   /** Open with a snapshot of the logs dialog's buffer. */
   public open(configuration: string, name: string, lines: string[]): void {
+    this._stopValidateStream();
     this._configuration = configuration;
     this._name = name;
     this._session += 1;
-    this._phase = "collecting";
-    this._configYaml = "";
-    this._configFailed = false;
+    this._configYaml = null;
+    this._copyFailed = false;
     this._scrape = scrapeCrashData(lines);
     this._dialog.open = true;
     this._captureConfig(this._session);
@@ -173,35 +167,32 @@ export class ESPHomeCrashReportDialog extends LitElement {
 
   private _captureConfig(session: number): void {
     const collected: string[] = [];
-    const finish = (yaml: string, failed: boolean) => {
-      if (session !== this._session || !this._dialog.open) return;
-      this._configYaml = yaml;
-      this._configFailed = failed;
-      this._phase = "ready";
+    const finish = (yaml: string) => {
+      if (session !== this._session) return;
+      this._validateStreamId = "";
+      if (this._dialog.open) this._configYaml = yaml;
     };
-    this._api.validate(this._configuration, {
+    this._validateStreamId = this._api.validate(this._configuration, {
       onOutput: (line) => collected.push(line),
-      onResult: (result) => {
-        if (!result.success) {
-          finish("", true);
-          return;
-        }
-        const yaml = collected
-          .map((line) => stripAnsi(line).replace(/[\r\n]+$/, ""))
-          .filter((line) => !CLI_LOG_LINE_RE.test(line))
-          .join("\n")
-          .trim();
-        finish(yaml, yaml === "");
-      },
-      onError: () => finish("", true),
+      onResult: (result) =>
+        finish(result.success ? distillValidatedConfig(collected) : ""),
+      onError: () => finish(""),
     });
+  }
+
+  // Kill an in-flight validate so an abandoned session doesn't leave the
+  // backend's esphome config subprocess running to completion.
+  private _stopValidateStream(): void {
+    if (!this._validateStreamId) return;
+    void this._api.stopStream(this._validateStreamId).catch(() => undefined);
+    this._validateStreamId = "";
   }
 
   private _buildReport(): CrashReport {
     const device = this._devices.find((d) => d.configuration === this._configuration);
     return {
-      scrape: this._scrape ?? scrapeCrashData([]),
-      configYaml: this._configYaml,
+      scrape: this._scrape,
+      configYaml: this._configYaml ?? "",
       meta: {
         deviceName: this._name,
         configuration: this._configuration,
@@ -217,20 +208,22 @@ export class ESPHomeCrashReportDialog extends LitElement {
 
   private async _copyAndOpen(): Promise<void> {
     const report = this._buildReport();
-    const copied = await copyToClipboard(buildFullReport(report));
-    if (!copied) {
-      this._phase = "copy-failed";
+    if (!(await copyToClipboard(buildFullReport(report)))) {
+      this._copyFailed = true;
       return;
     }
-    window.open(buildIssueUrl(report, "clipboard"), "_blank", "noopener");
-    this._dialog.open = false;
+    this._openIssue(report, "clipboard");
   }
 
   private _downloadAndOpen(): void {
     const report = this._buildReport();
     const stem = configurationStem(this._configuration, "device");
     downloadBlob(buildFullReport(report), `${stem}-crash-report.md`, "text/markdown");
-    window.open(buildIssueUrl(report, "download"), "_blank", "noopener");
+    this._openIssue(report, "download");
+  }
+
+  private _openIssue(report: CrashReport, delivery: "clipboard" | "download"): void {
+    window.open(buildIssueUrl(report, delivery), "_blank", "noopener");
     this._dialog.open = false;
   }
 
@@ -246,26 +239,20 @@ export class ESPHomeCrashReportDialog extends LitElement {
 
   private _renderReady() {
     const scrape = this._scrape;
-    if (!scrape) return nothing;
     const decoded = scrape.decodedFrames.length > 0;
-    const copyFailed = this._phase === "copy-failed";
+    const configFailed = this._configYaml === "";
     return html`
       <ul class="summary">
-        ${
-          scrape.crashFound
-            ? this._renderSummaryRow(
-                this._localize(
-                  decoded
-                    ? "crash_report.includes_backtrace_decoded"
-                    : "crash_report.includes_backtrace_raw"
-                ),
-                !decoded
-              )
-            : this._renderSummaryRow(
-                this._localize("crash_report.crash_scrolled_out"),
-                true
-              )
-        }
+        ${this._renderSummaryRow(
+          this._localize(
+            !scrape.crashFound
+              ? "crash_report.crash_scrolled_out"
+              : decoded
+                ? "crash_report.includes_backtrace_decoded"
+                : "crash_report.includes_backtrace_raw"
+          ),
+          !scrape.crashFound || !decoded
+        )}
         ${this._renderSummaryRow(
           this._localize("crash_report.includes_log_lines", {
             warnings: String(scrape.warnings.length),
@@ -273,27 +260,26 @@ export class ESPHomeCrashReportDialog extends LitElement {
           }),
           false
         )}
-        ${
-          this._configFailed
-            ? this._renderSummaryRow(
-                this._localize("crash_report.config_unavailable"),
-                true
-              )
-            : this._renderSummaryRow(
-                this._localize("crash_report.includes_config"),
-                false
-              )
-        }
+        ${this._renderSummaryRow(
+          this._localize(
+            configFailed
+              ? "crash_report.config_unavailable"
+              : "crash_report.includes_config"
+          ),
+          configFailed
+        )}
       </ul>
       <p class="hint">
-        ${this._localize(copyFailed ? "crash_report.copy_failed_hint" : "crash_report.hint")}
+        ${this._localize(
+          this._copyFailed ? "crash_report.copy_failed_hint" : "crash_report.hint"
+        )}
       </p>
       <div class="actions">
         <button class="btn btn--cancel" @click=${() => (this._dialog.open = false)}>
           ${this._localize("layout.cancel")}
         </button>
         ${
-          copyFailed
+          this._copyFailed
             ? html`<button class="btn btn--confirm" @click=${this._downloadAndOpen}>
                 <wa-icon library="mdi" name="download"></wa-icon>
                 ${this._localize("crash_report.download_and_open")}
@@ -306,16 +292,21 @@ export class ESPHomeCrashReportDialog extends LitElement {
     `;
   }
 
+  private _onAfterHide = (): void => {
+    this._dialog.open = false;
+    this._stopValidateStream();
+  };
+
   protected render() {
     return html`
       <esphome-base-dialog
         ?open=${this._dialog.open}
         .label=${this._localize("crash_report.title", { name: this._name })}
         @request-close=${this._dialog.onRequestClose}
-        @after-hide=${() => (this._dialog.open = false)}
+        @after-hide=${this._onAfterHide}
       >
         ${
-          this._phase === "collecting"
+          this._configYaml === null
             ? html`<div class="collecting">
                 <wa-spinner></wa-spinner>
                 <span>${this._localize("crash_report.collecting")}</span>

--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -39,6 +39,9 @@ registerMdiIcons({
   download: mdiDownload,
 });
 
+// The backend caps `esphome config` at 60s; the margin covers WS latency.
+const VALIDATE_TIMEOUT_MS = 90_000;
+
 /**
  * "Report this crash" flow: scrape the log buffer handed over by the
  * logs dialog, capture the sanitized config via `devices/validate`,
@@ -178,11 +181,20 @@ export class ESPHomeCrashReportDialog extends LitElement {
 
   private _captureConfig(session: number): void {
     const collected: string[] = [];
+    let timer = 0;
     const finish = (yaml: string) => {
+      clearTimeout(timer);
       if (session !== this._session) return;
       this._validateStreamId = "";
       if (this._dialog.open) this._configYaml = yaml;
     };
+    // A stream dropped without a result must not stick the spinner
+    // forever; degrade to the config-unavailable note instead.
+    timer = window.setTimeout(() => {
+      if (session !== this._session) return;
+      this._stopValidateStream();
+      finish("");
+    }, VALIDATE_TIMEOUT_MS);
     this._validateStreamId = this._api.validate(this._configuration, {
       onOutput: (line) => collected.push(line),
       onResult: (result) =>

--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -16,6 +16,7 @@ import {
 import { modalDialogStyles } from "../styles/modal-dialog.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { copyToClipboard } from "../util/copy-to-clipboard.js";
+import { notifyError, notifySuccess } from "../util/notify.js";
 import {
   type CrashReport,
   type CrashScrape,
@@ -82,8 +83,16 @@ export class ESPHomeCrashReportDialog extends LitElement {
   @state()
   private _copyFailed = false;
 
+  // Set once the report was delivered (copied/downloaded) and the issue
+  // opened; the dialog then stays up offering copy-again / download, so a
+  // clipboard overwritten before the paste isn't a dead end.
+  @state()
+  private _delivered = false;
+
   private _configuration = "";
   private _name = "";
+  // The rendered report backing the delivered-state re-copy / download.
+  private _reportText = "";
   // Bumped per open(); a validate stream from a previous open must not
   // populate this session's config.
   private _session = 0;
@@ -160,6 +169,8 @@ export class ESPHomeCrashReportDialog extends LitElement {
     this._session += 1;
     this._configYaml = null;
     this._copyFailed = false;
+    this._delivered = false;
+    this._reportText = "";
     this._scrape = scrapeCrashData(lines);
     this._dialog.open = true;
     this._captureConfig(this._session);
@@ -208,7 +219,8 @@ export class ESPHomeCrashReportDialog extends LitElement {
 
   private async _copyAndOpen(): Promise<void> {
     const report = this._buildReport();
-    if (!(await copyToClipboard(buildFullReport(report)))) {
+    this._reportText = buildFullReport(report);
+    if (!(await copyToClipboard(this._reportText))) {
       this._copyFailed = true;
       return;
     }
@@ -217,14 +229,30 @@ export class ESPHomeCrashReportDialog extends LitElement {
 
   private _downloadAndOpen(): void {
     const report = this._buildReport();
-    const stem = configurationStem(this._configuration, "device");
-    downloadBlob(buildFullReport(report), `${stem}-crash-report.md`, "text/markdown");
+    this._reportText = buildFullReport(report);
+    this._downloadReport();
     this._openIssue(report, "download");
   }
 
+  // The dialog stays open after delivery: switching to the GitHub tab can
+  // cost the user the clipboard contents, so copy-again / download stay
+  // one click away until they close it themselves.
   private _openIssue(report: CrashReport, delivery: "clipboard" | "download"): void {
     window.open(buildIssueUrl(report, delivery), "_blank", "noopener");
-    this._dialog.open = false;
+    this._delivered = true;
+  }
+
+  private async _copyAgain(): Promise<void> {
+    if (await copyToClipboard(this._reportText)) {
+      notifySuccess(this._localize("crash_report.copied"));
+    } else {
+      notifyError(this._localize("crash_report.copy_failed"));
+    }
+  }
+
+  private _downloadReport(): void {
+    const stem = configurationStem(this._configuration, "device");
+    downloadBlob(this._reportText, `${stem}-crash-report.md`, "text/markdown");
   }
 
   private _renderSummaryRow(text: string, degraded: boolean) {
@@ -235,6 +263,24 @@ export class ESPHomeCrashReportDialog extends LitElement {
       ></wa-icon>
       <span>${text}</span>
     </li>`;
+  }
+
+  private _renderDelivered() {
+    return html`
+      <p class="hint">${this._localize("crash_report.delivered_hint")}</p>
+      <div class="actions">
+        <button class="btn btn--cancel" @click=${() => (this._dialog.open = false)}>
+          ${this._localize("layout.close")}
+        </button>
+        <button class="btn btn--cancel" @click=${this._downloadReport}>
+          <wa-icon library="mdi" name="download"></wa-icon>
+          ${this._localize("crash_report.download_report")}
+        </button>
+        <button class="btn btn--confirm" @click=${this._copyAgain}>
+          ${this._localize("crash_report.copy_again")}
+        </button>
+      </div>
+    `;
   }
 
   private _renderReady() {
@@ -311,7 +357,9 @@ export class ESPHomeCrashReportDialog extends LitElement {
                 <wa-spinner></wa-spinner>
                 <span>${this._localize("crash_report.collecting")}</span>
               </div>`
-            : this._renderReady()
+            : this._delivered
+              ? this._renderDelivered()
+              : this._renderReady()
         }
       </esphome-base-dialog>
     `;

--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -92,10 +92,17 @@ export class ESPHomeCrashReportDialog extends LitElement {
   @state()
   private _delivered = false;
 
+  // window.open returned null (popup blocker); the delivered state then
+  // leads with the manual "Open GitHub issue" link instead of claiming
+  // a tab opened.
+  @state()
+  private _popupBlocked = false;
+
   private _configuration = "";
   private _name = "";
   // The rendered report backing the delivered-state re-copy / download.
   private _reportText = "";
+  private _issueUrl = "";
   // Bumped per open(); a validate stream from a previous open must not
   // populate this session's config.
   private _session = 0;
@@ -173,7 +180,9 @@ export class ESPHomeCrashReportDialog extends LitElement {
     this._configYaml = null;
     this._copyFailed = false;
     this._delivered = false;
+    this._popupBlocked = false;
     this._reportText = "";
+    this._issueUrl = "";
     this._scrape = scrapeCrashData(lines);
     this._dialog.open = true;
     this._captureConfig(this._session);
@@ -207,7 +216,9 @@ export class ESPHomeCrashReportDialog extends LitElement {
   // backend's esphome config subprocess running to completion.
   private _stopValidateStream(): void {
     if (!this._validateStreamId) return;
-    void this._api.stopStream(this._validateStreamId).catch(() => undefined);
+    void this._api
+      .stopStream(this._validateStreamId)
+      .catch((err) => console.warn("Failed to stop the validate stream", err));
     this._validateStreamId = "";
   }
 
@@ -247,10 +258,11 @@ export class ESPHomeCrashReportDialog extends LitElement {
   }
 
   // The dialog stays open after delivery: switching to the GitHub tab can
-  // cost the user the clipboard contents, so copy-again / download stay
-  // one click away until they close it themselves.
+  // cost the user the clipboard contents, so copy-again / download / the
+  // issue link stay one click away until they close it themselves.
   private _openIssue(report: CrashReport, delivery: "clipboard" | "download"): void {
-    window.open(buildIssueUrl(report, delivery), "_blank", "noopener");
+    this._issueUrl = buildIssueUrl(report, delivery);
+    this._popupBlocked = window.open(this._issueUrl, "_blank", "noopener") === null;
     this._delivered = true;
   }
 
@@ -278,8 +290,13 @@ export class ESPHomeCrashReportDialog extends LitElement {
   }
 
   private _renderDelivered() {
+    const blocked = this._popupBlocked;
     return html`
-      <p class="hint">${this._localize("crash_report.delivered_hint")}</p>
+      <p class="hint">
+        ${this._localize(
+          blocked ? "crash_report.popup_blocked_hint" : "crash_report.delivered_hint"
+        )}
+      </p>
       <div class="actions">
         <button class="btn btn--cancel" @click=${() => (this._dialog.open = false)}>
           ${this._localize("layout.close")}
@@ -288,9 +305,20 @@ export class ESPHomeCrashReportDialog extends LitElement {
           <wa-icon library="mdi" name="download"></wa-icon>
           ${this._localize("crash_report.download_report")}
         </button>
-        <button class="btn btn--confirm" @click=${this._copyAgain}>
+        <button
+          class="btn ${blocked ? "btn--cancel" : "btn--confirm"}"
+          @click=${this._copyAgain}
+        >
           ${this._localize("crash_report.copy_again")}
         </button>
+        <a
+          class="btn ${blocked ? "btn--confirm" : "btn--cancel"}"
+          href=${this._issueUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ${this._localize("crash_report.open_issue")}
+        </a>
       </div>
     `;
   }

--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -86,6 +86,13 @@ export class ESPHomeCrashReportDialog extends LitElement {
   @state()
   private _configYaml: string | null = null;
 
+  // Why the config is unavailable, so a transport failure reads
+  // differently from a genuinely invalid config. "" once config is
+  // present; "invalid" when validation rejected; "transport" when the
+  // stream errored or stalled (a connection issue, not the user's YAML).
+  @state()
+  private _configError: "" | "invalid" | "transport" = "";
+
   // The user's own "what was the device doing" context; required before
   // the report can be sent — a crash report without it isn't actionable.
   @state()
@@ -213,6 +220,7 @@ export class ESPHomeCrashReportDialog extends LitElement {
     this._name = name;
     this._session += 1;
     this._configYaml = null;
+    this._configError = "";
     this._delivered = false;
     this._userDescription = "";
     this._reportText = "";
@@ -225,28 +233,33 @@ export class ESPHomeCrashReportDialog extends LitElement {
   private _captureConfig(session: number): void {
     const collected: string[] = [];
     let timer = 0;
-    const finish = (yaml: string) => {
+    const finish = (yaml: string, error: "" | "invalid" | "transport") => {
       clearTimeout(timer);
       if (session !== this._session) return;
       this._validateStreamId = "";
-      if (this._dialog.open) this._configYaml = yaml;
+      if (this._dialog.open) {
+        this._configYaml = yaml;
+        this._configError = error;
+      }
     };
-    // A stream dropped without a result must not stick the spinner
-    // forever; degrade to the config-unavailable note instead.
+    // A stalled stream must not stick the spinner forever; a stall is a
+    // transport issue, not the user's config.
     timer = window.setTimeout(() => {
       if (session !== this._session) return;
       this._stopValidateStream();
-      finish("");
+      finish("", "transport");
     }, VALIDATE_TIMEOUT_MS);
     this._validateStreamId = this._api.validate(this._configuration, {
       onOutput: (line) => collected.push(line),
       onResult: (result) =>
-        finish(result.success ? distillValidatedConfig(collected) : ""),
+        result.success
+          ? finish(distillValidatedConfig(collected), "")
+          : finish("", "invalid"),
       onError: (err) => {
-        // Degrades to the same config-unavailable note as an invalid
-        // config; log so a real transport failure is distinguishable.
+        // A WS/transport failure, distinct from an invalid config; log it
+        // and surface a "capture failed" note rather than "invalid".
         console.warn("Config validation stream failed", err);
-        finish("");
+        finish("", "transport");
       },
     });
   }
@@ -409,9 +422,11 @@ export class ESPHomeCrashReportDialog extends LitElement {
         )}
         ${this._renderSummaryRow(
           this._localize(
-            configFailed
-              ? "crash_report.config_unavailable"
-              : "crash_report.includes_config"
+            this._configError === "transport"
+              ? "crash_report.config_capture_failed"
+              : configFailed
+                ? "crash_report.config_unavailable"
+                : "crash_report.includes_config"
           ),
           configFailed
         )}

--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -1,0 +1,334 @@
+import { consume } from "@lit/context";
+import { mdiAlertCircleOutline, mdiClipboardTextOutline, mdiDownload } from "@mdi/js";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import type { ESPHomeAPI } from "../api/index.js";
+import type { ConfiguredDevice } from "../api/types/devices.js";
+import type { LocalizeFunc } from "../common/localize.js";
+import {
+  apiContext,
+  devicesContext,
+  isHaAddonContext,
+  localizeContext,
+  serverVersionContext,
+  versionContext,
+} from "../context/index.js";
+import { modalDialogStyles } from "../styles/modal-dialog.js";
+import { espHomeStyles } from "../styles/shared.js";
+import { stripAnsi } from "../util/ansi-escapes.js";
+import { copyToClipboard } from "../util/copy-to-clipboard.js";
+import {
+  type CrashReport,
+  type CrashScrape,
+  buildFullReport,
+  buildIssueUrl,
+  scrapeCrashData,
+} from "../util/crash-report.js";
+import { DialogOpenController } from "../util/dialog-open-controller.js";
+import { configurationStem, downloadBlob } from "../util/download-text.js";
+import { registerMdiIcons } from "../util/register-icons.js";
+
+import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
+import "./base-dialog.js";
+
+registerMdiIcons({
+  "alert-circle-outline": mdiAlertCircleOutline,
+  "clipboard-text-outline": mdiClipboardTextOutline,
+  download: mdiDownload,
+});
+
+// esphome CLI log noise interleaved with the YAML dump on the merged
+// validate stream.
+const CLI_LOG_LINE_RE = /^(INFO|WARNING|ERROR|DEBUG|CRITICAL|VERBOSE)\b/;
+
+type Phase = "collecting" | "ready" | "copy-failed";
+
+/**
+ * "Report this crash" flow: scrape the log buffer handed over by the
+ * logs dialog, capture the sanitized config via `devices/validate`,
+ * then copy the full report to the clipboard and open a pre-filled
+ * esphome/esphome issue.
+ */
+@customElement("esphome-crash-report-dialog")
+export class ESPHomeCrashReportDialog extends LitElement {
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  private _localize: LocalizeFunc = (key) => key;
+
+  @consume({ context: apiContext })
+  private _api!: ESPHomeAPI;
+
+  @consume({ context: devicesContext, subscribe: true })
+  @state()
+  private _devices: ConfiguredDevice[] = [];
+
+  @consume({ context: isHaAddonContext, subscribe: true })
+  @state()
+  private _isHaAddon = false;
+
+  @consume({ context: serverVersionContext, subscribe: true })
+  @state()
+  private _serverVersion = "";
+
+  @consume({ context: versionContext, subscribe: true })
+  @state()
+  private _esphomeVersion = "";
+
+  private readonly _dialog = new DialogOpenController(this);
+
+  @state()
+  private _phase: Phase = "collecting";
+
+  @state()
+  private _scrape: CrashScrape | null = null;
+
+  @state()
+  private _configYaml = "";
+
+  @state()
+  private _configFailed = false;
+
+  private _configuration = "";
+  private _name = "";
+  // Bumped per open(); an in-flight validate stream from a previous
+  // open must not populate this session's config.
+  private _session = 0;
+
+  static styles = [
+    espHomeStyles,
+    modalDialogStyles,
+    css`
+      esphome-base-dialog {
+        --width: 480px;
+      }
+
+      .collecting {
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-s);
+        padding: var(--wa-space-m) 0;
+        color: var(--wa-color-text-quiet);
+      }
+
+      .summary {
+        display: flex;
+        flex-direction: column;
+        gap: var(--wa-space-2xs);
+        margin: 0 0 var(--wa-space-m);
+        padding: 0;
+        list-style: none;
+        font-size: var(--wa-font-size-s);
+      }
+
+      .summary li {
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-xs);
+      }
+
+      .summary wa-icon {
+        flex-shrink: 0;
+        color: var(--esphome-primary);
+      }
+
+      .summary li.degraded {
+        color: var(--wa-color-text-quiet);
+      }
+
+      .summary li.degraded wa-icon {
+        color: var(--wa-color-warning-fill-loud, orange);
+      }
+
+      .hint {
+        font-size: var(--wa-font-size-s);
+        color: var(--wa-color-text-quiet);
+        line-height: 1.5;
+        margin: 0 0 var(--wa-space-s);
+      }
+
+      .btn--confirm {
+        background: var(--esphome-primary);
+        color: var(--esphome-on-primary);
+      }
+
+      .btn--confirm:hover {
+        background: var(--esphome-primary-hover);
+      }
+    `,
+  ];
+
+  /** Open with a snapshot of the logs dialog's buffer. */
+  public open(configuration: string, name: string, lines: string[]): void {
+    this._configuration = configuration;
+    this._name = name;
+    this._session += 1;
+    this._phase = "collecting";
+    this._configYaml = "";
+    this._configFailed = false;
+    this._scrape = scrapeCrashData(lines);
+    this._dialog.open = true;
+    this._captureConfig(this._session);
+  }
+
+  private _captureConfig(session: number): void {
+    const collected: string[] = [];
+    const finish = (yaml: string, failed: boolean) => {
+      if (session !== this._session || !this._dialog.open) return;
+      this._configYaml = yaml;
+      this._configFailed = failed;
+      this._phase = "ready";
+    };
+    this._api.validate(this._configuration, {
+      onOutput: (line) => collected.push(line),
+      onResult: (result) => {
+        if (!result.success) {
+          finish("", true);
+          return;
+        }
+        const yaml = collected
+          .map((line) => stripAnsi(line).replace(/[\r\n]+$/, ""))
+          .filter((line) => !CLI_LOG_LINE_RE.test(line))
+          .join("\n")
+          .trim();
+        finish(yaml, yaml === "");
+      },
+      onError: () => finish("", true),
+    });
+  }
+
+  private _buildReport(): CrashReport {
+    const device = this._devices.find((d) => d.configuration === this._configuration);
+    return {
+      scrape: this._scrape ?? scrapeCrashData([]),
+      configYaml: this._configYaml,
+      meta: {
+        deviceName: this._name,
+        configuration: this._configuration,
+        esphomeVersion: device?.current_version || this._esphomeVersion,
+        deployedVersion: device?.runtime_state.deployed_version ?? "",
+        dashboardVersion: this._serverVersion,
+        targetPlatform: device?.target_platform ?? "",
+        board: device?.board_id ?? "",
+        isHaAddon: this._isHaAddon,
+      },
+    };
+  }
+
+  private async _copyAndOpen(): Promise<void> {
+    const report = this._buildReport();
+    const copied = await copyToClipboard(buildFullReport(report));
+    if (!copied) {
+      this._phase = "copy-failed";
+      return;
+    }
+    window.open(buildIssueUrl(report, "clipboard"), "_blank", "noopener");
+    this._dialog.open = false;
+  }
+
+  private _downloadAndOpen(): void {
+    const report = this._buildReport();
+    const stem = configurationStem(this._configuration, "device");
+    downloadBlob(buildFullReport(report), `${stem}-crash-report.md`, "text/markdown");
+    window.open(buildIssueUrl(report, "download"), "_blank", "noopener");
+    this._dialog.open = false;
+  }
+
+  private _renderSummaryRow(text: string, degraded: boolean) {
+    return html`<li class=${degraded ? "degraded" : ""}>
+      <wa-icon
+        library="mdi"
+        name=${degraded ? "alert-circle-outline" : "clipboard-text-outline"}
+      ></wa-icon>
+      <span>${text}</span>
+    </li>`;
+  }
+
+  private _renderReady() {
+    const scrape = this._scrape;
+    if (!scrape) return nothing;
+    const decoded = scrape.decodedFrames.length > 0;
+    const copyFailed = this._phase === "copy-failed";
+    return html`
+      <ul class="summary">
+        ${
+          scrape.crashFound
+            ? this._renderSummaryRow(
+                this._localize(
+                  decoded
+                    ? "crash_report.includes_backtrace_decoded"
+                    : "crash_report.includes_backtrace_raw"
+                ),
+                !decoded
+              )
+            : this._renderSummaryRow(
+                this._localize("crash_report.crash_scrolled_out"),
+                true
+              )
+        }
+        ${this._renderSummaryRow(
+          this._localize("crash_report.includes_log_lines", {
+            warnings: String(scrape.warnings.length),
+            config: String(scrape.configLines.length),
+          }),
+          false
+        )}
+        ${
+          this._configFailed
+            ? this._renderSummaryRow(
+                this._localize("crash_report.config_unavailable"),
+                true
+              )
+            : this._renderSummaryRow(
+                this._localize("crash_report.includes_config"),
+                false
+              )
+        }
+      </ul>
+      <p class="hint">
+        ${this._localize(copyFailed ? "crash_report.copy_failed_hint" : "crash_report.hint")}
+      </p>
+      <div class="actions">
+        <button class="btn btn--cancel" @click=${() => (this._dialog.open = false)}>
+          ${this._localize("layout.cancel")}
+        </button>
+        ${
+          copyFailed
+            ? html`<button class="btn btn--confirm" @click=${this._downloadAndOpen}>
+                <wa-icon library="mdi" name="download"></wa-icon>
+                ${this._localize("crash_report.download_and_open")}
+              </button>`
+            : html`<button class="btn btn--confirm" @click=${this._copyAndOpen}>
+                ${this._localize("crash_report.copy_and_open")}
+              </button>`
+        }
+      </div>
+    `;
+  }
+
+  protected render() {
+    return html`
+      <esphome-base-dialog
+        ?open=${this._dialog.open}
+        .label=${this._localize("crash_report.title", { name: this._name })}
+        @request-close=${this._dialog.onRequestClose}
+        @after-hide=${() => (this._dialog.open = false)}
+      >
+        ${
+          this._phase === "collecting"
+            ? html`<div class="collecting">
+                <wa-spinner></wa-spinner>
+                <span>${this._localize("crash_report.collecting")}</span>
+              </div>`
+            : this._renderReady()
+        }
+      </esphome-base-dialog>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-crash-report-dialog": ESPHomeCrashReportDialog;
+  }
+}

--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -303,7 +303,9 @@ export class ESPHomeCrashReportDialog extends LitElement {
   private _detectInstallation(): string {
     if (this._isHaAddon) return "Home Assistant Add-on";
     const info = this._api.serverInfo;
-    if (!info || info.desktop_version) return "";
+    // Unknown (no serverInfo, desktop app, or a backend that predates
+    // in_docker) omits the fact rather than guessing pip vs Docker.
+    if (!info || info.desktop_version || info.in_docker === undefined) return "";
     return info.in_docker ? "Docker" : "pip";
   }
 

--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -285,13 +285,13 @@ export class ESPHomeCrashReportDialog extends LitElement {
   }
 
   // Maps the deployment signals onto the bug form's installation
-  // dropdown. The desktop app has no matching option, so it stays ""
-  // and the user picks in the form.
+  // dropdown. Unknown ("" — the desktop app, or before the handshake
+  // populates serverInfo) omits the fact so the value isn't guessed.
   private _detectInstallation(): string {
     if (this._isHaAddon) return "Home Assistant Add-on";
     const info = this._api.serverInfo;
-    if (info?.desktop_version) return "";
-    return info?.in_docker ? "Docker" : "pip";
+    if (!info || info.desktop_version) return "";
+    return info.in_docker ? "Docker" : "pip";
   }
 
   // Download the full report first — the user always keeps a complete

--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -97,12 +97,6 @@ export class ESPHomeCrashReportDialog extends LitElement {
   @state()
   private _delivered = false;
 
-  // window.open returned null (popup blocker); the delivered state then
-  // leads with the manual "Open GitHub issue" link instead of claiming
-  // a tab opened.
-  @state()
-  private _popupBlocked = false;
-
   // True when the whole report fit the pre-filled URL — no paste needed.
   @state()
   private _prefillComplete = false;
@@ -214,7 +208,6 @@ export class ESPHomeCrashReportDialog extends LitElement {
     this._session += 1;
     this._configYaml = null;
     this._delivered = false;
-    this._popupBlocked = false;
     this._userDescription = "";
     this._reportText = "";
     this._issueUrl = "";
@@ -293,7 +286,9 @@ export class ESPHomeCrashReportDialog extends LitElement {
   // Download the full report first — the user always keeps a complete
   // copy even if the pre-fill was truncated — then open the issue. The
   // dialog stays open so the download / copy / issue link stay one click
-  // away until the user closes it themselves.
+  // away until the user closes it themselves. window.open with noopener
+  // returns null by spec, so blocking can't be detected here; the manual
+  // "Open GitHub issue" link in the delivered state is the fallback.
   private _openIssue(): void {
     const report = this._buildReport();
     this._reportText = buildFullReport(report);
@@ -301,7 +296,7 @@ export class ESPHomeCrashReportDialog extends LitElement {
     this._issueUrl = url;
     this._prefillComplete = complete;
     this._downloadReport();
-    this._popupBlocked = window.open(url, "_blank", "noopener") === null;
+    window.open(url, "_blank", "noopener");
     this._delivered = true;
   }
 
@@ -329,15 +324,12 @@ export class ESPHomeCrashReportDialog extends LitElement {
   }
 
   private _renderDelivered() {
-    const blocked = this._popupBlocked;
     return html`
       <p class="hint">
         ${this._localize(
-          blocked
-            ? "crash_report.popup_blocked_hint"
-            : this._prefillComplete
-              ? "crash_report.delivered_hint_complete"
-              : "crash_report.delivered_hint"
+          this._prefillComplete
+            ? "crash_report.delivered_hint_complete"
+            : "crash_report.delivered_hint"
         )}
       </p>
       <div class="actions">

--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -1,6 +1,6 @@
 import { consume } from "@lit/context";
 import { mdiAlertCircleOutline, mdiClipboardTextOutline, mdiDownload } from "@mdi/js";
-import { LitElement, css, html } from "lit";
+import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { ConfiguredDevice } from "../api/types/devices.js";
@@ -23,6 +23,7 @@ import {
   buildFullReport,
   buildIssueUrl,
   distillValidatedConfig,
+  platformFromIntegrations,
   scrapeCrashData,
 } from "../util/crash-report.js";
 import { DialogOpenController } from "../util/dialog-open-controller.js";
@@ -45,8 +46,10 @@ const VALIDATE_TIMEOUT_MS = 90_000;
 /**
  * "Report this crash" flow: scrape the log buffer handed over by the
  * logs dialog, capture the sanitized config via `devices/validate`,
- * then copy the full report to the clipboard and open a pre-filled
- * esphome/esphome issue.
+ * then open a fully pre-filled esphome/esphome issue. The URL prefill
+ * is the sole delivery channel (it survives GitHub's form rehydration;
+ * manual pasting does not); truncated content stays available via the
+ * downloadable report.
  */
 @customElement("esphome-crash-report-dialog")
 export class ESPHomeCrashReportDialog extends LitElement {
@@ -83,8 +86,10 @@ export class ESPHomeCrashReportDialog extends LitElement {
   @state()
   private _configYaml: string | null = null;
 
+  // The user's own "what was the device doing" context; required before
+  // the report can be sent — a crash report without it isn't actionable.
   @state()
-  private _copyFailed = false;
+  private _userDescription = "";
 
   // Set once the report was delivered (copied/downloaded) and the issue
   // opened; the dialog then stays up offering copy-again / download, so a
@@ -97,6 +102,10 @@ export class ESPHomeCrashReportDialog extends LitElement {
   // a tab opened.
   @state()
   private _popupBlocked = false;
+
+  // True when the whole report fit the pre-filled URL — no paste needed.
+  @state()
+  private _prefillComplete = false;
 
   private _configuration = "";
   private _name = "";
@@ -160,13 +169,39 @@ export class ESPHomeCrashReportDialog extends LitElement {
         margin: 0 0 var(--wa-space-s);
       }
 
+      .describe-label {
+        display: block;
+        font-size: var(--wa-font-size-s);
+        font-weight: var(--wa-font-weight-semibold);
+        margin: 0 0 var(--wa-space-2xs);
+      }
+
+      .describe-input {
+        width: 100%;
+        box-sizing: border-box;
+        resize: vertical;
+        font: inherit;
+        font-size: var(--wa-font-size-s);
+        padding: var(--wa-space-xs);
+        border-radius: var(--wa-border-radius-m);
+        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+        background: var(--wa-color-surface-default);
+        color: var(--wa-color-text-normal);
+        margin: 0 0 var(--wa-space-m);
+      }
+
       .btn--confirm {
         background: var(--esphome-primary);
         color: var(--esphome-on-primary);
       }
 
-      .btn--confirm:hover {
+      .btn--confirm:hover:not(:disabled) {
         background: var(--esphome-primary-hover);
+      }
+
+      .btn--confirm:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
       }
     `,
   ];
@@ -178,9 +213,9 @@ export class ESPHomeCrashReportDialog extends LitElement {
     this._name = name;
     this._session += 1;
     this._configYaml = null;
-    this._copyFailed = false;
     this._delivered = false;
     this._popupBlocked = false;
+    this._userDescription = "";
     this._reportText = "";
     this._issueUrl = "";
     this._scrape = scrapeCrashData(lines);
@@ -227,56 +262,60 @@ export class ESPHomeCrashReportDialog extends LitElement {
     return {
       scrape: this._scrape,
       configYaml: this._configYaml ?? "",
+      userDescription: this._userDescription.trim(),
       meta: {
         deviceName: this._name,
         configuration: this._configuration,
         esphomeVersion: device?.current_version || this._esphomeVersion,
         deployedVersion: device?.runtime_state.deployed_version ?? "",
         dashboardVersion: this._serverVersion,
-        targetPlatform: device?.target_platform ?? "",
+        // Plain-ESP32 sidecars can leave target_platform empty; the
+        // integration list always names the platform component.
+        targetPlatform:
+          device?.target_platform ||
+          platformFromIntegrations(device?.loaded_integrations ?? []),
         board: device?.board_id ?? "",
-        isHaAddon: this._isHaAddon,
+        installation: this._detectInstallation(),
       },
     };
   }
 
-  private async _copyAndOpen(): Promise<void> {
-    const report = this._buildReport();
-    this._reportText = buildFullReport(report);
-    if (!(await copyToClipboard(this._reportText))) {
-      this._copyFailed = true;
-      return;
-    }
-    this._openIssue(report, "clipboard");
+  // Maps the deployment signals onto the bug form's installation
+  // dropdown. The desktop app has no matching option, so it stays ""
+  // and the user picks in the form.
+  private _detectInstallation(): string {
+    if (this._isHaAddon) return "Home Assistant Add-on";
+    const info = this._api.serverInfo;
+    if (info?.desktop_version) return "";
+    return info?.in_docker ? "Docker" : "pip";
   }
 
-  private _downloadAndOpen(): void {
+  // Download the full report first — the user always keeps a complete
+  // copy even if the pre-fill was truncated — then open the issue. The
+  // dialog stays open so the download / copy / issue link stay one click
+  // away until the user closes it themselves.
+  private _openIssue(): void {
     const report = this._buildReport();
     this._reportText = buildFullReport(report);
+    const { url, complete } = buildIssueUrl(report);
+    this._issueUrl = url;
+    this._prefillComplete = complete;
     this._downloadReport();
-    this._openIssue(report, "download");
-  }
-
-  // The dialog stays open after delivery: switching to the GitHub tab can
-  // cost the user the clipboard contents, so copy-again / download / the
-  // issue link stay one click away until they close it themselves.
-  private _openIssue(report: CrashReport, delivery: "clipboard" | "download"): void {
-    this._issueUrl = buildIssueUrl(report, delivery);
-    this._popupBlocked = window.open(this._issueUrl, "_blank", "noopener") === null;
+    this._popupBlocked = window.open(url, "_blank", "noopener") === null;
     this._delivered = true;
-  }
-
-  private async _copyAgain(): Promise<void> {
-    if (await copyToClipboard(this._reportText)) {
-      notifySuccess(this._localize("crash_report.copied"));
-    } else {
-      notifyError(this._localize("crash_report.copy_failed"));
-    }
   }
 
   private _downloadReport(): void {
     const stem = configurationStem(this._configuration, "device");
     downloadBlob(this._reportText, `${stem}-crash-report.md`, "text/markdown");
+  }
+
+  private async _copyReport(): Promise<void> {
+    if (await copyToClipboard(this._reportText)) {
+      notifySuccess(this._localize("crash_report.copied"));
+    } else {
+      notifyError(this._localize("crash_report.copy_failed"));
+    }
   }
 
   private _renderSummaryRow(text: string, degraded: boolean) {
@@ -294,25 +333,26 @@ export class ESPHomeCrashReportDialog extends LitElement {
     return html`
       <p class="hint">
         ${this._localize(
-          blocked ? "crash_report.popup_blocked_hint" : "crash_report.delivered_hint"
+          blocked
+            ? "crash_report.popup_blocked_hint"
+            : this._prefillComplete
+              ? "crash_report.delivered_hint_complete"
+              : "crash_report.delivered_hint"
         )}
       </p>
       <div class="actions">
         <button class="btn btn--cancel" @click=${() => (this._dialog.open = false)}>
           ${this._localize("layout.close")}
         </button>
+        <button class="btn btn--cancel" @click=${this._copyReport}>
+          ${this._localize("crash_report.copy_report")}
+        </button>
         <button class="btn btn--cancel" @click=${this._downloadReport}>
           <wa-icon library="mdi" name="download"></wa-icon>
           ${this._localize("crash_report.download_report")}
         </button>
-        <button
-          class="btn ${blocked ? "btn--cancel" : "btn--confirm"}"
-          @click=${this._copyAgain}
-        >
-          ${this._localize("crash_report.copy_again")}
-        </button>
         <a
-          class="btn ${blocked ? "btn--confirm" : "btn--cancel"}"
+          class="btn btn--confirm"
           href=${this._issueUrl}
           target="_blank"
           rel="noopener noreferrer"
@@ -323,11 +363,27 @@ export class ESPHomeCrashReportDialog extends LitElement {
     `;
   }
 
+  private _onDescriptionInput = (e: Event): void => {
+    this._userDescription = (e.target as HTMLTextAreaElement).value;
+  };
+
   private _renderReady() {
     const scrape = this._scrape;
     const decoded = scrape.decodedFrames.length > 0;
     const configFailed = this._configYaml === "";
+    const described = this._userDescription.trim() !== "";
     return html`
+      <label class="describe-label" for="crash-description"
+        >${this._localize("crash_report.describe_label")}</label
+      >
+      <textarea
+        id="crash-description"
+        class="describe-input"
+        rows="3"
+        placeholder=${this._localize("crash_report.describe_placeholder")}
+        .value=${this._userDescription}
+        @input=${this._onDescriptionInput}
+      ></textarea>
       <ul class="summary">
         ${this._renderSummaryRow(
           this._localize(
@@ -355,25 +411,19 @@ export class ESPHomeCrashReportDialog extends LitElement {
           configFailed
         )}
       </ul>
-      <p class="hint">
-        ${this._localize(
-          this._copyFailed ? "crash_report.copy_failed_hint" : "crash_report.hint"
-        )}
-      </p>
+      <p class="hint">${this._localize("crash_report.hint")}</p>
       <div class="actions">
         <button class="btn btn--cancel" @click=${() => (this._dialog.open = false)}>
           ${this._localize("layout.cancel")}
         </button>
-        ${
-          this._copyFailed
-            ? html`<button class="btn btn--confirm" @click=${this._downloadAndOpen}>
-                <wa-icon library="mdi" name="download"></wa-icon>
-                ${this._localize("crash_report.download_and_open")}
-              </button>`
-            : html`<button class="btn btn--confirm" @click=${this._copyAndOpen}>
-                ${this._localize("crash_report.copy_and_open")}
-              </button>`
-        }
+        <button
+          class="btn btn--confirm"
+          ?disabled=${!described}
+          title=${described ? nothing : this._localize("crash_report.describe_required")}
+          @click=${this._openIssue}
+        >
+          ${this._localize("crash_report.open_issue")}
+        </button>
       </div>
     `;
   }

--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -242,7 +242,12 @@ export class ESPHomeCrashReportDialog extends LitElement {
       onOutput: (line) => collected.push(line),
       onResult: (result) =>
         finish(result.success ? distillValidatedConfig(collected) : ""),
-      onError: () => finish(""),
+      onError: (err) => {
+        // Degrades to the same config-unavailable note as an invalid
+        // config; log so a real transport failure is distinguishable.
+        console.warn("Config validation stream failed", err);
+        finish("");
+      },
     });
   }
 
@@ -295,7 +300,9 @@ export class ESPHomeCrashReportDialog extends LitElement {
   // away until the user closes it themselves. window.open with noopener
   // returns null by spec, so blocking can't be detected here; the manual
   // "Open GitHub issue" link in the delivered state is the fallback.
-  private _openIssue(): void {
+  // Arrow properties: used directly as @click handlers, so `this` must
+  // stay the dialog instance (repo convention for handlers).
+  private _openIssue = (): void => {
     const report = this._buildReport();
     this._reportText = buildFullReport(report);
     const { url, complete } = buildIssueUrl(report);
@@ -304,20 +311,20 @@ export class ESPHomeCrashReportDialog extends LitElement {
     this._downloadReport();
     window.open(url, "_blank", "noopener");
     this._delivered = true;
-  }
+  };
 
-  private _downloadReport(): void {
+  private _downloadReport = (): void => {
     const stem = configurationStem(this._configuration, "device");
     downloadBlob(this._reportText, `${stem}-crash-report.md`, "text/markdown");
-  }
+  };
 
-  private async _copyReport(): Promise<void> {
+  private _copyReport = async (): Promise<void> => {
     if (await copyToClipboard(this._reportText)) {
       notifySuccess(this._localize("crash_report.copied"));
     } else {
       notifyError(this._localize("crash_report.copy_failed"));
     }
-  }
+  };
 
   private _renderSummaryRow(text: string, degraded: boolean) {
     return html`<li class=${degraded ? "degraded" : ""}>

--- a/src/components/logs-dialog.styles.ts
+++ b/src/components/logs-dialog.styles.ts
@@ -83,16 +83,13 @@ export const logsDialogStyles = css`
     flex: 1;
   }
 
+  /* Composes .term-btn (shape/typography from termButtonStyles); only the
+     primary-CTA colours are local. */
   .crash-callout-button {
     flex-shrink: 0;
-    padding: 4px 12px;
-    border: none;
-    border-radius: var(--wa-border-radius-m);
+    border-color: transparent;
     background: var(--esphome-primary);
     color: var(--esphome-on-primary);
-    font: inherit;
-    font-weight: var(--wa-font-weight-semibold);
-    cursor: pointer;
   }
 
   .crash-callout-button:hover {

--- a/src/components/logs-dialog.styles.ts
+++ b/src/components/logs-dialog.styles.ts
@@ -60,6 +60,45 @@ export const logsDialogStyles = css`
     display: none;
   }
 
+  /* Crash callout — slotted into the terminal's suggestion slot. Louder
+     than the muted reset-suggestion idiom on purpose: this is the primary
+     "report it" affordance, shown the moment a crash lands in the log. */
+  .crash-callout {
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-s);
+    padding: 8px 20px;
+    border-top: 1px solid var(--term-border);
+    background: color-mix(in srgb, var(--esphome-error, #d32f2f) 14%, var(--term-bg));
+    color: var(--term-fg);
+    font-size: var(--wa-font-size-s);
+  }
+
+  .crash-callout wa-icon {
+    flex-shrink: 0;
+    color: var(--esphome-error, #d32f2f);
+  }
+
+  .crash-callout-text {
+    flex: 1;
+  }
+
+  .crash-callout-button {
+    flex-shrink: 0;
+    padding: 4px 12px;
+    border: none;
+    border-radius: var(--wa-border-radius-m);
+    background: var(--esphome-primary);
+    color: var(--esphome-on-primary);
+    font: inherit;
+    font-weight: var(--wa-font-weight-semibold);
+    cursor: pointer;
+  }
+
+  .crash-callout-button:hover {
+    background: var(--esphome-primary-hover);
+  }
+
   /* Expanded → "just give me logs": full viewport, the terminal fills the
      space between the slim title bar and the toolbar. The component fills the
      dialog body (height: 100%) and its content stretches via the height vars. */

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -20,7 +20,7 @@ import { apiContext, darkModeContext, localizeContext } from "../context/index.j
 import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { CrashDetector } from "../util/crash-detector.js";
+import { hasCrashMarker } from "../util/crash-detector.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { configurationStem, downloadAnsiText } from "../util/download-text.js";
 import { LineBatcher } from "../util/line-batcher.js";
@@ -123,7 +123,6 @@ export class ESPHomeLogsDialog extends LitElement {
   // "Report this crash" callout for the rest of the session.
   @state()
   private _crashDetected = false;
-  private _crashDetector = new CrashDetector();
 
   @query("esphome-crash-report-dialog")
   private _crashReportDialog?: ESPHomeCrashReportDialog;
@@ -204,7 +203,6 @@ export class ESPHomeLogsDialog extends LitElement {
     void this._teardownSession();
     this._resetPendingLines();
     this._lines = [];
-    this._crashDetector.reset();
     this._crashDetected = false;
     this._expanded = false;
     this._showStates = true;
@@ -361,7 +359,7 @@ export class ESPHomeLogsDialog extends LitElement {
                   >
                   <button
                     type="button"
-                    class="crash-callout-button"
+                    class="term-btn crash-callout-button"
                     @click=${this._openCrashReport}
                   >
                     ${this._localize("crash_report.report_button")}
@@ -561,7 +559,6 @@ export class ESPHomeLogsDialog extends LitElement {
   private _clearLogs() {
     this._resetPendingLines();
     this._lines = [];
-    this._crashDetector.reset();
     this._crashDetected = false;
   }
 
@@ -577,14 +574,11 @@ export class ESPHomeLogsDialog extends LitElement {
   private _appendCapped(lines: string[]): void {
     const merged = [...this._lines, ...lines];
     this._lines = merged.length > MAX_LOG_LINES ? merged.slice(-MAX_LOG_LINES) : merged;
-    if (!this._crashDetected) {
-      this._crashDetector.feed(lines);
-      if (this._crashDetector.detected) {
-        this._crashDetected = true;
-        // The callout shrinks the log container; re-pin so the crash
-        // tail stays visible.
-        this.updateComplete.then(() => this._terminal?.scrollToBottom());
-      }
+    if (!this._crashDetected && hasCrashMarker(lines)) {
+      this._crashDetected = true;
+      // The callout shrinks the log container; re-pin so the crash
+      // tail stays visible.
+      this.updateComplete.then(() => this._terminal?.scrollToBottom());
     }
   }
 

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -591,7 +591,9 @@ export class ESPHomeLogsDialog extends LitElement {
         // The callout shrinks the log container; re-pin so the crash
         // tail stays visible.
         if (firstDetection) {
-          void this.updateComplete.then(() => this._terminal?.scrollToBottom());
+          void this.updateComplete
+            .then(() => this._terminal?.scrollToBottom())
+            .catch(() => undefined);
         }
       }
     }

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -20,7 +20,7 @@ import { apiContext, darkModeContext, localizeContext } from "../context/index.j
 import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { hasCrashMarker } from "../util/crash-detector.js";
+import { type CrashKind, detectCrashKind } from "../util/crash-detector.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { configurationStem, downloadAnsiText } from "../util/download-text.js";
 import { LineBatcher } from "../util/line-batcher.js";
@@ -120,9 +120,10 @@ export class ESPHomeLogsDialog extends LitElement {
   _lines: string[] = [];
 
   // Latched once a crash marker flows through _appendCapped; drives the
-  // "Report this crash" callout for the rest of the session.
+  // "Report this crash" callout for the rest of the session. A live panic
+  // upgrades a previous-boot report; nothing downgrades it.
   @state()
-  private _crashDetected = false;
+  private _crashKind: CrashKind | null = null;
 
   // Rendered unconditionally in this dialog's template, so the query is
   // always resolved by the time the callout button can be clicked.
@@ -205,7 +206,7 @@ export class ESPHomeLogsDialog extends LitElement {
     void this._teardownSession();
     this._resetPendingLines();
     this._lines = [];
-    this._crashDetected = false;
+    this._crashKind = null;
     this._expanded = false;
     this._showStates = true;
     this._backToInstallHandler = onBackToInstall ?? null;
@@ -353,13 +354,17 @@ export class ESPHomeLogsDialog extends LitElement {
               : ""
           }
           ${
-            this._crashDetected
+            this._crashKind !== null
               ? html`<div class="crash-callout" slot="suggestion">
                   <wa-icon library="mdi" name="alert-circle"></wa-icon>
                   <!-- Live region on the text only: announcing the whole row
                        would read the button as part of a status message. -->
                   <span class="crash-callout-text" role="status"
-                    >${this._localize("crash_report.banner")}</span
+                    >${this._localize(
+                      this._crashKind === "previous-boot"
+                        ? "crash_report.banner_previous_boot"
+                        : "crash_report.banner"
+                    )}</span
                   >
                   <button
                     type="button"
@@ -563,7 +568,7 @@ export class ESPHomeLogsDialog extends LitElement {
   private _clearLogs() {
     this._resetPendingLines();
     this._lines = [];
-    this._crashDetected = false;
+    this._crashKind = null;
   }
 
   // Buffer a streamed line; flushed on the next animation frame. The serial
@@ -578,11 +583,17 @@ export class ESPHomeLogsDialog extends LitElement {
   private _appendCapped(lines: string[]): void {
     const merged = [...this._lines, ...lines];
     this._lines = merged.length > MAX_LOG_LINES ? merged.slice(-MAX_LOG_LINES) : merged;
-    if (!this._crashDetected && hasCrashMarker(lines)) {
-      this._crashDetected = true;
-      // The callout shrinks the log container; re-pin so the crash
-      // tail stays visible.
-      this.updateComplete.then(() => this._terminal?.scrollToBottom());
+    if (this._crashKind !== "live") {
+      const kind = detectCrashKind(lines);
+      if (kind && kind !== this._crashKind) {
+        const firstDetection = this._crashKind === null;
+        this._crashKind = kind;
+        // The callout shrinks the log container; re-pin so the crash
+        // tail stays visible.
+        if (firstDetection) {
+          this.updateComplete.then(() => this._terminal?.scrollToBottom());
+        }
+      }
     }
   }
 

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -593,7 +593,7 @@ export class ESPHomeLogsDialog extends LitElement {
         if (firstDetection) {
           void this.updateComplete
             .then(() => this._terminal?.scrollToBottom())
-            .catch(() => undefined);
+            .catch((err) => console.warn("crash callout re-pin scroll failed", err));
         }
       }
     }

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -591,7 +591,7 @@ export class ESPHomeLogsDialog extends LitElement {
         // The callout shrinks the log container; re-pin so the crash
         // tail stays visible.
         if (firstDetection) {
-          this.updateComplete.then(() => this._terminal?.scrollToBottom());
+          void this.updateComplete.then(() => this._terminal?.scrollToBottom());
         }
       }
     }

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -1,5 +1,6 @@
 import { consume } from "@lit/context";
 import {
+  mdiAlertCircle,
   mdiArrowCollapse,
   mdiArrowExpand,
   mdiArrowLeft,
@@ -19,11 +20,13 @@ import { apiContext, darkModeContext, localizeContext } from "../context/index.j
 import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { CrashDetector } from "../util/crash-detector.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { configurationStem, downloadAnsiText } from "../util/download-text.js";
 import { LineBatcher } from "../util/line-batcher.js";
 import { notifyError } from "../util/notify.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import type { ESPHomeCrashReportDialog } from "./crash-report-dialog.js";
 import { logsDialogStyles } from "./logs-dialog.styles.js";
 import {
   type LogsSession,
@@ -43,9 +46,11 @@ import { renderTermButton, renderTermToggle } from "./process-terminal/toolbar-b
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "./base-dialog.js";
+import "./crash-report-dialog.js";
 import "./process-terminal/process-terminal.js";
 
 registerMdiIcons({
+  "alert-circle": mdiAlertCircle,
   "arrow-collapse": mdiArrowCollapse,
   "arrow-expand": mdiArrowExpand,
   "arrow-left": mdiArrowLeft,
@@ -113,6 +118,15 @@ export class ESPHomeLogsDialog extends LitElement {
 
   @state()
   _lines: string[] = [];
+
+  // Latched once a crash marker flows through _appendCapped; drives the
+  // "Report this crash" callout for the rest of the session.
+  @state()
+  private _crashDetected = false;
+  private _crashDetector = new CrashDetector();
+
+  @query("esphome-crash-report-dialog")
+  private _crashReportDialog?: ESPHomeCrashReportDialog;
 
   // rAF batch buffer: coalesce per-line appends into one render per frame
   // instead of one per line (mirrors command-dialog, #348). A fast serial
@@ -190,6 +204,8 @@ export class ESPHomeLogsDialog extends LitElement {
     void this._teardownSession();
     this._resetPendingLines();
     this._lines = [];
+    this._crashDetector.reset();
+    this._crashDetected = false;
     this._expanded = false;
     this._showStates = true;
     this._backToInstallHandler = onBackToInstall ?? null;
@@ -336,6 +352,23 @@ export class ESPHomeLogsDialog extends LitElement {
                 </div>`
               : ""
           }
+          ${
+            this._crashDetected
+              ? html`<div class="crash-callout" role="status" slot="suggestion">
+                  <wa-icon library="mdi" name="alert-circle"></wa-icon>
+                  <span class="crash-callout-text"
+                    >${this._localize("crash_report.banner")}</span
+                  >
+                  <button
+                    type="button"
+                    class="crash-callout-button"
+                    @click=${this._openCrashReport}
+                  >
+                    ${this._localize("crash_report.report_button")}
+                  </button>
+                </div>`
+              : ""
+          }
           <div class="toolbar-slot" slot="toolbar-right">
             ${
               passive
@@ -399,8 +432,17 @@ export class ESPHomeLogsDialog extends LitElement {
           </div>
         </esphome-process-terminal>
       </esphome-base-dialog>
+      <esphome-crash-report-dialog></esphome-crash-report-dialog>
     `;
   }
+
+  // Snapshot the buffer (post-flush, so nothing batched for the next frame
+  // is missed) and hand it to the report dialog. The logs dialog stays open
+  // underneath; the stream keeps running.
+  private _openCrashReport = () => {
+    this._flushPendingLines();
+    this._crashReportDialog?.open(this.configuration, this.name, [...this._lines]);
+  };
 
   // Start button (only shown while not streaming; the leading guard also
   // absorbs a double-click in the same microtask). Per state:
@@ -519,6 +561,8 @@ export class ESPHomeLogsDialog extends LitElement {
   private _clearLogs() {
     this._resetPendingLines();
     this._lines = [];
+    this._crashDetector.reset();
+    this._crashDetected = false;
   }
 
   // Buffer a streamed line; flushed on the next animation frame. The serial
@@ -533,6 +577,15 @@ export class ESPHomeLogsDialog extends LitElement {
   private _appendCapped(lines: string[]): void {
     const merged = [...this._lines, ...lines];
     this._lines = merged.length > MAX_LOG_LINES ? merged.slice(-MAX_LOG_LINES) : merged;
+    if (!this._crashDetected) {
+      this._crashDetector.feed(lines);
+      if (this._crashDetector.detected) {
+        this._crashDetected = true;
+        // The callout shrinks the log container; re-pin so the crash
+        // tail stays visible.
+        this.updateComplete.then(() => this._terminal?.scrollToBottom());
+      }
+    }
   }
 
   // Drain pending lines into ``_lines`` now, trimmed to the newest

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -124,8 +124,10 @@ export class ESPHomeLogsDialog extends LitElement {
   @state()
   private _crashDetected = false;
 
+  // Rendered unconditionally in this dialog's template, so the query is
+  // always resolved by the time the callout button can be clicked.
   @query("esphome-crash-report-dialog")
-  private _crashReportDialog?: ESPHomeCrashReportDialog;
+  private _crashReportDialog!: ESPHomeCrashReportDialog;
 
   // rAF batch buffer: coalesce per-line appends into one render per frame
   // instead of one per line (mirrors command-dialog, #348). A fast serial
@@ -352,9 +354,11 @@ export class ESPHomeLogsDialog extends LitElement {
           }
           ${
             this._crashDetected
-              ? html`<div class="crash-callout" role="status" slot="suggestion">
+              ? html`<div class="crash-callout" slot="suggestion">
                   <wa-icon library="mdi" name="alert-circle"></wa-icon>
-                  <span class="crash-callout-text"
+                  <!-- Live region on the text only: announcing the whole row
+                       would read the button as part of a status message. -->
+                  <span class="crash-callout-text" role="status"
                     >${this._localize("crash_report.banner")}</span
                   >
                   <button
@@ -439,7 +443,7 @@ export class ESPHomeLogsDialog extends LitElement {
   // underneath; the stream keeps running.
   private _openCrashReport = () => {
     this._flushPendingLines();
-    this._crashReportDialog?.open(this.configuration, this.name, [...this._lines]);
+    this._crashReportDialog.open(this.configuration, this.name, [...this._lines]);
   };
 
   // Start button (only shown while not streaming; the leading guard also

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1675,6 +1675,11 @@
     "hint": "The full report will be copied to your clipboard and a pre-filled GitHub issue will open. Paste the report into the issue's \"Additional information\" field.",
     "copy_failed_hint": "Copying to the clipboard failed. Download the report instead and attach it to the issue.",
     "copy_and_open": "Copy report & open GitHub issue",
-    "download_and_open": "Download report & open GitHub issue"
+    "download_and_open": "Download report & open GitHub issue",
+    "delivered_hint": "The report is on your clipboard and the GitHub issue form opened in a new tab. If something overwrites your clipboard before you paste, copy or download the report again from here.",
+    "copy_again": "Copy report again",
+    "download_report": "Download report",
+    "copied": "Report copied to clipboard",
+    "copy_failed": "Copying the report failed"
   }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1684,6 +1684,7 @@
     "banner_previous_boot": "This device crashed on a previous boot",
     "delivered_hint_complete": "The full report was downloaded and a pre-filled GitHub issue opened in a new tab; everything fit, so nothing needs to be pasted. If the tab didn't open, use \"Open GitHub issue\" below. You can also re-download or copy the report here.",
     "copy_report": "Copy report",
-    "download_and_open": "Download report & open GitHub issue"
+    "download_and_open": "Download report & open GitHub issue",
+    "config_capture_failed": "Couldn't reach the server to capture the config; it's not included (this is a connection issue, not a problem with your YAML)"
   }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1660,5 +1660,21 @@
     "disabled_title": "Remote builds are disabled",
     "disabled_desc": "This install is set up as a remote build server, but the remote build listener is turned off.",
     "disabled_cta": "Open build server settings"
+  },
+  "crash_report": {
+    "banner": "This device crashed",
+    "report_button": "Report this crash",
+    "title": "Report crash - {name}",
+    "collecting": "Collecting crash details and validating the configuration...",
+    "includes_backtrace_decoded": "Decoded backtrace captured",
+    "includes_backtrace_raw": "Backtrace captured, but it was not decoded in this session",
+    "crash_scrolled_out": "The crash output scrolled out of the log buffer",
+    "includes_log_lines": "{warnings} warning/error lines and {config} config lines included",
+    "includes_config": "Configuration included, secrets redacted",
+    "config_unavailable": "Configuration could not be validated, so it is not included",
+    "hint": "The full report will be copied to your clipboard and a pre-filled GitHub issue will open. Paste the report into the issue's \"Additional information\" field.",
+    "copy_failed_hint": "Copying to the clipboard failed. Download the report instead and attach it to the issue.",
+    "copy_and_open": "Copy report & open GitHub issue",
+    "download_and_open": "Download report & open GitHub issue"
   }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1683,6 +1683,7 @@
     "describe_required": "Describe what the device was doing first; a report without context is hard to act on",
     "banner_previous_boot": "This device crashed on a previous boot",
     "delivered_hint_complete": "The full report was downloaded and a pre-filled GitHub issue opened in a new tab; everything fit, so nothing needs to be pasted. If the tab didn't open, use \"Open GitHub issue\" below. You can also re-download or copy the report here.",
-    "copy_report": "Copy report"
+    "copy_report": "Copy report",
+    "download_and_open": "Download report & open GitHub issue"
   }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1680,6 +1680,8 @@
     "copy_again": "Copy report again",
     "download_report": "Download report",
     "copied": "Report copied to clipboard",
-    "copy_failed": "Copying the report failed"
+    "copy_failed": "Copying the report failed",
+    "popup_blocked_hint": "Your browser blocked the GitHub tab. The report is on your clipboard; use \"Open GitHub issue\" below and paste it there.",
+    "open_issue": "Open GitHub issue"
   }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1672,18 +1672,17 @@
     "includes_log_lines": "{warnings} warning/error lines and {config} config lines included",
     "includes_config": "Configuration included, secrets redacted",
     "config_unavailable": "Configuration could not be validated, so it is not included",
-    "hint": "A copy of the full report will be downloaded, then a pre-filled GitHub issue opens with the crash details, config, and logs.",
-    "delivered_hint": "The full report was downloaded. Some sections were too large for the pre-filled form; drag the downloaded file onto the issue's \"Additional information\" field to include everything.",
+    "hint": "When you continue, the full report downloads first, then a pre-filled GitHub issue opens in a new tab with the crash details, config, and logs.",
+    "delivered_hint": "The full report was downloaded and a pre-filled GitHub issue opened in a new tab. Some sections were too large for the form; drag the downloaded file onto the issue's \"Additional information\" field to include everything. If the tab didn't open, use \"Open GitHub issue\" below.",
     "download_report": "Download report",
     "copied": "Report copied to clipboard",
     "copy_failed": "Copying the report failed",
-    "popup_blocked_hint": "The full report was downloaded, but your browser blocked the GitHub tab. Use \"Open GitHub issue\" below to continue.",
     "open_issue": "Open GitHub issue",
     "describe_label": "What was the device doing when it crashed?",
     "describe_placeholder": "e.g. Pressed the garage button in Home Assistant; crashes every time a BLE device connects",
     "describe_required": "Describe what the device was doing first; a report without context is hard to act on",
     "banner_previous_boot": "This device crashed on a previous boot",
-    "delivered_hint_complete": "The full report was downloaded and everything fit into the pre-filled GitHub form, so nothing needs to be pasted. You can re-download or copy the report here.",
+    "delivered_hint_complete": "The full report was downloaded and a pre-filled GitHub issue opened in a new tab; everything fit, so nothing needs to be pasted. If the tab didn't open, use \"Open GitHub issue\" below. You can also re-download or copy the report here.",
     "copy_report": "Copy report"
   }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1672,16 +1672,18 @@
     "includes_log_lines": "{warnings} warning/error lines and {config} config lines included",
     "includes_config": "Configuration included, secrets redacted",
     "config_unavailable": "Configuration could not be validated, so it is not included",
-    "hint": "The full report will be copied to your clipboard and a pre-filled GitHub issue will open. Paste the report into the issue's \"Additional information\" field.",
-    "copy_failed_hint": "Copying to the clipboard failed. Download the report instead and attach it to the issue.",
-    "copy_and_open": "Copy report & open GitHub issue",
-    "download_and_open": "Download report & open GitHub issue",
-    "delivered_hint": "The report is on your clipboard and the GitHub issue form opened in a new tab. If something overwrites your clipboard before you paste, copy or download the report again from here.",
-    "copy_again": "Copy report again",
+    "hint": "A copy of the full report will be downloaded, then a pre-filled GitHub issue opens with the crash details, config, and logs.",
+    "delivered_hint": "The full report was downloaded. Some sections were too large for the pre-filled form; drag the downloaded file onto the issue's \"Additional information\" field to include everything.",
     "download_report": "Download report",
     "copied": "Report copied to clipboard",
     "copy_failed": "Copying the report failed",
-    "popup_blocked_hint": "Your browser blocked the GitHub tab. The report is on your clipboard; use \"Open GitHub issue\" below and paste it there.",
-    "open_issue": "Open GitHub issue"
+    "popup_blocked_hint": "The full report was downloaded, but your browser blocked the GitHub tab. Use \"Open GitHub issue\" below to continue.",
+    "open_issue": "Open GitHub issue",
+    "describe_label": "What was the device doing when it crashed?",
+    "describe_placeholder": "e.g. Pressed the garage button in Home Assistant; crashes every time a BLE device connects",
+    "describe_required": "Describe what the device was doing first; a report without context is hard to act on",
+    "banner_previous_boot": "This device crashed on a previous boot",
+    "delivered_hint_complete": "The full report was downloaded and everything fit into the pre-filled GitHub form, so nothing needs to be pasted. You can re-download or copy the report here.",
+    "copy_report": "Copy report"
   }
 }

--- a/src/util/crash-detector.ts
+++ b/src/util/crash-detector.ts
@@ -1,0 +1,83 @@
+import { stripAnsi } from "./ansi-escapes.js";
+
+/**
+ * Crash detection over device log lines.
+ *
+ * The marker patterns are ported from the regexes ESPHome's own
+ * stacktrace decoders key on (`esphome/components/{esp32,esp8266}/
+ * __init__.py`: `Backtrace:`, `BT<n>:`, register dumps, the esp8266
+ * `>>>stack>>>` dump) plus the panic banners those decoders assume
+ * scrolled past first (`Guru Meditation Error`, `abort() was called`,
+ * ...). Matching runs against `normalizeLogLine` output so the same
+ * pattern hits regardless of transport (raw UART bytes vs the
+ * backend's `\033`-literal ANSI vs the dialog's timestamp prefix).
+ */
+
+// The dialog prepends `[HH:MM:SS]` (optionally with millis) to every line.
+// Trailing whitespace stays: on a continuation line the indent after the
+// timestamp is content (it's what marks the line as a continuation).
+const TIMESTAMP_RE = /^\[\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?\]/;
+
+/** Strip ANSI (both escape forms), trailing CR/LF, and the timestamp prefix. */
+export function normalizeLogLine(line: string): string {
+  return stripAnsi(line)
+    .replace(/[\r\n]+$/, "")
+    .replace(TIMESTAMP_RE, "");
+}
+
+// One entry per crash shape; tested per normalized line. Anchored patterns
+// stay anchored (a prose sentence mentioning "Backtrace" must not trip the
+// detector — the address pair requirement guards the unanchored ones).
+const CRASH_MARKERS: readonly RegExp[] = [
+  /Guru Meditation Error/, // esp32 panic banner
+  /Backtrace:\s*0x[0-9a-fA-F]{8}:0x[0-9a-fA-F]{8}/, // esp32 single-line backtrace
+  /^BT\d+:\s*0x[0-9a-fA-F]{8}/, // stored previous-boot backtrace (crash handler)
+  /^last failed alloc call: 4[0-9a-fA-F]{7}\(\d+\)/, // esp32 bad-alloc
+  /abort\(\) was called/, // esp-idf abort
+  /^assert failed:/, // esp-idf assertion
+  /^Core\s+\d+ register dump:/, // xtensa/riscv register dump header
+  /^MEPC\s*:\s*0x/, // riscv register dump
+  /CORRUPT HEAP/, // esp-idf heap poisoning check
+  /^Exception \(\d+\):/, // esp8266 exception header
+  />>>stack>>>/, // esp8266 stack dump start
+  /^Fatal exception/, // esp8266 postmortem banner
+  /Soft WDT reset/, // esp8266 software watchdog
+  /Stack smashing protect failure/, // esp8266 stack smashing
+];
+
+/** True when a normalized line is a crash marker. */
+export function isCrashMarker(line: string): boolean {
+  return CRASH_MARKERS.some((re) => re.test(line));
+}
+
+/** Terminators of a crash dump — the excerpt window closes here. */
+export const CRASH_END_RE = /<<<stack<<<|^ELF file SHA256:|^Rebooting\.\.\./;
+
+/**
+ * Session-scoped crash latch fed from the log dialog's append path.
+ *
+ * Stays cheap on hot streams: one pass over each appended batch and a
+ * full short-circuit once a crash has been seen.
+ */
+export class CrashDetector {
+  private _detected = false;
+
+  /** Scan a batch of raw (ANSI/timestamped) lines. */
+  feed(lines: string[]): void {
+    if (this._detected) return;
+    for (const line of lines) {
+      if (isCrashMarker(normalizeLogLine(line))) {
+        this._detected = true;
+        return;
+      }
+    }
+  }
+
+  get detected(): boolean {
+    return this._detected;
+  }
+
+  reset(): void {
+    this._detected = false;
+  }
+}

--- a/src/util/crash-detector.ts
+++ b/src/util/crash-detector.ts
@@ -11,6 +11,8 @@ import { stripAnsi } from "./ansi-escapes.js";
  * ...). Matching runs against `normalizeLogLine` output so the same
  * pattern hits regardless of transport (raw UART bytes vs the
  * backend's `\033`-literal ANSI vs the dialog's timestamp prefix).
+ * The logs dialog latches on the first hit, so on hot streams this is
+ * one batch scan until a crash is seen and zero cost after.
  */
 
 // The dialog prepends `[HH:MM:SS]` (optionally with millis) to every line.
@@ -50,34 +52,7 @@ export function isCrashMarker(line: string): boolean {
   return CRASH_MARKERS.some((re) => re.test(line));
 }
 
-/** Terminators of a crash dump — the excerpt window closes here. */
-export const CRASH_END_RE = /<<<stack<<<|^ELF file SHA256:|^Rebooting\.\.\./;
-
-/**
- * Session-scoped crash latch fed from the log dialog's append path.
- *
- * Stays cheap on hot streams: one pass over each appended batch and a
- * full short-circuit once a crash has been seen.
- */
-export class CrashDetector {
-  private _detected = false;
-
-  /** Scan a batch of raw (ANSI/timestamped) lines. */
-  feed(lines: string[]): void {
-    if (this._detected) return;
-    for (const line of lines) {
-      if (isCrashMarker(normalizeLogLine(line))) {
-        this._detected = true;
-        return;
-      }
-    }
-  }
-
-  get detected(): boolean {
-    return this._detected;
-  }
-
-  reset(): void {
-    this._detected = false;
-  }
+/** True when any raw (ANSI/timestamped) line in the batch is a crash marker. */
+export function hasCrashMarker(lines: string[]): boolean {
+  return lines.some((line) => isCrashMarker(normalizeLogLine(line)));
 }

--- a/src/util/crash-detector.ts
+++ b/src/util/crash-detector.ts
@@ -27,32 +27,59 @@ export function normalizeLogLine(line: string): string {
     .replace(TIMESTAMP_RE, "");
 }
 
+/**
+ * "live" = the panic scrolled past in this session; "previous-boot" =
+ * the crash handler's stored report replayed at boot. The callout wording
+ * differs — one is happening now, the other already rebooted.
+ */
+export type CrashKind = "live" | "previous-boot";
+
+// The stored previous-boot crash report replays through ESPHome's logger,
+// so those lines carry a `[E][esp32.crash:NNN]:` header. Anchored markers
+// tolerate one optional level/tag prefix so both raw panic output and the
+// logger-replayed form match.
+const TAG = /(?:\[[A-Z]{1,2}\]\[[^\]]*\]:\s*)?/.source;
+const tagged = (source: string): RegExp => new RegExp(`^${TAG}${source}`);
+
 // One entry per crash shape; tested per normalized line. Anchored patterns
 // stay anchored (a prose sentence mentioning "Backtrace" must not trip the
 // detector — the address pair requirement guards the unanchored ones).
-const CRASH_MARKERS: readonly RegExp[] = [
-  /Guru Meditation Error/, // esp32 panic banner
-  /Backtrace:\s*0x[0-9a-fA-F]{8}:0x[0-9a-fA-F]{8}/, // esp32 single-line backtrace
-  /^BT\d+:\s*0x[0-9a-fA-F]{8}/, // stored previous-boot backtrace (crash handler)
-  /^last failed alloc call: 4[0-9a-fA-F]{7}\(\d+\)/, // esp32 bad-alloc
-  /abort\(\) was called/, // esp-idf abort
-  /^assert failed:/, // esp-idf assertion
-  /^Core\s+\d+ register dump:/, // xtensa/riscv register dump header
-  /^MEPC\s*:\s*0x/, // riscv register dump
-  /CORRUPT HEAP/, // esp-idf heap poisoning check
-  /^Exception \(\d+\):/, // esp8266 exception header
-  />>>stack>>>/, // esp8266 stack dump start
-  /^Fatal exception/, // esp8266 postmortem banner
-  /Soft WDT reset/, // esp8266 software watchdog
-  /Stack smashing protect failure/, // esp8266 stack smashing
+const CRASH_MARKERS: ReadonlyArray<[RegExp, CrashKind]> = [
+  [/Guru Meditation Error/, "live"], // esp32 panic banner
+  [/\*\*\* CRASH DETECTED/, "previous-boot"], // crash handler's report banner
+  [/Backtrace:\s*0x[0-9a-fA-F]{8}:0x[0-9a-fA-F]{8}/, "live"], // esp32 backtrace
+  [tagged("BT\\d+:\\s*0x[0-9a-fA-F]{8}"), "previous-boot"], // stored backtrace
+  [tagged("last failed alloc call: 4[0-9a-fA-F]{7}\\(\\d+\\)"), "live"], // bad-alloc
+  [/abort\(\) was called/, "live"], // esp-idf abort
+  [tagged("assert failed:"), "live"], // esp-idf assertion
+  [tagged("Core\\s+\\d+ register dump:"), "live"], // xtensa/riscv register dump
+  [tagged("MEPC\\s*:\\s*0x"), "live"], // riscv register dump
+  [/CORRUPT HEAP/, "live"], // esp-idf heap poisoning check
+  [tagged("Exception \\(\\d+\\):"), "live"], // esp8266 exception header
+  [/>>>stack>>>/, "live"], // esp8266 stack dump start
+  [tagged("Fatal exception"), "live"], // esp8266 postmortem banner
+  [/Soft WDT reset/, "live"], // esp8266 software watchdog
+  [/Stack smashing protect failure/, "live"], // esp8266 stack smashing
 ];
 
-/** True when a normalized line is a crash marker. */
+/** True when a normalized line is a crash marker (either kind). */
 export function isCrashMarker(line: string): boolean {
-  return CRASH_MARKERS.some((re) => re.test(line));
+  return CRASH_MARKERS.some(([re]) => re.test(line));
 }
 
-/** True when any raw (ANSI/timestamped) line in the batch is a crash marker. */
-export function hasCrashMarker(lines: string[]): boolean {
-  return lines.some((line) => isCrashMarker(normalizeLogLine(line)));
+/**
+ * Classify a batch of raw (ANSI/timestamped) lines. "live" wins over
+ * "previous-boot" when both appear; null when no marker matched.
+ */
+export function detectCrashKind(lines: string[]): CrashKind | null {
+  let kind: CrashKind | null = null;
+  for (const line of lines) {
+    const normalized = normalizeLogLine(line);
+    for (const [re, markerKind] of CRASH_MARKERS) {
+      if (!re.test(normalized)) continue;
+      if (markerKind === "live") return "live";
+      kind = markerKind;
+    }
+  }
+  return kind;
 }

--- a/src/util/crash-detector.ts
+++ b/src/util/crash-detector.ts
@@ -37,9 +37,10 @@ export type CrashKind = "live" | "previous-boot";
 // The stored previous-boot crash report replays through ESPHome's logger,
 // so those lines carry a `[E][esp32.crash:NNN]:` header. Anchored markers
 // tolerate one optional level/tag prefix so both raw panic output and the
-// logger-replayed form match.
-const TAG = /(?:\[[A-Z]{1,2}\]\[[^\]]*\]:\s*)?/.source;
-const tagged = (source: string): RegExp => new RegExp(`^${TAG}${source}`);
+// logger-replayed form match. Exported so crash-report can build the same
+// tagged shapes without re-typing the grammar.
+export const TAG = /(?:\[[A-Z]{1,2}\]\[[^\]]*\]:\s*)?/.source;
+export const tagged = (source: string): RegExp => new RegExp(`^${TAG}${source}`);
 
 // One entry per crash shape; tested per normalized line. Anchored patterns
 // stay anchored (a prose sentence mentioning "Backtrace" must not trip the

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -414,9 +414,7 @@ export function buildIssueUrl(report: CrashReport): IssueUrl {
   // downloaded report on request. Drop trailing sections until the note
   // fits so prepending it can't push the URL over budget.
   if (missing) {
-    const note =
-      "(Some sections were truncated to fit this pre-filled form; the " +
-      "reporter has the full crash report and can attach it on request.)";
+    const note = "(Truncated to fit; full report available on request.)";
     for (;;) {
       params.set("additional", [note, ...extras].join("\n\n"));
       if (url.toString().length <= MAX_ISSUE_URL_LENGTH || extras.length === 0) break;

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -173,7 +173,14 @@ function extractTaggedLines(lines: string[]): {
   const configLines: string[] = [];
   for (const line of lines) {
     const match = TAGGED_LINE_RE.exec(line);
-    if (match) appendFolded(match[1] === "C" ? configLines : warnings, line);
+    if (!match) continue;
+    if (match[1] === "C") {
+      // Config-dump lines are structured output, not spam — keep them
+      // verbatim (folding would silently collapse repeated values).
+      configLines.push(line);
+    } else {
+      appendFolded(warnings, line);
+    }
   }
   return { warnings, configLines };
 }
@@ -328,11 +335,11 @@ export function buildIssueUrl(report: CrashReport): IssueUrl {
   const component = inferComponentName(scrape.decodedFrames);
   if (component) params.set("component_name", component);
   const platform = issuePlatform(meta.targetPlatform);
-  let missing = scrape.decodedFrames.length > MAX_PROBLEM_FRAMES;
+  let missing = false;
 
   // The user's own context leads the problem field, then the platform /
   // installation the dropdowns can't be prefilled with, then the trace.
-  const problem: string[] = report.userDescription
+  const head: string[] = report.userDescription
     ? [report.userDescription, "", "(Crash detected in the Device Builder log viewer.)"]
     : [`The device crashed (crash detected in the Device Builder log viewer).`];
   const facts = [
@@ -342,15 +349,11 @@ export function buildIssueUrl(report: CrashReport): IssueUrl {
     meta.deployedVersion && `${meta.deployedVersion} (running)`,
     meta.board && `Board: ${meta.board}`,
   ].filter(Boolean);
-  problem.push("", ...facts.map((fact) => `- ${fact}`));
-  if (scrape.decodedFrames.length > 0) {
-    problem.push(
-      "",
-      "Decoded backtrace:",
-      ...scrape.decodedFrames.slice(0, MAX_PROBLEM_FRAMES)
-    );
-  }
-  params.set("problem", problem.join("\n"));
+  head.push("", ...facts.map((fact) => `- ${fact}`));
+  // `problem` is set first but still bounded: a long description and/or
+  // many long decoded frames could blow the budget before logs/config
+  // trim. Drop trailing frames (then hard-truncate) until it fits.
+  if (fitProblem(url, params, head, scrape.decodedFrames)) missing = true;
 
   // The crash logs get first claim on the budget: they're a one-time
   // capture, whereas the config can always be re-obtained from the YAML
@@ -433,6 +436,46 @@ export function buildIssueUrl(report: CrashReport): IssueUrl {
     }
   }
   return { url: url.toString(), complete: !missing };
+}
+
+/**
+ * Set the `problem` param to *head* plus as many decoded *frames* as the
+ * URL budget allows, dropping trailing frames (then hard-truncating the
+ * text) until it fits. Returns true when anything was dropped/truncated.
+ */
+function fitProblem(
+  url: URL,
+  params: URLSearchParams,
+  head: string[],
+  frames: string[]
+): boolean {
+  let used = Math.min(frames.length, MAX_PROBLEM_FRAMES);
+  let dropped = frames.length > used;
+  for (;;) {
+    const body = used > 0 ? ["", "Decoded backtrace:", ...frames.slice(0, used)] : [];
+    const note =
+      frames.length > used
+        ? ["", `(+${frames.length - used} more frames in the report)`]
+        : [];
+    params.set("problem", [...head, ...body, ...note].join("\n"));
+    if (url.toString().length <= MAX_ISSUE_URL_LENGTH || used === 0) break;
+    used = Math.max(0, used - 4);
+    dropped = true;
+  }
+  if (url.toString().length <= MAX_ISSUE_URL_LENGTH) return dropped;
+  // Even head-only overflows (a huge description): hard-truncate to fit.
+  params.set("problem", "");
+  const budget = MAX_ISSUE_URL_LENGTH - url.toString().length;
+  const text = head.join("\n");
+  let end = Math.max(0, Math.min(text.length, budget - 20));
+  while (
+    end > 0 &&
+    encodeURIComponent(`${text.slice(0, end)}\n…[truncated]`).length > budget
+  ) {
+    end -= 32;
+  }
+  params.set("problem", `${text.slice(0, Math.max(0, end))}\n…[truncated]`);
+  return true;
 }
 
 const CONFIG_TRUNCATED_NOTE = "# [config truncated to fit the pre-filled URL]";

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -418,14 +418,18 @@ export function buildIssueUrl(report: CrashReport): IssueUrl {
 
   // When content was truncated, a note (for the maintainer reading the
   // issue) leads the additional field; the reporter can attach the
-  // downloaded report on request. Drop trailing sections until the note
-  // fits so prepending it can't push the URL over budget.
+  // downloaded report on request. Drop trailing sections until it fits,
+  // and drop `additional` entirely if even the note alone overflows.
   if (missing) {
-    const note = "(Truncated to fit; full report available on request.)";
+    const withNote = ["(Truncated to fit; full report available on request.)", ...extras];
     for (;;) {
-      params.set("additional", [note, ...extras].join("\n\n"));
-      if (url.toString().length <= MAX_ISSUE_URL_LENGTH || extras.length === 0) break;
-      extras.pop();
+      params.set("additional", withNote.join("\n\n"));
+      if (url.toString().length <= MAX_ISSUE_URL_LENGTH) break;
+      if (withNote.length === 1) {
+        params.delete("additional");
+        break;
+      }
+      withNote.pop();
     }
   }
   return { url: url.toString(), complete: !missing };

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -22,12 +22,8 @@ const CRASH_END_RE = /<<<stack<<<|^ELF file SHA256:|^Rebooting\.\.\./;
 const MAX_ISSUE_URL_LENGTH = 8000;
 
 // Cap on decoded frames placed in the issue's `problem` field; the full
-// list always rides in the clipboard report.
+// list always rides in the downloadable report.
 const MAX_PROBLEM_FRAMES = 40;
-
-// Prefilling the YAML Config box must still leave room for a meaningful
-// crash-log excerpt in the `logs` field.
-const MIN_LOGS_BUDGET = 1500;
 
 const ISSUE_URL_BASE =
   "https://github.com/esphome/esphome/issues/new?template=bug_report.yml";
@@ -356,21 +352,12 @@ export function buildIssueUrl(report: CrashReport): IssueUrl {
   }
   params.set("problem", problem.join("\n"));
 
-  // The sanitized YAML goes into the form's YAML Config box, truncated
-  // line-wise with a marker when it can't fit whole alongside a useful
-  // log excerpt — the downloadable report always carries the full dump.
-  const configYaml = report.configYaml.trimEnd();
-  if (configYaml) {
-    const configBudget = MAX_ISSUE_URL_LENGTH - url.toString().length - MIN_LOGS_BUDGET;
-    const fitted = fitConfig(configYaml, configBudget);
-    if (fitted.text) params.set("config", fitted.text);
-    if (fitted.truncated) missing = true;
-  }
-
-  // The `logs` field fits the crash block first, then as many preceding
-  // context lines as the budget allows. When the decoded backtrace
-  // already rides in `problem`, its echo lines are dropped here so the
-  // trace appears only once in the issue.
+  // The crash logs get first claim on the budget: they're a one-time
+  // capture, whereas the config can always be re-obtained from the YAML
+  // later. The `logs` field fits the crash block first, then as many
+  // preceding context lines as the budget allows. When the decoded
+  // backtrace already rides in `problem`, its echo lines are dropped
+  // here so the trace appears only once in the issue.
   const { lines: logLines, anchor } =
     scrape.decodedFrames.length > 0
       ? excerptWithoutDecodeEchoes(scrape.excerpt, scrape.crashIndex)
@@ -383,6 +370,17 @@ export function buildIssueUrl(report: CrashReport): IssueUrl {
   } else {
     params.delete("logs");
     if (logLines.length > 0) missing = true;
+  }
+
+  // The sanitized YAML takes whatever budget the logs left, truncated
+  // (with a marker) when it can't fit whole — the full dump is always in
+  // the downloadable report, and the config is recoverable from the YAML
+  // regardless. Secrets are already redacted to `<removed>`.
+  const configYaml = report.configYaml.trimEnd();
+  if (configYaml) {
+    const fitted = fitConfig(configYaml, MAX_ISSUE_URL_LENGTH - url.toString().length);
+    if (fitted.text) params.set("config", fitted.text);
+    if (fitted.truncated) missing = true;
   }
 
   // Pack the supplementary sections into `additional`, whole sections

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -375,11 +375,18 @@ export function buildIssueUrl(report: CrashReport): IssueUrl {
   // The sanitized YAML takes whatever budget the logs left, truncated
   // (with a marker) when it can't fit whole — the full dump is always in
   // the downloadable report, and the config is recoverable from the YAML
-  // regardless. Secrets are already redacted to `<removed>`.
+  // regardless. Secrets are already redacted to `<removed>`. Set an empty
+  // `config` param first so the `&config=` key overhead is counted in the
+  // measured budget, keeping the final URL reliably under the cap.
   const configYaml = report.configYaml.trimEnd();
   if (configYaml) {
+    params.set("config", "");
     const fitted = fitConfig(configYaml, MAX_ISSUE_URL_LENGTH - url.toString().length);
-    if (fitted.text) params.set("config", fitted.text);
+    if (fitted.text) {
+      params.set("config", fitted.text);
+    } else {
+      params.delete("config");
+    }
     if (fitted.truncated) missing = true;
   }
 

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -16,19 +16,39 @@ const MAX_LINES_AFTER_MARKER = 60;
 // Terminators of a crash dump — the excerpt window closes here.
 const CRASH_END_RE = /<<<stack<<<|^ELF file SHA256:|^Rebooting\.\.\./;
 
-// Total pre-filled URL budget. GitHub 414s somewhere past ~8k; staying
-// at 6k leaves headroom for their own redirect/query additions.
-const MAX_ISSUE_URL_LENGTH = 6000;
+// Total pre-filled URL budget. GitHub's server returns 414 past roughly
+// 8 KB of URL; 8000 keeps a small margin for their redirect/query
+// additions while fitting as much of the report as possible.
+const MAX_ISSUE_URL_LENGTH = 8000;
 
 // Cap on decoded frames placed in the issue's `problem` field; the full
 // list always rides in the clipboard report.
 const MAX_PROBLEM_FRAMES = 40;
 
+// Prefilling the YAML Config box must still leave room for a meaningful
+// crash-log excerpt in the `logs` field.
+const MIN_LOGS_BUDGET = 1500;
+
 const ISSUE_URL_BASE =
   "https://github.com/esphome/esphome/issues/new?template=bug_report.yml";
 
-// esphome logs' inline decoder emits `WARNING Decoded 0x...: func at file:line`.
+// esphome logs' inline decoder emits `WARNING Decoded 0x...: func at
+// file:line`, with ` (inlined by) ...` continuation lines for inlined frames.
 const DECODED_RE = /^(?:WARNING )?Decoded (0x[0-9a-fA-F]{8}.*)$/;
+const DECODED_CONTINUATION_RE = /^\s*\(inlined by\)/;
+
+// Lines that merely echo the backtrace the `problem` field already
+// carries in decoded form: the decode output itself, its progress
+// chatter, and the raw BT<n> address lines (optionally logger-tagged).
+const DECODE_ECHO_RES = [
+  DECODED_RE,
+  DECODED_CONTINUATION_RE,
+  /^(?:WARNING )?Found stack trace/,
+  /^(?:\[[A-Z]{1,2}\]\[[^\]]*\]:\s*)?BT\d+:\s*0x[0-9a-fA-F]{8}/,
+];
+
+const isDecodeEcho = (line: string): boolean =>
+  DECODE_ECHO_RES.some((re) => re.test(line));
 
 // A line that carries crash payload past the marker: any 8-hex-digit
 // address (registers, stack dumps, backtrace continuations) or a
@@ -65,7 +85,8 @@ export interface CrashReportMeta {
   dashboardVersion: string;
   targetPlatform: string;
   board: string;
-  isHaAddon: boolean;
+  /** Bug-form installation dropdown value; "" when unknown (desktop). */
+  installation: string;
 }
 
 export interface CrashScrape {
@@ -129,9 +150,17 @@ function extractCrashExcerpt(lines: string[]): { lines: string[]; crashIndex: nu
 
 function extractDecodedFrames(excerpt: string[]): string[] {
   const frames: string[] = [];
+  let inFrame = false;
   for (const line of excerpt) {
     const match = DECODED_RE.exec(line);
-    if (match) frames.push(match[1]);
+    if (match) {
+      frames.push(match[1]);
+      inFrame = true;
+    } else if (inFrame && DECODED_CONTINUATION_RE.test(line)) {
+      frames[frames.length - 1] += `\n  ${line.trim()}`;
+    } else {
+      inFrame = false;
+    }
   }
   return frames;
 }
@@ -178,6 +207,25 @@ export interface CrashReport {
   meta: CrashReportMeta;
   /** Sanitized `esphome config` dump; "" when unavailable. */
   configYaml: string;
+  /** The user's own account of what the device was doing when it crashed. */
+  userDescription: string;
+}
+
+// Every platform component that can appear in `loaded_integrations`;
+// fallback source for devices whose `target_platform` field is empty.
+const PLATFORM_INTEGRATIONS = [
+  "esp32",
+  "esp8266",
+  "rp2040",
+  "bk72xx",
+  "rtl87xx",
+  "ln882x",
+  "host",
+];
+
+/** Platform name from the integration list, for empty `target_platform`. */
+export function platformFromIntegrations(integrations: string[]): string {
+  return PLATFORM_INTEGRATIONS.find((platform) => integrations.includes(platform)) ?? "";
 }
 
 /** Component owning the top decoded frame, for the form's component field. */
@@ -200,6 +248,9 @@ const fence = (lines: string[], language = "text"): string =>
 export function buildFullReport(report: CrashReport): string {
   const { scrape, meta, configYaml } = report;
   const sections: string[] = [`# Crash report: ${meta.deviceName}`];
+  if (report.userDescription) {
+    sections.push("## What happened", report.userDescription);
+  }
   sections.push("## Decoded backtrace");
   if (scrape.decodedFrames.length > 0) {
     sections.push(fence(scrape.decodedFrames));
@@ -228,19 +279,20 @@ export function buildFullReport(report: CrashReport): string {
       ? fence([configYaml.trimEnd()], "yaml")
       : "The configuration could not be validated when this report was created."
   );
-  sections.push(
-    "## Environment",
-    [
-      `- Device: ${meta.deviceName} (${meta.configuration})`,
-      `- Board: ${meta.board || "unknown"}`,
-      `- Platform: ${meta.targetPlatform || "unknown"}`,
-      `- ESPHome (compiled): ${meta.esphomeVersion || "unknown"}`,
-      `- ESPHome (running): ${meta.deployedVersion || "unknown"}`,
-      `- Device Builder: ${meta.dashboardVersion || "unknown"}` +
-        (meta.isHaAddon ? " (Home Assistant add-on)" : ""),
-    ].join("\n")
-  );
+  sections.push("## Environment", environmentSection(meta));
   return `${sections.join("\n\n")}\n`;
+}
+
+function environmentSection(meta: CrashReportMeta): string {
+  return [
+    `- Device: ${meta.deviceName} (${meta.configuration})`,
+    `- Board: ${meta.board || "unknown"}`,
+    `- Platform: ${meta.targetPlatform || "unknown"}`,
+    `- ESPHome (compiled): ${meta.esphomeVersion || "unknown"}`,
+    `- ESPHome (running): ${meta.deployedVersion || "unknown"}`,
+    `- Device Builder: ${meta.dashboardVersion || "unknown"}` +
+      (meta.installation ? ` (${meta.installation})` : ""),
+  ].join("\n");
 }
 
 /** Issue title: the crash banner line when present, else a generic one. */
@@ -251,31 +303,41 @@ function buildIssueTitle(report: CrashReport): string {
   return title.length > 100 ? `${title.slice(0, 97)}...` : title;
 }
 
+export interface IssueUrl {
+  url: string;
+  /** False when some report content was truncated to fit the URL. */
+  complete: boolean;
+}
+
 /**
- * Pre-filled issue-form URL. Everything except the crash excerpt is
- * fixed; the excerpt fills whatever budget remains under
- * MAX_ISSUE_URL_LENGTH, prioritizing the crash block over the context
- * lines that precede it.
+ * Pre-filled issue-form URL — the sole delivery channel (URL prefill
+ * survives GitHub's form rehydration; manual pasting does not). Field
+ * priority under the budget: problem (description + decoded backtrace,
+ * fixed), config (truncated with a marker when needed), logs (crash
+ * excerpt, elastic), then the supplementary sections (environment,
+ * warnings, config dump) packed whole-section-at-a-time into
+ * `additional`. Truncated content stays available via the downloadable
+ * report.
  */
-export function buildIssueUrl(
-  report: CrashReport,
-  fullReportDelivery: "clipboard" | "download"
-): string {
+export function buildIssueUrl(report: CrashReport): IssueUrl {
   const { scrape, meta } = report;
   const url = new URL(ISSUE_URL_BASE);
   const params = url.searchParams;
   params.set("title", buildIssueTitle(report));
   const version = meta.esphomeVersion || meta.deployedVersion;
   if (version) params.set("version", version);
-  if (meta.isHaAddon) params.set("installation", "Home Assistant Add-on");
+  if (meta.installation) params.set("installation", meta.installation);
   const platform = issuePlatform(meta.targetPlatform);
   if (platform) params.set("platform", platform);
   const component = inferComponentName(scrape.decodedFrames);
   if (component) params.set("component_name", component);
+  let missing = scrape.decodedFrames.length > MAX_PROBLEM_FRAMES;
 
-  const problem: string[] = [
-    `The device crashed (crash detected in the Device Builder log viewer).`,
-  ];
+  // The user's own context leads the problem field; the technical
+  // payload follows it.
+  const problem: string[] = report.userDescription
+    ? [report.userDescription, "", "(Crash detected in the Device Builder log viewer.)"]
+    : [`The device crashed (crash detected in the Device Builder log viewer).`];
   if (scrape.decodedFrames.length > 0) {
     problem.push(
       "",
@@ -284,47 +346,144 @@ export function buildIssueUrl(
     );
   }
   params.set("problem", problem.join("\n"));
-  params.set(
-    "additional",
-    fullReportDelivery === "clipboard"
-      ? "The full crash report (decoded backtrace, warnings/errors, config dump, " +
-          "sanitized YAML config) was copied to the clipboard by ESPHome Device " +
-          "Builder. Please paste it here."
-      : "The full crash report was saved as a markdown file by ESPHome Device " +
-          "Builder. Please attach or paste it here."
-  );
 
-  // The `logs` field is the elastic part: fit the crash block first,
-  // then as many preceding context lines as the budget allows.
+  // The sanitized YAML goes into the form's YAML Config box, truncated
+  // line-wise with a marker when it can't fit whole alongside a useful
+  // log excerpt — the downloadable report always carries the full dump.
+  const configYaml = report.configYaml.trimEnd();
+  if (configYaml) {
+    const configBudget = MAX_ISSUE_URL_LENGTH - url.toString().length - MIN_LOGS_BUDGET;
+    const fitted = fitConfig(configYaml, configBudget);
+    if (fitted.text) params.set("config", fitted.text);
+    if (fitted.truncated) missing = true;
+  }
+
+  // The `logs` field fits the crash block first, then as many preceding
+  // context lines as the budget allows. When the decoded backtrace
+  // already rides in `problem`, its echo lines are dropped here so the
+  // trace appears only once in the issue.
+  const { lines: logLines, anchor } =
+    scrape.decodedFrames.length > 0
+      ? excerptWithoutDecodeEchoes(scrape.excerpt, scrape.crashIndex)
+      : { lines: scrape.excerpt, anchor: Math.max(0, scrape.crashIndex) };
   params.set("logs", "");
-  const overhead = url.toString().length;
-  const budget = MAX_ISSUE_URL_LENGTH - overhead;
-  const logs = fitLines(scrape.excerpt, Math.max(0, scrape.crashIndex), budget);
+  const logs = fitLines(logLines, anchor, MAX_ISSUE_URL_LENGTH - url.toString().length);
   if (logs) {
     params.set("logs", logs);
+    if (logs.includes(TRIM_MARKER)) missing = true;
   } else {
     params.delete("logs");
+    if (logLines.length > 0) missing = true;
   }
-  return url.toString();
+
+  // Pack the supplementary sections into `additional`, whole sections
+  // at a time, so the common case needs no manual paste at all.
+  const extras: string[] = [];
+  const tryAddSection = (text: string): void => {
+    params.set("additional", [...extras, text].join("\n\n"));
+    if (url.toString().length <= MAX_ISSUE_URL_LENGTH) {
+      extras.push(text);
+      return;
+    }
+    missing = true;
+    if (extras.length > 0) {
+      params.set("additional", extras.join("\n\n"));
+    } else {
+      params.delete("additional");
+    }
+  };
+  tryAddSection(`Environment:\n${environmentSection(meta)}`);
+  if (scrape.warnings.length > 0) {
+    tryAddSection(`Warnings and errors:\n${fence(scrape.warnings)}`);
+  }
+  if (scrape.configLines.length > 0) {
+    tryAddSection(`Config dump:\n${fence(scrape.configLines)}`);
+  }
+
+  // When content was truncated, a note (for the maintainer reading the
+  // issue) leads the additional field; the reporter can attach the
+  // downloaded report on request. Drop trailing sections until the note
+  // fits so prepending it can't push the URL over budget.
+  if (missing) {
+    const note =
+      "(Some sections were truncated to fit this pre-filled form; the " +
+      "reporter has the full crash report and can attach it on request.)";
+    for (;;) {
+      params.set("additional", [note, ...extras].join("\n\n"));
+      if (url.toString().length <= MAX_ISSUE_URL_LENGTH || extras.length === 0) break;
+      extras.pop();
+    }
+  }
+  return { url: url.toString(), complete: !missing };
+}
+
+const CONFIG_TRUNCATED_NOTE = "# [config truncated to fit the pre-filled URL]";
+
+function fitConfig(yaml: string, budget: number): { text: string; truncated: boolean } {
+  if (budget <= 0) return { text: "", truncated: true };
+  if (encodeURIComponent(yaml).length <= budget) return { text: yaml, truncated: false };
+  const kept: string[] = [];
+  let spent = encodedCost(CONFIG_TRUNCATED_NOTE);
+  for (const line of yaml.split("\n")) {
+    const lineCost = encodedCost(line);
+    if (spent + lineCost > budget) break;
+    kept.push(line);
+    spent += lineCost;
+  }
+  if (kept.length === 0) return { text: "", truncated: true };
+  kept.push(CONFIG_TRUNCATED_NOTE);
+  return { text: kept.join("\n"), truncated: true };
+}
+
+function excerptWithoutDecodeEchoes(
+  excerpt: string[],
+  crashIndex: number
+): { lines: string[]; anchor: number } {
+  const lines: string[] = [];
+  let anchor = 0;
+  for (let i = 0; i < excerpt.length; i++) {
+    if (isDecodeEcho(excerpt[i])) continue;
+    if (i <= crashIndex) anchor = lines.length;
+    lines.push(excerpt[i]);
+  }
+  return { lines, anchor: Math.min(anchor, Math.max(0, lines.length - 1)) };
 }
 
 const TRIM_MARKER = "[log excerpt trimmed; full logs in the attached report]";
+
+const encodedCost = (line: string): number => encodeURIComponent(`${line}\n`).length;
 
 /**
  * Join as much of *lines* as fits *budget* once URL-encoded: the block
  * from *anchor* to the end first (truncating its tail if even that
  * overflows), then context lines walking backwards from the anchor.
+ *
+ * Two passes: the first spends the whole budget on content; only when
+ * that truncates does the second re-fit with the trim marker's cost
+ * reserved, so the marker never pushes the result past the budget and
+ * an untrimmed excerpt never sacrifices content to an unused reserve.
  */
 function fitLines(lines: string[], anchor: number, budget: number): string {
   if (lines.length === 0 || budget <= 0) return "";
-  const cost = (line: string): number => encodeURIComponent(`${line}\n`).length;
+  let fit = fitWithReserve(lines, anchor, budget, 0);
+  if (fit.truncated) {
+    fit = fitWithReserve(lines, anchor, budget, encodedCost(TRIM_MARKER));
+    fit.kept.push(TRIM_MARKER);
+  }
+  return fit.kept.length > (fit.truncated ? 1 : 0) ? fit.kept.join("\n") : "";
+}
+
+function fitWithReserve(
+  lines: string[],
+  anchor: number,
+  budget: number,
+  reserve: number
+): { kept: string[]; truncated: boolean } {
   const kept: string[] = [];
-  // Reserve the marker's cost up front so appending it on truncation
-  // can't push the result past the budget.
-  let spent = cost(TRIM_MARKER);
+  let spent = reserve;
   let truncated = false;
   for (let i = anchor; i < lines.length; i++) {
-    const lineCost = cost(lines[i]);
+    const lineCost = encodedCost(lines[i]);
     if (spent + lineCost > budget) {
       truncated = true;
       break;
@@ -333,7 +492,7 @@ function fitLines(lines: string[], anchor: number, budget: number): string {
     spent += lineCost;
   }
   for (let i = anchor - 1; i >= 0; i--) {
-    const lineCost = cost(lines[i]);
+    const lineCost = encodedCost(lines[i]);
     if (spent + lineCost > budget) {
       truncated = true;
       break;
@@ -341,7 +500,5 @@ function fitLines(lines: string[], anchor: number, budget: number): string {
     kept.unshift(lines[i]);
     spent += lineCost;
   }
-  if (kept.length === 0) return "";
-  if (truncated) kept.push(TRIM_MARKER);
-  return kept.join("\n");
+  return { kept, truncated };
 }

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -308,6 +308,8 @@ export function buildIssueUrl(
   return url.toString();
 }
 
+const TRIM_MARKER = "[log excerpt trimmed; full logs in the attached report]";
+
 /**
  * Join as much of *lines* as fits *budget* once URL-encoded: the block
  * from *anchor* to the end first (truncating its tail if even that
@@ -317,7 +319,9 @@ function fitLines(lines: string[], anchor: number, budget: number): string {
   if (lines.length === 0 || budget <= 0) return "";
   const cost = (line: string): number => encodeURIComponent(`${line}\n`).length;
   const kept: string[] = [];
-  let spent = 0;
+  // Reserve the marker's cost up front so appending it on truncation
+  // can't push the result past the budget.
+  let spent = cost(TRIM_MARKER);
   let truncated = false;
   for (let i = anchor; i < lines.length; i++) {
     const lineCost = cost(lines[i]);
@@ -338,6 +342,6 @@ function fitLines(lines: string[], anchor: number, budget: number): string {
     spent += lineCost;
   }
   if (kept.length === 0) return "";
-  if (truncated) kept.push("[log excerpt trimmed; full logs in the attached report]");
+  if (truncated) kept.push(TRIM_MARKER);
   return kept.join("\n");
 }

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -1,0 +1,333 @@
+import { CRASH_END_RE, isCrashMarker, normalizeLogLine } from "./crash-detector.js";
+
+/**
+ * Crash-report assembly: scrape the log buffer the user is already
+ * looking at into a structured report, then render it two ways — a
+ * complete markdown document (clipboard / download) and a pre-filled
+ * GitHub issue URL against esphome/esphome's bug-report form.
+ */
+
+// Context kept ahead of the first crash marker, and the hard cap on how
+// far past it the excerpt extends when no explicit end marker arrives.
+const CONTEXT_LINES_BEFORE = 25;
+const MAX_LINES_AFTER_MARKER = 60;
+
+// Total pre-filled URL budget. GitHub 414s somewhere past ~8k; staying
+// at 6k leaves headroom for their own redirect/query additions.
+const MAX_ISSUE_URL_LENGTH = 6000;
+
+// Cap on decoded frames placed in the issue's `problem` field; the full
+// list always rides in the clipboard report.
+const MAX_PROBLEM_FRAMES = 40;
+
+const ISSUE_URL_BASE =
+  "https://github.com/esphome/esphome/issues/new?template=bug_report.yml";
+
+// esphome logs' inline decoder emits `WARNING Decoded 0x...: func at file:line`.
+const DECODED_RE = /^(?:WARNING )?Decoded (0x[0-9a-fA-F]{8}.*)$/;
+
+// A line that carries crash payload past the marker: any 8-hex-digit
+// address (registers, stack dumps, backtrace continuations) or a
+// decoded frame.
+const CRASH_RELATED_RE = /(?:0x)?[0-9a-fA-F]{8}(?::|\b)|Decoded 0x/;
+
+const TAGGED_LINE_RE = /^\[([CWE])\]\[[^\]]*\]/;
+
+/** `target_platform` → the bug form's platform dropdown values. */
+export const ISSUE_PLATFORM_MAP: ReadonlyArray<[RegExp, string]> = [
+  [/^ESP32/i, "ESP32"],
+  [/^ESP8266$/i, "ESP8266"],
+  [/^RP2040$/i, "RP2040"],
+  [/^BK72XX$/i, "BK72XX"],
+  [/^RTL87XX$/i, "RTL87XX"],
+  [/^LN882X$/i, "LN882X"],
+  [/^HOST$/i, "Host"],
+];
+
+export function issuePlatform(targetPlatform: string): string {
+  if (!targetPlatform) return "";
+  for (const [re, value] of ISSUE_PLATFORM_MAP) {
+    if (re.test(targetPlatform)) return value;
+  }
+  return "Other";
+}
+
+export interface CrashReportMeta {
+  deviceName: string;
+  configuration: string;
+  /** ESPHome version the firmware was compiled with. */
+  esphomeVersion: string;
+  /** Version the device reports it is running ("" unknown). */
+  deployedVersion: string;
+  dashboardVersion: string;
+  targetPlatform: string;
+  board: string;
+  isHaAddon: boolean;
+}
+
+export interface CrashScrape {
+  /** Normalized crash excerpt (context + crash block); [] when the crash
+   *  scrolled out of the capped buffer. */
+  excerpt: string[];
+  crashFound: boolean;
+  /** `0x...: func at file:line` frames from the inline decoder. */
+  decodedFrames: string[];
+  /** All `[W]` / `[E]` lines (continuations attached, duplicates folded). */
+  warnings: string[];
+  /** All `[C]` dump_config lines (continuations attached). */
+  configLines: string[];
+}
+
+/** Scrape everything the report needs out of the raw log buffer. */
+export function scrapeCrashData(rawLines: string[]): CrashScrape {
+  const lines = rawLines.map(normalizeLogLine);
+  const excerpt = extractCrashExcerpt(lines);
+  const { warnings, configLines } = extractTaggedLines(lines);
+  return {
+    excerpt: excerpt.lines,
+    crashFound: excerpt.found,
+    decodedFrames: extractDecodedFrames(excerpt.lines),
+    warnings,
+    configLines,
+  };
+}
+
+function extractCrashExcerpt(lines: string[]): { lines: string[]; found: boolean } {
+  const start = lines.findIndex((line) => isCrashMarker(line));
+  if (start === -1) return { lines: [], found: false };
+  const hardStop = Math.min(lines.length - 1, start + MAX_LINES_AFTER_MARKER);
+  let end = start;
+  for (let i = start; i <= hardStop; i++) {
+    const line = lines[i];
+    if (isCrashMarker(line) || CRASH_RELATED_RE.test(line)) end = i;
+    if (i > start && CRASH_END_RE.test(line)) {
+      end = i;
+      break;
+    }
+  }
+  return {
+    lines: lines.slice(Math.max(0, start - CONTEXT_LINES_BEFORE), end + 1),
+    found: true,
+  };
+}
+
+function extractDecodedFrames(excerpt: string[]): string[] {
+  const frames: string[] = [];
+  for (const line of excerpt) {
+    const match = DECODED_RE.exec(line);
+    if (match) frames.push(match[1]);
+  }
+  return frames;
+}
+
+function extractTaggedLines(lines: string[]): {
+  warnings: string[];
+  configLines: string[];
+} {
+  const warnings: string[] = [];
+  const configLines: string[] = [];
+  let bucket: string[] | null = null;
+  for (const line of lines) {
+    const match = TAGGED_LINE_RE.exec(line);
+    if (match) {
+      bucket = match[1] === "C" ? configLines : warnings;
+      appendFolded(bucket, line);
+    } else if (bucket !== null && /^\s/.test(line)) {
+      // Raw-UART continuations of a multi-line record are indented and
+      // untagged; keep them with their entry line.
+      bucket.push(line);
+    } else {
+      bucket = null;
+    }
+  }
+  return { warnings, configLines };
+}
+
+// Fold an immediate repeat (a warning spamming every loop iteration)
+// into a `(xN)` suffix instead of N rows.
+const FOLD_RE = / \(x(\d+)\)$/;
+
+function appendFolded(bucket: string[], line: string): void {
+  const previous = bucket[bucket.length - 1];
+  if (previous === undefined) {
+    bucket.push(line);
+    return;
+  }
+  const folded = FOLD_RE.exec(previous);
+  const base = folded ? previous.slice(0, -folded[0].length) : previous;
+  if (base !== line) {
+    bucket.push(line);
+    return;
+  }
+  const count = folded ? Number(folded[1]) + 1 : 2;
+  bucket[bucket.length - 1] = `${line} (x${count})`;
+}
+
+export interface CrashReport {
+  scrape: CrashScrape;
+  meta: CrashReportMeta;
+  /** Sanitized `esphome config` dump; "" when unavailable. */
+  configYaml: string;
+}
+
+/** Component owning the top decoded frame, for the form's component field. */
+export function inferComponentName(decodedFrames: string[]): string {
+  for (const frame of decodedFrames) {
+    const match = /esphome\/components\/([a-z0-9_]+)\//.exec(frame);
+    if (match) return match[1];
+  }
+  return "";
+}
+
+const fence = (lines: string[], language = "text"): string =>
+  `\`\`\`${language}\n${lines.join("\n")}\n\`\`\``;
+
+/**
+ * The complete report, ordered decoded-backtrace-first per the issue
+ * triage workflow. Deliberately English-only — it is pasted into a
+ * GitHub issue, not rendered in the dashboard.
+ */
+export function buildFullReport(report: CrashReport): string {
+  const { scrape, meta, configYaml } = report;
+  const sections: string[] = [`# Crash report: ${meta.deviceName}`];
+  sections.push("## Decoded backtrace");
+  if (scrape.decodedFrames.length > 0) {
+    sections.push(fence(scrape.decodedFrames));
+  } else if (scrape.crashFound) {
+    sections.push(
+      "The backtrace was not decoded in this log session (captured over " +
+        "Web Serial, or decoding was unavailable). Raw crash output is below."
+    );
+  } else {
+    sections.push(
+      "The crash scrolled out of the log buffer before the report was created."
+    );
+  }
+  if (scrape.excerpt.length > 0) {
+    sections.push("## Crash log", fence(scrape.excerpt));
+  }
+  if (scrape.warnings.length > 0) {
+    sections.push("## Warnings and errors", fence(scrape.warnings));
+  }
+  if (scrape.configLines.length > 0) {
+    sections.push("## Config dump", fence(scrape.configLines));
+  }
+  sections.push("## Configuration (secrets redacted)");
+  sections.push(
+    configYaml
+      ? fence([configYaml.trimEnd()], "yaml")
+      : "The configuration could not be validated when this report was created."
+  );
+  sections.push(
+    "## Environment",
+    [
+      `- Device: ${meta.deviceName} (${meta.configuration})`,
+      `- Board: ${meta.board || "unknown"}`,
+      `- Platform: ${meta.targetPlatform || "unknown"}`,
+      `- ESPHome (compiled): ${meta.esphomeVersion || "unknown"}`,
+      `- ESPHome (running): ${meta.deployedVersion || "unknown"}`,
+      `- Device Builder: ${meta.dashboardVersion || "unknown"}` +
+        (meta.isHaAddon ? " (Home Assistant add-on)" : ""),
+    ].join("\n")
+  );
+  return `${sections.join("\n\n")}\n`;
+}
+
+/** Issue title: the crash banner line when present, else a generic one. */
+export function buildIssueTitle(report: CrashReport): string {
+  const banner = report.scrape.excerpt.find((line) => isCrashMarker(line)) ?? "";
+  const title = banner ? `Crash: ${banner}` : `Device crash on ${report.meta.deviceName}`;
+  return title.length > 100 ? `${title.slice(0, 97)}...` : title;
+}
+
+/**
+ * Pre-filled issue-form URL. Everything except the crash excerpt is
+ * fixed; the excerpt fills whatever budget remains under
+ * MAX_ISSUE_URL_LENGTH, prioritizing the crash block over the context
+ * lines that precede it.
+ */
+export function buildIssueUrl(
+  report: CrashReport,
+  fullReportDelivery: "clipboard" | "download"
+): string {
+  const { scrape, meta } = report;
+  const url = new URL(ISSUE_URL_BASE);
+  const params = url.searchParams;
+  params.set("title", buildIssueTitle(report));
+  const version = meta.esphomeVersion || meta.deployedVersion;
+  if (version) params.set("version", version);
+  if (meta.isHaAddon) params.set("installation", "Home Assistant Add-on");
+  const platform = issuePlatform(meta.targetPlatform);
+  if (platform) params.set("platform", platform);
+  const component = inferComponentName(scrape.decodedFrames);
+  if (component) params.set("component_name", component);
+
+  const problem: string[] = [
+    `The device crashed (crash detected in the Device Builder log viewer).`,
+  ];
+  if (scrape.decodedFrames.length > 0) {
+    problem.push(
+      "",
+      "Decoded backtrace:",
+      ...scrape.decodedFrames.slice(0, MAX_PROBLEM_FRAMES)
+    );
+  }
+  params.set("problem", problem.join("\n"));
+  params.set(
+    "additional",
+    fullReportDelivery === "clipboard"
+      ? "The full crash report (decoded backtrace, warnings/errors, config dump, " +
+          "sanitized YAML config) was copied to the clipboard by ESPHome Device " +
+          "Builder. Please paste it here."
+      : "The full crash report was saved as a markdown file by ESPHome Device " +
+          "Builder. Please attach or paste it here."
+  );
+
+  // The `logs` field is the elastic part: fit the crash block first,
+  // then as many preceding context lines as the budget allows.
+  params.set("logs", "");
+  const overhead = url.toString().length;
+  const budget = MAX_ISSUE_URL_LENGTH - overhead;
+  const crashStart = scrape.excerpt.findIndex((line) => isCrashMarker(line));
+  const logs = fitLines(scrape.excerpt, Math.max(0, crashStart), budget);
+  if (logs) {
+    params.set("logs", logs);
+  } else {
+    params.delete("logs");
+  }
+  return url.toString();
+}
+
+/**
+ * Join as much of *lines* as fits *budget* once URL-encoded: the block
+ * from *anchor* to the end first (truncating its tail if even that
+ * overflows), then context lines walking backwards from the anchor.
+ */
+function fitLines(lines: string[], anchor: number, budget: number): string {
+  if (lines.length === 0 || budget <= 0) return "";
+  const cost = (line: string): number => encodeURIComponent(`${line}\n`).length;
+  const kept: string[] = [];
+  let spent = 0;
+  let truncated = false;
+  for (let i = anchor; i < lines.length; i++) {
+    const lineCost = cost(lines[i]);
+    if (spent + lineCost > budget) {
+      truncated = true;
+      break;
+    }
+    kept.push(lines[i]);
+    spent += lineCost;
+  }
+  for (let i = anchor - 1; i >= 0; i--) {
+    const lineCost = cost(lines[i]);
+    if (spent + lineCost > budget) {
+      truncated = true;
+      break;
+    }
+    kept.unshift(lines[i]);
+    spent += lineCost;
+  }
+  if (kept.length === 0) return "";
+  if (truncated) kept.push("[log excerpt trimmed; full logs in the attached report]");
+  return kept.join("\n");
+}

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -468,10 +468,7 @@ function fitProblem(
   const budget = MAX_ISSUE_URL_LENGTH - url.toString().length;
   const text = head.join("\n");
   let end = Math.max(0, Math.min(text.length, budget - 20));
-  while (
-    end > 0 &&
-    encodeURIComponent(`${text.slice(0, end)}\n…[truncated]`).length > budget
-  ) {
+  while (end > 0 && formEncodedLength(`${text.slice(0, end)}\n…[truncated]`) > budget) {
     end -= 32;
   }
   params.set("problem", `${text.slice(0, Math.max(0, end))}\n…[truncated]`);
@@ -482,7 +479,7 @@ const CONFIG_TRUNCATED_NOTE = "# [config truncated to fit the pre-filled URL]";
 
 function fitConfig(yaml: string, budget: number): { text: string; truncated: boolean } {
   if (budget <= 0) return { text: "", truncated: true };
-  if (encodeURIComponent(yaml).length <= budget) return { text: yaml, truncated: false };
+  if (formEncodedLength(yaml) <= budget) return { text: yaml, truncated: false };
   const kept: string[] = [];
   let spent = encodedCost(CONFIG_TRUNCATED_NOTE);
   for (const line of yaml.split("\n")) {
@@ -512,7 +509,16 @@ function excerptWithoutDecodeEchoes(
 
 const TRIM_MARKER = "[log excerpt trimmed; full logs in the attached report]";
 
-const encodedCost = (line: string): number => encodeURIComponent(`${line}\n`).length;
+// Encoded length of *s* the way the prefilled URL actually serializes it:
+// URLSearchParams uses application/x-www-form-urlencoded, which differs
+// from encodeURIComponent for `! ~ ' ( )` (3 chars vs 1) — and ESPHome
+// backtraces are full of parens, so encodeURIComponent under-counts and
+// can produce a >8000-char URL (414). Measuring via URLSearchParams is
+// exact; the trailing "v=" (2 chars) is subtracted off.
+const formEncodedLength = (s: string): number =>
+  new URLSearchParams({ v: s }).toString().length - 2;
+
+const encodedCost = (line: string): number => formEncodedLength(`${line}\n`);
 
 /**
  * Join as much of *lines* as fits *budget* once URL-encoded: the block

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -383,8 +383,11 @@ export function buildIssueUrl(report: CrashReport): IssueUrl {
     if (fitted.truncated) missing = true;
   }
 
-  // Pack the supplementary sections into `additional`, whole sections
-  // at a time, so the common case needs no manual paste at all.
+  // Pack the supplementary sections into `additional`, whole sections at
+  // a time, so the common case needs no manual paste. Only sections that
+  // aren't already elsewhere in the URL — environment (in `problem`),
+  // backtrace (in `problem`), config (in `config`) are deliberately not
+  // repeated here, since the budget is tight.
   const extras: string[] = [];
   const tryAddSection = (text: string): void => {
     params.set("additional", [...extras, text].join("\n\n"));
@@ -399,7 +402,6 @@ export function buildIssueUrl(report: CrashReport): IssueUrl {
       params.delete("additional");
     }
   };
-  tryAddSection(`Environment:\n${environmentSection(meta)}`);
   if (scrape.warnings.length > 0) {
     tryAddSection(`Warnings and errors:\n${fence(scrape.warnings)}`);
   }

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -241,8 +241,15 @@ export function inferComponentName(decodedFrames: string[]): string {
   return "";
 }
 
-const fence = (lines: string[], language = "text"): string =>
-  `\`\`\`${language}\n${lines.join("\n")}\n\`\`\``;
+// Wrap *lines* in a code fence longer than any backtick run they contain,
+// so user-controlled content (YAML strings, logs, descriptions) with a
+// ``` sequence can't close the fence early and corrupt the markdown.
+const fence = (lines: string[], language = "text"): string => {
+  const body = lines.join("\n");
+  const longestRun = Math.max(0, ...[...body.matchAll(/`+/g)].map((m) => m[0].length));
+  const bar = "`".repeat(Math.max(3, longestRun + 1));
+  return `${bar}${language}\n${body}\n${bar}`;
+};
 
 /**
  * The complete report, ordered decoded-backtrace-first per the issue

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -324,20 +324,29 @@ export function buildIssueUrl(report: CrashReport): IssueUrl {
   const url = new URL(ISSUE_URL_BASE);
   const params = url.searchParams;
   params.set("title", buildIssueTitle(report));
+  // Only `input` / `textarea` form fields accept a URL prefill; GitHub
+  // ignores it on `dropdown` fields (installation / platform), so those
+  // are surfaced inside `problem` instead of set as dead params.
   const version = meta.esphomeVersion || meta.deployedVersion;
   if (version) params.set("version", version);
-  if (meta.installation) params.set("installation", meta.installation);
-  const platform = issuePlatform(meta.targetPlatform);
-  if (platform) params.set("platform", platform);
   const component = inferComponentName(scrape.decodedFrames);
   if (component) params.set("component_name", component);
+  const platform = issuePlatform(meta.targetPlatform);
   let missing = scrape.decodedFrames.length > MAX_PROBLEM_FRAMES;
 
-  // The user's own context leads the problem field; the technical
-  // payload follows it.
+  // The user's own context leads the problem field, then the platform /
+  // installation the dropdowns can't be prefilled with, then the trace.
   const problem: string[] = report.userDescription
     ? [report.userDescription, "", "(Crash detected in the Device Builder log viewer.)"]
     : [`The device crashed (crash detected in the Device Builder log viewer).`];
+  const facts = [
+    platform && `Platform: ${platform}`,
+    meta.installation && `Installation: ${meta.installation}`,
+    `ESPHome ${meta.esphomeVersion || "unknown"} (compiled)`,
+    meta.deployedVersion && `${meta.deployedVersion} (running)`,
+    meta.board && `Board: ${meta.board}`,
+  ].filter(Boolean);
+  problem.push("", ...facts.map((fact) => `- ${fact}`));
   if (scrape.decodedFrames.length > 0) {
     problem.push(
       "",

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -1,4 +1,5 @@
-import { CRASH_END_RE, isCrashMarker, normalizeLogLine } from "./crash-detector.js";
+import { isCrashMarker, normalizeLogLine } from "./crash-detector.js";
+import { isCliLogLine } from "./validation-log.js";
 
 /**
  * Crash-report assembly: scrape the log buffer the user is already
@@ -11,6 +12,9 @@ import { CRASH_END_RE, isCrashMarker, normalizeLogLine } from "./crash-detector.
 // far past it the excerpt extends when no explicit end marker arrives.
 const CONTEXT_LINES_BEFORE = 25;
 const MAX_LINES_AFTER_MARKER = 60;
+
+// Terminators of a crash dump — the excerpt window closes here.
+const CRASH_END_RE = /<<<stack<<<|^ELF file SHA256:|^Rebooting\.\.\./;
 
 // Total pre-filled URL budget. GitHub 414s somewhere past ~8k; staying
 // at 6k leaves headroom for their own redirect/query additions.
@@ -33,23 +37,22 @@ const CRASH_RELATED_RE = /(?:0x)?[0-9a-fA-F]{8}(?::|\b)|Decoded 0x/;
 
 const TAGGED_LINE_RE = /^\[([CWE])\]\[[^\]]*\]/;
 
-/** `target_platform` → the bug form's platform dropdown values. */
-export const ISSUE_PLATFORM_MAP: ReadonlyArray<[RegExp, string]> = [
-  [/^ESP32/i, "ESP32"],
-  [/^ESP8266$/i, "ESP8266"],
-  [/^RP2040$/i, "RP2040"],
-  [/^BK72XX$/i, "BK72XX"],
-  [/^RTL87XX$/i, "RTL87XX"],
-  [/^LN882X$/i, "LN882X"],
-  [/^HOST$/i, "Host"],
-];
+// `target_platform` → the bug form's platform dropdown values. ESP32 is a
+// prefix match (variants like ESP32S3 report as ESP32).
+const ISSUE_PLATFORMS: Record<string, string> = {
+  ESP8266: "ESP8266",
+  RP2040: "RP2040",
+  BK72XX: "BK72XX",
+  RTL87XX: "RTL87XX",
+  LN882X: "LN882X",
+  HOST: "Host",
+};
 
 export function issuePlatform(targetPlatform: string): string {
   if (!targetPlatform) return "";
-  for (const [re, value] of ISSUE_PLATFORM_MAP) {
-    if (re.test(targetPlatform)) return value;
-  }
-  return "Other";
+  const upper = targetPlatform.toUpperCase();
+  if (upper.startsWith("ESP32")) return "ESP32";
+  return ISSUE_PLATFORMS[upper] ?? "Other";
 }
 
 export interface CrashReportMeta {
@@ -69,12 +72,14 @@ export interface CrashScrape {
   /** Normalized crash excerpt (context + crash block); [] when the crash
    *  scrolled out of the capped buffer. */
   excerpt: string[];
+  /** Index of the first crash marker within `excerpt`; -1 when none. */
+  crashIndex: number;
   crashFound: boolean;
   /** `0x...: func at file:line` frames from the inline decoder. */
   decodedFrames: string[];
-  /** All `[W]` / `[E]` lines (continuations attached, duplicates folded). */
+  /** All `[W]` / `[E]` lines (duplicates folded). */
   warnings: string[];
-  /** All `[C]` dump_config lines (continuations attached). */
+  /** All `[C]` dump_config lines. */
   configLines: string[];
 }
 
@@ -85,16 +90,29 @@ export function scrapeCrashData(rawLines: string[]): CrashScrape {
   const { warnings, configLines } = extractTaggedLines(lines);
   return {
     excerpt: excerpt.lines,
-    crashFound: excerpt.found,
+    crashIndex: excerpt.crashIndex,
+    crashFound: excerpt.crashIndex !== -1,
     decodedFrames: extractDecodedFrames(excerpt.lines),
     warnings,
     configLines,
   };
 }
 
-function extractCrashExcerpt(lines: string[]): { lines: string[]; found: boolean } {
+/**
+ * Clean YAML from a `devices/validate` stream: normalize each line and
+ * drop the esphome CLI log records interleaved on the merged stream.
+ */
+export function distillValidatedConfig(lines: string[]): string {
+  return lines
+    .map(normalizeLogLine)
+    .filter((line) => !isCliLogLine(line))
+    .join("\n")
+    .trim();
+}
+
+function extractCrashExcerpt(lines: string[]): { lines: string[]; crashIndex: number } {
   const start = lines.findIndex((line) => isCrashMarker(line));
-  if (start === -1) return { lines: [], found: false };
+  if (start === -1) return { lines: [], crashIndex: -1 };
   const hardStop = Math.min(lines.length - 1, start + MAX_LINES_AFTER_MARKER);
   let end = start;
   for (let i = start; i <= hardStop; i++) {
@@ -105,10 +123,8 @@ function extractCrashExcerpt(lines: string[]): { lines: string[]; found: boolean
       break;
     }
   }
-  return {
-    lines: lines.slice(Math.max(0, start - CONTEXT_LINES_BEFORE), end + 1),
-    found: true,
-  };
+  const from = Math.max(0, start - CONTEXT_LINES_BEFORE);
+  return { lines: lines.slice(from, end + 1), crashIndex: start - from };
 }
 
 function extractDecodedFrames(excerpt: string[]): string[] {
@@ -120,25 +136,19 @@ function extractDecodedFrames(excerpt: string[]): string[] {
   return frames;
 }
 
+// A bare tag match covers multi-line records too: both transports re-apply
+// the entry's `[L][tag]:` prefix to every continuation line before it
+// reaches the buffer (ESPHomeLogParser client-side, aioesphomeapi's
+// LogParser behind `esphome logs`).
 function extractTaggedLines(lines: string[]): {
   warnings: string[];
   configLines: string[];
 } {
   const warnings: string[] = [];
   const configLines: string[] = [];
-  let bucket: string[] | null = null;
   for (const line of lines) {
     const match = TAGGED_LINE_RE.exec(line);
-    if (match) {
-      bucket = match[1] === "C" ? configLines : warnings;
-      appendFolded(bucket, line);
-    } else if (bucket !== null && /^\s/.test(line)) {
-      // Raw-UART continuations of a multi-line record are indented and
-      // untagged; keep them with their entry line.
-      bucket.push(line);
-    } else {
-      bucket = null;
-    }
+    if (match) appendFolded(match[1] === "C" ? configLines : warnings, line);
   }
   return { warnings, configLines };
 }
@@ -234,8 +244,9 @@ export function buildFullReport(report: CrashReport): string {
 }
 
 /** Issue title: the crash banner line when present, else a generic one. */
-export function buildIssueTitle(report: CrashReport): string {
-  const banner = report.scrape.excerpt.find((line) => isCrashMarker(line)) ?? "";
+function buildIssueTitle(report: CrashReport): string {
+  const { excerpt, crashIndex } = report.scrape;
+  const banner = crashIndex === -1 ? "" : excerpt[crashIndex];
   const title = banner ? `Crash: ${banner}` : `Device crash on ${report.meta.deviceName}`;
   return title.length > 100 ? `${title.slice(0, 97)}...` : title;
 }
@@ -288,8 +299,7 @@ export function buildIssueUrl(
   params.set("logs", "");
   const overhead = url.toString().length;
   const budget = MAX_ISSUE_URL_LENGTH - overhead;
-  const crashStart = scrape.excerpt.findIndex((line) => isCrashMarker(line));
-  const logs = fitLines(scrape.excerpt, Math.max(0, crashStart), budget);
+  const logs = fitLines(scrape.excerpt, Math.max(0, scrape.crashIndex), budget);
   if (logs) {
     params.set("logs", logs);
   } else {

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -1,4 +1,4 @@
-import { isCrashMarker, normalizeLogLine } from "./crash-detector.js";
+import { isCrashMarker, normalizeLogLine, tagged } from "./crash-detector.js";
 import { isCliLogLine } from "./validation-log.js";
 
 /**
@@ -35,12 +35,13 @@ const DECODED_CONTINUATION_RE = /^\s*\(inlined by\)/;
 
 // Lines that merely echo the backtrace the `problem` field already
 // carries in decoded form: the decode output itself, its progress
-// chatter, and the raw BT<n> address lines (optionally logger-tagged).
+// chatter, and the raw BT<n> address lines (optionally logger-tagged —
+// the shared `tagged` grammar keeps the prefix in one place).
 const DECODE_ECHO_RES = [
   DECODED_RE,
   DECODED_CONTINUATION_RE,
   /^(?:WARNING )?Found stack trace/,
-  /^(?:\[[A-Z]{1,2}\]\[[^\]]*\]:\s*)?BT\d+:\s*0x[0-9a-fA-F]{8}/,
+  tagged("BT\\d+:\\s*0x[0-9a-fA-F]{8}"),
 ];
 
 const isDecodeEcho = (line: string): boolean =>
@@ -398,44 +399,44 @@ export function buildIssueUrl(report: CrashReport): IssueUrl {
   // aren't already elsewhere in the URL — environment (in `problem`),
   // backtrace (in `problem`), config (in `config`) are deliberately not
   // repeated here, since the budget is tight.
-  const extras: string[] = [];
-  const tryAddSection = (text: string): void => {
-    params.set("additional", [...extras, text].join("\n\n"));
-    if (url.toString().length <= MAX_ISSUE_URL_LENGTH) {
-      extras.push(text);
-      return;
-    }
-    missing = true;
-    if (extras.length > 0) {
-      params.set("additional", extras.join("\n\n"));
-    } else {
-      params.delete("additional");
-    }
-  };
-  if (scrape.warnings.length > 0) {
-    tryAddSection(`Warnings and errors:\n${fence(scrape.warnings)}`);
-  }
-  if (scrape.configLines.length > 0) {
-    tryAddSection(`Config dump:\n${fence(scrape.configLines)}`);
-  }
+  const sections = [
+    scrape.warnings.length > 0 && `Warnings and errors:\n${fence(scrape.warnings)}`,
+    scrape.configLines.length > 0 && `Config dump:\n${fence(scrape.configLines)}`,
+  ].filter((s): s is string => Boolean(s));
+  let kept = packParam(url, params, "additional", sections);
+  if (kept.length < sections.length) missing = true;
 
-  // When content was truncated, a note (for the maintainer reading the
-  // issue) leads the additional field; the reporter can attach the
-  // downloaded report on request. Drop trailing sections until it fits,
-  // and drop `additional` entirely if even the note alone overflows.
+  // When anything was truncated (here or in logs/config), lead `additional`
+  // with a note for the maintainer; re-pack so the note can't push the URL
+  // over budget (dropping trailing sections, or `additional` itself).
   if (missing) {
-    const withNote = ["(Truncated to fit; full report available on request.)", ...extras];
-    for (;;) {
-      params.set("additional", withNote.join("\n\n"));
-      if (url.toString().length <= MAX_ISSUE_URL_LENGTH) break;
-      if (withNote.length === 1) {
-        params.delete("additional");
-        break;
-      }
-      withNote.pop();
-    }
+    kept = packParam(url, params, "additional", [
+      "(Truncated to fit; full report available on request.)",
+      ...kept,
+    ]);
   }
   return { url: url.toString(), complete: !missing };
+}
+
+/**
+ * Set `params[key]` to the longest run of *parts* (joined by blank lines)
+ * that keeps the whole URL within budget, deleting the param when none
+ * fit. Returns the parts that were kept.
+ */
+function packParam(
+  url: URL,
+  params: URLSearchParams,
+  key: string,
+  parts: string[]
+): string[] {
+  const kept: string[] = [];
+  for (const part of parts) {
+    params.set(key, [...kept, part].join("\n\n"));
+    if (url.toString().length <= MAX_ISSUE_URL_LENGTH) kept.push(part);
+  }
+  if (kept.length > 0) params.set(key, kept.join("\n\n"));
+  else params.delete(key);
+  return kept;
 }
 
 /**
@@ -480,14 +481,11 @@ const CONFIG_TRUNCATED_NOTE = "# [config truncated to fit the pre-filled URL]";
 function fitConfig(yaml: string, budget: number): { text: string; truncated: boolean } {
   if (budget <= 0) return { text: "", truncated: true };
   if (formEncodedLength(yaml) <= budget) return { text: yaml, truncated: false };
-  const kept: string[] = [];
-  let spent = encodedCost(CONFIG_TRUNCATED_NOTE);
-  for (const line of yaml.split("\n")) {
-    const lineCost = encodedCost(line);
-    if (spent + lineCost > budget) break;
-    kept.push(line);
-    spent += lineCost;
-  }
+  const { kept } = takeLinesUnderBudget(
+    yaml.split("\n"),
+    budget,
+    encodedCost(CONFIG_TRUNCATED_NOTE)
+  );
   if (kept.length === 0) return { text: "", truncated: true };
   kept.push(CONFIG_TRUNCATED_NOTE);
   return { text: kept.join("\n"), truncated: true };
@@ -521,6 +519,26 @@ const formEncodedLength = (s: string): number =>
 const encodedCost = (line: string): number => formEncodedLength(`${line}\n`);
 
 /**
+ * Greedily take the longest prefix of *lines* whose per-line
+ * `encodedCost` fits `budget - spent`. Returns the kept prefix, the
+ * running spend, and whether any line was dropped.
+ */
+function takeLinesUnderBudget(
+  lines: string[],
+  budget: number,
+  spent: number
+): { kept: string[]; spent: number; truncated: boolean } {
+  const kept: string[] = [];
+  for (const line of lines) {
+    const cost = encodedCost(line);
+    if (spent + cost > budget) return { kept, spent, truncated: true };
+    kept.push(line);
+    spent += cost;
+  }
+  return { kept, spent, truncated: false };
+}
+
+/**
  * Join as much of *lines* as fits *budget* once URL-encoded: the block
  * from *anchor* to the end first (truncating its tail if even that
  * overflows), then context lines walking backwards from the anchor.
@@ -540,32 +558,22 @@ function fitLines(lines: string[], anchor: number, budget: number): string {
   return fit.kept.length > (fit.truncated ? 1 : 0) ? fit.kept.join("\n") : "";
 }
 
+// Fit forward from *anchor* to the end, then walk backward over the
+// preceding context, sharing one budget and marker reserve.
 function fitWithReserve(
   lines: string[],
   anchor: number,
   budget: number,
   reserve: number
 ): { kept: string[]; truncated: boolean } {
-  const kept: string[] = [];
-  let spent = reserve;
-  let truncated = false;
-  for (let i = anchor; i < lines.length; i++) {
-    const lineCost = encodedCost(lines[i]);
-    if (spent + lineCost > budget) {
-      truncated = true;
-      break;
-    }
-    kept.push(lines[i]);
-    spent += lineCost;
-  }
-  for (let i = anchor - 1; i >= 0; i--) {
-    const lineCost = encodedCost(lines[i]);
-    if (spent + lineCost > budget) {
-      truncated = true;
-      break;
-    }
-    kept.unshift(lines[i]);
-    spent += lineCost;
-  }
-  return { kept, truncated };
+  const forward = takeLinesUnderBudget(lines.slice(anchor), budget, reserve);
+  const back = takeLinesUnderBudget(
+    lines.slice(0, anchor).reverse(),
+    budget,
+    forward.spent
+  );
+  return {
+    kept: [...back.kept.reverse(), ...forward.kept],
+    truncated: forward.truncated || back.truncated,
+  };
 }

--- a/src/util/validation-log.ts
+++ b/src/util/validation-log.ts
@@ -4,6 +4,15 @@ import { stripAnsiSgr } from "./ansi-escapes.js";
 // Log format is "<asctime>? <LEVEL> <message>" (esphome/log.py).
 const LOADER_ERROR = /^(?:\d{2}:\d{2}:\d{2}\s+)?ERROR Error while reading config:/;
 
+// Any esphome CLI log record, same "<asctime>? <LEVEL> <message>" grammar.
+const CLI_LOG_LINE =
+  /^(?:\d{2}:\d{2}:\d{2}\s+)?(?:INFO|WARNING|ERROR|DEBUG|CRITICAL|VERBOSE)\b/;
+
+/** True when an (ANSI-stripped) line is esphome CLI logging, not payload. */
+export function isCliLogLine(line: string): boolean {
+  return CLI_LOG_LINE.test(line);
+}
+
 /**
  * True when a compile-log line marks an ESPHome validation failure.
  *

--- a/src/util/validation-log.ts
+++ b/src/util/validation-log.ts
@@ -5,8 +5,10 @@ import { stripAnsiSgr } from "./ansi-escapes.js";
 const LOADER_ERROR = /^(?:\d{2}:\d{2}:\d{2}\s+)?ERROR Error while reading config:/;
 
 // Any esphome CLI log record, same "<asctime>? <LEVEL> <message>" grammar.
+// Whitespace (not \b) must follow the level so a payload line that merely
+// starts with a level word (e.g. an `INFO:` YAML key) can't match.
 const CLI_LOG_LINE =
-  /^(?:\d{2}:\d{2}:\d{2}\s+)?(?:INFO|WARNING|ERROR|DEBUG|CRITICAL|VERBOSE)\b/;
+  /^(?:\d{2}:\d{2}:\d{2}\s+)?(?:INFO|WARNING|ERROR|DEBUG|CRITICAL|VERBOSE)\s/;
 
 /** True when an (ANSI-stripped) line is esphome CLI logging, not payload. */
 export function isCliLogLine(line: string): boolean {

--- a/test/_crash-lines.ts
+++ b/test/_crash-lines.ts
@@ -14,3 +14,18 @@ export const CRASH_BLOCK = [
   "WARNING Decoded 0x400da73c: esphome::wifi::WiFiComponent::loop() at esphome/components/wifi/wifi_component.cpp:100",
   "Rebooting...",
 ];
+
+// A `devices/validate` stream (esphome config output): CLI log records
+// interleaved with the sanitized YAML, and the YAML it distills to.
+export const VALIDATE_OUTPUT = [
+  "\\033[32mINFO ESPHome 2026.6.4\\033[0m",
+  "\\033[32mINFO Reading configuration smallgarage.yaml...\\033[0m",
+  "esphome:",
+  "  name: smallgarage",
+  "wifi:",
+  "  password: <removed>",
+  "\\033[32mINFO Configuration is valid!\\033[0m",
+];
+
+export const VALIDATED_CONFIG_YAML =
+  "esphome:\n  name: smallgarage\nwifi:\n  password: <removed>";

--- a/test/_crash-lines.ts
+++ b/test/_crash-lines.ts
@@ -1,0 +1,16 @@
+/** Shared crash-log fixtures for the crash-report suites. */
+
+export const CRASH_BANNER_LINE =
+  "Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.";
+
+// A realistic backend-streamed crash: panic banner, register dump,
+// backtrace, esphome logs' inline decode, and the reboot terminator.
+export const CRASH_BLOCK = [
+  CRASH_BANNER_LINE,
+  "Core  1 register dump:",
+  "PC      : 0x400d9150  PS      : 0x00060330  A0      : 0x800da73c",
+  "Backtrace: 0x400d9150:0x3ffb4f60 0x400da73c:0x3ffb4f90",
+  "WARNING Decoded 0x400d9150: esphome::Application::setup() at esphome/core/application.cpp:59",
+  "WARNING Decoded 0x400da73c: esphome::wifi::WiFiComponent::loop() at esphome/components/wifi/wifi_component.cpp:100",
+  "Rebooting...",
+];

--- a/test/components/crash-report-dialog.test.ts
+++ b/test/components/crash-report-dialog.test.ts
@@ -6,6 +6,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("sonner-js", () => ({
+  default: { error: vi.fn(), success: vi.fn(), info: vi.fn(), warning: vi.fn() },
+}));
 
 const { copyToClipboard } = vi.hoisted(() => ({ copyToClipboard: vi.fn() }));
 vi.mock("../../src/util/copy-to-clipboard.js", () => ({ copyToClipboard }));
@@ -115,6 +118,24 @@ describe("crash-report-dialog", () => {
     expect(openedUrls).toHaveLength(1);
     expect(openedUrls[0]).toContain("github.com/esphome/esphome/issues/new");
     expect(new URL(openedUrls[0]).searchParams.get("additional")).toContain("clipboard");
+
+    // The dialog stays open in the delivered state so a clipboard lost to
+    // the tab switch can be re-copied (or downloaded) without redoing the
+    // validate round-trip.
+    await el.updateComplete;
+    expect((el as any)._dialog.open).toBe(true);
+    expect((el as any)._delivered).toBe(true);
+
+    await (el as any)._copyAgain();
+    expect(copyToClipboard).toHaveBeenCalledTimes(2);
+    expect(copyToClipboard.mock.calls[1][0]).toBe(reportText);
+
+    (el as any)._downloadReport();
+    expect(downloadBlob).toHaveBeenCalledWith(
+      reportText,
+      "smallgarage-crash-report.md",
+      "text/markdown"
+    );
   });
 
   it("falls back to a report download when the copy fails", async () => {

--- a/test/components/crash-report-dialog.test.ts
+++ b/test/components/crash-report-dialog.test.ts
@@ -49,7 +49,7 @@ describe("crash-report-dialog", () => {
       "open",
       vi.fn((url: string) => {
         openedUrls.push(url);
-        return null;
+        return {} as Window;
       })
     );
     el = new ESPHomeCrashReportDialog();
@@ -88,6 +88,29 @@ describe("crash-report-dialog", () => {
     expect((el as any)._configYaml).toBe("");
     expect(el.shadowRoot!.querySelector(".collecting")).toBeNull();
     expect(el.shadowRoot!.textContent).toContain("crash_report.config_unavailable");
+  });
+
+  it("does not claim the tab opened when the popup was blocked", async () => {
+    vi.stubGlobal(
+      "open",
+      vi.fn((url: string) => {
+        openedUrls.push(url);
+        return null; // popup blocker
+      })
+    );
+    copyToClipboard.mockResolvedValue(true);
+    el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
+    finishValidate();
+    await el.updateComplete;
+
+    await (el as any)._copyAndOpen();
+    await el.updateComplete;
+    expect((el as any)._popupBlocked).toBe(true);
+    expect(el.shadowRoot!.textContent).toContain("crash_report.popup_blocked_hint");
+    // The manual link is the primary action when the popup was blocked.
+    const anchor = el.shadowRoot!.querySelector<HTMLAnchorElement>(".actions a");
+    expect(anchor!.classList.contains("btn--confirm")).toBe(true);
+    expect(anchor!.href).toBe(openedUrls[0]);
   });
 
   it("degrades to config-unavailable when the validate stream stalls", async () => {
@@ -138,6 +161,10 @@ describe("crash-report-dialog", () => {
     await el.updateComplete;
     expect((el as any)._dialog.open).toBe(true);
     expect((el as any)._delivered).toBe(true);
+    expect((el as any)._popupBlocked).toBe(false);
+    // The delivered state keeps a manual link to the issue as well.
+    const anchor = el.shadowRoot!.querySelector<HTMLAnchorElement>(".actions a");
+    expect(anchor!.href).toBe(openedUrls[0]);
 
     await (el as any)._copyAgain();
     expect(copyToClipboard).toHaveBeenCalledTimes(2);

--- a/test/components/crash-report-dialog.test.ts
+++ b/test/components/crash-report-dialog.test.ts
@@ -68,6 +68,10 @@ describe("crash-report-dialog", () => {
     validateCallbacks!.onResult!({ success, code: success ? 0 : 1 });
   };
 
+  const describe_ = (text: string) => {
+    (el as any)._userDescription = text;
+  };
+
   it("collects, filters CLI log noise out of the config, then goes ready", async () => {
     el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
     await el.updateComplete;
@@ -90,6 +94,20 @@ describe("crash-report-dialog", () => {
     expect(el.shadowRoot!.textContent).toContain("crash_report.config_unavailable");
   });
 
+  it("requires a description before the report can be opened", async () => {
+    el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
+    finishValidate();
+    await el.updateComplete;
+    const button = el.shadowRoot!.querySelector<HTMLButtonElement>(
+      ".actions .btn--confirm"
+    );
+    expect(button!.disabled).toBe(true);
+
+    describe_("Pressed the crash button");
+    await el.updateComplete;
+    expect(button!.disabled).toBe(false);
+  });
+
   it("does not claim the tab opened when the popup was blocked", async () => {
     vi.stubGlobal(
       "open",
@@ -98,18 +116,16 @@ describe("crash-report-dialog", () => {
         return null; // popup blocker
       })
     );
-    copyToClipboard.mockResolvedValue(true);
     el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
     finishValidate();
+    describe_("Pressed the crash button");
     await el.updateComplete;
 
-    await (el as any)._copyAndOpen();
+    (el as any)._openIssue();
     await el.updateComplete;
     expect((el as any)._popupBlocked).toBe(true);
     expect(el.shadowRoot!.textContent).toContain("crash_report.popup_blocked_hint");
-    // The manual link is the primary action when the popup was blocked.
     const anchor = el.shadowRoot!.querySelector<HTMLAnchorElement>(".actions a");
-    expect(anchor!.classList.contains("btn--confirm")).toBe(true);
     expect(anchor!.href).toBe(openedUrls[0]);
   });
 
@@ -137,68 +153,41 @@ describe("crash-report-dialog", () => {
     expect(stopStream).toHaveBeenCalledTimes(2);
   });
 
-  it("copies the full report and opens the pre-filled issue", async () => {
-    copyToClipboard.mockResolvedValue(true);
+  it("downloads the report, then opens the pre-filled issue", async () => {
     el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
     finishValidate();
+    describe_("Pressed the crash button");
     await el.updateComplete;
 
-    await (el as any)._copyAndOpen();
-    expect(copyToClipboard).toHaveBeenCalledTimes(1);
-    const reportText = copyToClipboard.mock.calls[0][0] as string;
-    expect(reportText).toContain("## Decoded backtrace");
-    expect(reportText.indexOf("## Decoded backtrace")).toBeLessThan(
-      reportText.indexOf("## Configuration")
+    (el as any)._openIssue();
+    // The full report is downloaded up front so the user always keeps it.
+    expect(downloadBlob).toHaveBeenCalledTimes(1);
+    const reportText = downloadBlob.mock.calls[0][0] as string;
+    expect(downloadBlob.mock.calls[0][1]).toBe("smallgarage-crash-report.md");
+    expect(reportText).toContain("## What happened");
+    expect(reportText.indexOf("## What happened")).toBeLessThan(
+      reportText.indexOf("## Decoded backtrace")
     );
     expect(reportText).toContain("password: <removed>");
-    expect(openedUrls).toHaveLength(1);
-    expect(openedUrls[0]).toContain("github.com/esphome/esphome/issues/new");
-    expect(new URL(openedUrls[0]).searchParams.get("additional")).toContain("clipboard");
 
-    // The dialog stays open in the delivered state so a clipboard lost to
-    // the tab switch can be re-copied (or downloaded) without redoing the
-    // validate round-trip.
+    expect(openedUrls).toHaveLength(1);
+    const params = new URL(openedUrls[0]).searchParams;
+    expect(openedUrls[0]).toContain("github.com/esphome/esphome/issues/new");
+    // Config lands in the form's YAML Config box, backtrace in problem.
+    expect(params.get("config")).toContain("password: <removed>");
+    expect(params.get("problem")).toContain("Pressed the crash button");
+
     await el.updateComplete;
     expect((el as any)._dialog.open).toBe(true);
     expect((el as any)._delivered).toBe(true);
     expect((el as any)._popupBlocked).toBe(false);
-    // The delivered state keeps a manual link to the issue as well.
     const anchor = el.shadowRoot!.querySelector<HTMLAnchorElement>(".actions a");
     expect(anchor!.href).toBe(openedUrls[0]);
 
-    await (el as any)._copyAgain();
-    expect(copyToClipboard).toHaveBeenCalledTimes(2);
-    expect(copyToClipboard.mock.calls[1][0]).toBe(reportText);
-
-    (el as any)._downloadReport();
-    expect(downloadBlob).toHaveBeenCalledWith(
-      reportText,
-      "smallgarage-crash-report.md",
-      "text/markdown"
-    );
-  });
-
-  it("falls back to a report download when the copy fails", async () => {
-    copyToClipboard.mockResolvedValue(false);
-    el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
-    finishValidate();
-    await el.updateComplete;
-
-    await (el as any)._copyAndOpen();
-    expect(openedUrls).toHaveLength(0); // no tab until the report is delivered
-    await el.updateComplete;
-    expect((el as any)._copyFailed).toBe(true);
-
-    (el as any)._downloadAndOpen();
-    expect(downloadBlob).toHaveBeenCalledWith(
-      expect.stringContaining("## Decoded backtrace"),
-      "smallgarage-crash-report.md",
-      "text/markdown"
-    );
-    expect(openedUrls).toHaveLength(1);
-    expect(new URL(openedUrls[0]).searchParams.get("additional")).toContain(
-      "markdown file"
-    );
+    // Copy-to-clipboard stays available on demand.
+    copyToClipboard.mockResolvedValue(true);
+    await (el as any)._copyReport();
+    expect(copyToClipboard).toHaveBeenCalledWith(reportText);
   });
 
   it("ignores a stale validate result from a previous open", async () => {

--- a/test/components/crash-report-dialog.test.ts
+++ b/test/components/crash-report-dialog.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment happy-dom
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
@@ -55,6 +55,11 @@ describe("crash-report-dialog", () => {
       stopStream: vi.fn(() => Promise.resolve()),
     };
     document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    // The stubbed `window.open` must not leak into other files in this worker.
+    vi.unstubAllGlobals();
   });
 
   const finishValidate = (lines = VALIDATE_OUTPUT, success = true) => {

--- a/test/components/crash-report-dialog.test.ts
+++ b/test/components/crash-report-dialog.test.ts
@@ -18,14 +18,9 @@ vi.mock("../../src/util/download-text.js", async (importOriginal) => ({
 
 import { ESPHomeCrashReportDialog } from "../../src/components/crash-report-dialog.js";
 import type { StreamCallbacks } from "../../src/api/types/streaming.js";
+import { CRASH_BLOCK as CRASH_LINES } from "../_crash-lines.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
-const CRASH_LINES = [
-  "Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.",
-  "Backtrace: 0x400d9150:0x3ffb4f60",
-  "WARNING Decoded 0x400d9150: esphome::wifi::WiFiComponent::loop() at esphome/components/wifi/wifi_component.cpp:100",
-];
 
 const VALIDATE_OUTPUT = [
   "\\033[32mINFO ESPHome 2026.6.4\\033[0m",
@@ -60,6 +55,7 @@ describe("crash-report-dialog", () => {
         validateCallbacks = callbacks;
         return "v1";
       },
+      stopStream: vi.fn(() => Promise.resolve()),
     };
     document.body.appendChild(el);
   });
@@ -80,7 +76,6 @@ describe("crash-report-dialog", () => {
     expect((el as any)._configYaml).toBe(
       "esphome:\n  name: smallgarage\nwifi:\n  password: <removed>"
     );
-    expect((el as any)._configFailed).toBe(false);
   });
 
   it("degrades to a config-unavailable note when validation fails", async () => {
@@ -88,8 +83,19 @@ describe("crash-report-dialog", () => {
     finishValidate(["\\033[31mERROR something\\033[0m"], false);
     await el.updateComplete;
     expect((el as any)._configYaml).toBe("");
-    expect((el as any)._configFailed).toBe(true);
     expect(el.shadowRoot!.querySelector(".collecting")).toBeNull();
+    expect(el.shadowRoot!.textContent).toContain("crash_report.config_unavailable");
+  });
+
+  it("stops an abandoned validate stream on close and on re-open", () => {
+    const stopStream = (el as any)._api.stopStream;
+    el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
+    (el as any)._onAfterHide();
+    expect(stopStream).toHaveBeenCalledWith("v1");
+
+    el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
+    el.open("other.yaml", "Other", CRASH_LINES);
+    expect(stopStream).toHaveBeenCalledTimes(2);
   });
 
   it("copies the full report and opens the pre-filled issue", async () => {
@@ -120,7 +126,7 @@ describe("crash-report-dialog", () => {
     await (el as any)._copyAndOpen();
     expect(openedUrls).toHaveLength(0); // no tab until the report is delivered
     await el.updateComplete;
-    expect((el as any)._phase).toBe("copy-failed");
+    expect((el as any)._copyFailed).toBe(true);
 
     (el as any)._downloadAndOpen();
     expect(downloadBlob).toHaveBeenCalledWith(
@@ -141,7 +147,7 @@ describe("crash-report-dialog", () => {
     stale.onResult!({ success: false, code: 1 });
     await el.updateComplete;
     // Still collecting: the stale stream must not flip this session ready.
-    expect((el as any)._phase).toBe("collecting");
+    expect((el as any)._configYaml).toBeNull();
   });
 });
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/test/components/crash-report-dialog.test.ts
+++ b/test/components/crash-report-dialog.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+
+const { copyToClipboard } = vi.hoisted(() => ({ copyToClipboard: vi.fn() }));
+vi.mock("../../src/util/copy-to-clipboard.js", () => ({ copyToClipboard }));
+
+const { downloadBlob } = vi.hoisted(() => ({ downloadBlob: vi.fn() }));
+vi.mock("../../src/util/download-text.js", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  downloadBlob,
+}));
+
+import { ESPHomeCrashReportDialog } from "../../src/components/crash-report-dialog.js";
+import type { StreamCallbacks } from "../../src/api/types/streaming.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const CRASH_LINES = [
+  "Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.",
+  "Backtrace: 0x400d9150:0x3ffb4f60",
+  "WARNING Decoded 0x400d9150: esphome::wifi::WiFiComponent::loop() at esphome/components/wifi/wifi_component.cpp:100",
+];
+
+const VALIDATE_OUTPUT = [
+  "\\033[32mINFO ESPHome 2026.6.4\\033[0m",
+  "\\033[32mINFO Reading configuration smallgarage.yaml...\\033[0m",
+  "esphome:",
+  "  name: smallgarage",
+  "wifi:",
+  "  password: <removed>",
+  "\\033[32mINFO Configuration is valid!\\033[0m",
+];
+
+describe("crash-report-dialog", () => {
+  let el: ESPHomeCrashReportDialog;
+  let validateCallbacks: StreamCallbacks | null;
+  let openedUrls: string[];
+
+  beforeEach(() => {
+    copyToClipboard.mockReset();
+    downloadBlob.mockReset();
+    validateCallbacks = null;
+    openedUrls = [];
+    vi.stubGlobal(
+      "open",
+      vi.fn((url: string) => {
+        openedUrls.push(url);
+        return null;
+      })
+    );
+    el = new ESPHomeCrashReportDialog();
+    (el as any)._api = {
+      validate: (_config: string, callbacks: StreamCallbacks) => {
+        validateCallbacks = callbacks;
+        return "v1";
+      },
+    };
+    document.body.appendChild(el);
+  });
+
+  const finishValidate = (lines = VALIDATE_OUTPUT, success = true) => {
+    for (const line of lines) validateCallbacks!.onOutput!(line);
+    validateCallbacks!.onResult!({ success, code: success ? 0 : 1 });
+  };
+
+  it("collects, filters CLI log noise out of the config, then goes ready", async () => {
+    el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector(".collecting")).not.toBeNull();
+
+    finishValidate();
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector(".collecting")).toBeNull();
+    expect((el as any)._configYaml).toBe(
+      "esphome:\n  name: smallgarage\nwifi:\n  password: <removed>"
+    );
+    expect((el as any)._configFailed).toBe(false);
+  });
+
+  it("degrades to a config-unavailable note when validation fails", async () => {
+    el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
+    finishValidate(["\\033[31mERROR something\\033[0m"], false);
+    await el.updateComplete;
+    expect((el as any)._configYaml).toBe("");
+    expect((el as any)._configFailed).toBe(true);
+    expect(el.shadowRoot!.querySelector(".collecting")).toBeNull();
+  });
+
+  it("copies the full report and opens the pre-filled issue", async () => {
+    copyToClipboard.mockResolvedValue(true);
+    el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
+    finishValidate();
+    await el.updateComplete;
+
+    await (el as any)._copyAndOpen();
+    expect(copyToClipboard).toHaveBeenCalledTimes(1);
+    const reportText = copyToClipboard.mock.calls[0][0] as string;
+    expect(reportText).toContain("## Decoded backtrace");
+    expect(reportText.indexOf("## Decoded backtrace")).toBeLessThan(
+      reportText.indexOf("## Configuration")
+    );
+    expect(reportText).toContain("password: <removed>");
+    expect(openedUrls).toHaveLength(1);
+    expect(openedUrls[0]).toContain("github.com/esphome/esphome/issues/new");
+    expect(new URL(openedUrls[0]).searchParams.get("additional")).toContain("clipboard");
+  });
+
+  it("falls back to a report download when the copy fails", async () => {
+    copyToClipboard.mockResolvedValue(false);
+    el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
+    finishValidate();
+    await el.updateComplete;
+
+    await (el as any)._copyAndOpen();
+    expect(openedUrls).toHaveLength(0); // no tab until the report is delivered
+    await el.updateComplete;
+    expect((el as any)._phase).toBe("copy-failed");
+
+    (el as any)._downloadAndOpen();
+    expect(downloadBlob).toHaveBeenCalledWith(
+      expect.stringContaining("## Decoded backtrace"),
+      "smallgarage-crash-report.md",
+      "text/markdown"
+    );
+    expect(openedUrls).toHaveLength(1);
+    expect(new URL(openedUrls[0]).searchParams.get("additional")).toContain(
+      "markdown file"
+    );
+  });
+
+  it("ignores a stale validate result from a previous open", async () => {
+    el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
+    const stale = validateCallbacks!;
+    el.open("other.yaml", "Other", CRASH_LINES);
+    stale.onResult!({ success: false, code: 1 });
+    await el.updateComplete;
+    // Still collecting: the stale stream must not flip this session ready.
+    expect((el as any)._phase).toBe("collecting");
+  });
+});
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/test/components/crash-report-dialog.test.ts
+++ b/test/components/crash-report-dialog.test.ts
@@ -21,19 +21,13 @@ vi.mock("../../src/util/download-text.js", async (importOriginal) => ({
 
 import { ESPHomeCrashReportDialog } from "../../src/components/crash-report-dialog.js";
 import type { StreamCallbacks } from "../../src/api/types/streaming.js";
-import { CRASH_BLOCK as CRASH_LINES } from "../_crash-lines.js";
+import {
+  CRASH_BLOCK as CRASH_LINES,
+  VALIDATED_CONFIG_YAML,
+  VALIDATE_OUTPUT,
+} from "../_crash-lines.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
-const VALIDATE_OUTPUT = [
-  "\\033[32mINFO ESPHome 2026.6.4\\033[0m",
-  "\\033[32mINFO Reading configuration smallgarage.yaml...\\033[0m",
-  "esphome:",
-  "  name: smallgarage",
-  "wifi:",
-  "  password: <removed>",
-  "\\033[32mINFO Configuration is valid!\\033[0m",
-];
 
 describe("crash-report-dialog", () => {
   let el: ESPHomeCrashReportDialog;
@@ -80,9 +74,7 @@ describe("crash-report-dialog", () => {
     finishValidate();
     await el.updateComplete;
     expect(el.shadowRoot!.querySelector(".collecting")).toBeNull();
-    expect((el as any)._configYaml).toBe(
-      "esphome:\n  name: smallgarage\nwifi:\n  password: <removed>"
-    );
+    expect((el as any)._configYaml).toBe(VALIDATED_CONFIG_YAML);
   });
 
   it("degrades to a config-unavailable note when validation fails", async () => {

--- a/test/components/crash-report-dialog.test.ts
+++ b/test/components/crash-report-dialog.test.ts
@@ -108,12 +108,14 @@ describe("crash-report-dialog", () => {
     expect(button!.disabled).toBe(false);
   });
 
-  it("does not claim the tab opened when the popup was blocked", async () => {
+  it("always offers the manual issue link in the delivered state", async () => {
+    // window.open with noopener returns null by spec even on success, so
+    // the delivered state can't infer blocking; the link is always there.
     vi.stubGlobal(
       "open",
       vi.fn((url: string) => {
         openedUrls.push(url);
-        return null; // popup blocker
+        return null;
       })
     );
     el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
@@ -123,10 +125,9 @@ describe("crash-report-dialog", () => {
 
     (el as any)._openIssue();
     await el.updateComplete;
-    expect((el as any)._popupBlocked).toBe(true);
-    expect(el.shadowRoot!.textContent).toContain("crash_report.popup_blocked_hint");
     const anchor = el.shadowRoot!.querySelector<HTMLAnchorElement>(".actions a");
     expect(anchor!.href).toBe(openedUrls[0]);
+    expect(anchor!.classList.contains("btn--confirm")).toBe(true);
   });
 
   it("degrades to config-unavailable when the validate stream stalls", async () => {
@@ -180,7 +181,6 @@ describe("crash-report-dialog", () => {
     await el.updateComplete;
     expect((el as any)._dialog.open).toBe(true);
     expect((el as any)._delivered).toBe(true);
-    expect((el as any)._popupBlocked).toBe(false);
     const anchor = el.shadowRoot!.querySelector<HTMLAnchorElement>(".actions a");
     expect(anchor!.href).toBe(openedUrls[0]);
 

--- a/test/components/crash-report-dialog.test.ts
+++ b/test/components/crash-report-dialog.test.ts
@@ -90,8 +90,19 @@ describe("crash-report-dialog", () => {
     finishValidate(["\\033[31mERROR something\\033[0m"], false);
     await el.updateComplete;
     expect((el as any)._configYaml).toBe("");
+    expect((el as any)._configError).toBe("invalid");
     expect(el.shadowRoot!.querySelector(".collecting")).toBeNull();
     expect(el.shadowRoot!.textContent).toContain("crash_report.config_unavailable");
+  });
+
+  it("distinguishes a transport failure from an invalid config", async () => {
+    el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
+    validateCallbacks!.onError!("WebSocket not connected");
+    await el.updateComplete;
+    expect((el as any)._configYaml).toBe("");
+    expect((el as any)._configError).toBe("transport");
+    expect(el.shadowRoot!.textContent).toContain("crash_report.config_capture_failed");
+    expect(el.shadowRoot!.textContent).not.toContain("crash_report.config_unavailable");
   });
 
   it("requires a description before the report can be opened", async () => {
@@ -137,6 +148,8 @@ describe("crash-report-dialog", () => {
       expect((el as any)._configYaml).toBeNull();
       vi.advanceTimersByTime(90_000);
       expect((el as any)._configYaml).toBe("");
+      // A stall is a transport issue, not an invalid config.
+      expect((el as any)._configError).toBe("transport");
       expect((el as any)._api.stopStream).toHaveBeenCalledWith("v1");
     } finally {
       vi.useRealTimers();

--- a/test/components/crash-report-dialog.test.ts
+++ b/test/components/crash-report-dialog.test.ts
@@ -90,6 +90,19 @@ describe("crash-report-dialog", () => {
     expect(el.shadowRoot!.textContent).toContain("crash_report.config_unavailable");
   });
 
+  it("degrades to config-unavailable when the validate stream stalls", async () => {
+    vi.useFakeTimers();
+    try {
+      el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
+      expect((el as any)._configYaml).toBeNull();
+      vi.advanceTimersByTime(90_000);
+      expect((el as any)._configYaml).toBe("");
+      expect((el as any)._api.stopStream).toHaveBeenCalledWith("v1");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("stops an abandoned validate stream on close and on re-open", () => {
     const stopStream = (el as any)._api.stopStream;
     el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);

--- a/test/components/logs-dialog-crash.test.ts
+++ b/test/components/logs-dialog-crash.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const append = (el: ESPHomeLogsDialog, lines: string[]) =>
+  (el as any)._appendCapped(lines);
+
+const CRASH_LINE =
+  "Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.";
+
+describe("logs-dialog crash callout", () => {
+  let el: ESPHomeLogsDialog;
+
+  beforeEach(() => {
+    el = new ESPHomeLogsDialog();
+    (el as any)._api = { logs: () => "s1", stopStream: () => Promise.resolve() };
+    document.body.appendChild(el);
+  });
+
+  const callout = () => el.shadowRoot!.querySelector(".crash-callout");
+
+  it("appears once a crash line flows through the append path", async () => {
+    el.open("OTA");
+    await el.updateComplete;
+    append(el, ["[12:00:00][I][app:029]: boot"]);
+    await el.updateComplete;
+    expect(callout()).toBeNull();
+
+    append(el, [CRASH_LINE]);
+    await el.updateComplete;
+    expect(callout()).not.toBeNull();
+    expect(callout()!.querySelector("button")).not.toBeNull();
+  });
+
+  it("persists after the crash lines scroll out of the capped buffer", async () => {
+    el.open("OTA");
+    append(el, [CRASH_LINE]);
+    append(
+      el,
+      Array.from({ length: 6000 }, (_, i) => `line ${i}`)
+    );
+    await el.updateComplete;
+    expect(callout()).not.toBeNull();
+  });
+
+  it("clears on a new session", async () => {
+    el.open("OTA");
+    append(el, [CRASH_LINE]);
+    await el.updateComplete;
+    expect(callout()).not.toBeNull();
+
+    el.open("OTA");
+    await el.updateComplete;
+    expect(callout()).toBeNull();
+  });
+
+  it("clears when the user clears the log", async () => {
+    el.open("OTA");
+    append(el, [CRASH_LINE]);
+    await el.updateComplete;
+    (el as any)._clearLogs();
+    await el.updateComplete;
+    expect(callout()).toBeNull();
+  });
+
+  it("hands the report dialog a snapshot of the buffer on click", async () => {
+    el.open("OTA");
+    append(el, ["[I][app] boot", CRASH_LINE]);
+    await el.updateComplete;
+    const open = vi.fn();
+    Object.defineProperty(el, "_crashReportDialog", { value: { open } });
+    el.configuration = "smallgarage.yaml";
+    el.name = "Small Garage";
+    callout()!.querySelector("button")!.click();
+    expect(open).toHaveBeenCalledWith("smallgarage.yaml", "Small Garage", [
+      "[I][app] boot",
+      CRASH_LINE,
+    ]);
+  });
+});
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/test/components/logs-dialog-crash.test.ts
+++ b/test/components/logs-dialog-crash.test.ts
@@ -7,13 +7,11 @@ vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
+import { CRASH_BANNER_LINE as CRASH_LINE } from "../_crash-lines.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const append = (el: ESPHomeLogsDialog, lines: string[]) =>
   (el as any)._appendCapped(lines);
-
-const CRASH_LINE =
-  "Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.";
 
 describe("logs-dialog crash callout", () => {
   let el: ESPHomeLogsDialog;

--- a/test/util/crash-detector.test.ts
+++ b/test/util/crash-detector.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  hasCrashMarker,
+  detectCrashKind,
   isCrashMarker,
   normalizeLogLine,
 } from "../../src/util/crash-detector.js";
@@ -11,8 +11,16 @@ const CRASH_LINES: ReadonlyArray<[string, string]> = [
     "esp32 panic banner",
     "Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.",
   ],
+  [
+    "crash handler previous-boot banner (logger-tagged)",
+    "[E][esp32.crash:332]: *** CRASH DETECTED ON PREVIOUS BOOT ***",
+  ],
   ["esp32 backtrace", "Backtrace: 0x400d9150:0x3ffb4f60 0x400da73c:0x3ffb4f90"],
   ["stored previous-boot backtrace", "BT0: 0x400d9150"],
+  [
+    "stored backtrace replayed through the logger",
+    "[E][esp32.crash:305]:   BT0: 0x4015482D  (backtrace)",
+  ],
   ["esp32 bad-alloc", "last failed alloc call: 4009ac2c(1024)"],
   ["esp-idf abort", "abort() was called at PC 0x401a2b3c on core 1"],
   ["esp-idf assert", "assert failed: xQueueSemaphoreTake queue.c:1549 (( pxQueue ))"],
@@ -62,14 +70,32 @@ describe("isCrashMarker", () => {
   });
 });
 
-describe("hasCrashMarker", () => {
-  it("spots a crash line arriving wrapped in ANSI + timestamp", () => {
-    expect(hasCrashMarker(["[12:00:00][I][app:029]: boot"])).toBe(false);
+describe("detectCrashKind", () => {
+  it("spots a live crash line arriving wrapped in ANSI + timestamp", () => {
+    expect(detectCrashKind(["[12:00:00][I][app:029]: boot"])).toBeNull();
     expect(
-      hasCrashMarker([
+      detectCrashKind([
         "[12:00:00][I][app:029]: boot",
         wrapEsc("Guru Meditation Error: Core 1 panic'ed (StoreProhibited)."),
       ])
-    ).toBe(true);
+    ).toBe("live");
+  });
+
+  it("classifies the crash handler's boot replay as previous-boot", () => {
+    expect(
+      detectCrashKind([
+        "[11:21:19.093][E][esp32.crash:332]: *** CRASH DETECTED ON PREVIOUS BOOT ***",
+        "[11:21:19.167][E][esp32.crash:305]:   BT0: 0x4015482D  (backtrace)",
+      ])
+    ).toBe("previous-boot");
+  });
+
+  it("live wins when both kinds appear in one batch", () => {
+    expect(
+      detectCrashKind([
+        "[E][esp32.crash:332]: *** CRASH DETECTED ON PREVIOUS BOOT ***",
+        "Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.",
+      ])
+    ).toBe("live");
   });
 });

--- a/test/util/crash-detector.test.ts
+++ b/test/util/crash-detector.test.ts
@@ -4,13 +4,11 @@ import {
   isCrashMarker,
   normalizeLogLine,
 } from "../../src/util/crash-detector.js";
+import { CRASH_BANNER_LINE } from "../_crash-lines.js";
 
 // Realistic crash lines, one per supported shape.
 const CRASH_LINES: ReadonlyArray<[string, string]> = [
-  [
-    "esp32 panic banner",
-    "Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.",
-  ],
+  ["esp32 panic banner", CRASH_BANNER_LINE],
   [
     "crash handler previous-boot banner (logger-tagged)",
     "[E][esp32.crash:332]: *** CRASH DETECTED ON PREVIOUS BOOT ***",
@@ -94,7 +92,7 @@ describe("detectCrashKind", () => {
     expect(
       detectCrashKind([
         "[E][esp32.crash:332]: *** CRASH DETECTED ON PREVIOUS BOOT ***",
-        "Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.",
+        CRASH_BANNER_LINE,
       ])
     ).toBe("live");
   });

--- a/test/util/crash-detector.test.ts
+++ b/test/util/crash-detector.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  CrashDetector,
+  hasCrashMarker,
   isCrashMarker,
   normalizeLogLine,
 } from "../../src/util/crash-detector.js";
@@ -62,26 +62,14 @@ describe("isCrashMarker", () => {
   });
 });
 
-describe("CrashDetector", () => {
-  it("latches on a crash line arriving wrapped in ANSI + timestamp", () => {
-    const detector = new CrashDetector();
-    detector.feed(["[12:00:00][I][app:029]: boot"]);
-    expect(detector.detected).toBe(false);
-    detector.feed([wrapEsc("Guru Meditation Error: Core 1 panic'ed (StoreProhibited).")]);
-    expect(detector.detected).toBe(true);
-  });
-
-  it("stays latched across later batches", () => {
-    const detector = new CrashDetector();
-    detector.feed([">>>stack>>>"]);
-    detector.feed(["[12:00:05][I][app:029]: rebooted fine"]);
-    expect(detector.detected).toBe(true);
-  });
-
-  it("reset clears the latch", () => {
-    const detector = new CrashDetector();
-    detector.feed(["Soft WDT reset"]);
-    detector.reset();
-    expect(detector.detected).toBe(false);
+describe("hasCrashMarker", () => {
+  it("spots a crash line arriving wrapped in ANSI + timestamp", () => {
+    expect(hasCrashMarker(["[12:00:00][I][app:029]: boot"])).toBe(false);
+    expect(
+      hasCrashMarker([
+        "[12:00:00][I][app:029]: boot",
+        wrapEsc("Guru Meditation Error: Core 1 panic'ed (StoreProhibited)."),
+      ])
+    ).toBe(true);
   });
 });

--- a/test/util/crash-detector.test.ts
+++ b/test/util/crash-detector.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  CrashDetector,
+  isCrashMarker,
+  normalizeLogLine,
+} from "../../src/util/crash-detector.js";
+
+// Realistic crash lines, one per supported shape.
+const CRASH_LINES: ReadonlyArray<[string, string]> = [
+  [
+    "esp32 panic banner",
+    "Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.",
+  ],
+  ["esp32 backtrace", "Backtrace: 0x400d9150:0x3ffb4f60 0x400da73c:0x3ffb4f90"],
+  ["stored previous-boot backtrace", "BT0: 0x400d9150"],
+  ["esp32 bad-alloc", "last failed alloc call: 4009ac2c(1024)"],
+  ["esp-idf abort", "abort() was called at PC 0x401a2b3c on core 1"],
+  ["esp-idf assert", "assert failed: xQueueSemaphoreTake queue.c:1549 (( pxQueue ))"],
+  ["register dump header", "Core  1 register dump:"],
+  ["riscv register dump", "MEPC    : 0x4200b1a4  RA      : 0x4200b1a0"],
+  ["heap poisoning", "CORRUPT HEAP: Bad head at 0x3ffb8f00. Expected 0xabba1234"],
+  ["esp8266 exception", "Exception (28):"],
+  ["esp8266 stack dump start", ">>>stack>>>"],
+  ["esp8266 postmortem", "Fatal exception 28(LoadProhibitedCause):"],
+  ["esp8266 soft WDT", "Soft WDT reset"],
+  ["esp8266 stack smashing", "Stack smashing protect failure!"],
+];
+
+const NON_CRASH_LINES: ReadonlyArray<[string, string]> = [
+  ["plain error log", "[E][component:214]: Component wifi took a long time (128 ms)"],
+  ["prose mentioning Backtrace", "[I][app:100]: Backtrace decoding is available"],
+  ["config dump line", "[C][logger:224]: Logger:"],
+  ["esptool progress", "Writing at 0x00010000... (5 %)"],
+  ["baud-mismatch mojibake", "����rl��"],
+  ["BT prose without address", "BT scan finished"],
+  ["empty line", ""],
+];
+
+// The dialog's real transport wrapping: timestamp prefix + ANSI color in
+// both the ESC-byte (UART) and literal-\033 (backend) forms.
+const wrapEsc = (line: string) => `[12:34:56]\u001b[31m${line}\u001b[0m`;
+const wrapLiteral = (line: string) => `\\033[31m[12:34:56]${line}\\033[0m`;
+
+describe("normalizeLogLine", () => {
+  it("strips ANSI (both forms), the timestamp prefix, and trailing CRLF", () => {
+    expect(normalizeLogLine(wrapEsc("Soft WDT reset\r\n"))).toBe("Soft WDT reset");
+    expect(normalizeLogLine(wrapLiteral("Soft WDT reset"))).toBe("Soft WDT reset");
+  });
+
+  it("keeps a line with no wrapping untouched", () => {
+    expect(normalizeLogLine("Exception (28):")).toBe("Exception (28):");
+  });
+});
+
+describe("isCrashMarker", () => {
+  it.each(CRASH_LINES)("matches %s", (_name, line) => {
+    expect(isCrashMarker(line)).toBe(true);
+  });
+
+  it.each(NON_CRASH_LINES)("does not match %s", (_name, line) => {
+    expect(isCrashMarker(line)).toBe(false);
+  });
+});
+
+describe("CrashDetector", () => {
+  it("latches on a crash line arriving wrapped in ANSI + timestamp", () => {
+    const detector = new CrashDetector();
+    detector.feed(["[12:00:00][I][app:029]: boot"]);
+    expect(detector.detected).toBe(false);
+    detector.feed([wrapEsc("Guru Meditation Error: Core 1 panic'ed (StoreProhibited).")]);
+    expect(detector.detected).toBe(true);
+  });
+
+  it("stays latched across later batches", () => {
+    const detector = new CrashDetector();
+    detector.feed([">>>stack>>>"]);
+    detector.feed(["[12:00:05][I][app:029]: rebooted fine"]);
+    expect(detector.detected).toBe(true);
+  });
+
+  it("reset clears the latch", () => {
+    const detector = new CrashDetector();
+    detector.feed(["Soft WDT reset"]);
+    detector.reset();
+    expect(detector.detected).toBe(false);
+  });
+});

--- a/test/util/crash-report.test.ts
+++ b/test/util/crash-report.test.ts
@@ -37,13 +37,14 @@ const META = {
   dashboardVersion: "1.6.1",
   targetPlatform: "ESP32S3",
   board: "esp32dev",
-  isHaAddon: true,
+  installation: "Home Assistant Add-on",
 };
 
 const report = (overrides: Partial<CrashReport> = {}): CrashReport => ({
   scrape: scrapeCrashData(BUFFER),
   meta: META,
   configYaml: "esphome:\n  name: smallgarage\nwifi:\n  password: <removed>",
+  userDescription: "Pressed the crash button in Home Assistant",
   ...overrides,
 });
 
@@ -85,6 +86,28 @@ describe("scrapeCrashData", () => {
     expect(scrolled.crashFound).toBe(false);
     expect(scrolled.excerpt).toEqual([]);
   });
+
+  // Pinned against real ol (esp32-poe-iso) output: the crash handler
+  // replays the previous-boot crash through the logger with [E] tags,
+  // and the inline decoder emits multi-line frames for inlined calls.
+  it("handles the logger-replayed previous-boot crash report", () => {
+    const scrape = scrapeCrashData([
+      "[11:21:19.093][E][esp32.crash:332]: *** CRASH DETECTED ON PREVIOUS BOOT ***",
+      "[11:21:19.096][E][esp32.crash:335]:   Reason: Fault - StoreProhibited",
+      "[11:21:19.096][E][esp32.crash:340]:   PC:  0x40154830  (fault location)",
+      "[11:21:19.167][E][esp32.crash:305]:   BT0: 0x4015482D  (backtrace)",
+      "WARNING Decoded 0x4015482d: setup()::{lambda()#1}::_FUN() at configs/ol.yaml:52",
+      " (inlined by) _FUN at configs/ol.yaml:53",
+      "[11:21:19.211][E][esp32.crash:305]:   BT1: 0x40154879  (backtrace)",
+      "WARNING Decoded 0x40154879: esphome::StatelessLambdaAction<>::play() at base_automation.h:247",
+    ]);
+    expect(scrape.crashFound).toBe(true);
+    expect(scrape.decodedFrames).toEqual([
+      "0x4015482d: setup()::{lambda()#1}::_FUN() at configs/ol.yaml:52\n" +
+        "  (inlined by) _FUN at configs/ol.yaml:53",
+      "0x40154879: esphome::StatelessLambdaAction<>::play() at base_automation.h:247",
+    ]);
+  });
 });
 
 describe("distillValidatedConfig", () => {
@@ -118,9 +141,10 @@ describe("issuePlatform / inferComponentName", () => {
 });
 
 describe("buildFullReport", () => {
-  it("orders sections decoded-backtrace-first", () => {
+  it("leads with the user's context, then the decoded backtrace", () => {
     const text = buildFullReport(report());
     const order = [
+      "## What happened",
       "## Decoded backtrace",
       "## Crash log",
       "## Warnings and errors",
@@ -130,6 +154,7 @@ describe("buildFullReport", () => {
     ].map((heading) => text.indexOf(heading));
     expect(order.every((index) => index !== -1)).toBe(true);
     expect([...order].sort((a, b) => a - b)).toEqual(order);
+    expect(text).toContain("Pressed the crash button in Home Assistant");
     expect(text).toContain("password: <removed>");
   });
 
@@ -141,10 +166,9 @@ describe("buildFullReport", () => {
 });
 
 describe("buildIssueUrl", () => {
-  const params = (r: CrashReport, mode: "clipboard" | "download" = "clipboard") =>
-    new URL(buildIssueUrl(r, mode)).searchParams;
+  const params = (r: CrashReport) => new URL(buildIssueUrl(r).url).searchParams;
 
-  it("prefills the form fields and never sets config", () => {
+  it("prefills every form field, config into the YAML Config box", () => {
     const p = params(report());
     expect(p.get("template")).toBe("bug_report.yml");
     expect(p.get("version")).toBe("2026.6.4");
@@ -152,24 +176,34 @@ describe("buildIssueUrl", () => {
     expect(p.get("platform")).toBe("ESP32");
     expect(p.get("component_name")).toBe("wifi");
     expect(p.get("title")).toContain("Guru Meditation Error");
+    expect(p.get("problem")).toContain("Pressed the crash button in Home Assistant");
     expect(p.get("problem")).toContain("Decoded backtrace:");
     expect(p.get("problem")).toContain("0x400d9150: esphome::Application::setup()");
     expect(p.get("logs")).toContain("Backtrace: 0x400d9150");
-    expect(p.has("config")).toBe(false);
+    // The whole sanitized config lands in the form's config field.
+    expect(p.get("config")).toBe(
+      "esphome:\n  name: smallgarage\nwifi:\n  password: <removed>"
+    );
   });
 
-  it("omits installation outside the add-on and unknown platforms", () => {
-    const p = params(report({ meta: { ...META, isHaAddon: false, targetPlatform: "" } }));
+  it("reports complete when everything fit", () => {
+    expect(buildIssueUrl(report()).complete).toBe(true);
+  });
+
+  it("omits installation and unknown platforms when unset", () => {
+    const p = params(report({ meta: { ...META, installation: "", targetPlatform: "" } }));
     expect(p.has("installation")).toBe(false);
     expect(p.has("platform")).toBe(false);
   });
 
-  it("tells the user where the full report went", () => {
-    expect(params(report(), "clipboard").get("additional")).toContain("clipboard");
-    expect(params(report(), "download").get("additional")).toContain("markdown file");
+  it("packs supplementary sections into additional", () => {
+    const p = params(report());
+    const additional = p.get("additional") ?? "";
+    expect(additional).toContain("Environment:");
+    expect(additional).toContain("Warnings and errors:");
   });
 
-  it("stays under the URL budget, dropping context before the crash block", () => {
+  it("stays under budget, truncating config then logs, and reports incomplete", () => {
     const noisy = [
       ...Array.from(
         { length: 200 },
@@ -177,11 +211,17 @@ describe("buildIssueUrl", () => {
       ),
       ...CRASH_BLOCK,
     ];
-    const r = report({ scrape: scrapeCrashData(noisy) });
-    const url = buildIssueUrl(r, "clipboard");
-    expect(url.length).toBeLessThanOrEqual(6000);
-    const logs = new URL(url).searchParams.get("logs") ?? "";
-    expect(logs).toContain("Guru Meditation Error");
-    expect(logs).toContain("trimmed");
+    const bigConfig = Array.from(
+      { length: 2000 },
+      (_, i) => `  key_${i}: value_${i}`
+    ).join("\n");
+    const result = buildIssueUrl(
+      report({ scrape: scrapeCrashData(noisy), configYaml: `esphome:\n${bigConfig}` })
+    );
+    expect(result.url.length).toBeLessThanOrEqual(8000);
+    expect(result.complete).toBe(false);
+    const p = new URL(result.url).searchParams;
+    expect(p.get("logs")).toContain("Guru Meditation Error");
+    expect(p.get("config")).toContain("config truncated");
   });
 });

--- a/test/util/crash-report.test.ts
+++ b/test/util/crash-report.test.ts
@@ -3,30 +3,24 @@ import {
   type CrashReport,
   buildFullReport,
   buildIssueUrl,
+  distillValidatedConfig,
   inferComponentName,
   issuePlatform,
   scrapeCrashData,
 } from "../../src/util/crash-report.js";
+import { CRASH_BLOCK } from "../_crash-lines.js";
 
 const FILLER = Array.from(
   { length: 40 },
   (_, i) => `[12:00:00][I][app:029]: loop iteration ${i}`
 );
 
-const CRASH_BLOCK = [
-  "Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.",
-  "Core  1 register dump:",
-  "PC      : 0x400d9150  PS      : 0x00060330  A0      : 0x800da73c",
-  "Backtrace: 0x400d9150:0x3ffb4f60 0x400da73c:0x3ffb4f90",
-  "WARNING Decoded 0x400d9150: esphome::Application::setup() at esphome/core/application.cpp:59",
-  "WARNING Decoded 0x400da73c: esphome::wifi::WiFiComponent::loop() at esphome/components/wifi/wifi_component.cpp:100",
-  "Rebooting...",
-];
-
 const BUFFER = [
   ...FILLER,
+  // Continuation lines arrive with the entry's prefix re-applied (the
+  // log parsers on both transports do this before lines hit the buffer).
   "[12:00:01][C][wifi:001]: WiFi:",
-  "[12:00:01]  SSID: 'mynetwork'",
+  "[12:00:01][C][wifi:001]:   SSID: 'mynetwork'",
   "[12:00:02][W][component:214]: Component wifi took a long time (128 ms)",
   "[12:00:03][W][component:214]: Component wifi took a long time (128 ms)",
   "[12:00:04][W][component:214]: Component wifi took a long time (128 ms)",
@@ -79,14 +73,31 @@ describe("scrapeCrashData", () => {
     ]);
   });
 
-  it("keeps indented continuations attached to their [C] entry line", () => {
-    expect(scrape.configLines).toEqual(["[C][wifi:001]: WiFi:", "  SSID: 'mynetwork'"]);
+  it("collects multi-line [C] records (continuations carry the re-applied prefix)", () => {
+    expect(scrape.configLines).toEqual([
+      "[C][wifi:001]: WiFi:",
+      "[C][wifi:001]:   SSID: 'mynetwork'",
+    ]);
   });
 
   it("reports a crash that scrolled out of the buffer", () => {
     const scrolled = scrapeCrashData(FILLER);
     expect(scrolled.crashFound).toBe(false);
     expect(scrolled.excerpt).toEqual([]);
+  });
+});
+
+describe("distillValidatedConfig", () => {
+  it("keeps the YAML and drops CLI log records, timestamped or not", () => {
+    expect(
+      distillValidatedConfig([
+        "\\033[32mINFO ESPHome 2026.6.4\\033[0m",
+        "12:34:56 INFO Reading configuration...",
+        "esphome:",
+        "  name: smallgarage",
+        "\\033[32mINFO Configuration is valid!\\033[0m",
+      ])
+    ).toBe("esphome:\n  name: smallgarage");
   });
 });
 

--- a/test/util/crash-report.test.ts
+++ b/test/util/crash-report.test.ts
@@ -8,7 +8,7 @@ import {
   issuePlatform,
   scrapeCrashData,
 } from "../../src/util/crash-report.js";
-import { CRASH_BLOCK } from "../_crash-lines.js";
+import { CRASH_BLOCK, VALIDATED_CONFIG_YAML } from "../_crash-lines.js";
 
 const FILLER = Array.from(
   { length: 40 },
@@ -43,7 +43,7 @@ const META = {
 const report = (overrides: Partial<CrashReport> = {}): CrashReport => ({
   scrape: scrapeCrashData(BUFFER),
   meta: META,
-  configYaml: "esphome:\n  name: smallgarage\nwifi:\n  password: <removed>",
+  configYaml: VALIDATED_CONFIG_YAML,
   userDescription: "Pressed the crash button in Home Assistant",
   ...overrides,
 });
@@ -194,9 +194,7 @@ describe("buildIssueUrl", () => {
     expect(p.get("problem")).toContain("0x400d9150: esphome::Application::setup()");
     expect(p.get("logs")).toContain("Backtrace: 0x400d9150");
     // The whole sanitized config lands in the form's config field.
-    expect(p.get("config")).toBe(
-      "esphome:\n  name: smallgarage\nwifi:\n  password: <removed>"
-    );
+    expect(p.get("config")).toBe(VALIDATED_CONFIG_YAML);
   });
 
   it("surfaces platform and installation in problem (dropdowns can't prefill)", () => {

--- a/test/util/crash-report.test.ts
+++ b/test/util/crash-report.test.ts
@@ -168,12 +168,10 @@ describe("buildFullReport", () => {
 describe("buildIssueUrl", () => {
   const params = (r: CrashReport) => new URL(buildIssueUrl(r).url).searchParams;
 
-  it("prefills every form field, config into the YAML Config box", () => {
+  it("prefills the text fields, config into the YAML Config box", () => {
     const p = params(report());
     expect(p.get("template")).toBe("bug_report.yml");
     expect(p.get("version")).toBe("2026.6.4");
-    expect(p.get("installation")).toBe("Home Assistant Add-on");
-    expect(p.get("platform")).toBe("ESP32");
     expect(p.get("component_name")).toBe("wifi");
     expect(p.get("title")).toContain("Guru Meditation Error");
     expect(p.get("problem")).toContain("Pressed the crash button in Home Assistant");
@@ -186,14 +184,24 @@ describe("buildIssueUrl", () => {
     );
   });
 
+  it("surfaces platform and installation in problem (dropdowns can't prefill)", () => {
+    const p = params(report());
+    // GitHub ignores URL prefill on dropdown fields, so they are NOT set.
+    expect(p.has("platform")).toBe(false);
+    expect(p.has("installation")).toBe(false);
+    // The values ride in the problem text where the maintainer sees them.
+    expect(p.get("problem")).toContain("Platform: ESP32");
+    expect(p.get("problem")).toContain("Installation: Home Assistant Add-on");
+  });
+
   it("reports complete when everything fit", () => {
     expect(buildIssueUrl(report()).complete).toBe(true);
   });
 
-  it("omits installation and unknown platforms when unset", () => {
+  it("omits the platform fact when unknown", () => {
     const p = params(report({ meta: { ...META, installation: "", targetPlatform: "" } }));
-    expect(p.has("installation")).toBe(false);
-    expect(p.has("platform")).toBe(false);
+    expect(p.get("problem")).not.toContain("Platform:");
+    expect(p.get("problem")).not.toContain("Installation:");
   });
 
   it("packs supplementary sections into additional", () => {

--- a/test/util/crash-report.test.ts
+++ b/test/util/crash-report.test.ts
@@ -178,6 +178,13 @@ describe("buildFullReport", () => {
     expect(text).toContain("could not be validated");
     expect(text).not.toContain("```yaml");
   });
+
+  it("widens the code fence when content contains a backtick run", () => {
+    // A config with a ``` run must not close the fence early.
+    const text = buildFullReport(report({ configYaml: "note: |\n  ``` not a fence" }));
+    expect(text).toContain("````yaml");
+    expect(text).toContain("note: |\n  ``` not a fence");
+  });
 });
 
 describe("buildIssueUrl", () => {

--- a/test/util/crash-report.test.ts
+++ b/test/util/crash-report.test.ts
@@ -220,6 +220,25 @@ describe("buildIssueUrl", () => {
     expect(new URL(result.url).searchParams.get("problem")).toContain("truncated");
   });
 
+  it("stays under budget with paren/!-heavy content (form-encoding cost)", () => {
+    // encodeURIComponent leaves ( ) ! ~ ' as 1 char but URLSearchParams
+    // encodes them as 3 — a real budget hazard for C++ backtraces and
+    // !lambda/!secret YAML. The real URL must still be under the cap.
+    const heavy =
+      "esphome::Callback<void ()>::create()::{lambda(void*)#1}::operator()() !~'";
+    const result = buildIssueUrl(
+      report({
+        userDescription: heavy.repeat(120),
+        configYaml: `esphome:\n${`  x: ${heavy}\n`.repeat(120)}`,
+        scrape: scrapeCrashData([
+          "Guru Meditation Error: crash",
+          ...Array.from({ length: 60 }, () => `  ${heavy}`),
+        ]),
+      })
+    );
+    expect(result.url.length).toBeLessThanOrEqual(8000);
+  });
+
   it("omits the platform fact when unknown", () => {
     const p = params(report({ meta: { ...META, installation: "", targetPlatform: "" } }));
     expect(p.get("problem")).not.toContain("Platform:");

--- a/test/util/crash-report.test.ts
+++ b/test/util/crash-report.test.ts
@@ -204,11 +204,14 @@ describe("buildIssueUrl", () => {
     expect(p.get("problem")).not.toContain("Installation:");
   });
 
-  it("packs supplementary sections into additional", () => {
+  it("packs only non-duplicated sections into additional", () => {
     const p = params(report());
     const additional = p.get("additional") ?? "";
-    expect(additional).toContain("Environment:");
     expect(additional).toContain("Warnings and errors:");
+    // Environment already rides in `problem`; don't repeat it under the
+    // tight URL budget.
+    expect(additional).not.toContain("Environment:");
+    expect(p.get("problem")).toContain("Platform: ESP32");
   });
 
   it("stays under budget, truncating config then logs, and reports incomplete", () => {

--- a/test/util/crash-report.test.ts
+++ b/test/util/crash-report.test.ts
@@ -81,6 +81,21 @@ describe("scrapeCrashData", () => {
     ]);
   });
 
+  it("preserves repeated [C] config lines verbatim (no folding)", () => {
+    const scraped = scrapeCrashData([
+      "Guru Meditation Error: crash",
+      "[C][gpio:001]: Pin: GPIO2",
+      "[C][gpio:001]: Pin: GPIO2",
+      "[C][gpio:001]: Pin: GPIO2",
+    ]);
+    // Config dump keeps each line (folding is only for [W]/[E] spam).
+    expect(scraped.configLines).toEqual([
+      "[C][gpio:001]: Pin: GPIO2",
+      "[C][gpio:001]: Pin: GPIO2",
+      "[C][gpio:001]: Pin: GPIO2",
+    ]);
+  });
+
   it("reports a crash that scrolled out of the buffer", () => {
     const scrolled = scrapeCrashData(FILLER);
     expect(scrolled.crashFound).toBe(false);
@@ -196,6 +211,13 @@ describe("buildIssueUrl", () => {
 
   it("reports complete when everything fit", () => {
     expect(buildIssueUrl(report()).complete).toBe(true);
+  });
+
+  it("keeps the URL under budget even with a huge user description", () => {
+    const result = buildIssueUrl(report({ userDescription: "x".repeat(20000) }));
+    expect(result.url.length).toBeLessThanOrEqual(8000);
+    expect(result.complete).toBe(false);
+    expect(new URL(result.url).searchParams.get("problem")).toContain("truncated");
   });
 
   it("omits the platform fact when unknown", () => {

--- a/test/util/crash-report.test.ts
+++ b/test/util/crash-report.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CrashReport,
+  buildFullReport,
+  buildIssueUrl,
+  inferComponentName,
+  issuePlatform,
+  scrapeCrashData,
+} from "../../src/util/crash-report.js";
+
+const FILLER = Array.from(
+  { length: 40 },
+  (_, i) => `[12:00:00][I][app:029]: loop iteration ${i}`
+);
+
+const CRASH_BLOCK = [
+  "Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.",
+  "Core  1 register dump:",
+  "PC      : 0x400d9150  PS      : 0x00060330  A0      : 0x800da73c",
+  "Backtrace: 0x400d9150:0x3ffb4f60 0x400da73c:0x3ffb4f90",
+  "WARNING Decoded 0x400d9150: esphome::Application::setup() at esphome/core/application.cpp:59",
+  "WARNING Decoded 0x400da73c: esphome::wifi::WiFiComponent::loop() at esphome/components/wifi/wifi_component.cpp:100",
+  "Rebooting...",
+];
+
+const BUFFER = [
+  ...FILLER,
+  "[12:00:01][C][wifi:001]: WiFi:",
+  "[12:00:01]  SSID: 'mynetwork'",
+  "[12:00:02][W][component:214]: Component wifi took a long time (128 ms)",
+  "[12:00:03][W][component:214]: Component wifi took a long time (128 ms)",
+  "[12:00:04][W][component:214]: Component wifi took a long time (128 ms)",
+  "[12:00:05][E][uart:123]: Reading from UART timed out",
+  ...CRASH_BLOCK,
+  "[12:00:10][I][app:029]: booted again",
+];
+
+const META = {
+  deviceName: "Small Garage",
+  configuration: "smallgarage.yaml",
+  esphomeVersion: "2026.6.4",
+  deployedVersion: "2026.6.2",
+  dashboardVersion: "1.6.1",
+  targetPlatform: "ESP32S3",
+  board: "esp32dev",
+  isHaAddon: true,
+};
+
+const report = (overrides: Partial<CrashReport> = {}): CrashReport => ({
+  scrape: scrapeCrashData(BUFFER),
+  meta: META,
+  configYaml: "esphome:\n  name: smallgarage\nwifi:\n  password: <removed>",
+  ...overrides,
+});
+
+describe("scrapeCrashData", () => {
+  const scrape = scrapeCrashData(BUFFER);
+
+  it("finds the crash and bounds the excerpt at the reboot marker", () => {
+    expect(scrape.crashFound).toBe(true);
+    expect(scrape.excerpt[scrape.excerpt.length - 1]).toBe("Rebooting...");
+    // Context lines before the banner ride along...
+    expect(scrape.excerpt).toContain("[E][uart:123]: Reading from UART timed out");
+    // ...but the post-reboot line does not.
+    expect(scrape.excerpt).not.toContain("[I][app:029]: booted again");
+  });
+
+  it("extracts the inline-decoded frames", () => {
+    expect(scrape.decodedFrames).toEqual([
+      "0x400d9150: esphome::Application::setup() at esphome/core/application.cpp:59",
+      "0x400da73c: esphome::wifi::WiFiComponent::loop() at esphome/components/wifi/wifi_component.cpp:100",
+    ]);
+  });
+
+  it("collects [W]/[E] lines, folding immediate repeats", () => {
+    expect(scrape.warnings).toEqual([
+      "[W][component:214]: Component wifi took a long time (128 ms) (x3)",
+      "[E][uart:123]: Reading from UART timed out",
+    ]);
+  });
+
+  it("keeps indented continuations attached to their [C] entry line", () => {
+    expect(scrape.configLines).toEqual(["[C][wifi:001]: WiFi:", "  SSID: 'mynetwork'"]);
+  });
+
+  it("reports a crash that scrolled out of the buffer", () => {
+    const scrolled = scrapeCrashData(FILLER);
+    expect(scrolled.crashFound).toBe(false);
+    expect(scrolled.excerpt).toEqual([]);
+  });
+});
+
+describe("issuePlatform / inferComponentName", () => {
+  it("maps target platforms onto the form's dropdown values", () => {
+    expect(issuePlatform("ESP32S3")).toBe("ESP32");
+    expect(issuePlatform("esp32")).toBe("ESP32");
+    expect(issuePlatform("ESP8266")).toBe("ESP8266");
+    expect(issuePlatform("BK72XX")).toBe("BK72XX");
+    expect(issuePlatform("nrf52840")).toBe("Other");
+    expect(issuePlatform("")).toBe("");
+  });
+
+  it("names the first component-owned decoded frame", () => {
+    expect(inferComponentName(report().scrape.decodedFrames)).toBe("wifi");
+    expect(inferComponentName(["0x1: main at src/main.cpp:1"])).toBe("");
+  });
+});
+
+describe("buildFullReport", () => {
+  it("orders sections decoded-backtrace-first", () => {
+    const text = buildFullReport(report());
+    const order = [
+      "## Decoded backtrace",
+      "## Crash log",
+      "## Warnings and errors",
+      "## Config dump",
+      "## Configuration (secrets redacted)",
+      "## Environment",
+    ].map((heading) => text.indexOf(heading));
+    expect(order.every((index) => index !== -1)).toBe(true);
+    expect([...order].sort((a, b) => a - b)).toEqual(order);
+    expect(text).toContain("password: <removed>");
+  });
+
+  it("notes an unavailable config instead of a yaml section", () => {
+    const text = buildFullReport(report({ configYaml: "" }));
+    expect(text).toContain("could not be validated");
+    expect(text).not.toContain("```yaml");
+  });
+});
+
+describe("buildIssueUrl", () => {
+  const params = (r: CrashReport, mode: "clipboard" | "download" = "clipboard") =>
+    new URL(buildIssueUrl(r, mode)).searchParams;
+
+  it("prefills the form fields and never sets config", () => {
+    const p = params(report());
+    expect(p.get("template")).toBe("bug_report.yml");
+    expect(p.get("version")).toBe("2026.6.4");
+    expect(p.get("installation")).toBe("Home Assistant Add-on");
+    expect(p.get("platform")).toBe("ESP32");
+    expect(p.get("component_name")).toBe("wifi");
+    expect(p.get("title")).toContain("Guru Meditation Error");
+    expect(p.get("problem")).toContain("Decoded backtrace:");
+    expect(p.get("problem")).toContain("0x400d9150: esphome::Application::setup()");
+    expect(p.get("logs")).toContain("Backtrace: 0x400d9150");
+    expect(p.has("config")).toBe(false);
+  });
+
+  it("omits installation outside the add-on and unknown platforms", () => {
+    const p = params(report({ meta: { ...META, isHaAddon: false, targetPlatform: "" } }));
+    expect(p.has("installation")).toBe(false);
+    expect(p.has("platform")).toBe(false);
+  });
+
+  it("tells the user where the full report went", () => {
+    expect(params(report(), "clipboard").get("additional")).toContain("clipboard");
+    expect(params(report(), "download").get("additional")).toContain("markdown file");
+  });
+
+  it("stays under the URL budget, dropping context before the crash block", () => {
+    const noisy = [
+      ...Array.from(
+        { length: 200 },
+        (_, i) => `[12:00:00][I][app:029]: filler context line ${i} ${"x".repeat(400)}`
+      ),
+      ...CRASH_BLOCK,
+    ];
+    const r = report({ scrape: scrapeCrashData(noisy) });
+    const url = buildIssueUrl(r, "clipboard");
+    expect(url.length).toBeLessThanOrEqual(6000);
+    const logs = new URL(url).searchParams.get("logs") ?? "";
+    expect(logs).toContain("Guru Meditation Error");
+    expect(logs).toContain("trimmed");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

When a device crash appears in the log viewer, a callout appears at the bottom of the logs dialog: "This device crashed" (or "…crashed on a previous boot" for the crash handler's stored report). Clicking "Report this crash" opens a dialog that scrapes everything a maintainer needs out of the log buffer the user is already looking at — the decoded backtrace (esphome logs decodes inline on backend-streamed sessions, including the multi-line `(inlined by)` frames), the crash log excerpt, every warning/error line, the `[C]` config dump lines — and captures the sanitized YAML config through the existing `devices/validate` command with secrets left redacted as `<removed>`.

The user is asked what the device was doing when it crashed (required; a crash report without context isn't actionable), then one button downloads the full markdown report and opens a pre-filled esphome/esphome bug-report form in a new tab. The form fields are filled as far as GitHub allows: the sanitized config lands in the **YAML Config** box; version and component name (inferred from the top decoded frame) fill the text inputs; the decoded backtrace, platform, and installation ride in the **problem** field. The crash log fills the **logs** field and supplementary sections (environment, warnings, config dump) pack into **Additional information**, all within an ~8KB URL budget; anything that doesn't fit is available in the downloaded report.

Two GitHub-platform limitations are handled explicitly: issue-form **dropdown** fields (installation, platform) cannot be prefilled via URL, so those values are surfaced in the problem text instead; and `window.open(..., "noopener")` returns null by spec even on success, so the delivered state always offers a manual "Open GitHub issue" link rather than guessing whether the tab was blocked. The dialog stays open after delivery with re-download and copy-to-clipboard available.

Crash detection matches the shapes ESPHome's own stacktrace decoders key on, including the logger-replayed previous-boot report (`[E][esp32.crash:NNN]` lines the raw anchors miss). No backend changes are required for the core flow; the sanitized config reuses `devices/validate`. Verified end to end against a live esp32-poe-iso device that crashes on demand.

**Related issue or feature (if applicable):**

- Follow-ups: esphome/device-builder-frontend#1251 (consolidate the log-line grammar), esphome/device-builder#2086 (decode Web-Serial-captured backtraces). A small companion backend PR adds `in_docker` to the handshake so the installation fact can read "Docker" vs "pip".

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
