### PR TITLE
Link the Wi-Fi AP config warning to the captive portal docs

### DIFF
--- a/src/components/ansi-log-render.ts
+++ b/src/components/ansi-log-render.ts
@@ -144,6 +144,10 @@ const CURATED_COPY: Record<
     title: "dashboard.logs_doc_wifi_reconnect_title",
     body: "dashboard.logs_doc_wifi_reconnect_body",
   },
+  wifi_ap_no_portal: {
+    title: "dashboard.logs_doc_wifi_ap_no_portal_title",
+    body: "dashboard.logs_doc_wifi_ap_no_portal_body",
+  },
   boot_loop: {
     title: "dashboard.logs_doc_boot_loop_title",
     body: "dashboard.logs_doc_boot_loop_body",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -62,6 +62,8 @@
     "logs_doc_slow_component_body": "Something is stalling the main loop, which can cause disconnects and missed updates. The troubleshooting guide explains how to find and fix the slow component.",
     "logs_doc_wifi_reconnect_title": "Wi-Fi keeps disconnecting",
     "logs_doc_wifi_reconnect_body": "The FAQ covers the common causes of unstable Wi-Fi, from signal and power problems to router settings.",
+    "logs_doc_wifi_ap_no_portal_title": "Access point can't serve config",
+    "logs_doc_wifi_ap_no_portal_body": "The fallback access point has no captive portal or web server, so it can't show a configuration page. The captive portal documentation explains how to add one.",
     "logs_doc_boot_loop_title": "Repeated resets detected",
     "logs_doc_boot_loop_body": "The device is resetting before boot completes and will enter safe mode soon. The troubleshooting guide explains how to find the cause.",
     "logs_doc_ota_rollback_title": "OTA update rolled back",

--- a/src/util/log-doc-links.ts
+++ b/src/util/log-doc-links.ts
@@ -209,6 +209,14 @@ const ACTIONABLE_CLI: readonly ActionableCliEntry[] = (
 // Group 1 is the level word; the message follows, matched by pattern.
 const CLI_LINE_RE = /^(?:[\d:.\s-]*\s)?(WARNING|ERROR)\s/;
 
+// The CLI level word maps to the same single-letter level the firmware
+// lines carry, so a matched CLI line colours its icon like the firmware
+// path (``links.level`` -> ``LOG_LEVEL_COLORS`` in the renderer).
+const CLI_LEVEL_LETTER: Record<ActionableCliEntry["level"], string> = {
+  WARNING: "W",
+  ERROR: "E",
+};
+
 /** First ``https://esphome.io`` URL in a line (trailing sentence punctuation
  *  trimmed in ``resolveLogDocLink``). */
 const EMBEDDED_URL_RE = /https:\/\/esphome\.io\/[^\s)"']+/;
@@ -263,12 +271,14 @@ export function resolveLogDocLink(
   }
   // CLI validation lines (``WARNING <msg>``) carry no tag, so they miss
   // the firmware parse above; match them on the level word + message.
+  let cliLevel: string | undefined;
   if (!actionable) {
     const cli = clean.match(CLI_LINE_RE);
     if (cli) {
       for (const entry of ACTIONABLE_CLI) {
         if (entry.level === cli[1] && entry.pattern.test(clean)) {
           actionable = { kind: "actionable", url: entry.url, body: entry.body };
+          cliLevel = CLI_LEVEL_LETTER[entry.level];
           break;
         }
       }
@@ -315,6 +325,7 @@ export function resolveLogDocLink(
   if (actionable) links.actionable = actionable;
   if (component) links.component = component;
   if (parsed) links.level = parsed.level;
+  else if (cliLevel) links.level = cliLevel;
   return links;
 }
 

--- a/src/util/log-doc-links.ts
+++ b/src/util/log-doc-links.ts
@@ -30,6 +30,7 @@ export interface ActionableLogDocLink {
     | "ota_rollback"
     | "slow_component"
     | "sram1_as_iram"
+    | "wifi_ap_no_portal"
     | "wifi_reconnect";
 }
 
@@ -177,6 +178,37 @@ for (const entry of ACTIONABLE) {
   }
 }
 
+/** Curated actionable message emitted by the esphome CLI (config /
+ *  compile / logs validation phase), not the firmware. These lines are
+ *  ``<LEVEL> <message>`` with no ``[tag:line]`` token, so they can't
+ *  key off the tag index above. */
+interface ActionableCliEntry {
+  /** CLI level word as printed by ``ESPHomeLogFormatter``. */
+  level: "WARNING" | "ERROR";
+  pattern: RegExp;
+  url: string;
+  body: ActionableLogDocLink["body"];
+}
+
+// Verified live against esphome.io (200, no redirect). Kept small and
+// URL-verified, same bar as ``ACTIONABLE`` above.
+const ACTIONABLE_CLI: readonly ActionableCliEntry[] = (
+  [
+    {
+      // wifi/__init__.py final_validate: an ``ap:`` with no captive_portal
+      // or web_server can't serve its config page.
+      level: "WARNING",
+      pattern: /AP is configured but neither captive_portal nor web_server/,
+      url: "https://esphome.io/components/captive_portal/",
+      body: "wifi_ap_no_portal",
+    },
+  ] satisfies readonly ActionableCliEntry[]
+).filter((entry) => isSafeDocsUrl(entry.url));
+
+// CLI log record: ``<LEVEL> <message>`` (optionally a leading timestamp).
+// Group 1 is the level word; the message follows, matched by pattern.
+const CLI_LINE_RE = /^(?:[\d:.\s-]*\s)?(WARNING|ERROR)\s/;
+
 /** First ``https://esphome.io`` URL in a line (trailing sentence punctuation
  *  trimmed in ``resolveLogDocLink``). */
 const EMBEDDED_URL_RE = /https:\/\/esphome\.io\/[^\s)"']+/;
@@ -226,6 +258,19 @@ export function resolveLogDocLink(
       if (entry.level === parsed.level && entry.pattern.test(clean)) {
         actionable = { kind: "actionable", url: entry.url, body: entry.body };
         break;
+      }
+    }
+  }
+  // CLI validation lines (``WARNING <msg>``) carry no tag, so they miss
+  // the firmware parse above; match them on the level word + message.
+  if (!actionable) {
+    const cli = clean.match(CLI_LINE_RE);
+    if (cli) {
+      for (const entry of ACTIONABLE_CLI) {
+        if (entry.level === cli[1] && entry.pattern.test(clean)) {
+          actionable = { kind: "actionable", url: entry.url, body: entry.body };
+          break;
+        }
       }
     }
   }

--- a/test/util/log-doc-links.test.ts
+++ b/test/util/log-doc-links.test.ts
@@ -180,6 +180,21 @@ describe("resolveLogDocLink — actionable", () => {
       "[09:28:39.132][E][esp8266:186]:   Reason: Soft WDT - Level1Int (exccause=4)";
     expect(resolveLogDocLink(line, {})).toBeUndefined();
   });
+
+  it("maps the CLI wifi-AP validation warning to the captive portal docs", () => {
+    const line =
+      "\\033[33mWARNING WiFi AP is configured but neither captive_portal nor web_server is enabled. The AP will not be usable for configuration or monitoring. Add 'captive_portal:' or 'web_server:' to your configuration.\\033[0m";
+    expect(resolveLogDocLink(line, {})?.actionable).toEqual({
+      kind: "actionable",
+      url: "https://esphome.io/components/captive_portal/",
+      body: "wifi_ap_no_portal",
+    });
+  });
+
+  it("ignores an uncurated CLI warning line", () => {
+    const line = "\\033[33mWARNING Something else happened during validation\\033[0m";
+    expect(resolveLogDocLink(line, {})).toBeUndefined();
+  });
 });
 
 describe("resolveLogDocLink — component", () => {

--- a/test/util/log-doc-links.test.ts
+++ b/test/util/log-doc-links.test.ts
@@ -184,11 +184,15 @@ describe("resolveLogDocLink — actionable", () => {
   it("maps the CLI wifi-AP validation warning to the captive portal docs", () => {
     const line =
       "\\033[33mWARNING WiFi AP is configured but neither captive_portal nor web_server is enabled. The AP will not be usable for configuration or monitoring. Add 'captive_portal:' or 'web_server:' to your configuration.\\033[0m";
-    expect(resolveLogDocLink(line, {})?.actionable).toEqual({
+    const links = resolveLogDocLink(line, {});
+    expect(links?.actionable).toEqual({
       kind: "actionable",
       url: "https://esphome.io/components/captive_portal/",
       body: "wifi_ap_no_portal",
     });
+    // The icon inherits the container colour, so a tag-less CLI line still
+    // reports its level for the renderer to colour it like the warning text.
+    expect(links?.level).toBe("W");
   });
 
   it("ignores an uncurated CLI warning line", () => {


### PR DESCRIPTION
# What does this implement/fix?

ESPHome's config validation logs a common warning when a device has an access point configured but no `captive_portal:` or `web_server:`, so the AP can't serve a config page; that warning had no explainer link in the log viewer. This adds one pointing at the captive portal docs. The doc-link resolver only matched firmware log lines before, so it now also recognizes the CLI validation format these warnings use (`WARNING <message>` with no tag token); the info icon then shows up wherever logs render, so device logs, compile, validate, install, remote and adopt.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
