### PR TITLE
Show the build server's friendly name across the UI

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -2078,6 +2078,7 @@ export class ESPHomeAPI {
     receiver_label: string;
     offloader_label: string;
     pairing_key?: string;
+    offloader_label_auto?: boolean;
   }): Promise<PairingSummary> {
     return this.sendCommand<PairingSummary>("remote_build/request_pair", args);
   }

--- a/src/api/types/remote-build-events.ts
+++ b/src/api/types/remote-build-events.ts
@@ -33,6 +33,9 @@ export interface RemoteBuildPairRequestReceivedEventData {
   label: string;
   peer_ip: string;
   paired_at: number;
+  friendly_name: string;
+  ha_addon: boolean;
+  label_auto: boolean;
 }
 
 /**
@@ -161,6 +164,18 @@ export interface ReceiverPeerLinkSessionEventData {
 }
 
 /**
+ * Data payload for receiver_peer_link_session_opened.
+ *
+ * OPENED additionally carries the offloader's display identity —
+ * the stored row's post-refresh values, so an old offloader that
+ * sent nothing surfaces whatever pair time captured.
+ */
+export interface ReceiverPeerLinkSessionOpenedEventData extends ReceiverPeerLinkSessionEventData {
+  friendly_name: string;
+  ha_addon: boolean;
+}
+
+/**
  * Shared identity base for the peer-link session events
  * (OPENED / CLOSED).
  *
@@ -178,13 +193,17 @@ export interface OffloaderPeerLinkSessionEventData {
  * Data payload for offloader_peer_link_opened.
  *
  * The OPENED counterpart of the shared identity base, plus the
- * receiver's freshly-handshaked esphome_version. App-shell merges
- * it into the matching row keyed by pin_sha256 so a receiver
- * upgrade surfaces on the next reconnect without a page reload.
- * Empty until the first handshake fills it in.
+ * receiver's freshly-handshaked esphome_version, provisioning
+ * capability, and display identity. App-shell merges them into
+ * the matching row keyed by pin_sha256 so a receiver upgrade or
+ * rename surfaces on the next reconnect without a page reload.
+ * Empty / false until the first handshake fills them in.
  */
 export interface OffloaderPeerLinkOpenedEventData extends OffloaderPeerLinkSessionEventData {
   esphome_version: string;
+  auto_provision_supported: boolean;
+  friendly_name: string;
+  ha_addon: boolean;
 }
 
 /**

--- a/src/api/types/remote-build.ts
+++ b/src/api/types/remote-build.ts
@@ -80,6 +80,23 @@ export interface PeerSummary {
    * session.
    */
   connected: boolean;
+  /**
+   * Offloader's human machine label (its mDNS `friendly_name`)
+   * from the pair request / session handshake, refreshed on
+   * session-open (non-empty values only). Empty from old
+   * offloaders.
+   */
+  friendly_name: string;
+  /** Offloader's HA add-on flag from the handshake. */
+  ha_addon: boolean;
+  /**
+   * True when the offloader's pair-dialog label was left at its
+   * auto-derived prefill (often the browser's URL host, e.g.
+   * "localhost") — the signal that `peerDisplayName` may replace
+   * `label` with `friendly_name`. Old offloaders never send it,
+   * so a possibly-custom label always wins.
+   */
+  label_auto: boolean;
 }
 
 /**
@@ -185,6 +202,17 @@ export interface PairingSummary {
    * skew warning.
    */
   auto_provision_supported: boolean;
+  /**
+   * Receiver's human machine label (its mDNS `friendly_name`)
+   * from the session handshake, refreshed on every session-open
+   * (non-empty values only, so an older receiver can't clobber a
+   * captured name). Empty until a new-enough receiver connects.
+   * `pairingDisplayName` prefers it over an auto-derived
+   * hostname label.
+   */
+  friendly_name: string;
+  /** Receiver's HA add-on flag from the session handshake. */
+  ha_addon: boolean;
 }
 
 /**

--- a/src/components/accept-peer-dialog.ts
+++ b/src/components/accept-peer-dialog.ts
@@ -3,6 +3,7 @@ import { mdiShieldAlertOutline } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import type { PeerSummary } from "../api/types/remote-build.js";
+import { peerDisplayName } from "../util/pairing-display-name.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
@@ -190,7 +191,7 @@ export class ESPHomeAcceptPeerDialog extends LitElement {
             peer
               ? html`
                   <div class="peer-card">
-                    <div class="peer-name">${peer.label}</div>
+                    <div class="peer-name">${peerDisplayName(peer)}</div>
                     <div class="peer-row">
                       <span class="label">
                         ${this._localize(

--- a/src/components/app-shell/events.ts
+++ b/src/components/app-shell/events.ts
@@ -24,6 +24,7 @@ import type {
   OffloaderRemoteBuildsToggledEventData,
   OffloaderVersionMatchPolicyChangedEventData,
   ReceiverPeerLinkSessionEventData,
+  ReceiverPeerLinkSessionOpenedEventData,
   RemoteBuildHostAddedEventData,
   RemoteBuildHostRemovedEventData,
   RemoteBuildPairingWindowChangedEventData,
@@ -225,6 +226,9 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
         status: "pending",
         peer_ip: evt.peer_ip,
         connected: false,
+        friendly_name: evt.friendly_name,
+        ha_addon: evt.ha_addon,
+        label_auto: evt.label_auto,
       };
       const current = host._buildServerPeers ?? [];
       const idx = current.findIndex((p) => p.dashboard_id === incoming.dashboard_id);
@@ -248,13 +252,28 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
       }
       break;
     }
-    case DeviceEventType.RECEIVER_PEER_LINK_SESSION_OPENED:
+    case DeviceEventType.RECEIVER_PEER_LINK_SESSION_OPENED: {
+      // OPENED also refreshes the offloader's display identity —
+      // the event carries the stored row's post-refresh values.
+      if (host._buildServerPeers === null) break;
+      const evt = data as ReceiverPeerLinkSessionOpenedEventData;
+      host._buildServerPeers = host._buildServerPeers.map((p) =>
+        p.dashboard_id === evt.dashboard_id
+          ? {
+              ...p,
+              connected: true,
+              ha_addon: evt.ha_addon,
+              ...(evt.friendly_name ? { friendly_name: evt.friendly_name } : {}),
+            }
+          : p
+      );
+      break;
+    }
     case DeviceEventType.RECEIVER_PEER_LINK_SESSION_CLOSED: {
       if (host._buildServerPeers === null) break;
       const evt = data as ReceiverPeerLinkSessionEventData;
-      const connected = event === DeviceEventType.RECEIVER_PEER_LINK_SESSION_OPENED;
       host._buildServerPeers = host._buildServerPeers.map((p) =>
-        p.dashboard_id === evt.dashboard_id ? { ...p, connected } : p
+        p.dashboard_id === evt.dashboard_id ? { ...p, connected: false } : p
       );
       break;
     }
@@ -312,13 +331,18 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
     }
     case DeviceEventType.OFFLOADER_PEER_LINK_OPENED: {
       // OPENED clears the failure record: a successful session-open
-      // invalidates whatever caused the previous close.
+      // invalidates whatever caused the previous close. friendly_name
+      // patches non-empty-only (mirror of the backend persist policy)
+      // so an older receiver can't blank a captured name.
       const evt = data as OffloaderPeerLinkOpenedEventData;
       patchOffloadPairing(host, evt.pin_sha256, {
         connected: true,
         connecting: false,
         last_connect_error: "",
         esphome_version: evt.esphome_version,
+        auto_provision_supported: evt.auto_provision_supported,
+        ha_addon: evt.ha_addon,
+        ...(evt.friendly_name ? { friendly_name: evt.friendly_name } : {}),
       });
       break;
     }

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -3,6 +3,7 @@ import { type FirmwareJob, JobSource, JobStatus } from "../../api/types/firmware
 import { activeLocale } from "../../common/localize.js";
 import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
+import { jobSourceDisplayName } from "../../util/pairing-display-name.js";
 import { formatElapsed } from "../../util/format-job-time.js";
 import { isPinnableVersion } from "../../util/version-mismatch.js";
 import type { ESPHomeCommandDialog } from "../command-dialog.js";
@@ -48,7 +49,10 @@ export function renderRemoteBuilderSubLine(
     isPinnableVersion(host._appVersion) &&
     (host._pairings?.get(pin)?.auto_provision_supported ?? false);
   const version = buildsLocalVersion ? host._appVersion : receiverVersion;
-  const display = version ? `${label} (${version})` : label;
+  // The live pairing's display name (handshake friendly name, rename-aware)
+  // wins over the job's creation-time source_label snapshot.
+  const name = jobSourceDisplayName(host._pairings, pin, label);
+  const display = version ? `${name} (${version})` : name;
   // Only allow override for in-flight install — switching mid-upload or
   // mid-compile is a power-user shape without a UI today.
   const canOverride = host._commandType === "install";
@@ -145,7 +149,10 @@ function remotePeerLabel(host: ESPHomeCommandDialog): string | null {
   const live = host._jobId ? host._jobs.get(host._jobId) : undefined;
   const primed = host._primedSource;
   if ((live?.source ?? primed?.source) !== JobSource.REMOTE) return null;
-  return live?.source_label || primed?.source_label || null;
+  const label = live?.source_label || primed?.source_label || null;
+  if (label === null) return null;
+  const pin = live?.source_pin_sha256 ?? primed?.source_pin_sha256 ?? "";
+  return jobSourceDisplayName(host._pairings, pin, label);
 }
 
 // Don't show the run timer until it would read at least "1s" — below that it

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -3,7 +3,7 @@ import { type FirmwareJob, JobSource, JobStatus } from "../../api/types/firmware
 import { activeLocale } from "../../common/localize.js";
 import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
-import { jobSourceDisplayName } from "../../util/pairing-display-name.js";
+import { pairingDisplayNameForPin } from "../../util/pairing-display-name.js";
 import { formatElapsed } from "../../util/format-job-time.js";
 import { isPinnableVersion } from "../../util/version-mismatch.js";
 import type { ESPHomeCommandDialog } from "../command-dialog.js";
@@ -51,7 +51,7 @@ export function renderRemoteBuilderSubLine(
   const version = buildsLocalVersion ? host._appVersion : receiverVersion;
   // The live pairing's display name (handshake friendly name, rename-aware)
   // wins over the job's creation-time source_label snapshot.
-  const name = jobSourceDisplayName(host._pairings, pin, label);
+  const name = pairingDisplayNameForPin(host._pairings, pin, label);
   const display = version ? `${name} (${version})` : name;
   // Only allow override for in-flight install — switching mid-upload or
   // mid-compile is a power-user shape without a UI today.
@@ -152,7 +152,7 @@ function remotePeerLabel(host: ESPHomeCommandDialog): string | null {
   const label = live?.source_label || primed?.source_label || null;
   if (label === null) return null;
   const pin = live?.source_pin_sha256 ?? primed?.source_pin_sha256 ?? "";
-  return jobSourceDisplayName(host._pairings, pin, label);
+  return pairingDisplayNameForPin(host._pairings, pin, label);
 }
 
 // Don't show the run timer until it would read at least "1s" — below that it

--- a/src/components/edit-pairing-endpoint-dialog.ts
+++ b/src/components/edit-pairing-endpoint-dialog.ts
@@ -6,6 +6,7 @@ import { APIError } from "../api/api-error.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import { ErrorCode } from "../api/types/protocol.js";
 import type { PairingSummary } from "../api/types/remote-build.js";
+import { pairingDisplayName } from "../util/pairing-display-name.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
 import { inputStyles } from "../styles/inputs.js";
@@ -88,7 +89,7 @@ export class ESPHomeEditPairingEndpointDialog extends LitElement {
    *  knows. */
   open(pairing: PairingSummary): void {
     this._pinSha256 = pairing.pin_sha256;
-    this._label = pairing.label;
+    this._label = pairingDisplayName(pairing);
     // Render with the trailing dot stripped — a typo-prone
     // FQDN-form like ``desktop.local.`` reads as
     // ``desktop.local`` in the dashboard's host-display

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -138,6 +138,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   // (e.g. WS dropped) still shows the local hint.
   @state() _jobSource: JobSource = JobSource.LOCAL;
   @state() _jobSourceLabel = "";
+  @state() _jobSourcePin = "";
 
   @state() _logLines: string[] = [];
   @state() _logsExpanded = false;
@@ -286,6 +287,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._failedDuringValidate = false;
     this._jobSource = JobSource.LOCAL;
     this._jobSourceLabel = "";
+    this._jobSourcePin = "";
     this._timer.reset();
     this._usbFirmware = null;
     this._usbFirmwareName = "";

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -7,6 +7,7 @@ import { fetchBoard } from "../../util/board-body-cache.js";
 import { chipNameToVariant, chipPlatformFamily } from "../../util/chip-variant.js";
 import { triggerDownload } from "../../util/download-text.js";
 import { getErrorMessage } from "../../util/error-message.js";
+import { jobSourceDisplayName } from "../../util/pairing-display-name.js";
 import { formatApiError } from "../../util/format-api-error.js";
 import { dispatchShowLogsAfterInstall } from "../../util/post-install-logs.js";
 import { openFlasher } from "../../util/usb-flasher.js";
@@ -307,7 +308,8 @@ function failNoBinaries(
 ): void {
   if (isEmpty && host._jobSource === JobSource.REMOTE) {
     const receiver =
-      host._jobSourceLabel || host._localize("firmware.no_binaries_remote_server");
+      jobSourceDisplayName(host._pairings, host._jobSourcePin, host._jobSourceLabel) ||
+      host._localize("firmware.no_binaries_remote_server");
     host._fail(
       host._localize("firmware.no_binaries_remote", { receiver }),
       host._localize("firmware.no_binaries_remote_detail")
@@ -601,6 +603,7 @@ export function compileAndWait(
       // "ask the operator of <receiver>" instruction.
       host._jobSource = job.source;
       host._jobSourceLabel = job.source_label;
+      host._jobSourcePin = job.source_pin_sha256;
       host._streamId = host._api.firmwareFollowJob(job.job_id, {
         onOutput: (line) => {
           if (host._step === "queued") {

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -7,7 +7,7 @@ import { fetchBoard } from "../../util/board-body-cache.js";
 import { chipNameToVariant, chipPlatformFamily } from "../../util/chip-variant.js";
 import { triggerDownload } from "../../util/download-text.js";
 import { getErrorMessage } from "../../util/error-message.js";
-import { jobSourceDisplayName } from "../../util/pairing-display-name.js";
+import { pairingDisplayNameForPin } from "../../util/pairing-display-name.js";
 import { formatApiError } from "../../util/format-api-error.js";
 import { dispatchShowLogsAfterInstall } from "../../util/post-install-logs.js";
 import { openFlasher } from "../../util/usb-flasher.js";
@@ -308,8 +308,11 @@ function failNoBinaries(
 ): void {
   if (isEmpty && host._jobSource === JobSource.REMOTE) {
     const receiver =
-      jobSourceDisplayName(host._pairings, host._jobSourcePin, host._jobSourceLabel) ||
-      host._localize("firmware.no_binaries_remote_server");
+      pairingDisplayNameForPin(
+        host._pairings,
+        host._jobSourcePin,
+        host._jobSourceLabel
+      ) || host._localize("firmware.no_binaries_remote_server");
     host._fail(
       host._localize("firmware.no_binaries_remote", { receiver }),
       host._localize("firmware.no_binaries_remote_detail")

--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -4,6 +4,7 @@ import { FLASHER_HOST } from "../../common/docs.js";
 import { activeLocale } from "../../common/localize.js";
 import { configurationStem, downloadAnsiText } from "../../util/download-text.js";
 import { formatElapsed } from "../../util/format-job-time.js";
+import { jobSourceDisplayName } from "../../util/pairing-display-name.js";
 import type { ESPHomeFirmwareInstallDialog } from "../firmware-install-dialog.js";
 import {
   renderOffloadHint,
@@ -70,7 +71,7 @@ export function renderResetSuggestion(
   if (isPeerLinkSessionLostError(host._errorMessage)) return nothing;
   const remoteLabel =
     host._jobSource === JobSource.REMOTE && host._jobSourceLabel
-      ? host._jobSourceLabel
+      ? jobSourceDisplayName(host._pairings, host._jobSourcePin, host._jobSourceLabel)
       : null;
   return renderBuildFailureSuggestion(host, remoteLabel);
 }

--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -4,7 +4,7 @@ import { FLASHER_HOST } from "../../common/docs.js";
 import { activeLocale } from "../../common/localize.js";
 import { configurationStem, downloadAnsiText } from "../../util/download-text.js";
 import { formatElapsed } from "../../util/format-job-time.js";
-import { jobSourceDisplayName } from "../../util/pairing-display-name.js";
+import { pairingDisplayNameForPin } from "../../util/pairing-display-name.js";
 import type { ESPHomeFirmwareInstallDialog } from "../firmware-install-dialog.js";
 import {
   renderOffloadHint,
@@ -71,7 +71,7 @@ export function renderResetSuggestion(
   if (isPeerLinkSessionLostError(host._errorMessage)) return nothing;
   const remoteLabel =
     host._jobSource === JobSource.REMOTE && host._jobSourceLabel
-      ? jobSourceDisplayName(host._pairings, host._jobSourcePin, host._jobSourceLabel)
+      ? pairingDisplayNameForPin(host._pairings, host._jobSourcePin, host._jobSourceLabel)
       : null;
   return renderBuildFailureSuggestion(host, remoteLabel);
 }

--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -24,6 +24,8 @@ import type { FirmwareJob } from "../api/types/firmware-jobs.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
   apiContext,
+  buildOffloadPairingsContext,
+  buildServerPeersContext,
   devicesContext,
   firmwareJobsContext,
   localizeContext,
@@ -42,6 +44,7 @@ import type { ESPHomeCommandDialog } from "./command-dialog.js";
 import "./confirm-dialog.js";
 import type { ESPHomeConfirmDialog } from "./confirm-dialog.js";
 import { firmwareJobsDialogStyles } from "./firmware-jobs-dialog/styles.js";
+import type { PairingSummary, PeerSummary } from "../api/types/remote-build.js";
 import { bucketJobs, renderEmpty, renderGroups } from "./shared/firmware-jobs-list.js";
 import { firmwareJobsListStyles } from "./shared/firmware-jobs-list-styles.js";
 import "./logs-dialog.js";
@@ -75,6 +78,12 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
   @consume({ context: devicesContext, subscribe: true })
   @state()
   _devices: ConfiguredDevice[] = [];
+  @consume({ context: buildOffloadPairingsContext, subscribe: true })
+  @state()
+  _pairings: Map<string, PairingSummary> | null = null;
+  @consume({ context: buildServerPeersContext, subscribe: true })
+  @state()
+  _buildServerPeers: PeerSummary[] | null = null;
 
   private readonly _dialog = new DialogOpenController(this);
   @query("esphome-command-dialog") private _commandDialog!: ESPHomeCommandDialog;

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -86,6 +86,11 @@ export class ESPHomePairBuildServerDialog extends LitElement {
   // Resets on open() so the next pair attempt re-derives from hostname.
   @state() _receiverLabelTouched = false;
 
+  // Mirrors _receiverLabelTouched for the offloader-label field. An
+  // untouched prefill is sent as offloader_label_auto so the receiver's
+  // UI may replace it with this dashboard's advertised friendly name.
+  @state() _offloaderLabelTouched = false;
+
   // True when the confirm step was reached by auto-preview (mDNS-discovered
   // host), so the input step was never shown. Drives the confirm step's
   // secondary button: Cancel (close) rather than Back (to the skipped form).
@@ -152,6 +157,7 @@ export class ESPHomePairBuildServerDialog extends LitElement {
       prefill?.receiverLabel?.trim() || friendlyHostname(this._hostname);
     this._receiverLabelTouched = false;
     this._offloaderLabel = friendlyHostname(window.location.hostname);
+    this._offloaderLabelTouched = false;
     this._pairingKey = "";
     this._pairingKeyRequired = false;
     this._error = null;

--- a/src/components/pair-build-server-dialog/actions.ts
+++ b/src/components/pair-build-server-dialog/actions.ts
@@ -124,6 +124,7 @@ export async function onConfirmSubmit(host: ESPHomePairBuildServerDialog): Promi
       pin_sha256: host._previewedPin,
       receiver_label: receiverLabel,
       offloader_label: offloaderLabel,
+      offloader_label_auto: !host._offloaderLabelTouched,
       ...(pairingKey ? { pairing_key: pairingKey } : {}),
     });
     host._step = "sent";

--- a/src/components/pair-build-server-dialog/renderers.ts
+++ b/src/components/pair-build-server-dialog/renderers.ts
@@ -251,6 +251,7 @@ export function renderConfirmStep(host: ESPHomePairBuildServerDialog): TemplateR
         )}
         @input=${(e: Event) => {
           host._offloaderLabel = (e.target as HTMLInputElement).value;
+          host._offloaderLabelTouched = true;
           host._error = null;
         }}
       />

--- a/src/components/reauth-wizard-dialog.ts
+++ b/src/components/reauth-wizard-dialog.ts
@@ -6,11 +6,16 @@ import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { OffloaderPinMismatchAlert } from "../api/types/remote-build-events.js";
 import type { PairingSummary } from "../api/types/remote-build.js";
 import type { LocalizeFunc } from "../common/localize.js";
-import { apiContext, localizeContext } from "../context/index.js";
+import {
+  apiContext,
+  buildOffloadPairingsContext,
+  localizeContext,
+} from "../context/index.js";
 import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { friendlyHostname, trimTrailingDot } from "../util/hostname.js";
+import { pairingDisplayName } from "../util/pairing-display-name.js";
 import { formatPinSha256 } from "../util/pin-format.js";
 import {
   buildReauthPairRequest,
@@ -114,6 +119,10 @@ export class ESPHomeReauthWizardDialog extends LitElement {
   @consume({ context: apiContext })
   private _api?: ESPHomeAPI;
 
+  @consume({ context: buildOffloadPairingsContext, subscribe: true })
+  @state()
+  private _pairings: Map<string, PairingSummary> | null = null;
+
   @state() private _open = false;
   @state() private _step: Step = 1;
   @state() private _alert: OffloaderPinMismatchAlert | null = null;
@@ -146,6 +155,16 @@ export class ESPHomeReauthWizardDialog extends LitElement {
     this._busy = false;
     this._errorKey = null;
     this._open = true;
+  }
+
+  // Display name for the alert's receiver. The alert snapshot carries only
+  // the pair-time ``receiver_label`` (the auto-derived hostname for an
+  // unnamed pairing), so prefer the live pairing's resolved name; the
+  // ``target`` line shows the endpoint separately, so the bare name is
+  // right here. Falls back to the snapshot when the pairing is gone.
+  private _displayLabel(alert: OffloaderPinMismatchAlert): string {
+    const pairing = this._pairings?.get(alert.pin_sha256);
+    return pairing ? pairingDisplayName(pairing) : alert.receiver_label;
   }
 
   close(): void {
@@ -211,7 +230,7 @@ export class ESPHomeReauthWizardDialog extends LitElement {
           // restart from the alert so they re-OOB against a
           // fresh observation. Retrying inline would silently
           // rebind verification to a pin they never saw.
-          this._dispatchResult("pin_changed", alert.receiver_label);
+          this._dispatchResult("pin_changed", this._displayLabel(alert));
           this._open = false;
           return;
         }
@@ -255,7 +274,7 @@ export class ESPHomeReauthWizardDialog extends LitElement {
         composed: true,
       })
     );
-    this._dispatchResult("success", alert.receiver_label);
+    this._dispatchResult("success", this._displayLabel(alert));
     this._open = false;
   };
 
@@ -277,7 +296,7 @@ export class ESPHomeReauthWizardDialog extends LitElement {
     return html`
       <p class="lede">
         ${this._localize("settings.reauth_wizard_step1_body", {
-          label: alert.receiver_label,
+          label: this._displayLabel(alert),
           target,
         })}
       </p>
@@ -334,7 +353,7 @@ export class ESPHomeReauthWizardDialog extends LitElement {
     return html`
       <p class="lede">
         ${this._localize("settings.reauth_wizard_step3_lede", {
-          label: alert.receiver_label,
+          label: this._displayLabel(alert),
         })}
       </p>
       <div class="pin-block pin-block-solo">
@@ -361,7 +380,7 @@ export class ESPHomeReauthWizardDialog extends LitElement {
           ? html`
               <div class="step-error" role="alert">
                 ${this._localize(this._errorKey, {
-                  label: alert.receiver_label,
+                  label: this._displayLabel(alert),
                 })}
               </div>
             `

--- a/src/components/reauth-wizard-dialog.ts
+++ b/src/components/reauth-wizard-dialog.ts
@@ -15,7 +15,7 @@ import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { friendlyHostname, trimTrailingDot } from "../util/hostname.js";
-import { pairingDisplayName } from "../util/pairing-display-name.js";
+import { pairingDisplayNameForPin } from "../util/pairing-display-name.js";
 import { formatPinSha256 } from "../util/pin-format.js";
 import {
   buildReauthPairRequest,
@@ -163,8 +163,11 @@ export class ESPHomeReauthWizardDialog extends LitElement {
   // ``target`` line shows the endpoint separately, so the bare name is
   // right here. Falls back to the snapshot when the pairing is gone.
   private _displayLabel(alert: OffloaderPinMismatchAlert): string {
-    const pairing = this._pairings?.get(alert.pin_sha256);
-    return pairing ? pairingDisplayName(pairing) : alert.receiver_label;
+    return pairingDisplayNameForPin(
+      this._pairings,
+      alert.pin_sha256,
+      alert.receiver_label
+    );
   }
 
   close(): void {

--- a/src/components/remote-build-panel.ts
+++ b/src/components/remote-build-panel.ts
@@ -13,12 +13,17 @@ import memoizeOne from "memoize-one";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { ConfiguredDevice } from "../api/types/devices.js";
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
-import type { PairingWindowState, PeerSummary } from "../api/types/remote-build.js";
+import type {
+  PairingSummary,
+  PairingWindowState,
+  PeerSummary,
+} from "../api/types/remote-build.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
   apiContext,
   buildServerIdentityRotationCounterContext,
   buildServerPairingWindowStateContext,
+  buildOffloadPairingsContext,
   buildServerPeersContext,
   devicesContext,
   firmwareJobsContext,
@@ -94,6 +99,16 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
   @consume({ context: buildServerPeersContext, subscribe: true })
   @state()
   _peers: PeerSummary[] | null = null;
+
+  @consume({ context: buildOffloadPairingsContext, subscribe: true })
+  @state()
+  _pairings: Map<string, PairingSummary> | null = null;
+
+  // FirmwareJobsListHost's receiver-side registry — same value as _peers,
+  // named for the shared list renderer.
+  get _buildServerPeers(): PeerSummary[] | null {
+    return this._peers;
+  }
 
   @consume({ context: buildServerPairingWindowStateContext, subscribe: true })
   @state()

--- a/src/components/remote-build-panel/render-peers.ts
+++ b/src/components/remote-build-panel/render-peers.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import type { PeerSummary } from "../../api/types/remote-build.js";
 import { activeLocale } from "../../common/localize.js";
+import { peerDisplayName } from "../../util/pairing-display-name.js";
 import { pairedAgoSeconds, peerConnectionPill } from "../../util/peer-display.js";
 import { formatSecondsAgo } from "../../util/relative-time.js";
 import type { ESPHomeRemoteBuildPanel } from "../remote-build-panel.js";
@@ -17,7 +18,7 @@ export function renderRequestCard(
       <div class="request-body">
         <div class="request-title">
           ${host._localize("remote_build_dashboard.request_title", {
-            label: peer.label,
+            label: peerDisplayName(peer),
           })}
         </div>
         ${
@@ -35,7 +36,7 @@ export function renderRequestCard(
         type="button"
         class="primary-action"
         aria-label=${host._localize("settings.build_server_peer_review_aria", {
-          label: peer.label,
+          label: peerDisplayName(peer),
         })}
         @click=${() => host._reviewRequest(peer)}
       >
@@ -98,7 +99,7 @@ function renderPeerRow(host: ESPHomeRemoteBuildPanel, peer: PeerSummary): Templa
     <div class="peer-line">
       <wa-icon library="mdi" name="monitor-dashboard"></wa-icon>
       <div class="peer-line-body">
-        <span class="peer-line-title">${peer.label}</span>
+        <span class="peer-line-title">${peerDisplayName(peer)}</span>
         ${
           pairedAgo !== null
             ? html`

--- a/src/components/settings-dialog/build-offload-alert.ts
+++ b/src/components/settings-dialog/build-offload-alert.ts
@@ -5,27 +5,34 @@ import type { LocalizeFunc } from "../../common/localize.js";
 
 interface AlertContext {
   localize: LocalizeFunc;
+  /**
+   * Live display name for the row (handshake friendly name / custom
+   * label); the alert's own receiver_label snapshot is the fallback
+   * when the pairing is already gone.
+   */
+  displayLabel?: string;
   onRepair: (alert: OffloaderAlertSnapshotEntry) => void;
   onUnpair: (alert: OffloaderAlertSnapshotEntry) => void;
 }
 
 export function renderOffloaderAlert(
   alert: OffloaderAlertSnapshotEntry,
-  { localize, onRepair, onUnpair }: AlertContext
+  { localize, displayLabel, onRepair, onUnpair }: AlertContext
 ): TemplateResult {
   const target = `${alert.receiver_hostname}:${alert.receiver_port}`;
+  const label = displayLabel || alert.receiver_label;
   if (alert.kind === "pin_mismatch") {
     return html`
       <div class="offloader-alert offloader-alert-pin-mismatch" role="alert">
         <div class="offloader-alert-body">
           <div class="offloader-alert-title">
             ${localize("settings.offloader_alert_pin_mismatch_title", {
-              label: alert.receiver_label,
+              label,
             })}
           </div>
           <div class="offloader-alert-desc">
             ${localize("settings.offloader_alert_pin_mismatch_desc", {
-              label: alert.receiver_label,
+              label,
               target,
             })}
           </div>
@@ -35,7 +42,7 @@ export function renderOffloaderAlert(
             type="button"
             class="btn-pair-build-server"
             aria-label=${localize("settings.offloader_alert_repair_aria", {
-              label: alert.receiver_label,
+              label,
             })}
             @click=${() => onRepair(alert)}
           >
@@ -45,7 +52,7 @@ export function renderOffloaderAlert(
             type="button"
             class="offloader-alert-unpair"
             aria-label=${localize("settings.offloader_alert_unpair_aria", {
-              label: alert.receiver_label,
+              label,
             })}
             @click=${() => onUnpair(alert)}
           >
@@ -60,12 +67,12 @@ export function renderOffloaderAlert(
       <div class="offloader-alert-body">
         <div class="offloader-alert-title">
           ${localize("settings.offloader_alert_peer_revoked_title", {
-            label: alert.receiver_label,
+            label,
           })}
         </div>
         <div class="offloader-alert-desc">
           ${localize("settings.offloader_alert_peer_revoked_desc", {
-            label: alert.receiver_label,
+            label,
             target,
           })}
         </div>
@@ -75,7 +82,7 @@ export function renderOffloaderAlert(
           type="button"
           class="offloader-alert-unpair"
           aria-label=${localize("settings.offloader_alert_unpair_aria", {
-            label: alert.receiver_label,
+            label,
           })}
           @click=${() => onUnpair(alert)}
         >

--- a/src/components/settings-dialog/build-offload-alert.ts
+++ b/src/components/settings-dialog/build-offload-alert.ts
@@ -2,6 +2,7 @@ import { html, type TemplateResult } from "lit";
 
 import type { OffloaderAlertSnapshotEntry } from "../../api/types/remote-build-events.js";
 import type { LocalizeFunc } from "../../common/localize.js";
+import { trimTrailingDot } from "../../util/hostname.js";
 
 interface AlertContext {
   localize: LocalizeFunc;
@@ -19,7 +20,7 @@ export function renderOffloaderAlert(
   alert: OffloaderAlertSnapshotEntry,
   { localize, displayLabel, onRepair, onUnpair }: AlertContext
 ): TemplateResult {
-  const target = `${alert.receiver_hostname}:${alert.receiver_port}`;
+  const target = `${trimTrailingDot(alert.receiver_hostname)}:${alert.receiver_port}`;
   const label = displayLabel || alert.receiver_label;
   if (alert.kind === "pin_mismatch") {
     return html`

--- a/src/components/settings-dialog/build-offload-pairing-row.ts
+++ b/src/components/settings-dialog/build-offload-pairing-row.ts
@@ -4,6 +4,7 @@ import type { PairingSummary } from "../../api/types/remote-build.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import type { RemoteBuildJobState } from "../../context/index.js";
 import { trimTrailingDot } from "../../util/hostname.js";
+import { pairingDisplayName } from "../../util/pairing-display-name.js";
 import {
   classifyVersionMismatch,
   isPinnableVersion,
@@ -65,11 +66,12 @@ export function renderPairingRow(
     onUnpair,
   } = ctx;
   const { pillClass, pillLabel } = pillFor(pairing, localize);
+  const displayName = pairingDisplayName(pairing);
   return html`
     <div class="row peer-row row--stacked">
       <div class="row-label">
         <span class="row-title">
-          ${pairing.label}
+          ${displayName}
           <span class=${pillClass}>${pillLabel}</span>
           ${
             pairing.status === "approved"
@@ -78,7 +80,7 @@ export function renderPairingRow(
                     class="toggle pairing-toggle"
                     role="switch"
                     aria-label=${localize("settings.build_offload_pairing_enabled_aria", {
-                      label: pairing.label,
+                      label: displayName,
                     })}
                     aria-checked=${pairing.enabled}
                     title=${localize("settings.build_offload_pairing_enabled_title")}
@@ -114,7 +116,7 @@ export function renderPairingRow(
                   type="button"
                   class="btn-build-remote"
                   aria-label=${localize("settings.remote_build_submit_aria", {
-                    label: pairing.label,
+                    label: displayName,
                   })}
                   @click=${() => onBuildRemote(pairing)}
                 >
@@ -130,7 +132,7 @@ export function renderPairingRow(
                   type="button"
                   class="btn-view-remote-build"
                   aria-label=${localize("settings.remote_build_view_aria", {
-                    label: pairing.label,
+                    label: displayName,
                   })}
                   @click=${() => onViewBuild(latestJob.job_id)}
                 >
@@ -146,10 +148,10 @@ export function renderPairingRow(
                   type="button"
                   class="btn-edit-endpoint"
                   aria-label=${localize("settings.edit_pairing_endpoint_aria", {
-                    label: pairing.label,
+                    label: displayName,
                   })}
                   title=${localize("settings.edit_pairing_endpoint_aria", {
-                    label: pairing.label,
+                    label: displayName,
                   })}
                   @click=${() => onEditEndpoint(pairing)}
                 >
@@ -161,7 +163,7 @@ export function renderPairingRow(
         <button
           type="button"
           class="peer-remove"
-          aria-label=${localize("settings.unpair_aria", { label: pairing.label })}
+          aria-label=${localize("settings.unpair_aria", { label: displayName })}
           title=${localize("settings.unpair_action")}
           @click=${() => onUnpair(pairing)}
         >

--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -28,7 +28,7 @@ import { peerRowStyles } from "../../styles/peer-rows.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { normalizeHostnameForCompare, trimTrailingDot } from "../../util/hostname.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
-import { pairingDisplayName, peerEndpointName } from "../../util/pairing-display-name.js";
+import { pairingDisplayName } from "../../util/pairing-display-name.js";
 import { remoteBuildPeerName } from "../../util/remote-build-peer-name.js";
 import type { ESPHomeConfirmDialog } from "../confirm-dialog.js";
 import type { ESPHomeEditPairingEndpointDialog } from "../edit-pairing-endpoint-dialog.js";
@@ -485,22 +485,30 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
       pin_sha256: alert.pin_sha256,
       hostname: alert.receiver_hostname,
       port: alert.receiver_port,
-      label: alert.receiver_label,
+      label: this._pairingLabelForPin(alert.pin_sha256, alert.receiver_label),
     };
     this._unpairConfirmDialog?.open();
   };
 
   private _onUnpairRequest = (pairing: PairingSummary): void => {
-    // Endpoint-centric surface: the confirm dialog + toasts name the
-    // exact endpoint being dropped, not just the display name.
+    // Bare display name: the confirm-body template already appends
+    // ``({hostname}:{port})``, and the success toast reads "Unpaired
+    // {label}." — either endpoint copy comes from the template, not here.
     this._pendingUnpair = {
       pin_sha256: pairing.pin_sha256,
       hostname: pairing.receiver_hostname,
       port: pairing.receiver_port,
-      label: peerEndpointName(pairing),
+      label: pairingDisplayName(pairing),
     };
     this._unpairConfirmDialog?.open();
   };
+
+  // Resolved display name for a pin, falling back to a snapshot label when
+  // the live pairing is gone (an alert can outlive its pairing).
+  private _pairingLabelForPin(pin: string, fallback: string): string {
+    const pairing = this._pairings?.get(pin);
+    return pairing ? pairingDisplayName(pairing) : fallback;
+  }
 
   private _onUnpairConfirm = async (): Promise<void> => {
     const pending = this._pendingUnpair;

--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -28,6 +28,7 @@ import { peerRowStyles } from "../../styles/peer-rows.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { normalizeHostnameForCompare, trimTrailingDot } from "../../util/hostname.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { pairingDisplayName, peerEndpointName } from "../../util/pairing-display-name.js";
 import { remoteBuildPeerName } from "../../util/remote-build-peer-name.js";
 import type { ESPHomeConfirmDialog } from "../confirm-dialog.js";
 import type { ESPHomeEditPairingEndpointDialog } from "../edit-pairing-endpoint-dialog.js";
@@ -270,13 +271,15 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
 
   private _renderAlerts() {
     if (this._alerts === null || this._alerts.size === 0) return nothing;
-    return Array.from(this._alerts.values()).map((alert) =>
-      renderOffloaderAlert(alert, {
+    return Array.from(this._alerts.values()).map((alert) => {
+      const pairing = this._pairings?.get(alert.pin_sha256);
+      return renderOffloaderAlert(alert, {
         localize: this._localize,
+        displayLabel: pairing ? pairingDisplayName(pairing) : undefined,
         onRepair: this._onAlertRepair,
         onUnpair: this._onAlertUnpair,
-      })
-    );
+      });
+    });
   }
 
   private _renderPairings() {
@@ -488,11 +491,13 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
   };
 
   private _onUnpairRequest = (pairing: PairingSummary): void => {
+    // Endpoint-centric surface: the confirm dialog + toasts name the
+    // exact endpoint being dropped, not just the display name.
     this._pendingUnpair = {
       pin_sha256: pairing.pin_sha256,
       hostname: pairing.receiver_hostname,
       port: pairing.receiver_port,
-      label: pairing.label,
+      label: peerEndpointName(pairing),
     };
     this._unpairConfirmDialog?.open();
   };
@@ -514,7 +519,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
   private _onBuildRemoteClick = (pairing: PairingSummary): void => {
     this._jobDialog?.open({
       pin_sha256: pairing.pin_sha256,
-      receiver_label: pairing.label,
+      receiver_label: pairingDisplayName(pairing),
     });
   };
 

--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -28,7 +28,10 @@ import { peerRowStyles } from "../../styles/peer-rows.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { normalizeHostnameForCompare, trimTrailingDot } from "../../util/hostname.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
-import { pairingDisplayName } from "../../util/pairing-display-name.js";
+import {
+  pairingDisplayName,
+  pairingDisplayNameForPin,
+} from "../../util/pairing-display-name.js";
 import { remoteBuildPeerName } from "../../util/remote-build-peer-name.js";
 import type { ESPHomeConfirmDialog } from "../confirm-dialog.js";
 import type { ESPHomeEditPairingEndpointDialog } from "../edit-pairing-endpoint-dialog.js";
@@ -481,11 +484,16 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
   };
 
   private _onAlertUnpair = (alert: OffloaderAlertSnapshotEntry): void => {
+    // An alert can outlive its pairing, so fall back to the snapshot label.
     this._pendingUnpair = {
       pin_sha256: alert.pin_sha256,
       hostname: alert.receiver_hostname,
       port: alert.receiver_port,
-      label: this._pairingLabelForPin(alert.pin_sha256, alert.receiver_label),
+      label: pairingDisplayNameForPin(
+        this._pairings,
+        alert.pin_sha256,
+        alert.receiver_label
+      ),
     };
     this._unpairConfirmDialog?.open();
   };
@@ -502,13 +510,6 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
     };
     this._unpairConfirmDialog?.open();
   };
-
-  // Resolved display name for a pin, falling back to a snapshot label when
-  // the live pairing is gone (an alert can outlive its pairing).
-  private _pairingLabelForPin(pin: string, fallback: string): string {
-    const pairing = this._pairings?.get(pin);
-    return pairing ? pairingDisplayName(pairing) : fallback;
-  }
 
   private _onUnpairConfirm = async (): Promise<void> => {
     const pending = this._pendingUnpair;

--- a/src/components/settings-dialog/build-server-section.ts
+++ b/src/components/settings-dialog/build-server-section.ts
@@ -32,6 +32,7 @@ import { renderPairingAddress } from "../shared/pairing-address.js";
 import { formatPinSha256 } from "../../util/pin-format.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { pairedAgoSeconds, peerConnectionPill } from "../../util/peer-display.js";
+import { peerDisplayName } from "../../util/pairing-display-name.js";
 import { formatSecondsAgo } from "../../util/relative-time.js";
 import { RemoteBuildIdentityController } from "../../util/remote-build-identity-controller.js";
 import type { ESPHomeConfirmDialog } from "../confirm-dialog.js";
@@ -170,7 +171,7 @@ export class ESPHomeSettingsBuildServer extends LitElement {
       <div class="row peer-row peer-row-approved">
         <div class="row-label">
           <span class="row-title">
-            ${peer.label}
+            ${peerDisplayName(peer)}
             <span class=${pill.className}>${this._localize(pill.labelKey)}</span>
           </span>
           <!--
@@ -221,7 +222,7 @@ export class ESPHomeSettingsBuildServer extends LitElement {
           type="button"
           class="peer-remove"
           aria-label=${this._localize("settings.build_server_peer_remove_aria", {
-            label: peer.label,
+            label: peerDisplayName(peer),
           })}
           title=${this._localize("settings.build_server_peer_remove")}
           @click=${() => this._onRemovePeerRequest(peer.dashboard_id)}

--- a/src/components/settings-dialog/pairing-requests-section.ts
+++ b/src/components/settings-dialog/pairing-requests-section.ts
@@ -5,6 +5,7 @@ import { notify } from "../../util/notify.js";
 
 import type { ESPHomeAPI } from "../../api/esphome-api.js";
 import type { PairingWindowState, PeerSummary } from "../../api/types/remote-build.js";
+import { peerDisplayName } from "../../util/pairing-display-name.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import {
   apiContext,
@@ -116,7 +117,7 @@ export class ESPHomeSettingsPairingRequests extends LitElement {
     return html`
       <div class="row peer-row peer-row-pending">
         <div class="row-label">
-          <span class="row-title">${peer.label}</span>
+          <span class="row-title">${peerDisplayName(peer)}</span>
           ${
             peer.peer_ip
               ? html`
@@ -132,7 +133,7 @@ export class ESPHomeSettingsPairingRequests extends LitElement {
           <button
             type="button"
             aria-label=${this._localize("settings.build_server_peer_review_aria", {
-              label: peer.label,
+              label: peerDisplayName(peer),
             })}
             @click=${() => this._onReviewRequest(peer)}
           >

--- a/src/components/shared/firmware-jobs-list.ts
+++ b/src/components/shared/firmware-jobs-list.ts
@@ -5,10 +5,15 @@ import {
   JobStatus,
   JobType,
 } from "../../api/types/firmware-jobs.js";
+import type { PairingSummary, PeerSummary } from "../../api/types/remote-build.js";
 import { activeLocale, type LocalizeFunc } from "../../common/localize.js";
 import { effectiveJobType } from "../../util/firmware-job-display.js";
 import { isTerminalJob as isTerminal } from "../../util/firmware-job-status.js";
 import { formatAbsoluteTime, formatRelativeTime } from "../../util/format-job-time.js";
+import {
+  jobPeerDisplayName,
+  jobSourceDisplayName,
+} from "../../util/pairing-display-name.js";
 
 /**
  * What a host must expose to render the shared jobs list.
@@ -20,6 +25,13 @@ export interface FirmwareJobsListHost {
   _localize: LocalizeFunc;
   /** Wall-clock anchor for relative timestamps; hosts tick it while visible. */
   _now: number;
+  /**
+   * Live pairing / peer registries for display-name resolution — the
+   * handshake friendly name wins over the job's snapshot label. Either
+   * may be null on hosts (or deployments) without the matching side.
+   */
+  _pairings: Map<string, PairingSummary> | null;
+  _buildServerPeers: PeerSummary[] | null;
   _jobDisplayName(job: FirmwareJob): string;
   _openJob(job: FirmwareJob): void;
   _onCancelClick(e: Event, job: FirmwareJob): void;
@@ -180,9 +192,14 @@ export function renderSourceLine(
   job: FirmwareJob
 ): TemplateResult | typeof nothing {
   if (job.source === JobSource.REMOTE && job.source_label) {
+    const name = jobSourceDisplayName(
+      host._pairings,
+      job.source_pin_sha256,
+      job.source_label
+    );
     const display = job.source_esphome_version
-      ? `${job.source_label} (${job.source_esphome_version})`
-      : job.source_label;
+      ? `${name} (${job.source_esphome_version})`
+      : name;
     return html`
       <div class="job-source">
         ${host._localize("firmware_jobs.building_on", {
@@ -200,7 +217,7 @@ export function renderSourceLine(
     `;
   }
   if (job.remote_peer) {
-    const peer = job.remote_peer_label || job.remote_peer;
+    const peer = jobPeerDisplayName(host._buildServerPeers, job);
     return html`
       <div class="job-source">
         ${host._localize("firmware_jobs.submitted_by", { label: peer })}

--- a/src/components/shared/firmware-jobs-list.ts
+++ b/src/components/shared/firmware-jobs-list.ts
@@ -181,10 +181,11 @@ function renderRowAction(host: FirmwareJobsListHost, job: FirmwareJob): Template
   `;
 }
 
-// Picked up from source_label (snapshotted at job creation) so the row text
-// doesn't churn if the pairing is later renamed. Symmetric receiver-side
-// rendering: when remote_peer is set, the job was submitted from another
-// dashboard's offloader.
+// Names the build server from the live pairing (rename-aware, handshake
+// friendly name) via pairingDisplayNameForPin, falling back to the job's
+// creation-time source_label snapshot when the pairing is gone. Symmetric
+// receiver-side rendering: when remote_peer is set, the job was submitted
+// from another dashboard's offloader.
 // Exported for unit testing of the per-source row line (building-on /
 // waiting-for-server / submitted-by).
 export function renderSourceLine(

--- a/src/components/shared/firmware-jobs-list.ts
+++ b/src/components/shared/firmware-jobs-list.ts
@@ -12,7 +12,7 @@ import { isTerminalJob as isTerminal } from "../../util/firmware-job-status.js";
 import { formatAbsoluteTime, formatRelativeTime } from "../../util/format-job-time.js";
 import {
   jobPeerDisplayName,
-  jobSourceDisplayName,
+  pairingDisplayNameForPin,
 } from "../../util/pairing-display-name.js";
 
 /**
@@ -192,7 +192,7 @@ export function renderSourceLine(
   job: FirmwareJob
 ): TemplateResult | typeof nothing {
   if (job.source === JobSource.REMOTE && job.source_label) {
-    const name = jobSourceDisplayName(
+    const name = pairingDisplayNameForPin(
       host._pairings,
       job.source_pin_sha256,
       job.source_label

--- a/src/util/pairing-display-name.ts
+++ b/src/util/pairing-display-name.ts
@@ -1,6 +1,6 @@
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
 import type { PairingSummary, PeerSummary } from "../api/types/remote-build.js";
-import { friendlyHostname, trimTrailingDot } from "./hostname.js";
+import { friendlyHostname } from "./hostname.js";
 import { remoteBuildPeerName } from "./remote-build-peer-name.js";
 
 /**
@@ -75,19 +75,4 @@ export function jobPeerDisplayName(
     ? peers?.find((p) => p.dashboard_id === job.remote_peer)
     : undefined;
   return peer ? peerDisplayName(peer) : job.remote_peer_label || job.remote_peer || "";
-}
-
-/**
- * "Name (hostname:port)" for endpoint-centric surfaces (reauth
- * wizard, pairing alerts, unpair confirm) where the user verifies
- * a specific endpoint. Collapses to the bare endpoint when the
- * display name IS the hostname-derived label (no doubled text).
- */
-export function peerEndpointName(pairing: PairingSummary): string {
-  const endpoint = `${trimTrailingDot(pairing.receiver_hostname)}:${pairing.receiver_port}`;
-  const name = pairingDisplayName(pairing);
-  if (name === friendlyHostname(pairing.receiver_hostname)) {
-    return endpoint;
-  }
-  return `${name} (${endpoint})`;
 }

--- a/src/util/pairing-display-name.ts
+++ b/src/util/pairing-display-name.ts
@@ -26,13 +26,14 @@ export function pairingDisplayName(pairing: PairingSummary): string {
 }
 
 /**
- * Display name for a job's build server, preferring the live pairing.
+ * Resolve a pairing's display name by pin, preferring the live row.
  *
- * `FirmwareJob.source_label` is a creation-time snapshot; when the
- * pairing is still known (by `source_pin_sha256`) the live row's
- * display name reflects renames and the handshake friendly name.
+ * The caller holds a pin plus a snapshot label (a job's `source_label`
+ * stamped at creation, or an alert's `receiver_label`); when the pairing
+ * is still known the live row's name reflects renames and the handshake
+ * friendly name, otherwise the snapshot is the fallback.
  */
-export function jobSourceDisplayName(
+export function pairingDisplayNameForPin(
   pairings: Map<string, PairingSummary> | null | undefined,
   pin: string | undefined,
   fallbackLabel: string
@@ -63,7 +64,7 @@ export function peerDisplayName(peer: PeerSummary): string {
 /**
  * Display name for a receiver-side job's submitting offloader.
  *
- * Mirrors `jobSourceDisplayName`: `remote_peer_label` is the
+ * Mirrors `pairingDisplayNameForPin`: `remote_peer_label` is the
  * submit-time snapshot, the live `PeerSummary` (keyed on
  * `job.remote_peer`, the offloader's dashboard_id) wins when known.
  */

--- a/src/util/pairing-display-name.ts
+++ b/src/util/pairing-display-name.ts
@@ -1,0 +1,93 @@
+import type { FirmwareJob } from "../api/types/firmware-jobs.js";
+import type { PairingSummary, PeerSummary } from "../api/types/remote-build.js";
+import { friendlyHostname, trimTrailingDot } from "./hostname.js";
+import { remoteBuildPeerName } from "./remote-build-peer-name.js";
+
+/**
+ * Display name for a paired build server (offloader side).
+ *
+ * A label the user typed always wins. A label that still equals
+ * the hostname-derived prefill (the pair wizard's default, and
+ * what the walkthrough's paste-the-address flow produces) is
+ * replaced by the receiver's handshake-advertised friendly name
+ * when one has been captured — with the HA add-on container
+ * hostname mapped to "Home Assistant App" the same way discovery
+ * rows are.
+ */
+export function pairingDisplayName(pairing: PairingSummary): string {
+  if (pairing.label !== friendlyHostname(pairing.receiver_hostname)) {
+    return pairing.label;
+  }
+  return remoteBuildPeerName({
+    friendly_name: pairing.friendly_name,
+    name: pairing.label,
+    ha_addon: pairing.ha_addon,
+  });
+}
+
+/**
+ * Display name for a job's build server, preferring the live pairing.
+ *
+ * `FirmwareJob.source_label` is a creation-time snapshot; when the
+ * pairing is still known (by `source_pin_sha256`) the live row's
+ * display name reflects renames and the handshake friendly name.
+ */
+export function jobSourceDisplayName(
+  pairings: Map<string, PairingSummary> | null | undefined,
+  pin: string | undefined,
+  fallbackLabel: string
+): string {
+  const pairing = pin ? pairings?.get(pin) : undefined;
+  return pairing ? pairingDisplayName(pairing) : fallbackLabel;
+}
+
+/**
+ * Display name for a paired offloader (receiver side).
+ *
+ * The receiver can't derive "was this label auto-prefilled" from a
+ * hostname it never sees, so the offloader sends `label_auto`
+ * explicitly; old offloaders never do, keeping their label
+ * authoritative.
+ */
+export function peerDisplayName(peer: PeerSummary): string {
+  if (!peer.label_auto) {
+    return peer.label;
+  }
+  return remoteBuildPeerName({
+    friendly_name: peer.friendly_name,
+    name: peer.label,
+    ha_addon: peer.ha_addon,
+  });
+}
+
+/**
+ * Display name for a receiver-side job's submitting offloader.
+ *
+ * Mirrors `jobSourceDisplayName`: `remote_peer_label` is the
+ * submit-time snapshot, the live `PeerSummary` (keyed on
+ * `job.remote_peer`, the offloader's dashboard_id) wins when known.
+ */
+export function jobPeerDisplayName(
+  peers: PeerSummary[] | null | undefined,
+  job: Pick<FirmwareJob, "remote_peer" | "remote_peer_label">
+): string {
+  const peer = job.remote_peer
+    ? peers?.find((p) => p.dashboard_id === job.remote_peer)
+    : undefined;
+  return peer ? peerDisplayName(peer) : job.remote_peer_label || job.remote_peer || "";
+}
+
+/**
+ * "Name (hostname:port)" for endpoint-centric surfaces (reauth
+ * wizard, pairing alerts, unpair confirm) where the user verifies
+ * a specific endpoint. Collapses to the bare endpoint when the
+ * display name IS the hostname-derived label (no doubled text).
+ */
+export function peerEndpointName(pairing: PairingSummary): string {
+  const endpoint = `${trimTrailingDot(pairing.receiver_hostname)}:${pairing.receiver_port}`;
+  const name = pairingDisplayName(pairing);
+  if (name === friendlyHostname(pairing.receiver_hostname)) {
+    return endpoint;
+  }
+  return `${name} (${endpoint})`;
+}

--- a/test/components/app-shell/events-initial-state-pairings.test.ts
+++ b/test/components/app-shell/events-initial-state-pairings.test.ts
@@ -21,6 +21,8 @@ function makeSummary(pin: string, enabled: boolean): PairingSummary {
     esphome_version: "",
     enabled,
     auto_provision_supported: false,
+    friendly_name: "",
+    ha_addon: false,
   };
 }
 

--- a/test/components/app-shell/events-pairing-added.test.ts
+++ b/test/components/app-shell/events-pairing-added.test.ts
@@ -18,6 +18,8 @@ function makeSummary(pin: string): PairingSummary {
     esphome_version: "",
     enabled: true,
     auto_provision_supported: false,
+    friendly_name: "",
+    ha_addon: false,
   };
 }
 

--- a/test/components/app-shell/events-peer-link-opened.test.ts
+++ b/test/components/app-shell/events-peer-link-opened.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { DeviceEventType } from "../../../src/api/types/event-subscription.js";
-import type { OffloaderPeerLinkOpenedEventData } from "../../../src/api/types/remote-build-events.js";
-import type { PairingSummary } from "../../../src/api/types/remote-build.js";
+import type {
+  OffloaderPeerLinkOpenedEventData,
+  ReceiverPeerLinkSessionOpenedEventData,
+} from "../../../src/api/types/remote-build-events.js";
+import type { PairingSummary, PeerSummary } from "../../../src/api/types/remote-build.js";
 import type { ESPHomeApp } from "../../../src/components/app-shell.js";
 import { handleEvent } from "../../../src/components/app-shell/events.js";
 
@@ -100,5 +103,99 @@ describe("handleEvent OFFLOADER_PEER_LINK_OPENED", () => {
     dispatch(host, opened(pin, "2026.6.0", { friendly_name: "" }));
 
     expect(host._buildOffloadPairings?.get(pin)?.friendly_name).toBe("Nicks-Mac-Studio");
+  });
+});
+
+function makePeer(overrides: Partial<PeerSummary> = {}): PeerSummary {
+  return {
+    dashboard_id: "dash-1",
+    pin_sha256: "b".repeat(64),
+    label: "office-node",
+    paired_at: 1,
+    status: "approved",
+    peer_ip: "192.168.1.42",
+    connected: false,
+    friendly_name: "",
+    ha_addon: false,
+    label_auto: false,
+    ...overrides,
+  };
+}
+
+function receiverOpened(
+  dashboard_id: string,
+  extra?: Partial<ReceiverPeerLinkSessionOpenedEventData>
+): ReceiverPeerLinkSessionOpenedEventData {
+  return { dashboard_id, friendly_name: "", ha_addon: false, ...extra };
+}
+
+type ReceiverHost = Pick<ESPHomeApp, "_buildServerPeers">;
+
+function dispatchReceiver(
+  host: ReceiverHost,
+  event: string,
+  evt: ReceiverPeerLinkSessionOpenedEventData
+): void {
+  handleEvent(host as ESPHomeApp, event, evt);
+}
+
+describe("handleEvent RECEIVER_PEER_LINK_SESSION_OPENED", () => {
+  it("flips connected true, patches ha_addon, and refreshes a non-empty friendly_name", () => {
+    const host: ReceiverHost = { _buildServerPeers: [makePeer()] };
+
+    dispatchReceiver(
+      host,
+      DeviceEventType.RECEIVER_PEER_LINK_SESSION_OPENED,
+      receiverOpened("dash-1", { friendly_name: "Office-PC", ha_addon: true })
+    );
+
+    const peer = host._buildServerPeers?.[0];
+    expect(peer?.connected).toBe(true);
+    expect(peer?.friendly_name).toBe("Office-PC");
+    expect(peer?.ha_addon).toBe(true);
+  });
+
+  it("keeps a captured friendly_name on an empty OPENED but still flips connected", () => {
+    const host: ReceiverHost = {
+      _buildServerPeers: [makePeer({ friendly_name: "Office-PC" })],
+    };
+
+    dispatchReceiver(
+      host,
+      DeviceEventType.RECEIVER_PEER_LINK_SESSION_OPENED,
+      receiverOpened("dash-1", { friendly_name: "" })
+    );
+
+    const peer = host._buildServerPeers?.[0];
+    expect(peer?.connected).toBe(true);
+    expect(peer?.friendly_name).toBe("Office-PC");
+  });
+
+  it("CLOSED flips connected false without touching identity", () => {
+    const host: ReceiverHost = {
+      _buildServerPeers: [makePeer({ connected: true, friendly_name: "Office-PC" })],
+    };
+
+    dispatchReceiver(
+      host,
+      DeviceEventType.RECEIVER_PEER_LINK_SESSION_CLOSED,
+      receiverOpened("dash-1")
+    );
+
+    const peer = host._buildServerPeers?.[0];
+    expect(peer?.connected).toBe(false);
+    expect(peer?.friendly_name).toBe("Office-PC");
+  });
+
+  it("no-ops when the peers list is not yet seeded", () => {
+    const host: ReceiverHost = { _buildServerPeers: null };
+
+    dispatchReceiver(
+      host,
+      DeviceEventType.RECEIVER_PEER_LINK_SESSION_OPENED,
+      receiverOpened("dash-1", { friendly_name: "Office-PC" })
+    );
+
+    expect(host._buildServerPeers).toBeNull();
   });
 });

--- a/test/components/app-shell/events-peer-link-opened.test.ts
+++ b/test/components/app-shell/events-peer-link-opened.test.ts
@@ -19,15 +19,25 @@ function makeSummary(pin: string, esphome_version: string): PairingSummary {
     esphome_version,
     enabled: true,
     auto_provision_supported: false,
+    friendly_name: "",
+    ha_addon: false,
   };
 }
 
-function opened(pin: string, esphome_version: string): OffloaderPeerLinkOpenedEventData {
+function opened(
+  pin: string,
+  esphome_version: string,
+  extra?: Partial<OffloaderPeerLinkOpenedEventData>
+): OffloaderPeerLinkOpenedEventData {
   return {
     receiver_hostname: "192.168.1.50",
     receiver_port: 6052,
     pin_sha256: pin,
     esphome_version,
+    auto_provision_supported: false,
+    friendly_name: "",
+    ha_addon: false,
+    ...extra,
   };
 }
 
@@ -59,5 +69,36 @@ describe("handleEvent OFFLOADER_PEER_LINK_OPENED", () => {
     dispatch(host, opened("b".repeat(64), "2026.6.0"));
 
     expect(host._buildOffloadPairings?.size).toBe(0);
+  });
+
+  it("patches capability and display identity; a non-empty name refreshes", () => {
+    const pin = "a".repeat(64);
+    const host: Host = {
+      _buildOffloadPairings: new Map([[pin, makeSummary(pin, "2026.5.0")]]),
+    };
+
+    dispatch(
+      host,
+      opened(pin, "2026.6.0", {
+        auto_provision_supported: true,
+        friendly_name: "Nicks-Mac-Studio",
+        ha_addon: true,
+      })
+    );
+
+    const row = host._buildOffloadPairings?.get(pin);
+    expect(row?.auto_provision_supported).toBe(true);
+    expect(row?.friendly_name).toBe("Nicks-Mac-Studio");
+    expect(row?.ha_addon).toBe(true);
+  });
+
+  it("keeps a captured friendly_name when an OPENED carries an empty one", () => {
+    const pin = "a".repeat(64);
+    const seeded = { ...makeSummary(pin, "2026.5.0"), friendly_name: "Nicks-Mac-Studio" };
+    const host: Host = { _buildOffloadPairings: new Map([[pin, seeded]]) };
+
+    dispatch(host, opened(pin, "2026.6.0", { friendly_name: "" }));
+
+    expect(host._buildOffloadPairings?.get(pin)?.friendly_name).toBe("Nicks-Mac-Studio");
   });
 });

--- a/test/components/app-shell/settings-actions.test.ts
+++ b/test/components/app-shell/settings-actions.test.ts
@@ -205,6 +205,8 @@ function makePairing(enabled: boolean): PairingSummary {
     esphome_version: "",
     enabled,
     auto_provision_supported: false,
+    friendly_name: "",
+    ha_addon: false,
   };
 }
 

--- a/test/components/build-offload-section/render-offloader-alert.test.ts
+++ b/test/components/build-offload-section/render-offloader-alert.test.ts
@@ -52,4 +52,16 @@ describe("renderOffloaderAlert", () => {
     expect(tokens).toContain("offloader-alert-unpair");
     expect(tokens).not.toContain("peer-remove");
   });
+
+  it("trims the mDNS trailing dot from the endpoint in the alert text", () => {
+    const localizeSpy = vi.fn((key: string, _values?: Record<string, unknown>) => key);
+    renderOffloaderAlert(
+      { ...pinMismatch, receiver_hostname: "macbook-pro.local." },
+      { localize: localizeSpy, onRepair: vi.fn(), onUnpair: vi.fn() }
+    );
+    const descCall = localizeSpy.mock.calls.find(
+      ([key]) => key === "settings.offloader_alert_pin_mismatch_desc"
+    );
+    expect(descCall?.[1]).toMatchObject({ target: "macbook-pro.local:6053" });
+  });
 });

--- a/test/components/command-dialog-remote-sub-line.test.ts
+++ b/test/components/command-dialog-remote-sub-line.test.ts
@@ -31,6 +31,8 @@ function makePairing(auto: boolean): PairingSummary {
     esphome_version: "2026.6.5",
     enabled: true,
     auto_provision_supported: auto,
+    friendly_name: "",
+    ha_addon: false,
   };
 }
 
@@ -69,5 +71,19 @@ describe("renderRemoteBuilderSubLine version", () => {
       renderRemoteBuilderSubLine(makeHost({ auto: true, localVersion: "2026.8.0-dev" }))
     );
     expect(el.textContent).toContain("builder (2026.6.5)");
+  });
+
+  it("prefers the pairing's friendly name over the auto-derived snapshot label", () => {
+    const host = makeHost({ auto: false });
+    const pairing = {
+      ...makePairing(false),
+      label: "esphome-builder-x",
+      friendly_name: "Nicks-Mac-Studio",
+    };
+    (host as unknown as { _pairings: Map<string, PairingSummary> })._pairings = new Map([
+      [PIN, pairing],
+    ]);
+    const el = renderInto(renderRemoteBuilderSubLine(host));
+    expect(el.textContent).toContain("Nicks-Mac-Studio (2026.6.5)");
   });
 });

--- a/test/components/pair-build-server-dialog/on-confirm-submit.test.ts
+++ b/test/components/pair-build-server-dialog/on-confirm-submit.test.ts
@@ -29,6 +29,7 @@ function makeHost(pairingKey: string): {
     _offloaderLabel: "ha-green",
     _pairingKey: pairingKey,
     _pairingKeyRequired: false,
+    _offloaderLabelTouched: false,
     _error: null,
     _step: "confirm",
     _sentKey: null,
@@ -52,6 +53,24 @@ describe("onConfirmSubmit", () => {
       offloader_label: "ha-green",
     });
     expect(host._step).toBe("sent");
+  });
+
+  it("marks an untouched offloader label as auto-derived", async () => {
+    const { host, request } = makeHost("");
+    await onConfirmSubmit(host);
+
+    const args = request.mock.calls[0][0] as RequestArgs;
+    expect(args.offloader_label_auto).toBe(true);
+  });
+
+  it("marks a user-edited offloader label as not auto-derived", async () => {
+    const { host, request } = makeHost("");
+    (host as unknown as { _offloaderLabelTouched: boolean })._offloaderLabelTouched =
+      true;
+    await onConfirmSubmit(host);
+
+    const args = request.mock.calls[0][0] as RequestArgs;
+    expect(args.offloader_label_auto).toBe(false);
   });
 
   it("omits the pairing_key arg entirely when the field is blank", async () => {

--- a/test/components/remote-build-panel/render-sections.test.ts
+++ b/test/components/remote-build-panel/render-sections.test.ts
@@ -32,6 +32,9 @@ function makePeer(overrides: Partial<PeerSummary> = {}): PeerSummary {
     status: "approved",
     peer_ip: "192.168.1.42",
     connected: true,
+    friendly_name: "",
+    ha_addon: false,
+    label_auto: false,
     ...overrides,
   };
 }

--- a/test/components/settings-dialog/render-pairing-row.test.ts
+++ b/test/components/settings-dialog/render-pairing-row.test.ts
@@ -22,6 +22,8 @@ function makeSummary(esphome_version: string): PairingSummary {
     esphome_version,
     enabled: true,
     auto_provision_supported: false,
+    friendly_name: "",
+    ha_addon: false,
   };
 }
 
@@ -66,6 +68,8 @@ describe("renderPairingRow version line", () => {
     const pairing = {
       ...makeSummary("2026.5.0"),
       auto_provision_supported: true,
+      friendly_name: "",
+      ha_addon: false,
     };
     const text = renderedText(renderPairingRow(pairing, ctx()));
     expect(text).toContain("settings.build_offload_pairing_version_auto_provision");
@@ -83,5 +87,30 @@ describe("renderPairingRow version line", () => {
     const pending = { ...makeSummary("2026.6.0"), status: "pending" as const };
     const text = renderedText(renderPairingRow(pending, ctx()));
     expect(text).not.toContain("settings.remote_build_peer_version_line");
+  });
+});
+
+describe("renderPairingRow display name", () => {
+  it("shows the friendly name when the label is the auto-derived hostname stem", () => {
+    const pairing = {
+      ...makeSummary("2026.6.0"),
+      label: "mac",
+      friendly_name: "Nicks-Mac-Studio",
+    };
+    const text = renderedText(renderPairingRow(pairing, ctx()));
+    expect(text).toContain("Nicks-Mac-Studio");
+    // The hostname:port sub-line still shows the real endpoint.
+    expect(text).toContain("mac.local");
+  });
+
+  it("keeps a custom label over the friendly name", () => {
+    const pairing = {
+      ...makeSummary("2026.6.0"),
+      label: "Office Server",
+      friendly_name: "Nicks-Mac-Studio",
+    };
+    const text = renderedText(renderPairingRow(pairing, ctx()));
+    expect(text).toContain("Office Server");
+    expect(text).not.toContain("Nicks-Mac-Studio");
   });
 });

--- a/test/pages/dashboard-remote-panel.test.ts
+++ b/test/pages/dashboard-remote-panel.test.ts
@@ -58,6 +58,9 @@ function makePeer(overrides: Partial<PeerSummary> = {}): PeerSummary {
     status: "approved",
     peer_ip: "192.168.1.42",
     connected: true,
+    friendly_name: "",
+    ha_addon: false,
+    label_auto: false,
     ...overrides,
   };
 }

--- a/test/util/bulk-update.test.ts
+++ b/test/util/bulk-update.test.ts
@@ -32,6 +32,8 @@ function pairing(overrides: Partial<PairingSummary>): PairingSummary {
     esphome_version: "2026.5.0",
     enabled: true,
     auto_provision_supported: false,
+    friendly_name: "",
+    ha_addon: false,
     ...overrides,
   };
 }

--- a/test/util/pairing-display-name.test.ts
+++ b/test/util/pairing-display-name.test.ts
@@ -5,7 +5,6 @@ import {
   jobSourceDisplayName,
   pairingDisplayName,
   peerDisplayName,
-  peerEndpointName,
 } from "../../src/util/pairing-display-name.js";
 
 function pairing(overrides: Partial<PairingSummary> = {}): PairingSummary {
@@ -119,17 +118,5 @@ describe("jobPeerDisplayName", () => {
     expect(jobPeerDisplayName(null, { remote_peer: "zz", remote_peer_label: "" })).toBe(
       "zz"
     );
-  });
-});
-
-describe("peerEndpointName", () => {
-  it("combines the display name with the endpoint", () => {
-    expect(peerEndpointName(pairing({ friendly_name: "Nicks-Mac-Studio" }))).toBe(
-      "Nicks-Mac-Studio (esphome-builder-xnnspgdv.local:6056)"
-    );
-  });
-
-  it("collapses to the bare endpoint when the name is the hostname stem", () => {
-    expect(peerEndpointName(pairing())).toBe("esphome-builder-xnnspgdv.local:6056");
   });
 });

--- a/test/util/pairing-display-name.test.ts
+++ b/test/util/pairing-display-name.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { PairingSummary, PeerSummary } from "../../src/api/types/remote-build.js";
+import {
+  jobPeerDisplayName,
+  jobSourceDisplayName,
+  pairingDisplayName,
+  peerDisplayName,
+  peerEndpointName,
+} from "../../src/util/pairing-display-name.js";
+
+function pairing(overrides: Partial<PairingSummary> = {}): PairingSummary {
+  return {
+    receiver_hostname: "esphome-builder-xnnspgdv.local",
+    receiver_port: 6056,
+    pin_sha256: "a".repeat(64),
+    label: "esphome-builder-xnnspgdv",
+    paired_at: 1,
+    status: "approved",
+    connected: true,
+    connecting: false,
+    last_connect_error: "",
+    esphome_version: "2026.6.5",
+    enabled: true,
+    auto_provision_supported: false,
+    friendly_name: "",
+    ha_addon: false,
+    ...overrides,
+  };
+}
+
+function peer(overrides: Partial<PeerSummary> = {}): PeerSummary {
+  return {
+    dashboard_id: "abcdef0123456789",
+    pin_sha256: "b".repeat(64),
+    label: "localhost",
+    paired_at: 1,
+    status: "approved",
+    peer_ip: "192.168.1.10",
+    connected: true,
+    friendly_name: "",
+    ha_addon: false,
+    label_auto: false,
+    ...overrides,
+  };
+}
+
+describe("pairingDisplayName", () => {
+  it("replaces an auto-derived hostname label with the friendly name", () => {
+    expect(pairingDisplayName(pairing({ friendly_name: "Nicks-Mac-Studio" }))).toBe(
+      "Nicks-Mac-Studio"
+    );
+  });
+
+  it("keeps a custom label even when a friendly name is known", () => {
+    expect(
+      pairingDisplayName(
+        pairing({ label: "Office Server", friendly_name: "Nicks-Mac-Studio" })
+      )
+    ).toBe("Office Server");
+  });
+
+  it("falls back to the label when no friendly name was captured", () => {
+    expect(pairingDisplayName(pairing())).toBe("esphome-builder-xnnspgdv");
+  });
+
+  it("maps the HA add-on container hostname to a human label", () => {
+    expect(
+      pairingDisplayName(pairing({ friendly_name: "0123abcd-esphome", ha_addon: true }))
+    ).toBe("Home Assistant App");
+  });
+});
+
+describe("jobSourceDisplayName", () => {
+  it("prefers the live pairing's display name over the snapshot", () => {
+    const p = pairing({ friendly_name: "Nicks-Mac-Studio" });
+    const map = new Map([[p.pin_sha256, p]]);
+    expect(jobSourceDisplayName(map, p.pin_sha256, "esphome-builder-xnnspgdv")).toBe(
+      "Nicks-Mac-Studio"
+    );
+  });
+
+  it("falls back to the snapshot label for an unknown or missing pin", () => {
+    expect(jobSourceDisplayName(new Map(), "c".repeat(64), "snapshot")).toBe("snapshot");
+    expect(jobSourceDisplayName(null, undefined, "snapshot")).toBe("snapshot");
+  });
+});
+
+describe("peerDisplayName", () => {
+  it("replaces an auto-prefilled label with the friendly name", () => {
+    expect(peerDisplayName(peer({ label_auto: true, friendly_name: "Office-PC" }))).toBe(
+      "Office-PC"
+    );
+  });
+
+  it("keeps the label when label_auto is false (old offloader or custom)", () => {
+    expect(peerDisplayName(peer({ friendly_name: "Office-PC" }))).toBe("localhost");
+  });
+
+  it("keeps the label when no friendly name arrived", () => {
+    expect(peerDisplayName(peer({ label_auto: true }))).toBe("localhost");
+  });
+});
+
+describe("jobPeerDisplayName", () => {
+  it("prefers the live peer's display name over the job snapshot", () => {
+    const p = peer({ label_auto: true, friendly_name: "Office-PC" });
+    expect(
+      jobPeerDisplayName([p], {
+        remote_peer: p.dashboard_id,
+        remote_peer_label: "localhost",
+      })
+    ).toBe("Office-PC");
+  });
+
+  it("falls back to the job's snapshot label, then the dashboard id", () => {
+    expect(
+      jobPeerDisplayName([], { remote_peer: "zz", remote_peer_label: "snapshot" })
+    ).toBe("snapshot");
+    expect(jobPeerDisplayName(null, { remote_peer: "zz", remote_peer_label: "" })).toBe(
+      "zz"
+    );
+  });
+});
+
+describe("peerEndpointName", () => {
+  it("combines the display name with the endpoint", () => {
+    expect(peerEndpointName(pairing({ friendly_name: "Nicks-Mac-Studio" }))).toBe(
+      "Nicks-Mac-Studio (esphome-builder-xnnspgdv.local:6056)"
+    );
+  });
+
+  it("collapses to the bare endpoint when the name is the hostname stem", () => {
+    expect(peerEndpointName(pairing())).toBe("esphome-builder-xnnspgdv.local:6056");
+  });
+});

--- a/test/util/pairing-display-name.test.ts
+++ b/test/util/pairing-display-name.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { PairingSummary, PeerSummary } from "../../src/api/types/remote-build.js";
 import {
   jobPeerDisplayName,
-  jobSourceDisplayName,
+  pairingDisplayNameForPin,
   pairingDisplayName,
   peerDisplayName,
 } from "../../src/util/pairing-display-name.js";
@@ -69,18 +69,20 @@ describe("pairingDisplayName", () => {
   });
 });
 
-describe("jobSourceDisplayName", () => {
+describe("pairingDisplayNameForPin", () => {
   it("prefers the live pairing's display name over the snapshot", () => {
     const p = pairing({ friendly_name: "Nicks-Mac-Studio" });
     const map = new Map([[p.pin_sha256, p]]);
-    expect(jobSourceDisplayName(map, p.pin_sha256, "esphome-builder-xnnspgdv")).toBe(
+    expect(pairingDisplayNameForPin(map, p.pin_sha256, "esphome-builder-xnnspgdv")).toBe(
       "Nicks-Mac-Studio"
     );
   });
 
   it("falls back to the snapshot label for an unknown or missing pin", () => {
-    expect(jobSourceDisplayName(new Map(), "c".repeat(64), "snapshot")).toBe("snapshot");
-    expect(jobSourceDisplayName(null, undefined, "snapshot")).toBe("snapshot");
+    expect(pairingDisplayNameForPin(new Map(), "c".repeat(64), "snapshot")).toBe(
+      "snapshot"
+    );
+    expect(pairingDisplayNameForPin(null, undefined, "snapshot")).toBe("snapshot");
   });
 });
 

--- a/test/util/version-mismatch.test.ts
+++ b/test/util/version-mismatch.test.ts
@@ -20,6 +20,8 @@ function pairing(overrides: Partial<PairingSummary>): PairingSummary {
     esphome_version: "2026.5.0",
     enabled: true,
     auto_provision_supported: false,
+    friendly_name: "",
+    ha_addon: false,
     ...overrides,
   };
 }


### PR DESCRIPTION
# What does this implement/fix?

The UI names build servers by their opaque mDNS hostname ("Building on esphome-builder-xnnspgdv") because the pairing label is auto-derived from the hostname at pair time, and the receiver's Paired dashboards list shows browser-host-derived labels like "localhost". With the companion backend PR the peer link now carries each side's advertised friendly name; this PR displays it.

New shared helper `src/util/pairing-display-name.ts` holds the whole policy: a label the user typed always wins; a label still equal to its auto-derived prefill is replaced by the handshake friendly name (with the HA add-on container hostname mapped to "Home Assistant App", same as discovery rows). Job surfaces resolve through the live pairing/peer registries by pin or dashboard id so renames track, with the job's snapshot label as fallback. Applied to the pairing rows, the install dialog's "Building on" sub-line, the firmware jobs list on both sides, the failure hints, unpair confirm and pairing alerts (endpoint-centric surfaces show "Name (hostname:port)"), and the receiver's pairing inbox, accept dialog, and peer list.

The pair dialog now tracks whether the offloader-label field was edited and sends `offloader_label_auto`, the receiver side's signal that the label may be replaced. Also fixes an existing gap: the OFFLOADER_PEER_LINK_OPENED patch never applied `auto_provision_supported`, so the map only healed on reload.

New required `PairingSummary`/`PeerSummary` fields ride the companion backend PR per the lockstep deployment model. Old peers never send the fields, so labels render exactly as today.

**Related issue or feature (if applicable):**

- companion backend PR: esphome/device-builder#2087

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
