### PR TITLE
Document the null detail default on fireEvent

### DIFF
--- a/src/util/fire-event.ts
+++ b/src/util/fire-event.ts
@@ -3,6 +3,11 @@
  * cross-shadow-boundary shape component action events use. Events meant
  * for a direct listener only should stay non-bubbling (see
  * ``options-combobox-event.ts``).
+ *
+ * Omitting *detail* dispatches with ``event.detail === null``, same as
+ * an inline ``new CustomEvent(name)`` — WebIDL treats an ``undefined``
+ * dictionary member as absent, so the ``CustomEventInit`` default
+ * applies (pinned by the unit test).
  */
 export function fireEvent(target: EventTarget, name: string, detail?: unknown): void {
   target.dispatchEvent(new CustomEvent(name, { detail, bubbles: true, composed: true }));


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #1312; this doc commit was pushed to the branch moments after the squash merge, so it missed the train. Five comment lines on `fireEvent` stating that omitting `detail` dispatches with `event.detail === null` (WebIDL treats an undefined dictionary member as absent, so the `CustomEventInit` default applies, pinned by the unit test). The same review finding recurred on #1300, #1310 and #1312; documenting it on the helper lets it self answer.

**Related issue or feature (if applicable):**

- follow up to https://github.com/esphome/device-builder-frontend/pull/1312

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
