### PR TITLE
Suppress tooltips on touch devices

### DIFF
--- a/src/entrypoint.ts
+++ b/src/entrypoint.ts
@@ -31,10 +31,12 @@ const favicon = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
 if (favicon) favicon.href = withBase("/assets/logo/esphome-favicon.svg");
 
 import { installWaComboboxLeakFix } from "./util/wa-combobox-leak-fix.js";
+import { installWaTooltipTouchSuppression } from "./util/wa-tooltip-touch-suppression.js";
 
 // Register the wa-combobox stub before any wa-select / wa-option renders
 // so webawesome's never-resolving whenDefined promise can't leak (#1031).
 installWaComboboxLeakFix();
+installWaTooltipTouchSuppression();
 
 import "./components/app-shell.js";
 import "./styles/apply-theme.js";

--- a/src/util/wa-tooltip-touch-suppression.ts
+++ b/src/util/wa-tooltip-touch-suppression.ts
@@ -1,0 +1,22 @@
+/**
+ * Suppress ``wa-tooltip`` on touch devices.
+ *
+ * A tap fires the browser's emulated ``mouseover``, so the tooltip's
+ * delayed ``show()`` lands *after* the tap's click has already opened a
+ * dialog — and with no ``mouseout`` (and on iOS no ``blur``) ever coming,
+ * the tooltip sticks in the top layer above it. The tooltip dispatches a
+ * cancellable composed ``wa-show`` before painting, so one document-level
+ * listener suppresses every tooltip on hover-incapable devices. Anchors
+ * keep their ``aria-label``/``aria-labelledby``, so nothing is lost.
+ */
+export function installWaTooltipTouchSuppression(): void {
+  if (typeof document === "undefined") return;
+  document.addEventListener("wa-show", (e: Event) => {
+    // "wa-show" is shared by dialogs/dropdowns — only ever cancel tooltips.
+    // composedPath, not target: crossing the shadow boundary retargets
+    // the event to the host component.
+    if ((e.composedPath()[0] as Element | undefined)?.localName !== "wa-tooltip") return;
+    if (typeof window.matchMedia !== "function") return;
+    if (window.matchMedia("(hover: none)").matches) e.preventDefault();
+  });
+}

--- a/src/util/wa-tooltip-touch-suppression.ts
+++ b/src/util/wa-tooltip-touch-suppression.ts
@@ -11,12 +11,15 @@
  */
 export function installWaTooltipTouchSuppression(): void {
   if (typeof document === "undefined") return;
-  document.addEventListener("wa-show", (e: Event) => {
-    // "wa-show" is shared by dialogs/dropdowns — only ever cancel tooltips.
-    // composedPath, not target: crossing the shadow boundary retargets
-    // the event to the host component.
-    if ((e.composedPath()[0] as Element | undefined)?.localName !== "wa-tooltip") return;
-    if (typeof window.matchMedia !== "function") return;
-    if (window.matchMedia("(hover: none)").matches) e.preventDefault();
-  });
+  // Named handler so addEventListener dedupes a repeated install.
+  document.addEventListener("wa-show", suppressTooltipShowOnTouch);
+}
+
+function suppressTooltipShowOnTouch(e: Event): void {
+  // "wa-show" is shared by dialogs/dropdowns — only ever cancel tooltips.
+  // composedPath, not target: crossing the shadow boundary retargets
+  // the event to the host component.
+  if ((e.composedPath()[0] as Element | undefined)?.localName !== "wa-tooltip") return;
+  if (typeof window.matchMedia !== "function") return;
+  if (window.matchMedia("(hover: none)").matches) e.preventDefault();
 }

--- a/test/util/wa-tooltip-touch-suppression.test.ts
+++ b/test/util/wa-tooltip-touch-suppression.test.ts
@@ -48,6 +48,14 @@ describe("installWaTooltipTouchSuppression", () => {
     expect(dispatchWaShow("wa-dialog").defaultPrevented).toBe(false);
   });
 
+  it("registers a single listener even when installed repeatedly", () => {
+    installWaTooltipTouchSuppression();
+    installWaTooltipTouchSuppression();
+    mockHoverNone(true);
+    expect(dispatchWaShow("wa-tooltip").defaultPrevented).toBe(true);
+    expect(window.matchMedia).toHaveBeenCalledTimes(1);
+  });
+
   it("lets the show through when matchMedia is unavailable", () => {
     vi.stubGlobal("matchMedia", undefined);
     expect(dispatchWaShow("wa-tooltip").defaultPrevented).toBe(false);

--- a/test/util/wa-tooltip-touch-suppression.test.ts
+++ b/test/util/wa-tooltip-touch-suppression.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { installWaTooltipTouchSuppression } from "../../src/util/wa-tooltip-touch-suppression.js";
+
+function mockHoverNone(matches: boolean): void {
+  vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches } as MediaQueryList));
+}
+
+function dispatchWaShow(tagName: string): Event {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const el = document.createElement(tagName);
+  host.attachShadow({ mode: "open" }).appendChild(el);
+  const event = new Event("wa-show", {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  });
+  el.dispatchEvent(event);
+  host.remove();
+  return event;
+}
+
+describe("installWaTooltipTouchSuppression", () => {
+  beforeAll(() => {
+    installWaTooltipTouchSuppression();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("cancels a tooltip show on a hover-incapable device", () => {
+    mockHoverNone(true);
+    expect(dispatchWaShow("wa-tooltip").defaultPrevented).toBe(true);
+  });
+
+  it("lets a tooltip show on a hover-capable device", () => {
+    mockHoverNone(false);
+    expect(dispatchWaShow("wa-tooltip").defaultPrevented).toBe(false);
+  });
+
+  it("never cancels another component's wa-show", () => {
+    mockHoverNone(true);
+    expect(dispatchWaShow("wa-dialog").defaultPrevented).toBe(false);
+  });
+
+  it("lets the show through when matchMedia is unavailable", () => {
+    vi.stubGlobal("matchMedia", undefined);
+    expect(dispatchWaShow("wa-tooltip").defaultPrevented).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

On phones, tapping a card action like Logs leaves its tooltip stuck on screen, floating on top of the dialog the tap opened. A tap fires the browser's emulated mouseover, so the tooltip's delayed show lands after the click already opened the dialog; no mouseout or blur ever follows on touch, so the tooltip sits in the top layer forever. Reproduced on iOS Safari and in Chrome with iPhone emulation.

Tooltips are a hover affordance, so this suppresses them entirely on hover incapable devices: wa-tooltip dispatches a cancellable composed wa-show before painting, and one document level listener installed at the entrypoint cancels it when (hover: none) matches. The filter uses composedPath, since crossing the shadow boundary retargets the event to the host component. Every anchor keeps its aria label and the tooltip's aria-labelledby wiring happens at anchor time, so screen readers are unaffected.

Verified with puppeteer touch emulation against a live stack; before the change a tap on Logs left an open tooltip over the dialog, after it the dialog opens clean and desktop hover still shows tooltips.

**Related issue or feature (if applicable):**

- found on mobile, no tracking issue

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
