### PR TITLE
Convert the dialogs and settings area to fireEvent

### DIFF
--- a/src/components/accept-peer-dialog.ts
+++ b/src/components/accept-peer-dialog.ts
@@ -8,6 +8,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { fireEvent } from "../util/fire-event.js";
 import { formatPinSha256 } from "../util/pin-format.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import "./confirm-dialog.js";
@@ -241,24 +242,12 @@ export class ESPHomeAcceptPeerDialog extends LitElement {
 
   private _onAccept() {
     if (this.peer === null) return;
-    this.dispatchEvent(
-      new CustomEvent("confirm", {
-        detail: { dashboardId: this.peer.dashboard_id },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "confirm", { dashboardId: this.peer.dashboard_id });
   }
 
   private _onReject() {
     if (this.peer === null) return;
-    this.dispatchEvent(
-      new CustomEvent("reject", {
-        detail: { dashboardId: this.peer.dashboard_id },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "reject", { dashboardId: this.peer.dashboard_id });
   }
 }
 

--- a/src/components/edit-pairing-endpoint-dialog.ts
+++ b/src/components/edit-pairing-endpoint-dialog.ts
@@ -12,6 +12,7 @@ import { apiContext, localizeContext } from "../context/index.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { EnterController } from "../util/enter-controller.js";
+import { fireEvent } from "../util/fire-event.js";
 import {
   normalizeHostnameForCompare,
   parsePortInput,
@@ -149,17 +150,11 @@ export class ESPHomeEditPairingEndpointDialog extends LitElement {
       // event so this dialog doesn't have to write the
       // returned PairingSummary into state itself. Just
       // close.
-      this.dispatchEvent(
-        new CustomEvent("pairing-endpoint-edited", {
-          bubbles: true,
-          composed: true,
-          detail: {
-            pin_sha256: this._pinSha256,
-            hostname,
-            port,
-          },
-        })
-      );
+      fireEvent(this, "pairing-endpoint-edited", {
+        pin_sha256: this._pinSha256,
+        hostname,
+        port,
+      });
       this._open = false;
     } catch (err) {
       // Pass the values that actually went on the wire (trimmed

--- a/src/components/esphome-login.ts
+++ b/src/components/esphome-login.ts
@@ -13,6 +13,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { fireEvent } from "../util/fire-event.js";
 
 @customElement("esphome-login")
 export class ESPHomeLogin extends LitElement {
@@ -244,13 +245,10 @@ export class ESPHomeLogin extends LitElement {
     if (this.submitting) return;
     if (this.disconnected) return;
     if (this.rateLimitedUntil > Date.now()) return;
-    this.dispatchEvent(
-      new CustomEvent("submit-credentials", {
-        detail: { username: this._username, password: this._password },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "submit-credentials", {
+      username: this._username,
+      password: this._password,
+    });
   };
 }
 

--- a/src/components/guided-tour/esphome-guided-tour.ts
+++ b/src/components/guided-tour/esphome-guided-tour.ts
@@ -5,6 +5,7 @@ import { customElement, query, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { isTypingTarget } from "../../util/typing-target.js";
 import { guidedTourStyles } from "./esphome-guided-tour.styles.js";
@@ -494,7 +495,7 @@ export class ESPHomeGuidedTour extends LitElement {
 
   private _pause = (): void => {
     this._deactivate();
-    this.dispatchEvent(new CustomEvent("tour-paused", { bubbles: true, composed: true }));
+    fireEvent(this, "tour-paused");
   };
 
   private _deactivate(): void {
@@ -515,9 +516,7 @@ export class ESPHomeGuidedTour extends LitElement {
     clearTourConfiguration();
     clearTourPending();
     this._deactivate();
-    this.dispatchEvent(
-      new CustomEvent("tour-finished", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "tour-finished");
   }
 
   private _scheduleMeasure(): void {

--- a/src/components/labels/label-dialog.ts
+++ b/src/components/labels/label-dialog.ts
@@ -17,6 +17,7 @@ import {
   quietCloseButtonStyles,
 } from "../../styles/dialog-chrome.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { fireEvent } from "../../util/fire-event.js";
 import "../base-dialog.js";
 import "./label-form.js";
 
@@ -90,13 +91,11 @@ export class ESPHomeLabelDialog extends LitElement {
   }
 
   private _requestClose = () => {
-    this.dispatchEvent(
-      new CustomEvent("request-close", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "request-close");
   };
 
   private _onAfterHide = () => {
-    this.dispatchEvent(new CustomEvent("after-hide", { bubbles: true, composed: true }));
+    fireEvent(this, "after-hide");
   };
 }
 

--- a/src/components/reauth-wizard-dialog.ts
+++ b/src/components/reauth-wizard-dialog.ts
@@ -14,6 +14,7 @@ import {
 import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { fireEvent } from "../util/fire-event.js";
 import { friendlyHostname, trimTrailingDot } from "../util/hostname.js";
 import { pairingDisplayNameForPin } from "../util/pairing-display-name.js";
 import { formatPinSha256 } from "../util/pin-format.js";
@@ -285,13 +286,7 @@ export class ESPHomeReauthWizardDialog extends LitElement {
     outcome: "success" | "pin_changed",
     receiverLabel: string
   ): void {
-    this.dispatchEvent(
-      new CustomEvent("reauth-result", {
-        bubbles: true,
-        composed: true,
-        detail: { outcome, receiver_label: receiverLabel },
-      })
-    );
+    fireEvent(this, "reauth-result", { outcome, receiver_label: receiverLabel });
   }
 
   private _renderStep1(alert: OffloaderPinMismatchAlert) {

--- a/src/components/remote-build-hint.ts
+++ b/src/components/remote-build-hint.ts
@@ -1,6 +1,7 @@
 import { css, html, type TemplateResult } from "lit";
 import type { PairingSummary } from "../api/types/remote-build.js";
 import type { LocalizeFunc } from "../common/localize.js";
+import { fireEvent } from "../util/fire-event.js";
 import { splitTemplate } from "../util/template-split.js";
 
 /**
@@ -18,13 +19,7 @@ export function canResetBuildEnv(pairing: PairingSummary): boolean {
 
 /** Route *pin*'s confirm-then-follow remote reset to the firmware-jobs dialog. */
 export function requestResetPeerBuildEnv(el: HTMLElement, pin: string): void {
-  el.dispatchEvent(
-    new CustomEvent("open-reset-peer-build-env", {
-      detail: { pin_sha256: pin },
-      bubbles: true,
-      composed: true,
-    })
-  );
+  fireEvent(el, "open-reset-peer-build-env", { pin_sha256: pin });
 }
 
 // Visual boundary around the user-controlled receiver label inlined in the

--- a/src/components/rename-device-dialog.ts
+++ b/src/components/rename-device-dialog.ts
@@ -13,6 +13,7 @@ import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { validateDeviceName } from "../util/config-validation.js";
 import { DialogOpenController } from "../util/dialog-open-controller.js";
+import { fireEvent } from "../util/fire-event.js";
 import { deviceNameValidity, renderDeviceNameField } from "./shared/device-name-field.js";
 
 import "./base-dialog.js";
@@ -118,13 +119,7 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
     if (validateDeviceName(newName)) return;
     this._resolved = true;
     this.close();
-    this.dispatchEvent(
-      new CustomEvent("rename-confirm", {
-        detail: newName,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "rename-confirm", newName);
   };
 }
 

--- a/src/components/secrets/secrets-structured-editor.ts
+++ b/src/components/secrets/secrets-structured-editor.ts
@@ -15,6 +15,7 @@ import { inputStyles } from "../../styles/inputs.js";
 import { modalDialogStyles } from "../../styles/modal-dialog.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { withBase } from "../../util/base-path.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { navigate } from "../../util/navigation.js";
 import { notifyError } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -395,9 +396,7 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
     // misattribute to whatever row now sits at that line; clear it.
     this._keyError = null;
     this.value = value;
-    this.dispatchEvent(
-      new CustomEvent("yaml-change", { detail: { value }, bubbles: true, composed: true })
-    );
+    fireEvent(this, "yaml-change", { value });
   }
 }
 

--- a/src/components/settings-dialog/appearance-section.ts
+++ b/src/components/settings-dialog/appearance-section.ts
@@ -22,6 +22,7 @@ import { disclosureStyles } from "../../styles/disclosure.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { storedTheme } from "../../util/dark-mode.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { renderDisclosure } from "../shared/disclosure.js";
 import {
@@ -225,53 +226,23 @@ export class ESPHomeSettingsAppearance extends LitElement {
   private _onChange(e: Event) {
     const theme = (e.target as HTMLSelectElement).value;
     this._theme = theme;
-    this.dispatchEvent(
-      new CustomEvent("set-theme", {
-        detail: theme,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "set-theme", theme);
   }
 
   private _onToggleExpertMode() {
-    this.dispatchEvent(
-      new CustomEvent("set-expert-mode", {
-        detail: !this._expertMode,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "set-expert-mode", !this._expertMode);
   }
 
   private _onToggleRemoteCompute() {
-    this.dispatchEvent(
-      new CustomEvent("set-remote-compute-only", {
-        detail: !this._remoteComputeOnly,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "set-remote-compute-only", !this._remoteComputeOnly);
   }
 
   private _onToggleHideDeviceBuilder() {
-    this.dispatchEvent(
-      new CustomEvent("set-hide-device-builder", {
-        detail: !this._hideDeviceBuilder,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "set-hide-device-builder", !this._hideDeviceBuilder);
   }
 
   private _onToggleVersionHistory() {
-    this.dispatchEvent(
-      new CustomEvent("set-version-history-enabled", {
-        detail: !this._versionHistoryEnabled,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "set-version-history-enabled", !this._versionHistoryEnabled);
   }
 }
 

--- a/src/components/settings-dialog/build-offload-advanced.ts
+++ b/src/components/settings-dialog/build-offload-advanced.ts
@@ -8,6 +8,7 @@ import {
   offloaderIncludeLocalInPoolContext,
 } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { renderToggleRow } from "./settings-rows.js";
 import { settingsRowStyles, settingsSharedStyles } from "./shared-styles.js";
 
@@ -44,13 +45,7 @@ export class ESPHomeSettingsBuildOffloadAdvanced extends LitElement {
 
   private _onToggleIncludeLocal = () => {
     if (this._includeLocalInPool === null) return;
-    this.dispatchEvent(
-      new CustomEvent("set-offloader-include-local", {
-        detail: !this._includeLocalInPool,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "set-offloader-include-local", !this._includeLocalInPool);
   };
 }
 

--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -24,6 +24,7 @@ import {
 } from "../../context/index.js";
 import { peerRowStyles } from "../../styles/peer-rows.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { normalizeHostnameForCompare, trimTrailingDot } from "../../util/hostname.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import {
@@ -374,34 +375,19 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
     if (!_VERSION_MATCH_POLICIES.includes(raw as VersionMatchPolicy)) return;
     const policy = raw as VersionMatchPolicy;
     if (policy === this._versionMatchPolicy) return;
-    this.dispatchEvent(
-      new CustomEvent("set-offloader-version-match-policy", {
-        detail: policy,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "set-offloader-version-match-policy", policy);
   };
 
   private _onToggleRemoteBuilds = () => {
     if (this._remoteBuildsEnabled === null) return;
-    this.dispatchEvent(
-      new CustomEvent("set-offloader-remote-builds-enabled", {
-        detail: !this._remoteBuildsEnabled,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "set-offloader-remote-builds-enabled", !this._remoteBuildsEnabled);
   };
 
   private _onTogglePairingEnabled = (pairing: PairingSummary) => {
-    this.dispatchEvent(
-      new CustomEvent("set-offloader-pairing-enabled", {
-        detail: { pin_sha256: pairing.pin_sha256, enabled: !pairing.enabled },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "set-offloader-pairing-enabled", {
+      pin_sha256: pairing.pin_sha256,
+      enabled: !pairing.enabled,
+    });
   };
 
   private _onPairClick = (): void => {

--- a/src/components/settings-dialog/build-server-section.ts
+++ b/src/components/settings-dialog/build-server-section.ts
@@ -27,6 +27,7 @@ import { peerRowStyles } from "../../styles/peer-rows.js";
 import { pinHexStyles } from "../../styles/pin-hex.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { copyToClipboard } from "../../util/copy-to-clipboard.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { pairingAddress } from "../../util/pairing-address.js";
 import { renderPairingAddress } from "../shared/pairing-address.js";
 import { formatPinSha256 } from "../../util/pin-format.js";
@@ -391,13 +392,7 @@ export class ESPHomeSettingsBuildServer extends LitElement {
   }
 
   private _onToggleEnabled() {
-    this.dispatchEvent(
-      new CustomEvent("set-remote-build-enabled", {
-        detail: !this._remoteBuildEnabled,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "set-remote-build-enabled", !this._remoteBuildEnabled);
     return nothing;
   }
 

--- a/src/components/settings-dialog/language-section.ts
+++ b/src/components/settings-dialog/language-section.ts
@@ -12,6 +12,7 @@ import { LANGUAGES, languageLabel, readStoredLocale } from "../../common/localiz
 import { localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { settingsRowStyles, settingsSharedStyles } from "./shared-styles.js";
 
@@ -129,13 +130,7 @@ export class ESPHomeSettingsLanguage extends LitElement {
   private _onChange(e: Event) {
     const lang = (e.target as HTMLSelectElement).value as LanguageChoice;
     this._language = lang;
-    this.dispatchEvent(
-      new CustomEvent("set-language", {
-        detail: lang,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "set-language", lang);
   }
 }
 

--- a/src/components/unsaved-changes-dialog.ts
+++ b/src/components/unsaved-changes-dialog.ts
@@ -6,6 +6,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { DialogOpenController } from "../util/dialog-open-controller.js";
+import { fireEvent } from "../util/fire-event.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -204,20 +205,20 @@ export class ESPHomeUnsavedChangesDialog extends LitElement {
   private _onDiscard() {
     this._resolved = true;
     this.close();
-    this.dispatchEvent(new CustomEvent("discard", { bubbles: true, composed: true }));
+    fireEvent(this, "discard");
   }
 
   private _onSave() {
     if (this._resolved) return; // a repeated Enter must not dispatch twice
     this._resolved = true;
     this.close();
-    this.dispatchEvent(new CustomEvent("save", { bubbles: true, composed: true }));
+    fireEvent(this, "save");
   }
 
   private _onAfterHide() {
     this._dialog.open = false;
     if (!this._resolved) {
-      this.dispatchEvent(new CustomEvent("cancel", { bubbles: true, composed: true }));
+      fireEvent(this, "cancel");
     }
   }
 }

--- a/src/components/yaml-validation-dialog.ts
+++ b/src/components/yaml-validation-dialog.ts
@@ -7,6 +7,7 @@ import { localizeContext } from "../context/index.js";
 import { modalDialogStyles } from "../styles/modal-dialog.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { DialogOpenController } from "../util/dialog-open-controller.js";
+import { fireEvent } from "../util/fire-event.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -189,25 +190,19 @@ export class ESPHomeYamlValidationDialog extends LitElement {
     if (this._resolvedExit !== null) return; // a repeated Enter must not dispatch twice
     this._resolvedExit = "goto";
     this.close();
-    this.dispatchEvent(
-      new CustomEvent("goto", {
-        detail: { line: this.firstErrorLine, col: this.firstErrorCol },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "goto", { line: this.firstErrorLine, col: this.firstErrorCol });
   }
 
   private _saveAnyway() {
     this._resolvedExit = "save-anyway";
     this.close();
-    this.dispatchEvent(new CustomEvent("save-anyway", { bubbles: true, composed: true }));
+    fireEvent(this, "save-anyway");
   }
 
   private _onAfterHide() {
     this._dialog.open = false;
     if (this._resolvedExit === null) {
-      this.dispatchEvent(new CustomEvent("cancel", { bubbles: true, composed: true }));
+      fireEvent(this, "cancel");
     }
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

First conversion tranche for the `fireEvent` helper: the settings, labels, secrets and misc dialog area. Twenty nine untyped `dispatchEvent(new CustomEvent(name, { bubbles: true, composed: true, detail? }))` sites across sixteen files become `fireEvent(this, name, detail?)`, net −98 lines.

Per the #1302 rules, nine sites in the area were deliberately kept inline: typed `CustomEvent<T>` constructions (build-server-section, pair-build-server-dialog actions, reauth-wizard, friendly-name, clone) where the generic is load bearing; confirm-dialog's three bubbles-only non-composed events; and guided-tour's plain `window.dispatchEvent(new Event(...))`. The dashboard, device editor, automation editor and wizard areas follow in later tranches once the open style PRs land, so this one shares no files with them.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder-frontend/issues/1302

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
