### PR TITLE
Share the focus-visible outline through an --esphome-focus-outline token

### DIFF
--- a/src/components/dashboard/device-drawer-content/styles.ts
+++ b/src/components/dashboard/device-drawer-content/styles.ts
@@ -125,7 +125,7 @@ export const deviceDrawerContentStyles = css`
     color: var(--esphome-primary);
   }
   .address-visit-link:focus-visible {
-    outline: 2px solid var(--esphome-primary);
+    outline: var(--esphome-focus-outline);
     outline-offset: 2px;
     color: var(--esphome-primary);
   }
@@ -203,7 +203,7 @@ export const deviceDrawerContentStyles = css`
   }
 
   .tag--link:focus-visible {
-    outline: 2px solid var(--esphome-primary);
+    outline: var(--esphome-focus-outline);
     outline-offset: 2px;
   }
 

--- a/src/components/dashboard/device-grid-styles.ts
+++ b/src/components/dashboard/device-grid-styles.ts
@@ -120,7 +120,7 @@ export const deviceGridStyles = css`
     opacity: 1;
   }
   .discovered-section-toggle:focus-visible {
-    outline: 2px solid var(--esphome-primary);
+    outline: var(--esphome-focus-outline);
     outline-offset: 2px;
     opacity: 1;
   }

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -219,7 +219,7 @@ export const tableLayoutStyles = css`
     background: var(--esphome-tint-faint);
   }
   tbody tr:focus-visible {
-    outline: 2px solid var(--esphome-primary);
+    outline: var(--esphome-focus-outline);
     outline-offset: -2px;
   }
 

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -42,7 +42,7 @@ export const deviceCardStyles = [
 
     /* Focus ring on the inner card so it follows rounded corners. */
     :host(:focus-visible) .device-card {
-      outline: 2px solid var(--esphome-primary);
+      outline: var(--esphome-focus-outline);
       outline-offset: 2px;
     }
 

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -217,7 +217,7 @@ export const componentCatalogStyles = css`
   }
 
   .expand-button:focus-visible {
-    outline: 2px solid var(--esphome-primary);
+    outline: var(--esphome-focus-outline);
     outline-offset: 1px;
   }
 
@@ -369,7 +369,7 @@ export const componentCatalogStyles = css`
   }
 
   .select-component:focus-visible {
-    outline: 2px solid var(--esphome-primary);
+    outline: var(--esphome-focus-outline);
     outline-offset: 3px;
   }
 

--- a/src/components/device/device-board-info.styles.ts
+++ b/src/components/device/device-board-info.styles.ts
@@ -211,7 +211,7 @@ export const deviceBoardInfoStyles = css`
   }
 
   .action-item:focus-visible {
-    outline: 2px solid var(--esphome-primary);
+    outline: var(--esphome-focus-outline);
     outline-offset: 2px;
   }
 

--- a/src/components/install-method-dialog.styles.ts
+++ b/src/components/install-method-dialog.styles.ts
@@ -144,7 +144,7 @@ export const installMethodDialogStyles = css`
   }
 
   .option-collapsible__header:focus-visible {
-    outline: 2px solid var(--esphome-primary);
+    outline: var(--esphome-focus-outline);
     outline-offset: -2px;
   }
 

--- a/src/components/shared/firmware-jobs-list-styles.ts
+++ b/src/components/shared/firmware-jobs-list-styles.ts
@@ -65,7 +65,7 @@ export const firmwareJobsListStyles = css`
   /* Negative offset keeps the ring inside the scroll container; a real
      outline lets forced-colors mode substitute the system highlight. */
   .job:focus-visible {
-    outline: 2px solid var(--esphome-primary);
+    outline: var(--esphome-focus-outline);
     outline-offset: -2px;
   }
 

--- a/src/components/shared/stack-bar-styles.ts
+++ b/src/components/shared/stack-bar-styles.ts
@@ -53,7 +53,7 @@ export const stackBarStyles = css`
   /* Negative offset keeps the ring inside the full-bleed bar; a real
      outline lets forced-colors mode substitute the system highlight. */
   .stack-bar:focus-visible {
-    outline: 2px solid var(--esphome-primary);
+    outline: var(--esphome-focus-outline);
     outline-offset: -2px;
   }
 

--- a/src/components/wizard/wizard-step-board-port-select.ts
+++ b/src/components/wizard/wizard-step-board-port-select.ts
@@ -126,7 +126,7 @@ export class ESPHomeWizardStepBoardPortSelect extends LitElement {
       }
 
       .option:focus-visible {
-        outline: 2px solid var(--esphome-primary);
+        outline: var(--esphome-focus-outline);
         outline-offset: 2px;
       }
 

--- a/src/components/wizard/wizard-step-board.styles.ts
+++ b/src/components/wizard/wizard-step-board.styles.ts
@@ -282,7 +282,7 @@ export const wizardStepBoardStyles = css`
   }
 
   .select-board:focus-visible {
-    outline: 2px solid var(--esphome-primary);
+    outline: var(--esphome-focus-outline);
     outline-offset: 3px;
   }
 

--- a/src/styles/disclosure.ts
+++ b/src/styles/disclosure.ts
@@ -30,7 +30,7 @@ export const disclosureStyles = css`
   }
 
   .disclosure-toggle:focus-visible {
-    outline: 2px solid var(--esphome-primary);
+    outline: var(--esphome-focus-outline);
     outline-offset: 2px;
   }
 

--- a/src/styles/load-more-footer.ts
+++ b/src/styles/load-more-footer.ts
@@ -46,7 +46,7 @@ export const loadMoreFooterStyles = css`
   }
 
   .retry-link:focus-visible {
-    outline: 2px solid var(--esphome-primary);
+    outline: var(--esphome-focus-outline);
     outline-offset: 2px;
   }
 `;

--- a/src/styles/pairing-address.ts
+++ b/src/styles/pairing-address.ts
@@ -56,7 +56,7 @@ export const pairingAddressStyles = css`
   }
 
   .pairing-address-copy:focus-visible {
-    outline: 2px solid var(--esphome-primary);
+    outline: var(--esphome-focus-outline);
     outline-offset: -2px;
   }
 `;

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -29,6 +29,11 @@ export const espHomeStyles = css`
     --esphome-focus-ring-tight: 0 0 0 2px
       color-mix(in srgb, var(--esphome-primary), transparent 70%);
 
+    /* Outline sibling of the rings, for :focus-visible on plain
+       controls. Used as the full outline value; outline-offset stays
+       per site. */
+    --esphome-focus-outline: 2px solid var(--esphome-primary);
+
     /* Hover affordance for clickable rows / cards / option tiles: a primary
        ring plus the focus-ring glow, matching a focused input. Bundled into
        one box-shadow (inset ring + outer glow) so a :hover only sets


### PR DESCRIPTION
# What does this implement/fix?

Adds an `--esphome-focus-outline: 2px solid var(--esphome-primary)` token to `espHomeStyles`, next to the existing focus ring tokens, and switches the sixteen hand rolled `:focus-visible` outline declarations to `outline: var(--esphome-focus-outline)`. `outline-offset` and per site extras stay local, so every computed value is identical.

The two sites using `--esphome-primary-light` (adopt dialog source link, archived devices row buttons) are intentionally different and unchanged. Every consumer of the touched style modules composes `espHomeStyles`, so the token resolves at all sixteen sites.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1295

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
