### PR TITLE
Decode remote-built crashes through the hosted decoder

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -74,10 +74,22 @@
           all) leaves clickjacking unblocked; operators behind a
           reverse proxy can add their own frame-ancestors via
           response headers.
+        * frame-src https://esphome.github.io is the crash-backtrace
+          decoder, framed hidden by util/stacktrace-decoder.ts when
+          a device was built on a remote server: the build tree
+          never came with the firmware, so nothing here can resolve
+          addr2line, and the ELF is handed to that page over
+          postMessage instead. Named explicitly because frame-src
+          otherwise falls back through child-src to default-src
+          'self', which blocks it. It is a decoder, not an upload:
+          the page itself ships connect-src 'self', so the firmware
+          cannot leave the browser. Failures gracefully degrade to
+          no decode - util/crash-decode.ts treats every error path
+          as null and the raw dump stays readable.
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' ws: wss: data: https://schema.esphome.io; object-src 'none'; base-uri 'self'; form-action 'self'"
+      content="default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' ws: wss: data: https://schema.esphome.io; frame-src https://esphome.github.io; object-src 'none'; base-uri 'self'; form-action 'self'"
     />
     <title>ESPHome Device Builder</title>
     <!-- Backend rewrites ``__ESPHOME_BASE_HREF__`` per-request to

--- a/public/index.html
+++ b/public/index.html
@@ -74,22 +74,24 @@
           all) leaves clickjacking unblocked; operators behind a
           reverse proxy can add their own frame-ancestors via
           response headers.
-        * frame-src https://esphome.github.io is the crash-backtrace
-          decoder, framed hidden by util/stacktrace-decoder.ts when
-          a device was built on a remote server: the build tree
-          never came with the firmware, so nothing here can resolve
-          addr2line, and the ELF is handed to that page over
-          postMessage instead. Named explicitly because frame-src
-          otherwise falls back through child-src to default-src
-          'self', which blocks it. It is a decoder, not an upload:
-          the page itself ships connect-src 'self', so the firmware
-          cannot leave the browser. Failures gracefully degrade to
-          no decode - util/crash-decode.ts treats every error path
-          as null and the raw dump stays readable.
+        * frame-src names the crash-backtrace decoder, framed hidden
+          by util/stacktrace-decoder.ts when a device was built on a
+          remote server: the build tree never came with the firmware,
+          so nothing here can resolve addr2line, and the ELF is handed
+          to that page over postMessage instead. Named explicitly
+          because frame-src otherwise falls back through child-src to
+          default-src 'self', which blocks it. Scoped to the decoder's
+          path, not the origin, so the grant is the one page rather
+          than everything else published under esphome.github.io. It
+          is a decoder, not an upload: the page itself ships
+          connect-src 'self', so the firmware cannot leave the
+          browser. Failures gracefully degrade to no decode -
+          util/crash-decode.ts treats every error path as null and the
+          raw dump stays readable.
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' ws: wss: data: https://schema.esphome.io; frame-src https://esphome.github.io; object-src 'none'; base-uri 'self'; form-action 'self'"
+      content="default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' ws: wss: data: https://schema.esphome.io; frame-src https://esphome.github.io/device-builder/esp-stacktrace-decoder/; object-src 'none'; base-uri 'self'; form-action 'self'"
     />
     <title>ESPHome Device Builder</title>
     <!-- Backend rewrites ``__ESPHOME_BASE_HREF__`` per-request to

--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -345,9 +345,9 @@ export interface DecodeBacktraceResponse {
    *  those bytes can tell a rebuild from a re-crash; `stale_build` can't answer
    *  that, since it goes false the moment the device catches up with the local
    *  build, which is exactly when cached bytes are stale. */
-  local_build_hash: string;
+  local_config_hash: string;
   /** Why nothing was decoded: "no_backtrace" | "no_build" |
-   *  "no_local_toolchain" | "unsupported_platform" | "decode_failed" |
+   *  "elf_only" | "unsupported_platform" | "decode_failed" |
    *  "helper_failed"; "" on success.
    *
    *  Never shown: the report states that the backtrace was not decoded without

--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -340,9 +340,15 @@ export interface DecodeBacktraceResponse {
   /** The running firmware was built from a different config than the local
    *  build, so the symbols are confident but wrong. */
   stale_build: boolean;
+  /** The config hash the local build was compiled from, "" when there is none
+   *  to read. Identifies *which* build the on-disk ELF is, so a client caching
+   *  those bytes can tell a rebuild from a re-crash; `stale_build` can't answer
+   *  that, since it goes false the moment the device catches up with the local
+   *  build, which is exactly when cached bytes are stale. */
+  local_build_hash: string;
   /** Why nothing was decoded: "no_backtrace" | "no_build" |
-   *  "unsupported_platform" | "decode_failed" | "helper_failed"; "" on
-   *  success.
+   *  "no_local_toolchain" | "unsupported_platform" | "decode_failed" |
+   *  "helper_failed"; "" on success.
    *
    *  Never shown: the report states that the backtrace was not decoded without
    *  naming a cause, because most of these are indistinguishable to a reader

--- a/src/common/docs.ts
+++ b/src/common/docs.ts
@@ -36,3 +36,22 @@ export const FLASHER_URL = "https://web.esphome.io/";
 export const FLASHER_ORIGIN = new URL(FLASHER_URL).origin;
 // The bare host (no scheme), for user-facing copy; same single source as above.
 export const FLASHER_HOST = new URL(FLASHER_URL).host;
+
+/**
+ * Hosted crash-backtrace decoder, framed and handed an ELF over postMessage.
+ *
+ * Exists because a remote-built device has no CMake build tree locally, and
+ * native ESP-IDF resolves addr2line only through that tree's cache, so the
+ * backend can't decode it. The page runs esp-stacktrace-decoder's wasm and is
+ * served with a CSP that permits no network egress, so the firmware stays in
+ * the browser.
+ *
+ * Optional by design: unreachable (offline, GitHub down) means no decode, never
+ * a broken log. If this URL moves, the old host has to keep serving until the
+ * dashboards that shipped with it baked in have aged out.
+ */
+export const DECODER_URL =
+  "https://esphome.github.io/device-builder/esp-stacktrace-decoder/";
+// Derived so the postMessage targetOrigin / inbound-frame check can't drift
+// from DECODER_URL.
+export const DECODER_ORIGIN = new URL(DECODER_URL).origin;

--- a/src/util/crash-decode.ts
+++ b/src/util/crash-decode.ts
@@ -359,11 +359,13 @@ function framesToDecodedLines(
 ): DecodedBacktraceLine[] {
   // The address values in each line, once. Compared by value, not substring:
   // 4201b6e0 must not attach to a line where it only appears inside a longer
-  // hex run like 0x4201b6e0abcd. The lookbehind/lookahead pin it to a whole
-  // 8-digit token (optionally 0x-prefixed), the boundary ADDRESS_RE uses.
+  // hex run like 0x4201b6e0abcd. The `\w` boundaries pin it to a whole 8-digit
+  // token (optionally 0x-prefixed), rejecting both a hex neighbour and any word
+  // char after it, the same terminator ADDRESS_RE's `\b` gives (so `0x1234abcdx`
+  // is not a token here either).
   const addressesPerLine = lines.map((line) => {
     const found = new Set<number>();
-    for (const m of line.matchAll(/(?<![0-9a-fx])(?:0x)?([0-9a-f]{8})(?![0-9a-f])/gi)) {
+    for (const m of line.matchAll(/(?<!\w)(?:0x)?([0-9a-f]{8})(?!\w)/gi)) {
       found.add(parseInt(m[1], 16));
     }
     return found;

--- a/src/util/crash-decode.ts
+++ b/src/util/crash-decode.ts
@@ -8,6 +8,8 @@ import {
   isCrashMarker,
 } from "./crash-detector.js";
 import { normalizeLogLine } from "./log-line.js";
+import type { DecodedFrame } from "./stacktrace-decoder.js";
+import { hostedDecoder } from "./stacktrace-decoder.js";
 
 /**
  * Backend-decoded backtraces for crashes captured over Web Serial.
@@ -42,6 +44,27 @@ const ANSI_RESET = "\u001b[0m";
 // see genuinely different crashes.
 const MAX_CACHE_ENTRIES = 16;
 
+// The artifact the hosted decoder needs, as `firmware/get_binaries` names it.
+const ELF_FILE = "firmware.elf";
+
+/**
+ * ELF bytes per configuration, for the hosted-decoder path.
+ *
+ * Module-level and unbounded on purpose: an ELF is tens of megabytes and a
+ * crash loop decodes region after region, so refetching per region is the cost
+ * worth avoiding. The entry is the in-flight promise, so concurrent regions
+ * share one download rather than racing. Bounded in practice by how many
+ * distinct devices one tab streams logs from; the tab reload that ends the
+ * session clears it, which is also what makes it safe to keep a build's bytes
+ * after a reflash.
+ */
+const elfCache = new Map<string, Promise<ArrayBuffer | null>>();
+
+/** Drop the session's ELF bytes. Tests only; production keeps them for the tab. */
+export function resetElfCache(): void {
+  elfCache.clear();
+}
+
 /**
  * Decode outcomes already seen this log session, keyed on the region text.
  *
@@ -56,6 +79,23 @@ export type CrashDecodeCache = Map<string, CrashDecode | null>;
 // leave the crash it was decoding undecodable for the rest of the session,
 // which is the crash loop this feature exists for.
 const BACKEND_FAULT_REASONS: ReadonlySet<string> = new Set([
+  "decode_failed",
+  "helper_failed",
+]);
+
+// Reasons worth a second opinion from the hosted decoder (mirroring
+// constants.DecodeUnavailable).
+//
+// `no_build` is the one this exists for: a device built on a remote server has
+// no CMake build tree here, and native ESP-IDF resolves addr2line only through
+// that tree's cache, so the backend cannot decode a crash it has the ELF for.
+// The fault reasons are worth retrying for the same reason they are not cached.
+//
+// Deliberately absent: `no_backtrace`, where there is nothing to decode and the
+// hosted decoder would find nothing either, and `unsupported_platform`, where
+// the target is not an ESP the decoder handles.
+const HOSTED_FALLBACK_REASONS: ReadonlySet<string> = new Set([
+  "no_build",
   "decode_failed",
   "helper_failed",
 ]);
@@ -241,9 +281,20 @@ export async function decodeCrashRegion(
   if (cache.has(key)) return cache.get(key) ?? null;
   try {
     const result = await api.decodeBacktrace(configuration, lines);
-    const decode: CrashDecode | null = result.decoded.length
+    let decode: CrashDecode | null = result.decoded.length
       ? { decoded: result.decoded, staleBuild: result.stale_build }
       : null;
+    // The backend first: it decodes against the exact toolchain the build used,
+    // and costs no ELF transfer. Only when it says it cannot is the hosted
+    // decoder worth the round trip.
+    if (decode === null && HOSTED_FALLBACK_REASONS.has(result.unavailable_reason)) {
+      decode = await decodeViaHostedDecoder(
+        api,
+        configuration,
+        lines,
+        result.stale_build
+      );
+    }
     if (decode !== null || !BACKEND_FAULT_REASONS.has(result.unavailable_reason)) {
       if (cache.size >= MAX_CACHE_ENTRIES) {
         // Map iterates in insertion order, so this drops the oldest.
@@ -258,4 +309,95 @@ export async function decodeCrashRegion(
     console.warn("Backtrace decoding failed", err);
     return null;
   }
+}
+
+/**
+ * Decode *lines* in the browser, against the ELF the backend already serves.
+ *
+ * The path a remote-built device takes: the build tree it was compiled in lives
+ * on the build server, so nothing here can resolve addr2line, but the ELF
+ * itself was materialised locally and is all a decoder needs.
+ *
+ * Every step is allowed to decline, and declining means the raw dump stands.
+ * The gates run cheapest first so the common no-op costs the least: whether the
+ * ELF exists at all is a local list, whether the decoder is reachable is one
+ * page load, and only then is a multi-megabyte ELF worth fetching.
+ *
+ * *backendStaleBuild* rides through from the backend's reply, which knows both
+ * the running firmware's config hash and the local build's whether or not it
+ * could decode.
+ */
+async function decodeViaHostedDecoder(
+  api: ESPHomeAPI,
+  configuration: string,
+  lines: string[],
+  backendStaleBuild: boolean
+): Promise<CrashDecode | null> {
+  try {
+    const binaries = await api.firmwareGetBinaries(configuration);
+    // Absent for a device that was never built here, which is the other half of
+    // what `no_build` means and the case that must not reach the network.
+    if (!binaries.some((b) => b.file === ELF_FILE)) return null;
+    if (!(await hostedDecoder().available())) return null;
+    const elf = await loadElf(api, configuration);
+    if (elf === null) return null;
+    // Hand over a copy: postMessage transfers it (detaching what it is given),
+    // and the cached original has to survive for the next region of a crash loop.
+    const frames = await hostedDecoder().decode(elf.slice(0), lines.join("\n"));
+    if (!frames?.length) return null;
+    // Checked after mapping, not before: frames that resolve to no line leave
+    // nothing to splice, and an empty decode would be cached and reported as a
+    // success while rendering exactly like a failure.
+    const decoded = framesToDecodedLines(frames, lines);
+    if (!decoded.length) return null;
+    return { decoded, staleBuild: backendStaleBuild };
+  } catch (err) {
+    console.warn("Hosted backtrace decoding failed", err);
+    return null;
+  }
+}
+
+/**
+ * Attribute each frame to the log line whose text carries its address.
+ *
+ * The backend keys its output by line offset; the decoder keys by address,
+ * having found them itself. Mapping back is what lets a decode land under the
+ * line that produced it, which is the whole shape `interleaveDecoded` renders.
+ * A frame whose address matches no line is dropped rather than guessed at.
+ */
+function framesToDecodedLines(
+  frames: DecodedFrame[],
+  lines: string[]
+): DecodedBacktraceLine[] {
+  const decoded: DecodedBacktraceLine[] = [];
+  for (const frame of frames) {
+    // Addresses print as 8 hex digits, with or without the 0x, in either case.
+    const hex = frame.address.toString(16).padStart(8, "0");
+    const index = lines.findIndex((line) => line.toLowerCase().includes(hex));
+    if (index === -1) continue;
+    const location = frame.location ? ` at ${frame.location}` : "";
+    // The wording esphome's own decoders log, so a Web Serial decode reads like
+    // the OTA one the device's logger would have printed.
+    decoded.push({ index, text: `Decoded 0x${hex}: ${frame.function_name}${location}` });
+  }
+  return decoded;
+}
+
+/** The session's ELF bytes for *configuration*, fetched once. */
+async function loadElf(
+  api: ESPHomeAPI,
+  configuration: string
+): Promise<ArrayBuffer | null> {
+  const cached = elfCache.get(configuration);
+  if (cached !== undefined) return cached;
+  // Awaited by every region of a crash loop, so the fetch is shared rather than
+  // raced: an ELF runs to tens of megabytes.
+  const pending = api
+    .firmwareDownloadBytes(configuration, ELF_FILE)
+    .catch((err): null => {
+      console.warn("Could not download the ELF for decoding", err);
+      return null;
+    });
+  elfCache.set(configuration, pending);
+  return pending;
 }

--- a/src/util/crash-decode.ts
+++ b/src/util/crash-decode.ts
@@ -93,8 +93,11 @@ const BACKEND_FAULT_REASONS: ReadonlySet<string> = new Set([
 //
 // `elf_only` is the one this exists for: the backend has the ELF but
 // not the build tree it was compiled in, so nothing there can resolve
-// addr2line. The fault reasons join it for the same reason they are not cached
-// above. `no_build` is absent and must stay absent: it means the ELF isn't here
+// addr2line. The fault reasons join it, and unlike `elf_only` they are a
+// transient fault rather than a verdict, so a region that hit one is cached
+// null (the region text differs between crashes, so a loop still recovers on
+// the next one, and the ELF download itself retries per KeyedPromiseCache).
+// `no_build` is absent and must stay absent: it means the ELF isn't here
 // either, so there is nothing to send.
 const HOSTED_FALLBACK_REASONS: ReadonlySet<string> = new Set([
   ...BACKEND_FAULT_REASONS,
@@ -371,25 +374,30 @@ function framesToDecodedLines(
 }
 
 /**
- * The session's ELF bytes for *configuration*'s *buildHash*, fetched once.
+ * The session's ELF bytes for *configuration* at *configHash*, fetched once.
  *
- * Keyed on the build, not just the device: a rebuild mid-session replaces the
- * ELF on disk, and serving the old bytes would decode the next crash against
- * the wrong build and report it without a caveat (`stale_build` goes false the
- * moment the device is reflashed to match). A new hash simply misses.
+ * Keyed on the config hash, not just the device: a rebuild mid-session replaces
+ * the ELF on disk, and serving the old bytes would decode the next crash
+ * against the wrong build and report it without a caveat (`stale_build` goes
+ * false the moment the device is reflashed to match). A new hash simply misses.
+ *
+ * The bound is the config hash, not the binary: a recompile that changes the
+ * binary without changing the YAML (a toolchain or library bump) keeps the same
+ * key. That is the same precision the backend's `stale_build` has, and the
+ * accepted ceiling here.
  *
  * Throws as the download does, which the caller turns into "no decode".
  */
 function loadElf(
   api: ESPHomeAPI,
   configuration: string,
-  buildHash: string
+  configHash: string
 ): Promise<ArrayBuffer> {
   // No hash means the build can't be told apart from the next one (an ELF
   // present without a build_info.json). Caching under a hash-less key would
   // serve one build's bytes for another after a rebuild, so fetch uncached.
-  if (!buildHash) return api.firmwareDownloadBytes(configuration, ELF_FILE);
-  const key = `${configuration}\n${buildHash}`;
+  if (!configHash) return api.firmwareDownloadBytes(configuration, ELF_FILE);
+  const key = `${configuration}\n${configHash}`;
   if (key !== elfCacheKey) {
     elfCache.clear();
     elfCacheKey = key;

--- a/src/util/crash-decode.ts
+++ b/src/util/crash-decode.ts
@@ -52,18 +52,23 @@ const MAX_CACHE_ENTRIES = 16;
 const ELF_FILE = "firmware.elf";
 
 /**
- * ELF bytes per configuration, for the hosted-decoder path.
+ * ELF bytes for the hosted-decoder path, keyed on configuration + build.
  *
- * Unbounded on purpose: an ELF runs to tens of megabytes and a crash loop
- * decodes region after region, so refetching per region is the cost worth
- * avoiding. A rejected download is evicted (the default), so one blip doesn't
- * leave the device undecodable for the rest of the session.
+ * Holding them is the point: an ELF runs to tens of megabytes and a crash loop
+ * decodes region after region. Holding *more than one* is not. Every entry but
+ * the newest is provably dead, because the key names the build and a rebuild
+ * only ever asks for the new one; keeping them would strand 5-18MB per rebuild
+ * for the life of the tab, in exactly the edit-rebuild-crash session this
+ * feature exists for. A rejected download evicts itself (the default), so one
+ * blip doesn't leave the device undecodable either.
  */
 const elfCache = new KeyedPromiseCache<ArrayBuffer>();
+let elfCacheKey = "";
 
 /** Drop the session's ELF bytes. Tests only; production keeps them for the tab. */
 export function resetElfCache(): void {
   elfCache.clear();
+  elfCacheKey = "";
 }
 
 /**
@@ -86,14 +91,14 @@ const BACKEND_FAULT_REASONS: ReadonlySet<string> = new Set([
 
 // Reasons worth a second opinion from the hosted decoder.
 //
-// `no_local_toolchain` is the one this exists for: the backend has the ELF but
+// `elf_only` is the one this exists for: the backend has the ELF but
 // not the build tree it was compiled in, so nothing there can resolve
 // addr2line. The fault reasons join it for the same reason they are not cached
 // above. `no_build` is absent and must stay absent: it means the ELF isn't here
 // either, so there is nothing to send.
 const HOSTED_FALLBACK_REASONS: ReadonlySet<string> = new Set([
   ...BACKEND_FAULT_REASONS,
-  "no_local_toolchain",
+  "elf_only",
 ]);
 
 // Shown where the reader is looking. The report gets the same verdict as a
@@ -322,10 +327,8 @@ async function decodeViaHostedDecoder(
   const decoder = hostedDecoder();
   try {
     if (!(await decoder.available())) return null;
-    const elf = await loadElf(api, configuration, backend.local_build_hash);
-    // Hand over a copy: postMessage transfers it (detaching what it is given),
-    // and the cached original has to survive for the next region of a crash loop.
-    const frames = await decoder.decode(elf.slice(0), lines.join("\n"));
+    const elf = await loadElf(api, configuration, backend.local_config_hash);
+    const frames = await decoder.decode(elf, lines.join("\n"));
     if (!frames?.length) return null;
     // Checked after mapping, not before: frames that resolve to no line leave
     // nothing to splice, and an empty decode would be cached and reported as a
@@ -352,10 +355,12 @@ function framesToDecodedLines(
   lines: string[]
 ): DecodedBacktraceLine[] {
   const decoded: DecodedBacktraceLine[] = [];
+  // Lowered once, not once per frame: the scan below is frames x lines.
+  const lower = lines.map((line) => line.toLowerCase());
   for (const frame of frames) {
     // Addresses print as 8 hex digits, with or without the 0x, in either case.
     const hex = frame.address.toString(16).padStart(8, "0");
-    const index = lines.findIndex((line) => line.toLowerCase().includes(hex));
+    const index = lower.findIndex((line) => line.includes(hex));
     if (index === -1) continue;
     const location = frame.location ? ` at ${frame.location}` : "";
     // The wording esphome's own decoders log, so a Web Serial decode reads like
@@ -380,7 +385,10 @@ function loadElf(
   configuration: string,
   buildHash: string
 ): Promise<ArrayBuffer> {
-  return elfCache.fetch(`${configuration}\n${buildHash}`, () =>
-    api.firmwareDownloadBytes(configuration, ELF_FILE)
-  );
+  const key = `${configuration}\n${buildHash}`;
+  if (key !== elfCacheKey) {
+    elfCache.clear();
+    elfCacheKey = key;
+  }
+  return elfCache.fetch(key, () => api.firmwareDownloadBytes(configuration, ELF_FILE));
 }

--- a/src/util/crash-decode.ts
+++ b/src/util/crash-decode.ts
@@ -1,5 +1,8 @@
 import type { ESPHomeAPI } from "../api/index.js";
-import type { DecodedBacktraceLine } from "../api/types/devices.js";
+import type {
+  DecodeBacktraceResponse,
+  DecodedBacktraceLine,
+} from "../api/types/devices.js";
 import {
   ADDRESS_RE,
   CRASH_END_RE,
@@ -7,6 +10,7 @@ import {
   MAX_LINES_AFTER_MARKER,
   isCrashMarker,
 } from "./crash-detector.js";
+import { KeyedPromiseCache } from "./keyed-promise-cache.js";
 import { normalizeLogLine } from "./log-line.js";
 import type { DecodedFrame } from "./stacktrace-decoder.js";
 import { hostedDecoder } from "./stacktrace-decoder.js";
@@ -50,15 +54,12 @@ const ELF_FILE = "firmware.elf";
 /**
  * ELF bytes per configuration, for the hosted-decoder path.
  *
- * Module-level and unbounded on purpose: an ELF is tens of megabytes and a
- * crash loop decodes region after region, so refetching per region is the cost
- * worth avoiding. The entry is the in-flight promise, so concurrent regions
- * share one download rather than racing. Bounded in practice by how many
- * distinct devices one tab streams logs from; the tab reload that ends the
- * session clears it, which is also what makes it safe to keep a build's bytes
- * after a reflash.
+ * Unbounded on purpose: an ELF runs to tens of megabytes and a crash loop
+ * decodes region after region, so refetching per region is the cost worth
+ * avoiding. A rejected download is evicted (the default), so one blip doesn't
+ * leave the device undecodable for the rest of the session.
  */
-const elfCache = new Map<string, Promise<ArrayBuffer | null>>();
+const elfCache = new KeyedPromiseCache<ArrayBuffer>();
 
 /** Drop the session's ELF bytes. Tests only; production keeps them for the tab. */
 export function resetElfCache(): void {
@@ -83,21 +84,16 @@ const BACKEND_FAULT_REASONS: ReadonlySet<string> = new Set([
   "helper_failed",
 ]);
 
-// Reasons worth a second opinion from the hosted decoder (mirroring
-// constants.DecodeUnavailable).
+// Reasons worth a second opinion from the hosted decoder.
 //
-// `no_build` is the one this exists for: a device built on a remote server has
-// no CMake build tree here, and native ESP-IDF resolves addr2line only through
-// that tree's cache, so the backend cannot decode a crash it has the ELF for.
-// The fault reasons are worth retrying for the same reason they are not cached.
-//
-// Deliberately absent: `no_backtrace`, where there is nothing to decode and the
-// hosted decoder would find nothing either, and `unsupported_platform`, where
-// the target is not an ESP the decoder handles.
+// `no_local_toolchain` is the one this exists for: the backend has the ELF but
+// not the build tree it was compiled in, so nothing there can resolve
+// addr2line. The fault reasons join it for the same reason they are not cached
+// above. `no_build` is absent and must stay absent: it means the ELF isn't here
+// either, so there is nothing to send.
 const HOSTED_FALLBACK_REASONS: ReadonlySet<string> = new Set([
-  "no_build",
-  "decode_failed",
-  "helper_failed",
+  ...BACKEND_FAULT_REASONS,
+  "no_local_toolchain",
 ]);
 
 // Shown where the reader is looking. The report gets the same verdict as a
@@ -288,12 +284,7 @@ export async function decodeCrashRegion(
     // and costs no ELF transfer. Only when it says it cannot is the hosted
     // decoder worth the round trip.
     if (decode === null && HOSTED_FALLBACK_REASONS.has(result.unavailable_reason)) {
-      decode = await decodeViaHostedDecoder(
-        api,
-        configuration,
-        lines,
-        result.stale_build
-      );
+      decode = await decodeViaHostedDecoder(api, configuration, result, lines);
     }
     if (decode !== null || !BACKEND_FAULT_REASONS.has(result.unavailable_reason)) {
       if (cache.size >= MAX_CACHE_ENTRIES) {
@@ -314,43 +305,34 @@ export async function decodeCrashRegion(
 /**
  * Decode *lines* in the browser, against the ELF the backend already serves.
  *
- * The path a remote-built device takes: the build tree it was compiled in lives
- * on the build server, so nothing here can resolve addr2line, but the ELF
- * itself was materialised locally and is all a decoder needs.
+ * The path a remote-built device takes; see the decoder page's README for why
+ * the ELF is the only local input left. Every step may decline, and declining
+ * leaves the raw dump standing.
  *
- * Every step is allowed to decline, and declining means the raw dump stands.
- * The gates run cheapest first so the common no-op costs the least: whether the
- * ELF exists at all is a local list, whether the decoder is reachable is one
- * page load, and only then is a multi-megabyte ELF worth fetching.
- *
- * *backendStaleBuild* rides through from the backend's reply, which knows both
- * the running firmware's config hash and the local build's whether or not it
- * could decode.
+ * The decoder is asked before the ELF is fetched, not alongside it: an
+ * unreachable decoder costs a page load to discover, and finding out after a
+ * multi-megabyte download would waste the download.
  */
 async function decodeViaHostedDecoder(
   api: ESPHomeAPI,
   configuration: string,
-  lines: string[],
-  backendStaleBuild: boolean
+  backend: DecodeBacktraceResponse,
+  lines: string[]
 ): Promise<CrashDecode | null> {
+  const decoder = hostedDecoder();
   try {
-    const binaries = await api.firmwareGetBinaries(configuration);
-    // Absent for a device that was never built here, which is the other half of
-    // what `no_build` means and the case that must not reach the network.
-    if (!binaries.some((b) => b.file === ELF_FILE)) return null;
-    if (!(await hostedDecoder().available())) return null;
-    const elf = await loadElf(api, configuration);
-    if (elf === null) return null;
+    if (!(await decoder.available())) return null;
+    const elf = await loadElf(api, configuration, backend.local_build_hash);
     // Hand over a copy: postMessage transfers it (detaching what it is given),
     // and the cached original has to survive for the next region of a crash loop.
-    const frames = await hostedDecoder().decode(elf.slice(0), lines.join("\n"));
+    const frames = await decoder.decode(elf.slice(0), lines.join("\n"));
     if (!frames?.length) return null;
     // Checked after mapping, not before: frames that resolve to no line leave
     // nothing to splice, and an empty decode would be cached and reported as a
     // success while rendering exactly like a failure.
     const decoded = framesToDecodedLines(frames, lines);
     if (!decoded.length) return null;
-    return { decoded, staleBuild: backendStaleBuild };
+    return { decoded, staleBuild: backend.stale_build };
   } catch (err) {
     console.warn("Hosted backtrace decoding failed", err);
     return null;
@@ -383,21 +365,22 @@ function framesToDecodedLines(
   return decoded;
 }
 
-/** The session's ELF bytes for *configuration*, fetched once. */
-async function loadElf(
+/**
+ * The session's ELF bytes for *configuration*'s *buildHash*, fetched once.
+ *
+ * Keyed on the build, not just the device: a rebuild mid-session replaces the
+ * ELF on disk, and serving the old bytes would decode the next crash against
+ * the wrong build and report it without a caveat (`stale_build` goes false the
+ * moment the device is reflashed to match). A new hash simply misses.
+ *
+ * Throws as the download does, which the caller turns into "no decode".
+ */
+function loadElf(
   api: ESPHomeAPI,
-  configuration: string
-): Promise<ArrayBuffer | null> {
-  const cached = elfCache.get(configuration);
-  if (cached !== undefined) return cached;
-  // Awaited by every region of a crash loop, so the fetch is shared rather than
-  // raced: an ELF runs to tens of megabytes.
-  const pending = api
-    .firmwareDownloadBytes(configuration, ELF_FILE)
-    .catch((err): null => {
-      console.warn("Could not download the ELF for decoding", err);
-      return null;
-    });
-  elfCache.set(configuration, pending);
-  return pending;
+  configuration: string,
+  buildHash: string
+): Promise<ArrayBuffer> {
+  return elfCache.fetch(`${configuration}\n${buildHash}`, () =>
+    api.firmwareDownloadBytes(configuration, ELF_FILE)
+  );
 }

--- a/src/util/crash-decode.ts
+++ b/src/util/crash-decode.ts
@@ -357,14 +357,22 @@ function framesToDecodedLines(
   frames: DecodedFrame[],
   lines: string[]
 ): DecodedBacktraceLine[] {
+  // The address values in each line, once. Compared by value, not substring:
+  // 4201b6e0 must not attach to a line where it only appears inside a longer
+  // hex run like 0x4201b6e0abcd. The lookbehind/lookahead pin it to a whole
+  // 8-digit token (optionally 0x-prefixed), the boundary ADDRESS_RE uses.
+  const addressesPerLine = lines.map((line) => {
+    const found = new Set<number>();
+    for (const m of line.matchAll(/(?<![0-9a-fx])(?:0x)?([0-9a-f]{8})(?![0-9a-f])/gi)) {
+      found.add(parseInt(m[1], 16));
+    }
+    return found;
+  });
   const decoded: DecodedBacktraceLine[] = [];
-  // Lowered once, not once per frame: the scan below is frames x lines.
-  const lower = lines.map((line) => line.toLowerCase());
   for (const frame of frames) {
-    // Addresses print as 8 hex digits, with or without the 0x, in either case.
-    const hex = frame.address.toString(16).padStart(8, "0");
-    const index = lower.findIndex((line) => line.includes(hex));
+    const index = addressesPerLine.findIndex((addrs) => addrs.has(frame.address));
     if (index === -1) continue;
+    const hex = frame.address.toString(16).padStart(8, "0");
     const location = frame.location ? ` at ${frame.location}` : "";
     // The wording esphome's own decoders log, so a Web Serial decode reads like
     // the OTA one the device's logger would have printed.

--- a/src/util/crash-decode.ts
+++ b/src/util/crash-decode.ts
@@ -385,6 +385,10 @@ function loadElf(
   configuration: string,
   buildHash: string
 ): Promise<ArrayBuffer> {
+  // No hash means the build can't be told apart from the next one (an ELF
+  // present without a build_info.json). Caching under a hash-less key would
+  // serve one build's bytes for another after a rebuild, so fetch uncached.
+  if (!buildHash) return api.firmwareDownloadBytes(configuration, ELF_FILE);
   const key = `${configuration}\n${buildHash}`;
   if (key !== elfCacheKey) {
     elfCache.clear();

--- a/src/util/random-nonce.ts
+++ b/src/util/random-nonce.ts
@@ -1,0 +1,16 @@
+/**
+ * An unguessable one-time token for a postMessage hand-off.
+ *
+ * `crypto.randomUUID()` is `[SecureContext]`-gated and undefined on plain-http
+ * origins, which is exactly where these hand-offs run (the HA add-on).
+ * `getRandomValues` isn't gated, and the nonce only needs to be unguessable,
+ * not a UUID.
+ *
+ * Shared by the flasher and stack-trace-decoder hand-offs, whose pages check it
+ * against the value in their URL hash.
+ */
+export function randomNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}

--- a/src/util/stacktrace-decoder.ts
+++ b/src/util/stacktrace-decoder.ts
@@ -78,8 +78,9 @@ class HostedDecoder {
       window.addEventListener("message", onMessage);
       timer = setTimeout(() => done(null), DECODE_TIMEOUT_MS);
       try {
-        // The ELF is transferred, not copied: it runs to tens of megabytes and
-        // this side has no use for it afterwards (the cache holds its own copy).
+        // Cloned, not transferred. The decoder is a foreign origin, so the
+        // bytes cross a process boundary and get copied either way; transferring
+        // would only detach the caller's cached ELF, forcing it to copy first.
         target.postMessage(
           {
             type: MSG_REQUEST,
@@ -89,8 +90,7 @@ class HostedDecoder {
             elf,
             dump,
           },
-          DECODER_ORIGIN,
-          [elf]
+          DECODER_ORIGIN
         );
       } catch (err) {
         // postMessage can throw (a detached buffer, DataCloneError). Converge to

--- a/src/util/stacktrace-decoder.ts
+++ b/src/util/stacktrace-decoder.ts
@@ -107,6 +107,11 @@ class HostedDecoder {
       const frame = document.createElement("iframe");
       frame.hidden = true;
       frame.setAttribute("aria-hidden", "true");
+      // Scripts, so the wasm runs; same-origin, so the page keeps its own
+      // origin and its `connect-src 'self'` still resolves the wasm. Nothing
+      // else: no top-level navigation, popups, forms, or downloads. Keeping its
+      // origin can't un-sandbox it here, because it is cross-origin from us.
+      frame.setAttribute("sandbox", "allow-scripts allow-same-origin");
       // A tab would need a user gesture and would interrupt the log the user is
       // reading; the decode needs neither a gesture nor a secure context.
       frame.src = `${DECODER_URL}#nonce=${encodeURIComponent(nonce)}&origin=${encodeURIComponent(

--- a/src/util/stacktrace-decoder.ts
+++ b/src/util/stacktrace-decoder.ts
@@ -7,6 +7,8 @@ const MSG_READY = "esphome-stacktrace-decode:ready";
 const MSG_REQUEST = "esphome-stacktrace-decode:request";
 const MSG_RESULT = "esphome-stacktrace-decode:result";
 const MSG_ERROR = "esphome-stacktrace-decode:error";
+// The page announcing, before any request, that it will never answer.
+const MSG_UNAVAILABLE = "esphome-stacktrace-decode:unavailable";
 
 // The wire protocol version this dashboard speaks. Bumped only for a breaking
 // change; additive fields/messages don't need it. Sent in the request frame and
@@ -119,7 +121,18 @@ class HostedDecoder {
       };
       const onReady = (ev: MessageEvent) => {
         if (ev.origin !== DECODER_ORIGIN || ev.source !== frame.contentWindow) return;
-        const data = ev.data as { type?: string; version?: number };
+        const data = ev.data as { type?: string; version?: number; reason?: string };
+        if (data?.type === MSG_UNAVAILABLE) {
+          // It loaded and told us it won't answer, so there is nothing to wait
+          // for. Logged because this is a wiring mistake on our side, not an
+          // outage, and the page's own console is inside a hidden frame.
+          console.warn(
+            "Stack trace decoder is unavailable:",
+            data.reason ?? "no reason given"
+          );
+          settle(false);
+          return;
+        }
         if (data?.type !== MSG_READY) return;
         // Forward-compat: a decoder advertising a newer protocol still gets our
         // v1 frame (additive fields are ignored); just note the mismatch. When a

--- a/src/util/stacktrace-decoder.ts
+++ b/src/util/stacktrace-decoder.ts
@@ -1,0 +1,163 @@
+import { DECODER_ORIGIN, DECODER_URL } from "../common/docs.js";
+
+// Message types, mirroring esp-stacktrace-decoder/src/protocol.ts in the
+// device-builder repo. The nonce travels one way only (dashboard -> decoder).
+const MSG_READY = "esphome-stacktrace-decode:ready";
+const MSG_REQUEST = "esphome-stacktrace-decode:request";
+const MSG_RESULT = "esphome-stacktrace-decode:result";
+const MSG_ERROR = "esphome-stacktrace-decode:error";
+
+// The wire protocol version this dashboard speaks. Bumped only for a breaking
+// change; additive fields/messages don't need it. Sent in the request frame and
+// read from "ready" so a future version gate has both sides to branch on.
+const PROTOCOL_VERSION = 1;
+
+// Give up if the decoder never reports ready. This is the offline / GitHub-down
+// path, so it must be short: it is spent before the raw dump is shown, and the
+// answer when it expires is simply "no decode".
+const READY_TIMEOUT_MS = 10 * 1000;
+// Bound one decode. Parsing an 18MB ELF's DWARF is seconds, not minutes; this
+// only catches a wedged page.
+const DECODE_TIMEOUT_MS = 60 * 1000;
+
+/** One resolved frame, as the decoder reports it. */
+export interface DecodedFrame {
+  address: number;
+  function_name: string;
+  location: string;
+}
+
+function randomNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * The hosted decoder, framed once and reused.
+ *
+ * Optional by construction: every failure resolves to null rather than
+ * throwing, because a decode is an embellishment on a crash report and the raw
+ * dump has to stay readable when the decoder is unreachable. A dead decoder is
+ * remembered, so a crash loop doesn't re-frame it per region.
+ */
+class HostedDecoder {
+  private _frame: HTMLIFrameElement | null = null;
+  private _nonce = "";
+  private _ready: Promise<boolean> | null = null;
+  private _seq = 0;
+
+  /**
+   * Whether the decoder is reachable, framing it on first call.
+   *
+   * Separate from `decode` so the caller can skip fetching a multi-megabyte ELF
+   * when the answer is going to be "no decode" anyway.
+   */
+  available(): Promise<boolean> {
+    if (this._ready === null) this._ready = this._frameDecoder();
+    return this._ready;
+  }
+
+  /** Decode *dump* against *elf*; null when the decoder can't answer. */
+  async decode(elf: ArrayBuffer, dump: string): Promise<DecodedFrame[] | null> {
+    if (!(await this.available())) return null;
+    const target = this._frame?.contentWindow;
+    if (!target) return null;
+    const id = `d${++this._seq}`;
+    return new Promise((resolve) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const done = (frames: DecodedFrame[] | null) => {
+        window.removeEventListener("message", onMessage);
+        if (timer !== undefined) clearTimeout(timer);
+        resolve(frames);
+      };
+      const onMessage = (ev: MessageEvent) => {
+        if (ev.origin !== DECODER_ORIGIN || ev.source !== target) return;
+        const data = ev.data as { type?: string; id?: string; frames?: DecodedFrame[] };
+        if (data?.id !== id) return;
+        if (data.type === MSG_RESULT) done(data.frames ?? []);
+        else if (data.type === MSG_ERROR) done(null);
+      };
+      window.addEventListener("message", onMessage);
+      timer = setTimeout(() => done(null), DECODE_TIMEOUT_MS);
+      try {
+        // The ELF is transferred, not copied: it runs to tens of megabytes and
+        // this side has no use for it afterwards (the cache holds its own copy).
+        target.postMessage(
+          {
+            type: MSG_REQUEST,
+            version: PROTOCOL_VERSION,
+            nonce: this._nonce,
+            id,
+            elf,
+            dump,
+          },
+          DECODER_ORIGIN,
+          [elf]
+        );
+      } catch (err) {
+        // postMessage can throw (a detached buffer, DataCloneError). Converge to
+        // "no decode" rather than leaving the caller waiting on the timeout.
+        console.warn("Stack trace decode hand-off failed", err);
+        done(null);
+      }
+    });
+  }
+
+  private _frameDecoder(): Promise<boolean> {
+    return new Promise((resolve) => {
+      const nonce = randomNonce();
+      const frame = document.createElement("iframe");
+      frame.hidden = true;
+      frame.setAttribute("aria-hidden", "true");
+      // A tab would need a user gesture and would interrupt the log the user is
+      // reading; the decode needs neither a gesture nor a secure context.
+      frame.src = `${DECODER_URL}#nonce=${encodeURIComponent(nonce)}&origin=${encodeURIComponent(
+        location.origin
+      )}`;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const settle = (ok: boolean) => {
+        window.removeEventListener("message", onReady);
+        if (timer !== undefined) clearTimeout(timer);
+        if (!ok) frame.remove();
+        resolve(ok);
+      };
+      const onReady = (ev: MessageEvent) => {
+        if (ev.origin !== DECODER_ORIGIN || ev.source !== frame.contentWindow) return;
+        const data = ev.data as { type?: string; version?: number };
+        if (data?.type !== MSG_READY) return;
+        // Forward-compat: a decoder advertising a newer protocol still gets our
+        // v1 frame (additive fields are ignored); just note the mismatch. When a
+        // breaking change lands, branch on data.version here.
+        if (typeof data.version === "number" && data.version > PROTOCOL_VERSION) {
+          console.warn(
+            `Stack trace decoder protocol v${data.version} is newer than this dashboard's v${PROTOCOL_VERSION}; proceeding with v${PROTOCOL_VERSION}.`
+          );
+        }
+        this._frame = frame;
+        this._nonce = nonce;
+        settle(true);
+      };
+      window.addEventListener("message", onReady);
+      // The page is unreachable when offline or when Pages is down, and an
+      // iframe that never loads fires no error we can rely on, so time out.
+      timer = setTimeout(() => settle(false), READY_TIMEOUT_MS);
+      document.body.appendChild(frame);
+    });
+  }
+}
+
+// One per session: framing costs a page load and a ~1MB wasm compile, and a
+// device that crashes once tends to crash again.
+let decoder: HostedDecoder | null = null;
+
+/** The session's decoder, created on first use. */
+export function hostedDecoder(): HostedDecoder {
+  if (decoder === null) decoder = new HostedDecoder();
+  return decoder;
+}
+
+/** Drop the session's decoder. Tests only; production keeps one for the tab. */
+export function resetHostedDecoder(): void {
+  decoder = null;
+}

--- a/src/util/stacktrace-decoder.ts
+++ b/src/util/stacktrace-decoder.ts
@@ -1,4 +1,5 @@
 import { DECODER_ORIGIN, DECODER_URL } from "../common/docs.js";
+import { randomNonce } from "./random-nonce.js";
 
 // Message types, mirroring esp-stacktrace-decoder/src/protocol.ts in the
 // device-builder repo. The nonce travels one way only (dashboard -> decoder).
@@ -25,12 +26,6 @@ export interface DecodedFrame {
   address: number;
   function_name: string;
   location: string;
-}
-
-function randomNonce(): string {
-  const bytes = new Uint8Array(16);
-  crypto.getRandomValues(bytes);
-  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
 /**

--- a/src/util/usb-flasher.ts
+++ b/src/util/usb-flasher.ts
@@ -1,4 +1,5 @@
 import { FLASHER_ORIGIN, FLASHER_URL } from "../common/docs.js";
+import { randomNonce } from "./random-nonce.js";
 
 // Message types, mirroring flasher/src/protocol.ts in the device-builder repo.
 // The nonce travels one way only (dashboard -> flasher).
@@ -177,13 +178,4 @@ export function openFlasher(
   }, 1000);
   readyTimer = setTimeout(lost, READY_TIMEOUT_MS);
   return finish;
-}
-
-// crypto.randomUUID() is [SecureContext]-gated and undefined on plain-http
-// origins, which is exactly where this hand-off runs (the HA add-on). getRandom-
-// Values isn't gated; the nonce only needs to be unguessable, not a UUID.
-function randomNonce(): string {
-  const a = new Uint8Array(16);
-  crypto.getRandomValues(a);
-  return Array.from(a, (b) => b.toString(16).padStart(2, "0")).join("");
 }

--- a/test/common/csp.test.ts
+++ b/test/common/csp.test.ts
@@ -8,7 +8,7 @@
  * loads this file. That is exactly how the decoder iframe shipped blocked.
  */
 import { describe, expect, it } from "vitest";
-import { DECODER_ORIGIN } from "../../src/common/docs.js";
+import { DECODER_ORIGIN, DECODER_URL } from "../../src/common/docs.js";
 // The shipped file itself, not a copy of its text: a policy asserted against a
 // duplicate would pass while the real page blocked everything.
 import html from "../../public/index.html?raw";
@@ -34,7 +34,13 @@ describe("the shipped Content-Security-Policy", () => {
     // frame-src falls back through child-src to default-src 'self', so an
     // undeclared directive blocks the decoder outright and every crash on a
     // remote-built device silently stays raw.
-    expect(directive("frame-src")).toContain(DECODER_ORIGIN);
+    expect(directive("frame-src")).toContain(DECODER_URL);
+  });
+
+  it("grants framing to the decoder's page, not to everything on its origin", () => {
+    // esphome.github.io serves every project's Pages site. The path scopes the
+    // grant to the one page we frame; CSP matches source expressions by path.
+    expect(directive("frame-src")).not.toBe(DECODER_ORIGIN);
   });
 
   it("does not let the decoder's origin do anything but be framed", () => {

--- a/test/common/csp.test.ts
+++ b/test/common/csp.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Pins the shipped CSP against the origins the app actually talks to.
+ *
+ * The policy lives in a static `public/index.html` meta tag while the origins
+ * live in TypeScript, so nothing but this connects the two. A feature that
+ * reaches a new origin passes every other test and is then dead on arrival in
+ * the browser: the test environment does not enforce CSP, and the suite never
+ * loads this file. That is exactly how the decoder iframe shipped blocked.
+ */
+import { describe, expect, it } from "vitest";
+import { DECODER_ORIGIN } from "../../src/common/docs.js";
+// The shipped file itself, not a copy of its text: a policy asserted against a
+// duplicate would pass while the real page blocked everything.
+import html from "../../public/index.html?raw";
+
+const csp =
+  /http-equiv="Content-Security-Policy"\s+content="([^"]+)"/.exec(html)?.[1] ?? "";
+
+/** One directive's values, or the empty string when it isn't declared. */
+const directive = (name: string): string =>
+  csp
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part === name || part.startsWith(`${name} `))
+    ?.slice(name.length)
+    .trim() ?? "";
+
+describe("the shipped Content-Security-Policy", () => {
+  it("is present, so the rest of these assertions mean something", () => {
+    expect(csp).toContain("default-src 'self'");
+  });
+
+  it("lets the stack-trace decoder be framed", () => {
+    // frame-src falls back through child-src to default-src 'self', so an
+    // undeclared directive blocks the decoder outright and every crash on a
+    // remote-built device silently stays raw.
+    expect(directive("frame-src")).toContain(DECODER_ORIGIN);
+  });
+
+  it("does not let the decoder's origin do anything but be framed", () => {
+    // It is handed firmware. Framing is all it needs; a script-src or
+    // connect-src entry would be a different, much larger grant.
+    expect(directive("connect-src")).not.toContain(DECODER_ORIGIN);
+    expect(directive("script-src")).toBe("");
+    expect(directive("default-src")).not.toContain(DECODER_ORIGIN);
+  });
+});

--- a/test/common/csp.test.ts
+++ b/test/common/csp.test.ts
@@ -45,9 +45,11 @@ describe("the shipped Content-Security-Policy", () => {
 
   it("does not let the decoder's origin do anything but be framed", () => {
     // It is handed firmware. Framing is all it needs; a script-src or
-    // connect-src entry would be a different, much larger grant.
+    // connect-src entry for it would be a different, much larger grant. Assert
+    // the origin is absent from each rather than that the directive is bare, so
+    // tightening the CSP for unrelated reasons doesn't trip this.
     expect(directive("connect-src")).not.toContain(DECODER_ORIGIN);
-    expect(directive("script-src")).toBe("");
+    expect(directive("script-src")).not.toContain(DECODER_ORIGIN);
     expect(directive("default-src")).not.toContain(DECODER_ORIGIN);
   });
 });

--- a/test/common/csp.test.ts
+++ b/test/common/csp.test.ts
@@ -13,8 +13,12 @@ import { DECODER_ORIGIN, DECODER_URL } from "../../src/common/docs.js";
 // duplicate would pass while the real page blocked everything.
 import html from "../../public/index.html?raw";
 
-const csp =
-  /http-equiv="Content-Security-Policy"\s+content="([^"]+)"/.exec(html)?.[1] ?? "";
+// Find the CSP meta tag, then read its content, so attribute order or an added
+// attribute (a reformat) doesn't break the test while the policy is unchanged.
+const cspMeta = /<meta\b[^>]*\bhttp-equiv="Content-Security-Policy"[^>]*>/i.exec(
+  html
+)?.[0];
+const csp = cspMeta ? (/\bcontent="([^"]*)"/i.exec(cspMeta)?.[1] ?? "") : "";
 
 /** One directive's values, or the empty string when it isn't declared. */
 const directive = (name: string): string =>

--- a/test/fixtures/decoder-stub/index.html
+++ b/test/fixtures/decoder-stub/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<!--
+  Stands in for the hosted decoder so the unit tests never touch the network.
+
+  happy-dom really loads an iframe's src, and the src here is the production
+  decoder URL, so without this every run would fetch esphome.github.io: slow,
+  offline-hostile, and impolite. It is mapped over that URL by the
+  virtualServers option in stacktrace-decoder.test.ts.
+
+  Deliberately inert. The tests drive the protocol by dispatching messages
+  themselves; all this has to do is exist, so the frame gets a contentWindow to
+  use as the message source. The real page's behaviour is covered in the
+  device-builder repo, in a real browser, against a real ELF.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>decoder stub</title>
+  </head>
+  <body>
+    stub
+  </body>
+</html>

--- a/test/raw-modules.d.ts
+++ b/test/raw-modules.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Vite serves `?raw` imports as the file's text. Declared here rather than by
+ * pulling in `vite/client` repo-wide, which would widen the ambient types for
+ * src/ as well to type one import in one test.
+ */
+declare module "*?raw" {
+  const content: string;
+  export default content;
+}

--- a/test/util/crash-decode.test.ts
+++ b/test/util/crash-decode.test.ts
@@ -467,6 +467,27 @@ describe("decodeCrashRegion", () => {
       expect(firmwareDownloadBytes).toHaveBeenCalledTimes(3);
     });
 
+    it("does not cache the ELF when the build can't be identified", async () => {
+      // An empty hash (ELF present, no build_info.json) can't tell two builds
+      // apart, so caching under a hash-less key would serve stale bytes after a
+      // rebuild. Fetch fresh instead.
+      const firmwareDownloadBytes = vi.fn(async () => new ArrayBuffer(8));
+      const api = fakeApi(
+        async () =>
+          reply({ decoded: [], unavailable_reason: "elf_only", local_config_hash: "" }),
+        { firmwareDownloadBytes }
+      );
+      vi.spyOn(hostedDecoder(), "available").mockResolvedValue(true);
+      vi.spyOn(hostedDecoder(), "decode").mockResolvedValue([
+        { address: 0x400d1a2c, function_name: "setup()", location: "application.cpp:59" },
+      ]);
+
+      await decodeCrashRegion(api, "h.yaml", [...region, "boot 1"], cache);
+      await decodeCrashRegion(api, "h.yaml", [...region, "boot 2"], cache);
+
+      expect(firmwareDownloadBytes).toHaveBeenCalledTimes(2);
+    });
+
     it("downloads the ELF once across a crash loop", async () => {
       const firmwareDownloadBytes = vi.fn(async () => new ArrayBuffer(8));
       const api = fakeApi(remoteBuilt(), { firmwareDownloadBytes });

--- a/test/util/crash-decode.test.ts
+++ b/test/util/crash-decode.test.ts
@@ -423,7 +423,10 @@ describe("decodeCrashRegion", () => {
 
       const noToken = [
         "Guru Meditation Error",
+        // The hex sits inside a longer run, and once trailed by a word char
+        // (which ADDRESS_RE's \b rejects too), so neither is a token.
         "ELF file SHA256: 0x4201b6e0abcdef1234567890",
+        "note 0x4201b6e0x",
         "Rebooting...",
       ];
       expect(await decodeCrashRegion(api, "c.yaml", noToken, cache)).toBeNull();

--- a/test/util/crash-decode.test.ts
+++ b/test/util/crash-decode.test.ts
@@ -409,6 +409,46 @@ describe("decodeCrashRegion", () => {
       expect(await decodeCrashRegion(api, "c.yaml", region, cache)).toBeNull();
     });
 
+    it("attributes a frame by whole address token, not a hex substring", async () => {
+      // The address appears only inside a longer hex run (an ELF SHA line), never
+      // as a token. Matching by substring would misattribute the frame there; it
+      // must be dropped instead.
+      const api = fakeApi(remoteBuilt(), {
+        firmwareDownloadBytes: async () => new ArrayBuffer(8),
+      });
+      vi.spyOn(hostedDecoder(), "available").mockResolvedValue(true);
+      vi.spyOn(hostedDecoder(), "decode").mockResolvedValue([
+        { address: 0x4201b6e0, function_name: "setup()", location: "a.cpp:1" },
+      ]);
+
+      const noToken = [
+        "Guru Meditation Error",
+        "ELF file SHA256: 0x4201b6e0abcdef1234567890",
+        "Rebooting...",
+      ];
+      expect(await decodeCrashRegion(api, "c.yaml", noToken, cache)).toBeNull();
+    });
+
+    it("attributes a frame to the line whose backtrace token carries its address", async () => {
+      const api = fakeApi(remoteBuilt(), {
+        firmwareDownloadBytes: async () => new ArrayBuffer(8),
+      });
+      vi.spyOn(hostedDecoder(), "available").mockResolvedValue(true);
+      vi.spyOn(hostedDecoder(), "decode").mockResolvedValue([
+        { address: 0x4201b6e0, function_name: "setup()", location: "a.cpp:1" },
+      ]);
+
+      const withToken = [
+        "Guru Meditation Error",
+        "Backtrace: 0x4201b6e0:0x3fca0000",
+        "Rebooting...",
+      ];
+      const decode = await decodeCrashRegion(api, "c.yaml", withToken, cache);
+      expect(decode?.decoded).toEqual([
+        { index: 1, text: "Decoded 0x4201b6e0: setup() at a.cpp:1" },
+      ]);
+    });
+
     it("refetches the ELF after a rebuild rather than decoding the old one", async () => {
       // The scenario this feature lives in: the user is watching a crash loop,
       // edits the config, rebuilds and installs, and it crashes again. The

--- a/test/util/crash-decode.test.ts
+++ b/test/util/crash-decode.test.ts
@@ -7,7 +7,9 @@ import {
   STALE_BUILD_LOG_LINE,
   decodeCrashRegion,
   interleaveDecoded,
+  resetElfCache,
 } from "../../src/util/crash-decode.js";
+import { hostedDecoder, resetHostedDecoder } from "../../src/util/stacktrace-decoder.js";
 import { stripAnsi } from "../../src/util/ansi-escapes.js";
 import { normalizeLogLine } from "../../src/util/log-line.js";
 import { CRASH_BLOCK_UNDECODED } from "../_crash-lines.js";
@@ -19,12 +21,23 @@ const reply = (over: Partial<DecodeBacktraceResponse> = {}): DecodeBacktraceResp
   ...over,
 });
 
+// `firmwareGetBinaries` is stubbed alongside the decoder because a backend
+// decline now falls through to the hosted decoder, and that path asks for the
+// ELF first. Empty means "never built here", which is the other half of what
+// `no_build` says, so the fallback declines without touching the network. A
+// test that wants the hosted path passes its own binaries.
 const fakeApi = (
   decodeBacktrace: (
     configuration: string,
     lines: string[]
-  ) => Promise<DecodeBacktraceResponse>
-) => ({ decodeBacktrace }) as unknown as ESPHomeAPI;
+  ) => Promise<DecodeBacktraceResponse>,
+  over: Partial<ESPHomeAPI> = {}
+) =>
+  ({
+    decodeBacktrace,
+    firmwareGetBinaries: async () => [],
+    ...over,
+  }) as unknown as ESPHomeAPI;
 
 describe("CrashRegionCollector", () => {
   const feed = (lines: string[]) => {
@@ -186,6 +199,12 @@ describe("decodeCrashRegion", () => {
 
   beforeEach(() => {
     cache = new Map();
+    // Both outlive a single decode by design (an ELF and a framed decoder are
+    // expensive, and a crash loop reuses them), so a test that didn't reset
+    // them would inherit the previous one's.
+    resetElfCache();
+    resetHostedDecoder();
+    vi.restoreAllMocks();
   });
 
   it("sends normalized lines and returns the decode", async () => {
@@ -281,6 +300,138 @@ describe("decodeCrashRegion", () => {
     const region = ["Guru: x", "PC: 0x400d1a2c"];
 
     expect(await decodeCrashRegion(api, "c.yaml", region, cache)).toBeNull();
+  });
+
+  describe("hosted decoder fallback", () => {
+    // The remote-build shape: no CMake tree here, so the backend can't decode,
+    // but the ELF was materialised locally and is all a decoder needs.
+    const remoteBuilt = () =>
+      vi.fn(async () => reply({ decoded: [], unavailable_reason: "no_build" }));
+    const withElf = {
+      firmwareGetBinaries: async () => [{ title: "ELF", file: "firmware.elf" }],
+    };
+    const region = ["Guru Meditation Error", "PC: 0x400d1a2c", "Rebooting..."];
+
+    it("is not consulted when the backend decoded the region itself", async () => {
+      // The whole point of trying the backend first: a locally built device
+      // must not pay a page load and a multi-megabyte ELF transfer.
+      const firmwareGetBinaries = vi.fn(async () => []);
+      const api = fakeApi(async () => reply(), { firmwareGetBinaries });
+
+      expect(await decodeCrashRegion(api, "a.yaml", region, cache)).not.toBeNull();
+      expect(firmwareGetBinaries).not.toHaveBeenCalled();
+    });
+
+    it("is not consulted when there is nothing to decode", async () => {
+      const firmwareGetBinaries = vi.fn(async () => []);
+      const api = fakeApi(
+        async () => reply({ decoded: [], unavailable_reason: "no_backtrace" }),
+        { firmwareGetBinaries }
+      );
+
+      expect(await decodeCrashRegion(api, "a.yaml", region, cache)).toBeNull();
+      expect(firmwareGetBinaries).not.toHaveBeenCalled();
+    });
+
+    it("is not consulted for a platform it could not decode either", async () => {
+      const firmwareGetBinaries = vi.fn(async () => []);
+      const api = fakeApi(
+        async () => reply({ decoded: [], unavailable_reason: "unsupported_platform" }),
+        { firmwareGetBinaries }
+      );
+
+      expect(await decodeCrashRegion(api, "a.yaml", region, cache)).toBeNull();
+      expect(firmwareGetBinaries).not.toHaveBeenCalled();
+    });
+
+    it("does not fetch the ELF when the device was never built here", async () => {
+      // `no_build` covers both "built elsewhere" and "never built"; only the
+      // first has an ELF, and get_binaries is the cheap way to tell them apart.
+      const firmwareDownloadBytes = vi.fn();
+      const api = fakeApi(remoteBuilt(), { firmwareDownloadBytes });
+
+      expect(await decodeCrashRegion(api, "c.yaml", region, cache)).toBeNull();
+      expect(firmwareDownloadBytes).not.toHaveBeenCalled();
+    });
+
+    it("gives up quietly when the decoder can't be reached", async () => {
+      // GitHub down, or an install with no internet. The raw dump has to stand;
+      // a decode is an embellishment on a log, never a prerequisite for one.
+      const firmwareDownloadBytes = vi.fn();
+      const api = fakeApi(remoteBuilt(), { ...withElf, firmwareDownloadBytes });
+      vi.spyOn(hostedDecoder(), "available").mockResolvedValue(false);
+
+      expect(await decodeCrashRegion(api, "c.yaml", region, cache)).toBeNull();
+      // ...and without spending a multi-megabyte download to find that out.
+      expect(firmwareDownloadBytes).not.toHaveBeenCalled();
+    });
+
+    it("decodes through the hosted decoder when the backend can't", async () => {
+      const api = fakeApi(remoteBuilt(), {
+        ...withElf,
+        firmwareDownloadBytes: async () => new ArrayBuffer(8),
+      });
+      vi.spyOn(hostedDecoder(), "available").mockResolvedValue(true);
+      vi.spyOn(hostedDecoder(), "decode").mockResolvedValue([
+        { address: 0x400d1a2c, function_name: "setup()", location: "application.cpp:59" },
+      ]);
+
+      const decode = await decodeCrashRegion(api, "c.yaml", region, cache);
+
+      // Attributed to the line carrying the address, so it renders under it.
+      expect(decode).toEqual({
+        decoded: [
+          { index: 1, text: "Decoded 0x400d1a2c: setup() at application.cpp:59" },
+        ],
+        staleBuild: false,
+      });
+    });
+
+    it("carries the backend's stale-build verdict onto a hosted decode", async () => {
+      // The backend knows both hashes whether or not it can decode, and frames
+      // resolved against a build the device isn't running are confidently wrong.
+      const api = fakeApi(
+        async () =>
+          reply({ decoded: [], unavailable_reason: "no_build", stale_build: true }),
+        { ...withElf, firmwareDownloadBytes: async () => new ArrayBuffer(8) }
+      );
+      vi.spyOn(hostedDecoder(), "available").mockResolvedValue(true);
+      vi.spyOn(hostedDecoder(), "decode").mockResolvedValue([
+        { address: 0x400d1a2c, function_name: "setup()", location: "application.cpp:59" },
+      ]);
+
+      expect((await decodeCrashRegion(api, "c.yaml", region, cache))?.staleBuild).toBe(
+        true
+      );
+    });
+
+    it("drops a frame whose address is in no line rather than guessing", async () => {
+      const api = fakeApi(remoteBuilt(), {
+        ...withElf,
+        firmwareDownloadBytes: async () => new ArrayBuffer(8),
+      });
+      vi.spyOn(hostedDecoder(), "available").mockResolvedValue(true);
+      vi.spyOn(hostedDecoder(), "decode").mockResolvedValue([
+        { address: 0xdeadbeef, function_name: "nowhere()", location: "" },
+      ]);
+
+      expect(await decodeCrashRegion(api, "c.yaml", region, cache)).toBeNull();
+    });
+
+    it("downloads the ELF once across a crash loop", async () => {
+      const firmwareDownloadBytes = vi.fn(async () => new ArrayBuffer(8));
+      const api = fakeApi(remoteBuilt(), { ...withElf, firmwareDownloadBytes });
+      vi.spyOn(hostedDecoder(), "available").mockResolvedValue(true);
+      vi.spyOn(hostedDecoder(), "decode").mockResolvedValue([
+        { address: 0x400d1a2c, function_name: "setup()", location: "application.cpp:59" },
+      ]);
+
+      // Distinct regions, so the region cache can't be what saves the download.
+      await decodeCrashRegion(api, "loop.yaml", [...region, "boot 1"], cache);
+      await decodeCrashRegion(api, "loop.yaml", [...region, "boot 2"], cache);
+
+      expect(firmwareDownloadBytes).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("does not re-ask for a region the backend already declined", async () => {

--- a/test/util/crash-decode.test.ts
+++ b/test/util/crash-decode.test.ts
@@ -18,7 +18,7 @@ const reply = (over: Partial<DecodeBacktraceResponse> = {}): DecodeBacktraceResp
   decoded: [{ index: 2, text: "Decoded 0x400d9150: setup() at application.cpp:59" }],
   stale_build: false,
   unavailable_reason: "",
-  local_build_hash: "build-1",
+  local_config_hash: "build-1",
   ...over,
 });
 
@@ -301,7 +301,7 @@ describe("decodeCrashRegion", () => {
     // The remote-build shape: no CMake tree here, so the backend can't decode,
     // but the ELF was materialised locally and is all a decoder needs.
     const remoteBuilt = () =>
-      vi.fn(async () => reply({ decoded: [], unavailable_reason: "no_local_toolchain" }));
+      vi.fn(async () => reply({ decoded: [], unavailable_reason: "elf_only" }));
     const region = ["Guru Meditation Error", "PC: 0x400d1a2c", "Rebooting..."];
 
     /** Assert the reason never reaches the decoder: no frame, no download. */
@@ -382,7 +382,7 @@ describe("decodeCrashRegion", () => {
         async () =>
           reply({
             decoded: [],
-            unavailable_reason: "no_local_toolchain",
+            unavailable_reason: "elf_only",
             stale_build: true,
           }),
         { firmwareDownloadBytes: async () => new ArrayBuffer(8) }
@@ -421,8 +421,8 @@ describe("decodeCrashRegion", () => {
         async () =>
           reply({
             decoded: [],
-            unavailable_reason: "no_local_toolchain",
-            local_build_hash: hash,
+            unavailable_reason: "elf_only",
+            local_config_hash: hash,
           }),
         { firmwareDownloadBytes }
       );
@@ -436,6 +436,35 @@ describe("decodeCrashRegion", () => {
       await decodeCrashRegion(api, "r.yaml", [...region, "boot 2"], cache);
 
       expect(firmwareDownloadBytes).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps only the live build's ELF, not one per rebuild", async () => {
+      // Each entry is 5-18MB, and every build but the newest is provably dead:
+      // the key names the build, so nothing asks for the old one again. Keeping
+      // them would strand a build's bytes per rebuild for the life of the tab.
+      const firmwareDownloadBytes = vi.fn(async () => new ArrayBuffer(8));
+      let hash = "build-1";
+      const api = fakeApi(
+        async () =>
+          reply({
+            decoded: [],
+            unavailable_reason: "elf_only",
+            local_config_hash: hash,
+          }),
+        { firmwareDownloadBytes }
+      );
+      vi.spyOn(hostedDecoder(), "available").mockResolvedValue(true);
+      vi.spyOn(hostedDecoder(), "decode").mockResolvedValue([
+        { address: 0x400d1a2c, function_name: "setup()", location: "application.cpp:59" },
+      ]);
+
+      await decodeCrashRegion(api, "e.yaml", [...region, "boot 1"], cache);
+      hash = "build-2";
+      await decodeCrashRegion(api, "e.yaml", [...region, "boot 2"], cache);
+      hash = "build-1"; // back to the first build: its bytes must be gone
+      await decodeCrashRegion(api, "e.yaml", [...region, "boot 3"], cache);
+
+      expect(firmwareDownloadBytes).toHaveBeenCalledTimes(3);
     });
 
     it("downloads the ELF once across a crash loop", async () => {

--- a/test/util/crash-decode.test.ts
+++ b/test/util/crash-decode.test.ts
@@ -18,14 +18,10 @@ const reply = (over: Partial<DecodeBacktraceResponse> = {}): DecodeBacktraceResp
   decoded: [{ index: 2, text: "Decoded 0x400d9150: setup() at application.cpp:59" }],
   stale_build: false,
   unavailable_reason: "",
+  local_build_hash: "build-1",
   ...over,
 });
 
-// `firmwareGetBinaries` is stubbed alongside the decoder because a backend
-// decline now falls through to the hosted decoder, and that path asks for the
-// ELF first. Empty means "never built here", which is the other half of what
-// `no_build` says, so the fallback declines without touching the network. A
-// test that wants the hosted path passes its own binaries.
 const fakeApi = (
   decodeBacktrace: (
     configuration: string,
@@ -35,7 +31,6 @@ const fakeApi = (
 ) =>
   ({
     decodeBacktrace,
-    firmwareGetBinaries: async () => [],
     ...over,
   }) as unknown as ESPHomeAPI;
 
@@ -306,59 +301,53 @@ describe("decodeCrashRegion", () => {
     // The remote-build shape: no CMake tree here, so the backend can't decode,
     // but the ELF was materialised locally and is all a decoder needs.
     const remoteBuilt = () =>
-      vi.fn(async () => reply({ decoded: [], unavailable_reason: "no_build" }));
-    const withElf = {
-      firmwareGetBinaries: async () => [{ title: "ELF", file: "firmware.elf" }],
-    };
+      vi.fn(async () => reply({ decoded: [], unavailable_reason: "no_local_toolchain" }));
     const region = ["Guru Meditation Error", "PC: 0x400d1a2c", "Rebooting..."];
+
+    /** Assert the reason never reaches the decoder: no frame, no download. */
+    const expectNoFallback = async (
+      unavailable_reason: string,
+      decoded: DecodeBacktraceResponse["decoded"] = []
+    ) => {
+      const firmwareDownloadBytes = vi.fn();
+      const available = vi.spyOn(hostedDecoder(), "available");
+      const api = fakeApi(async () => reply({ decoded, unavailable_reason }), {
+        firmwareDownloadBytes,
+      });
+
+      await decodeCrashRegion(api, "a.yaml", region, cache);
+
+      // `available()` frames the page; the download moves megabytes. Neither is
+      // worth spending on a reason the decoder can do nothing with.
+      expect(available).not.toHaveBeenCalled();
+      expect(firmwareDownloadBytes).not.toHaveBeenCalled();
+    };
 
     it("is not consulted when the backend decoded the region itself", async () => {
       // The whole point of trying the backend first: a locally built device
       // must not pay a page load and a multi-megabyte ELF transfer.
-      const firmwareGetBinaries = vi.fn(async () => []);
-      const api = fakeApi(async () => reply(), { firmwareGetBinaries });
-
-      expect(await decodeCrashRegion(api, "a.yaml", region, cache)).not.toBeNull();
-      expect(firmwareGetBinaries).not.toHaveBeenCalled();
+      await expectNoFallback("", reply().decoded);
     });
 
     it("is not consulted when there is nothing to decode", async () => {
-      const firmwareGetBinaries = vi.fn(async () => []);
-      const api = fakeApi(
-        async () => reply({ decoded: [], unavailable_reason: "no_backtrace" }),
-        { firmwareGetBinaries }
-      );
-
-      expect(await decodeCrashRegion(api, "a.yaml", region, cache)).toBeNull();
-      expect(firmwareGetBinaries).not.toHaveBeenCalled();
+      await expectNoFallback("no_backtrace");
     });
 
     it("is not consulted for a platform it could not decode either", async () => {
-      const firmwareGetBinaries = vi.fn(async () => []);
-      const api = fakeApi(
-        async () => reply({ decoded: [], unavailable_reason: "unsupported_platform" }),
-        { firmwareGetBinaries }
-      );
-
-      expect(await decodeCrashRegion(api, "a.yaml", region, cache)).toBeNull();
-      expect(firmwareGetBinaries).not.toHaveBeenCalled();
+      await expectNoFallback("unsupported_platform");
     });
 
-    it("does not fetch the ELF when the device was never built here", async () => {
-      // `no_build` covers both "built elsewhere" and "never built"; only the
-      // first has an ELF, and get_binaries is the cheap way to tell them apart.
-      const firmwareDownloadBytes = vi.fn();
-      const api = fakeApi(remoteBuilt(), { firmwareDownloadBytes });
-
-      expect(await decodeCrashRegion(api, "c.yaml", region, cache)).toBeNull();
-      expect(firmwareDownloadBytes).not.toHaveBeenCalled();
+    it("is not consulted when the device was never built here", async () => {
+      // `no_build` means the ELF isn't here either, so there is nothing to send.
+      // This is the reason that must never join the fallback set.
+      await expectNoFallback("no_build");
     });
 
     it("gives up quietly when the decoder can't be reached", async () => {
       // GitHub down, or an install with no internet. The raw dump has to stand;
       // a decode is an embellishment on a log, never a prerequisite for one.
       const firmwareDownloadBytes = vi.fn();
-      const api = fakeApi(remoteBuilt(), { ...withElf, firmwareDownloadBytes });
+      const api = fakeApi(remoteBuilt(), { firmwareDownloadBytes });
       vi.spyOn(hostedDecoder(), "available").mockResolvedValue(false);
 
       expect(await decodeCrashRegion(api, "c.yaml", region, cache)).toBeNull();
@@ -368,7 +357,6 @@ describe("decodeCrashRegion", () => {
 
     it("decodes through the hosted decoder when the backend can't", async () => {
       const api = fakeApi(remoteBuilt(), {
-        ...withElf,
         firmwareDownloadBytes: async () => new ArrayBuffer(8),
       });
       vi.spyOn(hostedDecoder(), "available").mockResolvedValue(true);
@@ -392,8 +380,12 @@ describe("decodeCrashRegion", () => {
       // resolved against a build the device isn't running are confidently wrong.
       const api = fakeApi(
         async () =>
-          reply({ decoded: [], unavailable_reason: "no_build", stale_build: true }),
-        { ...withElf, firmwareDownloadBytes: async () => new ArrayBuffer(8) }
+          reply({
+            decoded: [],
+            unavailable_reason: "no_local_toolchain",
+            stale_build: true,
+          }),
+        { firmwareDownloadBytes: async () => new ArrayBuffer(8) }
       );
       vi.spyOn(hostedDecoder(), "available").mockResolvedValue(true);
       vi.spyOn(hostedDecoder(), "decode").mockResolvedValue([
@@ -407,7 +399,6 @@ describe("decodeCrashRegion", () => {
 
     it("drops a frame whose address is in no line rather than guessing", async () => {
       const api = fakeApi(remoteBuilt(), {
-        ...withElf,
         firmwareDownloadBytes: async () => new ArrayBuffer(8),
       });
       vi.spyOn(hostedDecoder(), "available").mockResolvedValue(true);
@@ -418,9 +409,38 @@ describe("decodeCrashRegion", () => {
       expect(await decodeCrashRegion(api, "c.yaml", region, cache)).toBeNull();
     });
 
+    it("refetches the ELF after a rebuild rather than decoding the old one", async () => {
+      // The scenario this feature lives in: the user is watching a crash loop,
+      // edits the config, rebuilds and installs, and it crashes again. The
+      // backend now reports stale_build false (the device matches the new local
+      // build), so nothing else would catch us serving the previous build's
+      // bytes, and the frames would name the wrong lines with no caveat.
+      const firmwareDownloadBytes = vi.fn(async () => new ArrayBuffer(8));
+      let hash = "build-1";
+      const api = fakeApi(
+        async () =>
+          reply({
+            decoded: [],
+            unavailable_reason: "no_local_toolchain",
+            local_build_hash: hash,
+          }),
+        { firmwareDownloadBytes }
+      );
+      vi.spyOn(hostedDecoder(), "available").mockResolvedValue(true);
+      vi.spyOn(hostedDecoder(), "decode").mockResolvedValue([
+        { address: 0x400d1a2c, function_name: "setup()", location: "application.cpp:59" },
+      ]);
+
+      await decodeCrashRegion(api, "r.yaml", [...region, "boot 1"], cache);
+      hash = "build-2"; // the user rebuilt and installed
+      await decodeCrashRegion(api, "r.yaml", [...region, "boot 2"], cache);
+
+      expect(firmwareDownloadBytes).toHaveBeenCalledTimes(2);
+    });
+
     it("downloads the ELF once across a crash loop", async () => {
       const firmwareDownloadBytes = vi.fn(async () => new ArrayBuffer(8));
-      const api = fakeApi(remoteBuilt(), { ...withElf, firmwareDownloadBytes });
+      const api = fakeApi(remoteBuilt(), { firmwareDownloadBytes });
       vi.spyOn(hostedDecoder(), "available").mockResolvedValue(true);
       vi.spyOn(hostedDecoder(), "decode").mockResolvedValue([
         { address: 0x400d1a2c, function_name: "setup()", location: "application.cpp:59" },

--- a/test/util/stacktrace-decoder.test.ts
+++ b/test/util/stacktrace-decoder.test.ts
@@ -1,0 +1,189 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the hosted decoder's contract: it frames the page once, authenticates
+ * with a one-way nonce, and treats every failure as "no decode" rather than
+ * letting it reach the log.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DECODER_ORIGIN } from "../../src/common/docs.js";
+import { hostedDecoder, resetHostedDecoder } from "../../src/util/stacktrace-decoder.js";
+
+const READY = "esphome-stacktrace-decode:ready";
+const REQUEST = "esphome-stacktrace-decode:request";
+const RESULT = "esphome-stacktrace-decode:result";
+const ERROR = "esphome-stacktrace-decode:error";
+
+/** The one iframe the decoder framed. */
+const frame = () => document.querySelector("iframe");
+
+/**
+ * Answer as the hosted page would.
+ *
+ * happy-dom does not load the iframe's document, so its contentWindow never
+ * speaks; stand in for it. `source` has to be the real contentWindow, because
+ * that identity check is half of what authenticates the channel.
+ */
+function reply(data: unknown): void {
+  window.dispatchEvent(
+    new MessageEvent("message", {
+      data,
+      origin: DECODER_ORIGIN,
+      source: frame()!.contentWindow as Window,
+    })
+  );
+}
+
+/** Answer `ready` as soon as the page is framed, as the real one does. */
+function autoReady(version = 1): void {
+  queueMicrotask(() => reply({ type: READY, version }));
+}
+
+beforeEach(() => {
+  resetHostedDecoder();
+  document.body.innerHTML = "";
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("hostedDecoder", () => {
+  it("frames the decoder hidden, with a nonce and the dashboard's origin", async () => {
+    autoReady();
+    await hostedDecoder().available();
+
+    const el = frame()!;
+    expect(el.hidden).toBe(true);
+    const hash = new URLSearchParams(new URL(el.src).hash.slice(1));
+    expect(hash.get("nonce")).toMatch(/^[0-9a-f]{32}$/);
+    // Pins the outbound targetOrigin from frame zero rather than leaving the
+    // page broadcasting until it learns ours.
+    expect(hash.get("origin")).toBe(location.origin);
+  });
+
+  it("reports unavailable when the decoder never answers", async () => {
+    // GitHub down, or an install with no internet. An iframe that never loads
+    // fires no error worth trusting, so this is the timeout path.
+    const available = hostedDecoder().available();
+    await vi.advanceTimersByTimeAsync(11_000);
+
+    expect(await available).toBe(false);
+    // ...and the dead frame is cleaned up rather than left in the document.
+    expect(frame()).toBeNull();
+  });
+
+  it("remembers the verdict, so a crash loop reframes nothing", async () => {
+    autoReady();
+    expect(await hostedDecoder().available()).toBe(true);
+    expect(await hostedDecoder().available()).toBe(true);
+
+    expect(document.querySelectorAll("iframe")).toHaveLength(1);
+  });
+
+  it("sends the ELF with the nonce and resolves the frames", async () => {
+    autoReady();
+    await hostedDecoder().available();
+    const post = vi.spyOn(frame()!.contentWindow as Window, "postMessage");
+    const elf = new ArrayBuffer(8);
+
+    const pending = hostedDecoder().decode(elf, "Backtrace: 0x400d1a2c");
+    await vi.advanceTimersByTimeAsync(0); // decode() awaits available() before it posts
+    // The 3-arg (message, targetOrigin, transfer) overload; the spy's inferred
+    // signature is the 2-arg (message, options) one, so name the shape we sent.
+    const call = post.mock.calls[0] as unknown as [
+      { type: string; nonce: string; id: string },
+      string,
+      Transferable[],
+    ];
+    const sent = call[0];
+    expect(sent.type).toBe(REQUEST);
+    expect(sent.nonce).toMatch(/^[0-9a-f]{32}$/);
+    // Targeted, never '*': the ELF is the user's firmware.
+    expect(call[1]).toBe(DECODER_ORIGIN);
+    // Transferred, so the page doesn't copy tens of megabytes again.
+    expect(call[2]).toEqual([elf]);
+
+    reply({
+      type: RESULT,
+      id: sent.id,
+      frames: [{ address: 0x400d1a2c, function_name: "setup()", location: "a.cpp:1" }],
+    });
+
+    expect(await pending).toEqual([
+      { address: 0x400d1a2c, function_name: "setup()", location: "a.cpp:1" },
+    ]);
+  });
+
+  it("resolves null when the decoder reports an error", async () => {
+    autoReady();
+    await hostedDecoder().available();
+    const post = vi.spyOn(frame()!.contentWindow as Window, "postMessage");
+
+    const pending = hostedDecoder().decode(new ArrayBuffer(8), "Backtrace: 0x1");
+    await vi.advanceTimersByTimeAsync(0); // decode() awaits available() before it posts
+    const { id } = post.mock.calls[0][0] as { id: string };
+    reply({ type: ERROR, id, message: "unreadable elf" });
+
+    expect(await pending).toBeNull();
+  });
+
+  it("resolves null when the decode never comes back", async () => {
+    autoReady();
+    await hostedDecoder().available();
+
+    const pending = hostedDecoder().decode(new ArrayBuffer(8), "Backtrace: 0x1");
+    await vi.advanceTimersByTimeAsync(61_000);
+
+    expect(await pending).toBeNull();
+  });
+
+  it("ignores a reply from the wrong origin", async () => {
+    autoReady();
+    await hostedDecoder().available();
+    const post = vi.spyOn(frame()!.contentWindow as Window, "postMessage");
+
+    const pending = hostedDecoder().decode(new ArrayBuffer(8), "Backtrace: 0x1");
+    await vi.advanceTimersByTimeAsync(0); // decode() awaits available() before it posts
+    const { id } = post.mock.calls[0][0] as { id: string };
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: {
+          type: RESULT,
+          id,
+          frames: [{ address: 1, function_name: "evil", location: "" }],
+        },
+        origin: "https://evil.example.com",
+        source: frame()!.contentWindow as Window,
+      })
+    );
+    await vi.advanceTimersByTimeAsync(61_000);
+
+    expect(await pending).toBeNull();
+  });
+
+  it("ignores a reply correlated to a different request", async () => {
+    autoReady();
+    await hostedDecoder().available();
+    const post = vi.spyOn(frame()!.contentWindow as Window, "postMessage");
+
+    const pending = hostedDecoder().decode(new ArrayBuffer(8), "Backtrace: 0x1");
+    reply({ type: RESULT, id: "someone-else", frames: [] });
+    await vi.advanceTimersByTimeAsync(61_000);
+
+    expect(await pending).toBeNull();
+    expect(post).toHaveBeenCalled();
+  });
+
+  it("proceeds against a decoder speaking a newer protocol", async () => {
+    // Additive changes don't bump the version, so a newer page still
+    // understands our v1 frame; warn rather than refuse to decode.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    autoReady(99);
+
+    expect(await hostedDecoder().available()).toBe(true);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("v99"));
+  });
+});

--- a/test/util/stacktrace-decoder.test.ts
+++ b/test/util/stacktrace-decoder.test.ts
@@ -54,8 +54,16 @@ beforeEach(() => {
   vi.useFakeTimers();
 });
 
-afterEach(() => {
+afterEach(async () => {
   vi.useRealTimers();
+  // Give the frame's navigation a moment to settle before the global afterEach
+  // wipes the body. happy-dom navigates on its own schedule and then reaches
+  // into a window the teardown has already dropped, which throws deep in its
+  // internals. Cosmetic only: the assertions pass either way, and the fake
+  // timers mean a test can retire a frame while its real navigation is still in
+  // flight, so this is best-effort noise suppression rather than a fix. If the
+  // stack traces come back on a loaded machine, that is all that has happened.
+  await new Promise((resolve) => setTimeout(resolve, 25));
   vi.restoreAllMocks();
 });
 

--- a/test/util/stacktrace-decoder.test.ts
+++ b/test/util/stacktrace-decoder.test.ts
@@ -134,8 +134,11 @@ describe("hostedDecoder", () => {
     expect(sent.nonce).toMatch(/^[0-9a-f]{32}$/);
     // Targeted, never '*': the ELF is the user's firmware.
     expect(call[1]).toBe(DECODER_ORIGIN);
-    // Transferred, so the page doesn't copy tens of megabytes again.
-    expect(call[2]).toEqual([elf]);
+    // Not transferred. The decoder is a foreign origin, so the bytes are copied
+    // across the process boundary either way; transferring would only detach
+    // the caller's cached ELF and force it to copy first.
+    expect(call[2]).toBeUndefined();
+    expect(elf.byteLength).toBe(8); // still ours, not detached
 
     reply({
       type: RESULT,

--- a/test/util/stacktrace-decoder.test.ts
+++ b/test/util/stacktrace-decoder.test.ts
@@ -22,6 +22,7 @@ const READY = "esphome-stacktrace-decode:ready";
 const REQUEST = "esphome-stacktrace-decode:request";
 const RESULT = "esphome-stacktrace-decode:result";
 const ERROR = "esphome-stacktrace-decode:error";
+const UNAVAILABLE = "esphome-stacktrace-decode:unavailable";
 
 /** The one iframe the decoder framed. */
 const frame = () => document.querySelector("iframe");
@@ -89,6 +90,19 @@ describe("hostedDecoder", () => {
 
     expect(await available).toBe(false);
     // ...and the dead frame is cleaned up rather than left in the document.
+    expect(frame()).toBeNull();
+  });
+
+  it("gives up at once when the page says it cannot answer", async () => {
+    // A wiring mistake (no nonce in the hash) is not an outage, and the page's
+    // own console is inside a hidden frame where nobody reads it. Told
+    // directly, we stop rather than sit out the full timeout.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    queueMicrotask(() => reply({ type: UNAVAILABLE, reason: "framed without a nonce" }));
+
+    // No timer advance: the point is that it does not wait.
+    expect(await hostedDecoder().available()).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.any(String), "framed without a nonce");
     expect(frame()).toBeNull();
   });
 

--- a/test/util/stacktrace-decoder.test.ts
+++ b/test/util/stacktrace-decoder.test.ts
@@ -1,9 +1,18 @@
 /**
  * @vitest-environment happy-dom
+ * @vitest-environment-options { "settings": { "fetch": { "virtualServers": [ { "url": "https://esphome.github.io/device-builder/esp-stacktrace-decoder/", "directory": "./test/fixtures/decoder-stub" } ] } } }
  *
  * Pins the hosted decoder's contract: it frames the page once, authenticates
  * with a one-way nonce, and treats every failure as "no decode" rather than
  * letting it reach the log.
+ *
+ * The decoder URL is served from a local stub, because happy-dom really loads
+ * an iframe's src and the src here is the production URL: without this, every
+ * run would fetch esphome.github.io, which is slow, fails offline, and is the
+ * exact coupling this design exists to avoid. Disabling iframe loading outright
+ * would be simpler but leaves contentWindow null, and that window is what the
+ * source check authenticates against. The real page is covered in the
+ * device-builder repo, in a real browser, against a real ELF.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DECODER_ORIGIN } from "../../src/common/docs.js";
@@ -20,9 +29,9 @@ const frame = () => document.querySelector("iframe");
 /**
  * Answer as the hosted page would.
  *
- * happy-dom does not load the iframe's document, so its contentWindow never
- * speaks; stand in for it. `source` has to be the real contentWindow, because
- * that identity check is half of what authenticates the channel.
+ * The stub the frame loads is inert, so nothing inside it ever speaks; stand in
+ * for it. `source` has to be the frame's real contentWindow, because that
+ * identity check is half of what authenticates the channel.
  */
 function reply(data: unknown): void {
   window.dispatchEvent(


### PR DESCRIPTION
# What does this implement/fix?

A device compiled on a remote build server never decodes its crash backtraces, over `esphome logs` or Web Serial; the raw `Backtrace: 0x...` is all you get.

Native ESP-IDF resolves `addr2line` only through the build's CMake cache, and the remote artifact tarball ships `build/firmware.elf` but not the build tree, so the backend answers `elf_only` for a crash it has the ELF for. (PlatformIO builds like esp8266 are unaffected: `idedata.json` ships and the materialiser remaps `cc_path`, which `addr2line_path` is derived from.)

**The backend is still asked first.** It decodes against the exact toolchain the build used and costs no ELF transfer, so a locally built device is untouched and pays nothing, over OTA or over serial. Only when it declines with `elf_only` (the ELF is here, the build tree isn't), `decode_failed`, or `helper_failed` does the ELF go to the hosted decoder. Never on `no_build`, which means the ELF isn't here either. Not on `no_backtrace`, where there is nothing to decode, and not on `unsupported_platform`, where the decoder would fail too.

| scenario | esphome inline | backend | ELF fetch + decode |
|---|---|---|---|
| local build, OTA logs | decodes | not asked | no |
| local build, Web Serial | never runs | decodes off the CMake cache | no |
| remote build, OTA logs | fails, the bug | `elf_only` | yes |
| remote build, Web Serial | never runs | `elf_only` | yes |

So the ELF only moves for the case that is actually broken. This also covers `esphome logs` precisely when esphome cannot decode: `needsDecode` is true only when a region has addresses and carries no `Decoded` line, which is exactly what a failed inline decode leaves behind. Verified against the real logs from the reported device, both transports.

**It degrades to no decode, never to a broken log.** GitHub down or an install with no internet means the handshake never completes, the dashboard gives up after a timeout, and the raw dump stands. The gates run cheapest first so that verdict costs nothing: whether an ELF exists at all is a local list, whether the decoder answers is one page load, and only then is a multi-megabyte ELF worth fetching. The verdict and the ELF are both remembered, so a crash loop pays once.

The decoder page and its no-egress guarantee are in esphome/device-builder#2140 (merged); the `elf_only` reason and the `local_config_hash` field this keys its ELF cache on are in esphome/device-builder#2141, which must land per the lockstep rule. The firmware is decoded in the browser and never uploaded.

Frames come back keyed by address rather than by line, so each is attributed to the line whose text carries its address; one matching nothing is dropped rather than guessed at. `staleBuild` rides through from the backend's reply, which knows both hashes whether or not it could decode, so frames resolved against a build the device is not running still carry the caveat.

**Related issue or feature (if applicable):**

- Companion to esphome/device-builder#2140 (hosts the decoder, merged) and esphome/device-builder#2141 (the `elf_only` reason + `local_config_hash` field). This PR needs #2141's reason to trigger the fallback; without it a remote-built crash reports `no_build` and shows the same raw dump as today, which is harmless.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

