### PR TITLE
Give the log buffer an owner

### DIFF
--- a/src/components/ansi-log.ts
+++ b/src/components/ansi-log.ts
@@ -217,7 +217,7 @@ export class ESPHomeAnsiLog extends LitElement {
 
   /** The log lines to render. */
   @property({ attribute: false })
-  lines: string[] = [];
+  lines: readonly string[] = [];
 
   /** Placeholder text when no lines. */
   @property({ type: String })

--- a/src/components/crash-decode-controller.ts
+++ b/src/components/crash-decode-controller.ts
@@ -1,6 +1,5 @@
 import type { ESPHomeAPI } from "../api/index.js";
 import {
-  type CrashDecode,
   type CrashDecodeCache,
   type CrashRegion,
   CrashRegionCollector,
@@ -8,37 +7,27 @@ import {
   decodeCrashRegion,
   interleaveDecoded,
 } from "../util/crash-decode.js";
+import type { LogBuffer } from "../util/log-buffer.js";
+
+/** Read lazily so the host can construct this alongside its buffer. */
+export interface CrashDecodeHost {
+  api(): ESPHomeAPI;
+  configuration(): string;
+  buffer(): LogBuffer;
+}
 
 /**
  * Inline crash decoding for a streamed log buffer.
  *
- * Owns the map from a line's absolute stream position onto the buffer it
- * currently sits at, which is the whole difficulty: the cap drops lines off
- * the front and decoding splices lines in, and both move everything after
- * them. Deliberately not a Lit ``ReactiveController`` — every counter here is
- * meaningful only against one buffer, so this resets with the buffer, never
- * with the host's DOM lifetime.
+ * A consumer of the buffer, not a co-owner: positioning a region against a
+ * buffer the cap keeps trimming is the buffer's job, so this only has to
+ * recognise a crash, colour it, and rewrite it once the backend answers.
  */
-
-/** The buffer this decorates, read lazily so the host can construct first. */
-export interface CrashDecodeHost {
-  api(): ESPHomeAPI;
-  configuration(): string;
-  getLines(): string[];
-  /** Replace the buffer, applying the host's cap. */
-  setLines(next: string[]): void;
-}
-
 export class CrashDecodeController {
   private _region = new CrashRegionCollector();
   // Scoped to the session: a reflash can leave the same addresses meaning
   // different lines, so a decode must not outlive its buffer.
   private _cache: CrashDecodeCache = new Map();
-  private _streamIndex = 0;
-  private _indexShift = 0;
-  // Bumped whenever the buffer is reset; a decode in flight against the old
-  // buffer must not splice into the new one.
-  private _epoch = 0;
   // Serialises decodes so each splice lands before the next is positioned.
   private _chain: Promise<void> = Promise.resolve();
   private _staleBuild = false;
@@ -51,14 +40,13 @@ export class CrashDecodeController {
   }
 
   /**
-   * Feed one streamed line, already in the buffer.
+   * Feed one streamed line, already appended to the buffer at *streamIndex*.
    *
    * Takes the normalized form rather than deriving it: the host needs it too,
    * and this runs for every line of a stream that can push thousands a second.
    */
-  observe(raw: string, normalized: string): void {
-    const region = this._region.push(raw, normalized, this._streamIndex);
-    this._streamIndex += 1;
+  observe(raw: string, normalized: string, streamIndex: number): void {
+    const region = this._region.push(raw, normalized, streamIndex);
     if (!region) return;
     // Paint before decoding: colouring is 1:1, so it never moves the shift,
     // and the region comes back as it now sits in the buffer so a decode
@@ -71,16 +59,8 @@ export class CrashDecodeController {
     this._queueDecode(painted);
   }
 
-  /** The cap dropped *count* lines off the front of the buffer. */
-  noteTrimmed(count: number): void {
-    this._indexShift -= count;
-  }
-
-  /** Drop everything; the caller is replacing the buffer it all refers to. */
+  /** Drop everything; the caller is resetting the buffer it all refers to. */
   reset(): void {
-    this._epoch += 1;
-    this._streamIndex = 0;
-    this._indexShift = 0;
     this._staleBuild = false;
     this._region = new CrashRegionCollector();
     // Replaced, not cleared: a decode still in flight kept a reference to the
@@ -98,13 +78,14 @@ export class CrashDecodeController {
   // would scroll past looking like ordinary output. Null when the region is no
   // longer in the buffer to colour.
   private _paint(region: CrashRegion): CrashRegion | null {
+    const buffer = this.host.buffer();
     const raw = colorizeCrash(region.raw);
     if (raw.every((line, i) => line === region.raw[i])) {
       // An OTA crash arrives red from the device's logger, so there is nothing
       // to replace. It still has to be present to be worth decoding.
-      return this._positionOf(region) === null ? null : region;
+      return buffer.indexOf(region.startIndex, region.raw) === null ? null : region;
     }
-    return this._replaceRegion(region, raw)
+    return buffer.replace(region.startIndex, region.raw, raw)
       ? { raw, startIndex: region.startIndex }
       : null;
   }
@@ -113,60 +94,22 @@ export class CrashDecodeController {
   // region's position is computed. Fire-and-forget: the log keeps streaming
   // while the backend's child works, and a failure leaves the dump untouched.
   private _queueDecode(region: CrashRegion): void {
-    const epoch = this._epoch;
+    const epoch = this.host.buffer().epoch;
     this._chain = this._chain
       .then(async () => {
-        if (epoch !== this._epoch) return;
+        if (epoch !== this.host.buffer().epoch) return;
         const decode = await decodeCrashRegion(
           this.host.api(),
           this.host.configuration(),
           region.raw,
           this._cache
         );
-        if (decode === null || epoch !== this._epoch) return;
+        if (decode === null || epoch !== this.host.buffer().epoch) return;
         if (decode.staleBuild) this._staleBuild = true;
-        this._splice(region, decode);
+        this.host
+          .buffer()
+          .replace(region.startIndex, region.raw, interleaveDecoded(region.raw, decode));
       })
       .catch((err) => console.warn("Inline backtrace decode failed", err));
-  }
-
-  private _splice(region: CrashRegion, decode: CrashDecode): void {
-    this._replaceRegion(region, interleaveDecoded(region.raw, decode));
-  }
-
-  // Where *region* currently sits in the buffer; null when it isn't there.
-  //
-  // Verifies every line, not just the ends. A crash loop repeats one dump
-  // verbatim, so its regions share a first and last line; ends-only would
-  // accept a mispositioned splice in exactly the case that produces two
-  // regions to confuse.
-  private _positionOf(region: CrashRegion): number | null {
-    const { raw, startIndex } = region;
-    const lines = this.host.getLines();
-    const at = startIndex + this._indexShift;
-    // Out of bounds is ordinary: the cap drops from the front, so a region
-    // either survives whole or loses its head, and a flood can take one
-    // between its marker and its terminator.
-    if (at < 0 || at + raw.length > lines.length) return null;
-    if (raw.some((line, i) => lines[at + i] !== line)) {
-      // In bounds but not there. The cap moves every line by the same amount,
-      // so the only way here is a shift that has drifted from the buffer —
-      // which would otherwise read as decoding quietly ceasing to work.
-      console.warn("Crash region is not at its tracked position; not decorating it", at);
-      return null;
-    }
-    return at;
-  }
-
-  // Swap a region for *replacement*; false when it has churned out from under
-  // us and was left alone rather than decorated in the wrong place.
-  private _replaceRegion(region: CrashRegion, replacement: string[]): boolean {
-    const at = this._positionOf(region);
-    if (at === null) return false;
-    const next = [...this.host.getLines()];
-    next.splice(at, region.raw.length, ...replacement);
-    this._indexShift += replacement.length - region.raw.length;
-    this.host.setLines(next);
-    return true;
   }
 }

--- a/src/components/crash-decode-controller.ts
+++ b/src/components/crash-decode-controller.ts
@@ -94,21 +94,24 @@ export class CrashDecodeController {
   // region's position is computed. Fire-and-forget: the log keeps streaming
   // while the backend's child works, and a failure leaves the dump untouched.
   private _queueDecode(region: CrashRegion): void {
-    const epoch = this.host.buffer().epoch;
+    const buffer = this.host.buffer();
+    const epoch = buffer.epoch;
     this._chain = this._chain
       .then(async () => {
-        if (epoch !== this.host.buffer().epoch) return;
+        if (epoch !== buffer.epoch) return;
         const decode = await decodeCrashRegion(
           this.host.api(),
           this.host.configuration(),
           region.raw,
           this._cache
         );
-        if (decode === null || epoch !== this.host.buffer().epoch) return;
+        if (decode === null || epoch !== buffer.epoch) return;
         if (decode.staleBuild) this._staleBuild = true;
-        this.host
-          .buffer()
-          .replace(region.startIndex, region.raw, interleaveDecoded(region.raw, decode));
+        buffer.replace(
+          region.startIndex,
+          region.raw,
+          interleaveDecoded(region.raw, decode)
+        );
       })
       .catch((err) => console.warn("Inline backtrace decode failed", err));
   }

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -587,7 +587,7 @@ export class ESPHomeLogsDialog extends LitElement {
   }
 
   // Every line the buffer takes on, batched or direct, passes through here.
-  private _onLinesAppended(lines: string[], start: number): void {
+  private _onLinesAppended(lines: readonly string[], start: number): void {
     // One normalization per line, shared by the crash classifier and the
     // decode controller: this runs for every line of a stream that can push
     // thousands a second.

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -24,7 +24,7 @@ import { type CrashKind, classifyLine } from "../util/crash-detector.js";
 import { normalizeLogLine } from "../util/log-line.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { configurationStem, downloadAnsiText } from "../util/download-text.js";
-import { LineBatcher } from "../util/line-batcher.js";
+import { LogBuffer } from "../util/log-buffer.js";
 import { notifyError } from "../util/notify.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { CrashDecodeController } from "./crash-decode-controller.js";
@@ -118,37 +118,30 @@ export class ESPHomeLogsDialog extends LitElement {
   // failed -> `dead`); the "click Start to reconnect" recovery (#636).
   private _reconnect: (() => Promise<void>) | null = null;
 
-  @state()
-  _lines: string[] = [];
+  // The visible log, its cap, and the stream-position map inline decoding
+  // needs. Owns every line the dialog shows; the dialog holds no counters.
+  _log = new LogBuffer(this, {
+    maxLines: MAX_LOG_LINES,
+    onAppend: (lines, start) => this._onLinesAppended(lines, start),
+  });
 
-  // Latched once a crash marker flows through _appendCapped; drives the
+  // Latched once a crash marker flows through _onLinesAppended; drives the
   // "Report this crash" callout for the rest of the session. A live panic
   // upgrades a previous-boot report; nothing downgrades it.
   @state()
   private _crashKind: CrashKind | null = null;
 
-  // Inline crash decoding, including the absolute-position-onto-_lines map it
-  // needs. Read lazily so field-initialisation order doesn't matter.
+  // Read lazily so field-initialisation order doesn't matter.
   private _crashDecode = new CrashDecodeController({
     api: () => this._api,
     configuration: () => this.configuration,
-    getLines: () => this._lines,
-    setLines: (next) => this._setLinesCapped(next),
+    buffer: () => this._log,
   });
 
   // Rendered unconditionally in this dialog's template, so the query is
   // always resolved by the time the callout button can be clicked.
   @query("esphome-crash-report-dialog")
   private _crashReportDialog!: ESPHomeCrashReportDialog;
-
-  // rAF batch buffer: coalesce per-line appends into one render per frame
-  // instead of one per line (mirrors command-dialog, #348). A fast serial
-  // stream would otherwise schedule a full re-render of the whole list per
-  // line and freeze the tab. maxLines bounds the pending buffer while the
-  // tab is hidden; _appendCapped bounds the visible one.
-  private _lineBatch = new LineBatcher((batch) => this._appendCapped(batch), {
-    maxLines: MAX_LOG_LINES,
-  });
 
   @state()
   private _open = false;
@@ -215,10 +208,7 @@ export class ESPHomeLogsDialog extends LitElement {
    *  behaves the same way every time unless the user flips it this session. */
   private _beginSession(onBackToInstall?: () => void) {
     void this._teardownSession();
-    this._resetPendingLines();
-    this._lines = [];
-    this._crashDecode.reset();
-    this._crashKind = null;
+    this._clearLogs();
     this._expanded = false;
     this._showStates = true;
     this._backToInstallHandler = onBackToInstall ?? null;
@@ -267,8 +257,8 @@ export class ESPHomeLogsDialog extends LitElement {
     // an OTA session — don't tear that unrelated session down or flip it dead.
     if (!this._open || !isPassive(this._session)) return;
     void this._teardownSession();
-    this._resetPendingLines();
-    this._appendCapped([message]);
+    this._log.dropPending();
+    this._log.append([message]);
     this._session = { kind: "dead" };
   }
 
@@ -292,7 +282,7 @@ export class ESPHomeLogsDialog extends LitElement {
   private _teardownSession(): Promise<void> {
     // Drain any batched lines into the visible buffer before the session ends
     // so a stop/close doesn't drop what was buffered for the next frame.
-    this._flushPendingLines();
+    this._log.flush();
     const s = this._session;
     this._session = { kind: "idle" };
     if (s.kind === "serial") {
@@ -348,7 +338,7 @@ export class ESPHomeLogsDialog extends LitElement {
       >
         <span slot="header-suffix" class="source-chip" title=${source}>${source}</span>
         <esphome-process-terminal
-          .lines=${this._lines}
+          .lines=${this._log.lines}
           placeholder=${this._localize("dashboard.logs_placeholder")}
           ?light=${!this._darkMode}
           ?streaming=${streaming}
@@ -459,11 +449,11 @@ export class ESPHomeLogsDialog extends LitElement {
   // is missed) and hand it to the report dialog. The logs dialog stays open
   // underneath; the stream keeps running.
   private _openCrashReport = () => {
-    this._flushPendingLines();
+    this._log.flush();
     this._crashReportDialog.open(
       this.configuration,
       this.name,
-      [...this._lines],
+      [...this._log.lines],
       this._crashDecode.staleBuild
     );
   };
@@ -558,9 +548,9 @@ export class ESPHomeLogsDialog extends LitElement {
   }
 
   private _downloadLogs() {
-    this._flushPendingLines();
+    this._log.flush();
     const stem = configurationStem(this.configuration, "logs");
-    downloadAnsiText(this._lines, `${stem}-logs.txt`);
+    downloadAnsiText(this._log.lines, `${stem}-logs.txt`);
   }
 
   private _toggleExpanded() {
@@ -582,9 +572,10 @@ export class ESPHomeLogsDialog extends LitElement {
     this._startOtaStream();
   }
 
+  // Reset the log and everything derived from it. The single place that
+  // pairing lives, so a new caller can't reset the lines and forget the rest.
   private _clearLogs() {
-    this._resetPendingLines();
-    this._lines = [];
+    this._log.reset();
     this._crashDecode.reset();
     this._crashKind = null;
   }
@@ -592,21 +583,19 @@ export class ESPHomeLogsDialog extends LitElement {
   // Buffer a streamed line; flushed on the next animation frame. The serial
   // reader (streamSerialToDialog) and the OTA stream both feed through here.
   _enqueueLine(line: string): void {
-    this._lineBatch.enqueue(line);
+    this._log.enqueue(line);
   }
 
-  // Append to the visible buffer, trimmed to the newest MAX_LOG_LINES. The
-  // single place the cap is enforced, shared by the batched flush and the
-  // direct recovery-path append (setSerialOpenFailed).
-  private _appendCapped(lines: string[]): void {
-    this._setLinesCapped([...this._lines, ...lines]);
+  // Every line the buffer takes on, batched or direct, passes through here.
+  private _onLinesAppended(lines: string[], start: number): void {
     // One normalization per line, shared by the crash classifier and the
     // decode controller: this runs for every line of a stream that can push
     // thousands a second.
     let kind: CrashKind | null = null;
-    for (const line of lines) {
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
       const normalized = normalizeLogLine(line);
-      this._crashDecode.observe(line, normalized);
+      this._crashDecode.observe(line, normalized, start + i);
       const lineKind = classifyLine(normalized);
       if (lineKind === "live" || (lineKind && !kind)) kind = lineKind;
     }
@@ -621,27 +610,6 @@ export class ESPHomeLogsDialog extends LitElement {
           .catch((err) => console.warn("crash callout re-pin scroll failed", err));
       }
     }
-  }
-
-  // The single place MAX_LOG_LINES is enforced, so the cap policy and the
-  // index shift it causes can't drift apart.
-  private _setLinesCapped(next: string[]): void {
-    const overflow = Math.max(0, next.length - MAX_LOG_LINES);
-    if (overflow) this._crashDecode.noteTrimmed(overflow);
-    this._lines = overflow ? next.slice(-MAX_LOG_LINES) : next;
-  }
-
-  // Drain pending lines into ``_lines`` now, trimmed to the newest
-  // MAX_LOG_LINES. Called from teardown / clear / download so consumers
-  // don't race the rAF.
-  _flushPendingLines(): void {
-    this._lineBatch.flush();
-  }
-
-  // Drop the pending batch and cancel any scheduled flush. Paired with every
-  // ``_lines = []`` reset.
-  _resetPendingLines(): void {
-    this._lineBatch.reset();
   }
 
   // Reset Device button (Web Serial only). Pulses RTS (wired to EN on the
@@ -665,7 +633,7 @@ export class ESPHomeLogsDialog extends LitElement {
   /**
    * Flip ``_open`` false the moment the user initiates a close (X / Esc /
    * outside-click), before wa-dialog finishes its hide animation. Streamed
-   * lines push into ``_lines`` and each push re-renders with
+   * lines push into the buffer and each push re-renders with
    * ``?open=${this._open}``; were ``_open`` still true mid-animation the
    * re-asserted ``open=true`` could cancel wa-dialog's hide. No
    * ``preventDefault`` — the close proceeds and ``after-hide`` tears down.

--- a/src/components/process-terminal/process-terminal.ts
+++ b/src/components/process-terminal/process-terminal.ts
@@ -48,7 +48,7 @@ export type ProcessTerminalState = "running" | "success" | "error" | null;
 @customElement("esphome-process-terminal")
 export class ESPHomeProcessTerminal extends LitElement {
   /** Log lines for the built-in ansi-log (stream variant only). */
-  @property({ attribute: false }) lines: string[] = [];
+  @property({ attribute: false }) lines: readonly string[] = [];
 
   @property() placeholder = "";
 

--- a/src/util/download-text.ts
+++ b/src/util/download-text.ts
@@ -81,7 +81,7 @@ export function configurationStem(
  * — and tests — can assert on what would be saved without having to
  * re-parse the Blob.
  */
-export function downloadAnsiText(lines: string[], filename: string): string {
+export function downloadAnsiText(lines: readonly string[], filename: string): string {
   /* Some streams (notably the firmware-job follow path) deliver
      each line *with* its trailing ``\n`` / ``\r\n`` baked into the
      payload, and a few — esptool / PlatformIO progress lines that

--- a/src/util/line-batcher.ts
+++ b/src/util/line-batcher.ts
@@ -27,7 +27,8 @@ export class LineBatcher {
 
   enqueue(line: string): void {
     this._pending.push(line);
-    // Trim with headroom — one slice per maxLines pushes, not every push.
+    // Trim with headroom — for a positive maxLines that's one slice per
+    // maxLines pushes rather than every push; at 0 every push slices, to empty.
     // Counted from the front rather than as slice(-maxLines): a maxLines of 0
     // makes -maxLines a negative zero, which keeps the whole array, so nothing
     // would ever be dropped and a hidden tab would buffer without bound.

--- a/src/util/line-batcher.ts
+++ b/src/util/line-batcher.ts
@@ -28,8 +28,11 @@ export class LineBatcher {
   enqueue(line: string): void {
     this._pending.push(line);
     // Trim with headroom — one slice per maxLines pushes, not every push.
+    // Counted from the front rather than as slice(-maxLines): a maxLines of 0
+    // makes -maxLines a negative zero, which keeps the whole array, so nothing
+    // would ever be dropped and a hidden tab would buffer without bound.
     if (this._maxLines !== undefined && this._pending.length > 2 * this._maxLines) {
-      this._pending = this._pending.slice(-this._maxLines);
+      this._pending = this._pending.slice(this._pending.length - this._maxLines);
     }
     if (this._scheduled) return;
     this._scheduled = requestAnimationFrame(() => {

--- a/src/util/line-batcher.ts
+++ b/src/util/line-batcher.ts
@@ -11,7 +11,7 @@
  * ``maxLines`` bounds only the PENDING buffer — rAF doesn't fire while
  * the tab is hidden, so a flood can pile up unflushed. Capping the
  * merged visible buffer is the append callback's job (it owns that
- * array; see ``LogBuffer._setLines``).
+ * array; see ``LogBuffer``).
  */
 export class LineBatcher {
   private _pending: string[] = [];

--- a/src/util/line-batcher.ts
+++ b/src/util/line-batcher.ts
@@ -11,7 +11,7 @@
  * ``maxLines`` bounds only the PENDING buffer — rAF doesn't fire while
  * the tab is hidden, so a flood can pile up unflushed. Capping the
  * merged visible buffer is the append callback's job (it owns that
- * array; see logs-dialog's ``_appendCapped``).
+ * array; see ``LogBuffer._setLines``).
  */
 export class LineBatcher {
   private _pending: string[] = [];

--- a/src/util/log-buffer.ts
+++ b/src/util/log-buffer.ts
@@ -1,0 +1,137 @@
+import type { ReactiveControllerHost } from "lit";
+import { LineBatcher } from "./line-batcher.js";
+
+export interface LogBufferOptions {
+  /** Retain only the newest *maxLines*. Unbounded when omitted. */
+  maxLines?: number;
+  /** Called after each append with the batch and the stream position of its first line. */
+  onAppend?: (lines: string[], start: number) => void;
+}
+
+/**
+ * A streamed log's line array, its cap, and the map from a line's absolute
+ * stream position onto the index it currently sits at.
+ *
+ * Those three belong together: the cap drops lines off the front, which moves
+ * every line after it, so an owner that caps without owning the shift forces
+ * its consumers to be told about the trim and to apply it in the right order.
+ *
+ * Takes the host only to request an update — it deliberately doesn't
+ * ``addController``, because its lifetime is the buffer's, not the DOM's: a
+ * reset must be driven by whoever replaces the lines, never by a disconnect.
+ */
+export class LogBuffer {
+  private _lines: string[] = [];
+  private _batcher: LineBatcher;
+  // bufferIndex = streamPosition + _shift.
+  private _shift = 0;
+  private _streamCount = 0;
+  private _epoch = 0;
+  private readonly _maxLines?: number;
+  private readonly _onAppend?: (lines: string[], start: number) => void;
+
+  constructor(
+    private readonly _host: ReactiveControllerHost,
+    opts: LogBufferOptions = {}
+  ) {
+    this._maxLines = opts.maxLines;
+    this._onAppend = opts.onAppend;
+    this._batcher = new LineBatcher((batch) => this.append(batch), {
+      maxLines: opts.maxLines,
+    });
+  }
+
+  /** A fresh array per mutation, so a Lit ``.lines=`` binding sees the change. */
+  get lines(): string[] {
+    return this._lines;
+  }
+
+  /** Bumped by every reset, so work started against a replaced buffer can drop itself. */
+  get epoch(): number {
+    return this._epoch;
+  }
+
+  /** Buffer a line for the next animation frame. */
+  enqueue(line: string): void {
+    this._batcher.enqueue(line);
+  }
+
+  /** Append *lines* now; returns the stream position of ``lines[0]``. */
+  append(lines: string[]): number {
+    const start = this._streamCount;
+    this._streamCount += lines.length;
+    this._setLines([...this._lines, ...lines]);
+    this._onAppend?.(lines, start);
+    return start;
+  }
+
+  /** Drain buffered lines now, so consumers don't race the frame. */
+  flush(): void {
+    this._batcher.flush();
+  }
+
+  /** Drop what's buffered for the next frame, keeping the lines already shown. */
+  dropPending(): void {
+    this._batcher.reset();
+  }
+
+  /** Drop everything, including anything buffered for the next frame. */
+  reset(): void {
+    this._batcher.reset();
+    this._lines = [];
+    this._shift = 0;
+    this._streamCount = 0;
+    this._epoch += 1;
+    this._host.requestUpdate();
+  }
+
+  /**
+   * Where the run of lines at *streamPosition* currently sits; null when it
+   * isn't there.
+   *
+   * Verifies every line against *expected* rather than just the ends: a
+   * repeating stream (a crash loop dumping the same panic) produces runs that
+   * share a first and last line, so an ends-only check would accept a
+   * mispositioned write in exactly the case that produces two runs to confuse.
+   */
+  indexOf(streamPosition: number, expected: string[]): number | null {
+    const at = streamPosition + this._shift;
+    // Out of bounds is ordinary: the cap drops from the front, so a run either
+    // survives whole or loses its head to a flood.
+    if (at < 0 || at + expected.length > this._lines.length) return null;
+    if (expected.some((line, i) => this._lines[at + i] !== line)) {
+      // In bounds but not there. The cap moves every line by the same amount,
+      // so the only way here is a shift that has drifted from the buffer, which
+      // would otherwise read as the caller quietly ceasing to work.
+      console.warn("Log run is not at its tracked position; not replacing it", at);
+      return null;
+    }
+    return at;
+  }
+
+  /**
+   * Swap the run at *streamPosition* for *replacement*.
+   *
+   * False when the run has churned out from under the caller and was left alone
+   * rather than written in the wrong place.
+   */
+  replace(streamPosition: number, expected: string[], replacement: string[]): boolean {
+    const at = this.indexOf(streamPosition, expected);
+    if (at === null) return false;
+    const next = [...this._lines];
+    next.splice(at, expected.length, ...replacement);
+    // Everything after `at` moves; nothing before it does. Callers only ever
+    // rewrite the newest run, so no live position precedes this one.
+    this._shift += replacement.length - expected.length;
+    this._setLines(next);
+    return true;
+  }
+
+  private _setLines(next: string[]): void {
+    const max = this._maxLines;
+    const overflow = max === undefined ? 0 : Math.max(0, next.length - max);
+    if (overflow) this._shift -= overflow;
+    this._lines = overflow ? next.slice(-max!) : next;
+    this._host.requestUpdate();
+  }
+}

--- a/src/util/log-buffer.ts
+++ b/src/util/log-buffer.ts
@@ -112,6 +112,10 @@ export class LogBuffer {
   /**
    * Swap the run at *streamPosition* for *replacement*.
    *
+   * Only the newest tracked run may be replaced: the position map is a single
+   * shift, so rewriting an earlier run would silently move every position that
+   * precedes it.
+   *
    * False when the run has churned out from under the caller and was left alone
    * rather than written in the wrong place.
    */
@@ -120,8 +124,6 @@ export class LogBuffer {
     if (at === null) return false;
     const next = [...this._lines];
     next.splice(at, expected.length, ...replacement);
-    // Everything after `at` moves; nothing before it does. Callers only ever
-    // rewrite the newest run, so no live position precedes this one.
     this._shift += replacement.length - expected.length;
     this._setLines(next);
     return true;
@@ -129,9 +131,16 @@ export class LogBuffer {
 
   private _setLines(next: string[]): void {
     const max = this._maxLines;
-    const overflow = max === undefined ? 0 : Math.max(0, next.length - max);
-    if (overflow) this._shift -= overflow;
-    this._lines = overflow ? next.slice(-max!) : next;
+    if (max === undefined || next.length <= max) {
+      this._lines = next;
+      this._host.requestUpdate();
+      return;
+    }
+    // Counted from the front rather than as slice(-max): a maxLines of 0 makes
+    // -max a negative zero, which slices the whole array while the shift below
+    // says every line went.
+    this._shift -= next.length - max;
+    this._lines = next.slice(next.length - max);
     this._host.requestUpdate();
   }
 }

--- a/src/util/log-buffer.ts
+++ b/src/util/log-buffer.ts
@@ -5,7 +5,7 @@ export interface LogBufferOptions {
   /** Retain only the newest *maxLines*. Unbounded when omitted. */
   maxLines?: number;
   /** Called after each append with the batch and the stream position of its first line. */
-  onAppend?: (lines: string[], start: number) => void;
+  onAppend?: (lines: readonly string[], start: number) => void;
 }
 
 /**
@@ -28,7 +28,7 @@ export class LogBuffer {
   private _streamCount = 0;
   private _epoch = 0;
   private readonly _maxLines?: number;
-  private readonly _onAppend?: (lines: string[], start: number) => void;
+  private readonly _onAppend?: (lines: readonly string[], start: number) => void;
 
   constructor(
     private readonly _host: ReactiveControllerHost,
@@ -41,8 +41,10 @@ export class LogBuffer {
     });
   }
 
-  /** A fresh array per mutation, so a Lit ``.lines=`` binding sees the change. */
-  get lines(): string[] {
+  /** A fresh array per mutation, so a Lit ``.lines=`` binding sees the change.
+   *  Readonly: the shift and the cap are only right if every write comes
+   *  through this class. */
+  get lines(): readonly string[] {
     return this._lines;
   }
 
@@ -57,7 +59,7 @@ export class LogBuffer {
   }
 
   /** Append *lines* now; returns the stream position of ``lines[0]``. */
-  append(lines: string[]): number {
+  append(lines: readonly string[]): number {
     const start = this._streamCount;
     this._streamCount += lines.length;
     this._setLines([...this._lines, ...lines]);
@@ -94,7 +96,7 @@ export class LogBuffer {
    * share a first and last line, so an ends-only check would accept a
    * mispositioned write in exactly the case that produces two runs to confuse.
    */
-  indexOf(streamPosition: number, expected: string[]): number | null {
+  indexOf(streamPosition: number, expected: readonly string[]): number | null {
     const at = streamPosition + this._shift;
     // Out of bounds is ordinary: the cap drops from the front, so a run either
     // survives whole or loses its head to a flood.
@@ -103,7 +105,7 @@ export class LogBuffer {
       // In bounds but not there. The cap moves every line by the same amount,
       // so the only way here is a shift that has drifted from the buffer, which
       // would otherwise read as the caller quietly ceasing to work.
-      console.warn("Log run is not at its tracked position; not replacing it", at);
+      console.warn("Log run is not at its tracked position; refusing to resolve it", at);
       return null;
     }
     return at;
@@ -112,14 +114,19 @@ export class LogBuffer {
   /**
    * Swap the run at *streamPosition* for *replacement*.
    *
-   * Only the newest tracked run may be replaced: the position map is a single
-   * shift, so rewriting an earlier run would silently move every position that
-   * precedes it.
+   * Only the newest tracked run may be replaced. The position map is a single
+   * shift, and a length-changing rewrite adds the delta to all of it, which is
+   * only true of the positions after *streamPosition*: everything up to and
+   * including it stops resolving from then on.
    *
    * False when the run has churned out from under the caller and was left alone
    * rather than written in the wrong place.
    */
-  replace(streamPosition: number, expected: string[], replacement: string[]): boolean {
+  replace(
+    streamPosition: number,
+    expected: readonly string[],
+    replacement: readonly string[]
+  ): boolean {
     const at = this.indexOf(streamPosition, expected);
     if (at === null) return false;
     const next = [...this._lines];

--- a/src/util/log-chunks.ts
+++ b/src/util/log-chunks.ts
@@ -19,7 +19,7 @@ export function cleanLine(line: string): string {
  * flag; without that, the next real tick pops a non-progress line
  * above the bar instead of starting fresh (#840).
  */
-export function chunksToVisualLines(chunks: string[]): string[] {
+export function chunksToVisualLines(chunks: readonly string[]): string[] {
   const visual: string[] = [];
   let prevEndedInCR = false;
   for (const chunk of chunks) {

--- a/test/components/logs-dialog-batching.test.ts
+++ b/test/components/logs-dialog-batching.test.ts
@@ -35,11 +35,11 @@ describe("logs-dialog line batching + cap", () => {
   it("coalesces many enqueues into a single flush per frame", () => {
     const d = new ESPHomeLogsDialog();
     for (let i = 0; i < 100; i++) d._enqueueLine(`line ${i}`);
-    expect(d._lines).toHaveLength(0); // nothing visible until the frame fires
+    expect(d._log.lines).toHaveLength(0); // nothing visible until the frame fires
     expect(raf).toHaveBeenCalledTimes(1); // one frame for the whole burst
     fireFrame();
-    expect(d._lines).toHaveLength(100);
-    expect(d._lines[0]).toBe("line 0");
+    expect(d._log.lines).toHaveLength(100);
+    expect(d._log.lines[0]).toBe("line 0");
   });
 
   it("caps the buffer to the newest 5000 lines", () => {
@@ -47,31 +47,28 @@ describe("logs-dialog line batching + cap", () => {
     const total = 5005;
     for (let i = 0; i < total; i++) d._enqueueLine(String(i));
     fireFrame();
-    expect(d._lines).toHaveLength(5000);
-    expect(d._lines[0]).toBe("5"); // oldest five dropped
-    expect(d._lines[d._lines.length - 1]).toBe(String(total - 1));
+    expect(d._log.lines).toHaveLength(5000);
+    expect(d._log.lines[0]).toBe("5"); // oldest five dropped
+    expect(d._log.lines[d._log.lines.length - 1]).toBe(String(total - 1));
   });
 
-  it("bounds the pending buffer when frames never fire (hidden tab)", () => {
-    // rAF is captured but never invoked, simulating a backgrounded tab; the
-    // pending buffer must not grow without bound during a flood.
+  it("holds a flood until the frame, then keeps the newest (hidden tab)", () => {
+    // rAF is captured but never invoked, simulating a backgrounded tab. That
+    // the pending buffer stays bounded through this is LogBuffer's contract
+    // (see test/util/log-buffer.test.ts); here it's the cap reaching it at all.
     const d = new ESPHomeLogsDialog();
     for (let i = 0; i < 12000; i++) d._enqueueLine(String(i));
-    const pending = (d as unknown as { _lineBatch: { _pending: string[] } })._lineBatch
-      ._pending;
-    expect(d._lines).toHaveLength(0); // nothing flushed without a frame
-    expect(pending.length).toBeLessThanOrEqual(10000); // 2 * MAX_LOG_LINES
-    expect(pending[pending.length - 1]).toBe("11999"); // newest retained
+    expect(d._log.lines).toHaveLength(0); // nothing flushed without a frame
     fireFrame();
-    expect(d._lines).toHaveLength(5000);
-    expect(d._lines[d._lines.length - 1]).toBe("11999");
+    expect(d._log.lines).toHaveLength(5000);
+    expect(d._log.lines[d._log.lines.length - 1]).toBe("11999");
   });
 
   it("caps the buffer on the recovery-path append (setSerialOpenFailed)", () => {
     const d = new ESPHomeLogsDialog();
     for (let i = 0; i < 5000; i++) d._enqueueLine(String(i));
     fireFrame();
-    expect(d._lines).toHaveLength(5000);
+    expect(d._log.lines).toHaveLength(5000);
     // Drive the reconnect-failure append with the dialog open + a passive
     // session so the guard passes; it must stay capped, not grow to 5001.
     const internal = d as unknown as {
@@ -81,16 +78,16 @@ describe("logs-dialog line batching + cap", () => {
     internal._open = true;
     internal._session = { kind: "reconnecting", paused: false };
     d.setSerialOpenFailed("reopen failed");
-    expect(d._lines).toHaveLength(5000);
-    expect(d._lines[d._lines.length - 1]).toBe("reopen failed");
+    expect(d._log.lines).toHaveLength(5000);
+    expect(d._log.lines[d._log.lines.length - 1]).toBe("reopen failed");
   });
 
-  it("resetPendingLines drops the batch and a late frame can't resurrect it", () => {
+  it("dropPending drops the batch and a late frame can't resurrect it", () => {
     const d = new ESPHomeLogsDialog();
     d._enqueueLine("x");
-    d._resetPendingLines();
+    d._log.dropPending();
     expect(caf).toHaveBeenCalledWith(1);
     fireFrame();
-    expect(d._lines).toHaveLength(0);
+    expect(d._log.lines).toHaveLength(0);
   });
 });

--- a/test/components/logs-dialog-crash.test.ts
+++ b/test/components/logs-dialog-crash.test.ts
@@ -10,8 +10,7 @@ import { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
 import { CRASH_BANNER_LINE as CRASH_LINE } from "../_crash-lines.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const append = (el: ESPHomeLogsDialog, lines: string[]) =>
-  (el as any)._appendCapped(lines);
+const append = (el: ESPHomeLogsDialog, lines: string[]) => (el as any)._log.append(lines);
 
 describe("logs-dialog crash callout", () => {
   let el: ESPHomeLogsDialog;

--- a/test/components/logs-dialog-decode.test.ts
+++ b/test/components/logs-dialog-decode.test.ts
@@ -11,9 +11,8 @@ import { STALE_BUILD_LOG_LINE } from "../../src/util/crash-decode.js";
 import { stripAnsi } from "../../src/util/ansi-escapes.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const append = (el: ESPHomeLogsDialog, lines: string[]) =>
-  (el as any)._appendCapped(lines);
-const lines = (el: ESPHomeLogsDialog): string[] => (el as any)._lines;
+const append = (el: ESPHomeLogsDialog, lines: string[]) => (el as any)._log.append(lines);
+const lines = (el: ESPHomeLogsDialog): string[] => (el as any)._log.lines;
 
 // A Web Serial crash: no decoder attached, so no Decoded lines arrive.
 const CRASH = [
@@ -232,7 +231,7 @@ describe("logs-dialog inline backtrace decode", () => {
       await inFlight;
       append(el, ["Guru Meditation Error: crash", "PC: 0x400d2222", "Rebooting..."]);
       // Point the first region's splice at the second one.
-      (el as any)._crashDecode._indexShift = 3;
+      (el as any)._log._shift = 3;
       land(null);
       await flush();
 

--- a/test/components/logs-dialog.test.ts
+++ b/test/components/logs-dialog.test.ts
@@ -375,7 +375,7 @@ describe("logs-dialog passive Web Serial session (#526)", () => {
     expect(session(el).kind).toBe("reconnecting");
     el.abortSerialReconnect();
     expect(session(el).kind).toBe("dead");
-    expect((el as any)._lines).toEqual([]); // a cancel isn't a failure
+    expect((el as any)._log.lines).toEqual([]); // a cancel isn't a failure
     expect(toastError).not.toHaveBeenCalled();
   });
 

--- a/test/util/line-batcher.test.ts
+++ b/test/util/line-batcher.test.ts
@@ -80,6 +80,17 @@ describe("LineBatcher", () => {
     expect(lines).toEqual(["a", "b", "c"]);
   });
 
+  it("buffers nothing at a maxLines of 0, rather than trimming by a negative zero", () => {
+    // slice(-0) is slice(0), which keeps everything: the trim would run on
+    // every push and drop nothing, so a hidden tab would buffer without bound.
+    withManualRaf();
+    const append = vi.fn();
+    const batcher = new LineBatcher(append, { maxLines: 0 });
+    for (let i = 0; i < 500; i++) batcher.enqueue(String(i));
+    batcher.flush();
+    expect(append).not.toHaveBeenCalled();
+  });
+
   it("maxLines bounds the pending buffer when frames never fire (hidden tab)", () => {
     const raf = withManualRaf();
     const append = vi.fn();

--- a/test/util/log-buffer.test.ts
+++ b/test/util/log-buffer.test.ts
@@ -230,6 +230,24 @@ describe("LogBuffer", () => {
       expect(buf.indexOf(2, ["c"])).toBe(3);
     });
 
+    it("costs every position up to the one it rewrote, which is why only the newest may be", () => {
+      // The documented precondition, demonstrated. The single shift is only
+      // true of the positions after the rewrite, so an out-of-order one leaves
+      // the earlier positions resolving nowhere rather than resolving wrong.
+      const buf = new LogBuffer(new FakeHost());
+      buf.append(["a", "b", "c", "d"]);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        buf.replace(2, ["c"], ["c1", "c2", "c3"]); // not the newest; changes length
+        expect(buf.lines).toEqual(["a", "b", "c1", "c2", "c3", "d"]);
+        expect(buf.indexOf(0, ["a"])).toBeNull(); // before it: lost
+        expect(buf.indexOf(2, ["c1"])).toBeNull(); // itself: lost
+        expect(buf.indexOf(3, ["d"])).toBe(5); // after it: still right
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
     it("leaves the buffer alone when the run isn't there", () => {
       const buf = new LogBuffer(new FakeHost());
       buf.append(["a", "b"]);

--- a/test/util/log-buffer.test.ts
+++ b/test/util/log-buffer.test.ts
@@ -78,6 +78,15 @@ describe("LogBuffer", () => {
     expect(buf.lines[99]).toBe("104");
   });
 
+  it("retains nothing at a maxLines of 0, rather than trimming by a negative zero", () => {
+    // slice(-0) is slice(0), which keeps the whole array while the shift says
+    // every line went — the buffer would look full and resolve no position.
+    const buf = new LogBuffer(new FakeHost(), { maxLines: 0 });
+    buf.append(["a", "b"]);
+    expect(buf.lines).toEqual([]);
+    expect(buf.indexOf(0, ["a"])).toBeNull();
+  });
+
   it("moves tracked positions by what the cap trimmed", () => {
     const buf = new LogBuffer(new FakeHost(), { maxLines: 100 });
     for (let i = 0; i < 100; i++) buf.append([String(i)]);
@@ -97,8 +106,10 @@ describe("LogBuffer", () => {
     expect(buf.lines).toHaveLength(0); // nothing painted without a frame
     raf.fire();
     const batch = onAppend.mock.calls[0][0] as string[];
-    expect(batch).toHaveLength(149); // not 250: the pending buffer was trimmed
-    expect(batch[batch.length - 1]).toBe("249");
+    // Bounded, not 250. The exact figure is the batcher's headroom heuristic
+    // and free to change; that it stays bounded is the contract.
+    expect(batch.length).toBeLessThanOrEqual(200); // 2 * maxLines
+    expect(batch[batch.length - 1]).toBe("249"); // newest retained
   });
 
   it("flush drains buffered lines immediately", () => {

--- a/test/util/log-buffer.test.ts
+++ b/test/util/log-buffer.test.ts
@@ -1,0 +1,253 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the LogBuffer contract: the cap trims from the front and moves
+ * tracked positions with it, replace verifies before writing, and reset
+ * bumps the epoch.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FakeHost } from "../_fake-host.js";
+import { LogBuffer } from "../../src/util/log-buffer.js";
+
+function withManualRaf() {
+  const frames: FrameRequestCallback[] = [];
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    frames.push(cb);
+    return frames.length;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => {});
+  return {
+    frames,
+    fire: () => {
+      const pending = frames.splice(0);
+      for (const cb of pending) cb(0);
+    },
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("LogBuffer", () => {
+  it("appends and reports the stream position of the batch", () => {
+    const buf = new LogBuffer(new FakeHost());
+    expect(buf.append(["a", "b"])).toBe(0);
+    expect(buf.append(["c"])).toBe(2);
+    expect(buf.lines).toEqual(["a", "b", "c"]);
+  });
+
+  it("hands each batch to onAppend with its starting position", () => {
+    const onAppend = vi.fn();
+    const buf = new LogBuffer(new FakeHost(), { onAppend });
+    buf.append(["a", "b"]);
+    buf.append(["c"]);
+    expect(onAppend.mock.calls).toEqual([
+      [["a", "b"], 0],
+      [["c"], 2],
+    ]);
+  });
+
+  it("requests a host update per mutation so Lit repaints", () => {
+    const host = new FakeHost();
+    const buf = new LogBuffer(host);
+    buf.append(["a"]);
+    expect(host.updates).toBe(1);
+    buf.reset();
+    expect(host.updates).toBe(2);
+  });
+
+  it("hands out a fresh array per mutation, so a Lit binding sees the change", () => {
+    const buf = new LogBuffer(new FakeHost());
+    buf.append(["a"]);
+    const first = buf.lines;
+    buf.append(["b"]);
+    expect(buf.lines).not.toBe(first);
+    expect(first).toEqual(["a"]); // the old identity wasn't mutated under it
+  });
+
+  it("is unbounded without maxLines", () => {
+    const buf = new LogBuffer(new FakeHost());
+    for (let i = 0; i < 300; i++) buf.append([String(i)]);
+    expect(buf.lines).toHaveLength(300);
+  });
+
+  it("caps to the newest maxLines, dropping from the front", () => {
+    const buf = new LogBuffer(new FakeHost(), { maxLines: 100 });
+    for (let i = 0; i < 105; i++) buf.append([String(i)]);
+    expect(buf.lines).toHaveLength(100);
+    expect(buf.lines[0]).toBe("5");
+    expect(buf.lines[99]).toBe("104");
+  });
+
+  it("moves tracked positions by what the cap trimmed", () => {
+    const buf = new LogBuffer(new FakeHost(), { maxLines: 100 });
+    for (let i = 0; i < 100; i++) buf.append([String(i)]);
+    expect(buf.indexOf(40, ["40"])).toBe(40);
+    buf.append(["100", "101", "102", "103", "104"]); // trims the oldest five
+    expect(buf.indexOf(40, ["40"])).toBe(35);
+  });
+
+  it("maxLines bounds the pending buffer when frames never fire (hidden tab)", () => {
+    // The batcher trims its own pending buffer at 2 * maxLines, so a flood
+    // into a backgrounded tab can't grow without bound. Observed through the
+    // batch that lands, not the batcher's internals.
+    const raf = withManualRaf();
+    const onAppend = vi.fn();
+    const buf = new LogBuffer(new FakeHost(), { maxLines: 100, onAppend });
+    for (let i = 0; i < 250; i++) buf.enqueue(String(i));
+    expect(buf.lines).toHaveLength(0); // nothing painted without a frame
+    raf.fire();
+    const batch = onAppend.mock.calls[0][0] as string[];
+    expect(batch).toHaveLength(149); // not 250: the pending buffer was trimmed
+    expect(batch[batch.length - 1]).toBe("249");
+  });
+
+  it("flush drains buffered lines immediately", () => {
+    withManualRaf();
+    const buf = new LogBuffer(new FakeHost());
+    buf.enqueue("a");
+    expect(buf.lines).toHaveLength(0);
+    buf.flush();
+    expect(buf.lines).toEqual(["a"]);
+  });
+
+  it("dropPending drops the batch but keeps the lines already shown", () => {
+    const raf = withManualRaf();
+    const buf = new LogBuffer(new FakeHost());
+    buf.append(["shown"]);
+    buf.enqueue("buffered");
+    buf.dropPending();
+    raf.fire();
+    expect(buf.lines).toEqual(["shown"]);
+  });
+
+  it("reset drops the lines, the pending batch, and the position map", () => {
+    const raf = withManualRaf();
+    const buf = new LogBuffer(new FakeHost());
+    buf.append(["a", "b"]);
+    buf.enqueue("c");
+    buf.reset();
+    raf.fire();
+    expect(buf.lines).toEqual([]);
+    // Stream positions restart, so the next line is position 0 again.
+    expect(buf.append(["fresh"])).toBe(0);
+    expect(buf.indexOf(0, ["fresh"])).toBe(0);
+  });
+
+  it("reset bumps the epoch so work in flight can drop itself", () => {
+    const buf = new LogBuffer(new FakeHost());
+    const before = buf.epoch;
+    buf.reset();
+    expect(buf.epoch).not.toBe(before);
+  });
+
+  describe("indexOf", () => {
+    it("finds a run at its tracked position", () => {
+      const buf = new LogBuffer(new FakeHost());
+      buf.append(["a", "b", "c"]);
+      expect(buf.indexOf(1, ["b", "c"])).toBe(1);
+    });
+
+    it("returns null for a run whose head the cap dropped", () => {
+      const buf = new LogBuffer(new FakeHost(), { maxLines: 3 });
+      buf.append(["a", "b"]);
+      buf.append(["c", "d", "e"]); // "a"/"b" trimmed out
+      expect(buf.indexOf(0, ["a", "b"])).toBeNull();
+    });
+
+    it("returns null for a run that runs past the end", () => {
+      const buf = new LogBuffer(new FakeHost());
+      buf.append(["a"]);
+      expect(buf.indexOf(0, ["a", "b"])).toBeNull();
+    });
+
+    it("verifies every line, not just the ends", () => {
+      // A crash loop repeats one dump verbatim, so two runs share a first and
+      // last line; an ends-only check would accept the wrong one.
+      const buf = new LogBuffer(new FakeHost());
+      buf.append(["head", "MIDDLE", "tail"]);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        expect(buf.indexOf(0, ["head", "other", "tail"])).toBeNull();
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it("says so when a run is in bounds but not there", () => {
+      const buf = new LogBuffer(new FakeHost());
+      buf.append(["a", "b"]);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        expect(buf.indexOf(0, ["x", "y"])).toBeNull();
+        expect(warn).toHaveBeenCalledWith(
+          expect.stringContaining("not at its tracked position"),
+          0
+        );
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it("stays quiet for the ordinary out-of-bounds case", () => {
+      const buf = new LogBuffer(new FakeHost(), { maxLines: 2 });
+      buf.append(["a", "b"]);
+      buf.append(["c", "d"]);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        expect(buf.indexOf(0, ["a", "b"])).toBeNull();
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
+    });
+  });
+
+  describe("replace", () => {
+    it("swaps a run and reports success", () => {
+      const buf = new LogBuffer(new FakeHost());
+      buf.append(["a", "b", "c"]);
+      expect(buf.replace(1, ["b"], ["B1", "B2"])).toBe(true);
+      expect(buf.lines).toEqual(["a", "B1", "B2", "c"]);
+    });
+
+    it("moves later positions by the lines it inserted", () => {
+      const buf = new LogBuffer(new FakeHost());
+      buf.append(["a", "b"]);
+      buf.replace(0, ["a"], ["A1", "A2"]); // one line becomes two
+      buf.append(["c"]);
+      expect(buf.lines).toEqual(["A1", "A2", "b", "c"]);
+      expect(buf.indexOf(2, ["c"])).toBe(3);
+    });
+
+    it("leaves the buffer alone when the run isn't there", () => {
+      const buf = new LogBuffer(new FakeHost());
+      buf.append(["a", "b"]);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        expect(buf.replace(0, ["x", "y"], ["z"])).toBe(false);
+      } finally {
+        warn.mockRestore();
+      }
+      expect(buf.lines).toEqual(["a", "b"]);
+    });
+
+    it("applies the cap to what it inserted", () => {
+      const buf = new LogBuffer(new FakeHost(), { maxLines: 3 });
+      buf.append(["a", "b", "c"]);
+      // Expanding "c" into three lines overflows the cap by two.
+      expect(buf.replace(2, ["c"], ["c1", "c2", "c3"])).toBe(true);
+      expect(buf.lines).toEqual(["c1", "c2", "c3"]);
+    });
+
+    it("keeps positions right when a replace overflows the cap", () => {
+      const buf = new LogBuffer(new FakeHost(), { maxLines: 4 });
+      buf.append(["a", "b", "c"]);
+      buf.replace(2, ["c"], ["c1", "c2", "c3"]); // -> a,b,c1,c2,c3 -> caps to b,c1,c2,c3
+      expect(buf.lines).toEqual(["b", "c1", "c2", "c3"]);
+      // "d" is the 4th line of the stream, and the append trims "b" to fit.
+      buf.append(["d"]);
+      expect(buf.lines).toEqual(["c1", "c2", "c3", "d"]);
+      expect(buf.indexOf(3, ["d"])).toBe(3);
+    });
+  });
+});

--- a/test/util/log-buffer.test.ts
+++ b/test/util/log-buffer.test.ts
@@ -87,6 +87,19 @@ describe("LogBuffer", () => {
     expect(buf.indexOf(0, ["a"])).toBeNull();
   });
 
+  it("buffers nothing at a maxLines of 0 either, so a hidden tab can't grow it", () => {
+    // maxLines is forwarded to the batcher, which hit the same negative zero:
+    // rAF doesn't fire while the tab is hidden, so an untrimmed pending buffer
+    // grows for as long as the device talks.
+    const raf = withManualRaf();
+    const onAppend = vi.fn();
+    const buf = new LogBuffer(new FakeHost(), { maxLines: 0, onAppend });
+    for (let i = 0; i < 500; i++) buf.enqueue(String(i));
+    raf.fire();
+    expect(buf.lines).toEqual([]);
+    expect(onAppend).not.toHaveBeenCalled();
+  });
+
   it("moves tracked positions by what the cap trimmed", () => {
     const buf = new LogBuffer(new FakeHost(), { maxLines: 100 });
     for (let i = 0; i < 100; i++) buf.append([String(i)]);


### PR DESCRIPTION
# What does this implement/fix?

First of three for #1271, which asks for an owner for the log buffer. That issue was filed against the pre-#1261 file (802 lines) and its state table has since aged: #1261 already moved `_streamIndex`, `_indexShift`, `_bufferEpoch`, and `_replaceRegion` off the element and into `CrashDecodeController`. The file is 703 lines today.

The issue's actual complaint survived that move, and #1261 arguably sharpened it. Three things are one concern (the cap drops lines off the front, which moves every line after it), and they ended up in two files calling back into each other:

```
CrashDecodeController._replaceRegion
  this._indexShift += replacement.length - region.raw.length;
  this.host.setLines(next);
    -> logs-dialog._setLinesCapped
         this._crashDecode.noteTrimmed(overflow);
           -> this._indexShift -= count;
```

Two files mutating one counter, in an order that is correct today with nothing enforcing it.

`LogBuffer` (`src/util/log-buffer.ts`) owns the lines, the cap, the batching, the stream index, the shift, and an epoch. `noteTrimmed` and the re-entrancy are gone, and `CrashDecodeController` drops to a consumer: recognise a crash, colour it, ask the buffer to rewrite it. The reset that had to be hand-paired across `_beginSession` and `_clearLogs` (the `_resetPendingLines` comment reading "Paired with every `_lines = []` reset" was, as the issue put it, a comment doing a type's job) is now one method.

`MAX_LOG_LINES` stays logs-dialog's policy and is passed as `maxLines`; the buffer is unbounded without it, which is what lets `command-dialog` and `firmware-install-dialog` adopt it in the follow-up.

Sizes: `logs-dialog.ts` 703 -> 670, `crash-decode-controller.ts` 172 -> 115, new `log-buffer.ts` 137. 670 is still over the 500-600 cap; PR 3 in this series carries the session state machine out and lands it around 485.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder-frontend/issues/1271

## Notes for review

- `LogBuffer` takes the host only to call `requestUpdate()`. It deliberately does not `addController` or implement `ReactiveController`, because it has no lifecycle hooks and its reset belongs to whoever replaces the lines, never to a DOM disconnect. That is the same reasoning `crash-decode-controller.ts` already documents; the `src/util/` controllers are the contrasting shape.
- `dropPending()` exists because `setSerialOpenFailed` drops the in-flight batch but keeps the lines already shown, so `reset()` would be wrong there.
- New `test/util/log-buffer.test.ts` (23 tests). It picks up the pending-buffer bound that `logs-dialog-batching.test.ts` used to assert by reaching two levels into `_lineBatch._pending`; that claim is not observable from the dialog's visible buffer (bounded and unbounded both end at 5000 lines with the same last line), so it moves to the level where it can be observed through the batch that lands, the way `line-batcher.test.ts` already does it.
- The `_indexShift` fault injection in `logs-dialog-decode.test.ts` now corrupts the buffer's shift instead. Verified it still bites: removing the verify branch fails that test.
- No separate `crash-decode-controller.test.ts`. The controller is genuinely unit-testable now, but the 16 tests in `logs-dialog-decode.test.ts` already cover it end to end and a parallel suite would be duplicate coverage.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
