### PR TITLE
Collapse the install dialog failure booleans into one failure kind

### DIFF
--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -86,6 +86,8 @@ export type InstallStep =
 
 export type Installer = "web-serial" | "binary-download" | "web-flash" | null;
 
+export type InstallFailureKind = "compile" | "validate" | "chip-mismatch";
+
 @customElement("esphome-firmware-install-dialog")
 export class ESPHomeFirmwareInstallDialog extends LitElement {
   @consume({ context: localizeContext, subscribe: true })
@@ -122,18 +124,12 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   @state() _statusMessage = "";
   @state() _errorMessage = "";
 
-  // Drives the reset-build-env hint — only build failures benefit; chip
-  // mismatch / Web Serial connection errors don't.
-  @state() _failedDuringCompile = false;
-
-  // Flips when output contains an ESPHome validation marker, swapping the
-  // hint from clean/reset (C++ help) to "open in editor" (YAML help).
-  @state() _failedDuringValidate = false;
-
-  // Pre-flash chip mismatch against the stored board_id. Swaps the footer's
-  // Retry (which would loop on the same stale board) for a change-board
-  // hand-off.
-  @state() _failedChipMismatch = false;
+  // What made the install fail, when a specific kind was recognised.
+  // "compile" drives the reset-build-env hint, "validate" swaps that hint to
+  // "open in editor" (YAML help), "chip-mismatch" swaps the footer's Retry
+  // (which would loop on the same stale board) for a change-board hand-off.
+  // null: no failure, or an unclassified one (e.g. Web Serial connection).
+  @state() _failureKind: InstallFailureKind | null = null;
 
   // Source of the most recent compile job. REMOTE means the toolchain lives
   // on a paired receiver, so the local "reset build environment" link can't
@@ -285,9 +281,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._binaries = [];
     this._showLogsAfterInstall = true;
     this._installer = null;
-    this._failedDuringCompile = false;
-    this._failedDuringValidate = false;
-    this._failedChipMismatch = false;
+    this._failureKind = null;
     this._jobSource = JobSource.LOCAL;
     this._jobSourceLabel = "";
     this._jobSourcePin = "";

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -86,7 +86,7 @@ export type InstallStep =
 
 export type Installer = "web-serial" | "binary-download" | "web-flash" | null;
 
-export type InstallFailureKind = "compile" | "validate" | "chip-mismatch";
+export type InstallFailureKind = "compile" | "validate" | "chip-mismatch" | null;
 
 @customElement("esphome-firmware-install-dialog")
 export class ESPHomeFirmwareInstallDialog extends LitElement {
@@ -129,7 +129,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   // "open in editor" (YAML help), "chip-mismatch" swaps the footer's Retry
   // (which would loop on the same stale board) for a change-board hand-off.
   // null: no failure, or an unclassified one (e.g. Web Serial connection).
-  @state() _failureKind: InstallFailureKind | null = null;
+  @state() _failureKind: InstallFailureKind = null;
 
   // Source of the most recent compile job. REMOTE means the toolchain lives
   // on a paired receiver, so the local "reset build environment" link can't

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -127,7 +127,7 @@ export async function startWebSerialInstall(
     !(expectedIsCoarseEsp32 && detectedVariant.startsWith("esp32"))
   ) {
     await releaseSerial(detected);
-    host._failedChipMismatch = true;
+    host._failureKind = "chip-mismatch";
     host._fail(
       host._localize("firmware.chip_mismatch", {
         detected: detected.chipName,
@@ -269,7 +269,8 @@ async function compileOrFail(
     await compileAndWait(host, configuration);
     return true;
   } catch (err) {
-    host._failedDuringCompile = true;
+    // ??= so a "validate" already recorded off the output stream survives.
+    host._failureKind ??= "compile";
     host._fail(host._localize("firmware.compile_failed"), compileFailureDetail(err));
     return false;
   }
@@ -616,7 +617,7 @@ export function compileAndWait(
           }
           host._timer.noteLine(line);
           host._log.enqueue(line);
-          if (isValidationFailureLine(line)) host._failedDuringValidate = true;
+          if (isValidationFailureLine(line)) host._failureKind = "validate";
         },
         onResult: (data) => {
           host._streamId = "";

--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -67,8 +67,8 @@ function isPeerLinkSessionLostError(message: string): boolean {
 export function renderResetSuggestion(
   host: ESPHomeFirmwareInstallDialog
 ): TemplateResult | typeof nothing {
-  if (host._failureKind !== "compile" && host._failureKind !== "validate") return nothing;
   if (host._failureKind === "validate") return renderValidationFailureSuggestion(host);
+  if (host._failureKind !== "compile") return nothing;
   if (isPeerLinkSessionLostError(host._errorMessage)) return nothing;
   const remoteLabel =
     host._jobSource === JobSource.REMOTE && host._jobSourceLabel

--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -67,8 +67,8 @@ function isPeerLinkSessionLostError(message: string): boolean {
 export function renderResetSuggestion(
   host: ESPHomeFirmwareInstallDialog
 ): TemplateResult | typeof nothing {
-  if (!host._failedDuringCompile) return nothing;
-  if (host._failedDuringValidate) return renderValidationFailureSuggestion(host);
+  if (host._failureKind !== "compile" && host._failureKind !== "validate") return nothing;
+  if (host._failureKind === "validate") return renderValidationFailureSuggestion(host);
   if (isPeerLinkSessionLostError(host._errorMessage)) return nothing;
   const remoteLabel =
     host._jobSource === JobSource.REMOTE && host._jobSourceLabel
@@ -353,7 +353,7 @@ export function renderFooter(host: ESPHomeFirmwareInstallDialog): TemplateResult
   }
   // A chip mismatch against the stored board can't be retried into success —
   // offer the board-reselect hand-off instead.
-  if (host._step === "error" && host._failedChipMismatch) {
+  if (host._step === "error" && host._failureKind === "chip-mismatch") {
     return html`
       <div class="footer">
         <button class="btn btn--ghost" @click=${host._close}>
@@ -372,9 +372,7 @@ export function renderFooter(host: ESPHomeFirmwareInstallDialog): TemplateResult
   const canRetry =
     host._step === "error" &&
     (host._installer === "web-serial" || host._installer === "web-flash") &&
-    !host._failedDuringCompile &&
-    !host._failedDuringValidate &&
-    !host._failedChipMismatch;
+    host._failureKind === null;
   if (canRetry) {
     return html`
       <div class="footer">

--- a/test/components/firmware-install-dialog-artifact-download.test.ts
+++ b/test/components/firmware-install-dialog-artifact-download.test.ts
@@ -24,7 +24,10 @@ import {
   JobSource,
   JobStatus,
 } from "../../src/api/types/firmware-jobs.js";
-import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
+import type {
+  ESPHomeFirmwareInstallDialog,
+  InstallFailureKind,
+} from "../../src/components/firmware-install-dialog.js";
 import {
   downloadSelectedBinary,
   startArtifactDownload,
@@ -75,7 +78,7 @@ function makeHost(getBinariesResults: FirmwareBinary[][]) {
     _binaries: [] as FirmwareBinary[],
     _downloadedFilename: "",
     _log: fakeLogBuffer(),
-    _failedDuringCompile: false,
+    _failureKind: null as InstallFailureKind | null,
     _jobId: "",
     _streamId: "",
     _jobSource: JobSource.LOCAL,

--- a/test/components/firmware-install-dialog-artifact-download.test.ts
+++ b/test/components/firmware-install-dialog-artifact-download.test.ts
@@ -24,10 +24,7 @@ import {
   JobSource,
   JobStatus,
 } from "../../src/api/types/firmware-jobs.js";
-import type {
-  ESPHomeFirmwareInstallDialog,
-  InstallFailureKind,
-} from "../../src/components/firmware-install-dialog.js";
+import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
 import {
   downloadSelectedBinary,
   startArtifactDownload,
@@ -78,7 +75,7 @@ function makeHost(getBinariesResults: FirmwareBinary[][]) {
     _binaries: [] as FirmwareBinary[],
     _downloadedFilename: "",
     _log: fakeLogBuffer(),
-    _failureKind: null as InstallFailureKind | null,
+    _failureKind: null,
     _jobId: "",
     _streamId: "",
     _jobSource: JobSource.LOCAL,

--- a/test/components/firmware-install-dialog-download-binary.test.ts
+++ b/test/components/firmware-install-dialog-download-binary.test.ts
@@ -26,10 +26,7 @@ import {
   JobSource,
   JobStatus,
 } from "../../src/api/types/firmware-jobs.js";
-import type {
-  ESPHomeFirmwareInstallDialog,
-  InstallFailureKind,
-} from "../../src/components/firmware-install-dialog.js";
+import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
 import {
   downloadSelectedBinary,
   startDownload,
@@ -71,7 +68,7 @@ function makeHost(installer: Installer, binaries: FirmwareBinary[]) {
     _binaries: [] as FirmwareBinary[],
     _downloadedFilename: "",
     _log: fakeLogBuffer(),
-    _failureKind: null as InstallFailureKind | null,
+    _failureKind: null,
     _jobId: "",
     _streamId: "",
     _jobSource: JobSource.LOCAL,

--- a/test/components/firmware-install-dialog-download-binary.test.ts
+++ b/test/components/firmware-install-dialog-download-binary.test.ts
@@ -26,7 +26,10 @@ import {
   JobSource,
   JobStatus,
 } from "../../src/api/types/firmware-jobs.js";
-import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
+import type {
+  ESPHomeFirmwareInstallDialog,
+  InstallFailureKind,
+} from "../../src/components/firmware-install-dialog.js";
 import {
   downloadSelectedBinary,
   startDownload,
@@ -68,8 +71,7 @@ function makeHost(installer: Installer, binaries: FirmwareBinary[]) {
     _binaries: [] as FirmwareBinary[],
     _downloadedFilename: "",
     _log: fakeLogBuffer(),
-    _failedDuringCompile: false,
-    _failedDuringValidate: false,
+    _failureKind: null as InstallFailureKind | null,
     _jobId: "",
     _streamId: "",
     _jobSource: JobSource.LOCAL,

--- a/test/components/firmware-install-dialog-footer.test.ts
+++ b/test/components/firmware-install-dialog-footer.test.ts
@@ -25,7 +25,7 @@ function footerHost(step: string) {
     _retry: vi.fn(),
     _showLogsAgain: vi.fn(),
     _detected: null,
-    _failureKind: null as InstallFailureKind | null,
+    _failureKind: null as InstallFailureKind,
     _tryChangeBoard: vi.fn(),
     _showLogsAfterInstall: false,
     _toggleShowLogsAfterInstall: vi.fn(),

--- a/test/components/firmware-install-dialog-footer.test.ts
+++ b/test/components/firmware-install-dialog-footer.test.ts
@@ -7,7 +7,10 @@
  * Stop button mid-download.
  */
 import { describe, expect, it, vi } from "vitest";
-import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
+import type {
+  ESPHomeFirmwareInstallDialog,
+  InstallFailureKind,
+} from "../../src/components/firmware-install-dialog.js";
 import { renderFooter } from "../../src/components/firmware-install-dialog/renderers.js";
 import { identityLocalize } from "../_dom.js";
 import { findTemplatesByAnchor } from "../_lit-template-walker.js";
@@ -22,9 +25,7 @@ function footerHost(step: string) {
     _retry: vi.fn(),
     _showLogsAgain: vi.fn(),
     _detected: null,
-    _failedDuringCompile: false,
-    _failedDuringValidate: false,
-    _failedChipMismatch: false,
+    _failureKind: null as InstallFailureKind | null,
     _tryChangeBoard: vi.fn(),
     _showLogsAfterInstall: false,
     _toggleShowLogsAfterInstall: vi.fn(),
@@ -67,7 +68,7 @@ describe("firmware-install-dialog footer", () => {
     // wouldn't address them, so it falls through to the plain Close footer.
     const host = footerHost("error");
     host._installer = "web-serial";
-    host._failedDuringCompile = true;
+    host._failureKind = "compile";
     const values = footerValues(host);
     expect(values).not.toContain(host._retry);
   });
@@ -83,7 +84,7 @@ describe("firmware-install-dialog footer", () => {
     // is the only way out.
     const host = footerHost("error");
     host._installer = "web-serial";
-    host._failedChipMismatch = true;
+    host._failureKind = "chip-mismatch";
     const values = footerValues(host);
     expect(values).toContain(host._tryChangeBoard);
     expect(values).toContain(host._close);

--- a/test/components/firmware-install-dialog-reset-suggestion.test.ts
+++ b/test/components/firmware-install-dialog-reset-suggestion.test.ts
@@ -9,7 +9,10 @@
  */
 import { describe, it } from "vitest";
 import { JobSource } from "../../src/api/types/firmware-jobs.js";
-import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
+import type {
+  ESPHomeFirmwareInstallDialog,
+  InstallFailureKind,
+} from "../../src/components/firmware-install-dialog.js";
 import { renderResetSuggestion } from "../../src/components/firmware-install-dialog/renderers.js";
 import {
   expectFallbackToLocal,
@@ -24,8 +27,7 @@ interface Host {
   _step: string;
   _statusMessage: string;
   _errorMessage: string;
-  _failedDuringCompile: boolean;
-  _failedDuringValidate: boolean;
+  _failureKind: InstallFailureKind | null;
   _jobSource: JobSource;
   _jobSourceLabel: string;
   _tryCleanBuild: () => void;
@@ -39,8 +41,7 @@ function baseHost(overrides: Partial<Host> = {}): Host {
     _step: "error",
     _statusMessage: "Install failed.",
     _errorMessage: "Boom",
-    _failedDuringCompile: true,
-    _failedDuringValidate: false,
+    _failureKind: "compile",
     _jobSource: JobSource.LOCAL,
     _jobSourceLabel: "",
     _tryCleanBuild: () => {},

--- a/test/components/firmware-install-dialog-reset-suggestion.test.ts
+++ b/test/components/firmware-install-dialog-reset-suggestion.test.ts
@@ -27,7 +27,7 @@ interface Host {
   _step: string;
   _statusMessage: string;
   _errorMessage: string;
-  _failureKind: InstallFailureKind | null;
+  _failureKind: InstallFailureKind;
   _jobSource: JobSource;
   _jobSourceLabel: string;
   _tryCleanBuild: () => void;

--- a/test/components/firmware-install-dialog-usb-flash.test.ts
+++ b/test/components/firmware-install-dialog-usb-flash.test.ts
@@ -3,10 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import type { ConfiguredDevice } from "../../src/api/types/devices.js";
 import type { FirmwareBinary } from "../../src/api/types/firmware-jobs.js";
-import type {
-  ESPHomeFirmwareInstallDialog,
-  InstallFailureKind,
-} from "../../src/components/firmware-install-dialog.js";
+import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
 import {
   pickFactoryBinary,
   showOtaLogs,
@@ -51,7 +48,7 @@ function makeHost(opts: { compileOk: boolean; binaries?: FirmwareBinary[] }) {
     _compileReject: null,
     _jobSource: 0,
     _jobSourceLabel: "",
-    _failureKind: null as InstallFailureKind | null,
+    _failureKind: null,
     _binaries: [] as FirmwareBinary[],
     _usbFirmware: null as ArrayBuffer | null,
     _usbFirmwareName: "",

--- a/test/components/firmware-install-dialog-usb-flash.test.ts
+++ b/test/components/firmware-install-dialog-usb-flash.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import type { ConfiguredDevice } from "../../src/api/types/devices.js";
 import type { FirmwareBinary } from "../../src/api/types/firmware-jobs.js";
-import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
+import type {
+  ESPHomeFirmwareInstallDialog,
+  InstallFailureKind,
+} from "../../src/components/firmware-install-dialog.js";
 import {
   pickFactoryBinary,
   showOtaLogs,
@@ -48,8 +51,7 @@ function makeHost(opts: { compileOk: boolean; binaries?: FirmwareBinary[] }) {
     _compileReject: null,
     _jobSource: 0,
     _jobSourceLabel: "",
-    _failedDuringCompile: false,
-    _failedDuringValidate: false,
+    _failureKind: null as InstallFailureKind | null,
     _binaries: [] as FirmwareBinary[],
     _usbFirmware: null as ArrayBuffer | null,
     _usbFirmwareName: "",

--- a/test/components/firmware-install-dialog-web-serial.test.ts
+++ b/test/components/firmware-install-dialog-web-serial.test.ts
@@ -24,7 +24,10 @@ vi.mock("../../src/util/post-install-logs.js", () => ({
 }));
 
 import { JobSource, JobStatus } from "../../src/api/types/firmware-jobs.js";
-import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
+import type {
+  ESPHomeFirmwareInstallDialog,
+  InstallFailureKind,
+} from "../../src/components/firmware-install-dialog.js";
 import { startWebSerialInstall } from "../../src/components/firmware-install-dialog/install-flow.js";
 import { _clearBoardBodyCache } from "../../src/util/board-body-cache.js";
 import { identityLocalize } from "../_dom.js";
@@ -62,9 +65,7 @@ function makeHost() {
     _open: true,
     _showLogsAfterInstall: false,
     _detected: null as unknown,
-    _failedDuringCompile: false,
-    _failedDuringValidate: false,
-    _failedChipMismatch: false,
+    _failureKind: null as InstallFailureKind | null,
     _jobId: "",
     _streamId: "",
     _jobSource: JobSource.LOCAL,
@@ -236,8 +237,8 @@ describe("Web Serial install — HTTP byte download", () => {
     await startWebSerialInstall(host as unknown as ESPHomeFirmwareInstallDialog);
 
     expect(host._fail).toHaveBeenCalledWith("firmware.chip_mismatch");
-    // The flag routes the footer to the change-board hand-off.
-    expect(host._failedChipMismatch).toBe(true);
+    // The kind routes the footer to the change-board hand-off.
+    expect(host._failureKind).toBe("chip-mismatch");
     expect(wsSerial.flashFirmware).not.toHaveBeenCalled();
   });
 
@@ -250,6 +251,6 @@ describe("Web Serial install — HTTP byte download", () => {
 
     await startWebSerialInstall(host as unknown as ESPHomeFirmwareInstallDialog);
 
-    expect(host._failedChipMismatch).toBe(false);
+    expect(host._failureKind).toBe(null);
   });
 });

--- a/test/components/firmware-install-dialog-web-serial.test.ts
+++ b/test/components/firmware-install-dialog-web-serial.test.ts
@@ -24,10 +24,7 @@ vi.mock("../../src/util/post-install-logs.js", () => ({
 }));
 
 import { JobSource, JobStatus } from "../../src/api/types/firmware-jobs.js";
-import type {
-  ESPHomeFirmwareInstallDialog,
-  InstallFailureKind,
-} from "../../src/components/firmware-install-dialog.js";
+import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
 import { startWebSerialInstall } from "../../src/components/firmware-install-dialog/install-flow.js";
 import { _clearBoardBodyCache } from "../../src/util/board-body-cache.js";
 import { identityLocalize } from "../_dom.js";
@@ -65,7 +62,7 @@ function makeHost() {
     _open: true,
     _showLogsAfterInstall: false,
     _detected: null as unknown,
-    _failureKind: null as InstallFailureKind | null,
+    _failureKind: null,
     _jobId: "",
     _streamId: "",
     _jobSource: JobSource.LOCAL,


### PR DESCRIPTION
# What does this implement/fix?

Replaces the install dialog's three failure booleans (`_failedDuringCompile`, `_failedDuringValidate`, `_failedChipMismatch`) with a single `_failureKind` field; the footer retry gate becomes a null check and a new failure kind has one obvious home.

A validation failure used to set both the validate and compile flags, so the compile catch now uses `??=` to keep an already recorded `"validate"`, and the reset suggestion renderer treats both kinds as compile path failures. The command dialog is untouched, it only ever had the single validate boolean.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1288

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
