### PR TITLE
Hoist the single-line truncation and 2-line clamp into shared text styles

### DIFF
--- a/src/components/archived-devices-dialog.ts
+++ b/src/components/archived-devices-dialog.ts
@@ -8,6 +8,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
 import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { textStyles } from "../styles/text.js";
 import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { getErrorMessage } from "../util/error-message.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -65,6 +66,7 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
     espHomeStyles,
     // Shared .btn / .btn--cancel chrome for the footer Close button.
     dialogActionButtonStyles,
+    textStyles,
     css`
       esphome-base-dialog {
         --width: 560px;
@@ -139,27 +141,18 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
         color: var(--wa-color-text-normal);
         font-weight: var(--wa-font-weight-bold);
         font-size: var(--wa-font-size-m);
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
 
       .row-config {
         color: var(--wa-color-text-quiet);
         font-size: var(--wa-font-size-2xs);
         font-family: var(--wa-font-family-code);
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
 
       .row-comment {
         color: var(--wa-color-text-quiet);
         font-size: var(--wa-font-size-xs);
         font-style: italic;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
 
       .row-actions {
@@ -288,11 +281,11 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
         (device) => html`
           <div class="row">
             <div class="row-info">
-              <div class="row-name">${device.friendly_name || device.name}</div>
-              <div class="row-config">${device.configuration}</div>
+              <div class="row-name truncate">${device.friendly_name || device.name}</div>
+              <div class="row-config truncate">${device.configuration}</div>
               ${
                 device.comment
-                  ? html`<div class="row-comment">${device.comment}</div>`
+                  ? html`<div class="row-comment truncate">${device.comment}</div>`
                   : nothing
               }
             </div>

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -6,6 +6,7 @@ import { customElement, property, state } from "lit/decorators.js";
 
 import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { centeredMobileDialog } from "../styles/dialog-mobile.js";
+import { textStyles } from "../styles/text.js";
 import { EnterController } from "../util/enter-controller.js";
 
 /** Wrappers currently open, maintained by the class below. Backs
@@ -324,7 +325,8 @@ export class ESPHomeBaseDialog extends LitElement {
         @wa-after-hide=${this._onWaAfterHide}
       >
         <header slot="label" part="label-row">
-          <slot name="header-prefix"></slot><span part="title-text">${this.label}</span
+          <slot name="header-prefix"></slot
+          ><span class="truncate" part="title-text">${this.label}</span
           ><slot name="header-suffix"></slot>
         </header>
         <slot></slot>
@@ -338,6 +340,7 @@ export class ESPHomeBaseDialog extends LitElement {
     // Mobile default: centered, dvh-capped. Heavy dialogs override with
     // fullscreenMobileDialog (their outer-tree ::part rule wins).
     centeredMobileDialog("wa-dialog"),
+    textStyles,
     css`
       :host {
         display: contents;
@@ -402,9 +405,6 @@ export class ESPHomeBaseDialog extends LitElement {
       }
       [part="title-text"] {
         min-width: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
       }
     `,
   ];

--- a/src/components/command-palette.styles.ts
+++ b/src/components/command-palette.styles.ts
@@ -160,9 +160,6 @@ export const commandPaletteStyles = css`
 
   .item-label {
     flex: 1;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   .empty {

--- a/src/components/command-palette.ts
+++ b/src/components/command-palette.ts
@@ -23,6 +23,7 @@ import {
   localizeContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { textStyles } from "../styles/text.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { yamlEmptyMessageKey } from "../util/yaml-search-helpers.js";
 import type { CommandAction } from "./command-palette-actions.js";
@@ -101,7 +102,7 @@ export class ESPHomeCommandPalette extends LitElement {
   @query(".search-input")
   private _searchInput?: HTMLInputElement;
 
-  static styles = [espHomeStyles, commandPaletteStyles];
+  static styles = [espHomeStyles, textStyles, commandPaletteStyles];
 
   /* Cmd+K is always-on (it opens the palette), so it stays on a
      dedicated keydown listener. Esc is wa-dialog's job: its
@@ -414,7 +415,7 @@ export class ESPHomeCommandPalette extends LitElement {
               ? html`<wa-icon library="mdi" name=${item.icon}></wa-icon>`
               : nothing
         }
-        <span class="item-label">${item.label}</span>
+        <span class="item-label truncate">${item.label}</span>
       </div>
     `;
   }

--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -15,6 +15,7 @@ import { DeviceState } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { textStyles } from "../../styles/text.js";
 import { showPendingChanges, showUpdateAvailable } from "../../util/device-sync.js";
 import { EscapeController } from "../../util/escape-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -50,6 +51,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
 
   static styles = [
     espHomeStyles,
+    textStyles,
     css`
       :host {
         display: block;
@@ -119,9 +121,6 @@ export class ESPHomeDeviceDrawer extends LitElement {
         font-size: var(--wa-font-size-l);
         font-weight: var(--wa-font-weight-bold);
         color: var(--wa-color-text-normal);
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
 
       .subtitle {
@@ -326,7 +325,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
       <div class="drawer">
         <div class="header">
           <div class="header-left">
-            <h2 class="title">${device.friendly_name || device.name}</h2>
+            <h2 class="title truncate">${device.friendly_name || device.name}</h2>
             <p class="subtitle">${device.configuration}</p>
           </div>
           <button

--- a/src/components/dashboard/device-grid-styles.ts
+++ b/src/components/dashboard/device-grid-styles.ts
@@ -309,9 +309,6 @@ export const deviceGridStyles = css`
   }
 
   .table-create-btn .label {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     /* Flex item must allow shrinking below its intrinsic width or the
        ellipsis never triggers when the mobile row gets tight. */
     min-width: 0;

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -38,6 +38,7 @@ import type { FirmwareJob } from "../../api/types/firmware-jobs.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { labelsContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { textStyles } from "../../styles/text.js";
 import { matchesDeviceRow } from "../../util/device-search.js";
 import {
   deployedIdentityTrusted,
@@ -318,7 +319,13 @@ export class ESPHomeDeviceTable extends LitElement {
     }
   }
 
-  static styles = [espHomeStyles, tableCellStyles, tableLayoutStyles, labelChipStyles];
+  static styles = [
+    espHomeStyles,
+    tableCellStyles,
+    tableLayoutStyles,
+    textStyles,
+    labelChipStyles,
+  ];
 
   protected render() {
     const effectivePageSize = effectiveTablePageSize(this._pageSize, this._rows.length);

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -240,7 +240,7 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
         @click=${() => host._createDialog.open()}
       >
         <wa-icon library="mdi" name="plus"></wa-icon>
-        <span class="label">${host._localize("dashboard.create_device")}</span>
+        <span class="label truncate">${host._localize("dashboard.create_device")}</span>
       </button>
       <div slot="no-results-extra" class="yaml-preview-banner">
         ${renderNoResultsExtras(host)}

--- a/src/components/dashboard/table-column-toggle.ts
+++ b/src/components/dashboard/table-column-toggle.ts
@@ -6,6 +6,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { dropdownMenuStyles } from "../../styles/dropdown-menu.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { textStyles } from "../../styles/text.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { OverflowMenuElement } from "../overflow-menu-element.js";
 
@@ -31,6 +32,7 @@ export class ESPHomeTableColumnToggle extends OverflowMenuElement {
   static styles = [
     espHomeStyles,
     dropdownMenuStyles,
+    textStyles,
     css`
       :host {
         display: block;
@@ -77,9 +79,6 @@ export class ESPHomeTableColumnToggle extends OverflowMenuElement {
          rather than wrapping the row when space is tight (e.g. a long
          translated "Columns" string); the icon stays put. */
       .toggle-btn .label {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
         /* Flex item must allow shrinking below its intrinsic width or
            the ellipsis never triggers on a tight toolbar row. */
         min-width: 0;
@@ -208,7 +207,7 @@ export class ESPHomeTableColumnToggle extends OverflowMenuElement {
         @click=${this._toggle}
       >
         <wa-icon library="mdi" name="cog-outline"></wa-icon>
-        <span class="label">${this._localize("dashboard.table_columns")}</span>
+        <span class="label truncate">${this._localize("dashboard.table_columns")}</span>
       </button>
       ${
         this._open

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -186,7 +186,7 @@ export class ESPHomeDeviceCard extends LitElement {
           }
           <div class="device-card-header-left">
             <div class="device-name-wrap">
-              <h3 class="device-name">${this.name}</h3>
+              <h3 class="device-name truncate">${this.name}</h3>
               ${
                 this.showModified
                   ? html`<span
@@ -233,7 +233,7 @@ export class ESPHomeDeviceCard extends LitElement {
               }
               ${renderEncryptionIcon(this)}
             </div>
-            <p class="device-config">${this.configuration}</p>
+            <p class="device-config truncate">${this.configuration}</p>
           </div>
           ${renderStatusBadge(this)}
         </div>

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -1,6 +1,9 @@
 import { css } from "lit";
 
+import { textStyles } from "../../styles/text.js";
+
 export const deviceCardStyles = [
+  textStyles,
   css`
     /* Only rendered when the device carries labels; an untagged device
        gets no chip row and the card collapses naturally. Padding leans
@@ -112,9 +115,6 @@ export const deviceCardStyles = [
       font-size: var(--wa-font-size-m);
       font-weight: var(--wa-font-weight-bold);
       color: var(--wa-color-text-normal);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
     }
 
     .indicator-dot {
@@ -159,9 +159,6 @@ export const deviceCardStyles = [
       margin: 0;
       font-size: var(--wa-font-size-xs);
       color: var(--wa-color-text-quiet);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
     }
 
     .device-status {

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -252,7 +252,9 @@ export class ESPHomeAutomationActionNode extends LitElement {
             title=${this._localize("device.automation_action_pick")}
             @click=${this._openPicker}
           >
-            <span class="ae-row-picker-name"> ${def?.name ?? this.value.action_id} </span>
+            <span class="ae-row-picker-name truncate">
+              ${def?.name ?? this.value.action_id}
+            </span>
             <wa-icon library="mdi" name="pencil-outline"></wa-icon>
           </button>
           <div class="ae-row-controls">

--- a/src/components/device/automation-editor/automation-condition-tree.ts
+++ b/src/components/device/automation-editor/automation-condition-tree.ts
@@ -201,7 +201,9 @@ export class ESPHomeAutomationConditionTree extends LitElement {
             ?disabled=${this.disabled}
             @click=${() => this._openPickerForChange(idx)}
           >
-            <span class="ae-row-picker-name"> ${def?.name ?? node.condition_id} </span>
+            <span class="ae-row-picker-name truncate">
+              ${def?.name ?? node.condition_id}
+            </span>
             <wa-icon library="mdi" name="pencil-outline"></wa-icon>
           </button>
           <div class="ae-row-controls">

--- a/src/components/device/automation-editor/automation-editor-rows.styles.ts
+++ b/src/components/device/automation-editor/automation-editor-rows.styles.ts
@@ -91,9 +91,6 @@ export const automationEditorRowStyles = css`
   .ae-row-picker-name {
     font-size: var(--wa-font-size-m);
     font-weight: var(--wa-font-weight-bold);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   .ae-row-picker wa-icon {

--- a/src/components/device/automation-editor/automation-editor.styles.ts
+++ b/src/components/device/automation-editor/automation-editor.styles.ts
@@ -1,6 +1,7 @@
 import { css } from "lit";
 
 import { emptyStateStyles } from "../../../styles/empty-state.js";
+import { textStyles } from "../../../styles/text.js";
 import { substitutionNoteStyles } from "../substitution-note.styles.js";
 import { automationEditorActionStyles } from "./automation-editor-actions.styles.js";
 import { automationEditorRowStyles } from "./automation-editor-rows.styles.js";
@@ -219,4 +220,5 @@ export const automationEditorStyles = [
   automationEditorActionStyles,
   emptyStateStyles,
   substitutionNoteStyles,
+  textStyles,
 ];

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -47,6 +47,7 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
+import { textStyles } from "../../../styles/text.js";
 import { DialogOpenController } from "../../../util/dialog-open-controller.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
@@ -118,6 +119,7 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
   static styles = [
     espHomeStyles,
     inputStyles,
+    textStyles,
     css`
       esphome-base-dialog {
         --width: 640px;
@@ -247,12 +249,6 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
         font-size: var(--wa-font-size-2xs);
         color: var(--wa-color-text-quiet);
         line-height: 1.4;
-        /* Clamp to two lines — descriptions can be long but the
-           picker shouldn't grow each row past a manageable height. */
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
-        overflow: hidden;
       }
 
       .picker-row-add {
@@ -505,7 +501,7 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
         <span class="picker-row-title">${item.name}</span>
         ${
           item.description
-            ? html`<span class="picker-row-desc">
+            ? html`<span class="picker-row-desc line-clamp-2">
                 ${renderMarkdown(item.description)}
               </span>`
             : nothing

--- a/src/components/device/automation-editor/component-target-picker.styles.ts
+++ b/src/components/device/automation-editor/component-target-picker.styles.ts
@@ -96,9 +96,6 @@ export const componentTargetPickerStyles = css`
   .component-choice-name {
     font-size: var(--wa-font-size-s);
     color: var(--wa-color-text-normal);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
   .component-domain {
     flex: 0 0 auto;

--- a/src/components/device/automation-editor/component-target-picker.ts
+++ b/src/components/device/automation-editor/component-target-picker.ts
@@ -11,6 +11,7 @@ import type { AvailableComponentInstance } from "../../../api/types/automations.
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { espHomeStyles } from "../../../styles/shared.js";
+import { textStyles } from "../../../styles/text.js";
 import { componentTargetPickerStyles } from "./component-target-picker.styles.js";
 import { instanceName } from "./component-targets.js";
 
@@ -34,7 +35,7 @@ export class ESPHomeComponentTargetPicker extends LitElement {
   @property() value = "";
   @property({ type: Boolean }) disabled = false;
 
-  static styles = [espHomeStyles, componentTargetPickerStyles];
+  static styles = [espHomeStyles, textStyles, componentTargetPickerStyles];
 
   protected render() {
     const { plan, order } = this._plan();
@@ -116,7 +117,7 @@ export class ESPHomeComponentTargetPicker extends LitElement {
       tabindex=${tabbable ? "0" : "-1"}
       @click=${() => this._select(d.id)}
     >
-      <span class="component-choice-name">${instanceName(d)}</span>
+      <span class="component-choice-name truncate">${instanceName(d)}</span>
       <span class="component-domain">${d.component_id}</span>
     </div>`;
   }

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -18,6 +18,7 @@ import { apiContext, localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { loadMoreFooterStyles } from "../../styles/load-more-footer.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { textStyles } from "../../styles/text.js";
 import { debounce } from "../../util/debounce.js";
 import { isFeaturedId } from "../../util/featured-id.js";
 import { IntersectionController } from "../../util/intersection-controller.js";
@@ -240,6 +241,7 @@ export class ESPHomeComponentCatalog extends LitElement {
   static styles = [
     espHomeStyles,
     inputStyles,
+    textStyles,
     componentCatalogStyles,
     loadMoreFooterStyles,
   ];

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -88,7 +88,7 @@ export function renderBundleCard(
               </div>`
         }
         <div class="component-card-header-text">
-          <h3 class="component-title">${bundle.name}</h3>
+          <h3 class="component-title truncate">${bundle.name}</h3>
           ${renderRecommendedChip(
             `recommended-chip-bundle-${bundle.id}`,
             recommendedTooltip
@@ -104,7 +104,7 @@ export function renderBundleCard(
         bundle.description
           ? html`<p
               class="component-description ${
-                expanded ? "" : "component-description--clamp"
+                expanded ? "" : "component-description--clamp line-clamp-2"
               }"
               data-component-id=${expandKey}
             >
@@ -182,7 +182,7 @@ export function renderCard(
               </div>`
         }
         <div class="component-card-header-text">
-          <h3 class="component-title">${component.name}</h3>
+          <h3 class="component-title truncate">${component.name}</h3>
           ${
             featured
               ? renderRecommendedChip(
@@ -205,7 +205,7 @@ export function renderCard(
         ${expandable ? renderExpandButton(host, component.id) : nothing}
       </div>
       <p
-        class="component-description ${expanded ? "" : "component-description--clamp"}"
+        class="component-description ${expanded ? "" : "component-description--clamp line-clamp-2"}"
         data-component-id=${component.id}
       >
         ${renderMarkdown(component.description)}

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -274,9 +274,6 @@ export const componentCatalogStyles = css`
     font-weight: var(--wa-font-weight-bold);
     color: var(--wa-color-text-normal);
     line-height: 1.3;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   /* Category chip disambiguates same-name catalog entries (sensor.debug
@@ -319,13 +316,6 @@ export const componentCatalogStyles = css`
     font-size: var(--wa-font-size-2xs);
     color: var(--wa-color-text-quiet);
     line-height: 1.4;
-  }
-
-  .component-description--clamp {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
   }
 
   .card-footer {

--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -72,9 +72,6 @@ export const deviceEditorStyles = css`
     margin: 0;
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     min-width: 0;
   }
 
@@ -82,9 +79,6 @@ export const deviceEditorStyles = css`
     font-size: var(--wa-font-size-2xs);
     font-weight: var(--wa-font-weight-normal);
     color: var(--esphome-primary);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     min-width: 0;
     /* Yield before the device name when the header is tight; the
        filename is the secondary half of the title row. */

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -16,6 +16,7 @@ import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { expertModeContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { textStyles } from "../../styles/text.js";
 import {
   NO_INSTANCE_ERRORS,
   type InstanceBackendErrors,
@@ -270,7 +271,7 @@ export class ESPHomeDeviceEditor extends LitElement {
   @query("esphome-confirm-dialog.auto-fix-confirm")
   private _autoFixConfirmDialog?: ESPHomeConfirmDialog;
 
-  static styles = [espHomeStyles, deviceEditorStyles];
+  static styles = [espHomeStyles, textStyles, deviceEditorStyles];
 
   protected render() {
     // On mobile we collapse the split view down to a single pane to
@@ -307,10 +308,12 @@ export class ESPHomeDeviceEditor extends LitElement {
           <slot name="header-start"></slot>
           <div class="editor-header-main">
             <div class="editor-header-titlerow">
-              <h2 class="editor-header-title">${title}</h2>
+              <h2 class="editor-header-title truncate">${title}</h2>
               ${
                 this.configuration && !compactHeader
-                  ? html`<span class="editor-header-file">${this.configuration}</span>`
+                  ? html`<span class="editor-header-file truncate"
+                      >${this.configuration}</span
+                    >`
                   : nothing
               }
             </div>

--- a/src/components/device/device-navigator.styles.ts
+++ b/src/components/device/device-navigator.styles.ts
@@ -45,9 +45,6 @@ export const deviceNavigatorStyles = css`
        line-height 1 clipped the descender 'g' (#827) and left this header about
        0.4px shorter than the editor's, offsetting the divider by a pixel. */
     line-height: var(--wa-line-height-normal);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     min-width: 0;
   }
 
@@ -285,9 +282,6 @@ export const deviceNavigatorStyles = css`
     margin: 0;
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-semibold);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   .nav-item-subtitle {
@@ -296,9 +290,6 @@ export const deviceNavigatorStyles = css`
     font-weight: normal;
     margin: 0;
     line-height: 1.2;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   /* Error-count pill on a row (or a collapsed subgroup header) whose

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -17,6 +17,7 @@ import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, expertModeContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { textStyles } from "../../styles/text.js";
 import { subscribeAutomationCatalogCache } from "../../util/automation-catalog-cache.js";
 import { instanceKey } from "../../util/backend-field-errors.js";
 import {
@@ -228,7 +229,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
   @state()
   private _collapsedGroups = new Set<string>();
 
-  static styles = [espHomeStyles, deviceNavigatorStyles];
+  static styles = [espHomeStyles, textStyles, deviceNavigatorStyles];
 
   protected willUpdate(changedProperties: Map<string, unknown>) {
     // Fire on the edge that satisfies the gate — typically just
@@ -418,7 +419,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
           @automation-added=${this._onAutomationAdded}
         ></esphome-add-script-dialog>
         <header class="card-header">
-          <h2 class="card-title">${this._localize("device.navigator_title")}</h2>
+          <h2 class="card-title truncate">${this._localize("device.navigator_title")}</h2>
           <div class="header-actions">
             ${
               showSearchToggle

--- a/src/components/device/device-section-automation-list.styles.ts
+++ b/src/components/device/device-section-automation-list.styles.ts
@@ -102,9 +102,6 @@ export const deviceSectionAutomationListStyles = css`
     font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
     font-size: var(--wa-font-size-s);
     color: var(--wa-color-text-normal);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   .row-buttons {

--- a/src/components/device/device-section-automation-list.ts
+++ b/src/components/device/device-section-automation-list.ts
@@ -4,6 +4,7 @@ import { customElement, property } from "lit/decorators.js";
 
 import { emptyStateStyles } from "../../styles/empty-state.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { textStyles } from "../../styles/text.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { deviceSectionAutomationListStyles } from "./device-section-automation-list.styles.js";
 
@@ -39,7 +40,12 @@ export interface AutomationListRow {
  */
 @customElement("esphome-section-automation-list")
 export class ESPHomeSectionAutomationList extends LitElement {
-  static styles = [espHomeStyles, emptyStateStyles, deviceSectionAutomationListStyles];
+  static styles = [
+    espHomeStyles,
+    emptyStateStyles,
+    textStyles,
+    deviceSectionAutomationListStyles,
+  ];
 
   @property()
   heading = "";
@@ -91,7 +97,7 @@ export class ESPHomeSectionAutomationList extends LitElement {
               ${this.rows.map(
                 (row) =>
                   html`<li class="row">
-                    <span class="name">${row.label}</span>
+                    <span class="name truncate">${row.label}</span>
                     <div class="row-buttons">
                       <button
                         type="button"

--- a/src/components/device/navigator-render.ts
+++ b/src/components/device/navigator-render.ts
@@ -91,8 +91,12 @@ function renderNavRow(row: NavRow, v: NavSectionView, showIcon: boolean): Templa
     >
       ${showIcon ? renderRowGlyph(domain) : nothing}
       <div class="nav-item-content">
-        <p>${primary}</p>
-        ${secondary ? html`<span class="nav-item-subtitle">${secondary}</span>` : nothing}
+        <p class="truncate">${primary}</p>
+        ${
+          secondary
+            ? html`<span class="nav-item-subtitle truncate">${secondary}</span>`
+            : nothing
+        }
       </div>
       ${errors > 0 ? renderErrorBadge(errors, v) : nothing}
       <wa-icon class="nav-item-chevron" library="mdi" name="chevron-right"></wa-icon>

--- a/src/components/discovered-device-card.ts
+++ b/src/components/discovered-device-card.ts
@@ -6,6 +6,7 @@ import type { AdoptableDevice } from "../api/types/devices.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { textStyles } from "../styles/text.js";
 import { fireEvent } from "../util/fire-event.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { renderVisitWebUiLink } from "../util/visit-web-ui-link.js";
@@ -37,6 +38,7 @@ export class ESPHomeDiscoveredDeviceCard extends LitElement {
 
   static styles = [
     espHomeStyles,
+    textStyles,
     css`
       :host {
         display: block;
@@ -105,9 +107,6 @@ export class ESPHomeDiscoveredDeviceCard extends LitElement {
         font-size: var(--wa-font-size-m);
         font-weight: var(--wa-font-weight-bold);
         color: var(--wa-color-text-normal);
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
 
       .subtitle {
@@ -270,7 +269,7 @@ export class ESPHomeDiscoveredDeviceCard extends LitElement {
           }
         </span>
         <div class="header">
-          <h3 class="title">${title}</h3>
+          <h3 class="title truncate">${title}</h3>
           <div class="subtitle">
             ${
               showHostname

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -12,6 +12,7 @@ import {
 } from "../context/index.js";
 import { MOBILE_BREAKPOINT } from "../styles/breakpoints.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { textStyles } from "../styles/text.js";
 import { stripBase, withBase } from "../util/base-path.js";
 import { deviceBuilderChannel } from "../util/device-builder-channel.js";
 import { navigate, runLeaveGuard } from "../util/navigation.js";
@@ -107,6 +108,7 @@ export class ESPHomeLayout extends LitElement {
 
   static styles = [
     espHomeStyles,
+    textStyles,
     css`
       :host {
         display: block;
@@ -208,9 +210,6 @@ export class ESPHomeLayout extends LitElement {
         font-size: var(--wa-font-size-m);
         font-weight: var(--wa-font-weight-bold);
         color: var(--esphome-on-primary);
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         display: flex;
         align-items: center;
         gap: var(--wa-space-xs);
@@ -247,9 +246,6 @@ export class ESPHomeLayout extends LitElement {
         font-size: var(--wa-font-size-xs);
         color: var(--esphome-on-primary);
         opacity: 0.75;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
 
       .header-spacer {
@@ -390,7 +386,7 @@ export class ESPHomeLayout extends LitElement {
           </button>
         </div>
         <div class="header-text">
-          <h1>
+          <h1 class="truncate">
             <span class="header-title-text">${this._localize("dashboard.title")}</span>
             ${
               this._versionBadge
@@ -398,7 +394,7 @@ export class ESPHomeLayout extends LitElement {
                 : nothing
             }
           </h1>
-          <p>${this._localize("dashboard.subtitle")}</p>
+          <p class="truncate">${this._localize("dashboard.subtitle")}</p>
         </div>
         <div class="header-spacer"></div>
         <esphome-header-actions

--- a/src/components/filters/filter-section.styles.ts
+++ b/src/components/filters/filter-section.styles.ts
@@ -54,9 +54,6 @@ export const filterSectionStyles = css`
   .section-name {
     flex: 1;
     min-width: 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   /* Per-dimension active-selection count. Carries the signal the

--- a/src/components/filters/filter-section.ts
+++ b/src/components/filters/filter-section.ts
@@ -13,6 +13,7 @@ import { mdiCheck, mdiChevronDown, mdiMagnify } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { textStyles } from "../../styles/text.js";
 import type { FacetOption } from "../../util/facets.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { toggleSelection } from "../../util/toggle-selection.js";
@@ -65,7 +66,7 @@ export class ESPHomeFilterSection extends LitElement {
 
   @query(".facet-search-input") private _searchInputEl?: HTMLInputElement;
 
-  static styles = [espHomeStyles, filterStyles, filterSectionStyles];
+  static styles = [espHomeStyles, textStyles, filterStyles, filterSectionStyles];
 
   protected willUpdate(changed: Map<string, unknown>) {
     if (changed.has("expanded") && !this.expanded) this._query = "";
@@ -85,7 +86,7 @@ export class ESPHomeFilterSection extends LitElement {
         aria-expanded=${this.expanded ? "true" : "false"}
         @click=${this._onHeaderClick}
       >
-        <span class="section-name">${this.name}</span>
+        <span class="section-name truncate">${this.name}</span>
         ${
           this.selected.length > 0
             ? html`<span class="section-count" aria-hidden="true"
@@ -154,7 +155,7 @@ export class ESPHomeFilterSection extends LitElement {
                           : nothing
                       }
                     </span>
-                    <span class="facet-row-name">${option.name}</span>
+                    <span class="facet-row-name truncate">${option.name}</span>
                     ${
                       option.count >= 0
                         ? html`<span class="facet-row-count" aria-hidden="true"

--- a/src/components/filters/filter-styles.ts
+++ b/src/components/filters/filter-styles.ts
@@ -191,9 +191,6 @@ export const filterStyles = css`
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   .facet-row-count {

--- a/src/components/filters/filters-popover.ts
+++ b/src/components/filters/filters-popover.ts
@@ -15,6 +15,7 @@ import { mdiFilterVariant } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { textStyles } from "../../styles/text.js";
 import { LightDismissController } from "../../util/light-dismiss-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { filterStyles } from "./filter-styles.js";
@@ -65,7 +66,7 @@ export class ESPHomeFiltersPopover extends LitElement {
     },
   });
 
-  static styles = [espHomeStyles, filterStyles, filtersPopoverStyles];
+  static styles = [espHomeStyles, textStyles, filterStyles, filtersPopoverStyles];
 
   protected willUpdate(changed: Map<string, unknown>) {
     if (changed.has("_open")) this._dismiss.set(this._open);

--- a/src/components/filters/labels-filter-section.ts
+++ b/src/components/filters/labels-filter-section.ts
@@ -24,6 +24,7 @@ import type { Label } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { labelsContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { textStyles } from "../../styles/text.js";
 import { labelChipStyles } from "../../util/label-chip-template.js";
 import { labelChipStyleString } from "../../util/label-style.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -75,6 +76,7 @@ export class ESPHomeLabelsFilterSection extends LitElement {
 
   static styles = [
     espHomeStyles,
+    textStyles,
     filterStyles,
     filterSectionStyles,
     labelChipStyles,
@@ -89,7 +91,9 @@ export class ESPHomeLabelsFilterSection extends LitElement {
         aria-expanded=${this.expanded ? "true" : "false"}
         @click=${this._onHeaderClick}
       >
-        <span class="section-name">${this._localize("dashboard.filter_labels")}</span>
+        <span class="section-name truncate"
+          >${this._localize("dashboard.filter_labels")}</span
+        >
         ${
           this.selected.length > 0
             ? html`<span class="section-count" aria-hidden="true"
@@ -155,8 +159,8 @@ export class ESPHomeLabelsFilterSection extends LitElement {
         <span class="facet-row-check" aria-hidden="true">
           ${checked ? html`<wa-icon library="mdi" name="check"></wa-icon>` : nothing}
         </span>
-        <span class="facet-row-name">
-          <span class="label-chip" style=${labelChipStyleString(label.color)}
+        <span class="facet-row-name truncate">
+          <span class="label-chip truncate" style=${labelChipStyleString(label.color)}
             >${label.name}</span
           >
         </span>

--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -32,6 +32,7 @@ import {
 } from "../context/index.js";
 import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { textStyles } from "../styles/text.js";
 import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { getErrorMessage } from "../util/error-message.js";
 import { cancelFirmwareJob } from "../util/firmware-job-actions.js";
@@ -160,6 +161,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
   static styles = [
     espHomeStyles,
     primaryDialogHeaderStyles,
+    textStyles,
     firmwareJobsListStyles,
     firmwareJobsDialogStyles,
   ];

--- a/src/components/labels/bulk-labels-dialog.ts
+++ b/src/components/labels/bulk-labels-dialog.ts
@@ -36,6 +36,7 @@ import {
 import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
 import { dialogChromeStyles } from "../../styles/dialog-chrome.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { textStyles } from "../../styles/text.js";
 import { labelChipStyles, renderLabelChip } from "../../util/label-chip-template.js";
 import { notifyError, notifyInfo, notifySuccess } from "../../util/notify.js";
 import { setsEqual } from "../../util/set-equal.js";
@@ -275,6 +276,7 @@ export class ESPHomeBulkLabelsDialog extends LitElement {
 
   static styles = [
     espHomeStyles,
+    textStyles,
     labelChipStyles,
     labelsListStyles,
     dialogActionButtonStyles,

--- a/src/components/labels/device-labels-editor.ts
+++ b/src/components/labels/device-labels-editor.ts
@@ -36,6 +36,7 @@ import {
   quietCloseButtonStyles,
 } from "../../styles/dialog-chrome.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { textStyles } from "../../styles/text.js";
 import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import {
   labelChipStyles,
@@ -116,6 +117,7 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
 
   static styles = [
     espHomeStyles,
+    textStyles,
     labelChipStyles,
     labelsListStyles,
     // Neutral header + title + quiet close button (shared) — dialog-chrome.ts.
@@ -277,7 +279,7 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
         ${assigned.map(
           (label) =>
             html`<span
-              class="label-chip assigned-chip"
+              class="label-chip assigned-chip truncate"
               style=${labelChipStyleString(label.color)}
               title=${label.name}
               >${label.name}<button

--- a/src/components/labels/label-form.ts
+++ b/src/components/labels/label-form.ts
@@ -30,6 +30,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { textStyles } from "../../styles/text.js";
 import { labelChipStyles } from "../../util/label-chip-template.js";
 import {
   LABEL_COLOR_SWATCHES,
@@ -245,7 +246,13 @@ export class ESPHomeLabelForm extends LitElement {
       .filter((s) => s && !taken.has(s.toLowerCase()));
   }
 
-  static styles = [espHomeStyles, inputStyles, labelChipStyles, labelFormStyles];
+  static styles = [
+    espHomeStyles,
+    inputStyles,
+    textStyles,
+    labelChipStyles,
+    labelFormStyles,
+  ];
 
   /** Open the form programmatically. Hosts that drive the open
    *  state externally (e.g. seeding from a filter input) can call

--- a/src/components/logs-dialog.styles.ts
+++ b/src/components/logs-dialog.styles.ts
@@ -44,8 +44,6 @@ export const logsDialogStyles = css`
        (full value stays on the title tooltip). */
     flex-shrink: 0;
     max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
     padding: 1px 8px;
     border-radius: 999px;
     font-family: var(--term-mono-font);
@@ -54,7 +52,6 @@ export const logsDialogStyles = css`
     color: var(--esphome-on-primary);
     background: color-mix(in srgb, var(--esphome-on-primary) 16%, transparent);
     border: 1px solid color-mix(in srgb, var(--esphome-on-primary) 32%, transparent);
-    white-space: nowrap;
   }
   esphome-base-dialog::part(footer) {
     display: none;

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -20,6 +20,7 @@ import { apiContext, darkModeContext, localizeContext } from "../context/index.j
 import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { textStyles } from "../styles/text.js";
 import { type CrashKind, classifyLine } from "../util/crash-detector.js";
 import { normalizeLogLine } from "../util/log-line.js";
 import { initialDarkMode } from "../util/dark-mode.js";
@@ -172,6 +173,7 @@ export class ESPHomeLogsDialog extends LitElement {
     primaryDialogHeaderStyles,
     termTokens,
     termButtonStyles,
+    textStyles,
     logsDialogStyles,
     // Full-screen on mobile, terminal fills it.
     fullscreenMobileDialog("esphome-base-dialog"),
@@ -257,7 +259,9 @@ export class ESPHomeLogsDialog extends LitElement {
         @request-close=${this._onDialogRequestClose}
         @after-hide=${this._onDialogHide}
       >
-        <span slot="header-suffix" class="source-chip" title=${source}>${source}</span>
+        <span slot="header-suffix" class="source-chip truncate" title=${source}
+          >${source}</span
+        >
         <esphome-process-terminal
           .lines=${this._log.lines}
           placeholder=${this._localize("dashboard.logs_placeholder")}

--- a/src/components/mdi-icon-picker.styles.ts
+++ b/src/components/mdi-icon-picker.styles.ts
@@ -74,9 +74,6 @@ export const mdiIconPickerStyles = css`
   .trigger-label {
     flex: 1;
     min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     font-family: var(--wa-font-family-code, monospace);
     font-size: var(--wa-font-size-s);
   }

--- a/src/components/mdi-icon-picker.ts
+++ b/src/components/mdi-icon-picker.ts
@@ -13,6 +13,7 @@ import { mdiClose, mdiMagnify, mdiPalette } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { inputStyles } from "../styles/inputs.js";
+import { textStyles } from "../styles/text.js";
 import { LightDismissController } from "../util/light-dismiss-controller.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { mdiIconPickerStyles } from "./mdi-icon-picker.styles.js";
@@ -117,7 +118,7 @@ export class ESPHomeMdiIconPicker extends LitElement {
 
   @query(".search-input") private _searchInput?: HTMLInputElement;
 
-  static styles = [inputStyles, mdiIconPickerStyles];
+  static styles = [inputStyles, textStyles, mdiIconPickerStyles];
 
   protected willUpdate(changed: Map<string, unknown>) {
     if (changed.has("_open")) this._dismiss.set(this._open);
@@ -314,7 +315,9 @@ export class ESPHomeMdiIconPicker extends LitElement {
         @click=${this._toggle}
       >
         ${this._renderTriggerIcon()}
-        <span class=${name ? "trigger-label" : "trigger-label placeholder"}>
+        <span
+          class=${name ? "trigger-label truncate" : "trigger-label placeholder truncate"}
+        >
           ${name ? `mdi:${name}` : this.placeholder}
         </span>
         ${

--- a/src/components/options-combobox.styles.ts
+++ b/src/components/options-combobox.styles.ts
@@ -58,9 +58,6 @@ export const optionsComboboxStyles = css`
     font-size: var(--wa-font-size-s);
     color: var(--wa-color-text-normal);
     cursor: pointer;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   .option--active {

--- a/src/components/options-combobox.ts
+++ b/src/components/options-combobox.ts
@@ -14,6 +14,7 @@ import { mdiChevronDown } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { inputStyles } from "../styles/inputs.js";
+import { textStyles } from "../styles/text.js";
 import { renderOptionStack } from "../util/option-stack.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { buildOptionsComboboxChangeEvent } from "./options-combobox-event.js";
@@ -87,7 +88,7 @@ export class ESPHomeOptionsCombobox extends LitElement {
   @query(".option--active")
   private _activeOption?: HTMLElement;
 
-  static styles = [inputStyles, optionsComboboxStyles];
+  static styles = [inputStyles, textStyles, optionsComboboxStyles];
 
   protected render() {
     const filtered = this._filtered;
@@ -148,7 +149,7 @@ export class ESPHomeOptionsCombobox extends LitElement {
                   (opt, i) =>
                     html`<div
                       id="option-${i}"
-                      class="option ${i === this._active ? "option--active" : ""}"
+                      class="option truncate ${i === this._active ? "option--active" : ""}"
                       role="option"
                       aria-selected=${opt.value === this.value ? "true" : "false"}
                       @mousedown=${this._preventBlur}

--- a/src/components/remote-build-panel.ts
+++ b/src/components/remote-build-panel.ts
@@ -34,6 +34,7 @@ import { pairingAddressStyles } from "../styles/pairing-address.js";
 import { pairingWindowStyles } from "../styles/pairing-window.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { textStyles } from "../styles/text.js";
 import { cancelFirmwareJob } from "../util/firmware-job-actions.js";
 import { firmwareJobDisplayName } from "../util/firmware-job-display.js";
 import { notify } from "../util/notify.js";
@@ -164,6 +165,7 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
     pairingAddressStyles,
     pairingWindowStyles,
     peerRowStyles,
+    textStyles,
     firmwareJobsListStyles,
     stackBarStyles,
     remoteBuildPanelStyles,

--- a/src/components/shared/firmware-jobs-list-styles.ts
+++ b/src/components/shared/firmware-jobs-list-styles.ts
@@ -101,9 +101,6 @@ export const firmwareJobsListStyles = css`
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);
     color: var(--wa-color-text-normal);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   .job-meta {

--- a/src/components/shared/firmware-jobs-list.ts
+++ b/src/components/shared/firmware-jobs-list.ts
@@ -116,7 +116,7 @@ function renderJob(host: FirmwareJobsListHost, job: FirmwareJob): TemplateResult
         <wa-icon library="mdi" name=${typeIcon}></wa-icon>
       </div>
       <div class="job-content">
-        <div class="job-name">${name}</div>
+        <div class="job-name truncate">${name}</div>
         <div class="job-meta">
           <span>${typeLabel}</span>
           <span>•</span>

--- a/src/components/wizard/wizard-step-board-list.ts
+++ b/src/components/wizard/wizard-step-board-list.ts
@@ -210,9 +210,7 @@ export class ESPHomeWizardStepBoardList extends LitElement {
           </button>
         </div>
 
-        <p
-          class="board-description ${expanded ? "" : "board-description--clamp line-clamp-2"}"
-        >
+        <p class="board-description ${expanded ? "" : "line-clamp-2"}">
           ${renderMarkdown(board.description)}
         </p>
 

--- a/src/components/wizard/wizard-step-board-list.ts
+++ b/src/components/wizard/wizard-step-board-list.ts
@@ -6,6 +6,7 @@ import type { SlimBoard } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { loadMoreFooterStyles } from "../../styles/load-more-footer.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { textStyles } from "../../styles/text.js";
 import { boardImageUrl } from "../../util/board-image.js";
 import { IntersectionController } from "../../util/intersection-controller.js";
 import { renderMarkdown } from "../../util/markdown.js";
@@ -79,7 +80,12 @@ export class ESPHomeWizardStepBoardList extends LitElement {
     regular: boards.filter((b) => !b.featured),
   }));
 
-  static styles = [espHomeStyles, wizardStepBoardStyles, loadMoreFooterStyles];
+  static styles = [
+    espHomeStyles,
+    textStyles,
+    wizardStepBoardStyles,
+    loadMoreFooterStyles,
+  ];
 
   protected render() {
     const { featured, regular } = this._splitBoards(this.boards);
@@ -204,7 +210,9 @@ export class ESPHomeWizardStepBoardList extends LitElement {
           </button>
         </div>
 
-        <p class="board-description ${expanded ? "" : "board-description--clamp"}">
+        <p
+          class="board-description ${expanded ? "" : "board-description--clamp line-clamp-2"}"
+        >
           ${renderMarkdown(board.description)}
         </p>
 

--- a/src/components/wizard/wizard-step-board.styles.ts
+++ b/src/components/wizard/wizard-step-board.styles.ts
@@ -218,13 +218,6 @@ export const wizardStepBoardStyles = css`
     overflow-wrap: anywhere;
   }
 
-  .board-description--clamp {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-
   .tags {
     display: flex;
     flex-wrap: wrap;

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -9,6 +9,7 @@ import { ESPHOME_DOCS_BASE } from "../../common/docs.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { textStyles } from "../../styles/text.js";
 import { fetchBoard } from "../../util/board-body-cache.js";
 import { debounce } from "../../util/debounce.js";
 import { detectEnvironment, type DeploymentEnvironment } from "../../util/environment.js";
@@ -138,7 +139,13 @@ export class ESPHomeWizardStepBoard extends LitElement {
     );
   }
 
-  static styles = [espHomeStyles, inputStyles, linkButtonStyles, wizardStepBoardStyles];
+  static styles = [
+    espHomeStyles,
+    inputStyles,
+    linkButtonStyles,
+    textStyles,
+    wizardStepBoardStyles,
+  ];
 
   protected render() {
     if (this._view === "select-port") {

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -9,7 +9,6 @@ import { ESPHOME_DOCS_BASE } from "../../common/docs.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import { textStyles } from "../../styles/text.js";
 import { fetchBoard } from "../../util/board-body-cache.js";
 import { debounce } from "../../util/debounce.js";
 import { detectEnvironment, type DeploymentEnvironment } from "../../util/environment.js";
@@ -139,13 +138,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
     );
   }
 
-  static styles = [
-    espHomeStyles,
-    inputStyles,
-    linkButtonStyles,
-    textStyles,
-    wizardStepBoardStyles,
-  ];
+  static styles = [espHomeStyles, inputStyles, linkButtonStyles, wizardStepBoardStyles];
 
   protected render() {
     if (this._view === "select-port") {

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -105,6 +105,7 @@ import {
 } from "../context/index.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { textStyles } from "../styles/text.js";
 import { runBulkCompile, runBulkUpdate } from "../util/bulk-update.js";
 import {
   loadDashboardFilters,
@@ -340,6 +341,7 @@ export class ESPHomePageDashboard extends LitElement {
     dashboardStyles,
     stackBarStyles,
     dashboardStacksStyles,
+    textStyles,
     deviceGridStyles,
     yamlModeStyles,
     skeletonStyles,

--- a/src/styles/text.ts
+++ b/src/styles/text.ts
@@ -1,0 +1,17 @@
+import { css } from "lit";
+
+/** Text overflow helpers: single-line ellipsis and the 2-line clamp. */
+export const textStyles = css`
+  .truncate {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .line-clamp-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+`;

--- a/src/util/label-chip-template.ts
+++ b/src/util/label-chip-template.ts
@@ -59,6 +59,9 @@ export const labelChipStyles: CSSResult = css`
 
 /** Render a label chip.
  *
+ *  Hosts must compose ``textStyles`` alongside ``labelChipStyles``
+ *  (the chip's overflow handling is the shared ``.truncate`` class).
+ *
  *  ``options.suppressTitle`` lets a parent that owns its own
  *  row-level ``title`` attribute opt out of the chip's native
  *  tooltip; otherwise two tooltips fight for the same row (one

--- a/src/util/label-chip-template.ts
+++ b/src/util/label-chip-template.ts
@@ -33,10 +33,7 @@ export const labelChipStyles: CSSResult = css`
     font-weight: var(--wa-font-weight-bold);
     line-height: 1.4;
     border: var(--wa-border-width-s) solid transparent;
-    white-space: nowrap;
     max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   /* Overflow chip ("+N") — uses the neutral palette regardless of
@@ -72,7 +69,7 @@ export function renderLabelChip(
   options: { suppressTitle?: boolean } = {}
 ): TemplateResult {
   return html`<span
-    class="label-chip"
+    class="label-chip truncate"
     style=${labelChipStyleString(label.color)}
     title=${options.suppressTitle ? nothing : label.name}
     >${label.name}</span
@@ -102,7 +99,7 @@ export function renderLabelChips(
   const overflowTitle = hidden.map((l) => l.name).join(", ");
   return html`<span class="label-chips">
     ${visible.map((l) => renderLabelChip(l))}
-    <span class="label-chip label-chip--overflow" title=${overflowTitle}
+    <span class="label-chip label-chip--overflow truncate" title=${overflowTitle}
       >+${hidden.length}</span
     >
   </span>`;


### PR DESCRIPTION
# What does this implement/fix?

Adds `src/styles/text.ts` with `.truncate` (the single line ellipsis triad) and `.line-clamp-2` (the 2 line clamp block), then converts the 29 style blocks that hand rolled the triad and the 3 clamp blocks: the declarations come out of each block (everything else stays), the markup element gains the shared class, and each consumer component composes `textStyles`. Shared style modules keep their original single `css` export shape; composition happens at the consumers, so the diff is the real change, 53 files at +142/−160.

Deliberately skipped and unchanged: the `td` rule in dashboard/table-styles.ts (element selector, no class hook) and the five partial blocks that lack `white-space: nowrap` (table-cell `.cell-comment`, secret-picker trigger label, esphome-layout `.header-title-text`, select-bar `.count` and `.toggle`), where adding the full triad would change wrapping behavior. device-labels-editor's `.assigned-chip { overflow: visible }` override still wins over the shared class by stylesheet order, preserving its un-clipped focus ring.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1294

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
