### PR TITLE
Show deployed version and config hash from the _http._tcp identity TXT

### DIFF
--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -23,11 +23,14 @@ export enum DeviceState {
 export interface DeviceRuntimeState {
   state: DeviceState;
   /** Reachability channel currently driving the device's online state
-   *  (``mdns`` > ``mqtt`` > ``ping``). The deployed version / config
-   *  hash come only from the mDNS broadcast, so the out-of-sync /
-   *  update indicators are gated on ``active_source === "mdns"`` (see
+   *  (``mdns`` > ``mqtt`` > ``ping``). For an api: device the deployed
+   *  version / config hash come from the same ``_esphomelib._tcp``
+   *  broadcast that claims mDNS, so the out-of-sync / update indicators
+   *  are gated on ``active_source === "mdns"`` (see
    *  ``src/util/device-sync.ts``): when mDNS is dark those values are
-   *  stale. ``"unknown"`` means no source has claimed the device yet,
+   *  stale. A device without api: receives them on ``_http._tcp``,
+   *  which never claims reachability, so this field can't vouch for
+   *  them. ``"unknown"`` means no source has claimed the device yet,
    *  which reads as "not mDNS". */
   active_source: ReachabilitySource;
   /** All resolved addresses from mDNS (IPv4 + IPv6) — empty array until
@@ -38,7 +41,8 @@ export interface DeviceRuntimeState {
   /**
    * 8-char hex hash the running firmware reports via the
    * ``config_hash`` TXT record on its ``_esphomelib._tcp`` mDNS
-   * broadcast. Drives ``has_pending_changes`` together with
+   * broadcast — or on ``_http._tcp`` for a device without api:
+   * (ESPHome 2026.7.0+). Drives ``has_pending_changes`` together with
    * ``expected_config_hash``. Empty string when the device hasn't
    * announced yet, or runs firmware older than the broadcast
    * (esphome/esphome#16145) — the dashboard then falls back to
@@ -132,7 +136,8 @@ export interface ConfiguredDevice {
   has_pending_changes: boolean;
   /** True when ``has_pending_changes`` came from the mDNS-sourced
    *  config-hash compare (vs the local mtime fallback). The UI gates
-   *  only this case on a live mDNS, so a local YAML edit still cues
+   *  only this case on a trusted deployed identity (see
+   *  ``deployedIdentityTrusted``), so a local YAML edit still cues
    *  "install" when mDNS is dark. Optional / absent reads as a local
    *  (non-mDNS-dependent) pending. */
   pending_changes_via_hash?: boolean;
@@ -156,8 +161,9 @@ export interface ConfiguredDevice {
    * ``devices/get_api_key``.
    */
   api_encrypted: boolean;
-  /** Canonical ``XX:XX:XX:XX:XX:XX`` MAC observed in the device's
-   *  ``_esphomelib._tcp.local.`` ``mac`` TXT record (e.g.
+  /** Canonical ``XX:XX:XX:XX:XX:XX`` MAC observed in the ``mac`` TXT
+   *  record of the device's ``_esphomelib._tcp.local.`` broadcast, or
+   *  of ``_http._tcp.local.`` for a device without api: (e.g.
    *  ``"94:C9:60:1F:8C:F1"``). Empty string when mDNS hasn't surfaced
    *  one yet. The backend normalizes at ingest so this field always
    *  carries the colon-separated uppercase form regardless of which

--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -23,15 +23,10 @@ export enum DeviceState {
 export interface DeviceRuntimeState {
   state: DeviceState;
   /** Reachability channel currently driving the device's online state
-   *  (``mdns`` > ``mqtt`` > ``ping``). For an api: device the deployed
-   *  version / config hash come from the same ``_esphomelib._tcp``
-   *  broadcast that claims mDNS, so the out-of-sync / update indicators
-   *  are gated on ``active_source === "mdns"`` (see
-   *  ``src/util/device-sync.ts``): when mDNS is dark those values are
-   *  stale. A device without api: receives them on ``_http._tcp``,
-   *  which never claims reachability, so this field can't vouch for
-   *  them. ``"unknown"`` means no source has claimed the device yet,
-   *  which reads as "not mDNS". */
+   *  (``mdns`` > ``mqtt`` > ``ping``). The out-of-sync / update
+   *  indicators gate on it per the rule in ``deployedIdentityTrusted``
+   *  (``src/util/device-sync.ts``). ``"unknown"`` means no source has
+   *  claimed the device yet, which reads as "not mDNS". */
   active_source: ReachabilitySource;
   /** All resolved addresses from mDNS (IPv4 + IPv6) — empty array until
    *  the device is seen online. ``ip_addresses[0]`` matches the flat

--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -24,9 +24,10 @@ export interface DeviceRuntimeState {
   state: DeviceState;
   /** Reachability channel currently driving the device's online state
    *  (``mdns`` > ``mqtt`` > ``ping``). The out-of-sync / update
-   *  indicators gate on it per the rule in ``deployedIdentityTrusted``
-   *  (``src/util/device-sync.ts``). ``"unknown"`` means no source has
-   *  claimed the device yet, which reads as "not mDNS". */
+   *  indicators consult it only for api: devices, via
+   *  ``deployedIdentityTrusted`` (``src/util/device-sync.ts``), which
+   *  owns the gating rule. ``"unknown"`` means no source has claimed
+   *  the device yet, which reads as "not mDNS". */
   active_source: ReachabilitySource;
   /** All resolved addresses from mDNS (IPv4 + IPv6) — empty array until
    *  the device is seen online. ``ip_addresses[0]`` matches the flat

--- a/src/components/dashboard/device-drawer-content/render-sections.ts
+++ b/src/components/dashboard/device-drawer-content/render-sections.ts
@@ -37,11 +37,13 @@ export function renderRow(
   `;
 }
 
-// A device with no api: only broadcasts the identity trio (mac, version,
-// config hash) on _http._tcp from ESPHome 2026.7.0; on older firmware the
-// field never arrives, so a "waiting for mDNS" spinner would spin forever.
-// The no-native-API text stays as the "may never arrive" explanation for the
-// empty case. Mirrors the api_enabled gate in encryption-state.
+// Empty-state text for the MAC and deployed-config-hash rows. A device with
+// no api: only broadcasts those on _http._tcp from ESPHome 2026.7.0; on older
+// firmware the field never arrives, so a "waiting for mDNS" spinner would
+// spin forever — the no-native-API text stays as the "may never arrive"
+// explanation. The deployed-version row deliberately doesn't use this helper:
+// version also rides the older _http._tcp fallback, so waiting is honest
+// there. Mirrors the api_enabled gate in encryption-state.
 function emptyMdnsText(d: ConfiguredDevice, localize: LocalizeFunc): string {
   return localize(
     d.api_enabled ? "dashboard.drawer_waiting_for_mdns" : "dashboard.drawer_no_native_api"

--- a/src/components/dashboard/device-drawer-content/render-sections.ts
+++ b/src/components/dashboard/device-drawer-content/render-sections.ts
@@ -3,7 +3,7 @@ import type { IntegrationDoc } from "../../../api/types/components.js";
 import type { ConfiguredDevice } from "../../../api/types/devices.js";
 import { isSafeDocsUrl } from "../../../common/docs.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
-import { mdnsOnline } from "../../../util/device-sync.js";
+import { deployedIdentityTrusted } from "../../../util/device-sync.js";
 import {
   getEncryptionVisual,
   type EncryptionState,
@@ -37,11 +37,11 @@ export function renderRow(
   `;
 }
 
-// MAC address and deployed config hash reach the dashboard only over the
-// native-API mDNS service (_esphomelib._tcp); a device with no api: never
-// broadcasts them, so a "waiting for mDNS" spinner would spin forever. Gate on
-// api_enabled (the field can never arrive), not mdnsOnline() (only whether mDNS
-// is live right now). Mirrors the api_enabled gate in encryption-state.
+// A device with no api: only broadcasts the identity trio (mac, version,
+// config hash) on _http._tcp from ESPHome 2026.7.0; on older firmware the
+// field never arrives, so a "waiting for mDNS" spinner would spin forever.
+// The no-native-API text stays as the "may never arrive" explanation for the
+// empty case. Mirrors the api_enabled gate in encryption-state.
 function emptyMdnsText(d: ConfiguredDevice, localize: LocalizeFunc): string {
   return localize(
     d.api_enabled ? "dashboard.drawer_waiting_for_mdns" : "dashboard.drawer_no_native_api"
@@ -135,10 +135,10 @@ export function renderVersionSection(
   localize: LocalizeFunc
 ): TemplateResult | typeof nothing {
   const local = d.current_version || "";
-  // The deployed version comes only from mDNS; when mDNS is dark it's stale, so
-  // treat it as unknown and let the existing empty-deployed path show
-  // "waiting for mDNS" instead of a false "out of sync".
-  const deployed = mdnsOnline(d) ? d.runtime_state.deployed_version : "";
+  // mDNS-sourced; treat as unknown when it can't be trusted (see
+  // deployedIdentityTrusted) so the empty-deployed path shows the waiting /
+  // no-native-API text instead of a false "out of sync".
+  const deployed = deployedIdentityTrusted(d) ? d.runtime_state.deployed_version : "";
   if (!local && !deployed) return nothing;
   const matches = !!local && !!deployed && local === deployed;
   const statusIcon = matches ? "check-circle-outline" : "sync";
@@ -190,8 +190,8 @@ export function renderConfigHashSection(
   localize: LocalizeFunc
 ): TemplateResult | typeof nothing {
   const expected = d.expected_config_hash || "";
-  // mDNS-sourced; treat as unknown when mDNS is dark (see renderVersionSection).
-  const deployed = mdnsOnline(d) ? d.runtime_state.deployed_config_hash : "";
+  // mDNS-sourced; treat as unknown when it can't be trusted (see renderVersionSection).
+  const deployed = deployedIdentityTrusted(d) ? d.runtime_state.deployed_config_hash : "";
   if (!expected && !deployed) return nothing;
   const matches = !!expected && !!deployed && expected === deployed;
   const statusIcon = matches ? "check-circle-outline" : "sync";

--- a/src/components/dashboard/device-drawer-content/render-sections.ts
+++ b/src/components/dashboard/device-drawer-content/render-sections.ts
@@ -138,8 +138,8 @@ export function renderVersionSection(
 ): TemplateResult | typeof nothing {
   const local = d.current_version || "";
   // mDNS-sourced; treat as unknown when it can't be trusted (see
-  // deployedIdentityTrusted) so the empty-deployed path shows the waiting /
-  // no-native-API text instead of a false "out of sync".
+  // deployedIdentityTrusted) so the empty-deployed path shows the waiting
+  // text instead of a false "out of sync".
   const deployed = deployedIdentityTrusted(d) ? d.runtime_state.deployed_version : "";
   if (!local && !deployed) return nothing;
   const matches = !!local && !!deployed && local === deployed;

--- a/src/util/device-sync.ts
+++ b/src/util/device-sync.ts
@@ -1,23 +1,23 @@
 import type { ConfiguredDevice } from "../api/types/devices.js";
 
-// The deployed version / config hash come only from the device's mDNS
-// broadcast, so they are trustworthy only while mDNS is the live source. When
-// mDNS is dark (a ping/MQTT-only "odd setup", e.g. a Docker-bridge dashboard),
-// those values go stale, so we gate the out-of-sync / update indicators on a
-// live mDNS rather than flagging a false "out of sync". The device reappears
-// as out-of-sync once mDNS hears from it again.
+// Whether mDNS is the channel currently driving the device's online state.
+// For gating the deployed identity (version / config hash) use
+// deployedIdentityTrusted below, never this directly — this predicate can
+// never be true for a device without api:.
 export const mdnsOnline = (d: ConfiguredDevice): boolean =>
   d.runtime_state.active_source === "mdns";
 
 // Whether the mDNS-sourced deployed identity (version / config hash) is
 // trustworthy. An api: device broadcasts it on _esphomelib._tcp, the same
 // service that claims active_source === "mdns", so that source doubles as the
-// freshness signal. A device without api: broadcasts the same identity trio on
-// _http._tcp (ESPHome 2026.7.0+), which by backend design never claims
-// reachability, so active_source can't vouch for it and would blank the values
-// forever; trust what the backend delivered instead. The drawer's mDNS-stale
-// warning already covers the "reachable but mDNS dark, values may be stale"
-// case for these devices.
+// freshness signal: when mDNS is dark (a ping/MQTT-only "odd setup", e.g. a
+// Docker-bridge dashboard) the values go stale, so blanking them avoids a
+// false "out of sync". A device without api: broadcasts the same identity
+// trio on _http._tcp (ESPHome 2026.7.0+), which by backend design never
+// claims reachability, so active_source can't vouch for it and would blank
+// the values forever; trust what the backend delivered instead. The drawer's
+// mDNS-stale warning already covers the "reachable but mDNS dark, values may
+// be stale" case for these devices.
 export const deployedIdentityTrusted = (d: ConfiguredDevice): boolean =>
   d.api_enabled ? mdnsOnline(d) : true;
 

--- a/src/util/device-sync.ts
+++ b/src/util/device-sync.ts
@@ -29,8 +29,9 @@ export const deployedIdentityTrusted = (d: ConfiguredDevice): boolean =>
 // ``update_available``); these say whether to surface it. Every indicator site
 // derives from these so the rule lives in one place.
 //
-// ``update_available`` (device version vs server) is purely mDNS-sourced, so it
-// always needs a trusted deployed identity. ``has_pending_changes`` is only
+// ``update_available`` (``deployed_version`` vs ``current_version``) is purely
+// mDNS-sourced, so it always needs a trusted deployed identity.
+// ``has_pending_changes`` is only
 // mDNS-dependent when it came from the config-hash compare
 // (``pending_changes_via_hash``); a local mtime-driven edit is trustworthy
 // without mDNS, so it still cues "install".

--- a/src/util/device-sync.ts
+++ b/src/util/device-sync.ts
@@ -9,6 +9,18 @@ import type { ConfiguredDevice } from "../api/types/devices.js";
 export const mdnsOnline = (d: ConfiguredDevice): boolean =>
   d.runtime_state.active_source === "mdns";
 
+// Whether the mDNS-sourced deployed identity (version / config hash) is
+// trustworthy. An api: device broadcasts it on _esphomelib._tcp, the same
+// service that claims active_source === "mdns", so that source doubles as the
+// freshness signal. A device without api: broadcasts the same identity trio on
+// _http._tcp (ESPHome 2026.7.0+), which by backend design never claims
+// reachability, so active_source can't vouch for it and would blank the values
+// forever; trust what the backend delivered instead. The drawer's mDNS-stale
+// warning already covers the "reachable but mDNS dark, values may be stale"
+// case for these devices.
+export const deployedIdentityTrusted = (d: ConfiguredDevice): boolean =>
+  d.api_enabled ? mdnsOnline(d) : true;
+
 // Whether to SHOW the "modified" (needs-install) and "update available"
 // indicators, gated so a stale mDNS-dark value can't flag a false "out of
 // sync". The raw truth stays on the device fields (``has_pending_changes`` /
@@ -16,12 +28,13 @@ export const mdnsOnline = (d: ConfiguredDevice): boolean =>
 // derives from these so the rule lives in one place.
 //
 // ``update_available`` (device version vs server) is purely mDNS-sourced, so it
-// always needs a live mDNS. ``has_pending_changes`` is only mDNS-dependent when
-// it came from the config-hash compare (``pending_changes_via_hash``); a local
-// mtime-driven edit is trustworthy without mDNS, so it still cues "install".
+// always needs a trusted deployed identity. ``has_pending_changes`` is only
+// mDNS-dependent when it came from the config-hash compare
+// (``pending_changes_via_hash``); a local mtime-driven edit is trustworthy
+// without mDNS, so it still cues "install".
 export const showPendingChanges = (d: ConfiguredDevice): boolean =>
   d.has_pending_changes === true &&
-  (mdnsOnline(d) || d.pending_changes_via_hash !== true);
+  (deployedIdentityTrusted(d) || d.pending_changes_via_hash !== true);
 
 export const showUpdateAvailable = (d: ConfiguredDevice): boolean =>
-  d.update_available === true && mdnsOnline(d);
+  d.update_available === true && deployedIdentityTrusted(d);

--- a/src/util/device-sync.ts
+++ b/src/util/device-sync.ts
@@ -1,10 +1,10 @@
 import type { ConfiguredDevice } from "../api/types/devices.js";
 
 // Whether mDNS is the channel currently driving the device's online state.
-// For gating the deployed identity (version / config hash) use
-// deployedIdentityTrusted below, never this directly — this predicate can
-// never be true for a device without api:.
-export const mdnsOnline = (d: ConfiguredDevice): boolean =>
+// Deliberately unexported: for gating the deployed identity (version /
+// config hash) use deployedIdentityTrusted below, never this directly —
+// this predicate can never be true for a device without api:.
+const mdnsOnline = (d: ConfiguredDevice): boolean =>
   d.runtime_state.active_source === "mdns";
 
 // Whether the mDNS-sourced deployed identity (version / config hash) is
@@ -17,7 +17,9 @@ export const mdnsOnline = (d: ConfiguredDevice): boolean =>
 // claims reachability, so active_source can't vouch for it and would blank
 // the values forever; trust what the backend delivered instead. The drawer's
 // mDNS-stale warning already covers the "reachable but mDNS dark, values may
-// be stale" case for these devices.
+// be stale" case for these devices; a fully OFFLINE device falls outside that
+// warning yet still renders its last-heard identity — accepted, since that's
+// the best information available for a powered-down device.
 export const deployedIdentityTrusted = (d: ConfiguredDevice): boolean =>
   d.api_enabled ? mdnsOnline(d) : true;
 

--- a/test/components/dashboard/render-card-grid.test.ts
+++ b/test/components/dashboard/render-card-grid.test.ts
@@ -71,9 +71,10 @@ describe("renderCardGrid", () => {
     expect(card.hasAttribute("show-update")).toBe(true);
   });
 
-  it("hides the update indicator when mDNS is dark", () => {
+  it("hides the update indicator when an api device's mDNS is dark", () => {
     const device = makeConfiguredDevice({
       update_available: true,
+      api_enabled: true,
       runtime_state: { active_source: "ping" },
     });
     const card = renderCard(device);

--- a/test/components/dashboard/render-mac-address-row.test.ts
+++ b/test/components/dashboard/render-mac-address-row.test.ts
@@ -3,9 +3,10 @@
  *
  * MAC address and deployed config hash show "Waiting for mDNS discovery" while a
  * native-API device hasn't announced (#1453), but "This device does not have
- * Native API" for a no-api device whose MAC / config hash can never arrive; the
+ * Native API" for a no-api device, whose MAC / config hash arrive only on
+ * ESPHome 2026.7.0+ (_http._tcp identity TXT) and never on older firmware; the
  * ethernet / bluetooth waiting rows hide entirely for such devices. The deployed
- * version row is exempt: it can still arrive over the _http._tcp fallback.
+ * version row is exempt: it can arrive over the _http._tcp fallback on any firmware.
  */
 import { nothing } from "lit";
 import { describe, expect, it } from "vitest";

--- a/test/components/dashboard/render-mac-address-row.test.ts
+++ b/test/components/dashboard/render-mac-address-row.test.ts
@@ -166,6 +166,36 @@ describe("renderVersionSection deployed row", () => {
     expect(texts).toContain("2026.5.2");
     expect(texts).toContain("dashboard.drawer_waiting_for_mdns");
   });
+
+  it("shows the deployed version for a no-api device reachable over MQTT", () => {
+    // Delivered via the _http._tcp identity TXT; active_source never claims
+    // mDNS for these devices, so the value must not be gated on it.
+    const result = renderVersionSection(
+      _device({
+        current_version: "2026.7.1",
+        api_enabled: false,
+        runtime_state: { active_source: "mqtt", deployed_version: "2026.7.0" },
+      }),
+      _localize
+    );
+    const texts = valueTexts(result);
+    expect(texts).toContain("2026.7.1");
+    expect(texts).toContain("2026.7.0");
+  });
+
+  it("blanks an api device's deployed version while mDNS is dark", () => {
+    const result = renderVersionSection(
+      _device({
+        current_version: "2026.7.1",
+        api_enabled: true,
+        runtime_state: { active_source: "ping", deployed_version: "2026.7.0" },
+      }),
+      _localize
+    );
+    const texts = valueTexts(result);
+    expect(texts).not.toContain("2026.7.0");
+    expect(texts).toContain("dashboard.drawer_waiting_for_mdns");
+  });
 });
 
 describe("renderConfigHashSection deployed row", () => {
@@ -195,5 +225,33 @@ describe("renderConfigHashSection deployed row", () => {
     const texts = valueTexts(result);
     expect(texts).toContain("abc123");
     expect(texts).toContain("dashboard.drawer_no_native_api");
+  });
+
+  it("shows the deployed hash for a no-api device reachable over MQTT", () => {
+    const result = renderConfigHashSection(
+      _device({
+        expected_config_hash: "abc123",
+        api_enabled: false,
+        runtime_state: { active_source: "mqtt", deployed_config_hash: "22e8e223" },
+      }),
+      _localize
+    );
+    const texts = valueTexts(result);
+    expect(texts).toContain("abc123");
+    expect(texts).toContain("22e8e223");
+  });
+
+  it("blanks an api device's deployed hash while mDNS is dark", () => {
+    const result = renderConfigHashSection(
+      _device({
+        expected_config_hash: "abc123",
+        api_enabled: true,
+        runtime_state: { active_source: "ping", deployed_config_hash: "22e8e223" },
+      }),
+      _localize
+    );
+    const texts = valueTexts(result);
+    expect(texts).not.toContain("22e8e223");
+    expect(texts).toContain("dashboard.drawer_waiting_for_mdns");
   });
 });

--- a/test/util/device-sync.test.ts
+++ b/test/util/device-sync.test.ts
@@ -20,36 +20,18 @@ describe("device-sync mDNS gating", () => {
     }
   });
 
-  it("trusts an api device's deployed identity only while mDNS is the live source", () => {
-    expect(
-      deployedIdentityTrusted(
-        makeConfiguredDevice({
-          api_enabled: true,
-          runtime_state: { active_source: "mdns" },
-        })
-      )
-    ).toBe(true);
-    for (const s of ["ping", "mqtt", "unknown"] as const) {
-      expect(
-        deployedIdentityTrusted(
-          makeConfiguredDevice({ api_enabled: true, runtime_state: { active_source: s } })
-        )
-      ).toBe(false);
-    }
-  });
-
-  it("trusts a no-api device's deployed identity regardless of the live source", () => {
-    // Delivered over _http._tcp, which never claims reachability, so
-    // active_source can't vouch for it.
+  it("trusts the deployed identity per api_enabled and live source", () => {
+    // An api device needs a live mDNS; a no-api device's identity arrives
+    // over _http._tcp, which never claims reachability, so active_source
+    // can't vouch for it and the delivered value is trusted as-is.
     for (const s of ["mdns", "ping", "mqtt", "unknown"] as const) {
-      expect(
-        deployedIdentityTrusted(
-          makeConfiguredDevice({
-            api_enabled: false,
-            runtime_state: { active_source: s },
-          })
-        )
-      ).toBe(true);
+      for (const api_enabled of [true, false]) {
+        expect(
+          deployedIdentityTrusted(
+            makeConfiguredDevice({ api_enabled, runtime_state: { active_source: s } })
+          )
+        ).toBe(api_enabled ? s === "mdns" : true);
+      }
     }
   });
 

--- a/test/util/device-sync.test.ts
+++ b/test/util/device-sync.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  deployedIdentityTrusted,
   mdnsOnline,
   showPendingChanges,
   showUpdateAvailable,
@@ -19,8 +20,42 @@ describe("device-sync mDNS gating", () => {
     }
   });
 
-  it("hides the hash-driven modified / update signals while mDNS is dark", () => {
+  it("trusts an api device's deployed identity only while mDNS is the live source", () => {
+    expect(
+      deployedIdentityTrusted(
+        makeConfiguredDevice({
+          api_enabled: true,
+          runtime_state: { active_source: "mdns" },
+        })
+      )
+    ).toBe(true);
+    for (const s of ["ping", "mqtt", "unknown"] as const) {
+      expect(
+        deployedIdentityTrusted(
+          makeConfiguredDevice({ api_enabled: true, runtime_state: { active_source: s } })
+        )
+      ).toBe(false);
+    }
+  });
+
+  it("trusts a no-api device's deployed identity regardless of the live source", () => {
+    // Delivered over _http._tcp, which never claims reachability, so
+    // active_source can't vouch for it.
+    for (const s of ["mdns", "ping", "mqtt", "unknown"] as const) {
+      expect(
+        deployedIdentityTrusted(
+          makeConfiguredDevice({
+            api_enabled: false,
+            runtime_state: { active_source: s },
+          })
+        )
+      ).toBe(true);
+    }
+  });
+
+  it("hides an api device's hash-driven modified / update signals while mDNS is dark", () => {
     const dark = makeConfiguredDevice({
+      api_enabled: true,
       runtime_state: { active_source: "ping" },
       has_pending_changes: true,
       pending_changes_via_hash: true,
@@ -30,11 +65,12 @@ describe("device-sync mDNS gating", () => {
     expect(showUpdateAvailable(dark)).toBe(false);
   });
 
-  it("keeps a local mtime-driven modified cue while mDNS is dark", () => {
+  it("keeps an api device's local mtime-driven modified cue while mDNS is dark", () => {
     // pending_changes_via_hash absent / false ⇒ a local YAML edit, trustworthy
     // without mDNS, so the needs-install cue stays. update_available is still
     // mDNS-sourced, so it stays hidden.
     const dark = makeConfiguredDevice({
+      api_enabled: true,
       runtime_state: { active_source: "ping" },
       has_pending_changes: true,
       update_available: true,
@@ -45,11 +81,24 @@ describe("device-sync mDNS gating", () => {
 
   it("shows the modified / update signals once mDNS is the live source", () => {
     const live = makeConfiguredDevice({
+      api_enabled: true,
       runtime_state: { active_source: "mdns" },
       has_pending_changes: true,
       update_available: true,
     });
     expect(showPendingChanges(live)).toBe(true);
     expect(showUpdateAvailable(live)).toBe(true);
+  });
+
+  it("shows a no-api device's hash-driven modified / update signals without mDNS reachability", () => {
+    const mqttOnly = makeConfiguredDevice({
+      api_enabled: false,
+      runtime_state: { active_source: "mqtt" },
+      has_pending_changes: true,
+      pending_changes_via_hash: true,
+      update_available: true,
+    });
+    expect(showPendingChanges(mqttOnly)).toBe(true);
+    expect(showUpdateAvailable(mqttOnly)).toBe(true);
   });
 });

--- a/test/util/device-sync.test.ts
+++ b/test/util/device-sync.test.ts
@@ -2,24 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   deployedIdentityTrusted,
-  mdnsOnline,
   showPendingChanges,
   showUpdateAvailable,
 } from "../../src/util/device-sync.js";
 import { makeConfiguredDevice } from "../_make-configured-device.js";
 
 describe("device-sync mDNS gating", () => {
-  it("is mDNS-online only when the live source is mDNS", () => {
-    expect(
-      mdnsOnline(makeConfiguredDevice({ runtime_state: { active_source: "mdns" } }))
-    ).toBe(true);
-    for (const s of ["ping", "mqtt", "unknown"] as const) {
-      expect(
-        mdnsOnline(makeConfiguredDevice({ runtime_state: { active_source: s } }))
-      ).toBe(false);
-    }
-  });
-
   it("trusts the deployed identity per api_enabled and live source", () => {
     // An api device needs a live mDNS; a no-api device's identity arrives
     // over _http._tcp, which never claims reachability, so active_source


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Devices without a native api block, such as MQTT only configs, broadcast their version, mac and config_hash on the _http._tcp identity TXT since ESPHome 2026.7.0, and the backend has been applying them since 1.6.1. The drawer still blanked Deployed Version and Deployed Config Hash behind the active_source === "mdns" gate, a condition these devices can never satisfy because the _http._tcp path deliberately claims no reachability; the update and modified badges were suppressed the same way.

Add a deployedIdentityTrusted predicate: api devices keep the existing mdns gate as their freshness signal, no api devices trust the delivered value. The drawer rows and the showUpdateAvailable / showPendingChanges helpers now use it, so the deployed fields render and the badges surface for these devices. Tests pin the new no api behavior and the unchanged api device gating.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2117

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
