### PR TITLE
Hoist the duplicated empty-state blocks into a shared style module

### DIFF
--- a/src/components/device/automation-editor/automation-action-list.ts
+++ b/src/components/device/automation-editor/automation-action-list.ts
@@ -108,7 +108,7 @@ export class ESPHomeAutomationActionList extends LitElement {
         }
         ${
           this.actions.length === 0
-            ? html`<p class="ae-empty-block" role="status">
+            ? html`<p class="empty-message--dashed" role="status">
                 ${this._localize("device.automation_actions_empty")}
               </p>`
             : this.actions.map((node, idx) =>

--- a/src/components/device/automation-editor/automation-editor-actions.styles.ts
+++ b/src/components/device/automation-editor/automation-editor-actions.styles.ts
@@ -124,18 +124,6 @@ export const automationEditorActionStyles = css`
     font-size: 14px;
   }
 
-  .ae-empty-block {
-    margin: 0;
-    padding: var(--wa-space-m) var(--wa-space-s);
-    text-align: center;
-    color: var(--wa-color-text-quiet);
-    font-size: var(--wa-font-size-s);
-    font-style: italic;
-    border: 1px dashed var(--wa-color-surface-border);
-    border-radius: var(--wa-border-radius-m);
-    background: var(--wa-color-surface-lowered, transparent);
-  }
-
   /* Bottom-of-editor save / delete buttons. */
   .ae-actions {
     display: flex;

--- a/src/components/device/automation-editor/automation-editor.styles.ts
+++ b/src/components/device/automation-editor/automation-editor.styles.ts
@@ -1,5 +1,6 @@
 import { css } from "lit";
 
+import { emptyStateStyles } from "../../../styles/empty-state.js";
 import { substitutionNoteStyles } from "../substitution-note.styles.js";
 import { automationEditorActionStyles } from "./automation-editor-actions.styles.js";
 import { automationEditorRowStyles } from "./automation-editor-rows.styles.js";
@@ -216,5 +217,6 @@ export const automationEditorStyles = [
   automationEditorScriptParamStyles,
   automationEditorRowStyles,
   automationEditorActionStyles,
+  emptyStateStyles,
   substitutionNoteStyles,
 ];

--- a/src/components/device/automation-editor/parse-error-controller.ts
+++ b/src/components/device/automation-editor/parse-error-controller.ts
@@ -73,11 +73,11 @@ export class ParseErrorController implements ReactiveController {
     // A known action with no structured form is not an error — show the
     // neutral "edit in YAML" hint, no alert styling.
     if (this._unsupported) {
-      return html`<div class="ae-empty-block" role="note">
+      return html`<div class="empty-message--dashed" role="note">
         <p>${localize("device.yaml_only_section")}</p>
       </div>`;
     }
-    return html`<div class="ae-empty-block" role="alert">
+    return html`<div class="empty-message--dashed" role="alert">
       <p class="ae-error">${localize("device.automation_parse_error")}</p>
       ${this._message ? html`<p>${this._message}</p>` : nothing}
     </div>`;

--- a/src/components/device/device-section-automation-list.styles.ts
+++ b/src/components/device/device-section-automation-list.styles.ts
@@ -67,18 +67,6 @@ export const deviceSectionAutomationListStyles = css`
     font-size: 14px;
   }
 
-  .empty {
-    margin: 0;
-    padding: var(--wa-space-m) var(--wa-space-s);
-    text-align: center;
-    color: var(--wa-color-text-quiet);
-    font-size: var(--wa-font-size-s);
-    font-style: italic;
-    border: 1px dashed var(--wa-color-surface-border);
-    border-radius: var(--wa-border-radius-m);
-    background: var(--wa-color-surface-lowered, transparent);
-  }
-
   .rows {
     list-style: none;
     margin: 0;

--- a/src/components/device/device-section-automation-list.ts
+++ b/src/components/device/device-section-automation-list.ts
@@ -2,6 +2,7 @@ import { mdiDelete, mdiPencil, mdiPlus } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
+import { emptyStateStyles } from "../../styles/empty-state.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { deviceSectionAutomationListStyles } from "./device-section-automation-list.styles.js";
@@ -38,7 +39,7 @@ export interface AutomationListRow {
  */
 @customElement("esphome-section-automation-list")
 export class ESPHomeSectionAutomationList extends LitElement {
-  static styles = [espHomeStyles, deviceSectionAutomationListStyles];
+  static styles = [espHomeStyles, emptyStateStyles, deviceSectionAutomationListStyles];
 
   @property()
   heading = "";
@@ -84,7 +85,7 @@ export class ESPHomeSectionAutomationList extends LitElement {
           ? // Only paint the placeholder when there's copy for it — a blank
             // dashed box + empty ARIA status would just be noise otherwise.
             this.emptyText !== undefined
-            ? html`<p class="empty" role="status">${this.emptyText}</p>`
+            ? html`<p class="empty-message--dashed" role="status">${this.emptyText}</p>`
             : nothing
           : html`<ul class="rows">
               ${this.rows.map(

--- a/src/components/install-method-dialog.styles.ts
+++ b/src/components/install-method-dialog.styles.ts
@@ -259,12 +259,4 @@ export const installMethodDialogStyles = css`
     color: var(--wa-color-text-quiet);
     font-size: var(--wa-font-size-s);
   }
-
-  .empty {
-    text-align: center;
-    padding: var(--wa-space-l) 0;
-    color: var(--wa-color-text-quiet);
-    font-size: var(--wa-font-size-s);
-    line-height: 1.5;
-  }
 `;

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -20,6 +20,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
 import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { disclosureStyles } from "../styles/disclosure.js";
+import { emptyStateStyles } from "../styles/empty-state.js";
 import { inputStyles } from "../styles/inputs.js";
 import { newItemHighlightStyles } from "../styles/new-item-highlight.js";
 import { serialPortHintStyles } from "../styles/serial-port-hints.js";
@@ -173,6 +174,7 @@ export class ESPHomeInstallMethodDialog extends LitElement {
     inputStyles,
     newItemHighlightStyles,
     serialPortHintStyles,
+    emptyStateStyles,
     installMethodDialogStyles,
   ];
 
@@ -337,7 +339,7 @@ export class ESPHomeInstallMethodDialog extends LitElement {
       </button>
       ${
         this._portsPoll.ports.length === 0
-          ? html`<div class="empty">
+          ? html`<div class="empty-message">
               ${this._localize("dashboard.install_method_no_ports")}
             </div>`
           : html`

--- a/src/components/wizard/wizard-step-board-port-select.ts
+++ b/src/components/wizard/wizard-step-board-port-select.ts
@@ -6,6 +6,7 @@ import { classMap } from "lit/directives/class-map.js";
 import type { SerialPort } from "../../api/types/system.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
+import { emptyStateStyles } from "../../styles/empty-state.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { newItemHighlightStyles } from "../../styles/new-item-highlight.js";
 import { serialPortHintStyles } from "../../styles/serial-port-hints.js";
@@ -62,6 +63,7 @@ export class ESPHomeWizardStepBoardPortSelect extends LitElement {
     inputStyles,
     newItemHighlightStyles,
     serialPortHintStyles,
+    emptyStateStyles,
     css`
       :host {
         display: flex;
@@ -164,22 +166,6 @@ export class ESPHomeWizardStepBoardPortSelect extends LitElement {
         color: var(--wa-color-text-quiet);
         font-size: var(--wa-font-size-s);
       }
-
-      .empty {
-        text-align: center;
-        padding: var(--wa-space-l) 0;
-        color: var(--wa-color-text-quiet);
-        font-size: var(--wa-font-size-s);
-        line-height: 1.5;
-      }
-
-      .error {
-        text-align: center;
-        padding: var(--wa-space-l) 0;
-        color: var(--wa-color-text-quiet);
-        font-size: var(--wa-font-size-s);
-        line-height: 1.5;
-      }
     `,
   ];
 
@@ -212,11 +198,13 @@ export class ESPHomeWizardStepBoardPortSelect extends LitElement {
       `;
     }
     if (this.errorMessage) {
-      return html`<div class="error">${this.errorMessage}</div>`;
+      return html`<div class="empty-message">${this.errorMessage}</div>`;
     }
     if (this.ports.length === 0) {
       return html`
-        <div class="empty">${this._localize("wizard.connect_your_board_no_ports")}</div>
+        <div class="empty-message">
+          ${this._localize("wizard.connect_your_board_no_ports")}
+        </div>
       `;
     }
     return html`

--- a/src/styles/empty-state.ts
+++ b/src/styles/empty-state.ts
@@ -1,0 +1,31 @@
+import { css } from "lit";
+
+/**
+ * Shared empty-state blocks.
+ *
+ * ``empty-message`` is the centered quiet message for "nothing here" and
+ * inline error placeholders. ``empty-message--dashed`` is the standalone
+ * dashed placeholder card — used on its own, not stacked on the base,
+ * because its padding and line-height differ.
+ */
+export const emptyStateStyles = css`
+  .empty-message {
+    text-align: center;
+    padding: var(--wa-space-l) 0;
+    color: var(--wa-color-text-quiet);
+    font-size: var(--wa-font-size-s);
+    line-height: 1.5;
+  }
+
+  .empty-message--dashed {
+    margin: 0;
+    padding: var(--wa-space-m) var(--wa-space-s);
+    text-align: center;
+    color: var(--wa-color-text-quiet);
+    font-size: var(--wa-font-size-s);
+    font-style: italic;
+    border: 1px dashed var(--wa-color-surface-border);
+    border-radius: var(--wa-border-radius-m);
+    background: var(--wa-color-surface-lowered, transparent);
+  }
+`;

--- a/test/components/device/device-section-automation-list.test.ts
+++ b/test/components/device/device-section-automation-list.test.ts
@@ -35,7 +35,9 @@ describe("esphome-section-automation-list", () => {
       deleteLabel: "Delete",
     });
     expect(el.shadowRoot?.querySelector(".add")).not.toBeNull();
-    expect(el.shadowRoot?.querySelector(".empty")?.textContent).toContain("Nothing yet");
+    expect(el.shadowRoot?.querySelector(".empty-message--dashed")?.textContent).toContain(
+      "Nothing yet"
+    );
   });
 
   it("omits the empty placeholder when addable but emptyText is absent", async () => {
@@ -47,7 +49,7 @@ describe("esphome-section-automation-list", () => {
     });
     // Header + Add still render, but no blank dashed box / ARIA status.
     expect(el.shadowRoot?.querySelector(".add")).not.toBeNull();
-    expect(el.shadowRoot?.querySelector(".empty")).toBeNull();
+    expect(el.shadowRoot?.querySelector(".empty-message--dashed")).toBeNull();
   });
 
   it("emits edit / delete with the row key", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Adds `src/styles/empty-state.ts` with the two empty state blocks that were duplicated byte for byte: `.empty-message` (the centered quiet 5 property block, identical in install-method-dialog and twice in wizard-step-board-port-select) and `.empty-message--dashed` (the 9 property dashed placeholder, identical in automation-editor-actions and device-section-automation-list).

The five sites now compose `emptyStateStyles` and use the shared class names; the local blocks are deleted. The dashed variant is standalone rather than stacked on the base since its padding and line-height differ, keeping every computed value identical. The automation editor gets the module through the existing `automationEditorStyles` array, which also covers the parse error panels. The dozen near variants that differ in padding tokens are left alone; normalizing them would be a visual change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1297

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
