### PR TITLE
Adopt LogBuffer in the command and install dialogs

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -37,7 +37,7 @@ import { espHomeStyles } from "../styles/shared.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { configurationStem, downloadAnsiText } from "../util/download-text.js";
 import { LightDismissController } from "../util/light-dismiss-controller.js";
-import { LineBatcher } from "../util/line-batcher.js";
+import { LogBuffer } from "../util/log-buffer.js";
 import { dispatchShowLogsAfterInstall } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { RunTimerController } from "../util/run-timer-controller.js";
@@ -143,14 +143,12 @@ export class ESPHomeCommandDialog extends LitElement {
   @state() _open = false;
   @state() _commandType: CommandType = "validate";
   @state() _state: CommandState | null = null;
-  @state() _lines: string[] = [];
   @state() _statusMessage = "";
 
-  // rAF batch buffer for streamed output — coalesce per-line writes
-  // into one render per frame instead of one per line (#348).
-  private _lineBatch = new LineBatcher((batch) => {
-    this._lines = [...this._lines, ...batch];
-  });
+  // The streamed output, batched into one render per frame instead of one
+  // per line (#348). Uncapped: a compile log is finite and users scroll back
+  // through it.
+  _log = new LogBuffer(this);
 
   // Distinguishes user-stopped from backend-failed. Both flip _state to "error"
   // but only real failures get the reset-build-env hint.
@@ -294,8 +292,7 @@ export class ESPHomeCommandDialog extends LitElement {
     this._port = options?.port ?? "OTA";
     this._bootloader = options?.bootloader ?? false;
     this._state = null;
-    this._lines = [];
-    this._resetPendingLines();
+    this._log.reset();
     this._statusMessage = "";
     this._jobId = "";
     this._timerJobId = "";
@@ -354,7 +351,7 @@ export class ESPHomeCommandDialog extends LitElement {
     this._closeTimerDetail();
     // Cancel any prior follow before starting a new one — without this,
     // every reopen layered fresh streams while previous ones still pumped
-    // onOutput into _lines (lines duplicated per leaked subscription).
+    // onOutput into the buffer (lines duplicated per leaked subscription).
     void detachStream(this);
     this._open = true;
     this._resetAnsiLogScroll();
@@ -477,26 +474,13 @@ export class ESPHomeCommandDialog extends LitElement {
   // Buffer a streamed line; flushed on the next animation frame.
   _enqueueLine(line: string): void {
     this._timer.noteLine(line);
-    this._lineBatch.enqueue(line);
-  }
-
-  // Drain pending lines into ``_lines`` now. Called from terminal
-  // callbacks, detachStream, and _downloadOutput so consumers
-  // don't race the rAF.
-  _flushPendingLines(): void {
-    this._lineBatch.flush();
-  }
-
-  // Drop the pending batch and cancel any scheduled flush. Paired
-  // with every ``_lines = []`` reset.
-  _resetPendingLines(): void {
-    this._lineBatch.reset();
+    this._log.enqueue(line);
   }
 
   _downloadOutput = () => {
-    this._flushPendingLines();
+    this._log.flush();
     const stem = configurationStem(this.configuration, "output");
-    downloadAnsiText(this._lines, `${stem}-${this._commandType}.txt`);
+    downloadAnsiText(this._log.lines, `${stem}-${this._commandType}.txt`);
   };
 
   _start = () => startCommand(this);
@@ -525,7 +509,7 @@ export class ESPHomeCommandDialog extends LitElement {
         @after-hide=${this._onDialogHide}
       >
         <esphome-process-terminal
-          .lines=${this._lines}
+          .lines=${this._log.lines}
           ?light=${!this._darkMode}
           ?streaming=${this._state === "running" && !showRunTimer(this)}
           .state=${this._state}

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -53,8 +53,8 @@ export async function detachStream(host: ESPHomeCommandDialog): Promise<void> {
   host._streamId = "";
   // Flush the rAF batch so teardowns that keep the buffer visible
   // (close, hand-off, force-local) paint every line that arrived.
-  // Restart paths follow up with ``_resetPendingLines``.
-  host._flushPendingLines();
+  // Restart paths follow up with a reset.
+  host._log.flush();
   try {
     await host._api.stopStream(streamId);
   } catch {
@@ -67,8 +67,7 @@ export async function detachStream(host: ESPHomeCommandDialog): Promise<void> {
 // Shared by every entry point that reuses the singleton dialog for a new run.
 export function resetRunState(host: ESPHomeCommandDialog): void {
   host._state = "running";
-  host._lines = [];
-  host._resetPendingLines();
+  host._log.reset();
   host._statusMessage = "";
   host._userStopped = false;
   host._failedDuringValidate = false;
@@ -104,7 +103,7 @@ export function startValidateStream(host: ESPHomeCommandDialog): void {
       },
       onResult: (data) => {
         host._streamId = "";
-        host._flushPendingLines();
+        host._log.flush();
         host._state = data.success ? "success" : "error";
         host._statusMessage = host._localize(
           data.success ? "command.validate_success" : "command.validate_failed"
@@ -112,7 +111,7 @@ export function startValidateStream(host: ESPHomeCommandDialog): void {
       },
       onError: (error) => {
         host._streamId = "";
-        host._flushPendingLines();
+        host._log.flush();
         host._state = "error";
         host._statusMessage = error;
       },
@@ -134,8 +133,7 @@ export async function toggleShowSecrets(host: ESPHomeCommandDialog): Promise<voi
   host._restartInflight = true;
   try {
     await detachStream(host);
-    host._lines = [];
-    host._resetPendingLines();
+    host._log.reset();
     host._state = "running";
     host._statusMessage = "";
     host._resetAnsiLogScroll();
@@ -209,7 +207,7 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
     },
     onResult: (result) => {
       host._streamId = "";
-      host._flushPendingLines();
+      host._log.flush();
       const success = result.status === JobStatus.COMPLETED;
 
       // Queued is the outcome regardless of which job carried it; check
@@ -276,7 +274,7 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
     },
     onError: (error) => {
       host._streamId = "";
-      host._flushPendingLines();
+      host._log.flush();
       host._state = "error";
       host._statusMessage = error;
       host._jobId = "";
@@ -370,8 +368,8 @@ export async function onForceLocalClick(host: ESPHomeCommandDialog): Promise<voi
     host._statusMessage = host._localize("command.force_local_failed");
     const detail = formatForceLocalError(err);
     if (detail) {
-      host._flushPendingLines();
-      host._lines = [...host._lines, detail];
+      host._log.flush();
+      host._log.append([detail]);
     }
   } finally {
     host._switchingToLocal = false;

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -343,7 +343,7 @@ export function renderToolbar(host: ESPHomeCommandDialog): TemplateResult {
   return html`
     ${renderShowSecretsToggle(host)} ${renderShowLogsAfterInstallToggle(host)}
     ${
-      host._lines.length > 0
+      host._log.lines.length > 0
         ? renderTermButton({
             icon: "download",
             title: host._localize("command.download"),

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -29,7 +29,7 @@ import {
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { initialDarkMode } from "../util/dark-mode.js";
-import { LineBatcher } from "../util/line-batcher.js";
+import { LogBuffer } from "../util/log-buffer.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { RunTimerController } from "../util/run-timer-controller.js";
 import type { DetectedChip } from "../util/web-serial.js";
@@ -140,7 +140,6 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   @state() _jobSourceLabel = "";
   @state() _jobSourcePin = "";
 
-  @state() _logLines: string[] = [];
   @state() _logsExpanded = false;
   @state() _flashPercent = 0;
   @state() _downloadedFilename = "";
@@ -161,11 +160,10 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   _jobId = "";
   _streamId = "";
 
-  // rAF batch buffer for streamed output — coalesce per-line writes into
-  // one render per frame instead of one per line (#1203).
-  private _lineBatch = new LineBatcher((batch) => {
-    this._logLines = [...this._logLines, ...batch];
-  });
+  // The streamed output, batched into one render per frame instead of one
+  // per line (#1203). Uncapped: an install log is finite and the user reads
+  // back through it after a failure.
+  _log = new LogBuffer(this);
 
   // Build compile clocks — drives the compiling-step elapsed readout + the
   // offload hint. The step-based runEnded backstop freezes the span when the
@@ -265,7 +263,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     // Dispose any prior stream before resetting state. _init re-runs on every
     // installWebSerial including reopens after the user dismissed the previous
     // run (which only flips _open) — without this teardown, a still-attached
-    // followJob from the prior compile would push lines into _logLines.
+    // followJob from the prior compile would push lines into the buffer.
     this._detachStream();
     this._device = device;
     this._open = true;
@@ -275,8 +273,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     });
     this._statusMessage = "";
     this._errorMessage = "";
-    this._lineBatch.reset();
-    this._logLines = [];
+    this._log.reset();
     this._logsExpanded = false;
     this._flashPercent = 0;
     this._downloadedFilename = "";
@@ -302,7 +299,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   // then the job is released to finish in the background queue.
   _detachStream({ cancelJob = true }: { cancelJob?: boolean } = {}) {
     // Land any buffered lines before teardown so nothing streamed is lost.
-    this._flushLogLines();
+    this._log.flush();
     // Tear down an in-flight USB-flasher hand-off (message listener + timers)
     // too, so closing or reusing the dialog can't leak it or let a stale
     // flasher tab mutate the next install's state. Pure teardown, no _fail.
@@ -353,22 +350,11 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   // when empty so a single-string call doesn't paint the same text twice.
   _fail(title: string, detail = "") {
     // The expanded log must show every line up to the failure, not race the rAF.
-    this._flushLogLines();
+    this._log.flush();
     this._step = "error";
     this._statusMessage = title;
     this._errorMessage = detail;
     this._logsExpanded = true;
-  }
-
-  // Buffer a streamed line; flushed on the next animation frame.
-  _enqueueLogLine(line: string): void {
-    this._lineBatch.enqueue(line);
-  }
-
-  // Drain pending lines into ``_logLines`` now — terminal callbacks and
-  // teardown call this so consumers don't race the rAF.
-  _flushLogLines(): void {
-    this._lineBatch.flush();
   }
 
   // Close + navigate to /device/<configuration>. Same payload shape as
@@ -440,7 +426,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
       this._errorMessage = "";
       // Drop the failed run's log and clocks so the wait streams only the
       // foreign build, not the old failure's lines or elapsed time.
-      this._logLines = [];
+      this._log.reset();
       this._timer.reset();
       this._statusMessage = this._localize("firmware.status_waiting_build");
       const settled = await waitForRunningJob(

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -69,7 +69,7 @@ export async function startWebSerialInstall(
   // install showed no esptool logs at all, unlike the OTA / server-serial
   // paths which stream the backend job output (#346).
   const onLog = (line: string) => {
-    host._enqueueLogLine(line);
+    host._log.enqueue(line);
   };
 
   // 1. Connect and detect chip
@@ -571,12 +571,12 @@ export function waitForRunningJob(
       onOutput: (line) => {
         if (host._step === "queued") host._step = "compiling";
         host._timer.noteLine(line);
-        host._enqueueLogLine(line);
+        host._log.enqueue(line);
       },
       onResult: () => {
         host._streamId = "";
         host._compileReject = null;
-        host._flushLogLines();
+        host._log.flush();
         resolve(true);
       },
       onError: () => {
@@ -614,14 +614,14 @@ export function compileAndWait(
             host._statusMessage = host._localize("firmware.status_compiling");
           }
           host._timer.noteLine(line);
-          host._enqueueLogLine(line);
+          host._log.enqueue(line);
           if (isValidationFailureLine(line)) host._failedDuringValidate = true;
         },
         onResult: (data) => {
           host._streamId = "";
           host._jobId = "";
           host._compileReject = null;
-          host._flushLogLines();
+          host._log.flush();
           const result = data as unknown as {
             status: string;
             error?: string | null;

--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -245,15 +245,15 @@ export function renderStatusExtra(
 function downloadInstallLogs(host: ESPHomeFirmwareInstallDialog): void {
   // Land the pending rAF batch so a mid-stream download can't drop the
   // last frame of lines (mirrors command-dialog's _downloadOutput).
-  host._flushLogLines();
+  host._log.flush();
   const stem = configurationStem(host._device?.configuration, "install");
-  downloadAnsiText(host._logLines, `${stem}-install.txt`);
+  downloadAnsiText(host._log.lines, `${stem}-install.txt`);
 }
 
 export function renderLogs(
   host: ESPHomeFirmwareInstallDialog
 ): TemplateResult | typeof nothing {
-  if (host._logLines.length === 0) return nothing;
+  if (host._log.lines.length === 0) return nothing;
   return html`
     <div class="logs-header">
       <button
@@ -281,7 +281,7 @@ export function renderLogs(
       host._logsExpanded
         ? html`<div class="logs-container">
             <esphome-ansi-log
-              .lines=${host._logLines}
+              .lines=${host._log.lines}
               ?light=${!host._darkMode}
             ></esphome-ansi-log>
           </div>`

--- a/test/_fake-host.ts
+++ b/test/_fake-host.ts
@@ -1,5 +1,6 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { vi } from "vitest";
+import { LogBuffer } from "../src/util/log-buffer.js";
 
 /** Minimal ReactiveControllerHost for controller unit tests. */
 export class FakeHost implements ReactiveControllerHost {
@@ -23,3 +24,15 @@ export const fakeHost = (): ReactiveControllerHost =>
     requestUpdate: vi.fn(),
     updateComplete: Promise.resolve(true),
   }) as unknown as ReactiveControllerHost;
+
+/**
+ * A real LogBuffer whose enqueue lands synchronously.
+ *
+ * For flow tests, which drive a dialog's log sink but have no rAF to fire;
+ * the batching itself is pinned by the dialogs' own batching tests.
+ */
+export function fakeLogBuffer(): LogBuffer {
+  const buffer = new LogBuffer(new FakeHost());
+  buffer.enqueue = (line: string) => void buffer.append([line]);
+  return buffer;
+}

--- a/test/components/_command-dialog-host.ts
+++ b/test/components/_command-dialog-host.ts
@@ -3,6 +3,7 @@
 import type { FirmwareJob } from "../../src/api/types/firmware-jobs.js";
 import { JobStatus } from "../../src/api/types/firmware-jobs.js";
 import type { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
+import { fakeLogBuffer } from "../_fake-host.js";
 
 export interface StreamCbs {
   onOutput: (line: string) => void;
@@ -39,7 +40,7 @@ export function makeCommandDialogHost(
     configuration: "kitchen.yaml",
     name: "kitchen",
     _port: "OTA",
-    _lines: [] as string[],
+    _log: fakeLogBuffer(),
     _showLogsAfterInstall: true,
     _userStopped: false,
     _failedDuringValidate: false,
@@ -48,8 +49,6 @@ export function makeCommandDialogHost(
     _flipToLogs: () => {
       flipped = true;
     },
-    _flushPendingLines: () => {},
-    _resetPendingLines: () => {},
     _enqueueLine: () => {},
     ...overrides,
   };

--- a/test/components/_command-dialog-host.ts
+++ b/test/components/_command-dialog-host.ts
@@ -49,7 +49,9 @@ export function makeCommandDialogHost(
     _flipToLogs: () => {
       flipped = true;
     },
-    _enqueueLine: () => {},
+    _enqueueLine(line: string) {
+      this._log.enqueue(line);
+    },
     ...overrides,
   };
   return {

--- a/test/components/firmware-install-dialog-artifact-download.test.ts
+++ b/test/components/firmware-install-dialog-artifact-download.test.ts
@@ -30,6 +30,7 @@ import {
   startArtifactDownload,
 } from "../../src/components/firmware-install-dialog/install-flow.js";
 import { identityLocalize } from "../_dom.js";
+import { fakeLogBuffer } from "../_fake-host.js";
 
 const FACTORY: FirmwareBinary = { title: "Factory format", file: "firmware.factory.bin" };
 const OTA: FirmwareBinary = { title: "OTA format", file: "firmware.ota.bin" };
@@ -73,12 +74,7 @@ function makeHost(getBinariesResults: FirmwareBinary[][]) {
     _statusMessage: "",
     _binaries: [] as FirmwareBinary[],
     _downloadedFilename: "",
-    _logLines: [] as string[],
-    // Synchronous stand-ins for the dialog's rAF-batched log sink.
-    _enqueueLogLine(line: string) {
-      this._logLines = [...this._logLines, line];
-    },
-    _flushLogLines() {},
+    _log: fakeLogBuffer(),
     _failedDuringCompile: false,
     _jobId: "",
     _streamId: "",

--- a/test/components/firmware-install-dialog-artifact-labels.test.ts
+++ b/test/components/firmware-install-dialog-artifact-labels.test.ts
@@ -12,12 +12,13 @@ import { defaultLocalize } from "../../src/common/localize.js";
 import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
 import { renderStatusExtra } from "../../src/components/firmware-install-dialog/renderers.js";
 import { renderInto } from "../_dom.js";
+import { fakeLogBuffer } from "../_fake-host.js";
 
 function rowsText(binaries: FirmwareBinary[]): string {
   const host = {
     _step: "choose-binary",
     _binaries: binaries,
-    _logLines: [],
+    _log: fakeLogBuffer(),
     _localize: defaultLocalize,
     _onChooseBinary: () => {},
   };

--- a/test/components/firmware-install-dialog-download-binary.test.ts
+++ b/test/components/firmware-install-dialog-download-binary.test.ts
@@ -32,6 +32,7 @@ import {
   startDownload,
 } from "../../src/components/firmware-install-dialog/install-flow.js";
 import { identityLocalize } from "../_dom.js";
+import { fakeLogBuffer } from "../_fake-host.js";
 
 const FACTORY: FirmwareBinary = { title: "Factory format", file: "firmware.factory.bin" };
 const OTA: FirmwareBinary = {
@@ -66,12 +67,7 @@ function makeHost(installer: Installer, binaries: FirmwareBinary[]) {
     _statusMessage: "",
     _binaries: [] as FirmwareBinary[],
     _downloadedFilename: "",
-    _logLines: [] as string[],
-    // Synchronous stand-ins for the dialog's rAF-batched log sink.
-    _enqueueLogLine(line: string) {
-      this._logLines = [...this._logLines, line];
-    },
-    _flushLogLines() {},
+    _log: fakeLogBuffer(),
     _failedDuringCompile: false,
     _failedDuringValidate: false,
     _jobId: "",

--- a/test/components/firmware-install-dialog-log-batching.test.ts
+++ b/test/components/firmware-install-dialog-log-batching.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment happy-dom
  *
- * Pins the dialog-level batching wiring with a REAL LineBatcher (the flow
+ * Pins the dialog-level batching wiring with a REAL LogBuffer (the flow
  * harnesses stub the sink): lines buffer until a flush point, and _fail /
  * _detachStream land the pending batch synchronously.
  */
@@ -36,25 +36,25 @@ function makeDialog(): ESPHomeFirmwareInstallDialog {
 describe("install-dialog log batching wiring", () => {
   it("buffers lines until the frame, and _fail lands them synchronously", () => {
     const dialog = makeDialog();
-    dialog._enqueueLogLine("buffered line");
+    dialog._log.enqueue("buffered line");
     // Still pending — the rAF hasn't fired.
-    expect(dialog._logLines).toEqual([]);
+    expect(dialog._log.lines).toEqual([]);
     dialog._fail("boom");
     // The expanded error log must show every line, not race the rAF.
-    expect(dialog._logLines).toEqual(["buffered line"]);
+    expect(dialog._log.lines).toEqual(["buffered line"]);
   });
 
   it("_detachStream lands the pending batch before teardown", () => {
     const dialog = makeDialog();
-    dialog._enqueueLogLine("last line");
+    dialog._log.enqueue("last line");
     dialog._detachStream();
-    expect(dialog._logLines).toEqual(["last line"]);
+    expect(dialog._log.lines).toEqual(["last line"]);
   });
 
   it("a mid-stream log download flushes before reading", () => {
     const dialog = makeDialog();
-    Object.assign(dialog, { _logLines: ["landed line"] });
-    dialog._enqueueLogLine("buffered line");
+    dialog._log.append(["landed line"]);
+    dialog._log.enqueue("buffered line");
     const container = renderInto(renderLogs(dialog));
     // Second .logs-toggle is the download button (first is the expander).
     const buttons = container.querySelectorAll<HTMLElement>(".logs-toggle");

--- a/test/components/firmware-install-dialog-retry-busy.test.ts
+++ b/test/components/firmware-install-dialog-retry-busy.test.ts
@@ -21,6 +21,14 @@ import type { ConfiguredDevice } from "../../src/api/types/devices.js";
 import type { FirmwareJob } from "../../src/api/types/firmware-jobs.js";
 import { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
 import { identityLocalize } from "../_dom.js";
+import { fakeLogBuffer } from "../_fake-host.js";
+
+// The log as the failed run left it, so Retry has something to drop.
+const failedRunLog = () => {
+  const log = fakeLogBuffer();
+  log.append(["old failure line"]);
+  return log;
+};
 
 type FollowCbs = {
   onResult?: (d: unknown) => void;
@@ -39,7 +47,7 @@ function makeDialog(busy: boolean) {
     _device: { configuration: "device.yaml" } as ConfiguredDevice,
     _installer: "web-serial",
     _step: "error",
-    _logLines: ["old failure line"],
+    _log: failedRunLog(),
     _localize: identityLocalize,
     _activeJobs: busy ? new Map([["device.yaml", runningJob]]) : new Map(),
     _api: { firmwareFollowJob: followJob },
@@ -60,7 +68,7 @@ describe("install-dialog Retry while a foreign build runs", () => {
     // Never claims the foreign job: dismissal must not cancel it.
     expect(dialog._jobId).toBe("");
     // The failed run's log was dropped, not concatenated with the wait's.
-    expect(dialog._logLines).not.toContain("old failure line");
+    expect(dialog._log.lines).not.toContain("old failure line");
   });
 
   it("resets the compile clocks before streaming the foreign build", async () => {

--- a/test/components/firmware-install-dialog-usb-flash.test.ts
+++ b/test/components/firmware-install-dialog-usb-flash.test.ts
@@ -10,6 +10,7 @@ import {
   startUsbFlash,
 } from "../../src/components/firmware-install-dialog/install-flow.js";
 import { identityLocalize } from "../_dom.js";
+import { fakeLogBuffer } from "../_fake-host.js";
 
 const bin = (file: string): FirmwareBinary => ({ file, title: file });
 
@@ -41,12 +42,7 @@ function makeHost(opts: { compileOk: boolean; binaries?: FirmwareBinary[] }) {
     _step: "queued",
     _statusMessage: "",
     _errorMessage: "",
-    _logLines: [] as string[],
-    // Synchronous stand-ins for the dialog's rAF-batched log sink.
-    _enqueueLogLine(line: string) {
-      this._logLines = [...this._logLines, line];
-    },
-    _flushLogLines() {},
+    _log: fakeLogBuffer(),
     _jobId: "",
     _streamId: "",
     _compileReject: null,

--- a/test/components/firmware-install-dialog-web-serial.test.ts
+++ b/test/components/firmware-install-dialog-web-serial.test.ts
@@ -28,6 +28,7 @@ import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware
 import { startWebSerialInstall } from "../../src/components/firmware-install-dialog/install-flow.js";
 import { _clearBoardBodyCache } from "../../src/util/board-body-cache.js";
 import { identityLocalize } from "../_dom.js";
+import { fakeLogBuffer } from "../_fake-host.js";
 
 function makeHost() {
   const api = {
@@ -57,12 +58,7 @@ function makeHost() {
     _step: "connecting",
     _statusMessage: "",
     _flashPercent: 0,
-    _logLines: [] as string[],
-    // Synchronous stand-ins for the dialog's rAF-batched log sink.
-    _enqueueLogLine(line: string) {
-      this._logLines = [...this._logLines, line];
-    },
-    _flushLogLines() {},
+    _log: fakeLogBuffer(),
     _open: true,
     _showLogsAfterInstall: false,
     _detected: null as unknown,
@@ -131,8 +127,8 @@ describe("Web Serial install — HTTP byte download", () => {
 
     await startWebSerialInstall(host as unknown as ESPHomeFirmwareInstallDialog);
 
-    expect(host._logLines).toContain("Detecting chip type... ESP32");
-    expect(host._logLines).toContain("Writing at 0x00010000...");
+    expect(host._log.lines).toContain("Detecting chip type... ESP32");
+    expect(host._log.lines).toContain("Writing at 0x00010000...");
   });
 
   it("releases the port when the post-flash reset throws", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Second of three for #1271. Stacked on #1275, which adds `LogBuffer`; **review that one first**, and this diff is only the adoption once it lands.

`command-dialog` and `firmware-install-dialog` both hand-rolled the shape `logs-dialog` had: a lines array, a `LineBatcher` writing back into it, and a reset that had to remember to clear both. Neither caps its buffer, which is why `LogBuffer` takes `maxLines` as an option rather than baking one in; both construct it without one.

`_flushPendingLines`, `_resetPendingLines`, `_enqueueLogLine` and `_flushLogLines` were one-line delegates to the batcher, so their callers now say `_log.flush()` / `_log.reset()` / `_log.enqueue()` and the delegates are gone. Uniformly:

| Before | After |
|---|---|
| `host._lines` | `host._log.lines` |
| `host._lines = []` + `host._resetPendingLines()` | `host._log.reset()` |
| `host._flushPendingLines()` | `host._log.flush()` |
| `host._enqueueLine(line)` | `host._log.enqueue(line)` |
| `host._lines = [...host._lines, detail]` | `host._log.append([detail])` |

`command-dialog._enqueueLine` stays a method, because it also does `_timer.noteLine(line)`.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder-frontend/issues/1271

## Notes for review

- **One asymmetry worth a look.** The install dialog's `_retry` cleared `_logLines` without resetting the batcher, unlike its other reset at `_init`, so a pending line from the failed run could have flushed into the buffer the comment says it is clearing. `_log.reset()` does both. In practice nothing changes: `_retry` is only reachable from the error screen and `_fail` flushes on the way there, so pending is already empty. Flagging it because it is the one place the mapping is not purely mechanical.
- Test fakes: the flow harnesses stubbed the log sink by hand ("synchronous stand-ins for the dialog's rAF-batched log sink"). They now use `fakeLogBuffer()` in `test/_fake-host.ts`, which is a **real** `LogBuffer` with only `enqueue` short-circuited to land synchronously, so the fakes exercise real lines/append/flush/reset semantics instead of a reimplementation. The batching itself keeps its own tests.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
