### PR TITLE
Offer an indent auto-fix when a stray top-level key belongs to the section above

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1263,6 +1263,7 @@
     "error_go_to_line": "Go to line {line}",
     "error_dash_space_fix": "Missing space: line {line} \"-{key}\" is a list item missing the space after its \"-\". Add the space so it reads \"- {key}\".",
     "error_nest_under_fix": "Indentation mismatch: line {line} \"{key}\" is not an option of the block it sits in, but it is a valid option of \"{target}\". Indent line {line} by {spaces, plural, one {# space} other {# spaces}} to nest it under \"{target}\".",
+    "error_indent_under_section_fix": "Line {line} \"{key}\" is not a component, but it is a valid option of \"{section}\". Indent line {line} by {spaces, plural, one {# space} other {# spaces}} to move it inside \"{section}\".",
     "error_unnest_fix": "Indentation mismatch: line {line} \"{key}\" is not an option of \"{parent}\", but it is a valid option of \"{target}\". Remove {spaces, plural, one {# space} other {# spaces}} from the start of line {line} to move it out of \"{parent}\".",
     "error_auto_fix": "Try auto-fix",
     "error_auto_fix_hint": "Best-effort guess: it edits only the marked line. Review the result and undo it if that is not the fix you wanted.",

--- a/src/util/yaml-component-not-found-fix.ts
+++ b/src/util/yaml-component-not-found-fix.ts
@@ -1,0 +1,109 @@
+/**
+ * Schema-gated auto-fix for ESPHome "Component not found" errors.
+ *
+ * `Component not found: id` on a column-0 key usually means an option
+ * escaped the section above it (`logger:` then a dedented `id:`). The
+ * component catalog has to confirm the key really is an option of that
+ * section before the one-line indent is offered — the gate fails closed,
+ * so a genuinely unknown component gets no fix rather than a wrong one.
+ */
+import type { Text } from "@codemirror/state";
+import { getKeyPath } from "./yaml-ast.js";
+import { loadCatalog, resolveAvailableEntries } from "./yaml-completion-catalog.js";
+import {
+  lineKeyToken,
+  YAML_INDENT_STEP,
+  type ValueTypeCause,
+} from "./yaml-error-analysis.js";
+import type { InvalidOptionFixContext } from "./yaml-invalid-option-fix.js";
+import { indentOf, stripComment } from "./yaml-line-walker.js";
+
+const COMPONENT_NOT_FOUND_RE = /^Component not found: ([A-Za-z0-9_]+)\.?$/;
+const SECTION_OPENER_RE = /^([A-Za-z0-9_]+)\s*:$/;
+
+/** Cause + one-click indent for a stray top-level key the section above
+ *  accepts, or null when the buffer shape or the schema doesn't confirm
+ *  it. Never throws. */
+export async function describeComponentNotFoundFix(
+  ctx: InvalidOptionFixContext
+): Promise<ValueTypeCause | null> {
+  try {
+    return await resolveFix(ctx);
+  } catch {
+    return null;
+  }
+}
+
+async function resolveFix(ctx: InvalidOptionFixContext): Promise<ValueTypeCause | null> {
+  const parsed = ctx.message.match(COMPONENT_NOT_FOUND_RE);
+  if (!parsed) return null;
+  const key = parsed[1];
+  const doc = ctx.state.doc;
+  if (ctx.blamedLine < 1 || ctx.blamedLine > doc.lines) return null;
+  const blamedText = stripComment(doc.line(ctx.blamedLine).text);
+  if (indentOf(blamedText) !== 0 || lineKeyToken(blamedText) !== key) return null;
+
+  const opener = sectionOpenerAbove(doc, ctx.blamedLine);
+  if (!opener) return null;
+  const delta = childIndent(doc, opener.line, ctx.blamedLine);
+  if (delta === null) return null;
+
+  // The AST must agree the blamed key is a top-level mapping key (rules
+  // out block scalars the line walk can't see). Anchor inside the key
+  // token — side -1 at the line start would resolve to the preceding node.
+  const blamedPath = getKeyPath(ctx.state, doc.line(ctx.blamedLine).from + 1);
+  if (blamedPath.length !== 1 || blamedPath[0] !== key) return null;
+
+  const catalog = await loadCatalog(ctx.api);
+  // No platform / nested descent: the proposed parent is a top-level
+  // mapping section, so its entries are the component's own options.
+  const entries = await resolveAvailableEntries(
+    ctx.api,
+    catalog,
+    opener.key,
+    null,
+    opener.key,
+    () => []
+  );
+  if (!entries.some((e) => e.key === key)) return null;
+
+  return {
+    text: ctx.localize("yaml_editor.error_indent_under_section_fix", {
+      line: ctx.blamedLine,
+      key,
+      section: opener.key,
+      spaces: delta,
+    }),
+    fix: { line: ctx.blamedLine, indent: delta, key, fromIndent: 0 },
+  };
+}
+
+/** Nearest column-0 line above *line* when it is a valueless
+ *  ``section:`` opener; null when it's anything else (a complete
+ *  ``key: value`` pair owns no block for the stray key to join). */
+function sectionOpenerAbove(
+  doc: Text,
+  line: number
+): { key: string; line: number } | null {
+  for (let n = line - 1; n >= 1; n--) {
+    const stripped = stripComment(doc.line(n).text);
+    if (!stripped.trim()) continue;
+    if (indentOf(stripped) !== 0) continue;
+    const m = stripped.match(SECTION_OPENER_RE);
+    return m ? { key: m[1], line: n } : null;
+  }
+  return null;
+}
+
+/** Indent of the opener's first child (what the stray key should adopt);
+ *  the canonical step for a childless opener, null for a list-shaped body
+ *  (`sensor:` items give the stray key no single right target). */
+function childIndent(doc: Text, openerLine: number, strayLine: number): number | null {
+  for (let n = openerLine + 1; n < strayLine; n++) {
+    const stripped = stripComment(doc.line(n).text);
+    if (!stripped.trim()) continue;
+    if (/^\s*-(\s|$)/.test(stripped)) return null;
+    return indentOf(stripped);
+  }
+  return YAML_INDENT_STEP;
+}

--- a/src/util/yaml-component-not-found-fix.ts
+++ b/src/util/yaml-component-not-found-fix.ts
@@ -12,20 +12,25 @@ import { getKeyPath } from "./yaml-ast.js";
 import { loadCatalog, resolveAvailableEntries } from "./yaml-completion-catalog.js";
 import {
   lineKeyToken,
+  WALK_BOUND,
   YAML_INDENT_STEP,
   type ValueTypeCause,
 } from "./yaml-error-analysis.js";
-import type { InvalidOptionFixContext } from "./yaml-invalid-option-fix.js";
-import { indentOf, stripComment } from "./yaml-line-walker.js";
+import type { YamlFixContext } from "./yaml-fix-context.js";
+import {
+  indentOf,
+  RE_LIST_ITEM,
+  RE_TOP_LEVEL_KEY,
+  stripComment,
+} from "./yaml-line-walker.js";
 
 const COMPONENT_NOT_FOUND_RE = /^Component not found: ([A-Za-z0-9_]+)\.?$/;
-const SECTION_OPENER_RE = /^([A-Za-z0-9_]+)\s*:$/;
 
 /** Cause + one-click indent for a stray top-level key the section above
  *  accepts, or null when the buffer shape or the schema doesn't confirm
  *  it. Never throws. */
 export async function describeComponentNotFoundFix(
-  ctx: InvalidOptionFixContext
+  ctx: YamlFixContext
 ): Promise<ValueTypeCause | null> {
   try {
     return await resolveFix(ctx);
@@ -34,12 +39,11 @@ export async function describeComponentNotFoundFix(
   }
 }
 
-async function resolveFix(ctx: InvalidOptionFixContext): Promise<ValueTypeCause | null> {
+async function resolveFix(ctx: YamlFixContext): Promise<ValueTypeCause | null> {
   const parsed = ctx.message.match(COMPONENT_NOT_FOUND_RE);
   if (!parsed) return null;
   const key = parsed[1];
   const doc = ctx.state.doc;
-  if (ctx.blamedLine < 1 || ctx.blamedLine > doc.lines) return null;
   const blamedText = stripComment(doc.line(ctx.blamedLine).text);
   if (indentOf(blamedText) !== 0 || lineKeyToken(blamedText) !== key) return null;
 
@@ -80,17 +84,19 @@ async function resolveFix(ctx: InvalidOptionFixContext): Promise<ValueTypeCause 
 
 /** Nearest column-0 line above *line* when it is a valueless
  *  ``section:`` opener; null when it's anything else (a complete
- *  ``key: value`` pair owns no block for the stray key to join). */
+ *  ``key: value`` pair owns no block for the stray key to join).
+ *  Not ``findTopLevelBlock``: that walk skips non-key column-0 lines
+ *  and drops the line number this one needs. */
 function sectionOpenerAbove(
   doc: Text,
   line: number
 ): { key: string; line: number } | null {
-  for (let n = line - 1; n >= 1; n--) {
+  for (let n = line - 1; n >= Math.max(1, line - WALK_BOUND); n--) {
     const stripped = stripComment(doc.line(n).text);
     if (!stripped.trim()) continue;
     if (indentOf(stripped) !== 0) continue;
-    const m = stripped.match(SECTION_OPENER_RE);
-    return m ? { key: m[1], line: n } : null;
+    const m = stripped.match(RE_TOP_LEVEL_KEY);
+    return m && stripped.slice(m[0].length).trim() === "" ? { key: m[1], line: n } : null;
   }
   return null;
 }
@@ -102,7 +108,7 @@ function childIndent(doc: Text, openerLine: number, strayLine: number): number |
   for (let n = openerLine + 1; n < strayLine; n++) {
     const stripped = stripComment(doc.line(n).text);
     if (!stripped.trim()) continue;
-    if (/^\s*-(\s|$)/.test(stripped)) return null;
+    if (RE_LIST_ITEM.test(stripped)) return null;
     return indentOf(stripped);
   }
   return YAML_INDENT_STEP;

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -32,7 +32,7 @@ const WALK_BOUND = 50;
 /** Canonical child-indent step. A literal two: this module stays free of
  *  esphome-yaml-lang's CodeMirror import graph, where ESPHOME_YAML_INDENT
  *  is the same two spaces. */
-const YAML_INDENT_STEP = 2;
+export const YAML_INDENT_STEP = 2;
 
 /**
  * Strip absolute directory paths out of a backend error message.

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -27,7 +27,7 @@ const QUOTED_PATH_RE = /"([^"]*[/\\])([^"/\\]+)"/g;
 const PAIR_RE = /^\s*([^\s:#][^:]*?)\s*:(?:\s+(.*))?$/;
 
 /** Analysis walks never scan further than this many lines. */
-const WALK_BOUND = 50;
+export const WALK_BOUND = 50;
 
 /** Canonical child-indent step. A literal two: this module stays free of
  *  esphome-yaml-lang's CodeMirror import graph, where ESPHOME_YAML_INDENT

--- a/src/util/yaml-fix-context.ts
+++ b/src/util/yaml-fix-context.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared input contract for the async, catalog-gated fix analyzers the
+ * backend linter chains (`yaml-invalid-option-fix`,
+ * `yaml-component-not-found-fix`).
+ */
+import type { EditorState } from "@codemirror/state";
+import type { ESPHomeAPI } from "../api/esphome-api.js";
+import type { LocalizeFunc } from "../common/localize.js";
+
+export interface YamlFixContext {
+  api: ESPHomeAPI;
+  state: EditorState;
+  /** The sanitized validation-error message. */
+  message: string;
+  /** 1-indexed line the squiggle anchors on. */
+  blamedLine: number;
+  localize: LocalizeFunc;
+}

--- a/src/util/yaml-invalid-option-fix.ts
+++ b/src/util/yaml-invalid-option-fix.ts
@@ -11,9 +11,6 @@
  * offered — the gate fails closed, so packages / `!extend` / unknown
  * components simply get no fix rather than a wrong one.
  */
-import type { EditorState } from "@codemirror/state";
-import type { ESPHomeAPI } from "../api/esphome-api.js";
-import type { LocalizeFunc } from "../common/localize.js";
 import { getKeyPath, getPlatformValue } from "./yaml-ast.js";
 import { loadCatalog, resolveAvailableEntries } from "./yaml-completion-catalog.js";
 import {
@@ -24,22 +21,13 @@ import {
   type ReadLine,
   type ValueTypeCause,
 } from "./yaml-error-analysis.js";
+import type { YamlFixContext } from "./yaml-fix-context.js";
 import { indentOf } from "./yaml-line-walker.js";
-
-export interface InvalidOptionFixContext {
-  api: ESPHomeAPI;
-  state: EditorState;
-  /** The sanitized validation-error message. */
-  message: string;
-  /** 1-indexed line the squiggle anchors on. */
-  blamedLine: number;
-  localize: LocalizeFunc;
-}
 
 /** Cause + one-click re-indent for a misnested option, or null when the
  *  buffer shape or the schema doesn't confirm it. Never throws. */
 export async function describeInvalidOptionFix(
-  ctx: InvalidOptionFixContext
+  ctx: YamlFixContext
 ): Promise<ValueTypeCause | null> {
   try {
     return await resolveFix(ctx);
@@ -48,7 +36,7 @@ export async function describeInvalidOptionFix(
   }
 }
 
-async function resolveFix(ctx: InvalidOptionFixContext): Promise<ValueTypeCause | null> {
+async function resolveFix(ctx: YamlFixContext): Promise<ValueTypeCause | null> {
   const parsed = parseInvalidOptionMessage(ctx.message);
   if (!parsed) return null;
   const doc = ctx.state.doc;
@@ -70,7 +58,7 @@ async function resolveFix(ctx: InvalidOptionFixContext): Promise<ValueTypeCause 
  * become the grandparent's child.
  */
 async function gateCandidate(
-  ctx: InvalidOptionFixContext,
+  ctx: YamlFixContext,
   parsed: { key: string; parent: string },
   cand: DedentedOptionCandidate,
   nest: boolean

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -36,6 +36,7 @@ import {
   type ReadLine,
   type YamlAutoFix,
 } from "./yaml-error-analysis.js";
+import { describeComponentNotFoundFix } from "./yaml-component-not-found-fix.js";
 import { describeInvalidOptionFix } from "./yaml-invalid-option-fix.js";
 import { indentOf } from "./yaml-line-walker.js";
 import { isOpenConfigFile } from "./yaml-validation-summary.js";
@@ -403,15 +404,17 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
         // list items, a half-typed key with no ':', a dash stuck to its
         // key), name that cause, and carry its repair when it has one.
         const squiggleLineNum = doc.lineAt(from).number;
+        const fixCtx = {
+          api: opts.api,
+          state: view.state,
+          message,
+          blamedLine: squiggleLineNum,
+          localize: opts.localize,
+        };
         const cause =
           describeValueTypeCause(readLine, squiggleLineNum, opts.localize, message) ??
-          (await describeInvalidOptionFix({
-            api: opts.api,
-            state: view.state,
-            message,
-            blamedLine: squiggleLineNum,
-            localize: opts.localize,
-          }));
+          (await describeInvalidOptionFix(fixCtx)) ??
+          (await describeComponentNotFoundFix(fixCtx));
         if (cause) message = `${message} ${cause.text}`;
         diagnostics.push({
           from,

--- a/test/components/yaml-editor-auto-fix.test.ts
+++ b/test/components/yaml-editor-auto-fix.test.ts
@@ -268,6 +268,33 @@ describe("yaml-editor applyAutoFix (#1884)", () => {
     expect(validateYaml).not.toHaveBeenCalled();
   });
 
+  it("applies the stray-top-level-key indent (component-not-found fix)", async () => {
+    const validateYaml = vi.fn(async () => CLEAN);
+    const broken = "logger:\n  baud_rate: 115200\nid: mylogger\n";
+    const fixed = "logger:\n  baud_rate: 115200\n  id: mylogger\n";
+    const el = await mountEditor(validateYaml, broken);
+    const view = viewOf(el);
+
+    expect(await el.applyAutoFix({ line: 3, indent: 2, key: "id", fromIndent: 0 })).toBe(
+      "applied"
+    );
+
+    expect(view.state.doc.toString()).toBe(fixed);
+    undo(view);
+    expect(view.state.doc.toString()).toBe(broken);
+  });
+
+  it("no-ops a stale stray-key fix whose line was already indented", async () => {
+    const validateYaml = vi.fn(async () => CLEAN);
+    const doc = "logger:\n  baud_rate: 115200\n  id: mylogger\n";
+    const el = await mountEditor(validateYaml, doc);
+
+    expect(await el.applyAutoFix({ line: 3, indent: 2, key: "id", fromIndent: 0 })).toBe(
+      "stale"
+    );
+    expect(validateYaml).not.toHaveBeenCalled();
+  });
+
   it("applies a comment-out fix at the key's indent", async () => {
     const validateYaml = vi.fn(async () => CLEAN);
     const broken =

--- a/test/util/yaml-component-not-found-fix.test.ts
+++ b/test/util/yaml-component-not-found-fix.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for the schema-gated stray-top-level-key auto-fix: a column-0 key
+ * ESPHome rejects as an unknown component gets a one-line indent under the
+ * section above it only when the catalog confirms that section accepts it.
+ */
+import { EditorState } from "@codemirror/state";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  ComponentCategory,
+  type ComponentCatalogEntry,
+} from "../../src/api/types/components.js";
+import { _clearComponentCache } from "../../src/util/component-name-cache.js";
+import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
+import { describeComponentNotFoundFix } from "../../src/util/yaml-component-not-found-fix.js";
+import { makeComponentEntry } from "./_make-component-entry.js";
+import { makeConfigEntry } from "./_make-config-entry.js";
+
+const SLIMS = ["logger", "sensor"].map((id) =>
+  makeComponentEntry(id, { category: ComponentCategory.CORE })
+);
+const BODIES: Record<string, ComponentCatalogEntry> = {
+  logger: {
+    ...SLIMS[0],
+    config_entries: [
+      makeConfigEntry({ key: "baud_rate" }),
+      makeConfigEntry({ key: "id" }),
+    ],
+  },
+  sensor: { ...SLIMS[1], config_entries: [makeConfigEntry({ key: "id" })] },
+};
+
+const fakeApi = (
+  bodies: (ids: string[]) => Record<string, ComponentCatalogEntry> | never
+) =>
+  ({
+    getComponents: async () => ({ components: SLIMS }),
+    getComponentBodies: async (ids: string[]) => bodies(ids),
+  }) as never;
+
+const defaultApi = fakeApi((ids) =>
+  Object.fromEntries(ids.filter((id) => id in BODIES).map((id) => [id, BODIES[id]]))
+);
+
+const localize = (key: string, values?: Record<string, string | number>): string =>
+  `${key}:${JSON.stringify(values)}`;
+
+const run = (yaml: string, message: string, blamedLine: number, api = defaultApi) =>
+  describeComponentNotFoundFix({
+    api,
+    state: EditorState.create({ doc: yaml, extensions: [esphomeYaml()] }),
+    message,
+    blamedLine,
+    localize,
+  });
+
+const STRAY_ID = ["logger:", "  baud_rate: 115200", "id: mylogger"].join("\n");
+const MESSAGE = "Component not found: id.";
+
+describe("describeComponentNotFoundFix", () => {
+  beforeEach(() => _clearComponentCache());
+
+  it("offers the indent when the section above accepts the key", async () => {
+    expect(await run(STRAY_ID, MESSAGE, 3)).toEqual({
+      text: 'yaml_editor.error_indent_under_section_fix:{"line":3,"key":"id","section":"logger","spaces":2}',
+      fix: { line: 3, indent: 2, key: "id", fromIndent: 0 },
+    });
+  });
+
+  it("follows the section's own child indent", async () => {
+    const yaml = ["logger:", "    baud_rate: 115200", "id: mylogger"].join("\n");
+    expect(await run(yaml, MESSAGE, 3)).toMatchObject({
+      fix: { line: 3, indent: 4, key: "id", fromIndent: 0 },
+    });
+  });
+
+  it("uses the canonical step for a childless opener", async () => {
+    const yaml = ["logger:", "id: mylogger"].join("\n");
+    expect(await run(yaml, MESSAGE, 2)).toMatchObject({
+      fix: { line: 2, indent: 2, key: "id", fromIndent: 0 },
+    });
+  });
+
+  it("returns null when the key is not an option of the section", async () => {
+    expect(
+      await run(STRAY_ID.replace(/^id:/m, "ssid:"), "Component not found: ssid.", 3)
+    ).toBeNull();
+  });
+
+  it("returns null when there is no section above", async () => {
+    expect(await run("id: mylogger", MESSAGE, 1)).toBeNull();
+  });
+
+  it("returns null when the line above is a complete pair, not an opener", async () => {
+    const yaml = ["logger: {}", "id: mylogger"].join("\n");
+    expect(await run(yaml, MESSAGE, 2)).toBeNull();
+  });
+
+  it("returns null for a list-shaped section", async () => {
+    const yaml = ["sensor:", "  - platform: template", "id: mysensor"].join("\n");
+    expect(await run(yaml, MESSAGE, 3)).toBeNull();
+  });
+
+  it("returns null when the blamed line is not a column-0 key line", async () => {
+    const yaml = ["logger:", "  id: mylogger"].join("\n");
+    expect(await run(yaml, MESSAGE, 2)).toBeNull();
+  });
+
+  it("returns null for a message that names a different key", async () => {
+    expect(await run(STRAY_ID, "Component not found: tag.", 3)).toBeNull();
+  });
+
+  it("returns null for a non-matching message", async () => {
+    expect(await run(STRAY_ID, "expected a dictionary.", 3)).toBeNull();
+  });
+
+  it("returns null when the body fetch fails", async () => {
+    const failing = fakeApi(() => {
+      throw new Error("boom");
+    });
+    expect(await run(STRAY_ID, MESSAGE, 3, failing)).toBeNull();
+  });
+});

--- a/test/util/yaml-component-not-found-fix.test.ts
+++ b/test/util/yaml-component-not-found-fix.test.ts
@@ -29,9 +29,7 @@ const BODIES: Record<string, ComponentCatalogEntry> = {
   sensor: { ...SLIMS[1], config_entries: [makeConfigEntry({ key: "id" })] },
 };
 
-const fakeApi = (
-  bodies: (ids: string[]) => Record<string, ComponentCatalogEntry> | never
-) =>
+const fakeApi = (bodies: (ids: string[]) => Record<string, ComponentCatalogEntry>) =>
   ({
     getComponents: async () => ({ components: SLIMS }),
     getComponentBodies: async (ids: string[]) => bodies(ids),

--- a/test/util/yaml-lint-humanize.test.ts
+++ b/test/util/yaml-lint-humanize.test.ts
@@ -18,7 +18,10 @@ import {
   type BannerError,
   type MappedValidationError,
 } from "../../src/util/yaml-lint-backend.js";
+import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
 import { flush } from "../_dom.js";
+import { makeComponentEntry } from "./_make-component-entry.js";
+import { makeConfigEntry } from "./_make-config-entry.js";
 
 // Echo the key + line so a humanized hit is distinguishable from raw text.
 const localize = (key: string, values?: Record<string, string | number>): string =>
@@ -308,6 +311,79 @@ describe("backend linter humanizes + banners a locatable parse error", () => {
         fromIndent: 2,
         kind: "dash-space",
       });
+    } finally {
+      view.destroy();
+    }
+  });
+
+  it("squiggles + banners the stray-top-level-key hint with the indent fix", async () => {
+    const doc = "logger:\n  baud_rate: 115200\nid: mylogger\n";
+    // The catalog gate needs a logger body carrying `id`; mountView's api
+    // is validate-only, so this test wires the full surface itself.
+    const api = {
+      validateYaml: vi.fn(async () => ({
+        yaml_errors: [],
+        validation_errors: [
+          {
+            message: "Component not found: id.",
+            range: {
+              document: "x.yaml",
+              start_line: 2,
+              start_col: 0,
+              end_line: 2,
+              end_col: 2,
+            },
+          },
+        ],
+      })),
+      getComponents: async () => ({ components: [makeComponentEntry("logger")] }),
+      getComponentBodies: async () => ({
+        logger: {
+          ...makeComponentEntry("logger"),
+          config_entries: [makeConfigEntry({ key: "id" })],
+        },
+      }),
+    } as unknown as ESPHomeAPI;
+
+    let banner: BannerError[] = [];
+    const fixes: YamlAutoFix[] = [];
+    const view = new EditorView({
+      state: EditorState.create({
+        doc,
+        extensions: [
+          // The analyzer's AST agreement check needs the YAML parse tree
+          // the production editor always carries.
+          esphomeYaml(),
+          createBackendYamlLinter({
+            api,
+            getConfiguration: () => "x.yaml",
+            localize,
+            onResult: (errors) => {
+              banner = errors;
+            },
+            onAutoFix: (fix) => fixes.push(fix),
+          }),
+        ],
+      }),
+      parent: document.body,
+    });
+    try {
+      forceLinting(view);
+      await flush();
+      const messages: string[] = [];
+      forEachDiagnostic(view.state, (d) => messages.push(d.message));
+      expect(messages).toEqual([
+        "Component not found: id. yaml_editor.error_indent_under_section_fix:3",
+      ]);
+
+      const expectedFix = { line: 3, indent: 2, key: "id", fromIndent: 0 };
+      const actions = collectActions(view);
+      expect(actions.map((a) => a.name)).toEqual(["yaml_editor.error_auto_fix"]);
+      actions[0].apply(view, 0, 0);
+      expect(fixes).toEqual([expectedFix]);
+
+      expect(banner).toHaveLength(1);
+      expect(banner[0].fix).toEqual(expectedFix);
     } finally {
       view.destroy();
     }


### PR DESCRIPTION
# What does this implement/fix?

A stray top level key (`id: mylogger` at column 0 below a `logger:` block) only got esphome's raw "Component not found: id." squiggle and banner. We can do better: when the key is not a component but the component catalog confirms it is a valid option of the section above, the error now carries a plain language hint ("Indent line 13 by 2 spaces to move it inside \"logger\".") and a one click Try auto-fix that indents the line.

The new `describeComponentNotFoundFix` analyzer mirrors the merged invalid option fix: message regex, buffer shape checks (column 0 key line, a valueless section opener above, map shaped body), an AST agreement check, then the catalog gate, failing closed at every step so a genuinely unknown component gets no fix rather than a wrong one. The indent delta follows the section's own child indent. No new fix kind; the kind-less positive indent path in `applyAutoFix` (staleness guards, validate before apply, undo) delivers it unchanged, as does the banner button.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2215

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
