### PR TITLE
Offer Auto instead of a false empty state for an id-less reference target

### DIFF
--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -86,9 +86,13 @@ export function renderIdReferenceField(
   // An id-less singleton (plain logger:, wifi:, ...) yields no candidates
   // even though the domain is configured; ESPHome auto-resolves the
   // reference, so say that instead of claiming nothing is configured.
-  // Scanned from the YAML rather than ctx.presentComponents, which not
-  // every form host wires up (the automation action form doesn't).
-  const emptyButConfigured = empty && parseTopLevelComponents(ctx.yaml).has(domain);
+  // Only for an optional reference (same gate as the revert-to-auto
+  // option below): a required one needs an explicit id, so the Add CTA
+  // is the honest empty state. Scanned from the YAML rather than
+  // ctx.presentComponents, which not every form host wires up (the
+  // automation action form doesn't).
+  const emptyButConfigured =
+    empty && !entry.required && parseTopLevelComponents(ctx.yaml).has(domain);
 
   const onChange = (e: Event) => {
     const select = e.target as HTMLSelectElement;

--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -14,6 +14,7 @@ import {
 } from "../../util/config-entry-yaml-scan.js";
 import { renderInlineError } from "../../util/render-error.js";
 import { resolveSubstitutions } from "../../util/substitutions.js";
+import { parseTopLevelComponents } from "../../util/yaml-serialize.js";
 import {
   effectiveDisabled,
   fieldKeyAttr,
@@ -82,6 +83,12 @@ export function renderIdReferenceField(
     : nothing;
   // Solo "Add new" CTA only when there's genuinely nothing to show.
   const empty = candidates.length === 0 && !hasOrphanValue;
+  // An id-less singleton (plain logger:, wifi:, ...) yields no candidates
+  // even though the domain is configured; ESPHome auto-resolves the
+  // reference, so say that instead of claiming nothing is configured.
+  // Scanned from the YAML rather than ctx.presentComponents, which not
+  // every form host wires up (the automation action form doesn't).
+  const emptyButConfigured = empty && parseTopLevelComponents(ctx.yaml).has(domain);
 
   const onChange = (e: Event) => {
     const select = e.target as HTMLSelectElement;
@@ -118,7 +125,7 @@ export function renderIdReferenceField(
   // only option (empty state) the dropdown is a single CTA.
   const addOption = html`
     <wa-option
-      class="id-option id-option-add ${empty ? "id-option-add--solo" : ""}"
+      class="id-option id-option-add ${empty && !emptyButConfigured ? "id-option-add--solo" : ""}"
       value=${ADD_NEW_SENTINEL}
     >
       <span class="id-option-stack">
@@ -137,9 +144,23 @@ export function renderIdReferenceField(
         <wa-select
           class=${fieldError ? "invalid" : ""}
           ?disabled=${effectiveDisabled(entry, ctx)}
-          placeholder=${ctx.localize("device.id_reference_empty", { domain })}
+          placeholder=${ctx.localize(
+            emptyButConfigured
+              ? "device.id_reference_auto_configured"
+              : "device.id_reference_empty",
+            { domain }
+          )}
           @change=${onChange}
         >
+          ${
+            emptyButConfigured
+              ? idOption(
+                  AUTO_SENTINEL,
+                  ctx.localize("device.id_reference_auto"),
+                  ctx.localize("device.id_reference_auto_detail", { domain })
+                )
+              : nothing
+          }
           ${addOption}
         </wa-select>
         ${renderFieldError(path, ctx)}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -971,6 +971,7 @@
     "missing_dependencies_body": "Configure these first, then come back to add this one:",
     "missing_dependencies_add": "Add {domain}",
     "id_reference_empty": "No {domain} configured yet",
+    "id_reference_auto_configured": "Auto (uses the configured {domain})",
     "id_reference_add": "Add {domain}",
     "id_reference_auto": "Auto",
     "id_reference_auto_detail": "Let ESPHome pick the {domain}",

--- a/test/components/device/config-entry-id-reference-renderer.test.ts
+++ b/test/components/device/config-entry-id-reference-renderer.test.ts
@@ -8,6 +8,7 @@ import { nothing } from "lit";
 import { describe, expect, it } from "vitest";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import {
+  ADD_NEW_SENTINEL,
   AUTO_SENTINEL,
   renderIdReferenceField,
 } from "../../../src/components/device/config-entry-id-reference-renderer.js";
@@ -246,6 +247,64 @@ describe("renderIdReferenceField — inline error for an unknown id", () => {
   });
 });
 
+describe("renderIdReferenceField — id-less configured domain (device-builder#2212)", () => {
+  const IDLESS_LOGGER_YAML = "esphome:\n  name: d\nlogger:\n  baud_rate: 115200\n";
+
+  function renderLoggerRef(yaml: string) {
+    const entry = makeEntry(ConfigEntryType.STRING, { references_component: "logger" });
+    return renderIdReferenceField(
+      entry,
+      ["logger_id"],
+      makeRenderCtx({ logger_id: "" }, { overrides: { yaml } })
+    );
+  }
+
+  const placeholderOf = (tmpl: unknown): unknown =>
+    findElementBindings(tmpl, "wa-select")[0]?.placeholder;
+
+  // The class attribute mixes static text with a binding, so read the solo
+  // marker off the template values rather than the extracted bindings.
+  const hasSoloAdd = (tmpl: unknown): boolean =>
+    findTemplatesByAnchor(tmpl, "<wa-option").some((t) =>
+      (t.values as unknown[]).some((v) => v === "id-option-add--solo")
+    );
+
+  it("offers Auto instead of claiming no logger is configured", () => {
+    const tmpl = renderLoggerRef(IDLESS_LOGGER_YAML);
+    expect(placeholderOf(tmpl)).toBe("device.id_reference_auto_configured");
+    const values = findElementBindings(tmpl, "wa-option").map((o) => o.value);
+    expect(values).toContain(AUTO_SENTINEL);
+    expect(values).toContain(ADD_NEW_SENTINEL);
+  });
+
+  it("demotes the Add CTA out of its solo styling", () => {
+    expect(hasSoloAdd(renderLoggerRef(IDLESS_LOGGER_YAML))).toBe(false);
+  });
+
+  it("keeps the empty-state copy and solo Add CTA when the domain is absent", () => {
+    const tmpl = renderLoggerRef("esphome:\n  name: d\n");
+    expect(placeholderOf(tmpl)).toBe("device.id_reference_empty");
+    expect(findElementBindings(tmpl, "wa-option").map((o) => o.value)).not.toContain(
+      AUTO_SENTINEL
+    );
+    expect(hasSoloAdd(tmpl)).toBe(true);
+  });
+
+  it("selecting Auto emits the empty value (key omitted on save)", () => {
+    const ctx = makeRenderCtx(
+      { logger_id: "" },
+      { overrides: { yaml: IDLESS_LOGGER_YAML } }
+    );
+    const entry = makeEntry(ConfigEntryType.STRING, { references_component: "logger" });
+    const tmpl = renderIdReferenceField(entry, ["logger_id"], ctx);
+    const onChange = findElementBindings(tmpl, "wa-select")[0]["@change"] as (
+      e: Event
+    ) => void;
+    onChange({ target: { value: AUTO_SENTINEL } } as unknown as Event);
+    expect(ctx.emitChange).toHaveBeenCalledWith(["logger_id"], "");
+  });
+});
+
 describe("renderIdReferenceField — revert-to-auto option (#2208)", () => {
   const LOGGER_YAML = "logger:\n  baud_rate: 115200\n";
 
@@ -284,7 +343,13 @@ describe("renderIdReferenceField — revert-to-auto option (#2208)", () => {
   });
 
   it("hides Auto while the field is empty (auto is already the default)", () => {
-    expect(optionValues(renderRef(""))).not.toContain(AUTO_SENTINEL);
+    // An id'd candidate keeps this on the sole-candidate-placeholder path;
+    // the id-less empty state now offers Auto explicitly (device-builder#2212).
+    const ctx = makeRenderCtx(
+      { logger_id: "" },
+      { overrides: { yaml: "logger:\n  id: my_logger\n" } }
+    );
+    expect(optionValues(renderRef("", {}, ctx))).not.toContain(AUTO_SENTINEL);
   });
 
   it("hides Auto on a required reference", () => {

--- a/test/components/device/config-entry-id-reference-renderer.test.ts
+++ b/test/components/device/config-entry-id-reference-renderer.test.ts
@@ -290,6 +290,23 @@ describe("renderIdReferenceField — id-less configured domain (device-builder#2
     expect(hasSoloAdd(tmpl)).toBe(true);
   });
 
+  it("keeps the Add CTA for a required reference (no Auto way out)", () => {
+    const entry = makeEntry(ConfigEntryType.STRING, {
+      references_component: "logger",
+      required: true,
+    });
+    const tmpl = renderIdReferenceField(
+      entry,
+      ["logger_id"],
+      makeRenderCtx({ logger_id: "" }, { overrides: { yaml: IDLESS_LOGGER_YAML } })
+    );
+    expect(placeholderOf(tmpl)).toBe("device.id_reference_empty");
+    expect(findElementBindings(tmpl, "wa-option").map((o) => o.value)).not.toContain(
+      AUTO_SENTINEL
+    );
+    expect(hasSoloAdd(tmpl)).toBe(true);
+  });
+
   it("selecting Auto emits the empty value (key omitted on save)", () => {
     const ctx = makeRenderCtx(
       { logger_id: "" },


### PR DESCRIPTION
# What does this implement/fix?

When the referenced domain exists in the YAML but offers no id candidates (a plain `logger:` block with no `id:`), the id reference dropdown claimed "No logger configured yet" and offered only a solo "+ Add logger" CTA, nudging the user toward a duplicate component. The empty branch now detects section presence from the YAML and shows "Auto (uses the configured logger)" with an explicit Auto option; the Add CTA stays available but loses its solo styling. Presence is scanned from the YAML directly rather than `ctx.presentComponents`, which the automation action form never wires up. Verified live on the logger.log action form: the Logger ID field now reads "Auto (uses the configured logger)".

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2212

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
