### PR TITLE
Give the device card's action buttons and indicator icons discoverable tooltips

### DIFF
--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -189,27 +189,39 @@ export class ESPHomeDeviceCard extends LitElement {
               ${
                 this.showModified
                   ? html`<span
-                      class="indicator-dot indicator-dot--modified"
-                      title=${this._localize("dashboard.status_modified")}
-                    ></span>`
+                        id="ind-modified"
+                        class="indicator-dot indicator-dot--modified"
+                        tabindex="0"
+                      ></span>
+                      <wa-tooltip for="ind-modified">
+                        ${this._localize("dashboard.status_modified")}
+                      </wa-tooltip>`
                   : nothing
               }
               ${
                 this.showUpdate
                   ? html`<span
-                      class="indicator-dot indicator-dot--update"
-                      title=${this._localize("dashboard.status_update_available")}
-                    ></span>`
+                        id="ind-update"
+                        class="indicator-dot indicator-dot--update"
+                        tabindex="0"
+                      ></span>
+                      <wa-tooltip for="ind-update">
+                        ${this._localize("dashboard.status_update_available")}
+                      </wa-tooltip>`
                   : nothing
               }
               ${
                 this.queuedUpdate
                   ? html`<wa-icon
-                      class="indicator-queued"
-                      library="mdi"
-                      name="clock-outline"
-                      title=${this._localize("dashboard.status_queued_update")}
-                    ></wa-icon>`
+                        id="ind-queued"
+                        class="indicator-queued"
+                        library="mdi"
+                        name="clock-outline"
+                        tabindex="0"
+                      ></wa-icon>
+                      <wa-tooltip for="ind-queued">
+                        ${this._localize("dashboard.status_queued_update")}
+                      </wa-tooltip>`
                   : nothing
               }
               ${renderEncryptionIcon(this)}

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -41,6 +41,7 @@ import { deviceCardStyles } from "./device-card/styles.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
+import "@home-assistant/webawesome/dist/components/tooltip/tooltip.js";
 
 registerMdiIcons({
   cancel: mdiCancel,
@@ -231,28 +232,36 @@ export class ESPHomeDeviceCard extends LitElement {
                   </button>
                   ${this._renderAccentAction()}
                   <button
+                    id="btn-logs"
                     class="action-btn action-btn--ghost action-btn--tile"
                     @click=${() => this._emit("open-logs")}
                     aria-label=${this._localize("dashboard.drawer_logs")}
-                    title=${this._localize("dashboard.drawer_logs")}
                   >
                     <wa-icon library="mdi" name="text-box-outline"></wa-icon>
                   </button>
+                  <wa-tooltip for="btn-logs">
+                    ${this._localize("dashboard.drawer_logs")}
+                  </wa-tooltip>
                   ${
                     this.webUrl
                       ? renderVisitWebUiLink(this.webUrl, this._localize, {
                           className: "action-btn action-btn--ghost action-btn--tile",
                           onClick: (e) => e.stopPropagation(),
+                          tooltipId: "btn-web-ui",
                         })
                       : nothing
                   }
                   <button
+                    id="btn-more"
                     class="action-btn action-btn--ghost action-btn--icon-only"
                     aria-label=${this._localize("dashboard.more_options")}
                     @click=${this._onDotsClick}
                   >
                     <wa-icon library="mdi" name="dots-vertical"></wa-icon>
                   </button>
+                  <wa-tooltip for="btn-more">
+                    ${this._localize("dashboard.more_options")}
+                  </wa-tooltip>
                 </div>
               `
             : nothing
@@ -267,30 +276,34 @@ export class ESPHomeDeviceCard extends LitElement {
   private _renderAccentAction() {
     if (this.showUpdate) {
       return html`<button
-        class="action-btn action-btn--accent action-btn--tile"
-        @click=${() => this._emit(this.busy ? "show-progress" : "update-device")}
-        aria-label=${busyActionLabel(this._localize, this.busy, "dashboard.update")}
-        title=${updateActionTitle(
-          this._localize,
-          this.busy,
-          this.installedVersion,
-          this.availableVersion,
-          "dashboard.update"
-        )}
-      >
-        <wa-icon library="mdi" name="upload"></wa-icon>
-      </button>`;
+          id="btn-accent"
+          class="action-btn action-btn--accent action-btn--tile"
+          @click=${() => this._emit(this.busy ? "show-progress" : "update-device")}
+          aria-label=${busyActionLabel(this._localize, this.busy, "dashboard.update")}
+        >
+          <wa-icon library="mdi" name="upload"></wa-icon>
+        </button>
+        <wa-tooltip for="btn-accent">
+          ${updateActionTitle(
+            this._localize,
+            this.busy,
+            this.installedVersion,
+            this.availableVersion,
+            "dashboard.update"
+          )}
+        </wa-tooltip>`;
     }
     if (this.showModified) {
       const label = busyActionLabel(this._localize, this.busy, "dashboard.install");
       return html`<button
-        class="action-btn action-btn--accent action-btn--tile"
-        @click=${() => this._emit(this.busy ? "show-progress" : "install-device")}
-        aria-label=${label}
-        title=${label}
-      >
-        <wa-icon library="mdi" name="upload"></wa-icon>
-      </button>`;
+          id="btn-accent"
+          class="action-btn action-btn--accent action-btn--tile"
+          @click=${() => this._emit(this.busy ? "show-progress" : "install-device")}
+          aria-label=${label}
+        >
+          <wa-icon library="mdi" name="upload"></wa-icon>
+        </button>
+        <wa-tooltip for="btn-accent">${label}</wa-tooltip>`;
     }
     return nothing;
   }

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -192,6 +192,8 @@ export class ESPHomeDeviceCard extends LitElement {
                         id="ind-modified"
                         class="indicator-dot indicator-dot--modified"
                         tabindex="0"
+                        role="img"
+                        aria-label=${this._localize("dashboard.status_modified")}
                       ></span>
                       <wa-tooltip for="ind-modified">
                         ${this._localize("dashboard.status_modified")}
@@ -204,6 +206,8 @@ export class ESPHomeDeviceCard extends LitElement {
                         id="ind-update"
                         class="indicator-dot indicator-dot--update"
                         tabindex="0"
+                        role="img"
+                        aria-label=${this._localize("dashboard.status_update_available")}
                       ></span>
                       <wa-tooltip for="ind-update">
                         ${this._localize("dashboard.status_update_available")}
@@ -218,6 +222,8 @@ export class ESPHomeDeviceCard extends LitElement {
                         library="mdi"
                         name="clock-outline"
                         tabindex="0"
+                        role="img"
+                        aria-label=${this._localize("dashboard.status_queued_update")}
                       ></wa-icon>
                       <wa-tooltip for="ind-queued">
                         ${this._localize("dashboard.status_queued_update")}

--- a/src/components/device-card/render-bits.ts
+++ b/src/components/device-card/render-bits.ts
@@ -57,6 +57,8 @@ export function renderEncryptionIcon(
       library="mdi"
       name=${visual.iconName}
       tabindex="0"
+      role="img"
+      aria-label=${card._localize(visual.tooltipKey)}
     ></wa-icon>
     <wa-tooltip for="ind-encryption">${card._localize(visual.tooltipKey)}</wa-tooltip>`;
 }

--- a/src/components/device-card/render-bits.ts
+++ b/src/components/device-card/render-bits.ts
@@ -52,11 +52,13 @@ export function renderEncryptionIcon(
   });
   if (!visual) return nothing;
   return html`<wa-icon
-    class="encryption-icon ${visual.cssClass}"
-    library="mdi"
-    name=${visual.iconName}
-    title=${card._localize(visual.tooltipKey)}
-  ></wa-icon>`;
+      id="ind-encryption"
+      class="encryption-icon ${visual.cssClass}"
+      library="mdi"
+      name=${visual.iconName}
+      tabindex="0"
+    ></wa-icon>
+    <wa-tooltip for="ind-encryption">${card._localize(visual.tooltipKey)}</wa-tooltip>`;
 }
 
 export function renderStatusBadge(card: ESPHomeDeviceCard): TemplateResult {
@@ -82,10 +84,7 @@ export function renderStatusBadge(card: ESPHomeDeviceCard): TemplateResult {
     const status = card.recentJob.status;
     const icon = RECENT_JOB_ICON[status];
     if (icon) {
-      return html`<div
-        class="device-status ${RECENT_JOB_VARIANT[status]}"
-        title=${card._localize(RECENT_JOB_LABEL[status])}
-      >
+      return html`<div class="device-status ${RECENT_JOB_VARIANT[status]}">
         <wa-icon library="mdi" name=${icon}></wa-icon>
         ${card._localize(RECENT_JOB_LABEL[status])}
       </div>`;

--- a/src/util/visit-web-ui-link.ts
+++ b/src/util/visit-web-ui-link.ts
@@ -12,6 +12,9 @@ export interface VisitWebUiLinkOptions {
    *  children must be menuitem-family for AT menu navigation. Also wires
    *  Space to activate like sibling menu rows. */
   role?: "menuitem";
+  /** Anchor id to hang a ``wa-tooltip`` off (replaces the native ``title``);
+   *  must be unique within the caller's shadow root. */
+  tooltipId?: string;
 }
 
 /* Space activates a menuitem anchor like its sibling rows. Enter is left
@@ -41,18 +44,24 @@ export function renderVisitWebUiLink(
   // redundant aria/title there (``nothing`` removes the attribute).
   const a11yLabel = options.withLabel ? nothing : label;
   return html`<a
-    class=${options.className}
-    href=${url}
-    target="_blank"
-    rel="noopener noreferrer"
-    role=${options.role ?? nothing}
-    aria-label=${a11yLabel}
-    title=${a11yLabel}
-    @click=${options.onClick}
-    @keydown=${options.role === "menuitem" ? menuItemKeydown : undefined}
-  >
-    <wa-icon library="mdi" name="open-in-new"></wa-icon>${
-      options.withLabel ? html` ${label}` : nothing
-    }
-  </a>`;
+      class=${options.className}
+      id=${options.tooltipId ?? nothing}
+      href=${url}
+      target="_blank"
+      rel="noopener noreferrer"
+      role=${options.role ?? nothing}
+      aria-label=${a11yLabel}
+      title=${options.tooltipId ? nothing : a11yLabel}
+      @click=${options.onClick}
+      @keydown=${options.role === "menuitem" ? menuItemKeydown : undefined}
+    >
+      <wa-icon library="mdi" name="open-in-new"></wa-icon>${
+        options.withLabel ? html` ${label}` : nothing
+      }
+    </a>
+    ${
+      options.tooltipId
+        ? html`<wa-tooltip for=${options.tooltipId}>${label}</wa-tooltip>`
+        : nothing
+    }`;
 }

--- a/test/components/device-card-action-tooltips.test.ts
+++ b/test/components/device-card-action-tooltips.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Icon-only card actions carry a ``wa-tooltip`` anchored by id instead of a
+ * native ``title``, so hover names the action in the design-system style.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
+
+import { mountDeviceCard as mount } from "./_device-card.js";
+
+function tooltipFor(el: HTMLElement, id: string): Element | null {
+  return el.shadowRoot!.querySelector(`wa-tooltip[for="${id}"]`);
+}
+
+describe("device-card action tooltips", () => {
+  it("anchors a tooltip to the logs button and drops the native title", async () => {
+    const el = await mount({});
+    const button = el.shadowRoot!.querySelector("#btn-logs")!;
+    expect(button.hasAttribute("title")).toBe(false);
+    expect(tooltipFor(el, "btn-logs")!.textContent).toContain("dashboard.drawer_logs");
+  });
+
+  it("anchors a tooltip to the more-options button", async () => {
+    const el = await mount({});
+    expect(tooltipFor(el, "btn-more")!.textContent).toContain("dashboard.more_options");
+  });
+
+  it("names the install action on the accent button", async () => {
+    const el = await mount({ showModified: true });
+    const button = el.shadowRoot!.querySelector("#btn-accent")!;
+    expect(button.hasAttribute("title")).toBe(false);
+    expect(tooltipFor(el, "btn-accent")!.textContent).toContain("dashboard.install");
+  });
+
+  it("names the update action on the accent button", async () => {
+    const el = await mount({ showUpdate: true });
+    expect(tooltipFor(el, "btn-accent")!.textContent).toContain("dashboard.update");
+  });
+
+  it("anchors a tooltip to the web UI link and drops its native title", async () => {
+    const el = await mount({ webUrl: "http://device.local" });
+    const link = el.shadowRoot!.querySelector("#btn-web-ui")!;
+    expect(link.hasAttribute("title")).toBe(false);
+    expect(tooltipFor(el, "btn-web-ui")!.textContent).toContain(
+      "dashboard.action_visit_web_ui"
+    );
+  });
+
+  it("renders no orphan web UI tooltip without a web url", async () => {
+    const el = await mount({});
+    expect(tooltipFor(el, "btn-web-ui")).toBeNull();
+  });
+});

--- a/test/components/device-card-action-tooltips.test.ts
+++ b/test/components/device-card-action-tooltips.test.ts
@@ -55,3 +55,43 @@ describe("device-card action tooltips", () => {
     expect(tooltipFor(el, "btn-web-ui")).toBeNull();
   });
 });
+
+describe("device-card indicator tooltips", () => {
+  it("names the modified dot", async () => {
+    const el = await mount({ showModified: true });
+    const dot = el.shadowRoot!.querySelector("#ind-modified")!;
+    expect(dot.hasAttribute("title")).toBe(false);
+    expect(dot.getAttribute("tabindex")).toBe("0");
+    expect(tooltipFor(el, "ind-modified")!.textContent).toContain(
+      "dashboard.status_modified"
+    );
+  });
+
+  it("names the update dot", async () => {
+    const el = await mount({ showUpdate: true });
+    expect(tooltipFor(el, "ind-update")!.textContent).toContain(
+      "dashboard.status_update_available"
+    );
+  });
+
+  it("names the queued-update clock", async () => {
+    const el = await mount({ queuedUpdate: true });
+    expect(tooltipFor(el, "ind-queued")!.textContent).toContain(
+      "dashboard.status_queued_update"
+    );
+  });
+
+  it("names the encryption indicator with its state tooltip", async () => {
+    const el = await mount({
+      hasPendingChanges: true,
+      apiEnabled: true,
+      apiEncrypted: true,
+      apiEncryptionActive: null,
+    });
+    const icon = el.shadowRoot!.querySelector("#ind-encryption")!;
+    expect(icon.hasAttribute("title")).toBe(false);
+    expect(tooltipFor(el, "ind-encryption")!.textContent).toContain(
+      "dashboard.table_status_encryption_pending_tooltip"
+    );
+  });
+});

--- a/test/components/device-card-action-tooltips.test.ts
+++ b/test/components/device-card-action-tooltips.test.ts
@@ -62,6 +62,8 @@ describe("device-card indicator tooltips", () => {
     const dot = el.shadowRoot!.querySelector("#ind-modified")!;
     expect(dot.hasAttribute("title")).toBe(false);
     expect(dot.getAttribute("tabindex")).toBe("0");
+    expect(dot.getAttribute("role")).toBe("img");
+    expect(dot.getAttribute("aria-label")).toBe("dashboard.status_modified");
     expect(tooltipFor(el, "ind-modified")!.textContent).toContain(
       "dashboard.status_modified"
     );
@@ -90,8 +92,20 @@ describe("device-card indicator tooltips", () => {
     });
     const icon = el.shadowRoot!.querySelector("#ind-encryption")!;
     expect(icon.hasAttribute("title")).toBe(false);
+    expect(icon.getAttribute("aria-label")).toBe(
+      "dashboard.table_status_encryption_pending_tooltip"
+    );
     expect(tooltipFor(el, "ind-encryption")!.textContent).toContain(
       "dashboard.table_status_encryption_pending_tooltip"
     );
+  });
+
+  it("gives every focusable indicator an accessible name", async () => {
+    const el = await mount({ showUpdate: true, queuedUpdate: true });
+    for (const id of ["ind-update", "ind-queued"]) {
+      const node = el.shadowRoot!.querySelector(`#${id}`)!;
+      expect(node.getAttribute("role")).toBe("img");
+      expect(node.getAttribute("aria-label")).toBeTruthy();
+    }
   });
 });

--- a/test/components/device-card-busy-actions.test.ts
+++ b/test/components/device-card-busy-actions.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
 
 import type { ESPHomeDeviceCard } from "../../src/components/device-card.js";
 import { clickCollect } from "../_dom.js";

--- a/test/components/device-card-queued-indicator.test.ts
+++ b/test/components/device-card-queued-indicator.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
 
 import { DeviceState } from "../../src/api/types/devices.js";
 import { mountDeviceCard as mount } from "./_device-card.js";

--- a/test/components/device-card.test.ts
+++ b/test/components/device-card.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
 
 import { JobType } from "../../src/api/types/firmware-jobs.js";
 import { makeFirmwareJob } from "../_make-firmware-job.js";


### PR DESCRIPTION
# What does this implement/fix?

First time users reported they couldn't tell what the logs button did; it had to be demonstrated to them by hovering. The device card's icon-only actions (install/update, logs, visit web UI, more options) and its indicator icons (modified dot, update dot, queued clock, encryption lock) only had native `title` attributes, which are slow to appear and easy to miss. They now use the same `wa-tooltip` pattern as the editor's "Recommended" chip and the build offload pairing rows, so hovering any of them names it in the design-system style. The indicators are also focusable now, so keyboard users get the tooltip too.

The update button's tooltip keeps the richer version text ("Update available: 2026.6.4 -> 2026.7.0"). The shared web UI link helper gained an opt-in `tooltipId` option; other call sites (table menu, drawer) are unchanged. The recent-job badge lost its `title` since its label is already visible text.

**Related issue or feature (if applicable):**

- user feedback: first time users could not discover what the logs button did

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
