### PR TITLE
Share the device-name field and validation scaffold

### DIFF
--- a/src/components/clone-device-dialog.ts
+++ b/src/components/clone-device-dialog.ts
@@ -11,9 +11,13 @@ import { dialogChromeStyles, quietCloseButtonStyles } from "../styles/dialog-chr
 import { dialogFieldStyles } from "../styles/dialog-fields.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { getDeviceNameWarning, validateDeviceName } from "../util/config-validation.js";
+import { validateDeviceName } from "../util/config-validation.js";
 import { DialogOpenController } from "../util/dialog-open-controller.js";
-import { renderInlineError } from "../util/render-error.js";
+import {
+  deviceNameValidity,
+  renderDeviceNameField,
+  type DeviceNameValidity,
+} from "./shared/device-name-field.js";
 
 import "./base-dialog.js";
 
@@ -97,14 +101,11 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
     // the backend rejects ``new_name == source`` anyway, but
     // catching it client-side keeps the submit button disabled
     // instead of letting the user fire and see an error toast.
-    const err =
+    const validity: DeviceNameValidity =
       sameAsSource && showsValidation
-        ? { code: "dashboard.action_clone_same_name", params: undefined }
-        : showsValidation
-          ? validateDeviceName(trimmedName)
-          : null;
-    const warning = showsValidation && !err ? getDeviceNameWarning(trimmedName) : null;
-    const canSubmit = trimmedName.length > 0 && !err;
+        ? { err: { code: "dashboard.action_clone_same_name" }, warning: null }
+        : deviceNameValidity(trimmedName, showsValidation);
+    const canSubmit = trimmedName.length > 0 && !validity.err;
 
     return html`
       <esphome-base-dialog
@@ -115,31 +116,17 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
         .confirmOnEnter=${this._confirm}
         @request-close=${this._dialog.onRequestClose}
       >
-        <div class="field">
-          <label for="clone-new-name"
-            >${this._localize("dashboard.action_clone_name_label")}</label
-          >
-          <input
-            id="clone-new-name"
-            type="text"
-            autofocus
-            class=${err ? "invalid" : ""}
-            .value=${this._name}
-            placeholder=${this.sourceName}
-            @input=${(e: Event) => {
-              this._name = (e.target as HTMLInputElement).value;
-            }}
-          />
-          ${
-            err
-              ? renderInlineError(this._localize(err.code, err.params))
-              : warning
-                ? html`<span class="field-warning"
-                    >${this._localize(warning.code, warning.params)}</span
-                  >`
-                : nothing
-          }
-        </div>
+        ${renderDeviceNameField({
+          localize: this._localize,
+          labelKey: "dashboard.action_clone_name_label",
+          value: this._name,
+          validity,
+          onInput: (value) => {
+            this._name = value;
+          },
+          id: "clone-new-name",
+          placeholder: this.sourceName,
+        })}
         <div class="field">
           <label for="clone-friendly-name"
             >${this._localize("dashboard.action_clone_friendly_name_label")}</label

--- a/src/components/clone-device-dialog.ts
+++ b/src/components/clone-device-dialog.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { LitElement, css, html, nothing } from "lit";
+import { LitElement, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";

--- a/src/components/rename-device-dialog.ts
+++ b/src/components/rename-device-dialog.ts
@@ -91,6 +91,7 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
           onInput: (value) => {
             this._value = value;
           },
+          id: "rename-device-name",
         })}
         <div class="actions">
           <button class="btn btn--cancel" @click=${this.close}>

--- a/src/components/rename-device-dialog.ts
+++ b/src/components/rename-device-dialog.ts
@@ -11,9 +11,9 @@ import { dialogChromeStyles, quietCloseButtonStyles } from "../styles/dialog-chr
 import { dialogFieldStyles } from "../styles/dialog-fields.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { getDeviceNameWarning, validateDeviceName } from "../util/config-validation.js";
+import { validateDeviceName } from "../util/config-validation.js";
 import { DialogOpenController } from "../util/dialog-open-controller.js";
-import { renderInlineError } from "../util/render-error.js";
+import { deviceNameValidity, renderDeviceNameField } from "./shared/device-name-field.js";
 
 import "./base-dialog.js";
 
@@ -70,13 +70,11 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
   protected render() {
     const trimmed = this._value.trim();
     const unchanged = trimmed === this.deviceName || !trimmed;
-    const showsValidation = trimmed && trimmed !== this.deviceName;
-    const err = showsValidation ? validateDeviceName(trimmed) : null;
-    /* Warnings only render when there's no hard error to show — the
-       error messaging would otherwise compete with the warning for
-       the same slot. */
-    const warning = showsValidation && !err ? getDeviceNameWarning(trimmed) : null;
-    const canSubmit = !unchanged && !err;
+    const validity = deviceNameValidity(
+      trimmed,
+      !!trimmed && trimmed !== this.deviceName
+    );
+    const canSubmit = !unchanged && !validity.err;
 
     return html`
       <esphome-base-dialog
@@ -85,27 +83,15 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
         .confirmOnEnter=${this._confirm}
         @request-close=${this._dialog.onRequestClose}
       >
-        <div class="field">
-          <label>${this._localize("dashboard.action_rename_label")}</label>
-          <input
-            type="text"
-            autofocus
-            class=${err ? "invalid" : ""}
-            .value=${this._value}
-            @input=${(e: Event) => {
-              this._value = (e.target as HTMLInputElement).value;
-            }}
-          />
-          ${
-            err
-              ? renderInlineError(this._localize(err.code, err.params))
-              : warning
-                ? html`<span class="field-warning"
-                    >${this._localize(warning.code, warning.params)}</span
-                  >`
-                : nothing
-          }
-        </div>
+        ${renderDeviceNameField({
+          localize: this._localize,
+          labelKey: "dashboard.action_rename_label",
+          value: this._value,
+          validity,
+          onInput: (value) => {
+            this._value = value;
+          },
+        })}
         <div class="actions">
           <button class="btn btn--cancel" @click=${this.close}>
             ${this._localize("layout.cancel")}

--- a/src/components/rename-device-dialog.ts
+++ b/src/components/rename-device-dialog.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { LitElement, css, html, nothing } from "lit";
+import { LitElement, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";

--- a/src/components/shared/device-name-field.ts
+++ b/src/components/shared/device-name-field.ts
@@ -1,0 +1,72 @@
+import { html, nothing, type TemplateResult } from "lit";
+import type { LocalizeFunc } from "../../common/localize.js";
+import {
+  getDeviceNameWarning,
+  validateDeviceName,
+} from "../../util/config-validation.js";
+import { renderInlineError } from "../../util/render-error.js";
+
+/** Localizable message: ``ValidationError`` minus the field key. */
+export interface DeviceNameMessage {
+  code: string;
+  params?: Record<string, string | number>;
+}
+
+export interface DeviceNameValidity {
+  err: DeviceNameMessage | null;
+  warning: DeviceNameMessage | null;
+}
+
+/**
+ * Standard messaging precedence for a device-name input: nothing until
+ * *showsValidation*, a hard error owns the slot, a warning renders only
+ * error-free.
+ */
+export function deviceNameValidity(
+  trimmed: string,
+  showsValidation: boolean
+): DeviceNameValidity {
+  const err = showsValidation ? validateDeviceName(trimmed) : null;
+  const warning = showsValidation && !err ? getDeviceNameWarning(trimmed) : null;
+  return { err, warning };
+}
+
+export interface DeviceNameFieldOptions {
+  localize: LocalizeFunc;
+  labelKey: string;
+  value: string;
+  validity: DeviceNameValidity;
+  onInput: (value: string) => void;
+  /** Input id (and the label's ``for``); omit for an unassociated label. */
+  id?: string;
+  placeholder?: string;
+}
+
+/** The labelled device-name input plus its inline error / warning slot
+ *  (classes from ``dialogFieldStyles`` + ``inputStyles``). */
+export function renderDeviceNameField(o: DeviceNameFieldOptions): TemplateResult {
+  const { err, warning } = o.validity;
+  return html`
+    <div class="field">
+      <label for=${o.id ?? nothing}>${o.localize(o.labelKey)}</label>
+      <input
+        id=${o.id ?? nothing}
+        type="text"
+        autofocus
+        class=${err ? "invalid" : ""}
+        .value=${o.value}
+        placeholder=${o.placeholder ?? nothing}
+        @input=${(e: Event) => o.onInput((e.target as HTMLInputElement).value)}
+      />
+      ${
+        err
+          ? renderInlineError(o.localize(err.code, err.params))
+          : warning
+            ? html`<span class="field-warning"
+                >${o.localize(warning.code, warning.params)}</span
+              >`
+            : nothing
+      }
+    </div>
+  `;
+}

--- a/src/components/shared/device-name-field.ts
+++ b/src/components/shared/device-name-field.ts
@@ -6,7 +6,7 @@ import {
 } from "../../util/config-validation.js";
 import { renderInlineError } from "../../util/render-error.js";
 
-/** Localizable message: ``ValidationError`` minus the field key. */
+/** The localizable (code, params) subset of ``ValidationError``. */
 export interface DeviceNameMessage {
   code: string;
   params?: Record<string, string | number>;
@@ -23,11 +23,11 @@ export interface DeviceNameValidity {
  * error-free.
  */
 export function deviceNameValidity(
-  trimmed: string,
+  name: string,
   showsValidation: boolean
 ): DeviceNameValidity {
-  const err = showsValidation ? validateDeviceName(trimmed) : null;
-  const warning = showsValidation && !err ? getDeviceNameWarning(trimmed) : null;
+  const err = showsValidation ? validateDeviceName(name) : null;
+  const warning = showsValidation && !err ? getDeviceNameWarning(name) : null;
   return { err, warning };
 }
 

--- a/test/components/shared/device-name-field.test.ts
+++ b/test/components/shared/device-name-field.test.ts
@@ -1,0 +1,73 @@
+import type { LocalizeFunc } from "../../../src/common/localize.js";
+import { describe, expect, it } from "vitest";
+import {
+  deviceNameValidity,
+  renderDeviceNameField,
+} from "../../../src/components/shared/device-name-field.js";
+import { identityLocalize } from "../../_dom.js";
+import {
+  extractAttributeBindings,
+  findTemplatesByAnchor,
+  visitTemplates,
+} from "../../_lit-template-walker.js";
+
+const localize: LocalizeFunc = identityLocalize as LocalizeFunc;
+
+function renderedText(result: unknown): string {
+  const parts: string[] = [];
+  visitTemplates(result, (t) => {
+    parts.push(...t.strings);
+    for (const v of t.values) if (typeof v === "string") parts.push(v);
+  });
+  return parts.join(" ");
+}
+
+const field = (validity = deviceNameValidity("", false)) =>
+  renderDeviceNameField({
+    localize,
+    labelKey: "dashboard.action_rename_label",
+    value: "x",
+    validity,
+    onInput: () => {},
+  });
+
+describe("deviceNameValidity", () => {
+  it("reports nothing while showsValidation is false", () => {
+    expect(deviceNameValidity("Bad Name!", false)).toEqual({ err: null, warning: null });
+  });
+
+  it("a hard error wins the slot over a warning", () => {
+    const { err, warning } = deviceNameValidity("Bad_Name!", true);
+    expect(err?.code).toBe("validation.invalid_device_name");
+    expect(warning).toBeNull();
+  });
+
+  it("warns error-free on an underscore name", () => {
+    const { err, warning } = deviceNameValidity("master_tv", true);
+    expect(err).toBeNull();
+    expect(warning?.code).toBe("validation.device_name_underscore");
+  });
+});
+
+describe("renderDeviceNameField", () => {
+  it("marks the input invalid and renders the error text", () => {
+    const result = field(deviceNameValidity("Bad Name!", true));
+    const input = findTemplatesByAnchor(result, "<input")[0];
+    expect(extractAttributeBindings(input).class).toBe("invalid");
+    expect(renderedText(result)).toContain("validation.invalid_device_name");
+  });
+
+  it("renders the warning in the field-warning slot when error-free", () => {
+    const result = field(deviceNameValidity("master_tv", true));
+    const input = findTemplatesByAnchor(result, "<input")[0];
+    expect(extractAttributeBindings(input).class).toBe("");
+    expect(renderedText(result)).toContain("validation.device_name_underscore");
+    expect(renderedText(result)).toContain("field-warning");
+  });
+
+  it("renders neither slot with a clean validity", () => {
+    const text = renderedText(field());
+    expect(text).not.toContain("validation.");
+    expect(text).not.toContain("field-warning");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Adds `src/components/shared/device-name-field.ts` with `deviceNameValidity` (the err/warning/showsValidation precedence both dialogs computed by hand; error wins the slot, warnings render only error-free) and `renderDeviceNameField` (the labelled input plus inline error / field-warning markup). The rename and clone dialogs now call the pair; clone keeps its same-as-source gate caller side, substituting its own error into the shared validity shape, and keeps its input id and placeholder through the helper options.

Friendly-name-dialog stays out; its validation is required-only and forcing it through the helper would need an option only it uses. New unit test pins the precedence rules and the error / warning / clean render shapes; the existing rename and clone suites pass unchanged as the regression net.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1293

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
