### PR TITLE
Never pre-fill synthesized instance ids into action reference params

### DIFF
--- a/src/api/types/automations.ts
+++ b/src/api/types/automations.ts
@@ -287,7 +287,8 @@ export interface AvailableComponentInstance {
   /** Catalog component id (``switch.gpio``, ``light.binary``). A
    *  sub-entity carries the bare sub-domain (``sensor``) instead. */
   component_id: string;
-  /** The configured ``id:`` value from YAML. */
+  /** The declared ``id:``, or a synthesized round-trip identity (the domain
+   *  for an id-less singleton, ``<domain>_<idx>`` positional) when none. */
   id: string;
   /** The configured ``name:`` value, if any (purely for display). */
   name?: string;
@@ -298,4 +299,7 @@ export interface AvailableComponentInstance {
   is_entity_container?: boolean;
   /** A sub-entity's owning container id, for grouping it under that container. */
   parent_id?: string;
+  /** True only when the YAML declares ``id:``. A synthesized ``id`` must
+   *  never be written into an action's reference param (#2208). */
+  has_explicit_id?: boolean;
 }

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -55,6 +55,7 @@ import {
   componentDomain,
   instanceContext,
   instanceName,
+  preFillIdParam,
   selectableTargets,
 } from "./component-targets.js";
 
@@ -428,7 +429,7 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
           <span class="ae-muted">(${instanceContext(device, this.devices)})</span>
         </p>
         ${matching.map((item) =>
-          this._renderRow(item, () => this._pick(item.id, this._preFillFor(item, device)))
+          this._renderRow(item, () => this._pick(item.id, preFillIdParam(item, device)))
         )}
       `
     )}`;
@@ -511,27 +512,6 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
         <wa-icon library="mdi" name="plus"></wa-icon>
       </span>
     </div>`;
-  }
-
-  /**
-   * Find the action's id-shaped ConfigEntry that references the
-   * picked device's domain and pre-fill it with the device's id.
-   * Returns ``undefined`` when no such field exists (e.g. core
-   * actions, conditions that don't take an id) or when the device's
-   * id is synthesized rather than declared in YAML — writing a
-   * synthetic id (``logger`` / ``uart_0``) into a reference param
-   * produces a dangling id ESPHome rejects (#2208); left empty,
-   * ESPHome auto-resolves the instance.
-   */
-  private _preFillFor(
-    item: CatalogItem,
-    device: AvailableComponentInstance
-  ): Record<string, unknown> | undefined {
-    if (!device.has_explicit_id) return undefined;
-    const domain = componentDomain(device.component_id);
-    const idEntry = item.config_entries.find((e) => e.references_component === domain);
-    if (!idEntry) return undefined;
-    return { [idEntry.key]: device.id };
   }
 
   private _pick(id: string, preFilledParams?: Record<string, unknown>) {

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -517,12 +517,17 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
    * Find the action's id-shaped ConfigEntry that references the
    * picked device's domain and pre-fill it with the device's id.
    * Returns ``undefined`` when no such field exists (e.g. core
-   * actions, conditions that don't take an id).
+   * actions, conditions that don't take an id) or when the device's
+   * id is synthesized rather than declared in YAML — writing a
+   * synthetic id (``logger`` / ``uart_0``) into a reference param
+   * produces a dangling id ESPHome rejects (#2208); left empty,
+   * ESPHome auto-resolves the instance.
    */
   private _preFillFor(
     item: CatalogItem,
     device: AvailableComponentInstance
   ): Record<string, unknown> | undefined {
+    if (device.has_explicit_id !== true) return undefined;
     const domain = componentDomain(device.component_id);
     const idEntry = item.config_entries.find((e) => e.references_component === domain);
     if (!idEntry) return undefined;

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -527,7 +527,7 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
     item: CatalogItem,
     device: AvailableComponentInstance
   ): Record<string, unknown> | undefined {
-    if (device.has_explicit_id !== true) return undefined;
+    if (!device.has_explicit_id) return undefined;
     const domain = componentDomain(device.component_id);
     const idEntry = item.config_entries.find((e) => e.references_component === domain);
     if (!idEntry) return undefined;

--- a/src/components/device/automation-editor/component-targets.ts
+++ b/src/components/device/automation-editor/component-targets.ts
@@ -6,6 +6,7 @@ import type {
   AutomationTrigger,
   AvailableComponentInstance,
 } from "../../../api/types/automations.js";
+import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { stripRedundantComponentSuffix } from "../../../util/component-title.js";
 import { parseCatalogId } from "../../../util/config-entry-yaml-scan.js";
 import { CORE_KEYS } from "../../../util/yaml-sections.js";
@@ -70,6 +71,25 @@ export function scopeToContainer(
 ): AvailableComponentInstance[] {
   if (!container) return devices;
   return devices.filter((d) => d.id === container.id || d.parent_id === container.id);
+}
+
+/**
+ * Pre-fill for a picked item's id-shaped ConfigEntry referencing *device*'s
+ * domain: ``{key: device.id}``, or ``undefined`` when the item has no such
+ * field or the device's id is synthesized rather than declared in YAML —
+ * writing a synthetic id (``logger`` / ``uart_0``) into a reference param
+ * produces a dangling id ESPHome rejects (#2208); left empty, ESPHome
+ * auto-resolves the instance.
+ */
+export function preFillIdParam(
+  item: { config_entries: ConfigEntry[] },
+  device: AvailableComponentInstance
+): Record<string, unknown> | undefined {
+  if (!device.has_explicit_id) return undefined;
+  const domain = componentDomain(device.component_id);
+  const idEntry = item.config_entries.find((e) => e.references_component === domain);
+  if (!idEntry) return undefined;
+  return { [idEntry.key]: device.id };
 }
 
 /** Component-level triggers valid for *device*, matched on its bare or

--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -24,6 +24,7 @@ import {
 } from "./config-entry-renderers-shared.js";
 
 export const ADD_NEW_SENTINEL = "__esphome_add_new__";
+export const AUTO_SENTINEL = "__esphome_auto__";
 
 export function renderIdReferenceField(
   entry: ConfigEntry,
@@ -93,8 +94,24 @@ export function renderIdReferenceField(
       ctx.requestAddComponent(domain);
       return;
     }
-    ctx.emitChange(path, next);
+    // Empty string clears the key on serialization in every form host,
+    // reverting the field to ESPHome's auto-resolved instance.
+    ctx.emitChange(path, next === AUTO_SENTINEL ? "" : next);
   };
+
+  // Revert-to-auto for an optional reference with a committed value — the
+  // only visual-editor way out of a dangling id (e.g. the synthetic
+  // ``logger_id: logger`` older builds pre-filled, #2208). An empty field
+  // already reads as auto via the default-candidate placeholder, so the
+  // option only appears once a value is set.
+  const autoOption =
+    !entry.required && value !== ""
+      ? idOption(
+          AUTO_SENTINEL,
+          ctx.localize("device.id_reference_auto"),
+          ctx.localize("device.id_reference_auto_detail", { domain })
+        )
+      : nothing;
 
   // The "Add new <domain>" option lives at the bottom — same
   // affordance as Home Assistant's entity pickers. When it's the
@@ -144,7 +161,7 @@ export function renderIdReferenceField(
         }
         @change=${onChange}
       >
-        ${orphanOption}
+        ${autoOption} ${orphanOption}
         ${candidates.map((c) => {
           const secondary = c.name ? `${c.id} · ${domain}` : domain;
           // The label is display-only; the stored value stays c.id. Resolve

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -970,6 +970,8 @@
     "missing_dependencies_add": "Add {domain}",
     "id_reference_empty": "No {domain} configured yet",
     "id_reference_add": "Add {domain}",
+    "id_reference_auto": "Auto",
+    "id_reference_auto_detail": "Let ESPHome pick the {domain}",
     "id_reference_unresolved": "{domain} not defined in this file",
     "id_reference_unknown_error": "ID \"{id}\" is not defined in this configuration.",
     "return_to_after_dep_prefix": "Adding a dependency. We'll bring you back to",

--- a/test/components/device/automation-editor/catalog-picker-dialog.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog.test.ts
@@ -81,6 +81,14 @@ describe("catalog-picker-dialog filtering contract", () => {
     expect(body).toMatch(/references_component === domain/);
     expect(body).toMatch(/\[idEntry\.key\]: device\.id/);
   });
+
+  it("By-target never pre-fills a synthesized instance id (#2208)", async () => {
+    // A synthetic id (`logger`, `uart_0`) is a round-trip identity, not a
+    // YAML id — writing it into a reference param produces a dangling id.
+    const src = await readSource();
+    const body = methodBody(src, "_preFillFor");
+    expect(body).toMatch(/has_explicit_id !== true.*return undefined/);
+  });
 });
 
 describe("catalog-picker-dialog tab strip", () => {

--- a/test/components/device/automation-editor/catalog-picker-dialog.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog.test.ts
@@ -87,7 +87,7 @@ describe("catalog-picker-dialog filtering contract", () => {
     // YAML id — writing it into a reference param produces a dangling id.
     const src = await readSource();
     const body = methodBody(src, "_preFillFor");
-    expect(body).toMatch(/has_explicit_id !== true.*return undefined/);
+    expect(body).toMatch(/!device\.has_explicit_id\) return undefined/);
   });
 });
 

--- a/test/components/device/automation-editor/catalog-picker-dialog.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog.test.ts
@@ -75,19 +75,12 @@ describe("catalog-picker-dialog filtering contract", () => {
     expect(body).toMatch(/componentDomain\(item\.domain\)/);
   });
 
-  it("By-target pre-fills the action's id-shaped param with the picked device's id", async () => {
+  it("By-target routes each pick through the shared pre-fill helper", async () => {
+    // The pre-fill behavior itself (declared-id-only, #2208) is pinned by
+    // the pure-function tests in component-targets.test.ts.
     const src = await readSource();
-    const body = methodBody(src, "_preFillFor");
-    expect(body).toMatch(/references_component === domain/);
-    expect(body).toMatch(/\[idEntry\.key\]: device\.id/);
-  });
-
-  it("By-target never pre-fills a synthesized instance id (#2208)", async () => {
-    // A synthetic id (`logger`, `uart_0`) is a round-trip identity, not a
-    // YAML id — writing it into a reference param produces a dangling id.
-    const src = await readSource();
-    const body = methodBody(src, "_preFillFor");
-    expect(body).toMatch(/!device\.has_explicit_id\) return undefined/);
+    const body = methodBody(src, "_renderByTarget");
+    expect(body).toMatch(/preFillIdParam\(item, device\)/);
   });
 });
 

--- a/test/components/device/automation-editor/component-targets.test.ts
+++ b/test/components/device/automation-editor/component-targets.test.ts
@@ -10,6 +10,7 @@ import {
   instanceContext,
   instanceName,
   isSelectableTarget,
+  preFillIdParam,
   selectableTargets,
   triggersForComponent,
 } from "../../../../src/components/device/automation-editor/component-targets.js";
@@ -115,5 +116,46 @@ describe("instance label helpers", () => {
         devices
       )
     ).toBe("sensor");
+  });
+});
+
+describe("preFillIdParam", () => {
+  const logAction = {
+    config_entries: [
+      { key: "format", type: "string", required: true },
+      { key: "logger_id", type: "id", references_component: "logger" },
+    ] as never,
+  };
+
+  it("pre-fills the id-shaped entry from a device with a declared id", () => {
+    const device = inst({
+      id: "mylogger",
+      component_id: "logger",
+      has_explicit_id: true,
+    });
+    expect(preFillIdParam(logAction, device)).toEqual({ logger_id: "mylogger" });
+  });
+
+  it("never pre-fills a synthesized id (#2208)", () => {
+    // `logger` here is the backend's round-trip identity for an id-less
+    // singleton, not a YAML id — pre-filling it dangles.
+    expect(
+      preFillIdParam(logAction, inst({ id: "logger", component_id: "logger" }))
+    ).toBeUndefined();
+    expect(
+      preFillIdParam(
+        logAction,
+        inst({ id: "logger", component_id: "logger", has_explicit_id: false })
+      )
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the item has no entry referencing the domain", () => {
+    const device = inst({
+      id: "relay",
+      component_id: "switch.gpio",
+      has_explicit_id: true,
+    });
+    expect(preFillIdParam(logAction, device)).toBeUndefined();
   });
 });

--- a/test/components/device/config-entry-id-reference-renderer.test.ts
+++ b/test/components/device/config-entry-id-reference-renderer.test.ts
@@ -7,7 +7,10 @@
 import { nothing } from "lit";
 import { describe, expect, it } from "vitest";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
-import { renderIdReferenceField } from "../../../src/components/device/config-entry-id-reference-renderer.js";
+import {
+  AUTO_SENTINEL,
+  renderIdReferenceField,
+} from "../../../src/components/device/config-entry-id-reference-renderer.js";
 import { findTemplatesByAnchor } from "../../_lit-template-walker.js";
 import { findElementBindings, makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
 
@@ -240,5 +243,53 @@ describe("renderIdReferenceField — inline error for an unknown id", () => {
     const texts = errorTexts(tmpl);
     expect(texts).toHaveLength(1);
     expect(texts[0]).not.toBe("device.id_reference_unknown_error");
+  });
+});
+
+describe("renderIdReferenceField — revert-to-auto option (#2208)", () => {
+  const LOGGER_YAML = "logger:\n  baud_rate: 115200\n";
+
+  function renderRef(
+    value: string,
+    entryOverrides: Partial<Parameters<typeof makeEntry>[1]> = {},
+    ctx = makeRenderCtx({ logger_id: value }, { overrides: { yaml: LOGGER_YAML } })
+  ) {
+    const entry = makeEntry(ConfigEntryType.STRING, {
+      references_component: "logger",
+      ...entryOverrides,
+    });
+    return renderIdReferenceField(entry, ["logger_id"], ctx);
+  }
+
+  const optionValues = (tmpl: unknown): unknown[] =>
+    findElementBindings(tmpl, "wa-option").map((o) => o.value);
+
+  it("offers Auto on an optional reference with a committed value", () => {
+    // The dangling `logger_id: logger` older builds pre-filled has no other
+    // visual-editor way out.
+    expect(optionValues(renderRef("logger"))).toContain(AUTO_SENTINEL);
+  });
+
+  it("selecting Auto clears the value (key removed on serialization)", () => {
+    const ctx = makeRenderCtx(
+      { logger_id: "logger" },
+      { overrides: { yaml: LOGGER_YAML } }
+    );
+    const tmpl = renderRef("logger", {}, ctx);
+    const onChange = findElementBindings(tmpl, "wa-select")[0]["@change"] as (
+      e: Event
+    ) => void;
+    onChange({ target: { value: AUTO_SENTINEL } } as unknown as Event);
+    expect(ctx.emitChange).toHaveBeenCalledWith(["logger_id"], "");
+  });
+
+  it("hides Auto while the field is empty (auto is already the default)", () => {
+    expect(optionValues(renderRef(""))).not.toContain(AUTO_SENTINEL);
+  });
+
+  it("hides Auto on a required reference", () => {
+    expect(optionValues(renderRef("logger", { required: true }))).not.toContain(
+      AUTO_SENTINEL
+    );
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Adding a Logger → Log action from the picker's By target tab wrote `logger_id: logger` into the YAML. The backend synthesizes an instance id when the YAML declares none (`logger` for a singleton, `switch_1` positional), and `_preFillFor` copied it into the action's reference param, producing a dangling id ESPHome rejects. The pre fill now only fires when the backend flags the id as actually declared (`has_explicit_id`, esphome/device-builder#2209); left empty, ESPHome auto resolves the instance.

Configs already carrying the dangling id had no way out of it in the visual editor, so the id picker gains a revert to auto option on optional references with a committed value. Picking it clears the key on the next serialization, which also restores the `logger.log: message` shorthand.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2208

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
