### PR TITLE
Gate the no-api deployed identity on http_identity_live

### DIFF
--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -62,6 +62,13 @@ export interface DeviceRuntimeState {
    * mismatch / plaintext.
    */
   api_encryption_active: string | null;
+  /** Whether an unexpired ``_http._tcp`` identity TXT currently backs
+   *  the deployed identity of a device without api:. Session-only —
+   *  false on backend cold start until the broadcast is heard.
+   *  ``deployedIdentityTrusted`` gates the non-api deployed identity
+   *  on it, mirroring the ``active_source === "mdns"`` gate api
+   *  devices use. */
+  http_identity_live: boolean;
 }
 
 /** A configured ESPHome device. */

--- a/src/util/device-sync.ts
+++ b/src/util/device-sync.ts
@@ -14,14 +14,12 @@ const mdnsOnline = (d: ConfiguredDevice): boolean =>
 // Docker-bridge dashboard) the values go stale, so blanking them avoids a
 // false "out of sync". A device without api: broadcasts the same identity
 // trio on _http._tcp (ESPHome 2026.7.0+), which by backend design never
-// claims reachability, so active_source can't vouch for it and would blank
-// the values forever; trust what the backend delivered instead. The drawer's
-// mDNS-stale warning already covers the "reachable but mDNS dark, values may
-// be stale" case for these devices; a fully OFFLINE device falls outside that
-// warning yet still renders its last-heard identity — accepted, since that's
-// the best information available for a powered-down device.
+// claims reachability, so active_source can't vouch for it — the backend
+// tracks that broadcast's freshness itself and ships it as
+// runtime_state.http_identity_live (session-only; false on backend cold
+// start until the broadcast is heard).
 export const deployedIdentityTrusted = (d: ConfiguredDevice): boolean =>
-  d.api_enabled ? mdnsOnline(d) : true;
+  d.api_enabled ? mdnsOnline(d) : d.runtime_state.http_identity_live;
 
 // Whether to SHOW the "modified" (needs-install) and "update available"
 // indicators, gated so a stale mDNS-dark value can't flag a false "out of

--- a/src/util/device-sync.ts
+++ b/src/util/device-sync.ts
@@ -17,7 +17,10 @@ const mdnsOnline = (d: ConfiguredDevice): boolean =>
 // claims reachability, so active_source can't vouch for it — the backend
 // tracks that broadcast's freshness itself and ships it as
 // runtime_state.http_identity_live (session-only; false on backend cold
-// start until the broadcast is heard).
+// start until the broadcast is heard). A powered-down device blanks
+// rather than showing its last-heard identity: an arbitrarily old
+// broadcast is not evidence, matching how an api: device blanks when
+// mDNS goes dark.
 export const deployedIdentityTrusted = (d: ConfiguredDevice): boolean =>
   d.api_enabled ? mdnsOnline(d) : d.runtime_state.http_identity_live;
 

--- a/test/_make-configured-device.ts
+++ b/test/_make-configured-device.ts
@@ -38,9 +38,10 @@ const _BASE = {
   loaded_integrations: [],
   runtime_state: {
     state: DeviceState.UNKNOWN,
-    // Default to a live mDNS source so the happy-path fixture shows its
-    // out-of-sync / update indicators as before; tests covering the mDNS-dark
-    // "hide indicators" behaviour override this to "ping" / "unknown".
+    // Live mDNS source so an api-enabled test device shows its out-of-sync /
+    // update indicators (the fixture defaults to no-api, whose gate is
+    // http_identity_live below); tests covering the mDNS-dark "hide
+    // indicators" behaviour override this to "ping" / "unknown".
     active_source: "mdns",
     ip_addresses: [],
     deployed_version: "",

--- a/test/_make-configured-device.ts
+++ b/test/_make-configured-device.ts
@@ -47,6 +47,9 @@ const _BASE = {
     deployed_config_hash: "",
     queued_update: false,
     api_encryption_active: null,
+    // Same happy-path default for the no-api gate; tests covering the
+    // identity-went-dark behaviour override this to false.
+    http_identity_live: true,
   },
   expected_config_hash: "",
   has_pending_changes: false,

--- a/test/components/dashboard/render-card-grid.test.ts
+++ b/test/components/dashboard/render-card-grid.test.ts
@@ -82,6 +82,16 @@ describe("renderCardGrid", () => {
     expect(card.hasAttribute("queued-update")).toBe(false);
   });
 
+  it("hides the update indicator when a no-api device's identity TXT went dark", () => {
+    const device = makeConfiguredDevice({
+      update_available: true,
+      api_enabled: false,
+      runtime_state: { active_source: "mqtt", http_identity_live: false },
+    });
+    const card = renderCard(device);
+    expect(card.hasAttribute("show-update")).toBe(false);
+  });
+
   it("keeps the tour target in canonical device order", () => {
     const zulu = makeConfiguredDevice({
       name: "zulu",

--- a/test/components/dashboard/render-facets.test.ts
+++ b/test/components/dashboard/render-facets.test.ts
@@ -78,6 +78,7 @@ describe("renderFacets", () => {
       _devices: [
         {
           update_available: true,
+          api_enabled: true,
           runtime_state: { state: "online", active_source: "mdns" },
         },
       ],

--- a/test/components/dashboard/render-mac-address-row.test.ts
+++ b/test/components/dashboard/render-mac-address-row.test.ts
@@ -170,18 +170,40 @@ describe("renderVersionSection deployed row", () => {
 
   it("shows the deployed version for a no-api device reachable over MQTT", () => {
     // Delivered via the _http._tcp identity TXT; active_source never claims
-    // mDNS for these devices, so the value must not be gated on it.
+    // mDNS for these devices, so the gate is http_identity_live instead.
     const result = renderVersionSection(
       _device({
         current_version: "2026.7.1",
         api_enabled: false,
-        runtime_state: { active_source: "mqtt", deployed_version: "2026.7.0" },
+        runtime_state: {
+          active_source: "mqtt",
+          deployed_version: "2026.7.0",
+          http_identity_live: true,
+        },
       }),
       _localize
     );
     const texts = valueTexts(result);
     expect(texts).toContain("2026.7.1");
     expect(texts).toContain("2026.7.0");
+  });
+
+  it("blanks a no-api device's deployed version when the identity TXT went dark", () => {
+    const result = renderVersionSection(
+      _device({
+        current_version: "2026.7.1",
+        api_enabled: false,
+        runtime_state: {
+          active_source: "mqtt",
+          deployed_version: "2026.7.0",
+          http_identity_live: false,
+        },
+      }),
+      _localize
+    );
+    const texts = valueTexts(result);
+    expect(texts).not.toContain("2026.7.0");
+    expect(texts).toContain("dashboard.drawer_waiting_for_mdns");
   });
 
   it("blanks an api device's deployed version while mDNS is dark", () => {
@@ -233,13 +255,35 @@ describe("renderConfigHashSection deployed row", () => {
       _device({
         expected_config_hash: "abc123",
         api_enabled: false,
-        runtime_state: { active_source: "mqtt", deployed_config_hash: "22e8e223" },
+        runtime_state: {
+          active_source: "mqtt",
+          deployed_config_hash: "22e8e223",
+          http_identity_live: true,
+        },
       }),
       _localize
     );
     const texts = valueTexts(result);
     expect(texts).toContain("abc123");
     expect(texts).toContain("22e8e223");
+  });
+
+  it("blanks a no-api device's deployed hash when the identity TXT went dark", () => {
+    const result = renderConfigHashSection(
+      _device({
+        expected_config_hash: "abc123",
+        api_enabled: false,
+        runtime_state: {
+          active_source: "mqtt",
+          deployed_config_hash: "22e8e223",
+          http_identity_live: false,
+        },
+      }),
+      _localize
+    );
+    const texts = valueTexts(result);
+    expect(texts).not.toContain("22e8e223");
+    expect(texts).toContain("dashboard.drawer_no_native_api");
   });
 
   it("blanks an api device's deployed hash while mDNS is dark", () => {

--- a/test/util/device-sync.test.ts
+++ b/test/util/device-sync.test.ts
@@ -8,17 +8,22 @@ import {
 import { makeConfiguredDevice } from "../_make-configured-device.js";
 
 describe("device-sync mDNS gating", () => {
-  it("trusts the deployed identity per api_enabled and live source", () => {
+  it("trusts the deployed identity per api_enabled, live source, and http identity", () => {
     // An api device needs a live mDNS; a no-api device's identity arrives
     // over _http._tcp, which never claims reachability, so active_source
-    // can't vouch for it and the delivered value is trusted as-is.
+    // can't vouch for it — the backend's http_identity_live does.
     for (const s of ["mdns", "ping", "mqtt", "unknown"] as const) {
       for (const api_enabled of [true, false]) {
-        expect(
-          deployedIdentityTrusted(
-            makeConfiguredDevice({ api_enabled, runtime_state: { active_source: s } })
-          )
-        ).toBe(api_enabled ? s === "mdns" : true);
+        for (const http_identity_live of [true, false]) {
+          expect(
+            deployedIdentityTrusted(
+              makeConfiguredDevice({
+                api_enabled,
+                runtime_state: { active_source: s, http_identity_live },
+              })
+            )
+          ).toBe(api_enabled ? s === "mdns" : http_identity_live);
+        }
       }
     }
   });
@@ -63,12 +68,24 @@ describe("device-sync mDNS gating", () => {
   it("shows a no-api device's hash-driven modified / update signals without mDNS reachability", () => {
     const mqttOnly = makeConfiguredDevice({
       api_enabled: false,
-      runtime_state: { active_source: "mqtt" },
+      runtime_state: { active_source: "mqtt", http_identity_live: true },
       has_pending_changes: true,
       pending_changes_via_hash: true,
       update_available: true,
     });
     expect(showPendingChanges(mqttOnly)).toBe(true);
     expect(showUpdateAvailable(mqttOnly)).toBe(true);
+  });
+
+  it("hides a no-api device's hash-driven signals when the identity TXT went dark", () => {
+    const dark = makeConfiguredDevice({
+      api_enabled: false,
+      runtime_state: { active_source: "mqtt", http_identity_live: false },
+      has_pending_changes: true,
+      pending_changes_via_hash: true,
+      update_available: true,
+    });
+    expect(showPendingChanges(dark)).toBe(false);
+    expect(showUpdateAvailable(dark)).toBe(false);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The backend now tracks the freshness of the _http._tcp identity TXT as runtime_state.http_identity_live, stamped when the broadcast is applied and cleared only after a targeted re-resolve confirms it gone. Gate deployedIdentityTrusted's no api branch on it instead of trusting the delivered value unconditionally, so an mDNS dark deployment no longer shows sidecar seeded values in the drawer identity rows or the update and modified badges; api devices keep their active_source gate. The table's Version column stays ungated for both device kinds, same as today.

Coordinated with the backend PR that adds the field: esphome/device-builder#2129, merge that side first.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2121

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
