### PR TITLE
Fold infinite scroll sentinel wiring into IntersectionController

### DIFF
--- a/src/components/device/change-board-dialog.styles.ts
+++ b/src/components/device/change-board-dialog.styles.ts
@@ -78,7 +78,9 @@ export const changeBoardDialogStyles = css`
     color: var(--wa-color-text-quiet);
   }
 
-  .load-more-loading {
+  /* Compact override of the shared .load-more-loading default: dialog
+     spacing, no font-size bump. */
+  .load-more-loading-compact {
     text-align: center;
     color: var(--wa-color-text-quiet);
     padding: var(--wa-space-m);

--- a/src/components/device/change-board-dialog.ts
+++ b/src/components/device/change-board-dialog.ts
@@ -73,16 +73,15 @@ export class ESPHomeChangeBoardDialog extends LitElement {
   @query(".board-search")
   private _searchInput?: HTMLInputElement | null;
 
-  @query(".sentinel")
-  private _sentinel?: HTMLElement | null;
-
-  @query(".board-list")
-  private _scrollBox?: HTMLElement | null;
-
   private readonly _dialog = new DialogOpenController(this);
 
-  private readonly _intersection = new IntersectionController(this, () =>
-    this._requestLoadMore()
+  // The board list is always its own scroll box, so observe against it
+  // directly — an explicit root also makes the prefetch margin apply to
+  // the box the user actually scrolls, unlike the viewport-root form.
+  private readonly _intersection = new IntersectionController(
+    this,
+    () => this._requestLoadMore(),
+    { rootSelector: ".board-list" }
   );
 
   static styles = [
@@ -152,7 +151,7 @@ export class ESPHomeChangeBoardDialog extends LitElement {
             loadingLabelKey: "wizard.loading_boards",
             errorLabelKey: "wizard.boards_load_more_error",
             onRetry: this._requestLoadMore,
-            loadingClass: "load-more-loading",
+            loadingClass: "load-more-loading-compact",
           })}
         </div>
         <div class="actions">
@@ -191,13 +190,6 @@ export class ESPHomeChangeBoardDialog extends LitElement {
         }
       </button>
     `;
-  }
-
-  protected updated() {
-    // The board list is always its own scroll box, so observe against it
-    // directly — an explicit root also makes the prefetch margin apply to
-    // the box the user actually scrolls, unlike the null-root form.
-    this._intersection.observeIfPresent(this._sentinel, this._scrollBox ?? null, "200px");
   }
 
   private _requestLoadMore = () => {

--- a/src/components/device/change-board-dialog.ts
+++ b/src/components/device/change-board-dialog.ts
@@ -135,7 +135,7 @@ export class ESPHomeChangeBoardDialog extends LitElement {
         <div class="board-list">
           ${
             this.boards.length === 0 && this.searchable && !this.loadingMore
-              ? html`<p class="load-more-loading">
+              ? html`<p class="load-more-loading-compact">
                   ${this._localize(
                     this.loadError ? "wizard.boards_load_error" : "wizard.no_boards_found"
                   )}

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -8,7 +8,7 @@ import {
   mdiPlus,
 } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
-import { customElement, property, query, queryAll, state } from "lit/decorators.js";
+import { customElement, property, queryAll, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry, FeaturedBundle } from "../../api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../api/types/components.js";
@@ -118,13 +118,21 @@ export class ESPHomeComponentCatalog extends LitElement {
   })
   _overflowingDescriptions: ReadonlySet<string> = new Set();
 
-  @query(".sentinel") private _sentinel?: HTMLElement | null;
-
   @queryAll(".component-description--clamp[data-component-id]")
   private _clampedDescriptions!: NodeListOf<HTMLElement>;
 
   private _resize = new ResizeController(this, () => this._measureDescriptionOverflow());
 
+  // Observes against the viewport (no rootSelector) so paging works whether
+  // the grid scrolls itself or the surrounding dialog does; the sentinel is
+  // still clipped by the scroll container, and only exists while more pages
+  // remain (see render), so a missing one tears the observer down.
+  //
+  // Re-paging relies on each appended page overflowing the scroll container
+  // so the sentinel re-crosses on the next scroll. That holds because a full
+  // page far exceeds the container height and the only short page is the
+  // last (hasMore=false, sentinel removed); a short non-final page never
+  // occurs.
   private _intersection = new IntersectionController(this, () => this._list.loadMore());
 
   private _debouncedSearch = debounce(() => this._fetchComponents(), 300);
@@ -266,18 +274,6 @@ export class ESPHomeComponentCatalog extends LitElement {
       this._category = "all";
       this._fetchComponents();
     }
-
-    // Observe against the viewport (null root) so paging works whether the
-    // grid scrolls itself or the surrounding dialog does; the sentinel is
-    // still clipped by the scroll container, and only exists while more pages
-    // remain (see render), so a missing one tears the observer down.
-    //
-    // Re-paging relies on each appended page overflowing the scroll container
-    // so the sentinel re-crosses on the next scroll. That holds because a full
-    // page far exceeds the container height and the only short page is the
-    // last (hasMore=false, sentinel removed); a short non-final page never
-    // occurs.
-    this._intersection.observeIfPresent(this._sentinel, null, "200px");
   }
 
   protected render() {
@@ -387,7 +383,6 @@ export class ESPHomeComponentCatalog extends LitElement {
             loadingLabelKey: "device.loading_components",
             errorLabelKey: "device.components_load_more_error",
             onRetry: () => this._list.loadMore(),
-            loadingClass: "empty",
           })}
         </div>
       </div>

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -381,6 +381,10 @@ export const componentCatalogStyles = css`
     grid-column: 1 / -1;
   }
 
+  .load-more-loading {
+    grid-column: 1 / -1;
+  }
+
   .loading {
     flex: 1;
     display: flex;

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -381,10 +381,6 @@ export const componentCatalogStyles = css`
     grid-column: 1 / -1;
   }
 
-  .load-more-loading {
-    grid-column: 1 / -1;
-  }
-
   .loading {
     flex: 1;
     display: flex;

--- a/src/components/shared/load-more-footer.ts
+++ b/src/components/shared/load-more-footer.ts
@@ -15,9 +15,9 @@ export interface LoadMoreFooterOptions {
   errorLabelKey: string;
   /** Re-runs the failed page fetch. */
   onRetry: () => void;
-  /** Class for the spinner line; the host owns its centered-text style
-   *  (``"loading"`` for the board picker, ``"empty"`` for the catalog). */
-  loadingClass: string;
+  /** Class for the spinner line; defaults to the shared centered-quiet
+   *  ``load-more-loading`` in ``loadMoreFooterStyles``. */
+  loadingClass?: string;
 }
 
 /**
@@ -31,7 +31,8 @@ export function renderLoadMoreFooter(
   o: LoadMoreFooterOptions
 ): TemplateResult | typeof nothing {
   if (o.loadingMore) {
-    return html`<p class=${o.loadingClass}>${o.localize(o.loadingLabelKey)}</p>`;
+    const cls = o.loadingClass ?? "load-more-loading";
+    return html`<p class=${cls}>${o.localize(o.loadingLabelKey)}</p>`;
   }
   if (o.error) {
     return html`<div class="load-more-error" role="alert">

--- a/src/components/wizard/wizard-step-board-list.ts
+++ b/src/components/wizard/wizard-step-board-list.ts
@@ -1,6 +1,6 @@
 import { mdiArrowCollapseAll, mdiArrowExpandAll, mdiOpenInNew, mdiPlus } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import type { SlimBoard } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -55,9 +55,18 @@ export class ESPHomeWizardStepBoardList extends LitElement {
   @state()
   private _expandedBoardId: string | null = null;
 
-  @query(".sentinel")
-  private _sentinel?: HTMLElement | null;
-
+  // Observes against the viewport (no rootSelector), not the inner scroll box:
+  // on mobile the board list isn't its own scroll container (the dialog body
+  // scrolls as one), so a fixed root would never see the sentinel cross and
+  // paging would stall after one page. IntersectionObserver still clips the
+  // sentinel by the desktop scroll box, so this works in both layouts.
+  //
+  // Re-paging relies on each appended page overflowing the scroll container
+  // so the sentinel leaves the viewport and re-crosses on the next scroll.
+  // That always holds: a full page is far taller than the container, and the
+  // only short page is the last one, which lands hasMore=false and removes
+  // the sentinel. A short non-final page (which would keep the sentinel in
+  // view and not re-fire) never occurs.
   private _intersection = new IntersectionController(this, () =>
     this.dispatchEvent(new CustomEvent("load-more"))
   );
@@ -121,29 +130,11 @@ export class ESPHomeWizardStepBoardList extends LitElement {
                     loadingLabelKey: "wizard.loading_boards",
                     errorLabelKey: "wizard.boards_load_more_error",
                     onRetry: this._onRetry,
-                    loadingClass: "loading",
                   })}
                 `
         }
       </div>
     `;
-  }
-
-  protected updated() {
-    // Observe against the viewport (null root), not the inner scroll box: on
-    // mobile the board list isn't its own scroll container (the dialog body
-    // scrolls as one), so a fixed root would never see the sentinel cross and
-    // paging would stall after one page. IntersectionObserver still clips the
-    // sentinel by the desktop scroll box, so this works in both layouts. The
-    // 200px margin prefetches the next page before the sentinel is in view.
-    //
-    // Re-paging relies on each appended page overflowing the scroll container
-    // so the sentinel leaves the viewport and re-crosses on the next scroll.
-    // That always holds: a full page is far taller than the container, and the
-    // only short page is the last one, which lands hasMore=false and removes
-    // the sentinel. A short non-final page (which would keep the sentinel in
-    // view and not re-fire) never occurs.
-    this._intersection.observeIfPresent(this._sentinel, null, "200px");
   }
 
   private _renderFeatured(board: SlimBoard) {

--- a/src/styles/load-more-footer.ts
+++ b/src/styles/load-more-footer.ts
@@ -1,17 +1,23 @@
 import { css } from "lit";
 
 /**
- * Shared styles for the infinite-scroll footer (sentinel + retry) used by the
- * board picker and the component catalog. Pairs with ``renderLoadMoreFooter``
- * in ``components/shared/load-more-footer.ts``; the spinner line uses each
- * host's own ``.loading`` / ``.empty`` class, so only the sentinel and the
- * retry affordance live here.
+ * Shared styles for the infinite-scroll footer (sentinel + spinner + retry).
+ * Pairs with ``renderLoadMoreFooter`` in ``components/shared/load-more-footer.ts``;
+ * the spinner line defaults to ``.load-more-loading``, overridable per host
+ * via ``loadingClass``.
  */
 export const loadMoreFooterStyles = css`
   /* Infinite-scroll trigger: a zero-content marker the IntersectionObserver
      watches; given a sliver of height so it reliably crosses the root. */
   .sentinel {
     height: 1px;
+  }
+
+  .load-more-loading {
+    text-align: center;
+    color: var(--wa-color-text-quiet);
+    font-size: var(--wa-font-size-s);
+    padding: var(--wa-space-xl);
   }
 
   .load-more-error {

--- a/src/util/intersection-controller.ts
+++ b/src/util/intersection-controller.ts
@@ -1,8 +1,6 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 
 export interface IntersectionControllerOptions {
-  /** Selector for the observed sentinel (what ``renderLoadMoreFooter`` emits). */
-  targetSelector?: string;
   /** Selector for the scroll container to use as the observer root; omit to
    *  observe against the viewport. */
   rootSelector?: string;
@@ -11,7 +9,7 @@ export interface IntersectionControllerOptions {
 
 /**
  * Reactive controller wrapping an ``IntersectionObserver`` over a single
- * sentinel element.
+ * ``.sentinel`` element (what ``renderLoadMoreFooter`` emits).
  *
  * Discovers the sentinel (and optional root) in the host's render root after
  * every update, so hosts supply only the ``onIntersect`` callback, which fires
@@ -23,24 +21,21 @@ export class IntersectionController implements ReactiveController {
   private _observer: IntersectionObserver | null = null;
   private _target: Element | null = null;
   private _root: Element | null = null;
-  private _rootMargin = "";
-  private readonly _targetSelector: string;
   private readonly _rootSelector: string | null;
-  private readonly _observeMargin: string;
+  private readonly _rootMargin: string;
 
   constructor(
     private readonly _host: ReactiveControllerHost & { renderRoot: ParentNode },
     private readonly _onIntersect: () => void,
-    options?: IntersectionControllerOptions
+    options: IntersectionControllerOptions = {}
   ) {
-    this._targetSelector = options?.targetSelector ?? ".sentinel";
-    this._rootSelector = options?.rootSelector ?? null;
-    this._observeMargin = options?.rootMargin ?? "200px";
+    this._rootSelector = options.rootSelector ?? null;
+    this._rootMargin = options.rootMargin ?? "200px";
     _host.addController(this);
   }
 
   hostUpdated(): void {
-    const target = this._host.renderRoot.querySelector(this._targetSelector);
+    const target = this._host.renderRoot.querySelector(".sentinel");
     if (!target) {
       this.disconnect();
       return;
@@ -60,30 +55,23 @@ export class IntersectionController implements ReactiveController {
     this._observer = null;
     this._target = null;
     this._root = null;
-    this._rootMargin = "";
   }
 
   private _observe(target: Element, root: Element | null): void {
-    // Re-observe only when the target or an observer option actually changes,
-    // so a same-config call from ``hostUpdated`` is a cheap no-op but a new
-    // target / root rebuilds the observer.
-    if (
-      this._observer !== null &&
-      this._target === target &&
-      this._root === root &&
-      this._rootMargin === this._observeMargin
-    ) {
+    // Re-observe only when the target or root actually changes, so a
+    // same-config call from ``hostUpdated`` is a cheap no-op but a
+    // re-rendered node rebuilds the observer.
+    if (this._observer !== null && this._target === target && this._root === root) {
       return;
     }
     this.disconnect();
     this._target = target;
     this._root = root;
-    this._rootMargin = this._observeMargin;
     this._observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((e) => e.isIntersecting)) this._onIntersect();
       },
-      { root, rootMargin: this._observeMargin }
+      { root, rootMargin: this._rootMargin }
     );
     this._observer.observe(target);
   }

--- a/src/util/intersection-controller.ts
+++ b/src/util/intersection-controller.ts
@@ -1,63 +1,54 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 
+export interface IntersectionControllerOptions {
+  /** Selector for the observed sentinel (what ``renderLoadMoreFooter`` emits). */
+  targetSelector?: string;
+  /** Selector for the scroll container to use as the observer root; omit to
+   *  observe against the viewport. */
+  rootSelector?: string;
+  rootMargin?: string;
+}
+
 /**
  * Reactive controller wrapping an ``IntersectionObserver`` over a single
  * sentinel element.
-
- * The host calls ``observe(target, root)`` once the sentinel and its scroll
- * container are in the DOM (e.g. from ``updated``); ``onIntersect`` fires each
- * time the sentinel scrolls into view, driving infinite-scroll page fetches.
- * Re-observing the same target is a no-op; a new target replaces the old
- * subscription. The observer is torn down on host disconnect.
+ *
+ * Discovers the sentinel (and optional root) in the host's render root after
+ * every update, so hosts supply only the ``onIntersect`` callback, which fires
+ * each time the sentinel scrolls into view, driving infinite-scroll page
+ * fetches. A sentinel that leaves the DOM (no more pages) tears the observer
+ * down; a re-rendered one re-subscribes. Torn down on host disconnect.
  */
 export class IntersectionController implements ReactiveController {
   private _observer: IntersectionObserver | null = null;
   private _target: Element | null = null;
   private _root: Element | null = null;
   private _rootMargin = "";
+  private readonly _targetSelector: string;
+  private readonly _rootSelector: string | null;
+  private readonly _observeMargin: string;
 
   constructor(
-    host: ReactiveControllerHost,
-    private readonly _onIntersect: () => void
+    private readonly _host: ReactiveControllerHost & { renderRoot: ParentNode },
+    private readonly _onIntersect: () => void,
+    options?: IntersectionControllerOptions
   ) {
-    host.addController(this);
+    this._targetSelector = options?.targetSelector ?? ".sentinel";
+    this._rootSelector = options?.rootSelector ?? null;
+    this._observeMargin = options?.rootMargin ?? "200px";
+    _host.addController(this);
   }
 
-  /** Observe ``target`` when present, else tear down. ``root`` may be null
-   *  (the viewport). Hosts call this from ``updated`` with their (possibly
-   *  missing) sentinel. */
-  observeIfPresent(
-    target: Element | null | undefined,
-    root: Element | null,
-    rootMargin?: string
-  ): void {
-    if (target) this.observe(target, root, rootMargin);
-    else this.disconnect();
-  }
-
-  observe(target: Element, root: Element | null, rootMargin = "0px"): void {
-    // Re-observe only when the target or an observer option actually changes,
-    // so a same-config call from ``updated`` is a cheap no-op but a new
-    // ``root`` / ``rootMargin`` rebuilds the observer.
-    if (
-      this._observer !== null &&
-      this._target === target &&
-      this._root === root &&
-      this._rootMargin === rootMargin
-    ) {
+  hostUpdated(): void {
+    const target = this._host.renderRoot.querySelector(this._targetSelector);
+    if (!target) {
+      this.disconnect();
       return;
     }
-    this.disconnect();
-    this._target = target;
-    this._root = root;
-    this._rootMargin = rootMargin;
-    this._observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((e) => e.isIntersecting)) this._onIntersect();
-      },
-      { root, rootMargin }
-    );
-    this._observer.observe(target);
+    const root = this._rootSelector
+      ? this._host.renderRoot.querySelector(this._rootSelector)
+      : null;
+    this._observe(target, root);
   }
 
   hostDisconnected(): void {
@@ -70,5 +61,30 @@ export class IntersectionController implements ReactiveController {
     this._target = null;
     this._root = null;
     this._rootMargin = "";
+  }
+
+  private _observe(target: Element, root: Element | null): void {
+    // Re-observe only when the target or an observer option actually changes,
+    // so a same-config call from ``hostUpdated`` is a cheap no-op but a new
+    // target / root rebuilds the observer.
+    if (
+      this._observer !== null &&
+      this._target === target &&
+      this._root === root &&
+      this._rootMargin === this._observeMargin
+    ) {
+      return;
+    }
+    this.disconnect();
+    this._target = target;
+    this._root = root;
+    this._rootMargin = this._observeMargin;
+    this._observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) this._onIntersect();
+      },
+      { root, rootMargin: this._observeMargin }
+    );
+    this._observer.observe(target);
   }
 }

--- a/test/util/intersection-controller.test.ts
+++ b/test/util/intersection-controller.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { IntersectionController } from "../../src/util/intersection-controller.js";
 import { FakeHost } from "../_fake-host.js";
@@ -30,7 +31,18 @@ class MockObserver {
   }
 }
 
-const el = (id: string) => ({ id }) as unknown as Element;
+class SentinelHost extends FakeHost {
+  renderRoot = document.createElement("div");
+  addSentinel(): HTMLElement {
+    const sentinel = document.createElement("div");
+    sentinel.className = "sentinel";
+    this.renderRoot.appendChild(sentinel);
+    return sentinel;
+  }
+  removeSentinel() {
+    this.renderRoot.querySelector(".sentinel")?.remove();
+  }
+}
 
 beforeEach(() => {
   MockObserver.instances = [];
@@ -42,64 +54,108 @@ afterEach(() => {
 });
 
 describe("IntersectionController", () => {
-  it("invokes the callback only when the sentinel is intersecting", () => {
-    const onIntersect = vi.fn();
-    const ctrl = new IntersectionController(new FakeHost(), onIntersect);
-    const target = el("sentinel");
-    ctrl.observe(target, null, "200px");
+  it("observes the sentinel against the viewport with the 200px default margin", () => {
+    const host = new SentinelHost();
+    const ctrl = new IntersectionController(host, vi.fn());
+    const sentinel = host.addSentinel();
+    ctrl.hostUpdated();
 
     const obs = MockObserver.instances[0];
-    expect(obs.observed).toEqual([target]);
+    expect(obs.observed).toEqual([sentinel]);
     expect(obs.options).toMatchObject({ root: null, rootMargin: "200px" });
+  });
 
+  it("invokes the callback only when the sentinel is intersecting", () => {
+    const host = new SentinelHost();
+    const onIntersect = vi.fn();
+    const ctrl = new IntersectionController(host, onIntersect);
+    host.addSentinel();
+    ctrl.hostUpdated();
+
+    const obs = MockObserver.instances[0];
     obs.trigger(false);
     expect(onIntersect).not.toHaveBeenCalled();
     obs.trigger(true);
     expect(onIntersect).toHaveBeenCalledTimes(1);
   });
 
-  it("re-observing the same target is a no-op; a new target replaces the observer", () => {
-    const ctrl = new IntersectionController(new FakeHost(), vi.fn());
-    const a = el("a");
-    ctrl.observe(a, null);
-    ctrl.observe(a, null);
+  it("resolves rootSelector to the scroll container", () => {
+    const host = new SentinelHost();
+    const scrollBox = document.createElement("div");
+    scrollBox.className = "board-list";
+    host.renderRoot.appendChild(scrollBox);
+    const ctrl = new IntersectionController(host, vi.fn(), {
+      rootSelector: ".board-list",
+    });
+    host.addSentinel();
+    ctrl.hostUpdated();
+
+    expect(MockObserver.instances[0].options).toMatchObject({ root: scrollBox });
+  });
+
+  it("honours targetSelector and rootMargin overrides", () => {
+    const host = new SentinelHost();
+    const marker = document.createElement("div");
+    marker.className = "marker";
+    host.renderRoot.appendChild(marker);
+    const ctrl = new IntersectionController(host, vi.fn(), {
+      targetSelector: ".marker",
+      rootMargin: "50px",
+    });
+    ctrl.hostUpdated();
+
+    const obs = MockObserver.instances[0];
+    expect(obs.observed).toEqual([marker]);
+    expect(obs.options).toMatchObject({ rootMargin: "50px" });
+  });
+
+  it("creates no observer while the sentinel is absent", () => {
+    const host = new SentinelHost();
+    const ctrl = new IntersectionController(host, vi.fn());
+    ctrl.hostUpdated();
+    expect(MockObserver.instances).toHaveLength(0);
+  });
+
+  it("repeat updates with the same sentinel are a no-op", () => {
+    const host = new SentinelHost();
+    const ctrl = new IntersectionController(host, vi.fn());
+    host.addSentinel();
+    ctrl.hostUpdated();
+    ctrl.hostUpdated();
     expect(MockObserver.instances).toHaveLength(1);
+  });
 
-    const b = el("b");
-    ctrl.observe(b, null);
+  it("a re-rendered sentinel node replaces the observer", () => {
+    const host = new SentinelHost();
+    const ctrl = new IntersectionController(host, vi.fn());
+    host.addSentinel();
+    ctrl.hostUpdated();
+
+    host.removeSentinel();
+    const next = host.addSentinel();
+    ctrl.hostUpdated();
+
     expect(MockObserver.instances).toHaveLength(2);
     expect(MockObserver.instances[0].disconnected).toBe(true);
-    expect(MockObserver.instances[1].observed).toEqual([b]);
+    expect(MockObserver.instances[1].observed).toEqual([next]);
   });
 
-  it("re-observes the same target when root or rootMargin changes", () => {
-    const ctrl = new IntersectionController(new FakeHost(), vi.fn());
-    const a = el("a");
-    ctrl.observe(a, null, "0px");
-    ctrl.observe(a, null, "200px");
-    expect(MockObserver.instances).toHaveLength(2);
+  it("tears down when the sentinel leaves the DOM", () => {
+    const host = new SentinelHost();
+    const ctrl = new IntersectionController(host, vi.fn());
+    host.addSentinel();
+    ctrl.hostUpdated();
+
+    host.removeSentinel();
+    ctrl.hostUpdated();
     expect(MockObserver.instances[0].disconnected).toBe(true);
-    expect(MockObserver.instances[1].options).toMatchObject({ rootMargin: "200px" });
-  });
-
-  it("observeIfPresent tears down when the target is missing", () => {
-    const ctrl = new IntersectionController(new FakeHost(), vi.fn());
-    ctrl.observe(el("a"), null);
-    ctrl.observeIfPresent(null, null);
-    expect(MockObserver.instances[0].disconnected).toBe(true);
-  });
-
-  it("observeIfPresent observes against a null (viewport) root", () => {
-    const ctrl = new IntersectionController(new FakeHost(), vi.fn());
-    const target = el("sentinel");
-    ctrl.observeIfPresent(target, null, "200px");
-    expect(MockObserver.instances[0].observed).toEqual([target]);
-    expect(MockObserver.instances[0].options).toMatchObject({ root: null });
   });
 
   it("disconnects the observer on host disconnect", () => {
-    const ctrl = new IntersectionController(new FakeHost(), vi.fn());
-    ctrl.observe(el("a"), null);
+    const host = new SentinelHost();
+    const ctrl = new IntersectionController(host, vi.fn());
+    host.addSentinel();
+    ctrl.hostUpdated();
     ctrl.hostDisconnected();
     expect(MockObserver.instances[0].disconnected).toBe(true);
   });

--- a/test/util/intersection-controller.test.ts
+++ b/test/util/intersection-controller.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { IntersectionController } from "../../src/util/intersection-controller.js";
+import {
+  IntersectionController,
+  type IntersectionControllerOptions,
+} from "../../src/util/intersection-controller.js";
 import { FakeHost } from "../_fake-host.js";
 
 class MockObserver {
@@ -44,6 +47,13 @@ class SentinelHost extends FakeHost {
   }
 }
 
+function setup(options?: IntersectionControllerOptions) {
+  const host = new SentinelHost();
+  const onIntersect = vi.fn();
+  const ctrl = new IntersectionController(host, onIntersect, options);
+  return { host, ctrl, onIntersect };
+}
+
 beforeEach(() => {
   MockObserver.instances = [];
   vi.stubGlobal("IntersectionObserver", MockObserver);
@@ -55,8 +65,7 @@ afterEach(() => {
 
 describe("IntersectionController", () => {
   it("observes the sentinel against the viewport with the 200px default margin", () => {
-    const host = new SentinelHost();
-    const ctrl = new IntersectionController(host, vi.fn());
+    const { host, ctrl } = setup();
     const sentinel = host.addSentinel();
     ctrl.hostUpdated();
 
@@ -66,9 +75,7 @@ describe("IntersectionController", () => {
   });
 
   it("invokes the callback only when the sentinel is intersecting", () => {
-    const host = new SentinelHost();
-    const onIntersect = vi.fn();
-    const ctrl = new IntersectionController(host, onIntersect);
+    const { host, ctrl, onIntersect } = setup();
     host.addSentinel();
     ctrl.hostUpdated();
 
@@ -80,45 +87,32 @@ describe("IntersectionController", () => {
   });
 
   it("resolves rootSelector to the scroll container", () => {
-    const host = new SentinelHost();
+    const { host, ctrl } = setup({ rootSelector: ".board-list" });
     const scrollBox = document.createElement("div");
     scrollBox.className = "board-list";
     host.renderRoot.appendChild(scrollBox);
-    const ctrl = new IntersectionController(host, vi.fn(), {
-      rootSelector: ".board-list",
-    });
     host.addSentinel();
     ctrl.hostUpdated();
 
     expect(MockObserver.instances[0].options).toMatchObject({ root: scrollBox });
   });
 
-  it("honours targetSelector and rootMargin overrides", () => {
-    const host = new SentinelHost();
-    const marker = document.createElement("div");
-    marker.className = "marker";
-    host.renderRoot.appendChild(marker);
-    const ctrl = new IntersectionController(host, vi.fn(), {
-      targetSelector: ".marker",
-      rootMargin: "50px",
-    });
+  it("honours a rootMargin override", () => {
+    const { host, ctrl } = setup({ rootMargin: "50px" });
+    host.addSentinel();
     ctrl.hostUpdated();
 
-    const obs = MockObserver.instances[0];
-    expect(obs.observed).toEqual([marker]);
-    expect(obs.options).toMatchObject({ rootMargin: "50px" });
+    expect(MockObserver.instances[0].options).toMatchObject({ rootMargin: "50px" });
   });
 
   it("creates no observer while the sentinel is absent", () => {
-    const host = new SentinelHost();
-    const ctrl = new IntersectionController(host, vi.fn());
+    const { ctrl } = setup();
     ctrl.hostUpdated();
     expect(MockObserver.instances).toHaveLength(0);
   });
 
   it("repeat updates with the same sentinel are a no-op", () => {
-    const host = new SentinelHost();
-    const ctrl = new IntersectionController(host, vi.fn());
+    const { host, ctrl } = setup();
     host.addSentinel();
     ctrl.hostUpdated();
     ctrl.hostUpdated();
@@ -126,8 +120,7 @@ describe("IntersectionController", () => {
   });
 
   it("a re-rendered sentinel node replaces the observer", () => {
-    const host = new SentinelHost();
-    const ctrl = new IntersectionController(host, vi.fn());
+    const { host, ctrl } = setup();
     host.addSentinel();
     ctrl.hostUpdated();
 
@@ -141,8 +134,7 @@ describe("IntersectionController", () => {
   });
 
   it("tears down when the sentinel leaves the DOM", () => {
-    const host = new SentinelHost();
-    const ctrl = new IntersectionController(host, vi.fn());
+    const { host, ctrl } = setup();
     host.addSentinel();
     ctrl.hostUpdated();
 
@@ -152,8 +144,7 @@ describe("IntersectionController", () => {
   });
 
   it("disconnects the observer on host disconnect", () => {
-    const host = new SentinelHost();
-    const ctrl = new IntersectionController(host, vi.fn());
+    const { host, ctrl } = setup();
     host.addSentinel();
     ctrl.hostUpdated();
     ctrl.hostDisconnected();


### PR DESCRIPTION
# What does this implement/fix?

Moves infinite scroll sentinel discovery into `IntersectionController`; it now queries `.sentinel` (and an optional `rootSelector`) from the host render root in `hostUpdated`, with a 200px default margin, so hosts supply only the callback. The hand wired `@query` fields and `updated()` observe calls in wizard-step-board-list, component-catalog and change-board-dialog are gone; change-board-dialog passes `rootSelector: ".board-list"` for its scroll box.

`loadMoreFooterStyles` also gains a default centered quiet `.load-more-loading` spinner class, `loadingClass` is now an optional override. The catalog adds only its `grid-column` span on top of the default, the dialog keeps its compact spacing through a renamed override class, so nothing changes visually.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1287

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
