### PR TITLE
Share the Map-backed Web Storage test stub

### DIFF
--- a/test/_storage.ts
+++ b/test/_storage.ts
@@ -1,0 +1,37 @@
+import { vi } from "vitest";
+
+/**
+ * In-memory Web Storage stand-ins for node-environment tests (no
+ * ``localStorage`` / ``sessionStorage`` globals there).
+ *
+ * ``stubStorage`` installs a Map-backed stub via ``vi.stubGlobal`` and
+ * returns the backing map for direct inspection / seeding.
+ * ``stubThrowingStorage`` installs one whose every method throws — the
+ * private-mode / sandboxed-iframe failure shape storage helpers must
+ * tolerate. Callers keep ``vi.unstubAllGlobals()`` in ``afterEach``.
+ */
+export function stubStorage(
+  name: "localStorage" | "sessionStorage",
+  initial?: Record<string, string>
+): Map<string, string> {
+  const store = new Map<string, string>(Object.entries(initial ?? {}));
+  vi.stubGlobal(name, {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => store.set(k, v),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear(),
+  });
+  return store;
+}
+
+export function stubThrowingStorage(name: "localStorage" | "sessionStorage"): void {
+  const blocked = () => {
+    throw new Error("blocked");
+  };
+  vi.stubGlobal(name, {
+    getItem: blocked,
+    setItem: blocked,
+    removeItem: blocked,
+    clear: blocked,
+  });
+}

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -7,6 +7,7 @@ import {
   installMockWebSocket,
   uninstallMockWebSocket,
 } from "./mock-websocket.js";
+import { stubStorage } from "../_storage.js";
 
 const serverInfo = {
   server_version: "1.0.0",
@@ -21,16 +22,8 @@ const serverInfoAuthRequired = {
   requires_auth: true,
 };
 
-function stubLocalStorage(initial?: Record<string, string>): Map<string, string> {
-  const store = new Map<string, string>(Object.entries(initial ?? {}));
-  vi.stubGlobal("localStorage", {
-    getItem: (k: string) => store.get(k) ?? null,
-    setItem: (k: string, v: string) => store.set(k, v),
-    removeItem: (k: string) => store.delete(k),
-    clear: () => store.clear(),
-  });
-  return store;
-}
+const stubLocalStorage = (initial?: Record<string, string>) =>
+  stubStorage("localStorage", initial);
 
 async function connect(api: ESPHomeAPI): Promise<MockWebSocket> {
   const pending = api.connect();

--- a/test/util/auth-token.test.ts
+++ b/test/util/auth-token.test.ts
@@ -4,18 +4,11 @@ import {
   getStoredToken,
   setStoredToken,
 } from "../../src/util/auth-token.js";
+import { stubStorage, stubThrowingStorage } from "../_storage.js";
 
 describe("auth-token", () => {
-  // Mirrors the just-created.test.ts pattern: vitest runs in node, so
-  // localStorage has to be stubbed per-test.
   beforeEach(() => {
-    const store = new Map<string, string>();
-    vi.stubGlobal("localStorage", {
-      getItem: (k: string) => store.get(k) ?? null,
-      setItem: (k: string, v: string) => store.set(k, v),
-      removeItem: (k: string) => store.delete(k),
-      clear: () => store.clear(),
-    });
+    stubStorage("localStorage");
   });
 
   afterEach(() => {
@@ -61,20 +54,7 @@ describe("auth-token", () => {
     // Private-mode browsers and sandboxed iframes can throw on every
     // localStorage access. The helpers swallow these — auth still
     // works (in-memory token on the API client carries the session).
-    vi.stubGlobal("localStorage", {
-      getItem: () => {
-        throw new Error("blocked");
-      },
-      setItem: () => {
-        throw new Error("blocked");
-      },
-      removeItem: () => {
-        throw new Error("blocked");
-      },
-      clear: () => {
-        throw new Error("blocked");
-      },
-    });
+    stubThrowingStorage("localStorage");
     expect(() => setStoredToken("abc", 1)).not.toThrow();
     expect(getStoredToken()).toBeNull();
     expect(() => clearStoredToken()).not.toThrow();

--- a/test/util/dashboard-filters-session.test.ts
+++ b/test/util/dashboard-filters-session.test.ts
@@ -4,20 +4,12 @@ import {
   saveDashboardFilters,
   STORAGE_KEY,
 } from "../../src/util/dashboard-filters-session.js";
+import { stubStorage, stubThrowingStorage } from "../_storage.js";
 
 describe("dashboard-filters-session", () => {
-  // The vitest config runs in the ``node`` environment which has no
-  // ``sessionStorage``; a tiny in-memory Map stand-in covers the three
-  // methods the helper uses.
   let store: Map<string, string>;
   beforeEach(() => {
-    store = new Map<string, string>();
-    vi.stubGlobal("sessionStorage", {
-      getItem: (k: string) => store.get(k) ?? null,
-      setItem: (k: string, v: string) => store.set(k, v),
-      removeItem: (k: string) => store.delete(k),
-      clear: () => store.clear(),
-    });
+    store = stubStorage("sessionStorage");
   });
 
   afterEach(() => {
@@ -72,14 +64,7 @@ describe("dashboard-filters-session", () => {
   });
 
   it("does not throw when storage is unavailable", () => {
-    vi.stubGlobal("sessionStorage", {
-      getItem: () => {
-        throw new Error("denied");
-      },
-      setItem: () => {
-        throw new Error("denied");
-      },
-    });
+    stubThrowingStorage("sessionStorage");
     expect(() =>
       saveDashboardFilters({
         labels: [],

--- a/test/util/just-created.test.ts
+++ b/test/util/just-created.test.ts
@@ -4,20 +4,11 @@ import {
   consumeJustCreated,
   markJustCreated,
 } from "../../src/util/just-created.js";
+import { stubStorage, stubThrowingStorage } from "../_storage.js";
 
 describe("just-created", () => {
-  // The vitest config runs in the ``node`` environment which has no
-  // ``sessionStorage``. Stub it with a tiny in-memory Map per-test so
-  // we don't need to pull in jsdom for two methods. Same shape as
-  // ``pending-highlight.test.ts``.
   beforeEach(() => {
-    const store = new Map<string, string>();
-    vi.stubGlobal("sessionStorage", {
-      getItem: (k: string) => store.get(k) ?? null,
-      setItem: (k: string, v: string) => store.set(k, v),
-      removeItem: (k: string) => store.delete(k),
-      clear: () => store.clear(),
-    });
+    stubStorage("sessionStorage");
   });
 
   afterEach(() => {
@@ -70,20 +61,7 @@ describe("just-created", () => {
     // every ``sessionStorage`` access. The helpers swallow these
     // — the welcome banner is decoration, not worth blowing up
     // the wizard / rename / device-mount over.
-    vi.stubGlobal("sessionStorage", {
-      getItem: () => {
-        throw new Error("blocked");
-      },
-      setItem: () => {
-        throw new Error("blocked");
-      },
-      removeItem: () => {
-        throw new Error("blocked");
-      },
-      clear: () => {
-        throw new Error("blocked");
-      },
-    });
+    stubThrowingStorage("sessionStorage");
     expect(() => markJustCreated("kitchen.yaml")).not.toThrow();
     expect(consumeJustCreated("kitchen.yaml")).toBe(false);
     expect(() => clearJustCreated()).not.toThrow();

--- a/test/util/pending-highlight.test.ts
+++ b/test/util/pending-highlight.test.ts
@@ -3,20 +3,11 @@ import {
   consumePendingHighlight,
   markPendingHighlight,
 } from "../../src/util/pending-highlight.js";
+import { stubStorage } from "../_storage.js";
 
 describe("pending-highlight", () => {
-  // The vitest config runs in the ``node`` environment which has no
-  // ``sessionStorage``. The helper just calls ``getItem`` /
-  // ``setItem`` / ``removeItem`` so a tiny in-memory Map stand-in is
-  // enough — we don't need to pull in jsdom for two methods.
   beforeEach(() => {
-    const store = new Map<string, string>();
-    vi.stubGlobal("sessionStorage", {
-      getItem: (k: string) => store.get(k) ?? null,
-      setItem: (k: string, v: string) => store.set(k, v),
-      removeItem: (k: string) => store.delete(k),
-      clear: () => store.clear(),
-    });
+    stubStorage("sessionStorage");
   });
 
   afterEach(() => {

--- a/test/util/split-ratio.test.ts
+++ b/test/util/split-ratio.test.ts
@@ -8,18 +8,11 @@ import {
   nextSplitRatioForKey,
   saveSplitRatio,
 } from "../../src/util/split-ratio.js";
+import { stubStorage, stubThrowingStorage } from "../_storage.js";
 
 describe("split-ratio", () => {
-  // Mirrors the auth-token.test.ts pattern: vitest runs in node, so
-  // localStorage has to be stubbed per-test.
   beforeEach(() => {
-    const store = new Map<string, string>();
-    vi.stubGlobal("localStorage", {
-      getItem: (k: string) => store.get(k) ?? null,
-      setItem: (k: string, v: string) => store.set(k, v),
-      removeItem: (k: string) => store.delete(k),
-      clear: () => store.clear(),
-    });
+    stubStorage("localStorage");
   });
 
   afterEach(() => {
@@ -71,20 +64,7 @@ describe("split-ratio", () => {
 
   it("tolerates localStorage throwing on read and write", () => {
     // Private mode / sandboxed iframes can throw on every access.
-    vi.stubGlobal("localStorage", {
-      getItem: () => {
-        throw new Error("blocked");
-      },
-      setItem: () => {
-        throw new Error("blocked");
-      },
-      removeItem: () => {
-        throw new Error("blocked");
-      },
-      clear: () => {
-        throw new Error("blocked");
-      },
-    });
+    stubThrowingStorage("localStorage");
     expect(() => saveSplitRatio(0.6)).not.toThrow();
     expect(loadSplitRatio()).toBe(DEFAULT_SPLIT_RATIO);
   });


### PR DESCRIPTION
# What does this implement/fix?

Adds `test/_storage.ts` with `stubStorage(name, initial?)` (Map backed `localStorage` / `sessionStorage` stub, returns the backing map) and `stubThrowingStorage(name)` (every method throws, the private mode failure shape). The six files that each pasted the same 4 method stub now import it: split-ratio, auth-token, pending-highlight, dashboard-filters-session, just-created and esphome-api tests; their hand rolled throwing variants collapse onto the shared one too. esphome-api keeps its `stubLocalStorage` name as a one line alias since it has six call sites.

Part of #1298 (item 2); the webawesome mock consolidation and the other items land separately.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder-frontend/issues/1298

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
