### PR TITLE
Add a write-in-English note to the crash report and feedback dialogs

### DIFF
--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -410,11 +410,14 @@ export class ESPHomeCrashReportDialog extends LitElement {
         id="crash-description"
         class="describe-input"
         rows="3"
+        aria-describedby="crash-description-note"
         placeholder=${this._localize("crash_report.describe_placeholder")}
         .value=${this._userDescription}
         @input=${this._onDescriptionInput}
       ></textarea>
-      <p class="describe-note">${this._localize("crash_report.describe_english")}</p>
+      <p id="crash-description-note" class="describe-note">
+        ${this._localize("crash_report.describe_english")}
+      </p>
       <ul class="summary">
         ${this._renderSummaryRow(
           this._localize(

--- a/src/components/crash-report-dialog.ts
+++ b/src/components/crash-report-dialog.ts
@@ -197,6 +197,12 @@ export class ESPHomeCrashReportDialog extends LitElement {
         border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
         background: var(--wa-color-surface-default);
         color: var(--wa-color-text-normal);
+        margin: 0 0 var(--wa-space-2xs);
+      }
+
+      .describe-note {
+        font-size: var(--wa-font-size-xs);
+        color: var(--wa-color-text-quiet);
         margin: 0 0 var(--wa-space-m);
       }
 
@@ -408,6 +414,7 @@ export class ESPHomeCrashReportDialog extends LitElement {
         .value=${this._userDescription}
         @input=${this._onDescriptionInput}
       ></textarea>
+      <p class="describe-note">${this._localize("crash_report.describe_english")}</p>
       <ul class="summary">
         ${this._renderSummaryRow(
           this._localize(

--- a/src/components/feedback-dialog.ts
+++ b/src/components/feedback-dialog.ts
@@ -120,10 +120,14 @@ const BROWSE_LINKS: ReadonlyArray<FeedbackLink> = [
 
 const DRILL_SCREENS: Record<
   DrillScreen,
-  { titleKey: string; links: ReadonlyArray<FeedbackLink> }
+  { titleKey: string; noteKey?: string; links: ReadonlyArray<FeedbackLink> }
 > = {
   browse: { titleKey: "feedback.browse_issues", links: BROWSE_LINKS },
-  bug: { titleKey: "feedback.new_issue", links: BUG_LINKS },
+  bug: {
+    titleKey: "feedback.new_issue",
+    noteKey: "feedback.write_in_english",
+    links: BUG_LINKS,
+  },
 };
 
 const SECTIONS: ReadonlyArray<{
@@ -455,9 +459,16 @@ export class ESPHomeFeedbackDialog extends LitElement {
         }
         ${
           drill
-            ? html`<div class="links">
-                ${drill.links.map((link) => this._renderLink(link))}
-              </div>`
+            ? html`
+                ${
+                  drill.noteKey
+                    ? html`<p class="description">${this._localize(drill.noteKey)}</p>`
+                    : ""
+                }
+                <div class="links">
+                  ${drill.links.map((link) => this._renderLink(link))}
+                </div>
+              `
             : this._renderMainScreen()
         }
       </esphome-base-dialog>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1170,7 +1170,8 @@
     "bug_esphome_desc": "Compile errors, firmware crashes, boot loops, or component bugs in ESPHome itself; these belong in the core repo, not Device Builder.",
     "browse_features": "Browse feature requests",
     "new_feature": "Request a new feature",
-    "discord": "Chat on the ESPHome Discord"
+    "discord": "Chat on the ESPHome Discord",
+    "write_in_english": "Please write in English so the ESPHome maintainers can read your report."
   },
   "command_palette": {
     "title": "Command palette",
@@ -1690,6 +1691,7 @@
     "describe_label": "What was the device doing when it crashed?",
     "describe_placeholder": "e.g. Pressed the garage button in Home Assistant; crashes every time a BLE device connects",
     "describe_required": "Describe what the device was doing first; a report without context is hard to act on",
+    "describe_english": "Please write in English so the ESPHome maintainers can read your report.",
     "banner_previous_boot": "This device crashed on a previous boot",
     "delivered_hint_complete": "The full report was downloaded and a pre-filled GitHub issue opened in a new tab; everything fit, so nothing needs to be pasted. If the tab didn't open, use \"Open GitHub issue\" below. You can also re-download or copy the report here.",
     "copy_report": "Copy report",

--- a/test/components/crash-report-dialog.test.ts
+++ b/test/components/crash-report-dialog.test.ts
@@ -116,6 +116,17 @@ describe("crash-report-dialog", () => {
     expect(button!.disabled).toBe(false);
   });
 
+  it("shows the write-in-English note whether or not a description is entered", async () => {
+    el.open("smallgarage.yaml", "Small Garage", CRASH_LINES);
+    finishValidate();
+    await el.updateComplete;
+    expect(el.shadowRoot!.textContent).toContain("crash_report.describe_english");
+
+    describe_("Pressed the crash button");
+    await el.updateComplete;
+    expect(el.shadowRoot!.textContent).toContain("crash_report.describe_english");
+  });
+
   it("always offers the manual issue link in the delivered state", async () => {
     // window.open with noopener returns null by spec even on success, so
     // the delivered state can't infer blocking; the link is always there.

--- a/test/components/feedback-dialog.test.ts
+++ b/test/components/feedback-dialog.test.ts
@@ -1,9 +1,10 @@
 /**
  * @vitest-environment happy-dom
  *
- * Pins the version-prefill routing: Device Builder rows carry the server
+ * Pins the version-prefill routing (Device Builder rows carry the server
  * version, the ESPHome row carries the installed core version, and rows
- * without a source (or version) are left untouched.
+ * without a source or version are left untouched) and the write-in-English
+ * note that only the "Report a new issue" drill screen shows.
  */
 import { describe, expect, it, vi } from "vitest";
 
@@ -74,21 +75,29 @@ describe("feedback-dialog version prefill", () => {
 
 describe("feedback-dialog write-in-English note", () => {
   const NOTE = "feedback.write_in_english";
-  const setScreen = (el: ESPHomeFeedbackDialog, screen: string) => {
-    (el as unknown as { _screen: string })._screen = screen;
-  };
 
   it("shows the note on the new-issue screen only", async () => {
     const el = await mount(new ESPHomeFeedbackDialog());
     el.open();
     await el.updateComplete;
+    const drill = (screen: string) =>
+      el.shadowRoot!.querySelector<HTMLButtonElement>(
+        `button.link[data-drill="${screen}"]`
+      );
+    const back = () => el.shadowRoot!.querySelector<HTMLButtonElement>(".back-button");
+
+    // Main screen: no note.
     expect(el.shadowRoot!.textContent).not.toContain(NOTE);
 
-    setScreen(el, "bug");
+    // Drill into "Report a new issue" the way a user does: the note is there.
+    drill("bug")!.click();
     await el.updateComplete;
     expect(el.shadowRoot!.textContent).toContain(NOTE);
 
-    setScreen(el, "browse");
+    // Back out and into the read-only browse screen: no note.
+    back()!.click();
+    await el.updateComplete;
+    drill("browse")!.click();
     await el.updateComplete;
     expect(el.shadowRoot!.textContent).not.toContain(NOTE);
   });

--- a/test/components/feedback-dialog.test.ts
+++ b/test/components/feedback-dialog.test.ts
@@ -5,9 +5,13 @@
  * version, the ESPHome row carries the installed core version, and rows
  * without a source (or version) are left untouched.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { ESPHomeFeedbackDialog } from "../../src/components/feedback-dialog.js";
+import { mount } from "../_dom.js";
 
 interface HrefLink {
   href?: string;
@@ -65,5 +69,27 @@ describe("feedback-dialog version prefill", () => {
 
   it("returns an empty string for a drill row with no href", () => {
     expect(dialog()._hrefFor({})).toBe("");
+  });
+});
+
+describe("feedback-dialog write-in-English note", () => {
+  const NOTE = "feedback.write_in_english";
+  const setScreen = (el: ESPHomeFeedbackDialog, screen: string) => {
+    (el as unknown as { _screen: string })._screen = screen;
+  };
+
+  it("shows the note on the new-issue screen only", async () => {
+    const el = await mount(new ESPHomeFeedbackDialog());
+    el.open();
+    await el.updateComplete;
+    expect(el.shadowRoot!.textContent).not.toContain(NOTE);
+
+    setScreen(el, "bug");
+    await el.updateComplete;
+    expect(el.shadowRoot!.textContent).toContain(NOTE);
+
+    setScreen(el, "browse");
+    await el.updateComplete;
+    expect(el.shadowRoot!.textContent).not.toContain(NOTE);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The crash report form and the "Found a bug? Have an idea?" dialog both feed free text into a GitHub issue that the maintainers read in English; the UI is localizable, so a non-English user can easily type their own language there. This adds a short "please write in English" note under the crash report's description field and on the feedback dialog's "Report a new issue" screen. It shows unconditionally, since many non-English speakers still run the English UI while their language is untranslated.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2108

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
