### PR TITLE
Name the empty or commented-out block behind 'expected a dictionary.'

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1249,6 +1249,8 @@
     "error_nested_list_hint": "The \"- \" items below \"{key}\" are indented as its value. If they should be separate list entries, dedent them to line up with \"- {key}\".",
     "error_indent_hint": "YAML indentation problem near line {line}. Make sure the line and its neighbours are indented consistently with their block; an over-indented or under-indented line, or a stray \":\" in a value, causes this.",
     "error_missing_colon_hint": "Line {line}: \"{key}\" looks like an option name without a value. Add \":\" and a value after it, or remove the line.",
+    "error_commented_block_hint": "Line {line}: everything under \"{key}\" is commented out, so it has no options. Uncomment an option, or comment out \"{key}\" too.",
+    "error_empty_block_hint": "Line {line}: \"{key}\" has nothing indented under it, so its value is empty. Add at least one option under it, or remove the line.",
     "error_tab_hint": "A tab is used for indentation near line {line}; YAML needs spaces. Replace the tab with spaces.",
     "error_char_hint": "Unexpected character near line {line}; a value starting with a symbol such as @, %, or * must be wrapped in quotes.",
     "error_unterminated_string_hint": "Unterminated string near line {line}; a quote was opened but not closed. Add the missing closing quote.",

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -588,7 +588,7 @@ export function describeValueTypeCause(
   readLine: ReadLine,
   line: number,
   localize: LocalizeFunc,
-  message = ""
+  message: string
 ): ValueTypeCause | null {
   const nested = describeNestedListValue(readLine, line, localize);
   if (nested) return { text: nested };

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -577,16 +577,18 @@ function dashSpaceCause(
 /**
  * Add the misindent / half-typed-key cause to a wrong-value-type
  * validation message ("expected a dictionary.") anchored at *line*: a
- * value-less `- key:` whose items landed one level deeper, a bare word
- * with no ':' (a lone "le" under "logger:" parses as its string value),
- * or a dash stuck to its key (`-platform:` parses as a mapping key, so
- * the section fails schema validation instead of the YAML parse).
+ * value-less `- key:` whose items landed one level deeper, a dash stuck
+ * to its key (`-platform:` parses as a mapping key, so the section fails
+ * schema validation instead of the YAML parse), a value-less `key:` with
+ * nothing (or only comments) under it, or a bare word with no ':' (a
+ * lone "le" under "logger:" parses as its string value).
  * Null when the anchored line is none of these shapes.
  */
 export function describeValueTypeCause(
   readLine: ReadLine,
   line: number,
-  localize: LocalizeFunc
+  localize: LocalizeFunc,
+  message = ""
 ): ValueTypeCause | null {
   const nested = describeNestedListValue(readLine, line, localize);
   if (nested) return { text: nested };
@@ -595,6 +597,13 @@ export function describeValueTypeCause(
   const dashKey = botchedDashKey(text);
   if (dashKey !== null) {
     return dashSpaceCause(line, dashKey, indentOf(text), localize);
+  }
+  // Gated on the message: a value-less `key:` with no children is legal
+  // YAML (`logger:`), so an error anchored there for another reason
+  // ("'board' is a required option") must not pick up a remove-the-line hint.
+  if (EXPECTED_DICT_RE.test(message)) {
+    const emptyBlock = describeEmptyBlock(readLine, line, localize);
+    if (emptyBlock) return { text: emptyBlock };
   }
   const token = text.trim();
   if (token && !token.includes(":") && !token.startsWith("#") && !token.startsWith("-")) {
@@ -606,6 +615,60 @@ export function describeValueTypeCause(
     };
   }
   return null;
+}
+
+/** The wrong-value-type message the empty-block cause explains. */
+const EXPECTED_DICT_RE = /expected a dictionary/i;
+
+/**
+ * Whether a comment line reads as a commented-out *child* of a key at
+ * *keyIndent*: the `#` itself sits deeper, or the commented text is a
+ * `key:` / `- ` line whose own indent sits deeper (a `#` jammed at column
+ * 0 in front of a still-indented option — the hand-commented shape).
+ */
+function isCommentedChild(text: string, keyIndent: number): boolean {
+  if (indentOf(text) > keyIndent) return true;
+  const content = text.trimStart().replace(/^#+/, "");
+  if (indentOf(content) <= keyIndent) return false;
+  return parseListItemMarker(content) !== null || lineKeyToken(content) !== null;
+}
+
+/**
+ * The empty-block cause behind "expected a dictionary." anchored on a
+ * value-less plain `key:`: nothing is indented under it, so its value is
+ * null. Distinguishes children that are all commented out (the classic
+ * "commented the option, left the key" repair — uncomment or comment the
+ * key too) from a key with nothing under it at all. Null when the key has
+ * any real child, or the line isn't a value-less plain key.
+ */
+function describeEmptyBlock(
+  readLine: ReadLine,
+  line: number,
+  localize: LocalizeFunc
+): string | null {
+  const text = readLine(line);
+  if (text === undefined || parseListItemMarker(text)) return null;
+  const key = valuelessKeyOf(stripComment(text));
+  if (key === null) return null;
+  const keyIndent = indentOf(text);
+  let sawComment = false;
+  for (let n = line + 1; n <= line + WALK_BOUND; n++) {
+    const next = readLine(n);
+    if (next === undefined) break;
+    if (!next.trim()) continue;
+    if (next.trimStart().startsWith("#")) {
+      sawComment ||= isCommentedChild(next, keyIndent);
+      continue;
+    }
+    if (indentOf(next) > keyIndent) return null;
+    break;
+  }
+  return localize(
+    sawComment
+      ? "yaml_editor.error_commented_block_hint"
+      : "yaml_editor.error_empty_block_hint",
+    { line, key }
+  );
 }
 
 /** Matches `[X] is an invalid option for [Y].` with any trailing hint

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -630,7 +630,7 @@ function isCommentedChild(text: string, keyIndent: number): boolean {
   if (indentOf(text) > keyIndent) return true;
   const content = text.trimStart().replace(/^#+/, "");
   if (indentOf(content) <= keyIndent) return false;
-  return parseListItemMarker(content) !== null || lineKeyToken(content) !== null;
+  return lineKeyToken(content) !== null;
 }
 
 /**

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -404,7 +404,7 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
         // key), name that cause, and carry its repair when it has one.
         const squiggleLineNum = doc.lineAt(from).number;
         const cause =
-          describeValueTypeCause(readLine, squiggleLineNum, opts.localize) ??
+          describeValueTypeCause(readLine, squiggleLineNum, opts.localize, message) ??
           (await describeInvalidOptionFix({
             api: opts.api,
             state: view.state,

--- a/src/util/yaml-validation-summary.ts
+++ b/src/util/yaml-validation-summary.ts
@@ -102,7 +102,7 @@ export function summarizeValidation(
   // when the two diverge the shape check fails and the hint is simply
   // omitted, never wrong.
   if (hasRange && (!file || file === "<file>")) {
-    const cause = describeValueTypeCause(readLine, line, localize);
+    const cause = describeValueTypeCause(readLine, line, localize, message);
     if (cause) message = `${message} ${cause.text}`;
   }
   return { count, first: { line, col, message, file } };

--- a/test/util/yaml-error-analysis.test.ts
+++ b/test/util/yaml-error-analysis.test.ts
@@ -104,11 +104,11 @@ describe("describeValueTypeCause", () => {
     const { describeValueTypeCause } =
       await import("../../src/util/yaml-error-analysis.js");
     const doc = (n: number): string | undefined => ["logger:", "  le"][n - 1];
-    expect(describeValueTypeCause(doc, 2, localize)).toEqual({
+    expect(describeValueTypeCause(doc, 2, localize, "")).toEqual({
       text: 'yaml_editor.error_missing_colon_hint:{"line":2,"key":"le"}',
     });
     const keyed = (n: number): string | undefined => ["logger:", "  level: DEBUG"][n - 1];
-    expect(describeValueTypeCause(keyed, 2, localize)).toBeNull();
+    expect(describeValueTypeCause(keyed, 2, localize, "")).toBeNull();
   });
 
   // The valid-YAML variant of the stuck dash: `-platform:` with no deeper
@@ -119,7 +119,7 @@ describe("describeValueTypeCause", () => {
       await import("../../src/util/yaml-error-analysis.js");
     const doc = (n: number): string | undefined =>
       ["ota:", "  -platform: esphome"][n - 1];
-    expect(describeValueTypeCause(doc, 2, localize)).toEqual({
+    expect(describeValueTypeCause(doc, 2, localize, "")).toEqual({
       text: 'yaml_editor.error_dash_space_fix:{"line":2,"key":"platform"}',
       fix: { line: 2, indent: 0, key: "-platform", fromIndent: 2, kind: "dash-space" },
     });
@@ -131,18 +131,11 @@ describe("describeValueTypeCause", () => {
     const { describeValueTypeCause } =
       await import("../../src/util/yaml-error-analysis.js");
     const doc = (n: number): string | undefined =>
-      [
-        "esp32:",
-        "  board: esp32dev",
-        "  framework:",
-        "    type: arduino",
-        "    advanced:",
-        '#      minimum_chip_revision: "3.1"',
-        "",
-        "logger:",
-      ][n - 1];
-    expect(describeValueTypeCause(doc, 5, localize, "expected a dictionary.")).toEqual({
-      text: 'yaml_editor.error_commented_block_hint:{"line":5,"key":"advanced"}',
+      ["    advanced:", '#      minimum_chip_revision: "3.1"', "  board: esp32dev"][
+        n - 1
+      ];
+    expect(describeValueTypeCause(doc, 1, localize, "expected a dictionary.")).toEqual({
+      text: 'yaml_editor.error_commented_block_hint:{"line":1,"key":"advanced"}',
     });
   });
 
@@ -186,7 +179,7 @@ describe("describeValueTypeCause", () => {
         "'board' is a required option for [esp32]."
       )
     ).toBeNull();
-    expect(describeValueTypeCause(doc, 1, localize)).toBeNull();
+    expect(describeValueTypeCause(doc, 1, localize, "")).toBeNull();
   });
 
   it("stays silent when the key has a real child or a value", async () => {

--- a/test/util/yaml-error-analysis.test.ts
+++ b/test/util/yaml-error-analysis.test.ts
@@ -124,6 +124,94 @@ describe("describeValueTypeCause", () => {
       fix: { line: 2, indent: 0, key: "-platform", fromIndent: 2, kind: "dash-space" },
     });
   });
+
+  // The commented-out-children shape: a `#` at column 0 in front of a
+  // still-indented option (hand-commented), so `advanced:` parses as null.
+  it("names the commented-out block behind 'expected a dictionary.'", async () => {
+    const { describeValueTypeCause } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "esp32:",
+        "  board: esp32dev",
+        "  framework:",
+        "    type: arduino",
+        "    advanced:",
+        '#      minimum_chip_revision: "3.1"',
+        "",
+        "logger:",
+      ][n - 1];
+    expect(describeValueTypeCause(doc, 5, localize, "expected a dictionary.")).toEqual({
+      text: 'yaml_editor.error_commented_block_hint:{"line":5,"key":"advanced"}',
+    });
+  });
+
+  it("names the commented-out block when the comment keeps its indent", async () => {
+    const { describeValueTypeCause } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = (n: number): string | undefined =>
+      ["    advanced:", '      # minimum_chip_revision: "3.1"', "  board: esp32dev"][
+        n - 1
+      ];
+    expect(describeValueTypeCause(doc, 1, localize, "expected a dictionary.")).toEqual({
+      text: 'yaml_editor.error_commented_block_hint:{"line":1,"key":"advanced"}',
+    });
+  });
+
+  it("names the empty block when nothing follows the key at all", async () => {
+    const { describeValueTypeCause } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const beforeSibling = (n: number): string | undefined =>
+      ["  framework:", "  board: esp32dev"][n - 1];
+    expect(
+      describeValueTypeCause(beforeSibling, 1, localize, "expected a dictionary.")
+    ).toEqual({
+      text: 'yaml_editor.error_empty_block_hint:{"line":1,"key":"framework"}',
+    });
+    const atEof = (n: number): string | undefined => ["  advanced:"][n - 1];
+    expect(describeValueTypeCause(atEof, 1, localize, "expected a dictionary.")).toEqual({
+      text: 'yaml_editor.error_empty_block_hint:{"line":1,"key":"advanced"}',
+    });
+  });
+
+  it("stays silent on the empty-block shape for other messages", async () => {
+    const { describeValueTypeCause } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = (n: number): string | undefined => ["esp32:", "", "logger:"][n - 1];
+    expect(
+      describeValueTypeCause(
+        doc,
+        1,
+        localize,
+        "'board' is a required option for [esp32]."
+      )
+    ).toBeNull();
+    expect(describeValueTypeCause(doc, 1, localize)).toBeNull();
+  });
+
+  it("stays silent when the key has a real child or a value", async () => {
+    const { describeValueTypeCause } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const withChild = (n: number): string | undefined =>
+      ["  framework:", "# a note", "    type: arduino"][n - 1];
+    expect(
+      describeValueTypeCause(withChild, 1, localize, "expected a dictionary.")
+    ).toBeNull();
+    const valued = (n: number): string | undefined => ["  board: esp32dev"][n - 1];
+    expect(
+      describeValueTypeCause(valued, 1, localize, "expected a dictionary.")
+    ).toBeNull();
+  });
+
+  it("treats a column-0 commented sibling as an empty block, not commented content", async () => {
+    const { describeValueTypeCause } =
+      await import("../../src/util/yaml-error-analysis.js");
+    const doc = (n: number): string | undefined =>
+      ["web_server:", "#api:", "logger:"][n - 1];
+    expect(describeValueTypeCause(doc, 1, localize, "expected a dictionary.")).toEqual({
+      text: 'yaml_editor.error_empty_block_hint:{"line":1,"key":"web_server"}',
+    });
+  });
 });
 
 describe("analyzeIndentMismatch", () => {

--- a/test/util/yaml-lint-humanize.test.ts
+++ b/test/util/yaml-lint-humanize.test.ts
@@ -148,6 +148,52 @@ describe("backend linter humanizes + banners a locatable parse error", () => {
     }
   });
 
+  // A key whose only child is commented out parses as null; the inline
+  // diagnostic must name the commented-out block, not just echo the bare
+  // "expected a dictionary." the validator sends.
+  it("squiggles the commented-out-block hint onto 'expected a dictionary.'", async () => {
+    const doc = [
+      "esphome:", // 1
+      "  name: x", // 2
+      "esp32:", // 3
+      "  board: esp32dev", // 4
+      "  framework:", // 5
+      "    type: arduino", // 6
+      "    advanced:", // 7
+      '#      minimum_chip_revision: "3.1"', // 8
+      "logger:", // 9
+      "",
+    ].join("\n");
+    const validateYaml = vi.fn(async () => ({
+      yaml_errors: [],
+      validation_errors: [
+        {
+          message: "expected a dictionary.",
+          range: {
+            document: "x.yaml",
+            start_line: 6,
+            start_col: 4,
+            end_line: 6,
+            end_col: 12,
+          },
+        },
+      ],
+    })) as unknown as ESPHomeAPI["validateYaml"];
+
+    const view = mountView(validateYaml, () => {}, undefined, doc);
+    try {
+      forceLinting(view);
+      await flush();
+      const messages: string[] = [];
+      forEachDiagnostic(view.state, (d) => messages.push(d.message));
+      expect(messages).toEqual([
+        "expected a dictionary. yaml_editor.error_commented_block_hint:7",
+      ]);
+    } finally {
+      view.destroy();
+    }
+  });
+
   it("banners a locatable validation error with its line and nested-list hint", async () => {
     const doc = [
       "light:", // 1

--- a/test/util/yaml-validation-summary.test.ts
+++ b/test/util/yaml-validation-summary.test.ts
@@ -225,6 +225,49 @@ describe("summarizeValidation", () => {
     expect(summary.first?.message).toContain("yaml_editor.error_missing_colon_hint");
   });
 
+  // The reproduced wire payload for an `advanced:` whose only child is
+  // commented out (esphome strips the config path upstream, so the hint
+  // is the only thing naming the line and key).
+  it("adds the commented-out-block hint to a bare 'expected a dictionary.'", () => {
+    const content = [
+      "esphome:",
+      "  name: dict-error-repro",
+      "",
+      "esp32:",
+      "  board: esp32dev",
+      "  framework:",
+      "    type: arduino",
+      "    advanced:",
+      '#      minimum_chip_revision: "3.1"',
+      "",
+      "logger:",
+      "",
+    ].join("\n");
+    const summary = summarize(
+      res(
+        [],
+        [
+          {
+            message: "expected a dictionary.",
+            range: {
+              document: "<file>",
+              start_line: 7,
+              start_col: 4,
+              end_line: 7,
+              end_col: 12,
+            },
+          },
+        ]
+      ),
+      content
+    );
+    expect(summary.first?.line).toBe(8);
+    expect(summary.first?.message).toBe(
+      "expected a dictionary. " +
+        'yaml_editor.error_commented_block_hint:{"line":8,"key":"advanced"}'
+    );
+  });
+
   it("skips the cause hint when the error lives in an included file", () => {
     const content = "logger:\n  le\n";
     const summary = summarize(


### PR DESCRIPTION
# What does this implement/fix?

When a config has a section key whose options are all commented out, like `advanced:` with `# minimum_chip_revision: "3.1"` under it, the save dialog and the editor squiggle only said `expected a dictionary.` ESPHome strips the config path from the message before it reaches us, so the user had no idea which line was wrong or what to do about it. A real user hit exactly this after commenting out `minimum_chip_revision` to work around an OTA failure, and needed Discord support to learn the fix was removing the `advanced:` line too.

`describeValueTypeCause` now recognizes a value-less `key:` with nothing (or only comments) under it and names the line, the key, and the repair. The dialog and the inline tooltip both read: `expected a dictionary. Line 8: everything under "advanced" is commented out, so it has no options. Uncomment an option, or comment out "advanced" too.` A key with nothing under it at all gets a matching wording that suggests adding an option or removing the line. The hint is gated on the `expected a dictionary` message so an unrelated error anchored on a legal empty key (`logger:`) never picks up remove-the-line advice.

**Related issue or feature (if applicable):**

- fixes N/A (reported via Discord support thread)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
