### PR TITLE
Track Compile and upload submissions as firmware install jobs

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -2190,11 +2190,8 @@ export class ESPHomeAPI {
    * The returned job_id is target-dependent: COMPILE gets the
    * offloader-local wire id tracked via
    * ``buildOffloadJobsContext``; UPLOAD gets a local
-   * ``FirmwareJob`` id — the backend queues a server-pinned
-   * INSTALL (remote compile, local OTA flash) tracked via
-   * ``firmwareJobsContext``, and the missing-YAML NOT_FOUND
-   * above doesn't apply (a missing YAML fails the job at
-   * bundle time instead).
+   * ``FirmwareJob`` id tracked via ``firmwareJobsContext``,
+   * and the missing-YAML NOT_FOUND above doesn't apply.
    *
    * Phase 5c-3 backend, 5c-4 frontend.
    */
@@ -2213,16 +2210,14 @@ export class ESPHomeAPI {
   /**
    * Send a cooperative cancel for a remote build job (phase 5d).
    *
-   * Routes through ``remote_build/cancel_job``. A *job_id*
-   * matching a local ``FirmwareJob`` (a server-pinned INSTALL
-   * from ``target: UPLOAD``) cancels through the local firmware
-   * primitive — covering the queued, remote-compile, and
-   * local-flash phases — and never touches the wire. Otherwise
-   * the frame goes to the paired receiver behind *pin_sha256*,
-   * which maps *job_id* (the offloader-local id
-   * ``submitRemoteBuildJob`` returned) back to its local
-   * ``FirmwareJob`` and dispatches the same cancel primitive
-   * an operator-driven cancel uses.
+   * Routes through ``remote_build/cancel_job``. A *job_id* from
+   * a ``target: UPLOAD`` submit names a local ``FirmwareJob``;
+   * the backend routes the cancel accordingly, ``sent``
+   * semantics unchanged. Otherwise the frame goes to the paired
+   * receiver behind *pin_sha256*, which maps *job_id* (the
+   * offloader-local id ``submitRemoteBuildJob`` returned) back
+   * to its local ``FirmwareJob`` and dispatches the same cancel
+   * primitive an operator-driven cancel uses.
    *
    * Fire-and-forget on the wire — the resolved payload's
    * ``sent`` flag reflects whether the cancel frame made it

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -2187,6 +2187,15 @@ export class ESPHomeAPI {
    * job (queue full, manifest unsupported, hash mismatch);
    * reason carries the structured rejection code.
    *
+   * The returned job_id is target-dependent: COMPILE gets the
+   * offloader-local wire id tracked via
+   * ``buildOffloadJobsContext``; UPLOAD gets a local
+   * ``FirmwareJob`` id — the backend queues a server-pinned
+   * INSTALL (remote compile, local OTA flash) tracked via
+   * ``firmwareJobsContext``, and the missing-YAML NOT_FOUND
+   * above doesn't apply (a missing YAML fails the job at
+   * bundle time instead).
+   *
    * Phase 5c-3 backend, 5c-4 frontend.
    */
   async submitRemoteBuildJob(args: {
@@ -2204,11 +2213,16 @@ export class ESPHomeAPI {
   /**
    * Send a cooperative cancel for a remote build job (phase 5d).
    *
-   * Routes through ``remote_build/cancel_job`` to the paired
-   * receiver behind *pin_sha256*; the receiver maps *job_id*
-   * (the offloader-local id ``submitRemoteBuildJob`` returned)
-   * back to its local ``FirmwareJob`` and dispatches the same
-   * cancel primitive an operator-driven cancel uses.
+   * Routes through ``remote_build/cancel_job``. A *job_id*
+   * matching a local ``FirmwareJob`` (a server-pinned INSTALL
+   * from ``target: UPLOAD``) cancels through the local firmware
+   * primitive — covering the queued, remote-compile, and
+   * local-flash phases — and never touches the wire. Otherwise
+   * the frame goes to the paired receiver behind *pin_sha256*,
+   * which maps *job_id* (the offloader-local id
+   * ``submitRemoteBuildJob`` returned) back to its local
+   * ``FirmwareJob`` and dispatches the same cancel primitive
+   * an operator-driven cancel uses.
    *
    * Fire-and-forget on the wire — the resolved payload's
    * ``sent`` flag reflects whether the cancel frame made it

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -2175,8 +2175,8 @@ export class ESPHomeAPI {
    * - INVALID_ARGS: pin / target / configuration shape
    *   error, or bundle build failed (the receiver's
    *   validator diagnostic is in the message verbatim).
-   * - NOT_FOUND: no pairing for this pin, or the YAML is
-   *   missing from config_dir.
+   * - NOT_FOUND: no pairing for this pin, or (COMPILE only)
+   *   the YAML is missing from config_dir.
    * - PRECONDITION_FAILED: pairing isn't APPROVED, or the
    *   peer-link session isn't currently live (orphaned,
    *   unreachable, mid-reconnect).
@@ -2190,8 +2190,7 @@ export class ESPHomeAPI {
    * The returned job_id is target-dependent: COMPILE gets the
    * offloader-local wire id tracked via
    * ``buildOffloadJobsContext``; UPLOAD gets a local
-   * ``FirmwareJob`` id tracked via ``firmwareJobsContext``,
-   * and the missing-YAML NOT_FOUND above doesn't apply.
+   * ``FirmwareJob`` id tracked via ``firmwareJobsContext``.
    *
    * Phase 5c-3 backend, 5c-4 frontend.
    */

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -501,6 +501,20 @@ export class ESPHomeApp extends LitElement {
     this._guidedTour?.start();
   };
 
+  // "Compile and upload" queued a server-pinned INSTALL FirmwareJob; attach
+  // the firmware-jobs dialog's command dialog so the user watches the whole
+  // lifecycle (remote compile + local flash), with a working Stop.
+  private _onRemoteBuildInstallSubmitted = (e: CustomEvent<{ job_id: string }>) => {
+    const job = this._firmwareJobs.get(e.detail.job_id);
+    if (job === undefined) {
+      // The job_queued push precedes the submit response on the same WS, so
+      // a miss is theoretical; the jobs list is the graceful landing spot.
+      this._firmwareJobsDialog.open();
+      return;
+    }
+    this._firmwareJobsDialog.followJob(job);
+  };
+
   // Kebab "Set up / Change Wi-Fi credentials" — open the manual Wi-Fi dialog.
   private _onOpenOnboarding = () => {
     this._onboardingDialog?.open();
@@ -632,6 +646,7 @@ export class ESPHomeApp extends LitElement {
           )}
         @remote-build-job-dismissed=${(e: CustomEvent<{ job_id: string }>) =>
           onRemoteBuildJobDismissed(this, e)}
+        @remote-build-install-submitted=${this._onRemoteBuildInstallSubmitted}
       ></esphome-settings-dialog>
       <esphome-firmware-jobs-dialog
         @firmware-history-cleared=${() => onFirmwareHistoryCleared(this)}

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -86,6 +86,7 @@ import { createRouter } from "./app-shell/router.js";
 import { dispatchOrStashSerialSetup } from "./app-shell/serial-setup.js";
 import {
   onPairRequestSent,
+  onRemoteBuildInstallSubmitted,
   onRemoteBuildJobDismissed,
   onRemoteBuildJobSubmitted,
   onSetExpertMode,
@@ -247,8 +248,9 @@ export class ESPHomeApp extends LitElement {
   private _router = createRouter(this);
 
   @query("esphome-settings-dialog") private _settingsDialog!: ESPHomeSettingsDialog;
+  // Non-private: settings-actions' onRemoteBuildInstallSubmitted reaches it.
   @query("esphome-firmware-jobs-dialog")
-  private _firmwareJobsDialog!: ESPHomeFirmwareJobsDialog;
+  _firmwareJobsDialog!: ESPHomeFirmwareJobsDialog;
   @query("esphome-feedback-dialog") private _feedbackDialog!: ESPHomeFeedbackDialog;
   @query("esphome-update-all-dialog")
   private _updateAllDialog!: ESPHomeUpdateAllDialog;
@@ -501,20 +503,6 @@ export class ESPHomeApp extends LitElement {
     this._guidedTour?.start();
   };
 
-  // "Compile and upload" queued a server-pinned INSTALL FirmwareJob; attach
-  // the firmware-jobs dialog's command dialog so the user watches the whole
-  // lifecycle (remote compile + local flash), with a working Stop.
-  private _onRemoteBuildInstallSubmitted = (e: CustomEvent<{ job_id: string }>) => {
-    const job = this._firmwareJobs.get(e.detail.job_id);
-    if (job === undefined) {
-      // The job_queued push precedes the submit response on the same WS, so
-      // a miss is theoretical; the jobs list is the graceful landing spot.
-      this._firmwareJobsDialog.open();
-      return;
-    }
-    this._firmwareJobsDialog.followJob(job);
-  };
-
   // Kebab "Set up / Change Wi-Fi credentials" — open the manual Wi-Fi dialog.
   private _onOpenOnboarding = () => {
     this._onboardingDialog?.open();
@@ -646,7 +634,8 @@ export class ESPHomeApp extends LitElement {
           )}
         @remote-build-job-dismissed=${(e: CustomEvent<{ job_id: string }>) =>
           onRemoteBuildJobDismissed(this, e)}
-        @remote-build-install-submitted=${this._onRemoteBuildInstallSubmitted}
+        @remote-build-install-submitted=${(e: CustomEvent<{ job_id: string }>) =>
+          onRemoteBuildInstallSubmitted(this, e)}
       ></esphome-settings-dialog>
       <esphome-firmware-jobs-dialog
         @firmware-history-cleared=${() => onFirmwareHistoryCleared(this)}

--- a/src/components/app-shell/events.ts
+++ b/src/components/app-shell/events.ts
@@ -108,9 +108,8 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
       // remote_jobs: backend snapshot is authoritative for which jobs exist,
       // but merge onto local entries so a reconnect doesn't wipe display fields
       // (configuration / target / receiver_label) that submit_job seeded.
-      // Runs after seedJobs so the local-FirmwareJob filter sees a fresh map
-      // on a cold load: an id that exists locally is a REMOTE-source
-      // FirmwareJob the firmware-job UI owns, not a wire row.
+      // Runs after seedJobs so the local-FirmwareJob filter (see
+      // OFFLOADER_JOB_STATE_CHANGED) sees a fresh map on a cold load.
       if (remote_jobs !== undefined) {
         const seeded = new Map<string, RemoteBuildJobState>();
         for (const entry of remote_jobs) {

--- a/src/components/app-shell/events.ts
+++ b/src/components/app-shell/events.ts
@@ -97,12 +97,24 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
         host._buildOffloadPairings = seededMap(pairings, (p) => p.pin_sha256);
       }
       host._buildOffloadAlerts = seededMap(offloader_alerts, (a) => a.pin_sha256);
+      // Receiver settings scalars: same skip-while-write guard the
+      // loadRemoteBuildSettings refresh uses, so a reconnect snapshot
+      // can't revert an optimistic toggle mid-write.
+      if (remote_build_settings !== undefined && !host._remoteBuildSetInFlight) {
+        host._remoteBuildEnabled = remote_build_settings.enabled;
+        host._remoteBuildCleanupTtl = remote_build_settings.cleanup_ttl_seconds;
+      }
+      if (firmware_jobs !== undefined) seedJobs(host, firmware_jobs);
       // remote_jobs: backend snapshot is authoritative for which jobs exist,
       // but merge onto local entries so a reconnect doesn't wipe display fields
       // (configuration / target / receiver_label) that submit_job seeded.
+      // Runs after seedJobs so the local-FirmwareJob filter sees a fresh map
+      // on a cold load: an id that exists locally is a REMOTE-source
+      // FirmwareJob the firmware-job UI owns, not a wire row.
       if (remote_jobs !== undefined) {
         const seeded = new Map<string, RemoteBuildJobState>();
         for (const entry of remote_jobs) {
+          if (host._firmwareJobs.has(entry.job_id)) continue;
           const existing = host._buildOffloadJobs.get(entry.job_id);
           const base =
             existing ?? stubRemoteBuildJobState(entry.job_id, entry.pin_sha256);
@@ -115,14 +127,6 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
         }
         host._buildOffloadJobs = seeded;
       }
-      // Receiver settings scalars: same skip-while-write guard the
-      // loadRemoteBuildSettings refresh uses, so a reconnect snapshot
-      // can't revert an optimistic toggle mid-write.
-      if (remote_build_settings !== undefined && !host._remoteBuildSetInFlight) {
-        host._remoteBuildEnabled = remote_build_settings.enabled;
-        host._remoteBuildCleanupTtl = remote_build_settings.cleanup_ttl_seconds;
-      }
-      if (firmware_jobs !== undefined) seedJobs(host, firmware_jobs);
       // Skip re-applying offloader settings while a toggle write is in flight,
       // so a reconnect's snapshot can't revert the optimistic value mid-write.
       if (host._offloaderWritesInFlight === 0) {
@@ -420,6 +424,11 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
     }
     case DeviceEventType.OFFLOADER_JOB_STATE_CHANGED: {
       const evt = data as OffloaderJobStateChangedEventData;
+      // A job_id that exists locally is a REMOTE-source FirmwareJob (a
+      // server-pinned install or a pool-routed compile) whose lifecycle the
+      // firmware-job UI owns; a wire row here would be a blank ghost that
+      // flips "completed" while the local half still runs.
+      if (host._firmwareJobs.has(evt.job_id)) break;
       const base =
         host._buildOffloadJobs.get(evt.job_id) ??
         stubRemoteBuildJobState(evt.job_id, evt.pin_sha256);
@@ -432,6 +441,7 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
     }
     case DeviceEventType.OFFLOADER_JOB_OUTPUT: {
       const evt = data as OffloaderJobOutputEventData;
+      if (host._firmwareJobs.has(evt.job_id)) break;
       const base =
         host._buildOffloadJobs.get(evt.job_id) ??
         stubRemoteBuildJobState(evt.job_id, evt.pin_sha256);

--- a/src/components/app-shell/events.ts
+++ b/src/components/app-shell/events.ts
@@ -39,7 +39,7 @@ import {
 import { seededMap } from "../../util/snapshot.js";
 import type { ESPHomeApp } from "../app-shell.js";
 import { applyPreferences } from "./data-load.js";
-import { evictLocallyOwnedRow, seedJobs } from "./jobs.js";
+import { seedJobs } from "./jobs.js";
 
 // Merge a partial diff into the matching offloader pairing row keyed by pin_sha256.
 // _buildOffloadPairings === null = snapshot not seeded; missing row = event raced
@@ -423,16 +423,10 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
     }
     case DeviceEventType.OFFLOADER_JOB_STATE_CHANGED: {
       const evt = data as OffloaderJobStateChangedEventData;
-      // A job_id that exists locally is a REMOTE-source FirmwareJob (a
-      // server-pinned install or a pool-routed compile) whose lifecycle the
-      // firmware-job UI owns; a wire row here would be a blank ghost that
-      // flips "completed" while the local half still runs. Evict any row a
-      // pre-ownership event stubbed — later events are filtered too, so it
-      // would otherwise linger forever.
-      if (host._firmwareJobs.has(evt.job_id)) {
-        evictLocallyOwnedRow(host, evt.job_id);
-        break;
-      }
+      // A job_id that exists locally is a REMOTE-source FirmwareJob whose
+      // lifecycle the firmware-job UI owns; pre-ownership rows are evicted
+      // at ownership establishment (jobs.ts's evictLocallyOwnedRow).
+      if (host._firmwareJobs.has(evt.job_id)) break;
       const base =
         host._buildOffloadJobs.get(evt.job_id) ??
         stubRemoteBuildJobState(evt.job_id, evt.pin_sha256);
@@ -445,10 +439,7 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
     }
     case DeviceEventType.OFFLOADER_JOB_OUTPUT: {
       const evt = data as OffloaderJobOutputEventData;
-      if (host._firmwareJobs.has(evt.job_id)) {
-        evictLocallyOwnedRow(host, evt.job_id);
-        break;
-      }
+      if (host._firmwareJobs.has(evt.job_id)) break;
       const base =
         host._buildOffloadJobs.get(evt.job_id) ??
         stubRemoteBuildJobState(evt.job_id, evt.pin_sha256);

--- a/src/components/app-shell/events.ts
+++ b/src/components/app-shell/events.ts
@@ -57,6 +57,16 @@ export function patchOffloadPairing(
   host._buildOffloadPairings = next;
 }
 
+// Drop a wire row for a job the firmware-job UI owns. A row can predate
+// ownership (an event raced the firmware job's seeding); the ownership
+// filter would otherwise strand it forever.
+function evictLocallyOwnedRow(host: ESPHomeApp, job_id: string): void {
+  if (!host._buildOffloadJobs.has(job_id)) return;
+  const next = new Map(host._buildOffloadJobs);
+  next.delete(job_id);
+  host._buildOffloadJobs = next;
+}
+
 export function handleEvent(host: ESPHomeApp, event: string, data: unknown): void {
   switch (event) {
     case DeviceEventType.INITIAL_STATE: {
@@ -426,8 +436,13 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
       // A job_id that exists locally is a REMOTE-source FirmwareJob (a
       // server-pinned install or a pool-routed compile) whose lifecycle the
       // firmware-job UI owns; a wire row here would be a blank ghost that
-      // flips "completed" while the local half still runs.
-      if (host._firmwareJobs.has(evt.job_id)) break;
+      // flips "completed" while the local half still runs. Evict any row a
+      // pre-ownership event stubbed — later events are filtered too, so it
+      // would otherwise linger forever.
+      if (host._firmwareJobs.has(evt.job_id)) {
+        evictLocallyOwnedRow(host, evt.job_id);
+        break;
+      }
       const base =
         host._buildOffloadJobs.get(evt.job_id) ??
         stubRemoteBuildJobState(evt.job_id, evt.pin_sha256);
@@ -440,7 +455,10 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
     }
     case DeviceEventType.OFFLOADER_JOB_OUTPUT: {
       const evt = data as OffloaderJobOutputEventData;
-      if (host._firmwareJobs.has(evt.job_id)) break;
+      if (host._firmwareJobs.has(evt.job_id)) {
+        evictLocallyOwnedRow(host, evt.job_id);
+        break;
+      }
       const base =
         host._buildOffloadJobs.get(evt.job_id) ??
         stubRemoteBuildJobState(evt.job_id, evt.pin_sha256);

--- a/src/components/app-shell/events.ts
+++ b/src/components/app-shell/events.ts
@@ -39,7 +39,7 @@ import {
 import { seededMap } from "../../util/snapshot.js";
 import type { ESPHomeApp } from "../app-shell.js";
 import { applyPreferences } from "./data-load.js";
-import { seedJobs } from "./jobs.js";
+import { evictLocallyOwnedRow, seedJobs } from "./jobs.js";
 
 // Merge a partial diff into the matching offloader pairing row keyed by pin_sha256.
 // _buildOffloadPairings === null = snapshot not seeded; missing row = event raced
@@ -55,16 +55,6 @@ export function patchOffloadPairing(
   const next = new Map(host._buildOffloadPairings);
   next.set(pin, { ...existing, ...diff });
   host._buildOffloadPairings = next;
-}
-
-// Drop a wire row for a job the firmware-job UI owns. A row can predate
-// ownership (an event raced the firmware job's seeding); the ownership
-// filter would otherwise strand it forever.
-function evictLocallyOwnedRow(host: ESPHomeApp, job_id: string): void {
-  if (!host._buildOffloadJobs.has(job_id)) return;
-  const next = new Map(host._buildOffloadJobs);
-  next.delete(job_id);
-  host._buildOffloadJobs = next;
 }
 
 export function handleEvent(host: ESPHomeApp, event: string, data: unknown): void {

--- a/src/components/app-shell/jobs.ts
+++ b/src/components/app-shell/jobs.ts
@@ -66,6 +66,18 @@ export function seedJobs(host: ESPHomeApp, jobs: FirmwareJob[]): void {
   }
   host._firmwareJobs = all;
   host._activeJobs = active;
+  for (const id of all.keys()) evictLocallyOwnedRow(host, id);
+}
+
+// Drop a wire row for a job the firmware-job UI owns (a server-pinned install
+// or pool-routed compile echoes wire events under its FirmwareJob id). Called
+// wherever ownership is established so a row stubbed by a pre-ownership wire
+// event can't linger waiting for a follow-up event that may never arrive.
+export function evictLocallyOwnedRow(host: ESPHomeApp, job_id: string): void {
+  if (!host._buildOffloadJobs?.has(job_id)) return;
+  const next = new Map(host._buildOffloadJobs);
+  next.delete(job_id);
+  host._buildOffloadJobs = next;
 }
 
 export function handleJobEvent(host: ESPHomeApp, event: string, data: unknown): void {
@@ -103,6 +115,7 @@ function upsertJob(host: ESPHomeApp, job: FirmwareJob): void {
   const next = new Map(host._firmwareJobs);
   next.set(job.job_id, job);
   host._firmwareJobs = next;
+  evictLocallyOwnedRow(host, job.job_id);
   // Snapshots replay terminal jobs too — those belong only in history.
   if (isTerminalJobStatus(job.status)) return;
   const active = new Map(host._activeJobs);
@@ -116,6 +129,7 @@ function upsertJob(host: ESPHomeApp, job: FirmwareJob): void {
 // this device (a re-compile replaces the prior compile, not its upload); clear
 // the active slot. A cancellation with a live successor is a supersede — drop it.
 function terminateJob(host: ESPHomeApp, job: FirmwareJob): void {
+  evictLocallyOwnedRow(host, job.job_id);
   // Release the active slot whenever it points at *this* job, before the
   // supersede branch can return early. Stopping an install's compile cascades
   // a cancel onto its still-queued dependent upload; that non-terminal upload

--- a/src/components/app-shell/jobs.ts
+++ b/src/components/app-shell/jobs.ts
@@ -66,18 +66,16 @@ export function seedJobs(host: ESPHomeApp, jobs: FirmwareJob[]): void {
   }
   host._firmwareJobs = all;
   host._activeJobs = active;
-  for (const id of all.keys()) evictLocallyOwnedRow(host, id);
+  // Cold-load eviction of locally-owned wire rows happens in the
+  // initial_state handler's remote_jobs merge, which runs after this.
 }
 
 // Drop a wire row for a job the firmware-job UI owns (a server-pinned install
 // or pool-routed compile echoes wire events under its FirmwareJob id). Called
-// wherever ownership is established so a row stubbed by a pre-ownership wire
+// where ownership is established so a row stubbed by a pre-ownership wire
 // event can't linger waiting for a follow-up event that may never arrive.
-export function evictLocallyOwnedRow(host: ESPHomeApp, job_id: string): void {
-  if (!host._buildOffloadJobs?.has(job_id)) return;
-  const next = new Map(host._buildOffloadJobs);
-  next.delete(job_id);
-  host._buildOffloadJobs = next;
+function evictLocallyOwnedRow(host: ESPHomeApp, job_id: string): void {
+  host.dismissRemoteBuildJob(job_id);
 }
 
 export function handleJobEvent(host: ESPHomeApp, event: string, data: unknown): void {

--- a/src/components/app-shell/settings-actions.ts
+++ b/src/components/app-shell/settings-actions.ts
@@ -323,6 +323,23 @@ export function onRemoteBuildJobDismissed(
   host.dismissRemoteBuildJob(e.detail.job_id);
 }
 
+// "Compile and upload" queued a server-pinned INSTALL FirmwareJob; attach
+// the firmware-jobs dialog's command dialog so the user watches the whole
+// lifecycle (remote compile + local flash), with a working Stop.
+export function onRemoteBuildInstallSubmitted(
+  host: ESPHomeApp,
+  e: CustomEvent<{ job_id: string }>
+): void {
+  const job = host._firmwareJobs.get(e.detail.job_id);
+  if (job === undefined) {
+    // The job_queued push precedes the submit response on the same WS, so
+    // a miss is theoretical; the jobs list is the graceful landing spot.
+    host._firmwareJobsDialog?.open();
+    return;
+  }
+  host._firmwareJobsDialog?.followJob(job);
+}
+
 export async function onSetLanguage(
   host: ESPHomeApp,
   e: CustomEvent<SupportedLocale | "system">

--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -253,7 +253,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
   }
 
   _openJob(job: FirmwareJob) {
-    this._commandDialog.followJob(job, this._jobDisplayName(job));
+    this.followJob(job);
   }
 
   _onCancelClick(e: Event, job: FirmwareJob) {

--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -123,6 +123,13 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
     this._ticker.stop();
   }
 
+  // Attach the embedded command dialog to *job* without opening the list.
+  // Same sibling-in-shadow-DOM shape as the reset entry points below —
+  // surfaces like the Send-builds dialog can hand a job off directly.
+  followJob(job: FirmwareJob) {
+    this._commandDialog.followJob(job, this._jobDisplayName(job));
+  }
+
   // Open the Reset Build Environment confirm flow without needing this
   // dialog open. The confirm + command dialogs are siblings of the jobs
   // dialog in this host's shadow DOM, so they work even when it's closed

--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -278,7 +278,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
       return;
     }
     // Drop the user into the log viewer so they can watch the wipe.
-    this._commandDialog.followJob(job, this._jobDisplayName(job));
+    this.followJob(job);
   };
 
   private _onResetPeerConfirmed = async () => {
@@ -303,7 +303,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
     // Same landing as the local reset: watch the server-side wipe live.
     // A busy refusal surfaces in this job's stream (the mirror fails
     // with a retry-when-idle message), not as a command error.
-    this._commandDialog.followJob(job, this._jobDisplayName(job));
+    this.followJob(job);
   };
 
   private _onClearHistory = async () => {

--- a/src/components/remote-build-job-dialog.ts
+++ b/src/components/remote-build-job-dialog.ts
@@ -82,6 +82,13 @@ const FRESH_ROW_STATE: JobRowUIState = {
  * display fields. Wire frames don't carry those fields;
  * without the dispatch the list view would fall back to empty
  * placeholders.
+ *
+ * "Compile and upload" is the exception: the backend queues a
+ * server-pinned INSTALL FirmwareJob (remote compile, local OTA
+ * flash), so the dialog dispatches remote-build-install-submitted
+ * and closes — app-shell attaches the firmware-job command dialog,
+ * which tracks the whole lifecycle where this list would stop at
+ * the receiver's compile.
  */
 @customElement("esphome-remote-build-job-dialog")
 export class ESPHomeRemoteBuildJobDialog extends LitElement {
@@ -223,6 +230,22 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
           { reason: result.reason ?? "" }
         );
         this._step = "input";
+        return;
+      }
+      if (this._target === JobType.UPLOAD) {
+        // "Compile and upload" queues a server-pinned INSTALL
+        // FirmwareJob (remote compile, then a local OTA flash).
+        // Hand tracking to the firmware-job UI — this dialog's
+        // wire-event list ends at the receiver's compile, so it
+        // would show "completed" while the flash still runs.
+        this.dispatchEvent(
+          new CustomEvent("remote-build-install-submitted", {
+            bubbles: true,
+            composed: true,
+            detail: { job_id: result.job_id },
+          })
+        );
+        this._close();
         return;
       }
       // Bubble the seed up so app-shell stamps the in-flight

--- a/src/components/remote-build-job-dialog.ts
+++ b/src/components/remote-build-job-dialog.ts
@@ -83,12 +83,9 @@ const FRESH_ROW_STATE: JobRowUIState = {
  * without the dispatch the list view would fall back to empty
  * placeholders.
  *
- * "Compile and upload" is the exception: the backend queues a
- * server-pinned INSTALL FirmwareJob (remote compile, local OTA
- * flash), so the dialog dispatches remote-build-install-submitted
- * and closes — app-shell attaches the firmware-job command dialog,
- * which tracks the whole lifecycle where this list would stop at
- * the receiver's compile.
+ * "Compile and upload" is the exception: it dispatches
+ * remote-build-install-submitted and closes — the firmware-job
+ * UI owns that lifecycle.
  */
 @customElement("esphome-remote-build-job-dialog")
 export class ESPHomeRemoteBuildJobDialog extends LitElement {

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -442,7 +442,11 @@ export const buildOffloadAlertsContext = createContext<Map<
  * The receiver runs the build; the offloader doesn't own a
  * FirmwareJob row for these. App-shell maintains a Map keyed
  * on job_id, upserting on OFFLOADER_JOB_STATE_CHANGED and
- * appending output on OFFLOADER_JOB_OUTPUT.
+ * appending output on OFFLOADER_JOB_OUTPUT. Compile-only
+ * dispatches land here; "Compile and upload" queues a local
+ * server-pinned INSTALL FirmwareJob instead, so events whose
+ * job_id exists in firmwareJobsContext are filtered out —
+ * that job's owner is the firmware-job UI.
  *
  * Display fields (configuration, target, receiver_label) come
  * from the submit_job call site rather than the wire frame

--- a/test/components/app-shell-jobs-dedup.test.ts
+++ b/test/components/app-shell-jobs-dedup.test.ts
@@ -12,6 +12,7 @@ function makeHost(): ESPHomeApp {
     _activeJobs: new Map(),
     _recentJobs: new Map(),
     _recentJobTimers: new Map(),
+    dismissRemoteBuildJob: () => {},
   } as unknown as ESPHomeApp;
 }
 

--- a/test/components/app-shell/events-offloader-job-filter.test.ts
+++ b/test/components/app-shell/events-offloader-job-filter.test.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../../src/api/types/remote-build-events.js";
 import type { ESPHomeApp } from "../../../src/components/app-shell.js";
 import { handleEvent } from "../../../src/components/app-shell/events.js";
+import { handleJobEvent } from "../../../src/components/app-shell/jobs.js";
 
 const PIN = "a".repeat(64);
 
@@ -63,7 +64,7 @@ describe("offloader job events skip locally-owned FirmwareJobs", () => {
     expect(row?.output).toEqual(["compiling...\n"]);
   });
 
-  it("evicts a row stubbed before the firmware job was seeded", () => {
+  it("establishing ownership evicts a stubbed row without another wire event", () => {
     const host = makeHost();
     handleEvent(
       host as unknown as ESPHomeApp,
@@ -72,12 +73,11 @@ describe("offloader job events skip locally-owned FirmwareJobs", () => {
     );
     expect(host._buildOffloadJobs.size).toBe(1);
 
-    host._firmwareJobs.set("fw-1", { job_id: "fw-1" });
-    handleEvent(
-      host as unknown as ESPHomeApp,
-      DeviceEventType.OFFLOADER_JOB_OUTPUT,
-      output("fw-1")
-    );
+    handleJobEvent(host as unknown as ESPHomeApp, "job_queued", {
+      job_id: "fw-1",
+      configuration: "kitchen.yaml",
+      status: JobStatus.QUEUED,
+    });
 
     expect(host._buildOffloadJobs.size).toBe(0);
   });

--- a/test/components/app-shell/events-offloader-job-filter.test.ts
+++ b/test/components/app-shell/events-offloader-job-filter.test.ts
@@ -32,12 +32,16 @@ function output(job_id: string): OffloaderJobOutputEventData {
   };
 }
 
-type Host = Pick<ESPHomeApp, "_buildOffloadJobs" | "_firmwareJobs">;
+// The filter only reads _firmwareJobs keys, so the host models entries as
+// bare { job_id } stubs instead of full FirmwareJob rows.
+type Host = Pick<ESPHomeApp, "_buildOffloadJobs"> & {
+  _firmwareJobs: Map<string, { job_id: string }>;
+};
 
 function makeHost(firmwareJobIds: string[] = []): Host {
   return {
     _buildOffloadJobs: new Map(),
-    _firmwareJobs: new Map(firmwareJobIds.map((id) => [id, { job_id: id } as never])),
+    _firmwareJobs: new Map(firmwareJobIds.map((id) => [id, { job_id: id }])),
   };
 }
 
@@ -45,12 +49,12 @@ describe("offloader job events skip locally-owned FirmwareJobs", () => {
   it("a wire-only job id still stubs a row", () => {
     const host = makeHost();
     handleEvent(
-      host as ESPHomeApp,
+      host as unknown as ESPHomeApp,
       DeviceEventType.OFFLOADER_JOB_STATE_CHANGED,
       stateChanged("wire-1")
     );
     handleEvent(
-      host as ESPHomeApp,
+      host as unknown as ESPHomeApp,
       DeviceEventType.OFFLOADER_JOB_OUTPUT,
       output("wire-1")
     );
@@ -62,14 +66,18 @@ describe("offloader job events skip locally-owned FirmwareJobs", () => {
   it("evicts a row stubbed before the firmware job was seeded", () => {
     const host = makeHost();
     handleEvent(
-      host as ESPHomeApp,
+      host as unknown as ESPHomeApp,
       DeviceEventType.OFFLOADER_JOB_STATE_CHANGED,
       stateChanged("fw-1")
     );
     expect(host._buildOffloadJobs.size).toBe(1);
 
-    host._firmwareJobs.set("fw-1", { job_id: "fw-1" } as never);
-    handleEvent(host as ESPHomeApp, DeviceEventType.OFFLOADER_JOB_OUTPUT, output("fw-1"));
+    host._firmwareJobs.set("fw-1", { job_id: "fw-1" });
+    handleEvent(
+      host as unknown as ESPHomeApp,
+      DeviceEventType.OFFLOADER_JOB_OUTPUT,
+      output("fw-1")
+    );
 
     expect(host._buildOffloadJobs.size).toBe(0);
   });
@@ -80,11 +88,15 @@ describe("offloader job events skip locally-owned FirmwareJobs", () => {
     // firmware-job UI owns that lifecycle, so the offload list stays clear.
     const host = makeHost(["fw-1"]);
     handleEvent(
-      host as ESPHomeApp,
+      host as unknown as ESPHomeApp,
       DeviceEventType.OFFLOADER_JOB_STATE_CHANGED,
       stateChanged("fw-1")
     );
-    handleEvent(host as ESPHomeApp, DeviceEventType.OFFLOADER_JOB_OUTPUT, output("fw-1"));
+    handleEvent(
+      host as unknown as ESPHomeApp,
+      DeviceEventType.OFFLOADER_JOB_OUTPUT,
+      output("fw-1")
+    );
     expect(host._buildOffloadJobs.size).toBe(0);
   });
 });

--- a/test/components/app-shell/events-offloader-job-filter.test.ts
+++ b/test/components/app-shell/events-offloader-job-filter.test.ts
@@ -59,6 +59,21 @@ describe("offloader job events skip locally-owned FirmwareJobs", () => {
     expect(row?.output).toEqual(["compiling...\n"]);
   });
 
+  it("evicts a row stubbed before the firmware job was seeded", () => {
+    const host = makeHost();
+    handleEvent(
+      host as ESPHomeApp,
+      DeviceEventType.OFFLOADER_JOB_STATE_CHANGED,
+      stateChanged("fw-1")
+    );
+    expect(host._buildOffloadJobs.size).toBe(1);
+
+    host._firmwareJobs.set("fw-1", { job_id: "fw-1" } as never);
+    handleEvent(host as ESPHomeApp, DeviceEventType.OFFLOADER_JOB_OUTPUT, output("fw-1"));
+
+    expect(host._buildOffloadJobs.size).toBe(0);
+  });
+
   it("a server-pinned install's wire echo never lands a ghost row", () => {
     // The remote-compile phase of a REMOTE-source FirmwareJob (pool-routed
     // or server-pinned) echoes wire events under the firmware job's id; the

--- a/test/components/app-shell/events-offloader-job-filter.test.ts
+++ b/test/components/app-shell/events-offloader-job-filter.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { DeviceEventType } from "../../../src/api/types/event-subscription.js";
+import { JobStatus, JobStream } from "../../../src/api/types/firmware-jobs.js";
+import type {
+  OffloaderJobOutputEventData,
+  OffloaderJobStateChangedEventData,
+} from "../../../src/api/types/remote-build-events.js";
+import type { ESPHomeApp } from "../../../src/components/app-shell.js";
+import { handleEvent } from "../../../src/components/app-shell/events.js";
+
+const PIN = "a".repeat(64);
+
+function stateChanged(job_id: string): OffloaderJobStateChangedEventData {
+  return {
+    receiver_hostname: "192.168.1.50",
+    receiver_port: 6052,
+    pin_sha256: PIN,
+    job_id,
+    status: JobStatus.RUNNING,
+    error_message: "",
+  };
+}
+
+function output(job_id: string): OffloaderJobOutputEventData {
+  return {
+    receiver_hostname: "192.168.1.50",
+    receiver_port: 6052,
+    pin_sha256: PIN,
+    job_id,
+    stream: JobStream.STDOUT,
+    line: "compiling...\n",
+  };
+}
+
+type Host = Pick<ESPHomeApp, "_buildOffloadJobs" | "_firmwareJobs">;
+
+function makeHost(firmwareJobIds: string[] = []): Host {
+  return {
+    _buildOffloadJobs: new Map(),
+    _firmwareJobs: new Map(firmwareJobIds.map((id) => [id, { job_id: id } as never])),
+  };
+}
+
+describe("offloader job events skip locally-owned FirmwareJobs", () => {
+  it("a wire-only job id still stubs a row", () => {
+    const host = makeHost();
+    handleEvent(
+      host as ESPHomeApp,
+      DeviceEventType.OFFLOADER_JOB_STATE_CHANGED,
+      stateChanged("wire-1")
+    );
+    handleEvent(
+      host as ESPHomeApp,
+      DeviceEventType.OFFLOADER_JOB_OUTPUT,
+      output("wire-1")
+    );
+    const row = host._buildOffloadJobs.get("wire-1");
+    expect(row?.status).toBe(JobStatus.RUNNING);
+    expect(row?.output).toEqual(["compiling...\n"]);
+  });
+
+  it("a server-pinned install's wire echo never lands a ghost row", () => {
+    // The remote-compile phase of a REMOTE-source FirmwareJob (pool-routed
+    // or server-pinned) echoes wire events under the firmware job's id; the
+    // firmware-job UI owns that lifecycle, so the offload list stays clear.
+    const host = makeHost(["fw-1"]);
+    handleEvent(
+      host as ESPHomeApp,
+      DeviceEventType.OFFLOADER_JOB_STATE_CHANGED,
+      stateChanged("fw-1")
+    );
+    handleEvent(host as ESPHomeApp, DeviceEventType.OFFLOADER_JOB_OUTPUT, output("fw-1"));
+    expect(host._buildOffloadJobs.size).toBe(0);
+  });
+});

--- a/test/components/app-shell/events-offloader-job-filter.test.ts
+++ b/test/components/app-shell/events-offloader-job-filter.test.ts
@@ -35,15 +35,27 @@ function output(job_id: string): OffloaderJobOutputEventData {
 
 // The filter only reads _firmwareJobs keys, so the host models entries as
 // bare { job_id } stubs instead of full FirmwareJob rows.
-type Host = Pick<ESPHomeApp, "_buildOffloadJobs"> & {
+type Host = Pick<
+  ESPHomeApp,
+  "_buildOffloadJobs" | "_activeJobs" | "dismissRemoteBuildJob"
+> & {
   _firmwareJobs: Map<string, { job_id: string }>;
 };
 
 function makeHost(firmwareJobIds: string[] = []): Host {
-  return {
+  const host: Host = {
     _buildOffloadJobs: new Map(),
+    _activeJobs: new Map(),
     _firmwareJobs: new Map(firmwareJobIds.map((id) => [id, { job_id: id }])),
+    // Eviction at ownership establishment routes through this host seam;
+    // mirror the real method's row removal.
+    dismissRemoteBuildJob: (job_id: string) => {
+      const next = new Map(host._buildOffloadJobs);
+      next.delete(job_id);
+      host._buildOffloadJobs = next;
+    },
   };
+  return host;
 }
 
 describe("offloader job events skip locally-owned FirmwareJobs", () => {

--- a/test/components/app-shell/events-offloader-job-filter.test.ts
+++ b/test/components/app-shell/events-offloader-job-filter.test.ts
@@ -6,8 +6,10 @@ import type {
   OffloaderJobStateChangedEventData,
 } from "../../../src/api/types/remote-build-events.js";
 import type { ESPHomeApp } from "../../../src/components/app-shell.js";
+import { type InitialStateEventData } from "../../../src/api/types/event-subscription.js";
 import { handleEvent } from "../../../src/components/app-shell/events.js";
 import { handleJobEvent } from "../../../src/components/app-shell/jobs.js";
+import { makeFirmwareJob } from "../../_make-firmware-job.js";
 
 const PIN = "a".repeat(64);
 
@@ -110,5 +112,62 @@ describe("offloader job events skip locally-owned FirmwareJobs", () => {
       output("fw-1")
     );
     expect(host._buildOffloadJobs.size).toBe(0);
+  });
+});
+
+// The cold-load eviction path: the initial_state remote_jobs merge runs
+// after seedJobs and filters locally-owned ids. One assertion pins both
+// the filter and the block ordering it depends on.
+describe("initial_state remote_jobs merge skips locally-owned FirmwareJobs", () => {
+  it("drops a snapshot row whose id the firmware snapshot owns", () => {
+    const host = {
+      _buildOffloadJobs: new Map(),
+      _firmwareJobs: new Map(),
+      _activeJobs: new Map(),
+      // Fields the INITIAL_STATE handler writes unconditionally.
+      _remoteBuildEnabled: false,
+      _remoteBuildCleanupTtl: 0,
+      _remoteBuildSetInFlight: false,
+      _prefsLoaded: false,
+      _prefsWritesInFlight: 0,
+      _devices: [],
+      _importableDevices: [],
+      _devicesLoaded: false,
+      _buildServerPeers: null,
+      _buildOffloadDiscoveredHosts: null,
+      _buildOffloadPairings: null,
+      _offloaderWritesInFlight: 0,
+      _buildOffloadAlerts: null,
+      _offloaderRemoteBuildsEnabled: null,
+      _offloaderVersionMatchPolicy: null,
+      _offloaderIncludeLocalInPool: null,
+    };
+
+    handleEvent(host as unknown as ESPHomeApp, DeviceEventType.INITIAL_STATE, {
+      devices: [],
+      importable: [],
+      firmware_jobs: [makeFirmwareJob({ job_id: "fw-1" })],
+      remote_jobs: [
+        {
+          receiver_hostname: "192.168.1.50",
+          receiver_port: 6052,
+          pin_sha256: PIN,
+          job_id: "fw-1",
+          status: JobStatus.RUNNING,
+          error_message: "",
+        },
+        {
+          receiver_hostname: "192.168.1.50",
+          receiver_port: 6052,
+          pin_sha256: PIN,
+          job_id: "wire-1",
+          status: JobStatus.RUNNING,
+          error_message: "",
+        },
+      ],
+    } as unknown as InitialStateEventData);
+
+    expect(host._buildOffloadJobs.has("fw-1")).toBe(false);
+    expect(host._buildOffloadJobs.has("wire-1")).toBe(true);
   });
 });

--- a/test/components/app-shell/settings-actions.test.ts
+++ b/test/components/app-shell/settings-actions.test.ts
@@ -4,6 +4,7 @@ import type { PairingSummary } from "../../../src/api/types/remote-build.js";
 import { ExperienceLevel } from "../../../src/api/types/system.js";
 import type { ESPHomeApp } from "../../../src/components/app-shell.js";
 import {
+  onRemoteBuildInstallSubmitted,
   onSetExpertMode,
   onSetOffloaderIncludeLocal,
   onSetOffloaderPairingEnabled,
@@ -578,5 +579,47 @@ describe("prefs-write in-flight counter", () => {
     resolvers[1]();
     await flush();
     expect(host._prefsWritesInFlight).toBe(0);
+  });
+});
+
+describe("onRemoteBuildInstallSubmitted", () => {
+  type InstallHost = {
+    _firmwareJobs: Map<string, unknown>;
+    _firmwareJobsDialog: {
+      open: ReturnType<typeof vi.fn>;
+      followJob: ReturnType<typeof vi.fn>;
+    };
+  };
+
+  function makeInstallHost(jobs: Map<string, unknown>): InstallHost {
+    return {
+      _firmwareJobs: jobs,
+      _firmwareJobsDialog: { open: vi.fn(), followJob: vi.fn() },
+    };
+  }
+
+  it("attaches the command dialog to the submitted firmware job", () => {
+    const job = { job_id: "job-1" };
+    const host = makeInstallHost(new Map([["job-1", job]]));
+
+    onRemoteBuildInstallSubmitted(
+      host as unknown as ESPHomeApp,
+      new CustomEvent("remote-build-install-submitted", { detail: { job_id: "job-1" } })
+    );
+
+    expect(host._firmwareJobsDialog.followJob).toHaveBeenCalledWith(job);
+    expect(host._firmwareJobsDialog.open).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the jobs list when the id is not in the map", () => {
+    const host = makeInstallHost(new Map());
+
+    onRemoteBuildInstallSubmitted(
+      host as unknown as ESPHomeApp,
+      new CustomEvent("remote-build-install-submitted", { detail: { job_id: "job-1" } })
+    );
+
+    expect(host._firmwareJobsDialog.open).toHaveBeenCalled();
+    expect(host._firmwareJobsDialog.followJob).not.toHaveBeenCalled();
   });
 });

--- a/test/components/remote-build-job-dialog-submit.test.ts
+++ b/test/components/remote-build-job-dialog-submit.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
-import { describe, expect, test, vi } from "vitest";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 // happy-dom can't host webawesome's form-associated internals; the submit
 // flow's events and step transitions are what's under test.
@@ -12,7 +13,6 @@ import { JobType } from "../../src/api/types/firmware-jobs.js";
 import { ESPHomeRemoteBuildJobDialog } from "../../src/components/remote-build-job-dialog.js";
 import { identityLocalize } from "../_dom.js";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 async function mountForSubmit(target: JobType.COMPILE | JobType.UPLOAD) {
   const el = new ESPHomeRemoteBuildJobDialog();
   (el as any)._localize = identityLocalize;
@@ -29,14 +29,25 @@ async function mountForSubmit(target: JobType.COMPILE | JobType.UPLOAD) {
   await el.updateComplete;
   return el;
 }
-/* eslint-enable @typescript-eslint/no-explicit-any */
+
+// The global DOM cleanup only clears body children, so listeners detach via
+// this per-test abort instead of leaking across files in the same worker.
+let listenerScope = new AbortController();
+afterEach(() => {
+  listenerScope.abort();
+  listenerScope = new AbortController();
+});
 
 function captureEvents(names: string[]): Map<string, CustomEvent[]> {
   const seen = new Map<string, CustomEvent[]>(names.map((n) => [n, []]));
   for (const name of names) {
-    document.body.addEventListener(name, (e) => {
-      seen.get(name)!.push(e as CustomEvent);
-    });
+    document.body.addEventListener(
+      name,
+      (e) => {
+        seen.get(name)!.push(e as CustomEvent);
+      },
+      { signal: listenerScope.signal }
+    );
   }
   return seen;
 }
@@ -78,7 +89,6 @@ describe("remote-build-job-dialog submit routing", () => {
 
   test("a rejected upload ack stays on the input step", async () => {
     const el = await mountForSubmit(JobType.UPLOAD);
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     (el as any)._api.submitRemoteBuildJob = vi.fn().mockResolvedValue({
       job_id: "job-1",
       accepted: false,
@@ -86,13 +96,10 @@ describe("remote-build-job-dialog submit routing", () => {
     });
     const seen = captureEvents(["remote-build-install-submitted"]);
 
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     await (el as any)._onSubmit();
 
     expect(seen.get("remote-build-install-submitted")).toHaveLength(0);
-    /* eslint-disable @typescript-eslint/no-explicit-any */
     expect((el as any)._step).toBe("input");
     expect((el as any)._submitErrorMessage).not.toBe("");
-    /* eslint-enable @typescript-eslint/no-explicit-any */
   });
 });

--- a/test/components/remote-build-job-dialog-submit.test.ts
+++ b/test/components/remote-build-job-dialog-submit.test.ts
@@ -76,7 +76,7 @@ describe("remote-build-job-dialog submit routing", () => {
     expect((el as any)._open).toBe(false);
   });
 
-  test("a rejected ack stays on the input step for either target", async () => {
+  test("a rejected upload ack stays on the input step", async () => {
     const el = await mountForSubmit(JobType.UPLOAD);
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     (el as any)._api.submitRemoteBuildJob = vi.fn().mockResolvedValue({

--- a/test/components/remote-build-job-dialog-submit.test.ts
+++ b/test/components/remote-build-job-dialog-submit.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+import { describe, expect, test, vi } from "vitest";
+
+// happy-dom can't host webawesome's form-associated internals; the submit
+// flow's events and step transitions are what's under test.
+vi.mock("@home-assistant/webawesome/dist/components/button/button.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+
+import { JobType } from "../../src/api/types/firmware-jobs.js";
+import { ESPHomeRemoteBuildJobDialog } from "../../src/components/remote-build-job-dialog.js";
+import { identityLocalize } from "../_dom.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+async function mountForSubmit(target: JobType.COMPILE | JobType.UPLOAD) {
+  const el = new ESPHomeRemoteBuildJobDialog();
+  (el as any)._localize = identityLocalize;
+  (el as any)._open = true;
+  (el as any)._step = "input";
+  (el as any)._pinSha256 = "ab".repeat(32);
+  (el as any)._devices = [{ configuration: "kitchen.yaml", name: "Kitchen" }];
+  (el as any)._configuration = "kitchen.yaml";
+  (el as any)._target = target;
+  (el as any)._api = {
+    submitRemoteBuildJob: vi.fn().mockResolvedValue({ job_id: "job-1", accepted: true }),
+  };
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+function captureEvents(names: string[]): Map<string, CustomEvent[]> {
+  const seen = new Map<string, CustomEvent[]>(names.map((n) => [n, []]));
+  for (const name of names) {
+    document.body.addEventListener(name, (e) => {
+      seen.get(name)!.push(e as CustomEvent);
+    });
+  }
+  return seen;
+}
+
+describe("remote-build-job-dialog submit routing", () => {
+  test("Compile only seeds the wire-job list and stays open on the list step", async () => {
+    const el = await mountForSubmit(JobType.COMPILE);
+    const seen = captureEvents([
+      "remote-build-job-submitted",
+      "remote-build-install-submitted",
+    ]);
+
+    await (el as any)._onSubmit();
+
+    expect(seen.get("remote-build-job-submitted")).toHaveLength(1);
+    expect(seen.get("remote-build-install-submitted")).toHaveLength(0);
+    expect((el as any)._step).toBe("list");
+    expect((el as any)._open).toBe(true);
+    expect((el as any)._expandedJobId).toBe("job-1");
+  });
+
+  test("Compile and upload hands the firmware job off and closes", async () => {
+    const el = await mountForSubmit(JobType.UPLOAD);
+    const seen = captureEvents([
+      "remote-build-job-submitted",
+      "remote-build-install-submitted",
+    ]);
+
+    await (el as any)._onSubmit();
+
+    const handoff = seen.get("remote-build-install-submitted")!;
+    expect(handoff).toHaveLength(1);
+    expect(handoff[0].detail).toEqual({ job_id: "job-1" });
+    // No wire-list seed and no list step: the job is a FirmwareJob now,
+    // tracked by the command dialog app-shell attaches on the hand-off.
+    expect(seen.get("remote-build-job-submitted")).toHaveLength(0);
+    expect((el as any)._open).toBe(false);
+  });
+
+  test("a rejected ack stays on the input step for either target", async () => {
+    const el = await mountForSubmit(JobType.UPLOAD);
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    (el as any)._api.submitRemoteBuildJob = vi.fn().mockResolvedValue({
+      job_id: "job-1",
+      accepted: false,
+      reason: "upload_unsupported",
+    });
+    const seen = captureEvents(["remote-build-install-submitted"]);
+
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    await (el as any)._onSubmit();
+
+    expect(seen.get("remote-build-install-submitted")).toHaveLength(0);
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    expect((el as any)._step).toBe("input");
+    expect((el as any)._submitErrorMessage).not.toBe("");
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#2119, which turns the Send-builds dialog's "Compile and upload" into a server-pinned INSTALL `FirmwareJob`: the receiver compiles, this dashboard flashes locally. The dialog's wire-event list only carries the receiver side, so it would show the job completed when the remote compile finishes while the local flash is still running, and its per-row Cancel only reaches the receiver.

On an accepted upload submit the dialog now dispatches `remote-build-install-submitted` and closes; app-shell looks the job up in the firmware jobs map (the `job_queued` push precedes the submit response on the same WebSocket) and attaches the firmware-jobs dialog's embedded command dialog via a new `followJob` entry point. The user watches the whole lifecycle, remote compile plus local flash, with the standard Stop button that works through both phases. "Compile only" submissions keep the existing list-step flow. The ownership filter keys on the firmware jobs map rather than the submit target, so pool-routed compiles (device-card installs dispatched to a peer) also stop appearing as duplicate rows in the Send-builds list; their lifecycle already lives in the firmware-job UI.

**Related issue or feature (if applicable):**

- companion to esphome/device-builder#2119

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).


