### PR TITLE
Harden the crash report against user markdown and a leaked validate timer

### DIFF
--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -117,6 +117,9 @@ export class ESPHomeCrashReportDialog extends LitElement {
   // populate this session's config.
   private _session = 0;
   private _validateStreamId = "";
+  // Handle for the validate-stall timeout, cleared alongside the stream so
+  // a dialog closed/reopened mid-validate doesn't leave the timer to fire.
+  private _validateTimer = 0;
 
   static styles = [
     espHomeStyles,
@@ -229,9 +232,9 @@ export class ESPHomeCrashReportDialog extends LitElement {
 
   private _captureConfig(session: number): void {
     const collected: string[] = [];
-    let timer = 0;
     const finish = (yaml: string, error: "" | "invalid" | "transport") => {
-      clearTimeout(timer);
+      clearTimeout(this._validateTimer);
+      this._validateTimer = 0;
       if (session !== this._session) return;
       this._validateStreamId = "";
       if (this._dialog.open) {
@@ -241,7 +244,7 @@ export class ESPHomeCrashReportDialog extends LitElement {
     };
     // A stalled stream must not stick the spinner forever; a stall is a
     // transport issue, not the user's config.
-    timer = window.setTimeout(() => {
+    this._validateTimer = window.setTimeout(() => {
       if (session !== this._session) return;
       this._stopValidateStream();
       finish("", "transport");
@@ -264,6 +267,8 @@ export class ESPHomeCrashReportDialog extends LitElement {
   // Kill an in-flight validate so an abandoned session doesn't leave the
   // backend's esphome config subprocess running to completion.
   private _stopValidateStream(): void {
+    clearTimeout(this._validateTimer);
+    this._validateTimer = 0;
     if (!this._validateStreamId) return;
     void this._api
       .stopStream(this._validateStreamId)

--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -233,9 +233,11 @@ export class ESPHomeCrashReportDialog extends LitElement {
   private _captureConfig(session: number): void {
     const collected: string[] = [];
     const finish = (yaml: string, error: "" | "invalid" | "transport") => {
+      // Guard the session first: a stale stream's result must not clear the
+      // timer a newer open() already armed for the current session.
+      if (session !== this._session) return;
       clearTimeout(this._validateTimer);
       this._validateTimer = 0;
-      if (session !== this._session) return;
       this._validateStreamId = "";
       if (this._dialog.open) {
         this._configYaml = yaml;

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -260,7 +260,9 @@ export function buildFullReport(report: CrashReport): string {
   const { scrape, meta, configYaml } = report;
   const sections: string[] = [`# Crash report: ${meta.deviceName}`];
   if (report.userDescription) {
-    sections.push("## What happened", report.userDescription);
+    // Fence the user's prose so a stray ``` run in it can't close the
+    // surrounding markdown and hide the sections below.
+    sections.push("## What happened", fence([report.userDescription], ""));
   }
   sections.push("## Decoded backtrace");
   if (scrape.decodedFrames.length > 0) {
@@ -348,7 +350,13 @@ export function buildIssueUrl(report: CrashReport): IssueUrl {
   // The user's own context leads the problem field, then the platform /
   // installation the dropdowns can't be prefilled with, then the trace.
   const head: string[] = report.userDescription
-    ? [report.userDescription, "", "(Crash detected in the Device Builder log viewer.)"]
+    ? [
+        // Fenced so a stray ``` in the prose can't swallow the facts and
+        // backtrace that follow it in this field.
+        fence([report.userDescription], ""),
+        "",
+        "(Crash detected in the Device Builder log viewer.)",
+      ]
     : [`The device crashed (crash detected in the Device Builder log viewer).`];
   const facts = [
     platform && `Platform: ${platform}`,

--- a/test/components/crash-report-dialog.test.ts
+++ b/test/components/crash-report-dialog.test.ts
@@ -209,5 +209,23 @@ describe("crash-report-dialog", () => {
     // Still collecting: the stale stream must not flip this session ready.
     expect((el as any)._configYaml).toBeNull();
   });
+
+  it("keeps the new session's stall timer when a stale result arrives", () => {
+    vi.useFakeTimers();
+    try {
+      el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
+      const stale = validateCallbacks!;
+      el.open("other.yaml", "Other", CRASH_LINES);
+      // A late result from the previous session must not clear the new
+      // session's stall timer (the shared instance-field hazard).
+      stale.onResult!({ success: true, code: 0 });
+      expect((el as any)._configYaml).toBeNull();
+      vi.advanceTimersByTime(90_000);
+      expect((el as any)._configYaml).toBe("");
+      expect((el as any)._configError).toBe("transport");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/test/util/crash-report.test.ts
+++ b/test/util/crash-report.test.ts
@@ -179,6 +179,18 @@ describe("buildFullReport", () => {
     expect(text).not.toContain("```yaml");
   });
 
+  it("fences the user description so a stray backtick run can't hide sections", () => {
+    const text = buildFullReport(
+      report({ userDescription: "ran this:\n```\ncode\n```\nthen it crashed" })
+    );
+    // The description is fenced wider than its own ``` run, so every
+    // heading below "What happened" survives intact.
+    expect(text).toContain("````");
+    expect(text).toContain("ran this:");
+    expect(text).toContain("## Decoded backtrace");
+    expect(text).toContain("## Environment");
+  });
+
   it("widens the code fence when content contains a backtick run", () => {
     // A config with a ``` run must not close the fence early.
     const text = buildFullReport(report({ configYaml: "note: |\n  ``` not a fence" }));

--- a/test/util/crash-report.test.ts
+++ b/test/util/crash-report.test.ts
@@ -230,6 +230,14 @@ describe("buildIssueUrl", () => {
     expect(buildIssueUrl(report()).complete).toBe(true);
   });
 
+  it("fences the description in problem so a backtick run can't hide the trace", () => {
+    const p = params(report({ userDescription: "ran:\n```\ncode\n```\ncrash" }));
+    // The prose is fenced wider than its own ``` run, so the facts and the
+    // decoded backtrace that follow it in the problem field survive.
+    expect(p.get("problem")).toContain("ran:");
+    expect(p.get("problem")).toContain("Decoded backtrace:");
+  });
+
   it("keeps the URL under budget even with a huge user description", () => {
     const result = buildIssueUrl(report({ userDescription: "x".repeat(20000) }));
     expect(result.url.length).toBeLessThanOrEqual(8000);


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #1250 addressing two Copilot review comments on the crash-report flow.

- **User description could corrupt the report markdown.** The "what happened" prose was inserted raw into both the downloadable report and the issue-form `problem` field, so a stray ``` run in it could close the surrounding markdown and hide every section below. It is now wrapped with the existing `fence()` helper (which widens past any internal backtick run), the same treatment the config, logs and config-dump sections already get.
- **The validate-stall timeout leaked.** The 90s timer was a local in `_captureConfig` and only cleared via `finish()`; a dialog closed or reopened mid-validate stopped the stream but left the timer to fire later (accumulating no-op timers and keeping closures alive). It is now tracked on the instance and cleared in `_stopValidateStream()`, which already runs on `open()` and `_onAfterHide()`.

Added a regression test pinning that a description containing a ``` run keeps the sections below "What happened" intact.

**Related issue or feature (if applicable):**

- follow-up to #1250

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
