### PR TITLE
Convert the editor and install area to fireEvent

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -37,6 +37,7 @@ import { linkButtonStyles } from "../styles/link-button.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { configurationStem, downloadAnsiText } from "../util/download-text.js";
+import { fireEvent } from "../util/fire-event.js";
 import { LightDismissController } from "../util/light-dismiss-controller.js";
 import { LogBuffer } from "../util/log-buffer.js";
 import { dispatchShowLogsAfterInstall } from "../util/post-install-logs.js";
@@ -370,13 +371,7 @@ export class ESPHomeCommandDialog extends LitElement {
   // faster machine. The build keeps running in the background queue.
   _tryOpenBuildOffloadSettings = () => {
     this.close();
-    this.dispatchEvent(
-      new CustomEvent("open-settings", {
-        detail: { section: "build_offload" },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "open-settings", { section: "build_offload" });
   };
 
   // Reopen without clearing line buffer / status. Used by logs-dialog's
@@ -425,9 +420,7 @@ export class ESPHomeCommandDialog extends LitElement {
     // Closing frees the user to interact with the firmware-tasks list;
     // follow_job will reattach if they click back into this device's job.
     this.close();
-    this.dispatchEvent(
-      new CustomEvent("open-firmware-jobs", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "open-firmware-jobs");
   };
 
   // Close + navigate to /device/<config>. Device page just closes (user
@@ -436,13 +429,7 @@ export class ESPHomeCommandDialog extends LitElement {
     const configuration = this.configuration;
     this.close();
     if (!configuration) return;
-    this.dispatchEvent(
-      new CustomEvent("request-open-editor", {
-        detail: { configuration },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "request-open-editor", { configuration });
   };
 
   // Per-device clean: same dialog instance, same configuration. Non-
@@ -451,9 +438,7 @@ export class ESPHomeCommandDialog extends LitElement {
 
   _tryResetBuildEnv = () => {
     this.close();
-    this.dispatchEvent(
-      new CustomEvent("open-reset-build-env", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "open-reset-build-env");
   };
 
   _tryResetRemoteBuildEnv = (pin: string) => {

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -14,6 +14,7 @@ import type { BusPrefill } from "../../util/bus-constraint-prefill.js";
 import { collectExistingIds } from "../../util/default-component-id.js";
 import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import { buildFeaturedId, isFeaturedId } from "../../util/featured-id.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { formatApiError } from "../../util/format-api-error.js";
 import { notifyError, notifySuccess } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -669,9 +670,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
 
   /** Surface the merged YAML as an unsaved editor draft (host saves explicitly). */
   private _dispatchDraft(yaml: string) {
-    this.dispatchEvent(
-      new CustomEvent("yaml-draft", { detail: { yaml }, bubbles: true, composed: true })
-    );
+    fireEvent(this, "yaml-draft", { yaml });
   }
 
   /**
@@ -856,13 +855,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
           typeof newId === "string" ? newId : undefined
         );
         if (target) {
-          this.dispatchEvent(
-            new CustomEvent("section-select", {
-              detail: target,
-              bubbles: true,
-              composed: true,
-            })
-          );
+          fireEvent(this, "section-select", target);
         }
         this._dialog.open = false;
         this._selected = null;

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -42,6 +42,7 @@ import { isEntryVisible, type ValidationError } from "../../util/config-validati
 import { resolveDeviceName } from "../../util/device-name.js";
 import { getErrorMessage } from "../../util/error-message.js";
 import { fetchAllComponents } from "../../util/fetch-all-components.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { getIn, isPrimitiveOrNullish } from "../../util/nested-values.js";
 import {
   fetchPinRegistryModes,
@@ -608,13 +609,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
   }
 
   private _emitAdvancedToggle(show: boolean) {
-    this.dispatchEvent(
-      new CustomEvent("advanced-toggle", {
-        detail: { show },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "advanced-toggle", { show });
   }
 
   /** Fallback banner for *unsatisfied* constraint groups that aren't visually
@@ -1163,13 +1158,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
    * it at a higher level and opens the dialog from scratch.
    */
   private _requestAddComponent(domain: string) {
-    this.dispatchEvent(
-      new CustomEvent("request-add-component", {
-        detail: { domain },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "request-add-component", { domain });
   }
 
   /**

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -20,6 +20,7 @@ import {
   type InstanceBackendErrors,
 } from "../../util/backend-field-errors.js";
 import { boardImageUrl, onBoardImageError } from "../../util/board-image.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import type { ESPHomeAddAutomationDialog } from "./add-automation-dialog.js";
@@ -257,13 +258,7 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
   /** Re-emit the picker's selection as a page-level `change-board`. */
   private _onSelectBoard = (e: CustomEvent<{ boardId: string }>) => {
     e.stopPropagation();
-    this.dispatchEvent(
-      new CustomEvent("change-board", {
-        detail: e.detail,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "change-board", e.detail);
   };
 
   static styles = [espHomeStyles, deviceBoardInfoStyles];
@@ -487,13 +482,7 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
    * page's state shape from in here.
    */
   private _onShowNavSection(section: NavSectionName) {
-    this.dispatchEvent(
-      new CustomEvent("nav-section-show", {
-        detail: { section },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "nav-section-show", { section });
   }
 
   /**
@@ -537,21 +526,11 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
   }
 
   private _onDismissWelcome() {
-    this.dispatchEvent(
-      new CustomEvent("just-created-dismiss", {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "just-created-dismiss");
   }
 
   private _onWelcomeInstall() {
-    this.dispatchEvent(
-      new CustomEvent("request-install", {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "request-install");
   }
 }
 

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -25,6 +25,7 @@ import {
 import { defaultBoardImageUrl, onBoardImageError } from "../../util/board-image.js";
 import { pathIsAdvanced } from "../../util/config-entry-tree.js";
 import type { ValidationError } from "../../util/config-validation.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { formatApiError } from "../../util/format-api-error.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { notifyError } from "../../util/notify.js";
@@ -342,13 +343,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     // Announce so the page-level navigation guard (device.ts) can hold a
     // direct ref. The tree is page → device-editor → device-board-info → us;
     // a property passthrough chain would cost three edits per API change.
-    this.dispatchEvent(
-      new CustomEvent("section-mount", {
-        detail: { node: this },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "section-mount", { node: this });
   }
 
   disconnectedCallback() {
@@ -357,13 +352,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
       clearTimeout(this._draftTimer);
       this._draftTimer = null;
     }
-    this.dispatchEvent(
-      new CustomEvent("section-unmount", {
-        detail: { node: this },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "section-unmount", { node: this });
   }
 
   // Flush pending draft sync now. The page calls this before save / section
@@ -397,13 +386,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
   _setDirty(value: boolean): void {
     if (this._dirty === value) return;
     this._dirty = value;
-    this.dispatchEvent(
-      new CustomEvent("dirty-change", {
-        detail: { dirty: value },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "dirty-change", { dirty: value });
   }
 
   _scheduleDraftFlush() {
@@ -415,9 +398,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
   }
 
   private _onShowYamlEditor() {
-    this.dispatchEvent(
-      new CustomEvent("show-yaml-editor", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "show-yaml-editor");
   }
 
   private _onValueChange = (e: CustomEvent<ConfigEntryValueChange>) =>

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -1,4 +1,5 @@
 import { validateEntries } from "../../../util/config-validation.js";
+import { fireEvent } from "../../../util/fire-event.js";
 import { formatApiError } from "../../../util/format-api-error.js";
 import { setIn } from "../../../util/nested-values.js";
 import { notifySuccess } from "../../../util/notify.js";
@@ -57,13 +58,7 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): void {
   if (newYaml === host.yaml) return;
 
   host._lastSelfWrittenYaml = newYaml;
-  host.dispatchEvent(
-    new CustomEvent("yaml-draft", {
-      detail: { yaml: newYaml },
-      bubbles: true,
-      composed: true,
-    })
-  );
+  fireEvent(host, "yaml-draft", { yaml: newYaml });
 }
 
 export function onValueChange(
@@ -124,20 +119,8 @@ export async function onDeleteConfirmed(host: ESPHomeDeviceSectionConfig): Promi
     }
     await host._api.updateConfig(host.configuration, newYaml);
     host._setDirty(false);
-    host.dispatchEvent(
-      new CustomEvent("yaml-updated", {
-        detail: { yaml: newYaml },
-        bubbles: true,
-        composed: true,
-      })
-    );
-    host.dispatchEvent(
-      new CustomEvent("section-select", {
-        detail: { sectionKey: null },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(host, "yaml-updated", { yaml: newYaml });
+    fireEvent(host, "section-select", { sectionKey: null });
     notifySuccess(host._localize("device.section_deleted", { name: title }));
   } catch (e) {
     host._error = formatApiError(e, host._localize, "device.section_delete_error");

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -32,6 +32,7 @@ import {
 } from "../context/index.js";
 import { dropdownMenuStyles } from "../styles/dropdown-menu.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { fireEvent } from "../util/fire-event.js";
 import { navigate } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { OPEN_COMMAND_PALETTE_EVENT } from "./command-palette-actions.js";
@@ -394,42 +395,22 @@ export class ESPHomeHeaderActions extends OverflowMenuElement {
    *  hand-editing ``secrets.yaml``. */
   private _openOnboarding() {
     this._close();
-    this.dispatchEvent(
-      new CustomEvent("open-onboarding-wifi", {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "open-onboarding-wifi");
   }
 
   private _openFirmwareJobs() {
     this._close();
-    this.dispatchEvent(
-      new CustomEvent("open-firmware-jobs", {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "open-firmware-jobs");
   }
 
   private _openResetBuildEnv() {
     this._close();
-    this.dispatchEvent(
-      new CustomEvent("open-reset-build-env", {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "open-reset-build-env");
   }
 
   private _openSettings() {
     this._close();
-    this.dispatchEvent(
-      new CustomEvent("open-settings", {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "open-settings");
   }
 
   private _openSearch() {
@@ -439,12 +420,7 @@ export class ESPHomeHeaderActions extends OverflowMenuElement {
 
   private _openGuidedTour() {
     this._close();
-    this.dispatchEvent(
-      new CustomEvent("open-guided-tour", {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "open-guided-tour");
   }
 
   private _offloaderAlertsCount(): number {
@@ -453,22 +429,12 @@ export class ESPHomeHeaderActions extends OverflowMenuElement {
 
   private _openFeedback() {
     this._close();
-    this.dispatchEvent(
-      new CustomEvent("open-feedback", {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "open-feedback");
   }
 
   private _openCheckForUpdates() {
     this._close();
-    this.dispatchEvent(
-      new CustomEvent("open-check-updates", {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "open-check-updates");
   }
 }
 

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -29,6 +29,7 @@ import {
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { initialDarkMode } from "../util/dark-mode.js";
+import { fireEvent } from "../util/fire-event.js";
 import { LogBuffer } from "../util/log-buffer.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { RunTimerController } from "../util/run-timer-controller.js";
@@ -337,13 +338,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   _tryOpenBuildOffloadSettings = () => {
     this._detachStream({ cancelJob: false });
     this._close();
-    this.dispatchEvent(
-      new CustomEvent("open-settings", {
-        detail: { section: "build_offload" },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "open-settings", { section: "build_offload" });
   };
 
   // Drop into red error state. detail is optional — render skips it entirely
@@ -363,13 +358,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     const device = this._device;
     this._close();
     if (!device) return;
-    this.dispatchEvent(
-      new CustomEvent("request-open-editor", {
-        detail: { configuration: device.configuration },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "request-open-editor", { configuration: device.configuration });
   };
 
   // Chip-mismatch recovery: close and hand off to the host page's board
@@ -379,13 +368,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     const device = this._device;
     this._close();
     if (!device) return;
-    this.dispatchEvent(
-      new CustomEvent("request-change-board", {
-        detail: { configuration: device.configuration },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "request-change-board", { configuration: device.configuration });
   };
 
   // Per-device clean: dashboard routes through command-dialog's clean flow.
@@ -393,20 +376,12 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     const device = this._device;
     this._close();
     if (!device) return;
-    this.dispatchEvent(
-      new CustomEvent("clean-build", {
-        detail: device,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "clean-build", device);
   };
 
   _tryResetBuildEnv = () => {
     this._close();
-    this.dispatchEvent(
-      new CustomEvent("open-reset-build-env", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "open-reset-build-env");
   };
 
   _tryResetRemoteBuildEnv = (pin: string) => {
@@ -473,7 +448,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     // _detachStream already clears _jobId (and cancels the backend job +
     // settles any pending compile promise) — no need to clear it here.
     this._detachStream();
-    this.dispatchEvent(new CustomEvent("close", { bubbles: true, composed: true }));
+    fireEvent(this, "close");
   };
 
   // Flip _open the moment a close is requested (X / Escape / outside-click) so

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -28,6 +28,7 @@ import { serialPortHintStyles } from "../styles/serial-port-hints.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { detectEnvironment, type DeploymentEnvironment } from "../util/environment.js";
 import { isEsptoolPlatform } from "../util/esptool-platform.js";
+import { fireEvent } from "../util/fire-event.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { SerialPortsPollController } from "../util/serial-ports-poll-controller.js";
 import {
@@ -499,27 +500,15 @@ export class ESPHomeInstallMethodDialog extends LitElement {
   }
 
   private _selectMethod(method: string, port?: string) {
-    this.dispatchEvent(
-      new CustomEvent("select-method", {
-        detail: port ? { method, port } : { method },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "select-method", port ? { method, port } : { method });
   }
 
   private _selectPort(port: string) {
-    this.dispatchEvent(
-      new CustomEvent("select-method", {
-        detail: { method: "server-serial", port },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "select-method", { method: "server-serial", port });
   }
 
   private _onClose() {
-    this.dispatchEvent(new CustomEvent("close", { bubbles: true, composed: true }));
+    fireEvent(this, "close");
   }
 }
 

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -28,6 +28,7 @@ import {
 import { initialDarkMode } from "../util/dark-mode.js";
 import { editorSearchPhrases } from "../util/editor-search-phrases.js";
 import { ESPHOME_YAML_INDENT, esphomeYaml } from "../util/esphome-yaml-lang.js";
+import { fireEvent } from "../util/fire-event.js";
 import { idleCompletion } from "../util/idle-completion.js";
 import { createYamlCompletionSource } from "../util/yaml-completion.js";
 import { cursorKeyPathAt, indexedKeyPathAt } from "../util/yaml-cursor-paths.js";
@@ -430,13 +431,7 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
         const completionOpen = completionStatus(update.state) === "active";
         if (completionOpen !== this._lastCompletionOpen) {
           this._lastCompletionOpen = completionOpen;
-          this.dispatchEvent(
-            new CustomEvent("yaml-completion-open", {
-              detail: { open: completionOpen },
-              bubbles: true,
-              composed: true,
-            })
-          );
+          fireEvent(this, "yaml-completion-open", { open: completionOpen });
         }
         // LOAD-BEARING ORDER: `yaml-change` MUST be dispatched
         // before `yaml-cursor-line` within a single update.
@@ -452,13 +447,7 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
         // `pages/device.ts:_onYamlCursorLine` for the
         // matching mention of this invariant.)
         if (update.docChanged) {
-          this.dispatchEvent(
-            new CustomEvent("yaml-change", {
-              detail: { value: update.state.doc.toString() },
-              bubbles: true,
-              composed: true,
-            })
-          );
+          fireEvent(this, "yaml-change", { value: update.state.doc.toString() });
           // A hand edit invalidates a block highlight: the stored
           // range is a static line snapshot and the mark decoration
           // only position-maps, so lines typed inside the section
@@ -475,9 +464,7 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
               (tr) => tr.docChanged && tr.annotation(Transaction.userEvent) !== undefined
             )
           ) {
-            this.dispatchEvent(
-              new CustomEvent("yaml-user-edit", { bubbles: true, composed: true })
-            );
+            fireEvent(this, "yaml-user-edit");
           }
         }
         // Cursor moved (click, arrow keys, find-jump) or a user edit
@@ -509,20 +496,14 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
           ) {
             this._lastReportedCursorLine = line;
             this._lastReportedPathKey = pathKey;
-            this.dispatchEvent(
-              new CustomEvent("yaml-cursor-line", {
-                detail: {
-                  line,
-                  path,
-                  // AST-only sibling of ``path`` carrying block-sequence
-                  // list indices — what the automation editor needs to
-                  // resolve a node inside a handler body.
-                  indexedPath: indexedKeyPathAt(update.state, head),
-                },
-                bubbles: true,
-                composed: true,
-              })
-            );
+            fireEvent(this, "yaml-cursor-line", {
+              line,
+              path,
+              // AST-only sibling of ``path`` carrying block-sequence
+              // list indices — what the automation editor needs to
+              // resolve a node inside a handler body.
+              indexedPath: indexedKeyPathAt(update.state, head),
+            });
           }
         }
       }),
@@ -723,13 +704,7 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
     // or the host would hold the invalid banner forever.
     if (this._lastCompletionOpen) {
       this._lastCompletionOpen = false;
-      this.dispatchEvent(
-        new CustomEvent("yaml-completion-open", {
-          detail: { open: false },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      fireEvent(this, "yaml-completion-open", { open: false });
     }
     this._mountEditor();
   }


### PR DESCRIPTION
# What does this implement/fix?

Second `fireEvent` conversion tranche: the editor and install area. Forty untyped `dispatchEvent(new CustomEvent(name, { bubbles: true, composed: true, detail? }))` sites across ten files become `fireEvent(...)`: yaml-editor, esphome-header-actions, firmware-install-dialog, command-dialog, install-method-dialog, device-board-info, config-entry-form, add-component-dialog, device-section-config and its draft-and-delete module. Net −185 lines; detail object shapes and their inline comments carry over unchanged.

Twenty one sites in the area stay inline per the #1302 rules: typed `CustomEvent<T>` constructions (yaml-diagnostics, yaml-auto-fix, value-change, section-select and friends), header-actions' plain `window.dispatchEvent(new Event(...))` calls, and post-install-logs' cancelable event whose return value is consumed. The dashboard, wizard and automation editor areas remain for the final tranche once the open truncation PR lands, so this one shares no files with it.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder-frontend/issues/1302

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
