### PR TITLE
Gate the table Version column on the deployed identity trust

### DIFF
--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -39,7 +39,11 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { labelsContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { matchesDeviceRow } from "../../util/device-search.js";
-import { showPendingChanges, showUpdateAvailable } from "../../util/device-sync.js";
+import {
+  deployedIdentityTrusted,
+  showPendingChanges,
+  showUpdateAvailable,
+} from "../../util/device-sync.js";
 import { labelChipStyles, resolveLabelIds } from "../../util/label-chip-template.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { TourActivityController } from "../guided-tour/tour-activity-controller.js";
@@ -289,7 +293,7 @@ export class ESPHomeDeviceTable extends LitElement {
           // interface derived values are diagnostic detail that
           // belongs in the per-device drawer.
           platform: d.target_platform || "",
-          version: rt.deployed_version,
+          version: deployedIdentityTrusted(d) ? rt.deployed_version : "",
           build_size_bytes: d.build_size_bytes || 0,
           comment: d.comment || "",
           area: d.area || "",

--- a/test/components/dashboard/device-table.test.ts
+++ b/test/components/dashboard/device-table.test.ts
@@ -144,7 +144,10 @@ describe("device-table Version column identity gating", () => {
   it.each<[string, ConfiguredDeviceOverrides, string]>([
     [
       "api device with mdns ownership shows the deployed version",
-      { api_enabled: true },
+      {
+        api_enabled: true,
+        runtime_state: { active_source: "mdns", deployed_identity_live: false },
+      },
       "2026.6.0",
     ],
     [
@@ -157,7 +160,7 @@ describe("device-table Version column identity gating", () => {
     ],
     [
       "no-api device with a live identity TXT shows the deployed version",
-      { api_enabled: false },
+      { api_enabled: false, runtime_state: { deployed_identity_live: true } },
       "2026.6.0",
     ],
     [

--- a/test/components/dashboard/device-table.test.ts
+++ b/test/components/dashboard/device-table.test.ts
@@ -23,7 +23,10 @@ import {
   ALL_PAGE_SIZE,
   effectiveTablePageSize,
 } from "../../../src/components/dashboard/pagination.js";
-import { makeConfiguredDevice } from "../../_make-configured-device.js";
+import {
+  makeConfiguredDevice,
+  type ConfiguredDeviceOverrides,
+} from "../../_make-configured-device.js";
 
 afterEach(() => {
   setTourActive(false);
@@ -116,6 +119,61 @@ describe("device-table All rendering", () => {
     expect(
       el.shadowRoot!.querySelector('tbody tr[data-configuration="demo-0.yaml"]')
     ).not.toBeNull();
+  });
+});
+
+describe("device-table Version column identity gating", () => {
+  async function mountWithVersionColumn(
+    device: ConfiguredDevice
+  ): Promise<ESPHomeDeviceTable> {
+    const el = new ESPHomeDeviceTable();
+    el.devices = [device];
+    el.initialColumnVisibility = { version: true };
+    document.body.appendChild(el);
+    await el.updateComplete;
+    await el.updateComplete;
+    return el;
+  }
+
+  function versionCellText(el: ESPHomeDeviceTable): string {
+    const cell = el.shadowRoot!.querySelector("tbody td.col-version");
+    expect(cell).not.toBeNull();
+    return cell!.querySelector(".cell-mono, .cell-muted")!.textContent!.trim();
+  }
+
+  it.each<[string, ConfiguredDeviceOverrides, string]>([
+    [
+      "api device with mdns ownership shows the deployed version",
+      { api_enabled: true },
+      "2026.6.0",
+    ],
+    [
+      "api device with a dark identity blanks",
+      {
+        api_enabled: true,
+        runtime_state: { active_source: "ping", deployed_identity_live: false },
+      },
+      "—",
+    ],
+    [
+      "no-api device with a live identity TXT shows the deployed version",
+      { api_enabled: false },
+      "2026.6.0",
+    ],
+    [
+      "no-api device with a dark identity blanks",
+      { api_enabled: false, runtime_state: { deployed_identity_live: false } },
+      "—",
+    ],
+  ])("%s", async (_name, overrides, expected) => {
+    const { runtime_state, ...flat } = overrides;
+    const el = await mountWithVersionColumn(
+      makeConfiguredDevice({
+        ...flat,
+        runtime_state: { deployed_version: "2026.6.0", ...runtime_state },
+      })
+    );
+    expect(versionCellText(el)).toBe(expected);
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Follow up from review on #1272. The table's Version column rendered runtime_state.deployed_version ungated, so a device whose deployed identity is untrusted blanked in the drawer identity rows but kept showing the last heard value in the table. The row builder now routes the value through deployedIdentityTrusted, matching the drawer's Version section; an untrusted value renders as the shared em dash placeholder, and both device kinds converge at once. The modified and update dots in the Name column were already gated, so this was the only ungated surface (card and editor tooltips only render inside showUpdate branches, which are gated).

**Related issue or feature (if applicable):**

- fixes #1274

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
