### PR TITLE
Share the MockObserver test mock and canonical test helpers

### DIFF
--- a/test/_intersection-observer.ts
+++ b/test/_intersection-observer.ts
@@ -1,0 +1,34 @@
+/**
+ * IntersectionObserver mock for suites that drive sentinel-based
+ * infinite scroll. Install with
+ * ``vi.stubGlobal("IntersectionObserver", MockObserver)``; reset
+ * ``MockObserver.instances`` in ``beforeEach`` and fire crossings via
+ * ``instance.trigger(isIntersecting)``.
+ */
+export class MockObserver {
+  static instances: MockObserver[] = [];
+  observed: Element[] = [];
+  disconnected = false;
+  constructor(
+    public cb: IntersectionObserverCallback,
+    public options?: IntersectionObserverInit
+  ) {
+    MockObserver.instances.push(this);
+  }
+  observe(el: Element) {
+    this.observed.push(el);
+  }
+  unobserve() {}
+  disconnect() {
+    this.disconnected = true;
+  }
+  takeRecords() {
+    return [];
+  }
+  trigger(isIntersecting: boolean) {
+    this.cb(
+      [{ isIntersecting, target: this.observed[0] } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver
+    );
+  }
+}

--- a/test/components/device/add-component-form-seed-fns.test.ts
+++ b/test/components/device/add-component-form-seed-fns.test.ts
@@ -15,9 +15,10 @@ import {
   findReferencePath,
   seedDefaults,
 } from "../../../src/components/device/add-component-form-seed.js";
+import { identityLocalize } from "../../_dom.js";
 import { makeConfigEntry } from "../../util/_make-config-entry.js";
 
-const localize = (key: string): string => key;
+const localize = identityLocalize;
 
 function makeComponent(over: Partial<ComponentCatalogEntry> = {}): ComponentCatalogEntry {
   return {

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -27,7 +27,7 @@ import {
   type AutoApplyHost,
   type AutoApplyOptions,
 } from "../../../../src/components/device/automation-editor/auto-apply-controller.js";
-import { flushTimers } from "../../../_dom.js";
+import { flushTimers, identityLocalize } from "../../../_dom.js";
 
 const SCRIPT: AutomationLocation = {
   kind: "script",
@@ -55,7 +55,7 @@ class Host extends EventTarget implements AutoApplyHost {
   updateComplete = Promise.resolve(true);
 }
 
-const localize: LocalizeFunc = (key) => key;
+const localize: LocalizeFunc = identityLocalize as LocalizeFunc;
 
 function setup(over: Partial<AutoApplyOptions> = {}) {
   const host = new Host();

--- a/test/components/device/automation-editor/catalog-load-controller.test.ts
+++ b/test/components/device/automation-editor/catalog-load-controller.test.ts
@@ -2,16 +2,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
 
-import type { ReactiveControllerHost } from "lit";
 import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type { AvailableAutomations } from "../../../../src/api/types/automations.js";
 import { CatalogLoadController } from "../../../../src/components/device/automation-editor/catalog-load-controller.js";
 import { _clearAutomationBodyCache } from "../../../../src/util/automation-body-cache.js";
 import { identityLocalize } from "../../../_dom.js";
+import { fakeHost } from "../../../_fake-host.js";
 
 const localize = identityLocalize as never;
-const stubHost = () => ({ addController: vi.fn() }) as unknown as ReactiveControllerHost;
+const stubHost = fakeHost;
 
 const emptySlim = (): AvailableAutomations =>
   ({

--- a/test/components/wizard-step-board-list.test.ts
+++ b/test/components/wizard-step-board-list.test.ts
@@ -10,37 +10,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@home-assistant/webawesome/dist/components/badge/badge.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
-class MockObserver {
-  static instances: MockObserver[] = [];
-  observed: Element[] = [];
-  disconnected = false;
-  constructor(
-    public cb: IntersectionObserverCallback,
-    public options?: IntersectionObserverInit
-  ) {
-    MockObserver.instances.push(this);
-  }
-  observe(el: Element) {
-    this.observed.push(el);
-  }
-  unobserve() {}
-  disconnect() {
-    this.disconnected = true;
-  }
-  takeRecords() {
-    return [];
-  }
-  trigger(isIntersecting: boolean) {
-    this.cb(
-      [{ isIntersecting, target: this.observed[0] } as IntersectionObserverEntry],
-      this as unknown as IntersectionObserver
-    );
-  }
-}
-
 import type { BoardCatalogEntry } from "../../src/api/types/boards.js";
 import { ESPHomeWizardStepBoardList } from "../../src/components/wizard/wizard-step-board-list.js";
 import { identityLocalize } from "../_dom.js";
+import { MockObserver } from "../_intersection-observer.js";
 
 const board = (i: number): BoardCatalogEntry =>
   ({

--- a/test/util/enter-controller.test.ts
+++ b/test/util/enter-controller.test.ts
@@ -4,11 +4,11 @@
  * Pins EnterController: fires on a plain Enter, stays out of the way for
  * modifiers, IME, already-handled events, and self-handling focus targets.
  */
-import type { ReactiveControllerHost } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { EnterController } from "../../src/util/enter-controller.js";
+import { FakeHost } from "../_fake-host.js";
 
-const stubHost = { addController() {} } as unknown as ReactiveControllerHost;
+const stubHost = new FakeHost();
 
 let target: HTMLElement;
 

--- a/test/util/intersection-controller.test.ts
+++ b/test/util/intersection-controller.test.ts
@@ -5,34 +5,7 @@ import {
   type IntersectionControllerOptions,
 } from "../../src/util/intersection-controller.js";
 import { FakeHost } from "../_fake-host.js";
-
-class MockObserver {
-  static instances: MockObserver[] = [];
-  observed: Element[] = [];
-  disconnected = false;
-  constructor(
-    public cb: IntersectionObserverCallback,
-    public options?: IntersectionObserverInit
-  ) {
-    MockObserver.instances.push(this);
-  }
-  observe(el: Element) {
-    this.observed.push(el);
-  }
-  unobserve() {}
-  disconnect() {
-    this.disconnected = true;
-  }
-  takeRecords() {
-    return [];
-  }
-  trigger(isIntersecting: boolean) {
-    this.cb(
-      [{ isIntersecting, target: this.observed[0] } as IntersectionObserverEntry],
-      this as unknown as IntersectionObserver
-    );
-  }
-}
+import { MockObserver } from "../_intersection-observer.js";
 
 class SentinelHost extends FakeHost {
   renderRoot = document.createElement("div");


### PR DESCRIPTION
# What does this implement/fix?

Adds `test/_intersection-observer.ts` with the `MockObserver` class that was byte identical in the intersection-controller and wizard-step-board-list suites; both now import it. Also points the true identity localize duplicates at the existing `test/_dom.ts` export (auto-apply-controller, add-component-form-seed-fns) and folds two trivial `stubHost` variants onto `test/_fake-host.ts` (enter-controller uses `FakeHost`, catalog-load-controller uses `fakeHost`).

Deliberately unchanged: board-change keeps its inline localize, its comment documents that the suite runs in node and avoids importing `_dom.ts`; component-name-resolver keeps its stubHost, which is a real variant driving connect/disconnect through the captured controller, not a copy; the other `const localize` declarations across the suite format values, so they are not duplicates. The audit's claimed `flush` re-declarations turned out to be `flushMicrotasks` wrappers, nothing to change.

Part of #1298 (items 3 and 4); the webawesome mock consolidation remains.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder-frontend/issues/1298

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
