### PR TITLE
Add a shared fireEvent helper for bubbling composed CustomEvents

### DIFF
--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -27,6 +27,7 @@ import type { FirmwareJob } from "../api/types/firmware-jobs.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { labelsContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { fireEvent } from "../util/fire-event.js";
 import { labelChipStyles } from "../util/label-chip-template.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { busyActionLabel, updateActionTitle } from "../util/update-tooltip.js";
@@ -243,7 +244,7 @@ export class ESPHomeDeviceCard extends LitElement {
                 <div class="device-actions" @click=${(e: Event) => e.stopPropagation()}>
                   <button
                     class="action-btn action-btn--primary"
-                    @click=${() => this._emit("edit-device")}
+                    @click=${() => fireEvent(this, "edit-device")}
                   >
                     <wa-icon library="mdi" name="pencil"></wa-icon>
                     ${this._localize("dashboard.edit")}
@@ -252,7 +253,7 @@ export class ESPHomeDeviceCard extends LitElement {
                   <button
                     id="btn-logs"
                     class="action-btn action-btn--ghost action-btn--tile"
-                    @click=${() => this._emit("open-logs")}
+                    @click=${() => fireEvent(this, "open-logs")}
                     aria-label=${this._localize("dashboard.drawer_logs")}
                   >
                     <wa-icon library="mdi" name="text-box-outline"></wa-icon>
@@ -296,7 +297,7 @@ export class ESPHomeDeviceCard extends LitElement {
       return html`<button
           id="btn-accent"
           class="action-btn action-btn--accent action-btn--tile"
-          @click=${() => this._emit(this.busy ? "show-progress" : "update-device")}
+          @click=${() => fireEvent(this, this.busy ? "show-progress" : "update-device")}
           aria-label=${busyActionLabel(this._localize, this.busy, "dashboard.update")}
         >
           <wa-icon library="mdi" name="upload"></wa-icon>
@@ -316,7 +317,7 @@ export class ESPHomeDeviceCard extends LitElement {
       return html`<button
           id="btn-accent"
           class="action-btn action-btn--accent action-btn--tile"
-          @click=${() => this._emit(this.busy ? "show-progress" : "install-device")}
+          @click=${() => fireEvent(this, this.busy ? "show-progress" : "install-device")}
           aria-label=${label}
         >
           <wa-icon library="mdi" name="upload"></wa-icon>
@@ -335,7 +336,7 @@ export class ESPHomeDeviceCard extends LitElement {
       // Native buttons activate Enter on keydown — match for instant feedback.
       if (e.repeat) return;
       e.preventDefault();
-      this._emit(this.selectMode ? "toggle-select" : "card-click");
+      fireEvent(this, this.selectMode ? "toggle-select" : "card-click");
       return;
     }
 
@@ -367,11 +368,11 @@ export class ESPHomeDeviceCard extends LitElement {
     if (!this._spaceArmed) return;
     this._spaceArmed = false;
     e.preventDefault();
-    this._emit(this.selectMode ? "toggle-select" : "card-click");
+    fireEvent(this, this.selectMode ? "toggle-select" : "card-click");
   };
 
   private _onClick = () => {
-    this._emit(this.selectMode ? "toggle-select" : "card-click");
+    fireEvent(this, this.selectMode ? "toggle-select" : "card-click");
   };
 
   private _onHostContextMenu = (e: MouseEvent) => onHostContextMenu(this, e);
@@ -380,17 +381,7 @@ export class ESPHomeDeviceCard extends LitElement {
     e.stopPropagation();
     const btn = e.currentTarget as HTMLElement;
     const rect = btn.getBoundingClientRect();
-    this.dispatchEvent(
-      new CustomEvent("card-context-menu", {
-        detail: { x: rect.right, y: rect.bottom },
-        bubbles: true,
-        composed: true,
-      })
-    );
-  }
-
-  _emit(name: string) {
-    this.dispatchEvent(new CustomEvent(name, { bubbles: true, composed: true }));
+    fireEvent(this, "card-context-menu", { x: rect.right, y: rect.bottom });
   }
 }
 

--- a/src/components/device-card/render-bits.ts
+++ b/src/components/device-card/render-bits.ts
@@ -2,6 +2,7 @@ import { html, nothing, type TemplateResult } from "lit";
 import { DeviceState } from "../../api/types/devices.js";
 import { JobStatus, JobType } from "../../api/types/firmware-jobs.js";
 import { getCompactEncryptionVisual } from "../../util/encryption-state.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { renderLabelChips, resolveLabelIds } from "../../util/label-chip-template.js";
 import type { ESPHomeDeviceCard } from "../device-card.js";
 
@@ -75,7 +76,7 @@ export function renderStatusBadge(card: ESPHomeDeviceCard): TemplateResult {
       class="device-status busy"
       @click=${(e: Event) => {
         e.stopPropagation();
-        card._emit("show-progress");
+        fireEvent(card, "show-progress");
       }}
     >
       <wa-spinner></wa-spinner>

--- a/src/components/discovered-device-card.ts
+++ b/src/components/discovered-device-card.ts
@@ -6,6 +6,7 @@ import type { AdoptableDevice } from "../api/types/devices.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { fireEvent } from "../util/fire-event.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { renderVisitWebUiLink } from "../util/visit-web-ui-link.js";
 import { safeWebUiUrl } from "../util/web-ui-url.js";
@@ -288,7 +289,10 @@ export class ESPHomeDiscoveredDeviceCard extends LitElement {
             this.device.ignored
               ? nothing
               : html`
-                  <button class="btn btn--primary" @click=${() => this._emit("adopt")}>
+                  <button
+                    class="btn btn--primary"
+                    @click=${() => fireEvent(this, "adopt", this.device)}
+                  >
                     <wa-icon library="mdi" name="download"></wa-icon>
                     ${this._localize("dashboard.action_take_control")}
                   </button>
@@ -309,7 +313,7 @@ export class ESPHomeDiscoveredDeviceCard extends LitElement {
                 ? "dashboard.action_unignore"
                 : "dashboard.action_ignore"
             )}
-            @click=${() => this._emit("toggle-ignore")}
+            @click=${() => fireEvent(this, "toggle-ignore", this.device)}
           >
             <wa-icon
               library="mdi"
@@ -324,16 +328,6 @@ export class ESPHomeDiscoveredDeviceCard extends LitElement {
         </div>
       </div>
     `;
-  }
-
-  private _emit(name: string) {
-    this.dispatchEvent(
-      new CustomEvent(name, {
-        detail: this.device,
-        bubbles: true,
-        composed: true,
-      })
-    );
   }
 }
 

--- a/src/components/overflow-menu-element.ts
+++ b/src/components/overflow-menu-element.ts
@@ -1,6 +1,7 @@
 import { LitElement } from "lit";
 import { state } from "lit/decorators.js";
 import { EscapeController } from "../util/escape-controller.js";
+import { fireEvent } from "../util/fire-event.js";
 
 /**
  * Base for self-triggering kebab / toggle popover menus: owns the open
@@ -49,6 +50,6 @@ export abstract class OverflowMenuElement extends LitElement {
   };
 
   protected _emit(type: string, detail?: unknown) {
-    this.dispatchEvent(new CustomEvent(type, { detail, bubbles: true, composed: true }));
+    fireEvent(this, type, detail);
   }
 }

--- a/src/components/select-bar.ts
+++ b/src/components/select-bar.ts
@@ -16,6 +16,7 @@ import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
 import { dropdownMenuStyles } from "../styles/dropdown-menu.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { EscapeController } from "../util/escape-controller.js";
+import { fireEvent } from "../util/fire-event.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -364,7 +365,7 @@ export class ESPHomeSelectBar extends LitElement {
         <div class="left">
           <button
             class="toggle"
-            @click=${() => this._emit(allSelected ? "deselect-all" : "select-all")}
+            @click=${() => fireEvent(this, allSelected ? "deselect-all" : "select-all")}
           >
             ${
               allSelected
@@ -380,7 +381,7 @@ export class ESPHomeSelectBar extends LitElement {
           <button
             class="btn btn--cancel"
             aria-label=${cancelLabel}
-            @click=${() => this._emit("cancel")}
+            @click=${() => fireEvent(this, "cancel")}
           >
             <wa-icon library="mdi" name="close"></wa-icon>
             <span class="btn-label">${cancelLabel}</span>
@@ -389,7 +390,7 @@ export class ESPHomeSelectBar extends LitElement {
             class="btn btn--secondary"
             aria-label=${labelsAriaLabel}
             ?disabled=${count === 0}
-            @click=${() => this._emit("labels-selected")}
+            @click=${() => fireEvent(this, "labels-selected")}
           >
             <wa-icon library="mdi" name="tag-multiple"></wa-icon>
             <span class="btn-label">${labelsLabel}</span>
@@ -398,7 +399,7 @@ export class ESPHomeSelectBar extends LitElement {
             class="btn btn--secondary"
             aria-label=${archiveAriaLabel}
             ?disabled=${count === 0}
-            @click=${() => this._emit("archive-selected")}
+            @click=${() => fireEvent(this, "archive-selected")}
           >
             <wa-icon library="mdi" name="archive-outline"></wa-icon>
             <span class="btn-label">${archiveLabel}</span>
@@ -407,7 +408,7 @@ export class ESPHomeSelectBar extends LitElement {
             class="btn btn--danger"
             aria-label=${deleteAriaLabel}
             ?disabled=${count === 0}
-            @click=${() => this._emit("delete-selected")}
+            @click=${() => fireEvent(this, "delete-selected")}
           >
             <wa-icon library="mdi" name="delete"></wa-icon>
             <span class="btn-label">${deleteLabel}</span>
@@ -417,7 +418,7 @@ export class ESPHomeSelectBar extends LitElement {
               class="btn btn--primary update-split__main"
               aria-label=${updateAriaLabel}
               ?disabled=${count === 0}
-              @click=${() => this._emit("update-selected")}
+              @click=${() => fireEvent(this, "update-selected")}
             >
               <wa-icon library="mdi" name="update"></wa-icon>
               <span class="btn-label">${updateLabel}</span>
@@ -478,7 +479,7 @@ export class ESPHomeSelectBar extends LitElement {
 
   private _onCompile() {
     this._menuOpen = false;
-    this._emit("compile-selected");
+    fireEvent(this, "compile-selected");
   }
 
   /* role + tabindex make the menu row focusable; this maps Enter /
@@ -490,10 +491,6 @@ export class ESPHomeSelectBar extends LitElement {
       (e.currentTarget as HTMLElement).click();
     }
   };
-
-  private _emit(name: string) {
-    this.dispatchEvent(new CustomEvent(name, { bubbles: true, composed: true }));
-  }
 }
 
 declare global {

--- a/src/util/fire-event.ts
+++ b/src/util/fire-event.ts
@@ -1,0 +1,9 @@
+/**
+ * Dispatch a bubbling, composed ``CustomEvent`` from *target* — the
+ * cross-shadow-boundary shape component action events use. Events meant
+ * for a direct listener only should stay non-bubbling (see
+ * ``options-combobox-event.ts``).
+ */
+export function fireEvent(target: EventTarget, name: string, detail?: unknown): void {
+  target.dispatchEvent(new CustomEvent(name, { detail, bubbles: true, composed: true }));
+}

--- a/test/util/fire-event.test.ts
+++ b/test/util/fire-event.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent } from "../../src/util/fire-event.js";
+
+describe("fireEvent", () => {
+  it("dispatches a bubbling composed CustomEvent with the detail", () => {
+    const target = new EventTarget();
+    let seen: CustomEvent | null = null;
+    target.addEventListener("chosen", (e) => {
+      seen = e as CustomEvent;
+    });
+
+    fireEvent(target, "chosen", { v: 1 });
+
+    expect(seen).not.toBeNull();
+    expect(seen!.detail).toEqual({ v: 1 });
+    expect(seen!.bubbles).toBe(true);
+    expect(seen!.composed).toBe(true);
+  });
+
+  it("defaults detail to null when omitted", () => {
+    const target = new EventTarget();
+    let seen: CustomEvent | null = null;
+    target.addEventListener("plain", (e) => {
+      seen = e as CustomEvent;
+    });
+
+    fireEvent(target, "plain");
+
+    expect(seen!.detail).toBeNull();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Adds `src/util/fire-event.ts` with `fireEvent(target, name, detail?)`, the bubbling composed CustomEvent shape components use for action events. The four components that each declared their own `_emit` now use it: device-card, select-bar and discovered-device-card call it at their sites and lose the private method; overflow-menu-element keeps its protected `_emit` as the subclass API but delegates to the helper. The `card._emit` call in device-card's render-bits and the adjacent `card-context-menu` inline dispatch migrate too since those files were already in the diff.

The ~47 other inline dispatch sites are left for opportunistic adoption when their files are touched.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1292

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
