### PR TITLE
Hold the section switch while an unknown top-level key is being typed

### DIFF
--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -503,6 +503,10 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
             fireEvent(this, "yaml-cursor-line", {
               line,
               path,
+              // True when a doc edit (typing, paste, undo) moved the
+              // caret here — the page holds section switches onto a
+              // half-typed unknown key only for edit-driven moves.
+              viaEdit: update.docChanged,
               // AST-only sibling of ``path`` carrying block-sequence
               // list indices — what the automation editor needs to
               // resolve a node inside a handler body.

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -37,6 +37,7 @@ import {
   backendErrorCounts,
   backendErrorsForInstance,
   formRelativePath,
+  instanceKey,
   resolveBackendErrors,
   type BackendFieldError,
 } from "../util/backend-field-errors.js";
@@ -58,6 +59,8 @@ import {
 } from "../util/url-line-resolver.js";
 import { buildWebUiUrl } from "../util/web-ui-url.js";
 import { boardDisagreesWithYaml, readPlatformBoard } from "../util/yaml-board.js";
+import { loadCatalog } from "../util/yaml-completion-catalog.js";
+import { knownTopLevelKeys } from "../util/yaml-completion-items.js";
 import {
   getLastValidatedResult,
   type YamlDiagnosticsDetail,
@@ -213,11 +216,31 @@ export class ESPHomePageDevice extends LitElement {
   @state()
   private _backendErrors: BackendFieldError[] = [];
 
+  /** instanceKey of the half-typed unknown section whose selection switch
+   *  and navigator error chip are held while the user is still typing its
+   *  key; null when nothing is held. */
+  @state()
+  private _heldUnknownInstance: string | null = null;
+
+  /** Valid top-level keys (core + automation + catalog domains/ids); null
+   *  until the catalog resolves — treated as "everything is known" so a
+   *  failed catalog fetch degrades to no holds, never to holding all
+   *  typed section switches. */
+  private _knownTopLevelKeys: Set<string> | null = null;
+  private _catalogKicked = false;
+
   // Memoised so idle re-renders keep the prop identities stable — the
   // section editor keys its per-edit error suppression on the prop
   // changing, and a fresh object every render would wipe it immediately.
   private _instanceBackendErrors = memoizeOne(backendErrorsForInstance);
-  private _navErrorCounts = memoizeOne(backendErrorCounts);
+  private _navErrorCounts = memoizeOne(
+    (errors: readonly BackendFieldError[], held: string | null) => {
+      const counts = backendErrorCounts(errors);
+      // Freshly built each memo miss, so deleting the held entry is safe.
+      if (held !== null) counts.delete(held);
+      return counts;
+    }
+  );
 
   /** Form-relative path of the last focused field, and whether its YAML
    *  line wasn't found yet (a just-added value whose debounced write is
@@ -561,6 +584,8 @@ export class ESPHomePageDevice extends LitElement {
       // handler ignores results for other configurations, so these
       // would linger until the new device's first lint pass.
       if (this._backendErrors.length) this._backendErrors = [];
+      this._heldUnknownInstance = null;
+      this._kickKnownKeys();
       this._loadYaml();
     }
     // Devices context arrives async after connect; kick off the board
@@ -1285,6 +1310,7 @@ export class ESPHomePageDevice extends LitElement {
    *  the device entirely is the app-shell's top-left back button —
    *  not this one. */
   private _onBack = () => {
+    this._heldUnknownInstance = null;
     this._guardSectionSwitch(() => {
       const prev = this._sectionHistory.length
         ? this._sectionHistory[this._sectionHistory.length - 1]
@@ -1423,7 +1449,7 @@ export class ESPHomePageDevice extends LitElement {
       .platformReady=${this._platformReady}
       .selectedKey=${this._selectedSection}
       .selectedFromLine=${this._selectedFromLine}
-      .errorCounts=${this._navErrorCounts(this._backendErrors)}
+      .errorCounts=${this._navErrorCounts(this._backendErrors, this._heldUnknownInstance)}
     ></esphome-device-navigator>`;
   }
 
@@ -1491,6 +1517,7 @@ export class ESPHomePageDevice extends LitElement {
     e: CustomEvent<{
       line: number;
       path?: string[];
+      viaEdit?: boolean;
       indexedPath?: (string | number)[];
     }>
   ) {
@@ -1517,6 +1544,22 @@ export class ESPHomePageDevice extends LitElement {
       this._focusYamlPath = e.detail.indexedPath;
       return;
     }
+    // A doc edit that resolves an unknown top-level key is a key still
+    // being typed (`sendx:` on its way to `sensor:`) — hold the switch so
+    // the pane doesn't flip to the unknown-component error surface on
+    // every keystroke (#2211). Clicks and caret moves (viaEdit false)
+    // always switch, so a settled external component still opens its
+    // pane deliberately. One quirk to know: the editor's same-line
+    // throttle means clicking the held line itself emits no event; the
+    // navigator entry (kept visible) is the release path there.
+    if (e.detail.viaEdit === true) {
+      if (this._knownTopLevelKeys === null) this._kickKnownKeys();
+      if (this._knownTopLevelKeys !== null && !this._knownTopLevelKeys.has(match.key)) {
+        this._heldUnknownInstance = instanceKey(sectionKey, match.fromLine);
+        return;
+      }
+    }
+    this._heldUnknownInstance = null;
     // Cross-section: set the field path only when the switch actually
     // applies, so a guard veto (unsaved edits) can't point the old
     // section's form at a path meant for the new one.
@@ -1660,6 +1703,7 @@ export class ESPHomePageDevice extends LitElement {
     e: CustomEvent<{ sectionKey: string | null; fromLine?: number }>
   ) {
     const { sectionKey, fromLine } = e.detail;
+    this._heldUnknownInstance = null;
     if (sectionKey === this._selectedSection && fromLine === this._selectedFromLine) {
       this._drawerOpen = false;
       return;
@@ -1706,6 +1750,18 @@ export class ESPHomePageDevice extends LitElement {
   private _guardSectionSwitch(action: () => void): void {
     this._activeSection?.flushPending();
     action();
+  }
+
+  /** Resolve the known-top-level-key set off the session-cached catalog.
+   *  ``loadCatalog`` never rejects (a failed fetch resolves an empty index
+   *  and resets its cache), so re-kicking on the next held-candidate event
+   *  retries for free. */
+  private _kickKnownKeys(): void {
+    if (this._catalogKicked && this._knownTopLevelKeys !== null) return;
+    this._catalogKicked = true;
+    void loadCatalog(this._api).then((catalog) => {
+      this._knownTopLevelKeys = knownTopLevelKeys(catalog);
+    });
   }
 
   private _onSectionMount = (e: Event) => {

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1562,7 +1562,8 @@ export class ESPHomePageDevice extends LitElement {
     // throttle means clicking the held line itself emits no event; the
     // navigator entry (kept visible) is the release path there.
     if (e.detail.viaEdit === true) {
-      if (this._knownTopLevelKeys === null) this._kickKnownKeys();
+      // An unresolved key set (catalog still loading, or failed — retried
+      // on the next device load, never from this hot path) means no holds.
       if (this._knownTopLevelKeys !== null && !this._knownTopLevelKeys.has(match.key)) {
         this._heldUnknownInstance = instanceKey(sectionKey, match.fromLine);
         return;

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -233,14 +233,23 @@ export class ESPHomePageDevice extends LitElement {
   // section editor keys its per-edit error suppression on the prop
   // changing, and a fresh object every render would wipe it immediately.
   private _instanceBackendErrors = memoizeOne(backendErrorsForInstance);
-  private _navErrorCounts = memoizeOne(
-    (errors: readonly BackendFieldError[], held: string | null) => {
-      const counts = backendErrorCounts(errors);
-      // Freshly built each memo miss, so deleting the held entry is safe.
-      if (held !== null) counts.delete(held);
-      return counts;
-    }
-  );
+  private _baseErrorCounts = memoizeOne(backendErrorCounts);
+
+  /** Navigator error counts minus the held instance's chip. The held key
+   *  changes on every keystroke of a half-typed section name, so the base
+   *  map is memoized on the errors alone and returned as-is (stable
+   *  identity, no navigator churn) unless it actually contains the held
+   *  entry. */
+  private _navErrorCounts(
+    errors: readonly BackendFieldError[],
+    held: string | null
+  ): Map<string, number> {
+    const base = this._baseErrorCounts(errors);
+    if (held === null || !base.has(held)) return base;
+    const counts = new Map(base);
+    counts.delete(held);
+    return counts;
+  }
 
   /** Form-relative path of the last focused field, and whether its YAML
    *  line wasn't found yet (a just-added value whose debounced write is
@@ -1753,14 +1762,16 @@ export class ESPHomePageDevice extends LitElement {
   }
 
   /** Resolve the known-top-level-key set off the session-cached catalog.
-   *  ``loadCatalog`` never rejects (a failed fetch resolves an empty index
-   *  and resets its cache), so re-kicking on the next held-candidate event
-   *  retries for free. */
+   *  ``loadCatalog`` never rejects — a failed fetch resolves an empty index
+   *  (null set) and resets its cache — so clearing the kicked flag only on
+   *  that outcome allows a later retry without a per-keystroke refetch
+   *  storm against an already-unhealthy backend. */
   private _kickKnownKeys(): void {
-    if (this._catalogKicked && this._knownTopLevelKeys !== null) return;
+    if (this._catalogKicked) return;
     this._catalogKicked = true;
     void loadCatalog(this._api).then((catalog) => {
       this._knownTopLevelKeys = knownTopLevelKeys(catalog);
+      if (this._knownTopLevelKeys === null) this._catalogKicked = false;
     });
   }
 

--- a/src/util/yaml-completion-items.ts
+++ b/src/util/yaml-completion-items.ts
@@ -23,6 +23,7 @@ import type {
 } from "./esphome-schema.js";
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import type { CatalogIndex } from "./yaml-completion-catalog.js";
+import { AUTOMATION_KEYS, CORE_KEYS } from "./yaml-sections.js";
 
 // Leading-whitespace counter — used when computing indents and
 // list-item lead text for the trigger / action apply snippets.
@@ -189,6 +190,24 @@ export function buildTopLevelCompletions(catalog: CatalogIndex): Completion[] {
   }
   topLevelMemo.set(catalog, out);
   return out;
+}
+
+const knownKeysMemo = new WeakMap<CatalogIndex, Set<string>>();
+
+/**
+ * Every valid top-level key: catalog domains and standalone ids plus the
+ * core and automation sections. ``null`` for an empty catalog —
+ * ``loadCatalog``'s failure path resolves an empty index, and callers must
+ * fail toward "known" rather than classify every component as unknown.
+ */
+export function knownTopLevelKeys(catalog: CatalogIndex): Set<string> | null {
+  if (catalog.components.length === 0) return null;
+  const cached = knownKeysMemo.get(catalog);
+  if (cached) return cached;
+  const keys = new Set<string>([...CORE_KEYS, ...AUTOMATION_KEYS]);
+  for (const item of buildTopLevelCompletions(catalog)) keys.add(item.label);
+  knownKeysMemo.set(catalog, keys);
+  return keys;
 }
 
 export function platformValueCompletion(c: ComponentCatalogEntry): Completion {

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -87,7 +87,7 @@ export const CORE_KEYS = new Set([
 // In ESPHome, automations are inline on_* handlers within components.
 // `script` and `interval` are the standalone automation-adjacent
 // top-level keys.
-const AUTOMATION_KEYS = new Set(["script", "interval"]);
+export const AUTOMATION_KEYS = new Set(["script", "interval"]);
 
 export function categorizeSections(sections: YamlSection[]): CategorizedSections {
   const core: YamlSection[] = [];

--- a/test/components/yaml-editor-cursor-line.test.ts
+++ b/test/components/yaml-editor-cursor-line.test.ts
@@ -17,6 +17,7 @@ import { ESPHomeYamlEditor } from "../../src/components/yaml-editor.js";
 interface CursorLineDetail {
   line: number;
   path: string[];
+  viaEdit?: boolean;
   indexedPath?: (string | number)[];
 }
 
@@ -56,11 +57,13 @@ describe("yaml-editor cursor-line emission (#946)", () => {
     const events = record(el);
 
     // Caret rests on the blank top-level line 3 → first emit, no section.
+    // A pure caret move is not an edit.
     caretToLineEnd(view, 3);
     parseAll(view);
     expect(events).toHaveLength(1);
     expect(events[0].line).toBe(3);
     expect(events[0].path[0]).toBeUndefined();
+    expect(events[0].viaEdit).toBe(false);
 
     // Type the block header on the same line in one transaction — a real
     // keystroke carries both the edit and the caret move. The same-line
@@ -71,10 +74,12 @@ describe("yaml-editor cursor-line emission (#946)", () => {
       selection: EditorSelection.single(at + "http_request:".length),
     });
 
-    // One more emit, still line 3, now attributed to http_request.
+    // One more emit, still line 3, now attributed to http_request and
+    // flagged as edit-driven so the page can hold unknown keys (#2211).
     expect(events).toHaveLength(2);
     expect(events[1].line).toBe(3);
     expect(events[1].path[0]).toBe("http_request");
+    expect(events[1].viaEdit).toBe(true);
   });
 
   it("does not re-emit while typing within the same section", async () => {

--- a/test/pages/device-cursor-hold.test.ts
+++ b/test/pages/device-cursor-hold.test.ts
@@ -1,0 +1,168 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the mid-typing hold (esphome/device-builder#2211): an edit-driven
+ * cursor event that resolves an unknown top-level key must not switch the
+ * structured pane onto the half-typed section, and the held instance's
+ * navigator error chip is withheld. Clicks, known keys, and deliberate
+ * navigation always switch.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("../../src/components/command-dialog.js", () => ({}));
+vi.mock("../../src/components/device/device-editor.js", () => ({}));
+vi.mock("../../src/components/device/device-navigator.js", () => ({}));
+vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
+vi.mock("../../src/components/install-method-dialog.js", () => ({}));
+vi.mock("../../src/components/logs-dialog.js", () => ({}));
+vi.mock("../../src/components/unsaved-changes-dialog.js", () => ({}));
+vi.mock("../../src/components/yaml-validation-dialog.js", () => ({}));
+vi.mock("../../src/components/device/device-install-controller.js", () => ({
+  DeviceInstallController: class {
+    constructor() {}
+  },
+}));
+
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import { ESPHomePageDevice } from "../../src/pages/device.js";
+import type { BackendFieldError } from "../../src/util/backend-field-errors.js";
+
+// i2c: lines 1-3, the half-typed unknown key on line 4 with its just-pressed
+// Enter blank on line 5, sensor: from line 6.
+const YAML = [
+  "i2c:",
+  "  sda: 1",
+  "  scl: 0",
+  "sendx:",
+  "",
+  "sensor:",
+  "  - platform: aht10",
+  "    temperature:",
+  "      name: Temperature",
+  "",
+].join("\n");
+
+const KNOWN = new Set(["i2c", "sensor", "logger"]);
+
+function makePage(): ESPHomePageDevice {
+  const page = new ESPHomePageDevice();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._api = {} as ESPHomeAPI;
+  page.id = "kitchen.yaml";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._yaml = YAML;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._savedYaml = YAML;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._knownTopLevelKeys = KNOWN;
+  return page;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const internals = (page: ESPHomePageDevice) => page as any;
+
+function cursorEvent(
+  page: ESPHomePageDevice,
+  line: number,
+  opts: { path?: string[]; viaEdit?: boolean } = {}
+) {
+  internals(page)._onYamlCursorLine(
+    new CustomEvent("yaml-cursor-line", {
+      detail: { line, path: opts.path ?? [], viaEdit: opts.viaEdit ?? false },
+    })
+  );
+}
+
+describe("mid-typing hold for an unknown top-level key (#2211)", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("holds an edit-driven move onto an unknown key's header line", () => {
+    const page = makePage();
+    cursorEvent(page, 2); // click into i2c → selected
+    expect(internals(page)._selectedSection).toBe("i2c");
+
+    cursorEvent(page, 4, { viaEdit: true }); // typing `sendx:`
+    expect(internals(page)._selectedSection).toBe("i2c");
+    expect(internals(page)._heldUnknownInstance).toBe("sendx@4");
+  });
+
+  it("still holds from a blank child line of the unknown block (Enter leak)", () => {
+    const page = makePage();
+    cursorEvent(page, 2);
+    // Enter + indent under sendx: the indent fallback attributes the blank
+    // child line to the block via the path; the caret is no longer on the
+    // header line but the hold must persist.
+    cursorEvent(page, 5, { path: ["sendx"], viaEdit: true });
+    expect(internals(page)._selectedSection).toBe("i2c");
+    expect(internals(page)._heldUnknownInstance).not.toBeNull();
+  });
+
+  it("switches on an edit-driven move onto a known key (#956 contract)", () => {
+    const page = makePage();
+    cursorEvent(page, 2);
+    cursorEvent(page, 7, { viaEdit: true }); // typing inside sensor:
+    expect(internals(page)._selectedSection).toBe("sensor.aht10");
+    expect(internals(page)._heldUnknownInstance).toBeNull();
+  });
+
+  it("switches on a click onto the unknown section (deliberate visit)", () => {
+    const page = makePage();
+    cursorEvent(page, 2);
+    cursorEvent(page, 4, { viaEdit: false });
+    expect(internals(page)._selectedSection).toBe("sendx");
+    expect(internals(page)._heldUnknownInstance).toBeNull();
+  });
+
+  it("switches on edits while the knownness set has not resolved", () => {
+    const page = makePage();
+    internals(page)._knownTopLevelKeys = null;
+    cursorEvent(page, 2);
+    cursorEvent(page, 4, { viaEdit: true });
+    // Pre-catalog (or failed catalog) behavior is identical to today.
+    expect(internals(page)._selectedSection).toBe("sendx");
+  });
+
+  it("keeps the URL untouched while held", () => {
+    const page = makePage();
+    cursorEvent(page, 2);
+    const before = window.location.search;
+    cursorEvent(page, 4, { viaEdit: true });
+    expect(window.location.search).toBe(before);
+  });
+
+  it("releases through a navigator selection", () => {
+    const page = makePage();
+    cursorEvent(page, 4, { viaEdit: true });
+    expect(internals(page)._heldUnknownInstance).not.toBeNull();
+    internals(page)._onSectionSelect(
+      new CustomEvent("section-select", {
+        detail: { sectionKey: "sendx", fromLine: 4 },
+      })
+    );
+    expect(internals(page)._heldUnknownInstance).toBeNull();
+    expect(internals(page)._selectedSection).toBe("sendx");
+  });
+
+  it("withholds only the held instance's navigator error chip", () => {
+    const page = makePage();
+    const errors: BackendFieldError[] = [
+      { sectionKey: "sendx", fromLine: 4, keyPath: [], message: "x" },
+      { sectionKey: "i2c", fromLine: 1, keyPath: [], message: "y" },
+    ] as never;
+    const counts = internals(page)._navErrorCounts(errors, "sendx@4");
+    expect(counts.has("sendx@4")).toBe(false);
+    expect(counts.get("i2c@1")).toBe(1);
+    const unheld = internals(page)._navErrorCounts(errors, null);
+    expect(unheld.get("sendx@4")).toBe(1);
+  });
+});

--- a/test/util/known-top-level-keys.test.ts
+++ b/test/util/known-top-level-keys.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Pins ``knownTopLevelKeys`` — the set the device page uses to hold a
+ * section switch onto a half-typed unknown top-level key (#2211).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type ComponentCatalogEntry,
+  ComponentCategory,
+} from "../../src/api/types/components.js";
+import { knownTopLevelKeys } from "../../src/util/yaml-completion-items.js";
+import { makeComponentEntry } from "./_make-component-entry.js";
+
+type CatalogIndex = Parameters<typeof knownTopLevelKeys>[0];
+
+const entry = (id: string, category: ComponentCategory) =>
+  makeComponentEntry(id, { category });
+
+function catalog(entries: ComponentCatalogEntry[]): CatalogIndex {
+  const byId = new Map<string, ComponentCatalogEntry>();
+  const byCategory = new Map<string, ComponentCatalogEntry[]>();
+  for (const e of entries) {
+    byId.set(e.id, e);
+    const list = byCategory.get(e.category) ?? [];
+    list.push(e);
+    byCategory.set(e.category, list);
+  }
+  return { components: entries, byId, byCategory };
+}
+
+describe("knownTopLevelKeys", () => {
+  it("unions domain umbrellas, standalone ids, and core/automation keys", () => {
+    const keys = knownTopLevelKeys(
+      catalog([
+        entry("binary_sensor.gpio", ComponentCategory.BINARY_SENSOR),
+        entry("http_request", ComponentCategory.MISC),
+      ])
+    );
+    expect(keys).not.toBeNull();
+    // Domain umbrella from the dotted id; the dotted id itself is not a key.
+    expect(keys!.has("binary_sensor")).toBe(true);
+    expect(keys!.has("binary_sensor.gpio")).toBe(false);
+    // Standalone component id.
+    expect(keys!.has("http_request")).toBe(true);
+    // Core and automation sections without catalog entries.
+    expect(keys!.has("esphome")).toBe(true);
+    expect(keys!.has("substitutions")).toBe(true);
+    expect(keys!.has("script")).toBe(true);
+    // A half-typed key is unknown.
+    expect(keys!.has("sendx")).toBe(false);
+  });
+
+  it("returns null for an empty catalog (failed fetch resolves empty)", () => {
+    // Callers must treat null as everything-known so a transient catalog
+    // failure degrades to no holds, not to holding every typed switch.
+    expect(knownTopLevelKeys(catalog([]))).toBeNull();
+  });
+
+  it("memoizes per catalog identity", () => {
+    const c = catalog([entry("http_request", ComponentCategory.MISC)]);
+    expect(knownTopLevelKeys(c)).toBe(knownTopLevelKeys(c));
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Typing a new top level key letter by letter flipped the structured pane to the unknown component error surface the instant the `:` landed (`sendx:` gets "External component" with a red Delete section button) and the navigator entry grew a red error chip on the next lint pass, all while the key was still being typed.

The cursor follow now holds the cross section switch when the move was caused by a doc edit and the resolved key is not a known top level key (core sections, automation sections, catalog domains and standalone ids). The pane stays where it was, the navigator entry appears without its error chip, and everything releases the moment the key becomes real (`mqtt:` flips to the MQTT form instantly), the caret moves elsewhere, or the user clicks. Clicks are never edits, so deliberately visiting a settled external component still opens its pane with the Delete button. A failed catalog fetch degrades to today's behavior, never to holding known keys.

The error banner needed no change; it already damps near caret validation errors while the editor is focused.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2211

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
