### PR TITLE
Update GitHub Pages deploy actions to latest

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -59,7 +59,7 @@ jobs:
         run: npm run build:web
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: esphome_web
 

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -79,7 +79,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Configure Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Deploy
         id: deployment


### PR DESCRIPTION
# What does this implement/fix?

Bumps the pinned GitHub Actions used by the ESPHome Web deploy workflow (`.github/workflows/deploy-web.yml`) to their latest releases:

- `actions/configure-pages` v5.0.0 → v6.0.0 (`45bfe0192ca1faeb007ade9deae92b16b8254a0d`)
- `actions/upload-pages-artifact` v4.0.0 → v5.0.0 (`fc324d3547104276b827a68afc52ff2a11cc49c9`)

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [x] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] \`npm run lint\` passes.
- [x] \`npm run test\` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).