### PR TITLE
Consolidate the rendered log-line grammar into one shared util

### DIFF
--- a/src/components/ansi-log.ts
+++ b/src/components/ansi-log.ts
@@ -16,9 +16,9 @@ import { chunksToVisualLines } from "../util/log-chunks.js";
 import {
   type LogDocLink,
   type LogDocLinks,
-  parseLogLine,
   resolveLogDocLink,
 } from "../util/log-doc-links.js";
+import { parseLogLine } from "../util/log-line.js";
 import {
   type AnsiSpan,
   docPopoverText,

--- a/src/util/crash-detector.ts
+++ b/src/util/crash-detector.ts
@@ -1,4 +1,4 @@
-import { stripAnsi } from "./ansi-escapes.js";
+import { normalizeLogLine, tagged } from "./log-line.js";
 
 /**
  * Crash detection over device log lines.
@@ -15,32 +15,12 @@ import { stripAnsi } from "./ansi-escapes.js";
  * one batch scan until a crash is seen and zero cost after.
  */
 
-// The dialog prepends `[HH:MM:SS]` (optionally with millis) to every line.
-// Trailing whitespace stays: on a continuation line the indent after the
-// timestamp is content (it's what marks the line as a continuation).
-const TIMESTAMP_RE = /^\[\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?\]/;
-
-/** Strip ANSI (both escape forms), trailing CR/LF, and the timestamp prefix. */
-export function normalizeLogLine(line: string): string {
-  return stripAnsi(line)
-    .replace(/[\r\n]+$/, "")
-    .replace(TIMESTAMP_RE, "");
-}
-
 /**
  * "live" = the panic scrolled past in this session; "previous-boot" =
  * the crash handler's stored report replayed at boot. The callout wording
  * differs — one is happening now, the other already rebooted.
  */
 export type CrashKind = "live" | "previous-boot";
-
-// The stored previous-boot crash report replays through ESPHome's logger,
-// so those lines carry a `[E][esp32.crash:NNN]:` header. Anchored markers
-// tolerate one optional level/tag prefix so both raw panic output and the
-// logger-replayed form match. Exported so crash-report can build the same
-// tagged shapes without re-typing the grammar.
-export const TAG = /(?:\[[A-Z]{1,2}\]\[[^\]]*\]:\s*)?/.source;
-export const tagged = (source: string): RegExp => new RegExp(`^${TAG}${source}`);
 
 // One entry per crash shape; tested per normalized line. Anchored patterns
 // stay anchored (a prose sentence mentioning "Backtrace" must not trip the

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -1,4 +1,5 @@
-import { isCrashMarker, normalizeLogLine, tagged } from "./crash-detector.js";
+import { isCrashMarker } from "./crash-detector.js";
+import { normalizeLogLine, parseLogLine, tagged } from "./log-line.js";
 import { isCliLogLine } from "./validation-log.js";
 
 /**
@@ -51,8 +52,6 @@ const isDecodeEcho = (line: string): boolean =>
 // address (registers, stack dumps, backtrace continuations) or a
 // decoded frame.
 const CRASH_RELATED_RE = /(?:0x)?[0-9a-fA-F]{8}(?::|\b)|Decoded 0x/;
-
-const TAGGED_LINE_RE = /^\[([CWE])\]\[[^\]]*\]/;
 
 // `target_platform` → the bug form's platform dropdown values. ESP32 is a
 // prefix match (variants like ESP32S3 report as ESP32).
@@ -173,13 +172,12 @@ function extractTaggedLines(lines: string[]): {
   const warnings: string[] = [];
   const configLines: string[] = [];
   for (const line of lines) {
-    const match = TAGGED_LINE_RE.exec(line);
-    if (!match) continue;
-    if (match[1] === "C") {
+    const level = parseLogLine(line)?.level;
+    if (level === "C") {
       // Config-dump lines are structured output, not spam — keep them
       // verbatim (folding would silently collapse repeated values).
       configLines.push(line);
-    } else {
+    } else if (level === "W" || level === "E") {
       appendFolded(warnings, line);
     }
   }

--- a/src/util/log-doc-links.ts
+++ b/src/util/log-doc-links.ts
@@ -13,6 +13,7 @@
 import type { IntegrationDoc } from "../api/types/components.js";
 import { isSafeDocsUrl } from "../common/docs.js";
 import { stripAnsi } from "./ansi-escapes.js";
+import { parseLogLine } from "./log-line.js";
 
 export interface ActionableLogDocLink {
   kind: "actionable";
@@ -60,13 +61,6 @@ export interface LogDocLinks {
   /** Log level of a parsed line, so the renderer colours annotated lines
    *  without re-running the line regex every frame. */
   level?: string;
-}
-
-export interface ParsedLogLine {
-  level: string;
-  tag: string;
-  tagStart: number;
-  tagEnd: number;
 }
 
 /** Curated actionable message → verified docs page. */
@@ -221,29 +215,11 @@ const CLI_LEVEL_LETTER: Record<ActionableCliEntry["level"], string> = {
  *  trimmed in ``resolveLogDocLink``). */
 const EMBEDDED_URL_RE = /https:\/\/esphome\.io\/[^\s)"']+/;
 
-// A device-log record: [timestamp][LEVEL][tag:line]. Group 1 is the level,
-// group 2 the ``tag:line`` token. Firmware levels always append ``:<line>``;
-// ``S`` state lines (client-side reconstructed by aioesphomeapi's
-// state_log_formatter) carry a bare entity-domain tag with no line number.
-const LOG_LINE_RE = /^\[\d[\d:.]*\]\[([EWICDV]V?|S)\]\[([^\]]+)\]/;
-
 // Platform-specific tag suffixes, limited to the ones the esphome tree
 // actually emits (``wifi_esp32`` / ``wifi_esp8266`` / ``wifi_lt``). The
 // ``.idf`` / ``.arduino`` framework variants use a dot and are handled by
 // the before-the-dot split instead.
 const PLATFORM_SUFFIX_RE = /_(esp32\w*|esp8266|lt)$/;
-
-/** Parse level + tag (and the tag's char range) from a clean log line. */
-export function parseLogLine(clean: string): ParsedLogLine | undefined {
-  const match = clean.match(LOG_LINE_RE);
-  if (!match) return undefined;
-  const inner = match[2];
-  const tag = inner.replace(/:\d+$/, "");
-  // match[0] === `[time][LEVEL][` + inner + `]`, so the inner token starts
-  // one char before the closing bracket; the tag is inner's leading slice.
-  const tagStart = match[0].length - inner.length - 1;
-  return { level: match[1], tag, tagStart, tagEnd: tagStart + tag.length };
-}
 
 /**
  * Resolve *line* to its documentation links, or ``undefined`` when none

--- a/src/util/log-line.ts
+++ b/src/util/log-line.ts
@@ -1,0 +1,62 @@
+import { stripAnsi } from "./ansi-escapes.js";
+
+/**
+ * The rendered log-record grammar — ``[timestamp][LEVEL][tag]`` — in one
+ * place, so the doc-link parser, crash detector, and crash-report
+ * extraction can't drift apart on the timestamp shape or level alphabet.
+ */
+
+// The transport-prepended wall-clock stamp. Both prepend paths emit exactly
+// this shape: the backend's `esphome logs` stamp (optionally with millis)
+// and the Web Serial path's formatSerialTimestamp (seconds only).
+const TIMESTAMP_SOURCE = /\[\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?\]/.source;
+
+// Firmware log levels plus `S`: state lines client-side reconstructed by
+// aioesphomeapi's state_log_formatter, carrying a bare entity-domain tag
+// with no line number where firmware levels always append `:<line>`.
+const LEVEL_SOURCE = /[EWICDV]V?|S/.source;
+
+// A rendered log record: optional timestamp (present on buffered dialog
+// lines, already stripped on normalized ones), then the `[LEVEL][tag]`
+// header. Group 1 is the level, group 2 the `tag:line` token.
+const LOG_LINE_RE = new RegExp(
+  `^(?:${TIMESTAMP_SOURCE})?\\[(${LEVEL_SOURCE})\\]\\[([^\\]]+)\\]`
+);
+
+// The dialog prepends the timestamp to every line. Trailing whitespace
+// stays: on a continuation line the indent after the timestamp is content
+// (it's what marks the line as a continuation).
+const TIMESTAMP_RE = new RegExp(`^${TIMESTAMP_SOURCE}`);
+
+// The stored previous-boot crash report replays through ESPHome's logger,
+// so those lines carry a `[E][esp32.crash:NNN]:` header. Anchored crash
+// markers tolerate one optional level/tag prefix so both raw panic output
+// and the logger-replayed form match.
+export const TAG = `(?:\\[(?:${LEVEL_SOURCE})\\]\\[[^\\]]*\\]:\\s*)?`;
+export const tagged = (source: string): RegExp => new RegExp(`^${TAG}${source}`);
+
+export interface ParsedLogLine {
+  level: string;
+  tag: string;
+  tagStart: number;
+  tagEnd: number;
+}
+
+/** Parse level + tag (and the tag's char range) from a clean log line. */
+export function parseLogLine(clean: string): ParsedLogLine | undefined {
+  const match = clean.match(LOG_LINE_RE);
+  if (!match) return undefined;
+  const inner = match[2];
+  const tag = inner.replace(/:\d+$/, "");
+  // match[0] ends with `[` + inner + `]`, so the inner token starts one
+  // char before the closing bracket; the tag is inner's leading slice.
+  const tagStart = match[0].length - inner.length - 1;
+  return { level: match[1], tag, tagStart, tagEnd: tagStart + tag.length };
+}
+
+/** Strip ANSI (both escape forms), trailing CR/LF, and the timestamp prefix. */
+export function normalizeLogLine(line: string): string {
+  return stripAnsi(line)
+    .replace(/[\r\n]+$/, "")
+    .replace(TIMESTAMP_RE, "");
+}

--- a/test/util/crash-detector.test.ts
+++ b/test/util/crash-detector.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  detectCrashKind,
-  isCrashMarker,
-  normalizeLogLine,
-} from "../../src/util/crash-detector.js";
+import { detectCrashKind, isCrashMarker } from "../../src/util/crash-detector.js";
 import { CRASH_BANNER_LINE } from "../_crash-lines.js";
 
 // Realistic crash lines, one per supported shape.
@@ -42,21 +38,8 @@ const NON_CRASH_LINES: ReadonlyArray<[string, string]> = [
   ["empty line", ""],
 ];
 
-// The dialog's real transport wrapping: timestamp prefix + ANSI color in
-// both the ESC-byte (UART) and literal-\033 (backend) forms.
+// The dialog's real transport wrapping: timestamp prefix + ANSI color.
 const wrapEsc = (line: string) => `[12:34:56]\u001b[31m${line}\u001b[0m`;
-const wrapLiteral = (line: string) => `\\033[31m[12:34:56]${line}\\033[0m`;
-
-describe("normalizeLogLine", () => {
-  it("strips ANSI (both forms), the timestamp prefix, and trailing CRLF", () => {
-    expect(normalizeLogLine(wrapEsc("Soft WDT reset\r\n"))).toBe("Soft WDT reset");
-    expect(normalizeLogLine(wrapLiteral("Soft WDT reset"))).toBe("Soft WDT reset");
-  });
-
-  it("keeps a line with no wrapping untouched", () => {
-    expect(normalizeLogLine("Exception (28):")).toBe("Exception (28):");
-  });
-});
 
 describe("isCrashMarker", () => {
   it.each(CRASH_LINES)("matches %s", (_name, line) => {

--- a/test/util/log-line.test.ts
+++ b/test/util/log-line.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLogLine, parseLogLine, tagged } from "../../src/util/log-line.js";
+
+const ESC = String.fromCharCode(27);
+
+describe("parseLogLine", () => {
+  it("parses a stamped record and strips the tag's :line suffix", () => {
+    expect(parseLogLine("[12:34:56][W][wifi:123]: Disconnected")).toEqual({
+      level: "W",
+      tag: "wifi",
+      tagStart: 14,
+      tagEnd: 18,
+    });
+  });
+
+  it("returns a tag range that indexes into the parsed line", () => {
+    const line = "[11:21:19.093][E][esp32.crash:305]:   BT0: 0x4015482D";
+    const parsed = parseLogLine(line)!;
+    expect(line.slice(parsed.tagStart, parsed.tagEnd)).toBe("esp32.crash");
+  });
+
+  it("parses an unstamped (normalized) record", () => {
+    expect(parseLogLine("[C][logger:224]: Logger:")?.level).toBe("C");
+  });
+
+  it.each(["E", "W", "I", "C", "D", "V", "VV"])("knows level %s", (level) => {
+    expect(parseLogLine(`[12:00:00][${level}][app:029]: x`)?.level).toBe(level);
+  });
+
+  it("parses an S state line's bare entity-domain tag", () => {
+    expect(parseLogLine("[12:00:00][S][sensor]: Temperature: 21.5")).toMatchObject({
+      level: "S",
+      tag: "sensor",
+    });
+  });
+
+  it("rejects a pseudo-stamp that is not wall-clock shaped", () => {
+    expect(parseLogLine("[123][W][wifi:123]: x")).toBeUndefined();
+  });
+
+  it("rejects a plain line", () => {
+    expect(parseLogLine("Writing at 0x00010000... (5 %)")).toBeUndefined();
+  });
+});
+
+describe("normalizeLogLine", () => {
+  it("strips ANSI (both forms), the timestamp prefix, and trailing CRLF", () => {
+    expect(normalizeLogLine(`[12:34:56]${ESC}[31mSoft WDT reset\r\n${ESC}[0m`)).toBe(
+      "Soft WDT reset"
+    );
+    expect(normalizeLogLine("\\033[31m[12:34:56]Soft WDT reset\\033[0m")).toBe(
+      "Soft WDT reset"
+    );
+  });
+
+  it("strips a millisecond stamp", () => {
+    expect(normalizeLogLine("[11:21:19.093][E][app:029]: boot")).toBe(
+      "[E][app:029]: boot"
+    );
+  });
+
+  it("keeps a line with no wrapping untouched", () => {
+    expect(normalizeLogLine("Exception (28):")).toBe("Exception (28):");
+  });
+});
+
+describe("tagged", () => {
+  const re = tagged("BT\\d+:\\s*0x[0-9a-fA-F]{8}");
+
+  it("matches both the raw and the logger-replayed form", () => {
+    expect(re.test("BT0: 0x400d9150")).toBe(true);
+    expect(re.test("[E][esp32.crash:305]: BT0: 0x4015482D")).toBe(true);
+  });
+
+  it("stays anchored past a non-record prefix", () => {
+    expect(re.test("prose then BT0: 0x400d9150")).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The `[timestamp][LEVEL][tag]` log-record grammar was encoded in three independent regexes that had already drifted; `LOG_LINE_RE` in log-doc-links accepted any bracketed digit run as a stamp, `TIMESTAMP_RE` in crash-detector accepted only `HH:MM:SS(.mmm)`, and `TAGGED_LINE_RE` in crash-report knew only the `C`/`W`/`E` levels.

New `src/util/log-line.ts` holds the grammar once: the strict wall-clock stamp (the shape both prepend paths actually emit), the full level alphabet, `parseLogLine`, `normalizeLogLine`, and the `tagged` crash-marker prefix, now derived from the same level set. The stamp is optional in `parseLogLine` so the one function parses both buffered dialog lines and normalized stamp-stripped lines; crash-report's tagged extraction now parses then filters on level, with identical output. Behaviour is otherwise unchanged, which the untouched crash-report, crash-detector, and log-doc-links suites pin; a new log-line suite pins the shared grammar itself.

**Related issue or feature (if applicable):**

- fixes #1251

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
