### PR TITLE
Move the after-hide open-flag sync into DialogOpenController

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { LitElement, css, html, nothing, type PropertyValues } from "lit";
+import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { AdoptableDevice } from "../api/types/devices.js";
@@ -13,6 +13,7 @@ import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { validateDeviceName } from "../util/config-validation.js";
+import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { EnterController } from "../util/enter-controller.js";
 import { formatApiError } from "../util/format-api-error.js";
 import { markJustCreated } from "../util/just-created.js";
@@ -45,7 +46,6 @@ export class ESPHomeAdoptDialog extends LitElement {
   @state() private _encryption = true;
   @state() private _busy = false;
   @state() private _error: string | null = null;
-  @state() private _open = false;
   @state() private _ssid = "";
   @state() private _password = "";
   // undefined until config/get_secrets resolves; only fetched for a
@@ -207,11 +207,15 @@ export class ESPHomeAdoptDialog extends LitElement {
     `,
   ];
 
+  private readonly _dialog = new DialogOpenController(this);
+
   // Enter submits; _submit self-guards on name validity and re-entry.
   private _enter = new EnterController(this, () => this._submit());
 
-  protected willUpdate(changed: PropertyValues): void {
-    if (changed.has("_open")) this._enter.set(this._open);
+  protected willUpdate(): void {
+    // Re-sync every update (set() no-ops on same value) — the open flag
+    // lives on the controller, so it never appears in `changed`.
+    this._enter.set(this._dialog.open);
   }
 
   open(device: AdoptableDevice) {
@@ -230,7 +234,7 @@ export class ESPHomeAdoptDialog extends LitElement {
     this._ssid = "";
     this._password = "";
     this._hasWifiSecrets = undefined;
-    this._open = true;
+    this._dialog.open = true;
     // A Wi-Fi device whose install has no shared wifi_ssid/wifi_password
     // would import a config referencing an undefined !secret and fail to
     // validate (esphome/device-builder#1742). Probe the shared secrets so
@@ -276,15 +280,7 @@ export class ESPHomeAdoptDialog extends LitElement {
        Lit hands the listener to ``addEventListener`` which calls it
        with ``this === undefined`` (strict mode) and the property
        access below would blow up. */
-    this._open = false;
-  };
-
-  private _onAfterHide = (): void => {
-    // <esphome-base-dialog> re-emits after-hide for every
-    // dismissal path (Esc / outside-click / X / reactive
-    // ?open flip). Flip our local open flag so the next
-    // render's ?open binding matches.
-    this._open = false;
+    this._dialog.open = false;
   };
 
   protected render() {
@@ -305,10 +301,10 @@ export class ESPHomeAdoptDialog extends LitElement {
 
     return html`
       <esphome-base-dialog
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         ?busy=${this._busy}
         .label=${this._localize("dashboard.adopt_title")}
-        @after-hide=${this._onAfterHide}
+        @after-hide=${this._dialog.onAfterHide}
       >
         ${
           device

--- a/src/components/api-key-dialog.ts
+++ b/src/components/api-key-dialog.ts
@@ -7,6 +7,7 @@ import { localizeContext } from "../context/index.js";
 import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { copyToClipboard } from "../util/copy-to-clipboard.js";
+import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { notifySuccess } from "../util/notify.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
@@ -31,8 +32,7 @@ export class ESPHomeApiKeyDialog extends LitElement {
   @state()
   private _visible = false;
 
-  @state()
-  private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
 
   static styles = [
     espHomeStyles,
@@ -108,27 +108,19 @@ export class ESPHomeApiKeyDialog extends LitElement {
   open(key: string) {
     this.apiKey = key;
     this._visible = false;
-    this._open = true;
+    this._dialog.open = true;
   }
 
   close() {
-    this._open = false;
+    this._dialog.open = false;
   }
-
-  private _onAfterHide = (): void => {
-    // <esphome-base-dialog> re-emits after-hide for every
-    // dismissal path (Esc / outside-click / X / reactive
-    // ?open flip). Flip our local open flag so the next
-    // render's ?open binding matches.
-    this._open = false;
-  };
 
   protected render() {
     return html`
       <esphome-base-dialog
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         .label=${this._localize("dashboard.action_api_key_title")}
-        @after-hide=${this._onAfterHide}
+        @after-hide=${this._dialog.onAfterHide}
       >
         <div class="content">
           ${this.apiKey ? this._renderKey() : this._renderNoKey()}

--- a/src/components/archived-devices-dialog.ts
+++ b/src/components/archived-devices-dialog.ts
@@ -8,6 +8,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
 import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { getErrorMessage } from "../util/error-message.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { renderAsyncState } from "../util/render-async-state.js";
@@ -57,7 +58,8 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
   @state() private _devices: ArchivedDevice[] = [];
   @state() private _loading = false;
   @state() private _error: string | null = null;
-  @state() private _open = false;
+
+  private readonly _dialog = new DialogOpenController(this);
 
   static styles = [
     espHomeStyles,
@@ -221,21 +223,13 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
 
   /** Open the dialog and (re)fetch the archive list. */
   async open() {
-    this._open = true;
+    this._dialog.open = true;
     await this.refresh();
   }
 
   close() {
-    this._open = false;
+    this._dialog.open = false;
   }
-
-  private _onAfterHide = (): void => {
-    // <esphome-base-dialog> re-emits after-hide for every
-    // dismissal path (Esc / outside-click / X / reactive
-    // ?open flip). Flip our local open flag so the next
-    // render's ?open binding matches.
-    this._open = false;
-  };
 
   /** Re-pull the list. Caller invokes after unarchive / delete to
    *  reflect the new state without closing the dialog. */
@@ -257,9 +251,9 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
   protected render() {
     return html`
       <esphome-base-dialog
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         .label=${this._localize("dashboard.archived_dialog_title")}
-        @after-hide=${this._onAfterHide}
+        @after-hide=${this._dialog.onAfterHide}
       >
         <div class="body">
           <p class="desc">${this._localize("dashboard.archived_dialog_desc")}</p>

--- a/src/components/desktop-update-dialog.ts
+++ b/src/components/desktop-update-dialog.ts
@@ -12,6 +12,7 @@ import {
 } from "../styles/dialog-action-buttons.js";
 import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { renderAsyncState } from "../util/render-async-state.js";
 
 import "./base-dialog.js";
@@ -34,11 +35,12 @@ export class ESPHomeDesktopUpdateDialog extends LitElement {
   @state()
   private _api!: ESPHomeAPI;
 
-  @state() private _open = false;
   @state() private _loading = false;
   @state() private _check: DesktopUpdateCheck | null = null;
   @state() private _error = "";
   @state() private _updating = false;
+
+  private readonly _dialog = new DialogOpenController(this);
 
   static styles = [
     espHomeStyles,
@@ -79,18 +81,14 @@ export class ESPHomeDesktopUpdateDialog extends LitElement {
   ];
 
   async open() {
-    this._open = true;
+    this._dialog.open = true;
     this._updating = false;
     await this._runCheck();
   }
 
   close() {
-    this._open = false;
+    this._dialog.open = false;
   }
-
-  private _onAfterHide = (): void => {
-    this._open = false;
-  };
 
   private _runCheck = async (): Promise<void> => {
     this._loading = true;
@@ -149,12 +147,12 @@ export class ESPHomeDesktopUpdateDialog extends LitElement {
   protected render() {
     return html`
       <esphome-base-dialog
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         ?busy=${this._updating}
         .label=${this._localize("desktop_update_dialog.title")}
-        @after-hide=${this._onAfterHide}
+        @after-hide=${this._dialog.onAfterHide}
       >
-        ${this._open ? this._renderBody() : nothing}
+        ${this._dialog.open ? this._renderBody() : nothing}
       </esphome-base-dialog>
     `;
   }

--- a/src/components/friendly-name-dialog.ts
+++ b/src/components/friendly-name-dialog.ts
@@ -11,6 +11,7 @@ import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { dialogFieldStyles } from "../styles/dialog-fields.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { renderInlineError } from "../util/render-error.js";
 
 import "@home-assistant/webawesome/dist/components/checkbox/checkbox.js";
@@ -54,8 +55,7 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
   @state()
   private _install = true;
 
-  @state()
-  private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
 
   static styles = [
     espHomeStyles,
@@ -97,20 +97,12 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
     // want a YAML-only edit (offline device, batch later) can
     // toggle off — but the common case is "rename and apply."
     this._install = true;
-    this._open = true;
+    this._dialog.open = true;
   }
 
   close() {
-    this._open = false;
+    this._dialog.open = false;
   }
-
-  private _onAfterHide = (): void => {
-    // <esphome-base-dialog> re-emits after-hide for every
-    // dismissal path (Esc / outside-click / X / reactive
-    // ?open flip). Flip our local open flag so the next
-    // render's ?open binding matches.
-    this._open = false;
-  };
 
   protected render() {
     const trimmed = this._value.trim();
@@ -121,12 +113,12 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
 
     return html`
       <esphome-base-dialog
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         .label=${this._localize("dashboard.action_friendly_name_title", {
           name: this.deviceName,
         })}
         .confirmOnEnter=${this._confirm}
-        @after-hide=${this._onAfterHide}
+        @after-hide=${this._dialog.onAfterHide}
       >
         <div class="field">
           <label for="friendly-name-input"

--- a/src/components/update-all-dialog.ts
+++ b/src/components/update-all-dialog.ts
@@ -180,8 +180,8 @@ export class ESPHomeUpdateAllDialog extends LitElement {
   protected render() {
     // Keep one <esphome-base-dialog> so a close flips ?open reactively and
     // wa-dialog's exit animation plays on every path. Gate only the body +
-    // the facet/match compute on _open — this is a persistent child on the
-    // hot `devices` context, so nothing should recompute while closed.
+    // the facet/match compute on the open flag — this is a persistent child
+    // on the hot `devices` context, so nothing should recompute while closed.
     const matched = this._dialog.open ? this._matched() : [];
     return html`
       <esphome-base-dialog

--- a/src/components/update-all-dialog.ts
+++ b/src/components/update-all-dialog.ts
@@ -23,6 +23,7 @@ import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { runBulkUpdate } from "../util/bulk-update.js";
 import { applyFacetFilters, type FacetSelection } from "../util/device-filter.js";
+import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { computeLabelUsage } from "../util/label-usage.js";
 import { renderFacetSections } from "./filters/facet-sections.js";
 
@@ -77,10 +78,9 @@ export class ESPHomeUpdateAllDialog extends LitElement {
   private _activeJobs: Map<string, FirmwareJob> = new Map();
 
   @state()
-  private _open = false;
-
-  @state()
   private _selection: FacetSelection = defaultSelection();
+
+  private readonly _dialog = new DialogOpenController(this);
 
   // Memoized like the dashboard's facet pipeline so a re-render (or the
   // confirm read) over a large fleet doesn't refilter / re-tally on every
@@ -125,7 +125,7 @@ export class ESPHomeUpdateAllDialog extends LitElement {
 
   async open() {
     this._selection = defaultSelection();
-    this._open = true;
+    this._dialog.open = true;
     // Sections only exist after the open render; default-expand the two
     // facets carrying pre-checks. The helper doesn't bind `expanded`, so
     // these toggles are imperative and survive re-renders (as the popover
@@ -137,7 +137,7 @@ export class ESPHomeUpdateAllDialog extends LitElement {
   }
 
   close() {
-    this._open = false;
+    this._dialog.open = false;
   }
 
   private _sectionEls(): (HTMLElement & { expanded: boolean })[] {
@@ -147,10 +147,6 @@ export class ESPHomeUpdateAllDialog extends LitElement {
       ) ?? []
     );
   }
-
-  private _onAfterHide = (): void => {
-    this._open = false;
-  };
 
   private _onSectionToggle = (e: Event): void => {
     const target = e.target;
@@ -186,15 +182,15 @@ export class ESPHomeUpdateAllDialog extends LitElement {
     // wa-dialog's exit animation plays on every path. Gate only the body +
     // the facet/match compute on _open — this is a persistent child on the
     // hot `devices` context, so nothing should recompute while closed.
-    const matched = this._open ? this._matched() : [];
+    const matched = this._dialog.open ? this._matched() : [];
     return html`
       <esphome-base-dialog
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         .label=${this._localize("update_all_dialog.title")}
-        @after-hide=${this._onAfterHide}
+        @after-hide=${this._dialog.onAfterHide}
       >
         ${
-          this._open
+          this._dialog.open
             ? html`
                 <div class="sections" @filter-section-toggle=${this._onSectionToggle}>
                   ${renderFacetSections({

--- a/src/util/dialog-open-controller.ts
+++ b/src/util/dialog-open-controller.ts
@@ -17,8 +17,9 @@ import type { ReactiveController, ReactiveControllerHost } from "lit";
  * (Escape / X / outside-click), before wa-dialog finishes hiding, so a host
  * re-render can't re-assert ``?open`` and cancel the in-progress hide —
  * ``esphome-base-dialog`` never mutates its own ``open`` on a user-driven
- * close, the host owns the flag (see the wrapper's class docs). Teardown
- * stays in the host's ``@after-hide`` handler.
+ * close, the host owns the flag (see the wrapper's class docs). Hosts that
+ * sync on the wrapper's ``@after-hide`` re-emit instead bind
+ * ``onAfterHide``.
  *
  * Dialogs with a real veto (busy guard, unsaved-changes prompt) keep their
  * own ``@request-close`` handler instead; the trivial flip here never
@@ -49,6 +50,12 @@ export class DialogOpenController implements ReactiveController {
 
   /** The trivial ``@request-close`` handler: flip the flag, veto nothing. */
   readonly onRequestClose = (): void => {
+    this.open = false;
+  };
+
+  /** The trivial ``@after-hide`` handler — the wrapper re-emits it for every
+   *  dismissal path (Esc / outside-click / X / reactive ``?open`` flip). */
+  readonly onAfterHide = (): void => {
     this.open = false;
   };
 }

--- a/test/components/adopt-dialog.test.ts
+++ b/test/components/adopt-dialog.test.ts
@@ -198,7 +198,7 @@ describe("adopt-dialog wifi step (#1742)", () => {
     expect(importDevice).not.toHaveBeenCalled();
     expect(priv._error).toBe("disk full");
     expect(priv._busy).toBe(false);
-    expect(priv._open).toBe(true);
+    expect(priv._dialog.open).toBe(true);
   });
 
   it("does not collect wifi when the device advertised no network", async () => {

--- a/test/util/dialog-open-controller.test.ts
+++ b/test/util/dialog-open-controller.test.ts
@@ -54,4 +54,25 @@ describe("DialogOpenController", () => {
     ctrl.open = true;
     expect(ctrl.onRequestClose).toBe(first);
   });
+
+  it("onAfterHide flips the flag false", () => {
+    const host = new FakeHost();
+    const ctrl = new DialogOpenController(host);
+    ctrl.open = true;
+
+    ctrl.onAfterHide();
+    expect(ctrl.open).toBe(false);
+    expect(host.updates).toBe(2);
+  });
+
+  it("onAfterHide after a request-close flip is a no-op", () => {
+    const host = new FakeHost();
+    const ctrl = new DialogOpenController(host);
+    ctrl.open = true;
+
+    ctrl.onRequestClose();
+    ctrl.onAfterHide();
+    expect(ctrl.open).toBe(false);
+    expect(host.updates).toBe(2);
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Adds an `onAfterHide` handler to `DialogOpenController` (sibling of `onRequestClose`) and migrates the six dialogs that still hand rolled the open flag teardown: adopt, api-key, archived-devices, desktop-update, friendly-name and update-all. Each loses its `@state() _open`, the `close()` flip and the copy pasted `_onAfterHide` arrow; they now bind `?open=${this._dialog.open}` and `@after-hide=${this._dialog.onAfterHide}`.

Timing is unchanged; these hosts bind only `@after-hide`, so the flag still flips after the hide completes. The adopt dialog's EnterController arming moves from a `changed.has("_open")` guard to an unconditional re-sync in `willUpdate` (`set()` no-ops on same value), since the flag no longer appears in `changed`.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1291

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
