### PR TITLE
Share the Web Awesome trio mock through a side-effect test module

### DIFF
--- a/test/_mock-webawesome.ts
+++ b/test/_mock-webawesome.ts
@@ -1,0 +1,10 @@
+import { vi } from "vitest";
+
+// Stubs the Web Awesome components every dialog test must mock (real ones
+// crash under happy-dom). Import this before any component import:
+//   import "../_mock-webawesome.js";
+// The vi.mock calls run when this module is evaluated, so they register
+// before later imports pull in the components.
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));

--- a/test/_mock-webawesome.ts
+++ b/test/_mock-webawesome.ts
@@ -1,7 +1,8 @@
 import { vi } from "vitest";
 
 // Stubs the Web Awesome components every dialog test must mock (real ones
-// crash under happy-dom). Import this before any component import:
+// crash under happy-dom). Import for side effect before any component
+// import, with the relative path matching the test's depth:
 //   import "../_mock-webawesome.js";
 // The vi.mock calls run when this module is evaluated, so they register
 // before later imports pull in the components.

--- a/test/components/crash-report-dialog.test.ts
+++ b/test/components/crash-report-dialog.test.ts
@@ -3,9 +3,8 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+import "../_mock-webawesome.js";
+
 vi.mock("sonner-js", () => ({
   default: { error: vi.fn(), success: vi.fn(), info: vi.fn(), warning: vi.fn() },
 }));

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -11,11 +11,10 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+import "../../_mock-webawesome.js";
+
 vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
 
 import type { ESPHomeAPI } from "../../../src/api/index.js";

--- a/test/components/device/add-component-dialog-bundle.test.ts
+++ b/test/components/device/add-component-dialog-bundle.test.ts
@@ -8,9 +8,8 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+import "../../_mock-webawesome.js";
+
 vi.mock("../../../src/components/device/add-component-form.js", () => ({}));
 vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
 vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -9,9 +9,8 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+import "../../_mock-webawesome.js";
+
 vi.mock("../../../src/components/device/add-component-form.js", () => ({}));
 vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
 vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));

--- a/test/components/device/add-component-dialog-draft.test.ts
+++ b/test/components/device/add-component-dialog-draft.test.ts
@@ -7,9 +7,8 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+import "../../_mock-webawesome.js";
+
 vi.mock("../../../src/components/device/add-component-form.js", () => ({}));
 vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
 

--- a/test/components/device/add-component-dialog-open-close.test.ts
+++ b/test/components/device/add-component-dialog-open-close.test.ts
@@ -10,9 +10,8 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+import "../../_mock-webawesome.js";
+
 vi.mock("../../../src/components/device/add-component-form.js", () => ({}));
 // Stub the catalog with the two methods open()/openWithSearch() call on it.
 vi.mock("../../../src/components/device/component-catalog.js", () => {

--- a/test/components/device/add-component-dialog-restore-values.test.ts
+++ b/test/components/device/add-component-dialog-restore-values.test.ts
@@ -8,9 +8,8 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+import "../../_mock-webawesome.js";
+
 vi.mock("../../../src/components/device/add-component-form.js", () => ({}));
 vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
 vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));

--- a/test/components/device/add-dialogs-enter.test.ts
+++ b/test/components/device/add-dialogs-enter.test.ts
@@ -9,11 +9,10 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+import "../../_mock-webawesome.js";
+
 vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
 
 import { LitElement } from "lit";

--- a/test/components/dialog-enter-submit.test.ts
+++ b/test/components/dialog-enter-submit.test.ts
@@ -11,9 +11,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+import "../_mock-webawesome.js";
 
 import type { LitElement } from "lit";
 import { ESPHomeBulkLabelsDialog } from "../../src/components/labels/bulk-labels-dialog.js";

--- a/test/components/install-method-dialog-bootloader.test.ts
+++ b/test/components/install-method-dialog-bootloader.test.ts
@@ -7,10 +7,9 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
+import "../_mock-webawesome.js";
+
 vi.mock("@home-assistant/webawesome/dist/components/callout/callout.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 
 import { DeviceState } from "../../src/api/types/devices.js";
 import { defaultLocalize } from "../../src/common/localize.js";

--- a/test/components/install-method-dialog-never-flashed.test.ts
+++ b/test/components/install-method-dialog-never-flashed.test.ts
@@ -7,10 +7,9 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import "../_mock-webawesome.js";
+
 vi.mock("@home-assistant/webawesome/dist/components/callout/callout.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 
 import { DeviceState } from "../../src/api/types/devices.js";
 import { ESPHomeInstallMethodDialog } from "../../src/components/install-method-dialog.js";

--- a/test/components/install-method-dialog-ota-submit-label.test.ts
+++ b/test/components/install-method-dialog-ota-submit-label.test.ts
@@ -8,10 +8,9 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import "../_mock-webawesome.js";
+
 vi.mock("@home-assistant/webawesome/dist/components/callout/callout.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 
 import { DeviceState } from "../../src/api/types/devices.js";
 import { defaultLocalize } from "../../src/common/localize.js";

--- a/test/components/install-method-dialog-port-poll.test.ts
+++ b/test/components/install-method-dialog-port-poll.test.ts
@@ -7,10 +7,9 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import "../_mock-webawesome.js";
+
 vi.mock("@home-assistant/webawesome/dist/components/callout/callout.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 
 import type { SerialPort } from "../../src/api/types/system.js";
 import { defaultLocalize } from "../../src/common/localize.js";

--- a/test/components/install-method-dialog-web-serial-availability.test.ts
+++ b/test/components/install-method-dialog-web-serial-availability.test.ts
@@ -8,10 +8,9 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import "../_mock-webawesome.js";
+
 vi.mock("@home-assistant/webawesome/dist/components/callout/callout.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 
 import { DeviceState } from "../../src/api/types/devices.js";
 import { defaultLocalize } from "../../src/common/localize.js";

--- a/test/components/install-method-dialog-web-serial-platform.test.ts
+++ b/test/components/install-method-dialog-web-serial-platform.test.ts
@@ -9,10 +9,9 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import "../_mock-webawesome.js";
+
 vi.mock("@home-assistant/webawesome/dist/components/callout/callout.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 
 import { DeviceState } from "../../src/api/types/devices.js";
 import { defaultLocalize } from "../../src/common/localize.js";

--- a/test/components/pair-build-server-dialog/open-orchestration.test.ts
+++ b/test/components/pair-build-server-dialog/open-orchestration.test.ts
@@ -8,9 +8,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+import "../../_mock-webawesome.js";
 
 import { ESPHomePairBuildServerDialog } from "../../../src/components/pair-build-server-dialog.js";
 import { identityLocalize } from "../../_dom.js";


### PR DESCRIPTION
# What does this implement/fix?

Adds `test/_mock-webawesome.ts`, a side effect module whose top level `vi.mock` calls stub the Web Awesome dialog, icon and spinner components; a test imports it before any component import and the mocks register before the components load. The sixteen files that stubbed exactly that trio now use the single import; files stubbing extra components keep those extra local mocks. Net −18 lines, 48 duplicated mock lines gone.

The mechanism was spiked before the sweep: with the local mocks deleted and no replacement, crash-report-dialog's run exits 1 with 44 unhandled rejections from the real WaButton crashing under happy-dom; with the helper import it exits 0. So the consolidation is provably load bearing, not cosmetic. A `setupFiles` blanket mock was rejected since some suites exercise real Web Awesome paths.

Part of #1298 (item 1, first tranche); the long tail of files stubbing other component sets can adopt the helper as they are touched.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder-frontend/issues/1298

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
