### PR TITLE
Show a ready-made note for package boards in the create wizard

### DIFF
--- a/src/api/types/boards.ts
+++ b/src/api/types/boards.ts
@@ -142,6 +142,12 @@ export interface BoardCatalogEntry extends SlimBoard {
    * the create wizard's "set up with everything" default. Body-only.
    */
   full_config?: boolean;
+  /**
+   * Remote-package board: devices/create writes a thin packages: reference
+   * to this upstream config instead of expanding components; the wizard
+   * shows the ready-made note in place of the full-setup checkbox. Body-only.
+   */
+  package_import_url?: string;
   /** Components recommended for this board. */
   featured_components: FeaturedComponent[];
   /** Logical groups of featured components added together. */

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -423,7 +423,13 @@ export class ESPHomeWizardStepSetup extends LitElement {
                   ${this._localize("wizard.full_setup_desc")}
                 </p>
               </div>`
-            : null
+            : this.board?.package_import_url
+              ? html`<div class="full-setup">
+                  <p class="section-subtitle">
+                    ${this._localize("wizard.package_config_desc")}
+                  </p>
+                </div>`
+              : null
         }
       </section>
     `;

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -67,6 +67,16 @@ export class ESPHomeWizardStepSetup extends LitElement {
   @state()
   private _fullSetup = true;
 
+  /**
+   * Full setup never applies to a remote-package board — the package
+   * reference is the whole config, so both the checkbox and the emitted
+   * finish-setup flag must stay off even if the body also carries
+   * full_config and bundles.
+   */
+  private get _offersFullSetup(): boolean {
+    return !this.board?.package_import_url && boardOffersFullSetup(this.board);
+  }
+
   @state()
   private _wifiSsid = "";
 
@@ -414,7 +424,7 @@ export class ESPHomeWizardStepSetup extends LitElement {
                   ${this._localize("wizard.package_config_desc")}
                 </p>
               </div>`
-            : boardOffersFullSetup(this.board)
+            : this._offersFullSetup
               ? html`<div class="full-setup">
                   <wa-checkbox
                     .checked=${this._fullSetup}
@@ -531,7 +541,7 @@ export class ESPHomeWizardStepSetup extends LitElement {
           name: this._deviceName,
           wifiSsid,
           wifiPassword,
-          fullSetup: boardOffersFullSetup(this.board) && this._fullSetup,
+          fullSetup: this._offersFullSetup && this._fullSetup,
         },
         bubbles: true,
         composed: true,

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -408,25 +408,25 @@ export class ESPHomeWizardStepSetup extends LitElement {
         </div>
 
         ${
-          boardOffersFullSetup(this.board)
+          this.board?.package_import_url
             ? html`<div class="full-setup">
-                <wa-checkbox
-                  .checked=${this._fullSetup}
-                  @change=${(e: Event) => {
-                    this._fullSetup = (
-                      e.currentTarget as HTMLElement & { checked: boolean }
-                    ).checked;
-                  }}
-                  >${this._localize("wizard.full_setup")}</wa-checkbox
-                >
                 <p class="section-subtitle">
-                  ${this._localize("wizard.full_setup_desc")}
+                  ${this._localize("wizard.package_config_desc")}
                 </p>
               </div>`
-            : this.board?.package_import_url
+            : boardOffersFullSetup(this.board)
               ? html`<div class="full-setup">
+                  <wa-checkbox
+                    .checked=${this._fullSetup}
+                    @change=${(e: Event) => {
+                      this._fullSetup = (
+                        e.currentTarget as HTMLElement & { checked: boolean }
+                      ).checked;
+                    }}
+                    >${this._localize("wizard.full_setup")}</wa-checkbox
+                  >
                   <p class="section-subtitle">
-                    ${this._localize("wizard.package_config_desc")}
+                    ${this._localize("wizard.full_setup_desc")}
                   </p>
                 </div>`
               : null

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -554,7 +554,7 @@
     "section_name_device_desc": "Naming your project will show up in the ESPHome dashboard. Choose a recognisable, descriptive and memorable name. You can use component names or relevant words. You can edit this after you finish this project.",
     "full_setup": "Set up with all recommended components",
     "full_setup_desc": "Adds this device's onboard components (relays, sensors, and more) so it's ready to use. You can change them afterwards in the editor.",
-    "package_config_desc": "This device uses the official ready-made configuration and automatically stays up to date with it. You can add more components afterwards in the editor.",
+    "package_config_desc": "This device uses a ready-made configuration and automatically stays up to date with it. You can add more components afterwards in the editor.",
     "full_setup_partial": "{count, plural, one {Couldn't add recommended component {names}} other {Couldn't add recommended components {names}{extra, plural, =0 {} other { and # more}}}}; finish in the editor.",
     "wifi_configuration": "Wi-Fi Configuration",
     "wifi_required_desc": "This board connects over Wi-Fi. Enter your network once and Device Builder will securely reuse it for future Wi-Fi devices.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -554,6 +554,7 @@
     "section_name_device_desc": "Naming your project will show up in the ESPHome dashboard. Choose a recognisable, descriptive and memorable name. You can use component names or relevant words. You can edit this after you finish this project.",
     "full_setup": "Set up with all recommended components",
     "full_setup_desc": "Adds this device's onboard components (relays, sensors, and more) so it's ready to use. You can change them afterwards in the editor.",
+    "package_config_desc": "This device uses the official ready-made configuration and automatically stays up to date with it. You can add more components afterwards in the editor.",
     "full_setup_partial": "{count, plural, one {Couldn't add recommended component {names}} other {Couldn't add recommended components {names}{extra, plural, =0 {} other { and # more}}}}; finish in the editor.",
     "wifi_configuration": "Wi-Fi Configuration",
     "wifi_required_desc": "This board connects over Wi-Fi. Enter your network once and Device Builder will securely reuse it for future Wi-Fi devices.",

--- a/src/util/board-hydrate.ts
+++ b/src/util/board-hydrate.ts
@@ -46,6 +46,7 @@ export function hydrateBoard(entry: BoardCatalogEntry): BoardCatalogEntry {
   return {
     ...hydrateSlimBoard(entry),
     full_config: entry.full_config ?? false,
+    package_import_url: entry.package_import_url ?? "",
     featured_components: (entry.featured_components ?? []).map(_hydrateFeaturedComponent),
     featured_bundles: (entry.featured_bundles ?? []).map(_hydrateFeaturedBundle),
     requires_wifi: entry.requires_wifi ?? false,

--- a/test/components/wizard/wizard-step-setup.test.ts
+++ b/test/components/wizard/wizard-step-setup.test.ts
@@ -299,6 +299,38 @@ describe("wizard-step-setup", () => {
     expect((onFinish.mock.calls[0][0] as CustomEvent).detail.fullSetup).toBe(true);
   });
 
+  // A remote-package board: the ready-made note replaces the checkbox — the
+  // package reference is the whole config, nothing to opt out of.
+  const packageBoard = () =>
+    board({
+      requires_wifi: false,
+      package_import_url:
+        "github://esphome/bluetooth-proxies/olimex/olimex-esp32-poe-iso.yaml@main",
+    });
+
+  it("shows the ready-made note instead of a checkbox for a package board", async () => {
+    const el = await mount(packageBoard());
+    expect(el.shadowRoot!.querySelector("wa-checkbox")).toBeNull();
+    expect(el.shadowRoot!.querySelector(".full-setup .section-subtitle")).not.toBeNull();
+  });
+
+  it("prefers the ready-made note when a package board also claims full-config", async () => {
+    const el = await mount(
+      board({
+        requires_wifi: false,
+        package_import_url:
+          "github://esphome/bluetooth-proxies/olimex/olimex-esp32-poe-iso.yaml@main",
+        full_config: true,
+        featured_components: [{ id: "relay_1" }] as never,
+        featured_bundles: [
+          { id: "all_recommended", name: "x", component_ids: ["relay_1"] },
+        ] as never,
+      })
+    );
+    expect(el.shadowRoot!.querySelector("wa-checkbox")).toBeNull();
+    expect(el.shadowRoot!.querySelector(".full-setup .section-subtitle")).not.toBeNull();
+  });
+
   it("omits the full-setup option for an optional-component board", async () => {
     const el = await mount(noWifiBoard());
     expect(el.shadowRoot!.querySelector("wa-checkbox")).toBeNull();

--- a/test/components/wizard/wizard-step-setup.test.ts
+++ b/test/components/wizard/wizard-step-setup.test.ts
@@ -329,6 +329,13 @@ describe("wizard-step-setup", () => {
     );
     expect(el.shadowRoot!.querySelector("wa-checkbox")).toBeNull();
     expect(el.shadowRoot!.querySelector(".full-setup .section-subtitle")).not.toBeNull();
+    // The emitted flag must stay off too — a stale true would make the
+    // create dialog vendor components next to the package reference.
+    await setName(el, "kitchen");
+    const onFinish = vi.fn();
+    el.addEventListener("finish-setup", onFinish as EventListener);
+    pressEnter();
+    expect((onFinish.mock.calls[0][0] as CustomEvent).detail.fullSetup).toBe(false);
   });
 
   it("omits the full-setup option for an optional-component board", async () => {

--- a/test/util/board-hydrate.test.ts
+++ b/test/util/board-hydrate.test.ts
@@ -197,6 +197,7 @@ describe("hydrateBoard", () => {
       featured: true,
       is_generic: false,
       full_config: false,
+      package_import_url: "",
       featured_components: [],
       featured_bundles: [],
       requires_wifi: false,
@@ -239,6 +240,7 @@ describe("hydratePagedBoardsResponse", () => {
     expect(board).not.toHaveProperty("featured_bundles");
     expect(board).not.toHaveProperty("requires_wifi");
     expect(board).not.toHaveProperty("full_config");
+    expect(board).not.toHaveProperty("package_import_url");
   });
 
   it("re-defaults a wholly-stripped wrapper (forward-compat against omit_default on PagedResponse)", () => {


### PR DESCRIPTION
# What does this implement/fix?

Shows an informational note in the create wizard's setup step for remote-package boards (the bluetooth-proxies imports): "This device uses the official ready-made configuration and automatically stays up to date with it." It renders in the same spot the full-setup checkbox occupies for import boards, so the two board kinds read consistently; there is no checkbox because the package reference is the whole config, nothing to opt out of. Adds package_import_url to the board body type and hydration.

Companion backend PR: esphome/device-builder#2150 (ships the field in board bodies).

**Related issue or feature (if applicable):**

- none

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
