### PR TITLE
Preselect the trigger when only one is offerable in the add-automation dialog

### DIFF
--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -164,6 +164,7 @@ export class ESPHomeAddAutomationDialog extends LitElement {
         this._componentId =
           this._available.devices.find((d) => d.parent_id === container.id)?.id ?? "";
       }
+      this._preselectUniqueTrigger();
     } catch (err) {
       this._error = getErrorMessage(err);
     } finally {
@@ -443,11 +444,21 @@ export class ESPHomeAddAutomationDialog extends LitElement {
     } else {
       this._componentId = "";
     }
+    this._preselectUniqueTrigger();
   }
 
   private _onComponentChange(id: string) {
     this._componentId = id;
     this._triggerId = null;
+    this._preselectUniqueTrigger();
+  }
+
+  /** When exactly one trigger is offerable for the current target,
+   *  select it so Continue is a single click; the select stays
+   *  editable and the multi-trigger case is unchanged. */
+  private _preselectUniqueTrigger() {
+    const triggers = this._filteredTriggers();
+    if (triggers.length === 1) this._triggerId = triggers[0].id;
   }
 
   private _canContinue(): boolean {

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -465,6 +465,101 @@ describe("add-automation-dialog sub-entity targets (#1263)", () => {
   });
 });
 
+const buttonAvailable = (): AvailableAutomations =>
+  ({
+    triggers: [
+      {
+        id: "button.on_press",
+        name: "On Press",
+        applies_to: ["button"],
+        is_device_level: false,
+        supports_list: false,
+        config_entries: [],
+      },
+      {
+        id: "switch.on_turn_on",
+        name: "On Turn On",
+        applies_to: ["switch"],
+        is_device_level: false,
+        supports_list: false,
+        config_entries: [],
+      },
+      {
+        id: "switch.on_turn_off",
+        name: "On Turn Off",
+        applies_to: ["switch"],
+        is_device_level: false,
+        supports_list: false,
+        config_entries: [],
+      },
+    ],
+    actions: [],
+    conditions: [],
+    scripts: [],
+    devices: [
+      { id: "my_button", name: "Button", component_id: "button.template" },
+      { id: "relay", name: "Relay", component_id: "switch.gpio" },
+    ],
+  }) as unknown as AvailableAutomations;
+
+describe("add-automation-dialog unique-trigger preselect (device-builder#2214)", () => {
+  async function mountPrefilled(
+    componentId: string,
+    yaml = ""
+  ): Promise<ESPHomeAddAutomationDialog> {
+    const api = {
+      getAvailableAutomations: vi.fn(() => Promise.resolve(buttonAvailable())),
+    } as unknown as ESPHomeAPI;
+    const dialog = await mountDialog(api);
+    dialog.yaml = yaml;
+    dialog.open({ kind: "component_on", componentId });
+    await dialog.updateComplete;
+    await flush();
+    await dialog.updateComplete;
+    return dialog;
+  }
+
+  it("preselects the only trigger so Continue is a single click", async () => {
+    const dialog = await mountPrefilled("my_button");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((dialog as any)._triggerId).toBe("button.on_press");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((dialog as any)._canContinue()).toBe(true);
+  });
+
+  it("leaves the multi-trigger case unselected", async () => {
+    const dialog = await mountPrefilled("relay");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((dialog as any)._triggerId).toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((dialog as any)._canContinue()).toBe(false);
+  });
+
+  it("preselects the only remaining trigger when the rest are already used", async () => {
+    const yaml = `switch:
+  - platform: gpio
+    id: relay
+    on_turn_on:
+      - logger.log: hi
+`;
+    const dialog = await mountPrefilled("relay", yaml);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((dialog as any)._triggerId).toBe("switch.on_turn_off");
+  });
+
+  it("re-evaluates on component change in both directions", async () => {
+    const dialog = await mountPrefilled("relay");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (dialog as any)._onComponentChange("my_button");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((dialog as any)._triggerId).toBe("button.on_press");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (dialog as any)._onComponentChange("relay");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((dialog as any)._triggerId).toBeNull();
+  });
+});
+
 // The migration onto esphome-base-dialog swapped the imperative
 // @query _dialog.open for a reactive _open flag. Pin the open / request-close
 // contract — request-close flipping _open is what makes a user-driven close


### PR DESCRIPTION
# What does this implement/fix?

When the filtered trigger list for the chosen target has exactly one entry, the New automation dialog now preselects it, so the dialog is a single Continue click. The dropdown stays editable and the trigger description renders immediately; the multi trigger case is unchanged. The preselect runs at every point the selection is reset (load, kind change, component change), so it also applies when only one trigger remains after already used ones are filtered out.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2214

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
