### PR TITLE
Gate the pairing display name on an explicit receiver_label_auto flag

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -2079,6 +2079,7 @@ export class ESPHomeAPI {
     offloader_label: string;
     pairing_key?: string;
     offloader_label_auto?: boolean;
+    receiver_label_auto?: boolean;
   }): Promise<PairingSummary> {
     return this.sendCommand<PairingSummary>("remote_build/request_pair", args);
   }

--- a/src/api/types/remote-build.ts
+++ b/src/api/types/remote-build.ts
@@ -207,8 +207,8 @@ export interface PairingSummary {
    * from the session handshake, refreshed on every session-open
    * (non-empty values only, so an older receiver can't clobber a
    * captured name). Empty until a new-enough receiver connects.
-   * `pairingDisplayName` prefers it over an auto-derived
-   * hostname label.
+   * `pairingDisplayName` prefers it over `label` when
+   * `receiver_label_auto` is set.
    */
   friendly_name: string;
   /** Receiver's HA add-on flag from the session handshake. */
@@ -220,6 +220,14 @@ export interface PairingSummary {
    * ESPHome version, all build trees). False from old receivers.
    */
   reset_build_env_supported: boolean;
+  /**
+   * True when the pair-dialog `label` was left at its auto-derived
+   * hostname prefill — the explicit signal that `pairingDisplayName`
+   * may replace `label` with `friendly_name`. Offloader-local (the
+   * receiver never sees it); a pairing persisted before this flag,
+   * or from an older backend, reads `false` so its label wins.
+   */
+  receiver_label_auto: boolean;
 }
 
 /**

--- a/src/components/pair-build-server-dialog/actions.ts
+++ b/src/components/pair-build-server-dialog/actions.ts
@@ -125,6 +125,7 @@ export async function onConfirmSubmit(host: ESPHomePairBuildServerDialog): Promi
       receiver_label: receiverLabel,
       offloader_label: offloaderLabel,
       offloader_label_auto: !host._offloaderLabelTouched,
+      receiver_label_auto: !host._receiverLabelTouched,
       ...(pairingKey ? { pairing_key: pairingKey } : {}),
     });
     host._step = "sent";

--- a/src/util/pairing-display-name.ts
+++ b/src/util/pairing-display-name.ts
@@ -1,21 +1,20 @@
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
 import type { PairingSummary, PeerSummary } from "../api/types/remote-build.js";
-import { friendlyHostname } from "./hostname.js";
 import { remoteBuildPeerName } from "./remote-build-peer-name.js";
 
 /**
  * Display name for a paired build server (offloader side).
  *
- * A label the user typed always wins. A label that still equals
- * the hostname-derived prefill (the pair wizard's default, and
- * what the walkthrough's paste-the-address flow produces) is
- * replaced by the receiver's handshake-advertised friendly name
- * when one has been captured — with the HA add-on container
- * hostname mapped to "Home Assistant App" the same way discovery
- * rows are.
+ * A label the user typed always wins. A label left at its
+ * auto-derived prefill (`receiver_label_auto`, the pair wizard's
+ * default and what the walkthrough's paste-the-address flow
+ * produces) is replaced by the receiver's handshake-advertised
+ * friendly name when one has been captured — with the HA add-on
+ * container hostname mapped to "Home Assistant App" the same way
+ * discovery rows are. Mirrors `peerDisplayName`.
  */
 export function pairingDisplayName(pairing: PairingSummary): string {
-  if (pairing.label !== friendlyHostname(pairing.receiver_hostname)) {
+  if (!pairing.receiver_label_auto) {
     return pairing.label;
   }
   return remoteBuildPeerName({

--- a/test/components/app-shell/events-initial-state-pairings.test.ts
+++ b/test/components/app-shell/events-initial-state-pairings.test.ts
@@ -24,6 +24,7 @@ function makeSummary(pin: string, enabled: boolean): PairingSummary {
     friendly_name: "",
     ha_addon: false,
     reset_build_env_supported: false,
+    receiver_label_auto: false,
   };
 }
 

--- a/test/components/app-shell/events-pairing-added.test.ts
+++ b/test/components/app-shell/events-pairing-added.test.ts
@@ -21,6 +21,7 @@ function makeSummary(pin: string): PairingSummary {
     friendly_name: "",
     ha_addon: false,
     reset_build_env_supported: false,
+    receiver_label_auto: false,
   };
 }
 

--- a/test/components/app-shell/events-peer-link-opened.test.ts
+++ b/test/components/app-shell/events-peer-link-opened.test.ts
@@ -25,6 +25,7 @@ function makeSummary(pin: string, esphome_version: string): PairingSummary {
     friendly_name: "",
     ha_addon: false,
     reset_build_env_supported: false,
+    receiver_label_auto: false,
   };
 }
 

--- a/test/components/app-shell/settings-actions.test.ts
+++ b/test/components/app-shell/settings-actions.test.ts
@@ -208,6 +208,7 @@ function makePairing(enabled: boolean): PairingSummary {
     friendly_name: "",
     ha_addon: false,
     reset_build_env_supported: false,
+    receiver_label_auto: false,
   };
 }
 

--- a/test/components/command-dialog-remote-sub-line.test.ts
+++ b/test/components/command-dialog-remote-sub-line.test.ts
@@ -34,6 +34,7 @@ function makePairing(auto: boolean): PairingSummary {
     friendly_name: "",
     ha_addon: false,
     reset_build_env_supported: false,
+    receiver_label_auto: false,
   };
 }
 
@@ -80,6 +81,7 @@ describe("renderRemoteBuilderSubLine version", () => {
       ...makePairing(false),
       label: "esphome-builder-x",
       friendly_name: "Nicks-Mac-Studio",
+      receiver_label_auto: true,
     };
     (host as unknown as { _pairings: Map<string, PairingSummary> })._pairings = new Map([
       [PIN, pairing],

--- a/test/components/firmware-jobs-dialog-reset-peer.test.ts
+++ b/test/components/firmware-jobs-dialog-reset-peer.test.ts
@@ -40,6 +40,7 @@ function pairing(overrides: Partial<PairingSummary> = {}): PairingSummary {
     friendly_name: "",
     ha_addon: false,
     reset_build_env_supported: true,
+    receiver_label_auto: false,
     ...overrides,
   };
 }

--- a/test/components/pair-build-server-dialog/on-confirm-submit.test.ts
+++ b/test/components/pair-build-server-dialog/on-confirm-submit.test.ts
@@ -30,6 +30,7 @@ function makeHost(pairingKey: string): {
     _pairingKey: pairingKey,
     _pairingKeyRequired: false,
     _offloaderLabelTouched: false,
+    _receiverLabelTouched: false,
     _error: null,
     _step: "confirm",
     _sentKey: null,
@@ -71,6 +72,23 @@ describe("onConfirmSubmit", () => {
 
     const args = request.mock.calls[0][0] as RequestArgs;
     expect(args.offloader_label_auto).toBe(false);
+  });
+
+  it("marks an untouched receiver label as auto-derived", async () => {
+    const { host, request } = makeHost("");
+    await onConfirmSubmit(host);
+
+    const args = request.mock.calls[0][0] as RequestArgs;
+    expect(args.receiver_label_auto).toBe(true);
+  });
+
+  it("marks a user-edited receiver label as not auto-derived", async () => {
+    const { host, request } = makeHost("");
+    (host as unknown as { _receiverLabelTouched: boolean })._receiverLabelTouched = true;
+    await onConfirmSubmit(host);
+
+    const args = request.mock.calls[0][0] as RequestArgs;
+    expect(args.receiver_label_auto).toBe(false);
   });
 
   it("omits the pairing_key arg entirely when the field is blank", async () => {

--- a/test/components/remote-build-hint.test.ts
+++ b/test/components/remote-build-hint.test.ts
@@ -20,6 +20,7 @@ function pairing(overrides: Partial<PairingSummary> = {}): PairingSummary {
     friendly_name: "",
     ha_addon: false,
     reset_build_env_supported: true,
+    receiver_label_auto: false,
     ...overrides,
   };
 }

--- a/test/components/settings-dialog/render-pairing-row.test.ts
+++ b/test/components/settings-dialog/render-pairing-row.test.ts
@@ -25,6 +25,7 @@ function makeSummary(esphome_version: string): PairingSummary {
     friendly_name: "",
     ha_addon: false,
     reset_build_env_supported: false,
+    receiver_label_auto: false,
   };
 }
 
@@ -124,11 +125,12 @@ describe("renderPairingRow reset-build-env button", () => {
 });
 
 describe("renderPairingRow display name", () => {
-  it("shows the friendly name when the label is the auto-derived hostname stem", () => {
+  it("shows the friendly name when the label was left at its auto-derived prefill", () => {
     const pairing = {
       ...makeSummary("2026.6.0"),
       label: "mac",
       friendly_name: "Nicks-Mac-Studio",
+      receiver_label_auto: true,
     };
     const text = renderedText(renderPairingRow(pairing, ctx()));
     expect(text).toContain("Nicks-Mac-Studio");

--- a/test/util/bulk-update.test.ts
+++ b/test/util/bulk-update.test.ts
@@ -35,6 +35,7 @@ function pairing(overrides: Partial<PairingSummary>): PairingSummary {
     friendly_name: "",
     ha_addon: false,
     reset_build_env_supported: false,
+    receiver_label_auto: false,
     ...overrides,
   };
 }

--- a/test/util/pairing-display-name.test.ts
+++ b/test/util/pairing-display-name.test.ts
@@ -24,6 +24,7 @@ function pairing(overrides: Partial<PairingSummary> = {}): PairingSummary {
     friendly_name: "",
     ha_addon: false,
     reset_build_env_supported: false,
+    receiver_label_auto: false,
     ...overrides,
   };
 }
@@ -45,10 +46,12 @@ function peer(overrides: Partial<PeerSummary> = {}): PeerSummary {
 }
 
 describe("pairingDisplayName", () => {
-  it("replaces an auto-derived hostname label with the friendly name", () => {
-    expect(pairingDisplayName(pairing({ friendly_name: "Nicks-Mac-Studio" }))).toBe(
-      "Nicks-Mac-Studio"
-    );
+  it("replaces an auto-prefilled label with the friendly name", () => {
+    expect(
+      pairingDisplayName(
+        pairing({ receiver_label_auto: true, friendly_name: "Nicks-Mac-Studio" })
+      )
+    ).toBe("Nicks-Mac-Studio");
   });
 
   it("keeps a custom label even when a friendly name is known", () => {
@@ -60,19 +63,27 @@ describe("pairingDisplayName", () => {
   });
 
   it("falls back to the label when no friendly name was captured", () => {
-    expect(pairingDisplayName(pairing())).toBe("esphome-builder-xnnspgdv");
+    expect(pairingDisplayName(pairing({ receiver_label_auto: true }))).toBe(
+      "esphome-builder-xnnspgdv"
+    );
   });
 
   it("maps the HA add-on container hostname to a human label", () => {
     expect(
-      pairingDisplayName(pairing({ friendly_name: "0123abcd-esphome", ha_addon: true }))
+      pairingDisplayName(
+        pairing({
+          receiver_label_auto: true,
+          friendly_name: "0123abcd-esphome",
+          ha_addon: true,
+        })
+      )
     ).toBe("Home Assistant App");
   });
 });
 
 describe("pairingDisplayNameForPin", () => {
   it("prefers the live pairing's display name over the snapshot", () => {
-    const p = pairing({ friendly_name: "Nicks-Mac-Studio" });
+    const p = pairing({ receiver_label_auto: true, friendly_name: "Nicks-Mac-Studio" });
     const map = new Map([[p.pin_sha256, p]]);
     expect(pairingDisplayNameForPin(map, p.pin_sha256, "esphome-builder-xnnspgdv")).toBe(
       "Nicks-Mac-Studio"

--- a/test/util/version-mismatch.test.ts
+++ b/test/util/version-mismatch.test.ts
@@ -23,6 +23,7 @@ function pairing(overrides: Partial<PairingSummary>): PairingSummary {
     friendly_name: "",
     ha_addon: false,
     reset_build_env_supported: false,
+    receiver_label_auto: false,
     ...overrides,
   };
 }


### PR DESCRIPTION
# What does this implement/fix?

`pairingDisplayName` decided whether a build server's label was an auto-derived prefill (and could be replaced by the receiver's handshake friendly name) by comparing the label against the hostname; editing a pairing's endpoint changed the hostname but not the label, so the guess flipped to "custom" and the friendly name silently stopped showing. The receiver side already carries an explicit `label_auto` flag for exactly this; this gates `pairingDisplayName` on the symmetric `receiver_label_auto` instead, mirroring `peerDisplayName`.

The pair dialog already tracks whether the receiver-label field was edited; it now sends `receiver_label_auto: !_receiverLabelTouched`, and the new field rides `PairingSummary` from the companion backend. A pairing persisted before the flag reads `false` so its label wins, matching how the peer side handled its own rollout. Editing an endpoint no longer touches the flag, so the friendly name keeps showing.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1254
- companion backend PR: esphome/device-builder#2104

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
