### PR TITLE
Gate api device identity on mdns ownership or backend evidence

### DIFF
--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -139,12 +139,12 @@ export interface ConfiguredDevice {
   expected_config_hash: string;
   /** True until successfully compiled + deployed */
   has_pending_changes: boolean;
-  /** True when ``has_pending_changes`` came from the mDNS-sourced
+  /** True when ``has_pending_changes`` came from the deployed
    *  config-hash compare (vs the local mtime fallback). The UI gates
    *  only this case on a trusted deployed identity (see
    *  ``deployedIdentityTrusted``), so a local YAML edit still cues
-   *  "install" when mDNS is dark. Optional / absent reads as a local
-   *  (non-mDNS-dependent) pending. */
+   *  "install" when the deployed identity can't be trusted. Optional /
+   *  absent reads as a local (mtime-driven) pending. */
   pending_changes_via_hash?: boolean;
   /** True if compiled with older ESPHome version */
   update_available: boolean;

--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -62,13 +62,15 @@ export interface DeviceRuntimeState {
    * mismatch / plaintext.
    */
   api_encryption_active: string | null;
-  /** Whether an unexpired ``_http._tcp`` identity TXT currently backs
-   *  the deployed identity of a device without api:. Session-only —
-   *  false on backend cold start until the broadcast is heard.
-   *  ``deployedIdentityTrusted`` gates the non-api deployed identity
-   *  on it, mirroring the ``active_source === "mdns"`` gate api
-   *  devices use. */
-  http_identity_live: boolean;
+  /** Whether fresh first-party evidence backs the deployed identity:
+   *  an unexpired ``_http._tcp`` identity TXT (devices without api:),
+   *  a live Native API device_info connection the backend made (api
+   *  devices mDNS doesn't own, e.g. Docker-bridge), or a flash this
+   *  dashboard performed. Session-only — false on backend cold start
+   *  until evidence arrives. mDNS taking ownership of an api device
+   *  clears it; the announce lifecycle vouches from there, which is
+   *  the other half of ``deployedIdentityTrusted``'s gate. */
+  deployed_identity_live: boolean;
 }
 
 /** A configured ESPHome device. */

--- a/src/components/dashboard/device-drawer-content/render-sections.ts
+++ b/src/components/dashboard/device-drawer-content/render-sections.ts
@@ -137,9 +137,9 @@ export function renderVersionSection(
   localize: LocalizeFunc
 ): TemplateResult | typeof nothing {
   const local = d.current_version || "";
-  // mDNS-sourced; treat as unknown when it can't be trusted (see
-  // deployedIdentityTrusted) so the empty-deployed path shows the waiting
-  // text instead of a false "out of sync".
+  // Deployed-identity-sourced; treat as unknown when it can't be trusted
+  // (see deployedIdentityTrusted) so the empty-deployed path shows the
+  // waiting text instead of a false "out of sync".
   const deployed = deployedIdentityTrusted(d) ? d.runtime_state.deployed_version : "";
   if (!local && !deployed) return nothing;
   const matches = !!local && !!deployed && local === deployed;
@@ -192,7 +192,7 @@ export function renderConfigHashSection(
   localize: LocalizeFunc
 ): TemplateResult | typeof nothing {
   const expected = d.expected_config_hash || "";
-  // mDNS-sourced; treat as unknown when it can't be trusted (see renderVersionSection).
+  // Deployed-identity-sourced; treat as unknown when it can't be trusted (see renderVersionSection).
   const deployed = deployedIdentityTrusted(d) ? d.runtime_state.deployed_config_hash : "";
   if (!expected && !deployed) return nothing;
   const matches = !!expected && !!deployed && expected === deployed;

--- a/src/util/device-sync.ts
+++ b/src/util/device-sync.ts
@@ -19,8 +19,8 @@ const mdnsOnline = (d: ConfiguredDevice): boolean =>
 // lifecycle. In an mDNS-dark deployment the flag deliberately never
 // expires — no evidence of staleness can arrive, so the last-confirmed
 // identity stays up and reachability is signalled separately by the
-// state indicator. Full semantics: backend docs/API.md,
-// Device.runtime_state.
+// state indicator. Full semantics: docs/API.md in the backend repo
+// (esphome/device-builder), Device.runtime_state.
 export const deployedIdentityTrusted = (d: ConfiguredDevice): boolean =>
   (d.api_enabled && mdnsOnline(d)) || d.runtime_state.deployed_identity_live;
 

--- a/src/util/device-sync.ts
+++ b/src/util/device-sync.ts
@@ -8,21 +8,15 @@ const mdnsOnline = (d: ConfiguredDevice): boolean =>
 
 // Whether the deployed identity (version / config hash) is trustworthy.
 // Two evidence channels, one per disjunct. An api: device broadcasts the
-// identity on _esphomelib._tcp, the same service that claims
-// active_source === "mdns", so mdns ownership doubles as the freshness
-// signal — and the api_enabled guard on that disjunct is load-bearing:
-// a device without api: can also hold active_source === "mdns", but off
-// a bare A-record resolve that vouches for reachability only, never
-// identity. Everywhere mdns ownership can't vouch, the backend tracks
-// its own first-party evidence and ships it as
-// runtime_state.deployed_identity_live: the _http._tcp identity TXT for
-// devices without api: (ESPHome 2026.7.0+), a direct Native API
-// device_info connection for api: devices mDNS can't reach (the
-// Docker-bridge dashboard), and the dashboard's own flash. Session-only,
-// false on backend cold start until evidence arrives; the backend
-// clears it when mDNS takes ownership of an api: device, so a
-// powered-down device still blanks through the announce lifecycle
-// rather than showing its last-heard identity.
+// identity on _esphomelib._tcp, the service mdns ownership rides on —
+// and the api_enabled guard there is load-bearing: a device without
+// api: can also hold active_source === "mdns", but off a bare A-record
+// resolve that vouches for reachability only, never identity.
+// Everywhere mdns can't vouch, the backend ships its own first-party
+// evidence as runtime_state.deployed_identity_live (session-only; the
+// backend clears it when mDNS takes ownership of an api: device, so a
+// powered-down device still blanks through the announce lifecycle).
+// Full semantics: backend docs/API.md, Device.runtime_state.
 export const deployedIdentityTrusted = (d: ConfiguredDevice): boolean =>
   (d.api_enabled && mdnsOnline(d)) || d.runtime_state.deployed_identity_live;
 

--- a/src/util/device-sync.ts
+++ b/src/util/device-sync.ts
@@ -13,10 +13,14 @@ const mdnsOnline = (d: ConfiguredDevice): boolean =>
 // api: can also hold active_source === "mdns", but off a bare A-record
 // resolve that vouches for reachability only, never identity.
 // Everywhere mdns can't vouch, the backend ships its own first-party
-// evidence as runtime_state.deployed_identity_live (session-only; the
-// backend clears it when mDNS takes ownership of an api: device, so a
-// powered-down device still blanks through the announce lifecycle).
-// Full semantics: backend docs/API.md, Device.runtime_state.
+// evidence as runtime_state.deployed_identity_live (session-only). Where
+// mDNS can reach the device, the backend clears the flag when mDNS takes
+// ownership, so a powered-down device blanks through the announce
+// lifecycle. In an mDNS-dark deployment the flag deliberately never
+// expires — no evidence of staleness can arrive, so the last-confirmed
+// identity stays up and reachability is signalled separately by the
+// state indicator. Full semantics: backend docs/API.md,
+// Device.runtime_state.
 export const deployedIdentityTrusted = (d: ConfiguredDevice): boolean =>
   (d.api_enabled && mdnsOnline(d)) || d.runtime_state.deployed_identity_live;
 

--- a/src/util/device-sync.ts
+++ b/src/util/device-sync.ts
@@ -2,27 +2,29 @@ import type { ConfiguredDevice } from "../api/types/devices.js";
 
 // Whether mDNS is the channel currently driving the device's online state.
 // Deliberately unexported: for gating the deployed identity (version /
-// config hash) use deployedIdentityTrusted below, never this directly —
-// this predicate can never be true for a device without api:.
+// config hash) use deployedIdentityTrusted below, never this directly.
 const mdnsOnline = (d: ConfiguredDevice): boolean =>
   d.runtime_state.active_source === "mdns";
 
-// Whether the mDNS-sourced deployed identity (version / config hash) is
-// trustworthy. An api: device broadcasts it on _esphomelib._tcp, the same
-// service that claims active_source === "mdns", so that source doubles as the
-// freshness signal: when mDNS is dark (a ping/MQTT-only "odd setup", e.g. a
-// Docker-bridge dashboard) the values go stale, so blanking them avoids a
-// false "out of sync". A device without api: broadcasts the same identity
-// trio on _http._tcp (ESPHome 2026.7.0+), which by backend design never
-// claims reachability, so active_source can't vouch for it — the backend
-// tracks that broadcast's freshness itself and ships it as
-// runtime_state.http_identity_live (session-only; false on backend cold
-// start until the broadcast is heard). A powered-down device blanks
-// rather than showing its last-heard identity: an arbitrarily old
-// broadcast is not evidence, matching how an api: device blanks when
-// mDNS goes dark.
+// Whether the deployed identity (version / config hash) is trustworthy.
+// Two evidence channels, one per disjunct. An api: device broadcasts the
+// identity on _esphomelib._tcp, the same service that claims
+// active_source === "mdns", so mdns ownership doubles as the freshness
+// signal — and the api_enabled guard on that disjunct is load-bearing:
+// a device without api: can also hold active_source === "mdns", but off
+// a bare A-record resolve that vouches for reachability only, never
+// identity. Everywhere mdns ownership can't vouch, the backend tracks
+// its own first-party evidence and ships it as
+// runtime_state.deployed_identity_live: the _http._tcp identity TXT for
+// devices without api: (ESPHome 2026.7.0+), a direct Native API
+// device_info connection for api: devices mDNS can't reach (the
+// Docker-bridge dashboard), and the dashboard's own flash. Session-only,
+// false on backend cold start until evidence arrives; the backend
+// clears it when mDNS takes ownership of an api: device, so a
+// powered-down device still blanks through the announce lifecycle
+// rather than showing its last-heard identity.
 export const deployedIdentityTrusted = (d: ConfiguredDevice): boolean =>
-  d.api_enabled ? mdnsOnline(d) : d.runtime_state.http_identity_live;
+  (d.api_enabled && mdnsOnline(d)) || d.runtime_state.deployed_identity_live;
 
 // Whether to SHOW the "modified" (needs-install) and "update available"
 // indicators, gated so a stale mDNS-dark value can't flag a false "out of

--- a/src/util/device-sync.ts
+++ b/src/util/device-sync.ts
@@ -25,17 +25,16 @@ export const deployedIdentityTrusted = (d: ConfiguredDevice): boolean =>
   (d.api_enabled && mdnsOnline(d)) || d.runtime_state.deployed_identity_live;
 
 // Whether to SHOW the "modified" (needs-install) and "update available"
-// indicators, gated so a stale mDNS-dark value can't flag a false "out of
+// indicators, gated so a stale untrusted value can't flag a false "out of
 // sync". The raw truth stays on the device fields (``has_pending_changes`` /
 // ``update_available``); these say whether to surface it. Every indicator site
 // derives from these so the rule lives in one place.
 //
 // ``update_available`` (``deployed_version`` vs ``current_version``) is purely
-// mDNS-sourced, so it always needs a trusted deployed identity.
-// ``has_pending_changes`` is only
-// mDNS-dependent when it came from the config-hash compare
-// (``pending_changes_via_hash``); a local mtime-driven edit is trustworthy
-// without mDNS, so it still cues "install".
+// deployed-identity-sourced, so it always needs a trusted deployed identity.
+// ``has_pending_changes`` is only identity-dependent when it came from the
+// config-hash compare (``pending_changes_via_hash``); a local mtime-driven
+// edit is trustworthy without it, so it still cues "install".
 export const showPendingChanges = (d: ConfiguredDevice): boolean =>
   d.has_pending_changes === true &&
   (deployedIdentityTrusted(d) || d.pending_changes_via_hash !== true);

--- a/test/_make-configured-device.ts
+++ b/test/_make-configured-device.ts
@@ -39,18 +39,19 @@ const _BASE = {
   runtime_state: {
     state: DeviceState.UNKNOWN,
     // Live mDNS source so an api-enabled test device shows its out-of-sync /
-    // update indicators (the fixture defaults to no-api, whose gate is
-    // http_identity_live below); tests covering the mDNS-dark "hide
-    // indicators" behaviour override this to "ping" / "unknown".
+    // update indicators without leaning on deployed_identity_live below;
+    // tests covering the mDNS-dark "hide indicators" behaviour must
+    // override BOTH (either alone keeps an api device trusted).
     active_source: "mdns",
     ip_addresses: [],
     deployed_version: "",
     deployed_config_hash: "",
     queued_update: false,
     api_encryption_active: null,
-    // Same happy-path default for the no-api gate; tests covering the
-    // identity-went-dark behaviour override this to false.
-    http_identity_live: true,
+    // Happy-path default for the first-party evidence gate (both device
+    // kinds); tests covering the identity-went-dark behaviour override
+    // this to false.
+    deployed_identity_live: true,
   },
   expected_config_hash: "",
   has_pending_changes: false,

--- a/test/components/dashboard/render-card-grid.test.ts
+++ b/test/components/dashboard/render-card-grid.test.ts
@@ -75,18 +75,28 @@ describe("renderCardGrid", () => {
     const device = makeConfiguredDevice({
       update_available: true,
       api_enabled: true,
-      runtime_state: { active_source: "ping" },
+      runtime_state: { active_source: "ping", deployed_identity_live: false },
     });
     const card = renderCard(device);
     expect(card.hasAttribute("show-update")).toBe(false);
     expect(card.hasAttribute("queued-update")).toBe(false);
   });
 
+  it("keeps the update indicator off Native-API evidence when an api device's mDNS is dark", () => {
+    const device = makeConfiguredDevice({
+      update_available: true,
+      api_enabled: true,
+      runtime_state: { active_source: "ping", deployed_identity_live: true },
+    });
+    const card = renderCard(device);
+    expect(card.hasAttribute("show-update")).toBe(true);
+  });
+
   it("hides the update indicator when a no-api device's identity TXT went dark", () => {
     const device = makeConfiguredDevice({
       update_available: true,
       api_enabled: false,
-      runtime_state: { active_source: "mqtt", http_identity_live: false },
+      runtime_state: { active_source: "mqtt", deployed_identity_live: false },
     });
     const card = renderCard(device);
     expect(card.hasAttribute("show-update")).toBe(false);

--- a/test/components/dashboard/render-card-grid.test.ts
+++ b/test/components/dashboard/render-card-grid.test.ts
@@ -82,7 +82,7 @@ describe("renderCardGrid", () => {
     expect(card.hasAttribute("queued-update")).toBe(false);
   });
 
-  it("keeps the update indicator off Native-API evidence when an api device's mDNS is dark", () => {
+  it("shows the update indicator on Native-API evidence when an api device's mDNS is dark", () => {
     const device = makeConfiguredDevice({
       update_available: true,
       api_enabled: true,

--- a/test/components/dashboard/render-mac-address-row.test.ts
+++ b/test/components/dashboard/render-mac-address-row.test.ts
@@ -169,8 +169,8 @@ describe("renderVersionSection deployed row", () => {
   });
 
   it("shows the deployed version for a no-api device reachable over MQTT", () => {
-    // Delivered via the _http._tcp identity TXT; active_source never claims
-    // mDNS for these devices, so the gate is http_identity_live instead.
+    // Delivered via the _http._tcp identity TXT; a no-api mdns claim is a
+    // bare A-record resolve, so the gate is deployed_identity_live instead.
     const result = renderVersionSection(
       _device({
         current_version: "2026.7.1",
@@ -178,7 +178,7 @@ describe("renderVersionSection deployed row", () => {
         runtime_state: {
           active_source: "mqtt",
           deployed_version: "2026.7.0",
-          http_identity_live: true,
+          deployed_identity_live: true,
         },
       }),
       _localize
@@ -196,7 +196,7 @@ describe("renderVersionSection deployed row", () => {
         runtime_state: {
           active_source: "mqtt",
           deployed_version: "2026.7.0",
-          http_identity_live: false,
+          deployed_identity_live: false,
         },
       }),
       _localize
@@ -211,13 +211,36 @@ describe("renderVersionSection deployed row", () => {
       _device({
         current_version: "2026.7.1",
         api_enabled: true,
-        runtime_state: { active_source: "ping", deployed_version: "2026.7.0" },
+        runtime_state: {
+          active_source: "ping",
+          deployed_version: "2026.7.0",
+          deployed_identity_live: false,
+        },
       }),
       _localize
     );
     const texts = valueTexts(result);
     expect(texts).not.toContain("2026.7.0");
     expect(texts).toContain("dashboard.drawer_waiting_for_mdns");
+  });
+
+  it("shows an api device's deployed version off Native-API evidence while mDNS is dark", () => {
+    // The backend read the version over a direct device_info connection
+    // (Docker-bridge mDNS-dark) and vouches with deployed_identity_live.
+    const result = renderVersionSection(
+      _device({
+        current_version: "2026.7.1",
+        api_enabled: true,
+        runtime_state: {
+          active_source: "ping",
+          deployed_version: "2026.7.0",
+          deployed_identity_live: true,
+        },
+      }),
+      _localize
+    );
+    const texts = valueTexts(result);
+    expect(texts).toContain("2026.7.0");
   });
 });
 
@@ -258,7 +281,7 @@ describe("renderConfigHashSection deployed row", () => {
         runtime_state: {
           active_source: "mqtt",
           deployed_config_hash: "22e8e223",
-          http_identity_live: true,
+          deployed_identity_live: true,
         },
       }),
       _localize
@@ -276,7 +299,7 @@ describe("renderConfigHashSection deployed row", () => {
         runtime_state: {
           active_source: "mqtt",
           deployed_config_hash: "22e8e223",
-          http_identity_live: false,
+          deployed_identity_live: false,
         },
       }),
       _localize
@@ -291,12 +314,33 @@ describe("renderConfigHashSection deployed row", () => {
       _device({
         expected_config_hash: "abc123",
         api_enabled: true,
-        runtime_state: { active_source: "ping", deployed_config_hash: "22e8e223" },
+        runtime_state: {
+          active_source: "ping",
+          deployed_config_hash: "22e8e223",
+          deployed_identity_live: false,
+        },
       }),
       _localize
     );
     const texts = valueTexts(result);
     expect(texts).not.toContain("22e8e223");
     expect(texts).toContain("dashboard.drawer_waiting_for_mdns");
+  });
+
+  it("shows an api device's deployed hash under identity evidence while mDNS is dark", () => {
+    const result = renderConfigHashSection(
+      _device({
+        expected_config_hash: "abc123",
+        api_enabled: true,
+        runtime_state: {
+          active_source: "ping",
+          deployed_config_hash: "22e8e223",
+          deployed_identity_live: true,
+        },
+      }),
+      _localize
+    );
+    const texts = valueTexts(result);
+    expect(texts).toContain("22e8e223");
   });
 });

--- a/test/util/device-filter.test.ts
+++ b/test/util/device-filter.test.ts
@@ -22,9 +22,10 @@ import {
 
 function device(over: ConfiguredDeviceOverrides = {}): ConfiguredDevice {
   // Online with a trusted identity by default, so update/modified
-  // filters match; mDNS-dark cases must clear deployed_identity_live,
-  // and an api device also needs a non-mdns active_source (the gate
-  // trusts either).
+  // filters match. These fixtures are no-api (api_enabled defaults
+  // false), so the gate reduces to deployed_identity_live — override
+  // that to go dark; a case that also sets api_enabled: true must
+  // override active_source too.
   return makeConfiguredDevice({
     friendly_name: "Kitchen Lamp",
     ...over,

--- a/test/util/device-filter.test.ts
+++ b/test/util/device-filter.test.ts
@@ -21,8 +21,9 @@ import {
 } from "../_make-configured-device.js";
 
 function device(over: ConfiguredDeviceOverrides = {}): ConfiguredDevice {
-  // Online + live mDNS by default so update/modified filters match; mDNS-dark
-  // cases override active_source.
+  // Online with a trusted identity by default (live mDNS source AND
+  // deployed_identity_live) so update/modified filters match; mDNS-dark
+  // cases must override BOTH — either alone keeps the identity trusted.
   return makeConfiguredDevice({
     friendly_name: "Kitchen Lamp",
     ...over,

--- a/test/util/device-filter.test.ts
+++ b/test/util/device-filter.test.ts
@@ -21,9 +21,10 @@ import {
 } from "../_make-configured-device.js";
 
 function device(over: ConfiguredDeviceOverrides = {}): ConfiguredDevice {
-  // Online with a trusted identity by default (live mDNS source AND
-  // deployed_identity_live) so update/modified filters match; mDNS-dark
-  // cases must override BOTH — either alone keeps the identity trusted.
+  // Online with a trusted identity by default, so update/modified
+  // filters match; mDNS-dark cases must clear deployed_identity_live,
+  // and an api device also needs a non-mdns active_source (the gate
+  // trusts either).
   return makeConfiguredDevice({
     friendly_name: "Kitchen Lamp",
     ...over,

--- a/test/util/device-sync.test.ts
+++ b/test/util/device-sync.test.ts
@@ -9,24 +9,39 @@ import { makeConfiguredDevice } from "../_make-configured-device.js";
 
 describe("device-sync mDNS gating", () => {
   it("trusts the deployed identity per api_enabled, live source, and identity evidence", () => {
-    // An api device is trusted under mdns ownership OR the backend's
-    // first-party evidence flag (a direct Native API connection where
-    // mDNS is dark). A no-api device is trusted on the flag alone: its
-    // mdns ownership is a bare A-record resolve — reachability only —
-    // so that disjunct is deliberately api-scoped.
-    for (const s of ["mdns", "ping", "mqtt", "unknown"] as const) {
-      for (const api_enabled of [true, false]) {
-        for (const deployed_identity_live of [true, false]) {
-          expect(
-            deployedIdentityTrusted(
-              makeConfiguredDevice({
-                api_enabled,
-                runtime_state: { active_source: s, deployed_identity_live },
-              })
-            )
-          ).toBe((api_enabled && s === "mdns") || deployed_identity_live);
-        }
-      }
+    // Literal truth table (not the production expression) so a gate
+    // regression can't hide behind a mirrored oracle. Two trusted
+    // shapes only: the backend's first-party evidence flag, or an api
+    // device under mdns ownership — a no-api device's mdns ownership
+    // is a bare A-record resolve (reachability only) and earns nothing.
+    const rows = [
+      // [api_enabled, active_source, deployed_identity_live, trusted]
+      [true, "mdns", true, true],
+      [true, "mdns", false, true],
+      [true, "ping", true, true],
+      [true, "ping", false, false],
+      [true, "mqtt", true, true],
+      [true, "mqtt", false, false],
+      [true, "unknown", true, true],
+      [true, "unknown", false, false],
+      [false, "mdns", true, true],
+      [false, "mdns", false, false],
+      [false, "ping", true, true],
+      [false, "ping", false, false],
+      [false, "mqtt", true, true],
+      [false, "mqtt", false, false],
+      [false, "unknown", true, true],
+      [false, "unknown", false, false],
+    ] as const;
+    for (const [api_enabled, active_source, deployed_identity_live, trusted] of rows) {
+      expect(
+        deployedIdentityTrusted(
+          makeConfiguredDevice({
+            api_enabled,
+            runtime_state: { active_source, deployed_identity_live },
+          })
+        )
+      ).toBe(trusted);
     }
   });
 
@@ -41,16 +56,6 @@ describe("device-sync mDNS gating", () => {
     expect(deployedIdentityTrusted(probed)).toBe(true);
     expect(showPendingChanges(probed)).toBe(true);
     expect(showUpdateAvailable(probed)).toBe(true);
-  });
-
-  it("never trusts a no-api device off mdns ownership alone", () => {
-    // A no-api mdns claim comes from the active A-record resolve; it
-    // says the host answers, not that any identity broadcast is fresh.
-    const resolvedOnly = makeConfiguredDevice({
-      api_enabled: false,
-      runtime_state: { active_source: "mdns", deployed_identity_live: false },
-    });
-    expect(deployedIdentityTrusted(resolvedOnly)).toBe(false);
   });
 
   it("hides an api device's hash-driven modified / update signals while mDNS is dark", () => {

--- a/test/util/device-sync.test.ts
+++ b/test/util/device-sync.test.ts
@@ -8,30 +8,55 @@ import {
 import { makeConfiguredDevice } from "../_make-configured-device.js";
 
 describe("device-sync mDNS gating", () => {
-  it("trusts the deployed identity per api_enabled, live source, and http identity", () => {
-    // An api device needs a live mDNS; a no-api device's identity arrives
-    // over _http._tcp, which never claims reachability, so active_source
-    // can't vouch for it — the backend's http_identity_live does.
+  it("trusts the deployed identity per api_enabled, live source, and identity evidence", () => {
+    // An api device is trusted under mdns ownership OR the backend's
+    // first-party evidence flag (a direct Native API connection where
+    // mDNS is dark). A no-api device is trusted on the flag alone: its
+    // mdns ownership is a bare A-record resolve — reachability only —
+    // so that disjunct is deliberately api-scoped.
     for (const s of ["mdns", "ping", "mqtt", "unknown"] as const) {
       for (const api_enabled of [true, false]) {
-        for (const http_identity_live of [true, false]) {
+        for (const deployed_identity_live of [true, false]) {
           expect(
             deployedIdentityTrusted(
               makeConfiguredDevice({
                 api_enabled,
-                runtime_state: { active_source: s, http_identity_live },
+                runtime_state: { active_source: s, deployed_identity_live },
               })
             )
-          ).toBe(api_enabled ? s === "mdns" : http_identity_live);
+          ).toBe((api_enabled && s === "mdns") || deployed_identity_live);
         }
       }
     }
   });
 
+  it("shows an api device's signals off Native-API evidence while mDNS is dark", () => {
+    const probed = makeConfiguredDevice({
+      api_enabled: true,
+      runtime_state: { active_source: "ping", deployed_identity_live: true },
+      has_pending_changes: true,
+      pending_changes_via_hash: true,
+      update_available: true,
+    });
+    expect(deployedIdentityTrusted(probed)).toBe(true);
+    expect(showPendingChanges(probed)).toBe(true);
+    expect(showUpdateAvailable(probed)).toBe(true);
+  });
+
+  it("never trusts a no-api device off mdns ownership alone", () => {
+    // A no-api mdns claim comes from the active A-record resolve; it
+    // says the host answers, not that any identity broadcast is fresh.
+    const resolvedOnly = makeConfiguredDevice({
+      api_enabled: false,
+      runtime_state: { active_source: "mdns", deployed_identity_live: false },
+    });
+    expect(deployedIdentityTrusted(resolvedOnly)).toBe(false);
+  });
+
   it("hides an api device's hash-driven modified / update signals while mDNS is dark", () => {
     const dark = makeConfiguredDevice({
       api_enabled: true,
-      runtime_state: { active_source: "ping" },
+      runtime_state: { active_source: "ping", deployed_identity_live: false },
       has_pending_changes: true,
       pending_changes_via_hash: true,
       update_available: true,
@@ -46,7 +71,7 @@ describe("device-sync mDNS gating", () => {
     // mDNS-sourced, so it stays hidden.
     const dark = makeConfiguredDevice({
       api_enabled: true,
-      runtime_state: { active_source: "ping" },
+      runtime_state: { active_source: "ping", deployed_identity_live: false },
       has_pending_changes: true,
       update_available: true,
     });
@@ -68,7 +93,7 @@ describe("device-sync mDNS gating", () => {
   it("shows a no-api device's hash-driven modified / update signals without mDNS reachability", () => {
     const mqttOnly = makeConfiguredDevice({
       api_enabled: false,
-      runtime_state: { active_source: "mqtt", http_identity_live: true },
+      runtime_state: { active_source: "mqtt", deployed_identity_live: true },
       has_pending_changes: true,
       pending_changes_via_hash: true,
       update_available: true,
@@ -80,7 +105,7 @@ describe("device-sync mDNS gating", () => {
   it("hides a no-api device's hash-driven signals when the identity TXT went dark", () => {
     const dark = makeConfiguredDevice({
       api_enabled: false,
-      runtime_state: { active_source: "mqtt", http_identity_live: false },
+      runtime_state: { active_source: "mqtt", deployed_identity_live: false },
       has_pending_changes: true,
       pending_changes_via_hash: true,
       update_available: true,

--- a/test/util/facets.test.ts
+++ b/test/util/facets.test.ts
@@ -13,9 +13,9 @@ import { makeConfiguredDevice } from "../_make-configured-device.js";
 
 // computeUpdateFacet reads update_available / has_pending_changes, gated
 // through showUpdateAvailable / showPendingChanges. The shared fixture
-// defaults to a trusted identity (live mDNS source AND
-// deployed_identity_live) so update/modified buckets surface; mDNS-dark
-// cases must override BOTH — either alone keeps the identity trusted.
+// defaults to a trusted identity, so update/modified buckets surface;
+// mDNS-dark cases must clear deployed_identity_live, and an api device
+// also needs a non-mdns active_source (the gate trusts either).
 const device = makeConfiguredDevice;
 
 // Echo the key so assertions key off the i18n id, not display copy.

--- a/test/util/facets.test.ts
+++ b/test/util/facets.test.ts
@@ -13,9 +13,10 @@ import { makeConfiguredDevice } from "../_make-configured-device.js";
 
 // computeUpdateFacet reads update_available / has_pending_changes, gated
 // through showUpdateAvailable / showPendingChanges. The shared fixture
-// defaults to a trusted identity, so update/modified buckets surface;
-// mDNS-dark cases must clear deployed_identity_live, and an api device
-// also needs a non-mdns active_source (the gate trusts either).
+// defaults to a trusted identity, so update/modified buckets surface.
+// These fixtures are no-api (api_enabled defaults false), so the gate
+// reduces to deployed_identity_live — override that to go dark; a case
+// that also sets api_enabled: true must override active_source too.
 const device = makeConfiguredDevice;
 
 // Echo the key so assertions key off the i18n id, not display copy.

--- a/test/util/facets.test.ts
+++ b/test/util/facets.test.ts
@@ -11,10 +11,11 @@ import { computeUpdateFacet, normalizeUpdateBuckets } from "../../src/util/facet
 import { identityLocalize } from "../_dom.js";
 import { makeConfiguredDevice } from "../_make-configured-device.js";
 
-// computeUpdateFacet reads update_available / has_pending_changes, gated on
-// active_source via showUpdateAvailable / showPendingChanges. The shared
-// fixture defaults to a live mDNS source so update/modified buckets surface;
-// mDNS-dark cases pass runtime_state.active_source explicitly.
+// computeUpdateFacet reads update_available / has_pending_changes, gated
+// through showUpdateAvailable / showPendingChanges. The shared fixture
+// defaults to a trusted identity (live mDNS source AND
+// deployed_identity_live) so update/modified buckets surface; mDNS-dark
+// cases must override BOTH — either alone keeps the identity trusted.
 const device = makeConfiguredDevice;
 
 // Echo the key so assertions key off the i18n id, not display copy.


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#2136, which must merge first. The backend now tracks Native API device_info connections as first-party identity evidence and renamed the wire field to `deployed_identity_live`. The gate becomes `(api_enabled && mdnsOnline) || deployed_identity_live`, so an mDNS-dark api device whose version the backend read over a direct connection shows its deployed version and update badge instead of blanking forever.

This also corrects a wrong claim in the old comment: a device without api: can hold `active_source === "mdns"` off a bare A-record resolve, which vouches for reachability only, so the mdns disjunct stays api-scoped.

**Related issue or feature (if applicable):**

- companion to esphome/device-builder#2136

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
