### PR TITLE
Convert the remaining eligible dispatch sites to fireEvent

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -15,6 +15,7 @@ import { espHomeStyles } from "../styles/shared.js";
 import { validateDeviceName } from "../util/config-validation.js";
 import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { EnterController } from "../util/enter-controller.js";
+import { fireEvent } from "../util/fire-event.js";
 import { formatApiError } from "../util/format-api-error.js";
 import { markJustCreated } from "../util/just-created.js";
 import { previewPackageImportUrl } from "../util/package-import-url.js";
@@ -501,13 +502,7 @@ export class ESPHomeAdoptDialog extends LitElement {
       // so the welcome banner would just be noise.
       markJustCreated(`${name}.yaml`);
       this.close();
-      this.dispatchEvent(
-        new CustomEvent("adopted", {
-          detail: { name, friendlyName },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      fireEvent(this, "adopted", { name, friendlyName });
     } catch (err) {
       this._error = formatApiError(err, this._localize, "dashboard.adopt_error_generic");
     } finally {

--- a/src/components/archived-devices-dialog.ts
+++ b/src/components/archived-devices-dialog.ts
@@ -11,6 +11,7 @@ import { espHomeStyles } from "../styles/shared.js";
 import { textStyles } from "../styles/text.js";
 import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { getErrorMessage } from "../util/error-message.js";
+import { fireEvent } from "../util/fire-event.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { renderAsyncState } from "../util/render-async-state.js";
 
@@ -314,23 +315,11 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
   }
 
   private _unarchive(device: ArchivedDevice) {
-    this.dispatchEvent(
-      new CustomEvent("unarchive", {
-        detail: device,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "unarchive", device);
   }
 
   private _deletePermanently(device: ArchivedDevice) {
-    this.dispatchEvent(
-      new CustomEvent("delete-archived", {
-        detail: device,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "delete-archived", device);
   }
 }
 

--- a/src/components/command-palette.ts
+++ b/src/components/command-palette.ts
@@ -24,6 +24,7 @@ import {
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { textStyles } from "../styles/text.js";
+import { fireEvent } from "../util/fire-event.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { yamlEmptyMessageKey } from "../util/yaml-search-helpers.js";
 import type { CommandAction } from "./command-palette-actions.js";
@@ -499,39 +500,19 @@ export class ESPHomeCommandPalette extends LitElement {
   }
 
   private _setTheme(theme: string) {
-    this.dispatchEvent(
-      new CustomEvent("set-theme", {
-        detail: theme,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "set-theme", theme);
   }
 
   private _setLanguage(lang: LanguageChoice) {
-    this.dispatchEvent(
-      new CustomEvent("set-language", {
-        detail: lang,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "set-language", lang);
   }
 
   private _toggleExpertMode() {
-    this.dispatchEvent(
-      new CustomEvent("set-expert-mode", {
-        detail: !this._expertMode,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "set-expert-mode", !this._expertMode);
   }
 
   private _openUpdateAll() {
-    this.dispatchEvent(
-      new CustomEvent("open-update-all", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "open-update-all");
   }
 }
 

--- a/src/components/dashboard/device-drawer-content/render-sections.ts
+++ b/src/components/dashboard/device-drawer-content/render-sections.ts
@@ -8,6 +8,7 @@ import {
   getEncryptionVisual,
   type EncryptionState,
 } from "../../../util/encryption-state.js";
+import { fireEvent } from "../../../util/fire-event.js";
 import { formatFileSize } from "../../../util/format-file-size.js";
 import { splitIntegrations } from "../../../util/integration-split.js";
 import { buildWebUiUrlForHost } from "../../../util/web-ui-url.js";
@@ -437,13 +438,7 @@ function emitCleanBuild(
   host: ESPHomeDeviceDrawerContent,
   device: ConfiguredDevice
 ): void {
-  host.dispatchEvent(
-    new CustomEvent("clean-build", {
-      detail: device,
-      bubbles: true,
-      composed: true,
-    })
-  );
+  fireEvent(host, "clean-build", device);
 }
 
 // Build-size row with inline "Clean" button. Hidden on never-compiled devices

--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -18,6 +18,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 import { textStyles } from "../../styles/text.js";
 import { showPendingChanges, showUpdateAvailable } from "../../util/device-sync.js";
 import { EscapeController } from "../../util/escape-controller.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { busyActionLabel, updateActionTitle } from "../../util/update-tooltip.js";
 
@@ -402,9 +403,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
 
   private _close() {
     this.open = false;
-    this.dispatchEvent(
-      new CustomEvent("drawer-close", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "drawer-close");
   }
 
   private _escape = new EscapeController(this, (e) => {
@@ -417,13 +416,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
   }
 
   private _emitAction(name: string) {
-    this.dispatchEvent(
-      new CustomEvent(name, {
-        detail: this.device,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, name, this.device);
   }
 }
 

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -45,6 +45,7 @@ import {
   showPendingChanges,
   showUpdateAvailable,
 } from "../../util/device-sync.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { labelChipStyles, resolveLabelIds } from "../../util/label-chip-template.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { TourActivityController } from "../guided-tour/tour-activity-controller.js";
@@ -190,13 +191,7 @@ export class ESPHomeDeviceTable extends LitElement {
     updater: SortingState | ((old: SortingState) => SortingState)
   ) => {
     this._sorting = typeof updater === "function" ? updater(this._sorting) : updater;
-    this.dispatchEvent(
-      new CustomEvent("table-sort-change", {
-        detail: this._sorting,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "table-sort-change", this._sorting);
   };
 
   private _handleVisibilityChange = (
@@ -204,13 +199,7 @@ export class ESPHomeDeviceTable extends LitElement {
   ) => {
     this._columnVisibility =
       typeof updater === "function" ? updater(this._columnVisibility) : updater;
-    this.dispatchEvent(
-      new CustomEvent("table-visibility-change", {
-        detail: this._columnVisibility,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "table-visibility-change", this._columnVisibility);
   };
 
   private _handlePaginationChange = (
@@ -222,13 +211,7 @@ export class ESPHomeDeviceTable extends LitElement {
     this._pageSize = next.pageSize;
     this._pageIndex = next.pageIndex;
     if (pageSizeChanged) {
-      this.dispatchEvent(
-        new CustomEvent("table-page-size-change", {
-          detail: this._pageSize,
-          bubbles: true,
-          composed: true,
-        })
-      );
+      fireEvent(this, "table-page-size-change", this._pageSize);
     }
   };
 
@@ -412,13 +395,7 @@ export class ESPHomeDeviceTable extends LitElement {
             // The state we feed on the next render drives the slice.
             this._pageSize = e.detail;
             this._pageIndex = 0;
-            this.dispatchEvent(
-              new CustomEvent("table-page-size-change", {
-                detail: e.detail,
-                bubbles: true,
-                composed: true,
-              })
-            );
+            fireEvent(this, "table-page-size-change", e.detail);
             this._scrollToTop();
           }}
         ></esphome-table-pagination>
@@ -526,18 +503,14 @@ export class ESPHomeDeviceTable extends LitElement {
   }
 
   private _onToggleSelect(config: string) {
-    this.dispatchEvent(
-      new CustomEvent("toggle-select", { detail: config, bubbles: true, composed: true })
-    );
+    fireEvent(this, "toggle-select", config);
   }
 
   private _onToggleAll() {
-    this.dispatchEvent(
-      new CustomEvent(this._allSelected ? "deselect-all" : "select-all", {
-        detail: this._visibleConfigs.slice(),
-        bubbles: true,
-        composed: true,
-      })
+    fireEvent(
+      this,
+      this._allSelected ? "deselect-all" : "select-all",
+      this._visibleConfigs.slice()
     );
   }
 
@@ -582,17 +555,11 @@ export class ESPHomeDeviceTable extends LitElement {
   }
 
   private _forwardEvent(name: string, detail: unknown) {
-    this.dispatchEvent(new CustomEvent(name, { detail, bubbles: true, composed: true }));
+    fireEvent(this, name, detail);
   }
 
   private _enterSelectMode(device: ConfiguredDevice) {
-    this.dispatchEvent(
-      new CustomEvent("enter-select-mode", {
-        detail: device.configuration,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "enter-select-mode", device.configuration);
   }
 
   private _scrollToTop() {
@@ -600,9 +567,7 @@ export class ESPHomeDeviceTable extends LitElement {
   }
 
   private _onRowClick(device: ConfiguredDevice) {
-    this.dispatchEvent(
-      new CustomEvent("row-click", { detail: device, bubbles: true, composed: true })
-    );
+    fireEvent(this, "row-click", device);
   }
 }
 

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -7,6 +7,7 @@ import { JobStatus } from "../../api/types/firmware-jobs.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../util/device-sort.js";
 import { getCompactEncryptionVisual } from "../../util/encryption-state.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { formatFileSize } from "../../util/format-file-size.js";
 import { renderLabelChips } from "../../util/label-chip-template.js";
 import { busyActionLabel, updateActionTitle } from "../../util/update-tooltip.js";
@@ -73,9 +74,7 @@ const RECENT_LABEL_KEY: Record<JobStatus, string> = {
 
 const dispatchRowEvent = (e: Event, name: string, device: ConfiguredDevice) => {
   e.stopPropagation();
-  (e.currentTarget as HTMLElement).dispatchEvent(
-    new CustomEvent(name, { detail: device, bubbles: true, composed: true })
-  );
+  fireEvent(e.currentTarget as HTMLElement, name, device);
 };
 
 // One "no data" placeholder for every column. Rendered in the muted

--- a/src/components/dashboard/table-pagination.ts
+++ b/src/components/dashboard/table-pagination.ts
@@ -6,6 +6,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { MOBILE_BREAKPOINT } from "../../styles/breakpoints.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 
 import { ALL_PAGE_SIZE } from "./pagination.js";
@@ -260,23 +261,11 @@ export class ESPHomeTablePagination extends LitElement {
   }
 
   private _onPageSizeChange(e: Event) {
-    this.dispatchEvent(
-      new CustomEvent("page-size-change", {
-        detail: Number((e.target as HTMLSelectElement).value),
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "page-size-change", Number((e.target as HTMLSelectElement).value));
   }
 
   private _emitPageChange(pageIndex: number) {
-    this.dispatchEvent(
-      new CustomEvent("page-change", {
-        detail: pageIndex,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "page-change", pageIndex);
   }
 }
 

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -25,6 +25,7 @@ import { localizeContext } from "../../context/index.js";
 import { dropdownMenuStyles } from "../../styles/dropdown-menu.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { EscapeController } from "../../util/escape-controller.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { busyActionLabel } from "../../util/update-tooltip.js";
 import { renderVisitWebUiLink } from "../../util/visit-web-ui-link.js";
@@ -338,7 +339,7 @@ export class ESPHomeTableRowMenu extends LitElement {
   private _close() {
     this.device = null;
     this.position = null;
-    this.dispatchEvent(new CustomEvent("menu-close", { bubbles: true, composed: true }));
+    fireEvent(this, "menu-close");
   }
 
   private _preventAndClose(e: Event) {
@@ -347,13 +348,7 @@ export class ESPHomeTableRowMenu extends LitElement {
   }
 
   private _emit(name: string) {
-    this.dispatchEvent(
-      new CustomEvent(name, {
-        detail: this.device,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, name, this.device);
     this._close();
   }
 

--- a/src/components/device-card/keyboard-nav.ts
+++ b/src/components/device-card/keyboard-nav.ts
@@ -1,3 +1,4 @@
+import { fireEvent } from "../../util/fire-event.js";
 import type { ESPHomeDeviceCard } from "../device-card.js";
 
 // Pick the card on the next row whose horizontal centre is closest to ours.
@@ -63,11 +64,5 @@ export function onHostContextMenu(card: ESPHomeDeviceCard, e: MouseEvent): void 
   if (originatesOnControl(card, e)) return;
   e.preventDefault();
   e.stopPropagation();
-  card.dispatchEvent(
-    new CustomEvent("card-context-menu", {
-      detail: { x: e.clientX, y: e.clientY },
-      bubbles: true,
-      composed: true,
-    })
-  );
+  fireEvent(card, "card-context-menu", { x: e.clientX, y: e.clientY });
 }

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -16,6 +16,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 import { ComponentNameResolverController } from "../../util/component-name-resolver-controller.js";
 import { validateEntries, type ValidationError } from "../../util/config-validation.js";
 import { resolveFeaturedComponentId } from "../../util/featured-id.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { setIn } from "../../util/nested-values.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -393,13 +394,7 @@ export class ESPHomeAddComponentForm extends LitElement {
    * catalog view, filtered to the requested dependency domain.
    */
   private _onAddDep(domain: string) {
-    this.dispatchEvent(
-      new CustomEvent("navigate-to-dep", {
-        detail: { domain },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "navigate-to-dep", { domain });
   }
 
   /** True if any error in the map has the `validation.required` code. */
@@ -490,7 +485,7 @@ export class ESPHomeAddComponentForm extends LitElement {
   }
 
   private _onCancel() {
-    this.dispatchEvent(new CustomEvent("form-cancel", { bubbles: true, composed: true }));
+    fireEvent(this, "form-cancel");
   }
 
   private _onSubmit() {
@@ -554,13 +549,7 @@ export class ESPHomeAddComponentForm extends LitElement {
 
     const fields = coerceFields(this._entries, this._values);
 
-    this.dispatchEvent(
-      new CustomEvent("form-submit", {
-        detail: { fields },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "form-submit", { fields });
   }
 }
 

--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -6,6 +6,7 @@ import type {
   AutomationTree,
 } from "../../../api/types/automations.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
+import { fireEvent } from "../../../util/fire-event.js";
 import { formatApiError } from "../../../util/format-api-error.js";
 import { notifyError } from "../../../util/notify.js";
 import { applyYamlDiff, emptyAutomationTree } from "./serialise.js";
@@ -92,26 +93,14 @@ export class AutoApplyController implements ReactiveController {
    *  ``flushPending()`` before its global save. Mirrors
    *  device-section-config's section-mount event. */
   hostConnected(): void {
-    this._host.dispatchEvent(
-      new CustomEvent("section-mount", {
-        detail: { node: this._host },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this._host, "section-mount", { node: this._host });
   }
 
   hostDisconnected(): void {
     // Cancel the pending debounced upsert — a write scheduled by a
     // section that's no longer on screen must not fire.
     this._clearTimer();
-    this._host.dispatchEvent(
-      new CustomEvent("section-unmount", {
-        detail: { node: this._host },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this._host, "section-unmount", { node: this._host });
   }
 
   /** Brief-window dirty flag covering the debounce gap so the global
@@ -149,13 +138,7 @@ export class AutoApplyController implements ReactiveController {
       ...patch,
     };
     this._host.value = value;
-    this._host.dispatchEvent(
-      new CustomEvent("automation-change", {
-        detail: { value, location: this._host.location },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this._host, "automation-change", { value, location: this._host.location });
     this.scheduleAutoApply();
   }
 
@@ -332,13 +315,7 @@ export class AutoApplyController implements ReactiveController {
     if (this._dirty === value) return;
     this._dirty = value;
     this._host.requestUpdate();
-    this._host.dispatchEvent(
-      new CustomEvent("dirty-change", {
-        detail: { dirty: value },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this._host, "dirty-change", { dirty: value });
   }
 
   private _setDeleting(value: boolean): void {

--- a/src/components/device/automation-editor/automation-action-list.ts
+++ b/src/components/device/automation-editor/automation-action-list.ts
@@ -27,6 +27,7 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
+import { fireEvent } from "../../../util/fire-event.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import "./automation-action-node.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
@@ -190,13 +191,7 @@ export class ESPHomeAutomationActionList extends LitElement {
   }
 
   private _emit(actions: ActionNode[]) {
-    this.dispatchEvent(
-      new CustomEvent("actions-change", {
-        detail: { actions },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "actions-change", { actions });
   }
 }
 

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -38,6 +38,7 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
+import { fireEvent } from "../../../util/fire-event.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import "../config-entry-form.js";
@@ -580,32 +581,15 @@ export class ESPHomeAutomationActionNode extends LitElement {
   }
 
   private _reorder(delta: number) {
-    this.dispatchEvent(
-      new CustomEvent("action-reorder", {
-        detail: { delta },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "action-reorder", { delta });
   }
 
   private _onDelete = () => {
-    this.dispatchEvent(
-      new CustomEvent("action-delete", {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "action-delete");
   };
 
   private _emit(value: ActionNode) {
-    this.dispatchEvent(
-      new CustomEvent("action-change", {
-        detail: { value },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "action-change", { value });
   }
 }
 

--- a/src/components/device/automation-editor/automation-condition-tree.ts
+++ b/src/components/device/automation-editor/automation-condition-tree.ts
@@ -33,6 +33,7 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
+import { fireEvent } from "../../../util/fire-event.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import "../config-entry-form.js";
@@ -388,13 +389,7 @@ export class ESPHomeAutomationConditionTree extends LitElement {
   }
 
   private _emit(conditions: ConditionNode[]) {
-    this.dispatchEvent(
-      new CustomEvent("conditions-change", {
-        detail: { conditions },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "conditions-change", { conditions });
   }
 }
 

--- a/src/components/device/automation-editor/automation-trigger-picker.ts
+++ b/src/components/device/automation-editor/automation-trigger-picker.ts
@@ -30,6 +30,7 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
+import { fireEvent } from "../../../util/fire-event.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import "../config-entry-form.js";
 import type { ConfigEntryValueChange } from "../config-entry-form.js";
@@ -178,13 +179,7 @@ export class ESPHomeAutomationTriggerPicker extends LitElement {
 
   private _onTriggerChange = (e: Event) => {
     const id = (e.target as HTMLSelectElement).value;
-    this.dispatchEvent(
-      new CustomEvent("trigger-change", {
-        detail: { triggerId: id, params: {} },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "trigger-change", { triggerId: id, params: {} });
   };
 
   private _onAdvancedToggle = (e: CustomEvent<{ show: boolean }>) => {
@@ -194,13 +189,7 @@ export class ESPHomeAutomationTriggerPicker extends LitElement {
   private _onParamChange = (e: CustomEvent<ConfigEntryValueChange>) => {
     e.stopPropagation();
     const next = applyParamChange(this.triggerParams, e.detail.path, e.detail.value);
-    this.dispatchEvent(
-      new CustomEvent("trigger-params-change", {
-        detail: { params: next },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "trigger-params-change", { params: next });
   };
 }
 

--- a/src/components/device/automation-editor/component-target-picker.ts
+++ b/src/components/device/automation-editor/component-target-picker.ts
@@ -12,6 +12,7 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { espHomeStyles } from "../../../styles/shared.js";
 import { textStyles } from "../../../styles/text.js";
+import { fireEvent } from "../../../util/fire-event.js";
 import { componentTargetPickerStyles } from "./component-target-picker.styles.js";
 import { instanceName } from "./component-targets.js";
 
@@ -153,13 +154,7 @@ export class ESPHomeComponentTargetPicker extends LitElement {
 
   private _select(id: string) {
     if (this.disabled) return;
-    this.dispatchEvent(
-      new CustomEvent("component-change", {
-        detail: { componentId: id },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "component-change", { componentId: id });
   }
 }
 

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -21,6 +21,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 import { textStyles } from "../../styles/text.js";
 import { debounce } from "../../util/debounce.js";
 import { isFeaturedId } from "../../util/featured-id.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { IntersectionController } from "../../util/intersection-controller.js";
 import { isVisible } from "../../util/is-visible.js";
 import { PagedListController } from "../../util/paged-list-controller.js";
@@ -431,23 +432,11 @@ export class ESPHomeComponentCatalog extends LitElement {
   };
 
   _onAdd(component: ComponentCatalogEntry) {
-    this.dispatchEvent(
-      new CustomEvent("add-component", {
-        detail: { component },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "add-component", { component });
   }
 
   _onAddBundle(bundle: FeaturedBundle) {
-    this.dispatchEvent(
-      new CustomEvent("add-bundle", {
-        detail: { bundle, boardId: this.boardId },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "add-bundle", { bundle, boardId: this.boardId });
   }
 }
 

--- a/src/components/device/config-entry-renderers/lambda-editor.ts
+++ b/src/components/device/config-entry-renderers/lambda-editor.ts
@@ -30,6 +30,7 @@ import { darkModeContext, localizeContext } from "../../../context/index.js";
 import { editorHeightTheme, selectEditorTheme } from "../../../util/codemirror-theme.js";
 import { initialDarkMode } from "../../../util/dark-mode.js";
 import { editorSearchPhrases } from "../../../util/editor-search-phrases.js";
+import { fireEvent } from "../../../util/fire-event.js";
 import { CodeMirrorEditorElement } from "../../codemirror-editor-element.js";
 
 /** Marks the doc change that syncs the external ``value`` prop into the
@@ -147,13 +148,7 @@ export class ESPHomeLambdaEditor extends CodeMirrorEditorElement {
           !update.transactions.some((tr) => tr.annotation(externalSync) !== undefined)
         ) {
           const value = update.state.doc.toString();
-          this.dispatchEvent(
-            new CustomEvent("lambda-change", {
-              detail: { value },
-              bubbles: true,
-              composed: true,
-            })
-          );
+          fireEvent(this, "lambda-change", { value });
         }
       }),
     ]);

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -22,6 +22,7 @@ import {
   type InstanceBackendErrors,
 } from "../../util/backend-field-errors.js";
 import { effectiveDeviceLayout } from "../../util/editor-layout.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { notifyError, notifyWarning } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { SaveShortcutController } from "../../util/save-shortcut-controller.js";
@@ -142,13 +143,7 @@ export class ESPHomeDeviceEditor extends LitElement {
     const { id } = (event as CustomEvent<TourRevealEventDetail>).detail;
     const next = layoutRevealingAnchor(id, this.layout, this._isMobile);
     if (next) {
-      this.dispatchEvent(
-        new CustomEvent(TOUR_LAYOUT_CHANGE_EVENT, {
-          detail: next,
-          bubbles: true,
-          composed: true,
-        })
-      );
+      fireEvent(this, TOUR_LAYOUT_CHANGE_EVENT, next);
     }
   };
 
@@ -458,21 +453,11 @@ export class ESPHomeDeviceEditor extends LitElement {
   }
 
   private _onSave() {
-    this.dispatchEvent(
-      new CustomEvent("save-yaml", {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "save-yaml");
   }
 
   private _onValidate() {
-    this.dispatchEvent(
-      new CustomEvent("validate-device", {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "validate-device");
   }
 
   private _toggleDiff() {
@@ -497,21 +482,11 @@ export class ESPHomeDeviceEditor extends LitElement {
   }
 
   private _onInstall() {
-    this.dispatchEvent(
-      new CustomEvent("install-device", {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "install-device");
   }
 
   private _onUpdate() {
-    this.dispatchEvent(
-      new CustomEvent("update-device", {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "update-device");
   }
 
   willUpdate(changed: Map<string, unknown>) {
@@ -666,23 +641,11 @@ export class ESPHomeDeviceEditor extends LitElement {
 
   /** Ask the page to highlight and scroll to a banner error's line. */
   private _gotoErrorLine(line: number) {
-    this.dispatchEvent(
-      new CustomEvent("goto-line", {
-        detail: { line },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "goto-line", { line });
   }
 
   private _setLayout(layout: DeviceLayoutMode) {
-    this.dispatchEvent(
-      new CustomEvent("layout-change", {
-        detail: layout,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "layout-change", layout);
   }
 
   private _onDividerPointerDown = (e: PointerEvent) => {
@@ -748,13 +711,7 @@ export class ESPHomeDeviceEditor extends LitElement {
 
   private _onYamlChange(e: CustomEvent) {
     this._lastEditAt = performance.now();
-    this.dispatchEvent(
-      new CustomEvent("yaml-change", {
-        detail: e.detail,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "yaml-change", e.detail);
   }
 }
 

--- a/src/components/device/device-navigator-search.ts
+++ b/src/components/device/device-navigator-search.ts
@@ -5,6 +5,7 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { navigatorSearchStyles } from "./device-navigator-search.styles.js";
 
@@ -100,13 +101,7 @@ export class ESPHomeNavigatorSearch extends LitElement {
   };
 
   private _emit(value: string) {
-    this.dispatchEvent(
-      new CustomEvent("navigator-search", {
-        detail: { value },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "navigator-search", { value });
   }
 }
 

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -25,6 +25,7 @@ import {
   getCachedComponent,
   subscribeComponentCache,
 } from "../../util/component-name-cache.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import {
   type YamlSection,
@@ -528,13 +529,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
   };
 
   private _toggleSection(index: number) {
-    this.dispatchEvent(
-      new CustomEvent("section-toggle", {
-        detail: { index },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "section-toggle", { index });
   }
 
   /** Collapse/expand one domain subgroup (new Set so @state reacts). */
@@ -548,12 +543,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
    *  desktop (set ``_navCollapsed`` + persist) and mobile (close the
    *  drawer) — we just say "I'd like to disappear". */
   private _onCollapseClick = () => {
-    this.dispatchEvent(
-      new CustomEvent("nav-collapse", {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "nav-collapse");
   };
 
   /**
@@ -616,23 +606,11 @@ export class ESPHomeDeviceNavigator extends LitElement {
   }
 
   private _emitHighlight(range: HighlightRange | null, scroll: boolean) {
-    this.dispatchEvent(
-      new CustomEvent("yaml-highlight", {
-        detail: { range, scroll },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "yaml-highlight", { range, scroll });
   }
 
   private _emitSectionSelect(sectionKey: string | null, fromLine: number | undefined) {
-    this.dispatchEvent(
-      new CustomEvent("section-select", {
-        detail: { sectionKey, fromLine },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "section-select", { sectionKey, fromLine });
   }
 
   /**

--- a/src/components/device/device-section-automation-list.ts
+++ b/src/components/device/device-section-automation-list.ts
@@ -5,6 +5,7 @@ import { customElement, property } from "lit/decorators.js";
 import { emptyStateStyles } from "../../styles/empty-state.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { textStyles } from "../../styles/text.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { deviceSectionAutomationListStyles } from "./device-section-automation-list.styles.js";
 
@@ -128,13 +129,11 @@ export class ESPHomeSectionAutomationList extends LitElement {
   }
 
   private _onAdd = () => {
-    this.dispatchEvent(new CustomEvent("add", { bubbles: true, composed: true }));
+    fireEvent(this, "add");
   };
 
   private _emit(type: "edit" | "delete", key: string) {
-    this.dispatchEvent(
-      new CustomEvent(type, { detail: { key }, bubbles: true, composed: true })
-    );
+    fireEvent(this, type, { key });
   }
 }
 

--- a/src/components/filters/filter-section.ts
+++ b/src/components/filters/filter-section.ts
@@ -15,6 +15,7 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { textStyles } from "../../styles/text.js";
 import type { FacetOption } from "../../util/facets.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { toggleSelection } from "../../util/toggle-selection.js";
 import { filterSectionStyles } from "./filter-section.styles.js";
@@ -172,9 +173,7 @@ export class ESPHomeFilterSection extends LitElement {
   }
 
   private _onHeaderClick = () => {
-    this.dispatchEvent(
-      new CustomEvent("filter-section-toggle", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "filter-section-toggle");
   };
 
   private _toggleOption(id: string, select: boolean) {

--- a/src/components/filters/filters-popover.ts
+++ b/src/components/filters/filters-popover.ts
@@ -16,6 +16,7 @@ import { LitElement, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { textStyles } from "../../styles/text.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { LightDismissController } from "../../util/light-dismiss-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { filterStyles } from "./filter-styles.js";
@@ -182,9 +183,7 @@ export class ESPHomeFiltersPopover extends LitElement {
   }
 
   private _onClearAll = () => {
-    this.dispatchEvent(
-      new CustomEvent("clear-filters", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "clear-filters");
     this._close();
   };
 }

--- a/src/components/filters/labels-filter-section.ts
+++ b/src/components/filters/labels-filter-section.ts
@@ -25,6 +25,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { labelsContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { textStyles } from "../../styles/text.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { labelChipStyles } from "../../util/label-chip-template.js";
 import { labelChipStyleString } from "../../util/label-style.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -194,9 +195,7 @@ export class ESPHomeLabelsFilterSection extends LitElement {
   }
 
   private _onHeaderClick = () => {
-    this.dispatchEvent(
-      new CustomEvent("filter-section-toggle", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "filter-section-toggle");
   };
 
   private _onEditClick(e: Event, label: Label) {
@@ -225,15 +224,11 @@ export class ESPHomeLabelsFilterSection extends LitElement {
 
   private _onCreateClick = () => {
     this._requestPopoverClose();
-    this.dispatchEvent(
-      new CustomEvent("request-create-label", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "request-create-label");
   };
 
   private _requestPopoverClose() {
-    this.dispatchEvent(
-      new CustomEvent("request-popover-close", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "request-popover-close");
   }
 
   private _toggleLabel(labelId: string, select: boolean) {

--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -35,6 +35,7 @@ import { espHomeStyles } from "../styles/shared.js";
 import { textStyles } from "../styles/text.js";
 import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { getErrorMessage } from "../util/error-message.js";
+import { fireEvent } from "../util/fire-event.js";
 import { cancelFirmwareJob } from "../util/firmware-job-actions.js";
 import { firmwareJobDisplayName } from "../util/firmware-job-display.js";
 import { notifyError } from "../util/notify.js";
@@ -309,12 +310,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
       return;
     }
     // firmware/clear has no broadcast event — let app-shell prune local context.
-    this.dispatchEvent(
-      new CustomEvent("firmware-history-cleared", {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "firmware-history-cleared");
   };
 }
 

--- a/src/components/labels/label-form.ts
+++ b/src/components/labels/label-form.ts
@@ -31,6 +31,7 @@ import { apiContext, localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { textStyles } from "../../styles/text.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { labelChipStyles } from "../../util/label-chip-template.js";
 import {
   LABEL_COLOR_SWATCHES,
@@ -471,7 +472,7 @@ export class ESPHomeLabelForm extends LitElement {
     }
     // Edit mode and the standalone create dialog let the host own
     // "close".
-    this.dispatchEvent(new CustomEvent("form-cancel", { bubbles: true, composed: true }));
+    fireEvent(this, "form-cancel");
   }
 
   private async _submit() {
@@ -492,7 +493,7 @@ export class ESPHomeLabelForm extends LitElement {
     // user still on the same device?" check) can snapshot before
     // the await. The event has no detail; the host already knows
     // its own context.
-    this.dispatchEvent(new CustomEvent("submitting", { bubbles: true, composed: true }));
+    fireEvent(this, "submitting");
     this._saving = true;
     const editing = this.editing;
     try {

--- a/src/components/mdi-icon-picker.ts
+++ b/src/components/mdi-icon-picker.ts
@@ -14,6 +14,7 @@ import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { inputStyles } from "../styles/inputs.js";
 import { textStyles } from "../styles/text.js";
+import { fireEvent } from "../util/fire-event.js";
 import { LightDismissController } from "../util/light-dismiss-controller.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { mdiIconPickerStyles } from "./mdi-icon-picker.styles.js";
@@ -171,26 +172,14 @@ export class ESPHomeMdiIconPicker extends LitElement {
   private _select(name: string) {
     const next = `mdi:${name}`;
     this.value = next;
-    this.dispatchEvent(
-      new CustomEvent("change", {
-        detail: { value: next },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "change", { value: next });
     this._close();
   }
 
   private _clear(e: Event) {
     e.stopPropagation();
     this.value = "";
-    this.dispatchEvent(
-      new CustomEvent("change", {
-        detail: { value: "" },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "change", { value: "" });
   }
 
   private _onSearchInput(e: Event) {

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -25,6 +25,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 import { withBase } from "../../util/base-path.js";
 import { EnterController } from "../../util/enter-controller.js";
 import { EXPERIENCE_OPTIONS } from "../../util/experience.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { formatApiError } from "../../util/format-api-error.js";
 import { notifyWarning } from "../../util/notify.js";
 import { remoteBuildPeerName } from "../../util/remote-build-peer-name.js";
@@ -486,15 +487,11 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     this._open = false;
     if (!this._startTourAfterClose) return;
     this._startTourAfterClose = false;
-    this.dispatchEvent(
-      new CustomEvent("open-guided-tour", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "open-guided-tour");
   }
 
   private _emitAcknowledged() {
-    this.dispatchEvent(
-      new CustomEvent("onboarding-acknowledged", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "onboarding-acknowledged");
   }
 
   private _consumeResetParam(): void {

--- a/src/components/remote-build-panel.ts
+++ b/src/components/remote-build-panel.ts
@@ -35,6 +35,7 @@ import { pairingWindowStyles } from "../styles/pairing-window.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { textStyles } from "../styles/text.js";
+import { fireEvent } from "../util/fire-event.js";
 import { cancelFirmwareJob } from "../util/firmware-job-actions.js";
 import { firmwareJobDisplayName } from "../util/firmware-job-display.js";
 import { notify } from "../util/notify.js";
@@ -231,13 +232,7 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
   }
 
   _openBuildServerSettings = () => {
-    this.dispatchEvent(
-      new CustomEvent("open-settings", {
-        detail: { section: "build_server" },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "open-settings", { section: "build_server" });
   };
 
   _jobDisplayName(job: FirmwareJob): string {
@@ -308,9 +303,7 @@ export class ESPHomeRemoteBuildPanel extends LitElement {
   }
 
   private _onToggleCollapsed = () => {
-    this.dispatchEvent(
-      new CustomEvent("toggle-collapsed", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "toggle-collapsed");
   };
 
   private _renderBody() {

--- a/src/components/wizard/wizard-step-board-list.ts
+++ b/src/components/wizard/wizard-step-board-list.ts
@@ -8,6 +8,7 @@ import { loadMoreFooterStyles } from "../../styles/load-more-footer.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { textStyles } from "../../styles/text.js";
 import { boardImageUrl } from "../../util/board-image.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { IntersectionController } from "../../util/intersection-controller.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -262,13 +263,7 @@ export class ESPHomeWizardStepBoardList extends LitElement {
   }
 
   private _onAdd(board: SlimBoard) {
-    this.dispatchEvent(
-      new CustomEvent("add-board", {
-        detail: { board },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "add-board", { board });
   }
 }
 

--- a/src/components/wizard/wizard-step-board-port-select.ts
+++ b/src/components/wizard/wizard-step-board-port-select.ts
@@ -13,6 +13,7 @@ import { newItemHighlightStyles } from "../../styles/new-item-highlight.js";
 import { serialPortHintStyles } from "../../styles/serial-port-hints.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import type { DeploymentEnvironment } from "../../util/environment.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import {
   renderSerialPortBadges,
@@ -230,17 +231,11 @@ export class ESPHomeWizardStepBoardPortSelect extends LitElement {
   }
 
   private _onSelect(port: string) {
-    this.dispatchEvent(
-      new CustomEvent("select-port", {
-        detail: { port },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "select-port", { port });
   }
 
   private _onBack = () => {
-    this.dispatchEvent(new CustomEvent("back", { bubbles: true, composed: true }));
+    fireEvent(this, "back");
   };
 }
 

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -12,6 +12,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 import { fetchBoard } from "../../util/board-body-cache.js";
 import { debounce } from "../../util/debounce.js";
 import { detectEnvironment, type DeploymentEnvironment } from "../../util/environment.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { PagedListController } from "../../util/paged-list-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { SerialPortsPollController } from "../../util/serial-ports-poll-controller.js";
@@ -266,13 +267,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
   }
 
   private _onAdd(board: SlimBoard) {
-    this.dispatchEvent(
-      new CustomEvent("next-step", {
-        detail: { step: "setup", board },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "next-step", { step: "setup", board });
   }
 
   private get _environment(): DeploymentEnvironment {

--- a/src/components/wizard/wizard-step-empty-config.ts
+++ b/src/components/wizard/wizard-step-empty-config.ts
@@ -6,6 +6,7 @@ import { localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { EnterController } from "../../util/enter-controller.js";
+import { fireEvent } from "../../util/fire-event.js";
 
 @customElement("esphome-wizard-step-empty-config")
 export class ESPHomeWizardStepEmptyConfig extends LitElement {
@@ -128,19 +129,11 @@ export class ESPHomeWizardStepEmptyConfig extends LitElement {
   }
 
   private _cancel() {
-    this.dispatchEvent(
-      new CustomEvent("next-step", { detail: "method", bubbles: true, composed: true })
-    );
+    fireEvent(this, "next-step", "method");
   }
 
   private _next() {
-    this.dispatchEvent(
-      new CustomEvent("create-empty-config", {
-        detail: { name: this._name },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "create-empty-config", { name: this._name });
   }
 }
 

--- a/src/components/wizard/wizard-step-import-partial.ts
+++ b/src/components/wizard/wizard-step-import-partial.ts
@@ -6,6 +6,7 @@ import { localizeContext } from "../../context/index.js";
 import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { EnterController } from "../../util/enter-controller.js";
+import { fireEvent } from "../../util/fire-event.js";
 
 /** Terminal result of a bundle import that left some existing files in
  *  place, so a partial import reads as partial rather than a silent
@@ -81,7 +82,7 @@ export class ESPHomeWizardStepImportPartial extends LitElement {
   }
 
   private _open() {
-    this.dispatchEvent(new CustomEvent("open-device", { bubbles: true, composed: true }));
+    fireEvent(this, "open-device");
   }
 }
 

--- a/src/components/wizard/wizard-step-method.ts
+++ b/src/components/wizard/wizard-step-method.ts
@@ -8,6 +8,7 @@ import { localizeContext } from "../../context/index.js";
 import { disclosureStyles } from "../../styles/disclosure.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { FileDropController } from "../../util/file-drop-controller.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { ACCEPTED_UPLOAD_EXTENSIONS } from "../../util/upload-file-types.js";
 import { tourAnchor } from "../guided-tour/tour-anchor.js";
@@ -229,15 +230,11 @@ export class ESPHomeWizardStepMethod extends LitElement {
   private _toggleAdvanced() {
     // Just signal intent; the dialog owns the flag (it outlives this element)
     // and flips it.
-    this.dispatchEvent(
-      new CustomEvent("toggle-advanced", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "toggle-advanced");
   }
 
   private _goToBoard() {
-    this.dispatchEvent(
-      new CustomEvent("next-step", { detail: "board", bubbles: true, composed: true })
-    );
+    fireEvent(this, "next-step", "board");
   }
 
   private _importFile() {
@@ -256,23 +253,11 @@ export class ESPHomeWizardStepMethod extends LitElement {
   private _sendImportFile(file: File) {
     // Imports don't ask for a board — the YAML already declares its platform.
     // The dialog reads the file and creates the device immediately.
-    this.dispatchEvent(
-      new CustomEvent("import-file", {
-        detail: { file },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "import-file", { file });
   }
 
   private _emptyConfig() {
-    this.dispatchEvent(
-      new CustomEvent("next-step", {
-        detail: { step: "empty-config", method: "empty" },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "next-step", { step: "empty-config", method: "empty" });
   }
 }
 

--- a/src/components/wizard/wizard-step-overwrite-device.ts
+++ b/src/components/wizard/wizard-step-overwrite-device.ts
@@ -5,6 +5,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { fireEvent } from "../../util/fire-event.js";
 
 /** Asks before replacing an existing device's config on a YAML upload.
  *  Overwriting keeps the device's labels / comment / board; deleting it
@@ -61,19 +62,11 @@ export class ESPHomeWizardStepOverwriteDevice extends LitElement {
   }
 
   private _cancel() {
-    this.dispatchEvent(
-      new CustomEvent("next-step", {
-        detail: "method",
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "next-step", "method");
   }
 
   private _confirm() {
-    this.dispatchEvent(
-      new CustomEvent("overwrite-device", { bubbles: true, composed: true })
-    );
+    fireEvent(this, "overwrite-device");
   }
 }
 

--- a/src/components/wizard/wizard-step-resolve-conflicts.ts
+++ b/src/components/wizard/wizard-step-resolve-conflicts.ts
@@ -5,6 +5,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { fireEvent } from "../../util/fire-event.js";
 
 /** Lets the user choose which bundle files overwrite the ones already on
  *  disk. Unchecked files are kept; secrets.yaml is always merged and is
@@ -169,23 +170,11 @@ export class ESPHomeWizardStepResolveConflicts extends LitElement {
   }
 
   private _cancel() {
-    this.dispatchEvent(
-      new CustomEvent("next-step", {
-        detail: "method",
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "next-step", "method");
   }
 
   private _confirm() {
-    this.dispatchEvent(
-      new CustomEvent("resolve-conflicts", {
-        detail: { overwrite: [...this._overwrite] },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "resolve-conflicts", { overwrite: [...this._overwrite] });
   }
 }
 

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -9,6 +9,7 @@ import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { boardImageUrl } from "../../util/board-image.js";
 import { EnterController } from "../../util/enter-controller.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { boardOffersFullSetup } from "../../util/full-setup.js";
 import { fetchSecretKeys, hasSharedWifiSecret } from "../../util/secrets-cache.js";
 import { tourAnchor } from "../guided-tour/tour-anchor.js";
@@ -494,13 +495,7 @@ export class ESPHomeWizardStepSetup extends LitElement {
       this._stage = "name";
       return;
     }
-    this.dispatchEvent(
-      new CustomEvent("next-step", {
-        detail: "board",
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "next-step", "board");
   }
 
   private _onNext() {
@@ -534,19 +529,13 @@ export class ESPHomeWizardStepSetup extends LitElement {
   };
 
   private _finish(wifiSsid: string, wifiPassword: string) {
-    this.dispatchEvent(
-      new CustomEvent("finish-setup", {
-        detail: {
-          board: this.board,
-          name: this._deviceName,
-          wifiSsid,
-          wifiPassword,
-          fullSetup: this._offersFullSetup && this._fullSetup,
-        },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "finish-setup", {
+      board: this.board,
+      name: this._deviceName,
+      wifiSsid,
+      wifiPassword,
+      fullSetup: this._offersFullSetup && this._fullSetup,
+    });
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Final `fireEvent` conversion tranche: everything remaining. Eighty nine untyped `dispatchEvent(new CustomEvent(name, { bubbles: true, composed: true, detail? }))` sites across forty files (dashboard, wizard, filters, automation editor, device navigator and catalog, labels, cards, controllers) become `fireEvent(...)`, including the receiver variants (`host`, `card`, `this._host`, `e.currentTarget`) and device-table's private `_fire` helper. Net −363 lines.

Post sweep residual audit: 46 `bubbles: true` hits remain in `src/`, every one intentional; the helper itself, 37 typed `CustomEvent<T>` constructions (the generic is load bearing), confirm-dialog's three bubbles-only events, base-dialog's `composed: false` re-emit, post-install-logs' cancelable whose result is consumed, and navigator-reveal-controller, whose `RevealHost` interface deliberately exposes only `dispatchEvent` so converting would widen a public host contract.

With this, #1302's sweep is complete; anything still inline is one of the intentional shapes above.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1302

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
