### PR TITLE
Fix compile time shown as 0s when reopening a finished build

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -414,7 +414,7 @@
     "timer_detail_title": "Build time breakdown",
     "compile_time_label": "Compile time",
     "total_run_time_label": "Total run time",
-    "timer_offload_hint": "This compile is taking a while. Send builds to a faster machine on your network to speed it up.",
+    "timer_offload_hint": "This compile took a while. Send builds to a faster machine on your network to speed it up.",
     "validate_success": "Configuration is valid!",
     "validate_failed": "Validation failed.",
     "show_secrets": "Show secrets",

--- a/src/util/compile-phase.ts
+++ b/src/util/compile-phase.ts
@@ -49,14 +49,24 @@ export function isCompilePhaseLine(line: string): boolean {
 // PlatformIO closes each environment with a summary banner —
 // ``========= [SUCCESS] Took 15.36 seconds =========`` (or ``[FAILED]``). For
 // an install the flash phase streams after this, so freezing the compile clock
-// here keeps the upload out of the count.
-const COMPILE_END_LINE = /\[(?:SUCCESS|FAILED)\] Took /;
+// here keeps the upload out of the count. esp-idf's native (non-pio) build
+// prints no banner — there esphome's own ``Successfully compiled program``
+// INFO line (emitted right after ninja returns) closes the span, and ninja's
+// ``ninja: build stopped: subcommand failed.`` closes a failed build.
+const COMPILE_END_LINE =
+  /\[(?:SUCCESS|FAILED)\] Took |Successfully compiled program|ninja: build stopped/;
 
 /** True once a streamed line shows the compile has finished (or failed). */
 export function isCompileEndLine(line: string): boolean {
-  // Runs per streamed line for the whole compile window; "Took " is plain
-  // text in the banner (only the [SUCCESS]/[FAILED] token carries inline
-  // ANSI), so this skips the strip + regex on essentially every other line.
-  if (!line.includes("Took ")) return false;
+  // Runs per streamed line for the whole compile window; every end marker
+  // carries a plain-text token (only the [SUCCESS]/[FAILED] word carries
+  // inline ANSI), so this skips the strip + regex on essentially every line.
+  if (
+    !line.includes("Took ") &&
+    !line.includes("Successfully compiled") &&
+    !line.includes("build stopped")
+  ) {
+    return false;
+  }
   return COMPILE_END_LINE.test(stripAnsi(line));
 }

--- a/src/util/run-timer-controller.ts
+++ b/src/util/run-timer-controller.ts
@@ -1,5 +1,5 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
-import type { FirmwareJob } from "../api/types/firmware-jobs.js";
+import { type FirmwareJob, JobType } from "../api/types/firmware-jobs.js";
 import { isCompileEndLine, isCompilePhaseLine } from "./compile-phase.js";
 import {
   getCompileTiming,
@@ -137,13 +137,18 @@ export class RunTimerController implements ReactiveController {
     const job = this._options.job();
     const beStart = parseIsoMs(job?.compile_started_at);
     if (beStart !== null) {
-      // An ESP-IDF build never prints the "Took" banner, so its end stamp
-      // stays null; on a terminal job substitute completed_at rather than
-      // ``now`` — the ticker stopped whenever the dialog last closed, and a
-      // stale ``now`` before the start stamp clamps the readout to 0s.
+      const beEnd = parseIsoMs(job?.compile_ended_at);
+      if (beEnd !== null) return Math.max(0, beEnd - beStart);
+      // Old backends never stamp an ESP-IDF build's end; for a pure COMPILE
+      // job completion bounds the compile, so substitute completed_at rather
+      // than ``now`` — the ticker stopped whenever the dialog last closed,
+      // and a stale ``now`` before the start stamp clamps the readout to 0s.
+      // An INSTALL keeps flashing after the compile, so its completion would
+      // fold the flash into the readout — degrade to unknown instead.
       const end =
-        parseIsoMs(job?.compile_ended_at) ?? parseIsoMs(job?.completed_at) ?? this.now;
-      return Math.max(0, end - beStart);
+        job?.job_type === JobType.COMPILE ? parseIsoMs(job?.completed_at) : null;
+      if (end !== null) return Math.max(0, end - beStart);
+      return this.isRunFrozen ? null : Math.max(0, this.now - beStart);
     }
     return this.isRunFrozen ? null : this.compileElapsedMs;
   }

--- a/src/util/run-timer-controller.ts
+++ b/src/util/run-timer-controller.ts
@@ -137,7 +137,13 @@ export class RunTimerController implements ReactiveController {
     const job = this._options.job();
     const beStart = parseIsoMs(job?.compile_started_at);
     if (beStart !== null) {
-      return Math.max(0, (parseIsoMs(job?.compile_ended_at) ?? this.now) - beStart);
+      // An ESP-IDF build never prints the "Took" banner, so its end stamp
+      // stays null; on a terminal job substitute completed_at rather than
+      // ``now`` — the ticker stopped whenever the dialog last closed, and a
+      // stale ``now`` before the start stamp clamps the readout to 0s.
+      const end =
+        parseIsoMs(job?.compile_ended_at) ?? parseIsoMs(job?.completed_at) ?? this.now;
+      return Math.max(0, end - beStart);
     }
     return this.isRunFrozen ? null : this.compileElapsedMs;
   }

--- a/test/components/command-dialog-follow-restore.test.ts
+++ b/test/components/command-dialog-follow-restore.test.ts
@@ -259,6 +259,21 @@ describe("command-dialog compile detail (total never shorter than compile)", () 
     );
   });
 
+  it("degrades to unknown for a stampless-end INSTALL (completion includes flash)", () => {
+    const job = makeFirmwareJob({
+      job_id: "d5",
+      job_type: JobType.INSTALL,
+      started_at: "2026-01-01T00:00:00Z",
+      completed_at: "2026-01-01T00:12:00Z",
+      compile_started_at: "2026-01-01T00:01:54Z",
+      compile_ended_at: null,
+    });
+    const el = mount([job]);
+    el._timerJobId = "d5";
+    el._timer.now = Date.parse("2026-01-01T00:00:30Z");
+    expect(el._timer.compileDetailMs).toBeNull();
+  });
+
   it("is null for an old finished job with no backend stamps (not shown)", () => {
     const job = makeFirmwareJob({
       job_id: "d3",

--- a/test/components/command-dialog-follow-restore.test.ts
+++ b/test/components/command-dialog-follow-restore.test.ts
@@ -237,6 +237,28 @@ describe("command-dialog compile detail (total never shorter than compile)", () 
     expect(el._timer.compileDetailMs).toBe(5000);
   });
 
+  it("substitutes completed_at when the end stamp never landed (ESP-IDF)", () => {
+    // IDF builds don't print the "Took" banner, so the backend never stamps
+    // compile_ended_at. The ticker is also stale: the dialog was closed
+    // before the compile phase, so ``now`` predates the start stamp and the
+    // old ``now`` fallback clamped the readout to 0s.
+    const job = makeFirmwareJob({
+      job_id: "d4",
+      job_type: JobType.COMPILE,
+      started_at: "2026-01-01T00:00:00Z",
+      completed_at: "2026-01-01T00:10:41Z",
+      compile_started_at: "2026-01-01T00:01:54Z",
+      compile_ended_at: null,
+    });
+    const el = mount([job]);
+    el._timerJobId = "d4";
+    el._timer.now = Date.parse("2026-01-01T00:00:30Z");
+    expect(el._timer.compileDetailMs).toBe(527_000);
+    expect(el._timer.totalRunElapsedMs!).toBeGreaterThanOrEqual(
+      el._timer.compileDetailMs!
+    );
+  });
+
   it("is null for an old finished job with no backend stamps (not shown)", () => {
     const job = makeFirmwareJob({
       job_id: "d3",

--- a/test/util/compile-phase.test.ts
+++ b/test/util/compile-phase.test.ts
@@ -127,6 +127,19 @@ describe("isCompileEndLine", () => {
     );
   });
 
+  it("matches esphome's success line on native esp-idf (no pio banner)", () => {
+    expect(
+      isCompileEndLine(
+        "\x1b[32mINFO Successfully compiled program to path '/data/build/x/.pioenvs/x/program'\x1b[0m\n"
+      )
+    ).toBe(true);
+    expect(isCompileEndLine("INFO Successfully compiled program.")).toBe(true);
+  });
+
+  it("matches ninja's build-stopped closer on a failed esp-idf build", () => {
+    expect(isCompileEndLine("ninja: build stopped: subcommand failed.")).toBe(true);
+  });
+
   it("does not match ordinary build output", () => {
     expect(isCompileEndLine("Compiling .pio/build/esp32dev/src/main.cpp.o")).toBe(false);
     expect(isCompileEndLine("[117/1247] Building C object")).toBe(false);


### PR DESCRIPTION
# What does this implement/fix?

Reopening a completed compile from Firmware Tasks could show "Compile time 0s" while the total run time was correct, and after a page refresh the compile time showed a slightly inflated value instead.

ESP-IDF builds never print PlatformIO's `[SUCCESS] Took` banner, so the backend leaves `compile_ended_at` unset on the job. The popover then fell back to the run timer's `now` clock, which only ticks while the dialog is open on a live run; close the dialog before the compile phase starts and the frozen clock predates the start stamp, clamping the readout to 0s. The compile detail now substitutes the job's `completed_at` when the end stamp is missing; a compile job's stream ends at the compile, so completion is the honest bound, and the readout is now stable across reopen and reload. This also covers jobs already persisted without an end stamp and older backends. The backend companion esphome/device-builder#2101 stamps the end at the source (esphome's `Successfully compiled program` line, ninja's build-stopped closer for failures); this PR mirrors those markers in the live scanner so the ticking timer freezes at the same moment.

The popover's build server nudge also read "This compile is taking a while" on finished jobs. It can only render once the compile phase is over (the live case is the inline banner in the terminal), so the wording is now past tense: "This compile took a while."

Verified against a live backend with an ESP-IDF build: queue a compile, close the dialog before compiling starts, reopen from Firmware Tasks after completion; the popover now shows the real compile time instead of 0s, matching after a reload.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

