### PR TITLE
Offer one-click fixes for the empty and commented-out block hints

### DIFF
--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -33,12 +33,12 @@ import { idleCompletion } from "../util/idle-completion.js";
 import { createYamlCompletionSource } from "../util/yaml-completion.js";
 import { cursorKeyPathAt, indexedKeyPathAt } from "../util/yaml-cursor-paths.js";
 import {
+  emptyBlockFixKind,
   lineKeyToken,
-  valuelessKeyOf,
   type YamlAutoFix,
 } from "../util/yaml-error-analysis.js";
 import { createYamlHoverTooltip } from "../util/yaml-hover.js";
-import { indentOf, stripComment } from "../util/yaml-line-walker.js";
+import { indentOf } from "../util/yaml-line-walker.js";
 import {
   createBackendYamlLinter,
   lintErrorLineGutter,
@@ -606,9 +606,9 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
    * the proposed document is what actually catches fixing the wrong item or
    * double-fixing one already repaired. The destructive kinds lean harder on
    * the structural check — deleting or commenting the wrong line often still
-   * validates clean — so they additionally require the line to still be a
-   * value-less key. A validation failure rejects (the caller surfaces it)
-   * rather than silently applying.
+   * validates clean — so they additionally require the line to still hold
+   * the exact empty/commented shape the fix was diagnosed for. A validation
+   * failure rejects (the caller surfaces it) rather than silently applying.
    */
   async applyAutoFix(
     fix: YamlAutoFix,
@@ -636,9 +636,15 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
       }
       // A dedent must have the spaces it wants to remove.
       if (fix.indent < 0 && fix.fromIndent + fix.indent < 0) return null;
-      // A destructive fix was diagnosed on a value-less key; a line that has
-      // since gained a value must not be commented out or deleted.
-      if (destructive && valuelessKeyOf(stripComment(t.text)) === null) return null;
+      // A destructive fix's target IS its diagnosed line, so unlike the
+      // general anchored-elsewhere case above, re-running the shape check is
+      // valid — and required: a key that has since gained a value or a real
+      // child must not be commented out or deleted.
+      if (destructive) {
+        const readLine = (n: number): string | undefined =>
+          n >= 1 && n <= doc.lines ? doc.line(n).text : undefined;
+        if (emptyBlockFixKind(readLine, fix.line) !== fix.kind) return null;
+      }
       return t;
     };
     const line = targetLine();

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -608,7 +608,7 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
     confirm?: () => Promise<boolean>
   ): Promise<AutoFixOutcome> {
     const view = this._view;
-    if (!view || !this._api || (fix.kind !== "dash-space" && fix.indent === 0)) {
+    if (!view || !this._api || (fix.kind === undefined && fix.indent === 0)) {
       return "unavailable";
     }
     // Resolve the target only when the line the fix wants to edit is still
@@ -634,14 +634,23 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
     if (from === null) return "stale";
 
     const doc = view.state.doc;
-    // The dash-space repair inserts after the stuck dash; indent repairs
-    // insert or remove leading spaces at the line start.
-    const changeAt = (at: number): { from: number; to?: number; insert?: string } =>
-      fix.kind === "dash-space"
-        ? { from: at + fix.fromIndent + 1, insert: " " }
-        : fix.indent > 0
-          ? { from: at, insert: " ".repeat(fix.indent) }
-          : { from: at, to: at - fix.indent };
+    // The dash-space repair inserts after the stuck dash; comment-out
+    // inserts `# ` at the line's indent; remove-line deletes the whole
+    // line (extent read from the live doc — changeAt runs against the
+    // pre-await doc for the proposal and the settled doc for dispatch);
+    // indent repairs insert or remove leading spaces at the line start.
+    const changeAt = (at: number): { from: number; to?: number; insert?: string } => {
+      if (fix.kind === "dash-space")
+        return { from: at + fix.fromIndent + 1, insert: " " };
+      if (fix.kind === "comment-out") return { from: at + fix.fromIndent, insert: "# " };
+      if (fix.kind === "remove-line") {
+        const target = view.state.doc.lineAt(at);
+        return { from: target.from, to: Math.min(target.to + 1, view.state.doc.length) };
+      }
+      return fix.indent > 0
+        ? { from: at, insert: " ".repeat(fix.indent) }
+        : { from: at, to: at - fix.indent };
+    };
     const change = changeAt(from);
     const proposed =
       doc.sliceString(0, change.from) +

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -2,7 +2,7 @@ import { autocompletion, completionStatus } from "@codemirror/autocomplete";
 import { indentWithTab, undoDepth } from "@codemirror/commands";
 import { indentUnit } from "@codemirror/language";
 import { forceLinting } from "@codemirror/lint";
-import { StateEffect, StateField, Transaction } from "@codemirror/state";
+import { StateEffect, StateField, Transaction, type Line } from "@codemirror/state";
 import { Decoration, keymap, tooltips, type DecorationSet } from "@codemirror/view";
 import { consume } from "@lit/context";
 import { indentationMarkers } from "@replit/codemirror-indentation-markers";
@@ -32,9 +32,13 @@ import { fireEvent } from "../util/fire-event.js";
 import { idleCompletion } from "../util/idle-completion.js";
 import { createYamlCompletionSource } from "../util/yaml-completion.js";
 import { cursorKeyPathAt, indexedKeyPathAt } from "../util/yaml-cursor-paths.js";
-import { lineKeyToken, type YamlAutoFix } from "../util/yaml-error-analysis.js";
+import {
+  lineKeyToken,
+  valuelessKeyOf,
+  type YamlAutoFix,
+} from "../util/yaml-error-analysis.js";
 import { createYamlHoverTooltip } from "../util/yaml-hover.js";
-import { indentOf } from "../util/yaml-line-walker.js";
+import { indentOf, stripComment } from "../util/yaml-line-walker.js";
 import {
   createBackendYamlLinter,
   lintErrorLineGutter,
@@ -597,11 +601,14 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
    * undoable transaction.
    *
    * The re-validation is the real safety net against a stale banner: the
-   * `- <key>` re-check (before and after the async step) is a cheap filter,
-   * but the key is often a shared token (`platform`), so validating the
-   * proposed document is what actually catches fixing the wrong item or
-   * double-fixing one already repaired. A validation failure rejects (the
-   * caller surfaces it) rather than silently applying.
+   * key + indent re-check (before and after the async step) is a cheap
+   * filter, but the key is often a shared token (`platform`), so validating
+   * the proposed document is what actually catches fixing the wrong item or
+   * double-fixing one already repaired. The destructive kinds lean harder on
+   * the structural check — deleting or commenting the wrong line often still
+   * validates clean — so they additionally require the line to still be a
+   * value-less key. A validation failure rejects (the caller surfaces it)
+   * rather than silently applying.
    */
   async applyAutoFix(
     fix: YamlAutoFix,
@@ -611,6 +618,7 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
     if (!view || !this._api || (fix.kind === undefined && fix.indent === 0)) {
       return "unavailable";
     }
+    const destructive = fix.kind === "comment-out" || fix.kind === "remove-line";
     // Resolve the target only when the line the fix wants to edit is still
     // the line the analysis saw — same key, same indent — so a stale click
     // after edits shifted line numbers, or on a line the user already
@@ -619,7 +627,7 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
     // on a different line than the one it repairs (a continuation error
     // blames the line below the pair that moves), so re-analyzing at the
     // fix line can't reproduce every shape.
-    const targetFrom = (): number | null => {
+    const targetLine = (): Line | null => {
       const doc = view.state.doc;
       if (fix.line < 1 || fix.line > doc.lines) return null;
       const t = doc.line(fix.line);
@@ -628,30 +636,36 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
       }
       // A dedent must have the spaces it wants to remove.
       if (fix.indent < 0 && fix.fromIndent + fix.indent < 0) return null;
-      return t.from;
+      // A destructive fix was diagnosed on a value-less key; a line that has
+      // since gained a value must not be commented out or deleted.
+      if (destructive && valuelessKeyOf(stripComment(t.text)) === null) return null;
+      return t;
     };
-    const from = targetFrom();
-    if (from === null) return "stale";
+    const line = targetLine();
+    if (line === null) return "stale";
 
     const doc = view.state.doc;
     // The dash-space repair inserts after the stuck dash; comment-out
     // inserts `# ` at the line's indent; remove-line deletes the whole
-    // line (extent read from the live doc — changeAt runs against the
-    // pre-await doc for the proposal and the settled doc for dispatch);
-    // indent repairs insert or remove leading spaces at the line start.
-    const changeAt = (at: number): { from: number; to?: number; insert?: string } => {
+    // line; indent repairs insert or remove leading spaces at the line
+    // start. Pure arithmetic on the resolved line + its doc, so both
+    // invocations (pre-await proposal, post-await dispatch) stay
+    // consistent with the doc they resolved against.
+    const changeAt = (
+      target: Line,
+      docLength: number
+    ): { from: number; to?: number; insert?: string } => {
+      const at = target.from;
       if (fix.kind === "dash-space")
         return { from: at + fix.fromIndent + 1, insert: " " };
       if (fix.kind === "comment-out") return { from: at + fix.fromIndent, insert: "# " };
-      if (fix.kind === "remove-line") {
-        const target = view.state.doc.lineAt(at);
-        return { from: target.from, to: Math.min(target.to + 1, view.state.doc.length) };
-      }
+      if (fix.kind === "remove-line")
+        return { from: at, to: Math.min(target.to + 1, docLength) };
       return fix.indent > 0
         ? { from: at, insert: " ".repeat(fix.indent) }
         : { from: at, to: at - fix.indent };
     };
-    const change = changeAt(from);
+    const change = changeAt(line, doc.length);
     const proposed =
       doc.sliceString(0, change.from) +
       (change.insert ?? "") +
@@ -665,10 +679,10 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
     if (!proceed) return "declined";
 
     // Re-resolve the target: the doc may have changed while we awaited.
-    const settled = targetFrom();
+    const settled = targetLine();
     if (settled === null) return "stale";
     view.dispatch({
-      changes: changeAt(settled),
+      changes: changeAt(settled, view.state.doc.length),
       scrollIntoView: true,
     });
     view.focus();

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -190,7 +190,7 @@ function lineHasValue(text: string): boolean {
 
 /** The line's key when it is a value-less `key:` opener, else null.
  *  Callers pre-filter `- ` marker lines. */
-export function valuelessKeyOf(text: string): string | null {
+function valuelessKeyOf(text: string): string | null {
   return lineHasValue(text) ? null : lineKeyToken(text);
 }
 
@@ -634,23 +634,20 @@ function isCommentedChild(text: string, keyIndent: number): boolean {
 }
 
 /**
- * The empty-block cause behind "expected a dictionary." anchored on a
- * value-less plain `key:`: nothing is indented under it, so its value is
- * null. Distinguishes children that are all commented out (the classic
- * "commented the option, left the key" repair — the fix comments out the
- * key too) from a key with nothing under it at all (the fix removes the
- * line). Null when the key has any real child, or the line isn't a
- * value-less plain key.
+ * Classify the empty-block shape at *line*: a value-less plain `key:`
+ * whose children are all commented out ("comment-out") or absent
+ * entirely ("remove-line"); null when the key has any real child, or
+ * the line isn't a value-less plain key. Also the apply site's stale
+ * check for the destructive fixes — the diagnosed line must still hold
+ * the exact shape the fix was built for.
  */
-function describeEmptyBlock(
+export function emptyBlockFixKind(
   readLine: ReadLine,
-  line: number,
-  localize: LocalizeFunc
-): ValueTypeCause | null {
+  line: number
+): "comment-out" | "remove-line" | null {
   const text = readLine(line);
   if (text === undefined || parseListItemMarker(text)) return null;
-  const key = valuelessKeyOf(stripComment(text));
-  if (key === null) return null;
+  if (valuelessKeyOf(stripComment(text)) === null) return null;
   const keyIndent = indentOf(text);
   let sawComment = false;
   for (let n = line + 1; n <= line + WALK_BOUND; n++) {
@@ -664,20 +661,32 @@ function describeEmptyBlock(
     if (indentOf(next) > keyIndent) return null;
     break;
   }
+  return sawComment ? "comment-out" : "remove-line";
+}
+
+/**
+ * The empty-block cause behind "expected a dictionary.": the hint names
+ * the commented-out or empty shape and carries the matching repair
+ * (comment the key out too, or remove the line).
+ */
+function describeEmptyBlock(
+  readLine: ReadLine,
+  line: number,
+  localize: LocalizeFunc
+): ValueTypeCause | null {
+  const kind = emptyBlockFixKind(readLine, line);
+  if (kind === null) return null;
+  const text = readLine(line);
+  const key = valuelessKeyOf(stripComment(text ?? ""));
+  if (key === null) return null;
   return {
     text: localize(
-      sawComment
+      kind === "comment-out"
         ? "yaml_editor.error_commented_block_hint"
         : "yaml_editor.error_empty_block_hint",
       { line, key }
     ),
-    fix: {
-      line,
-      indent: 0,
-      key,
-      fromIndent: keyIndent,
-      kind: sawComment ? "comment-out" : "remove-line",
-    },
+    fix: { line, indent: 0, key, fromIndent: indentOf(text ?? ""), kind },
   };
 }
 

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -603,7 +603,7 @@ export function describeValueTypeCause(
   // ("'board' is a required option") must not pick up a remove-the-line hint.
   if (EXPECTED_DICT_RE.test(message)) {
     const emptyBlock = describeEmptyBlock(readLine, line, localize);
-    if (emptyBlock) return { text: emptyBlock };
+    if (emptyBlock) return emptyBlock;
   }
   const token = text.trim();
   if (token && !token.includes(":") && !token.startsWith("#") && !token.startsWith("-")) {
@@ -637,15 +637,16 @@ function isCommentedChild(text: string, keyIndent: number): boolean {
  * The empty-block cause behind "expected a dictionary." anchored on a
  * value-less plain `key:`: nothing is indented under it, so its value is
  * null. Distinguishes children that are all commented out (the classic
- * "commented the option, left the key" repair — uncomment or comment the
- * key too) from a key with nothing under it at all. Null when the key has
- * any real child, or the line isn't a value-less plain key.
+ * "commented the option, left the key" repair — the fix comments out the
+ * key too) from a key with nothing under it at all (the fix removes the
+ * line). Null when the key has any real child, or the line isn't a
+ * value-less plain key.
  */
 function describeEmptyBlock(
   readLine: ReadLine,
   line: number,
   localize: LocalizeFunc
-): string | null {
+): ValueTypeCause | null {
   const text = readLine(line);
   if (text === undefined || parseListItemMarker(text)) return null;
   const key = valuelessKeyOf(stripComment(text));
@@ -663,12 +664,21 @@ function describeEmptyBlock(
     if (indentOf(next) > keyIndent) return null;
     break;
   }
-  return localize(
-    sawComment
-      ? "yaml_editor.error_commented_block_hint"
-      : "yaml_editor.error_empty_block_hint",
-    { line, key }
-  );
+  return {
+    text: localize(
+      sawComment
+        ? "yaml_editor.error_commented_block_hint"
+        : "yaml_editor.error_empty_block_hint",
+      { line, key }
+    ),
+    fix: {
+      line,
+      indent: 0,
+      key,
+      fromIndent: keyIndent,
+      kind: sawComment ? "comment-out" : "remove-line",
+    },
+  };
 }
 
 /** Matches `[X] is an invalid option for [Y].` with any trailing hint
@@ -803,11 +813,11 @@ export function lineAccessorFor(content: string): ReadLine {
 }
 
 /** A one-click one-line repair: re-indent `line` by the signed `indent`
- *  delta, or (kind "dash-space") insert the missing space after its list
- *  dash. */
+ *  delta, or a kind-specific edit — insert the missing space after a list
+ *  dash, comment the line out, or delete it. */
 export interface YamlAutoFix {
   line: number;
-  /** Signed leading-space delta; 0 (unused) for kind "dash-space". */
+  /** Signed leading-space delta; 0 (unused) for the kind-specific edits. */
   indent: number;
   /** The target line's own key, so the apply site can confirm the line still
    *  targets the same item after edits shift line numbers. */
@@ -815,8 +825,10 @@ export interface YamlAutoFix {
   /** The target line's indent when the fix was computed; the apply site
    *  refuses when the line no longer starts there. */
   fromIndent: number;
-  /** Absent means re-indent; "dash-space" inserts a space after the dash. */
-  kind?: "dash-space";
+  /** Absent means re-indent; "dash-space" inserts a space after the dash,
+   *  "comment-out" inserts `# ` at the line's indent, "remove-line" deletes
+   *  the whole line. */
+  kind?: "dash-space" | "comment-out" | "remove-line";
 }
 
 /** A humanized YAML error: display text, best line to jump to, optional auto-fix. */

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -190,7 +190,7 @@ function lineHasValue(text: string): boolean {
 
 /** The line's key when it is a value-less `key:` opener, else null.
  *  Callers pre-filter `- ` marker lines. */
-function valuelessKeyOf(text: string): string | null {
+export function valuelessKeyOf(text: string): string | null {
   return lineHasValue(text) ? null : lineKeyToken(text);
 }
 

--- a/test/components/yaml-editor-auto-fix.test.ts
+++ b/test/components/yaml-editor-auto-fix.test.ts
@@ -354,9 +354,12 @@ describe("yaml-editor applyAutoFix (#1884)", () => {
     expect(validateYaml).toHaveBeenCalledWith("x.yaml", fixed);
   });
 
-  it("no-ops a stale remove-line fix whose line now holds a different key", async () => {
+  // Deleting or commenting the wrong line often still validates clean, so
+  // the destructive kinds must refuse structurally once the diagnosed
+  // value-less key has gained a value.
+  it("no-ops a stale destructive fix once the key has gained a value", async () => {
     const validateYaml = vi.fn(async () => CLEAN);
-    const doc = "esp32:\n  framework:\n    type: arduino\n";
+    const doc = "esp32:\n  framework:\n    advanced: true\n";
     const el = await mountEditor(validateYaml, doc);
 
     expect(
@@ -368,6 +371,7 @@ describe("yaml-editor applyAutoFix (#1884)", () => {
         kind: "remove-line",
       })
     ).toBe("stale");
+    expect(viewOf(el).state.doc.toString()).toBe(doc);
     expect(validateYaml).not.toHaveBeenCalled();
   });
 });

--- a/test/components/yaml-editor-auto-fix.test.ts
+++ b/test/components/yaml-editor-auto-fix.test.ts
@@ -267,4 +267,107 @@ describe("yaml-editor applyAutoFix (#1884)", () => {
     );
     expect(validateYaml).not.toHaveBeenCalled();
   });
+
+  it("applies a comment-out fix at the key's indent", async () => {
+    const validateYaml = vi.fn(async () => CLEAN);
+    const broken =
+      'esp32:\n  framework:\n    advanced:\n#      minimum_chip_revision: "3.1"\n';
+    const fixed =
+      'esp32:\n  framework:\n    # advanced:\n#      minimum_chip_revision: "3.1"\n';
+    const el = await mountEditor(validateYaml, broken);
+    const view = viewOf(el);
+
+    expect(
+      await el.applyAutoFix({
+        line: 3,
+        indent: 0,
+        key: "advanced",
+        fromIndent: 4,
+        kind: "comment-out",
+      })
+    ).toBe("applied");
+
+    expect(view.state.doc.toString()).toBe(fixed);
+    expect(validateYaml).toHaveBeenCalledWith("x.yaml", fixed);
+    undo(view);
+    expect(view.state.doc.toString()).toBe(broken);
+  });
+
+  it("no-ops a stale comment-out fix whose line was already commented", async () => {
+    const validateYaml = vi.fn(async () => CLEAN);
+    const doc = "esp32:\n  framework:\n    # advanced:\n";
+    const el = await mountEditor(validateYaml, doc);
+
+    expect(
+      await el.applyAutoFix({
+        line: 3,
+        indent: 0,
+        key: "advanced",
+        fromIndent: 4,
+        kind: "comment-out",
+      })
+    ).toBe("stale");
+    expect(validateYaml).not.toHaveBeenCalled();
+  });
+
+  it("applies a remove-line fix by deleting the whole line", async () => {
+    const validateYaml = vi.fn(async () => CLEAN);
+    const broken = "esp32:\n  framework:\n    advanced:\n  board: esp32dev\n";
+    const fixed = "esp32:\n  framework:\n  board: esp32dev\n";
+    const el = await mountEditor(validateYaml, broken);
+    const view = viewOf(el);
+
+    expect(
+      await el.applyAutoFix({
+        line: 3,
+        indent: 0,
+        key: "advanced",
+        fromIndent: 4,
+        kind: "remove-line",
+      })
+    ).toBe("applied");
+
+    expect(view.state.doc.toString()).toBe(fixed);
+    expect(validateYaml).toHaveBeenCalledWith("x.yaml", fixed);
+    undo(view);
+    expect(view.state.doc.toString()).toBe(broken);
+  });
+
+  it("applies a remove-line fix on the document's last line", async () => {
+    const validateYaml = vi.fn(async () => CLEAN);
+    const broken = "esp32:\n  framework:\n    advanced:";
+    const fixed = "esp32:\n  framework:\n";
+    const el = await mountEditor(validateYaml, broken);
+    const view = viewOf(el);
+
+    expect(
+      await el.applyAutoFix({
+        line: 3,
+        indent: 0,
+        key: "advanced",
+        fromIndent: 4,
+        kind: "remove-line",
+      })
+    ).toBe("applied");
+
+    expect(view.state.doc.toString()).toBe(fixed);
+    expect(validateYaml).toHaveBeenCalledWith("x.yaml", fixed);
+  });
+
+  it("no-ops a stale remove-line fix whose line now holds a different key", async () => {
+    const validateYaml = vi.fn(async () => CLEAN);
+    const doc = "esp32:\n  framework:\n    type: arduino\n";
+    const el = await mountEditor(validateYaml, doc);
+
+    expect(
+      await el.applyAutoFix({
+        line: 3,
+        indent: 0,
+        key: "advanced",
+        fromIndent: 4,
+        kind: "remove-line",
+      })
+    ).toBe("stale");
+    expect(validateYaml).not.toHaveBeenCalled();
+  });
 });

--- a/test/components/yaml-editor-auto-fix.test.ts
+++ b/test/components/yaml-editor-auto-fix.test.ts
@@ -356,10 +356,51 @@ describe("yaml-editor applyAutoFix (#1884)", () => {
 
   // Deleting or commenting the wrong line often still validates clean, so
   // the destructive kinds must refuse structurally once the diagnosed
-  // value-less key has gained a value.
+  // shape is gone: the key gained a value, gained a real child (which the
+  // fix would orphan), or flipped to the other empty-block shape.
   it("no-ops a stale destructive fix once the key has gained a value", async () => {
     const validateYaml = vi.fn(async () => CLEAN);
     const doc = "esp32:\n  framework:\n    advanced: true\n";
+    const el = await mountEditor(validateYaml, doc);
+
+    expect(
+      await el.applyAutoFix({
+        line: 3,
+        indent: 0,
+        key: "advanced",
+        fromIndent: 4,
+        kind: "remove-line",
+      })
+    ).toBe("stale");
+    expect(viewOf(el).state.doc.toString()).toBe(doc);
+    expect(validateYaml).not.toHaveBeenCalled();
+  });
+
+  it("no-ops a stale destructive fix once the key has gained a real child", async () => {
+    const validateYaml = vi.fn(async () => CLEAN);
+    const doc =
+      'esp32:\n  framework:\n    advanced:\n      minimum_chip_revision: "3.1"\n';
+    const el = await mountEditor(validateYaml, doc);
+
+    expect(
+      await el.applyAutoFix({
+        line: 3,
+        indent: 0,
+        key: "advanced",
+        fromIndent: 4,
+        kind: "remove-line",
+      })
+    ).toBe("stale");
+    expect(viewOf(el).state.doc.toString()).toBe(doc);
+    expect(validateYaml).not.toHaveBeenCalled();
+  });
+
+  it("no-ops a destructive fix whose empty-block shape has flipped", async () => {
+    const validateYaml = vi.fn(async () => CLEAN);
+    // Diagnosed remove-line (nothing under the key); a commented child has
+    // since appeared, so the right repair is now comment-out, not deletion.
+    const doc =
+      'esp32:\n  framework:\n    advanced:\n#      minimum_chip_revision: "3.1"\n';
     const el = await mountEditor(validateYaml, doc);
 
     expect(

--- a/test/util/yaml-error-analysis.test.ts
+++ b/test/util/yaml-error-analysis.test.ts
@@ -136,6 +136,7 @@ describe("describeValueTypeCause", () => {
       ];
     expect(describeValueTypeCause(doc, 1, localize, "expected a dictionary.")).toEqual({
       text: 'yaml_editor.error_commented_block_hint:{"line":1,"key":"advanced"}',
+      fix: { line: 1, indent: 0, key: "advanced", fromIndent: 4, kind: "comment-out" },
     });
   });
 
@@ -148,6 +149,7 @@ describe("describeValueTypeCause", () => {
       ];
     expect(describeValueTypeCause(doc, 1, localize, "expected a dictionary.")).toEqual({
       text: 'yaml_editor.error_commented_block_hint:{"line":1,"key":"advanced"}',
+      fix: { line: 1, indent: 0, key: "advanced", fromIndent: 4, kind: "comment-out" },
     });
   });
 
@@ -160,10 +162,12 @@ describe("describeValueTypeCause", () => {
       describeValueTypeCause(beforeSibling, 1, localize, "expected a dictionary.")
     ).toEqual({
       text: 'yaml_editor.error_empty_block_hint:{"line":1,"key":"framework"}',
+      fix: { line: 1, indent: 0, key: "framework", fromIndent: 2, kind: "remove-line" },
     });
     const atEof = (n: number): string | undefined => ["  advanced:"][n - 1];
     expect(describeValueTypeCause(atEof, 1, localize, "expected a dictionary.")).toEqual({
       text: 'yaml_editor.error_empty_block_hint:{"line":1,"key":"advanced"}',
+      fix: { line: 1, indent: 0, key: "advanced", fromIndent: 2, kind: "remove-line" },
     });
   });
 
@@ -203,6 +207,7 @@ describe("describeValueTypeCause", () => {
       ["web_server:", "#api:", "logger:"][n - 1];
     expect(describeValueTypeCause(doc, 1, localize, "expected a dictionary.")).toEqual({
       text: 'yaml_editor.error_empty_block_hint:{"line":1,"key":"web_server"}',
+      fix: { line: 1, indent: 0, key: "web_server", fromIndent: 0, kind: "remove-line" },
     });
   });
 });

--- a/test/util/yaml-lint-humanize.test.ts
+++ b/test/util/yaml-lint-humanize.test.ts
@@ -49,6 +49,18 @@ function mountView(
   });
 }
 
+/** All hover-tooltip actions across the current diagnostics. */
+function collectActions(
+  view: EditorView
+): { name: string; apply: (v: EditorView, a: number, b: number) => void }[] {
+  const actions: {
+    name: string;
+    apply: (v: EditorView, a: number, b: number) => void;
+  }[] = [];
+  forEachDiagnostic(view.state, (d) => actions.push(...(d.actions ?? [])));
+  return actions;
+}
+
 describe("backend linter humanizes + banners a locatable parse error", () => {
   it("pinpoints the fix in both the banner (with auto-fix) and an inline diagnostic", async () => {
     let banner: BannerError[] = [];
@@ -111,11 +123,7 @@ describe("backend linter humanizes + banners a locatable parse error", () => {
       forceLinting(view);
       await flush();
 
-      const actions: {
-        name: string;
-        apply: (v: EditorView, a: number, b: number) => void;
-      }[] = [];
-      forEachDiagnostic(view.state, (d) => actions.push(...(d.actions ?? [])));
+      const actions = collectActions(view);
       expect(actions.map((a) => a.name)).toEqual(["yaml_editor.error_auto_fix"]);
 
       actions[0].apply(view, 0, 0);
@@ -140,9 +148,7 @@ describe("backend linter humanizes + banners a locatable parse error", () => {
     try {
       forceLinting(view);
       await flush();
-      const actions: unknown[] = [];
-      forEachDiagnostic(view.state, (d) => actions.push(...(d.actions ?? [])));
-      expect(actions).toEqual([]);
+      expect(collectActions(view)).toEqual([]);
     } finally {
       view.destroy();
     }
@@ -191,19 +197,13 @@ describe("backend linter humanizes + banners a locatable parse error", () => {
       forceLinting(view);
       await flush();
       const messages: string[] = [];
-      const actions: {
-        name: string;
-        apply: (v: EditorView, a: number, b: number) => void;
-      }[] = [];
-      forEachDiagnostic(view.state, (d) => {
-        messages.push(d.message);
-        actions.push(...(d.actions ?? []));
-      });
+      forEachDiagnostic(view.state, (d) => messages.push(d.message));
       expect(messages).toEqual([
         "expected a dictionary. yaml_editor.error_commented_block_hint:7",
       ]);
 
       // The hint carries the comment-out repair as the tooltip action.
+      const actions = collectActions(view);
       expect(actions.map((a) => a.name)).toEqual(["yaml_editor.error_auto_fix"]);
       actions[0].apply(view, 0, 0);
       expect(fixes).toEqual([

--- a/test/util/yaml-lint-humanize.test.ts
+++ b/test/util/yaml-lint-humanize.test.ts
@@ -180,14 +180,34 @@ describe("backend linter humanizes + banners a locatable parse error", () => {
       ],
     })) as unknown as ESPHomeAPI["validateYaml"];
 
-    const view = mountView(validateYaml, () => {}, undefined, doc);
+    const fixes: YamlAutoFix[] = [];
+    const view = mountView(
+      validateYaml,
+      () => {},
+      (fix) => fixes.push(fix),
+      doc
+    );
     try {
       forceLinting(view);
       await flush();
       const messages: string[] = [];
-      forEachDiagnostic(view.state, (d) => messages.push(d.message));
+      const actions: {
+        name: string;
+        apply: (v: EditorView, a: number, b: number) => void;
+      }[] = [];
+      forEachDiagnostic(view.state, (d) => {
+        messages.push(d.message);
+        actions.push(...(d.actions ?? []));
+      });
       expect(messages).toEqual([
         "expected a dictionary. yaml_editor.error_commented_block_hint:7",
+      ]);
+
+      // The hint carries the comment-out repair as the tooltip action.
+      expect(actions.map((a) => a.name)).toEqual(["yaml_editor.error_auto_fix"]);
+      actions[0].apply(view, 0, 0);
+      expect(fixes).toEqual([
+        { line: 7, indent: 0, key: "advanced", fromIndent: 4, kind: "comment-out" },
       ]);
     } finally {
       view.destroy();


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #1314. The empty and commented-out block hints told the user what to do but made them do it by hand. The repair is mechanical, so both hints now carry it as the existing one click "Try auto-fix" action in the hover tooltip and the error banner.

A key whose options are all commented out gets a `comment-out` fix that comments the key at its own indent, so `advanced:` becomes `# advanced:` to match its commented children. A key with nothing under it gets a `remove-line` fix that deletes the line. Both ride the existing applyAutoFix safety rails: the proposed document is validated before anything is touched, a stale click on a shifted or already repaired line no-ops, and the edit is a single undoable transaction.

Verified live on the dev dashboard for both shapes: hovering the squiggle offers the fix, clicking it applies the exact repair, and undo restores the buffer.

**Related issue or feature (if applicable):**

- fixes N/A (follow up to #1314)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
