### PR TITLE
Surface backend error details in remote-build dialog catch-all errors

### DIFF
--- a/src/components/edit-pairing-endpoint-dialog.ts
+++ b/src/components/edit-pairing-endpoint-dialog.ts
@@ -13,6 +13,7 @@ import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { EnterController } from "../util/enter-controller.js";
 import { fireEvent } from "../util/fire-event.js";
+import { formatApiError } from "../util/format-api-error.js";
 import {
   normalizeHostnameForCompare,
   parsePortInput,
@@ -197,10 +198,14 @@ export class ESPHomeEditPairingEndpointDialog extends LitElement {
             detail: err.details,
           });
         default:
-          return this._localize("settings.edit_pairing_endpoint_generic_error");
+          break;
       }
     }
-    return this._localize("settings.edit_pairing_endpoint_generic_error");
+    return formatApiError(
+      err,
+      this._localize,
+      "settings.edit_pairing_endpoint_generic_error"
+    );
   }
 
   private _onRequestClose = (e: Event): void => {

--- a/src/components/pair-build-server-dialog/actions.ts
+++ b/src/components/pair-build-server-dialog/actions.ts
@@ -1,6 +1,7 @@
 import { APIError } from "../../api/api-error.js";
 import { ErrorCode } from "../../api/types/protocol.js";
 import type { PairingSummary } from "../../api/types/remote-build.js";
+import { formatApiError } from "../../util/format-api-error.js";
 import { parsePortInput } from "../../util/hostname.js";
 import type { ESPHomePairBuildServerDialog } from "../pair-build-server-dialog.js";
 
@@ -21,7 +22,7 @@ export function previewErrorMessage(
       });
     }
   }
-  return host._localize("settings.pair_build_server_preview_failed");
+  return formatApiError(err, host._localize, "settings.pair_build_server_preview_failed");
 }
 
 export function requestErrorMessage(
@@ -47,7 +48,7 @@ export function requestErrorMessage(
       });
     }
   }
-  return host._localize("settings.pair_build_server_request_failed");
+  return formatApiError(err, host._localize, "settings.pair_build_server_request_failed");
 }
 
 export async function onPreviewSubmit(host: ESPHomePairBuildServerDialog): Promise<void> {

--- a/test/components/pair-build-server-dialog/error-messages.test.ts
+++ b/test/components/pair-build-server-dialog/error-messages.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Pins that the pair-dialog catch-all error paths surface the backend's
+ * detail text instead of only pointing at the dashboard logs.
+ */
+import { describe, expect, it } from "vitest";
+import { APIError } from "../../../src/api/api-error.js";
+import { ErrorCode } from "../../../src/api/types/protocol.js";
+import type { ESPHomePairBuildServerDialog } from "../../../src/components/pair-build-server-dialog.js";
+import {
+  previewErrorMessage,
+  requestErrorMessage,
+} from "../../../src/components/pair-build-server-dialog/actions.js";
+import { identityLocalize } from "../../_dom.js";
+
+const host = {
+  _localize: identityLocalize,
+  _hostname: "buildbox.local",
+  _port: "6055",
+} as unknown as ESPHomePairBuildServerDialog;
+
+describe("previewErrorMessage", () => {
+  it("keeps the specific message for UNAVAILABLE", () => {
+    const msg = previewErrorMessage(host, new APIError(ErrorCode.UNAVAILABLE, "down"));
+    expect(msg).toBe("settings.pair_build_server_preview_unreachable");
+  });
+
+  it("surfaces the backend detail for an unmapped error code", () => {
+    const msg = previewErrorMessage(
+      host,
+      new APIError(ErrorCode.INTERNAL_ERROR, "identity not loaded yet")
+    );
+    expect(msg).toBe("identity not loaded yet");
+  });
+
+  it("falls back to the generic message when there is no detail", () => {
+    const msg = previewErrorMessage(host, new APIError(ErrorCode.INTERNAL_ERROR, ""));
+    expect(msg).toBe("settings.pair_build_server_preview_failed");
+  });
+});
+
+describe("requestErrorMessage", () => {
+  it("surfaces the backend detail for an unmapped error code", () => {
+    const msg = requestErrorMessage(
+      host,
+      new APIError(ErrorCode.INTERNAL_ERROR, "peer-link handshake timed out")
+    );
+    expect(msg).toBe("peer-link handshake timed out");
+  });
+
+  it("falls back to the generic message when there is no detail", () => {
+    const msg = requestErrorMessage(host, new APIError(ErrorCode.INTERNAL_ERROR, ""));
+    expect(msg).toBe("settings.pair_build_server_request_failed");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

A user reported "Couldn't dispatch the build. Check the dashboard logs for details." with no way to learn more without shell access to the dashboard logs. The remote build dialogs still have catch-all error paths with the same problem; they swallow the detail text the backend already sent and only point at the logs.

Route the pair build server dialog and the edit endpoint dialog fallbacks through the existing `formatApiError` helper, so the backend's detail shows inline; the generic message still appears when no detail is available.

**Related issue or feature (if applicable):**

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
