### PR TITLE
Simplify the device-section-config split seams

### DIFF
--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -62,7 +62,6 @@ import {
   renderPlatformDomainBranch,
   renderStructuredFormBranch,
   renderYamlOnlyBranch,
-  type StructuredFormOpts,
 } from "./device-section-config/render-branches.js";
 import {
   renderAddAutomationDialog,
@@ -188,6 +187,8 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
 
   _loadId = 0;
   _draftTimer: ReturnType<typeof setTimeout> | null = null;
+  /** ``focusFieldPath`` key already flashed — one-shot per target. */
+  _apiListFlashKey?: string;
   // Parent loops yaml-draft events back through our yaml prop, which would
   // trigger reload() and lose focus mid-edit. reload() short-circuits when
   // the live yaml matches this snapshot.
@@ -284,9 +285,6 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     maybeFlashApiActionsList(this);
   }
 
-  /** ``focusFieldPath`` key already flashed — one-shot per target. */
-  _apiListFlashKey?: string;
-
   connectedCallback() {
     super.connectedCallback();
     // Announce so the page-level navigation guard (device.ts) can hold a
@@ -376,7 +374,6 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     if (!this._config) return nothing;
     const config = this._config;
 
-    const showAdvanced = this._showAdvanced;
     // Handles overrides for sections whose backend schema doesn't match the
     // actual user-keyed shape (currently just substitutions).
     const renderEntries = resolveSectionEntries(this.sectionKey, config.entries);
@@ -397,44 +394,18 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
 
     const canDelete = !UNDELETABLE_SECTIONS.has(this.sectionKey);
 
-    // A catalog miss (external component or bare platform domain) swaps the
-    // title and drops the subtitle-less image header.
-    const catalogMiss = this._isUnknown || this._isPlatformDomain;
-    const headerTitle = this._isUnknown
-      ? this._localize("device.external_component_title")
-      : this._isPlatformDomain
-        ? this._localize("device.platform_section_title")
-        : config.title;
-
     return html`
-      ${renderSectionHeader(this, { config, catalogMiss, headerTitle, sectionAlerts })}
+      ${renderSectionHeader(this, config, sectionAlerts)}
       ${
         this._isPlatformDomain
-          ? this._renderPlatformDomainBranch(canDelete)
+          ? renderPlatformDomainBranch(this, canDelete)
           : yamlOnly
-            ? this._renderYamlOnlyBranch(canDelete)
-            : this._renderStructuredFormBranch({
-                config,
-                renderEntries,
-                showAdvanced,
-                canDelete,
-              })
+            ? renderYamlOnlyBranch(this, canDelete)
+            : renderStructuredFormBranch(this, config, canDelete)
       }
       ${renderApiActionDialog(this)} ${renderAddAutomationDialog(this)}
       ${renderDeleteConfirmDialog(this, canDelete, config)}
     `;
-  }
-
-  private _renderPlatformDomainBranch(canDelete: boolean) {
-    return renderPlatformDomainBranch(this, canDelete);
-  }
-
-  private _renderYamlOnlyBranch(canDelete: boolean) {
-    return renderYamlOnlyBranch(this, canDelete);
-  }
-
-  private _renderStructuredFormBranch(opts: StructuredFormOpts) {
-    return renderStructuredFormBranch(this, opts);
   }
 
   _onOpenAddApiAction = () => {
@@ -446,13 +417,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
    *  fill in variables + actions immediately. */
   _onApiActionAdded = (e: CustomEvent<{ sectionKey: string }>) => {
     e.stopPropagation();
-    this.dispatchEvent(
-      new CustomEvent<{ sectionKey: string }>("section-select", {
-        detail: { sectionKey: e.detail.sectionKey },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "section-select", { sectionKey: e.detail.sectionKey });
   };
 
   /** Edit any manage-list row: route the navigator to its stable
@@ -460,13 +425,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
    *  every row carries its ``automation:…`` key. */
   _onEditRow = (e: CustomEvent<{ key: string }>) => {
     e.stopPropagation();
-    this.dispatchEvent(
-      new CustomEvent<{ sectionKey: string }>("section-select", {
-        detail: { sectionKey: e.detail.key },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "section-select", { sectionKey: e.detail.key });
   };
 
   /**
@@ -491,13 +450,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
       );
       const newYaml = applyYamlDiff(this.yaml, yaml_diff);
       await this._api.updateConfig(this.configuration, newYaml);
-      this.dispatchEvent(
-        new CustomEvent<{ yaml: string }>("yaml-updated", {
-          detail: { yaml: newYaml },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      fireEvent(this, "yaml-updated", { yaml: newYaml });
     } catch (err) {
       const msg = formatApiError(err, this._localize, "device.automation_save_error");
       notifyError(this._localize("device.automation_save_error"), {
@@ -542,13 +495,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
 
   _onAutomationAdded = (e: CustomEvent<{ sectionKey: string }>) => {
     e.stopPropagation();
-    this.dispatchEvent(
-      new CustomEvent<{ sectionKey: string }>("section-select", {
-        detail: { sectionKey: e.detail.sectionKey },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "section-select", { sectionKey: e.detail.sectionKey });
   };
 
   /**
@@ -566,13 +513,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
       component_id: componentId,
       field: e.detail.field,
     });
-    this.dispatchEvent(
-      new CustomEvent<{ sectionKey: string }>("section-select", {
-        detail: { sectionKey },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    fireEvent(this, "section-select", { sectionKey });
   };
 }
 

--- a/src/components/device/device-section-config/automation-rows.ts
+++ b/src/components/device/device-section-config/automation-rows.ts
@@ -59,3 +59,10 @@ export function selectActionFieldRows(
       label: fieldLabel(s.actionField),
     }));
 }
+
+/** Rows for the api section's ``api_action`` manage-list. */
+export function selectApiActionRows(sections: readonly YamlSection[]): AutomationRow[] {
+  return sections
+    .filter((s) => s.key.startsWith("automation:api_action:"))
+    .map((s) => ({ key: s.key, label: s.id ?? "" }));
+}

--- a/src/components/device/device-section-config/render-branches.ts
+++ b/src/components/device/device-section-config/render-branches.ts
@@ -66,8 +66,9 @@ export function renderStructuredFormBranch(
   config: SectionConfigResponse,
   canDelete: boolean
 ) {
-  // Memoized on its inputs, so this repeat of render()'s call returns the
-  // same reference and the form's .entries identity stays stable.
+  // Repeats render()'s call. Cheap: the resolver returns a constant or the
+  // catalog's own array for map/default sections; only list sections
+  // allocate fresh, as every render already did.
   const renderEntries = resolveSectionEntries(host.sectionKey, config.entries);
   return html`
     ${

--- a/src/components/device/device-section-config/render-branches.ts
+++ b/src/components/device/device-section-config/render-branches.ts
@@ -2,8 +2,8 @@
  * The render body's three branches: bare platform-domain catalog miss,
  * YAML-only section, and the structured config-entry form.
  */
-import { html, nothing } from "lit";
-import type { ConfigEntry } from "../../../api/types/config-entries.js";
+import { html, nothing, type TemplateResult } from "lit";
+import { resolveSectionEntries } from "../../../util/section-entry-overrides.js";
 // The value imports (isSecuritySection / isDeprecationSection) already execute
 // the modules, registering the notice elements — no separate side-effect
 // imports needed.
@@ -13,20 +13,12 @@ import { isSecuritySection } from "../security-notice.js";
 import type { SectionConfigResponse } from "./loading.js";
 import {
   renderActionFieldsTable,
-  renderActionsRow,
   renderApiActionsTable,
-  renderNotice,
   renderTriggersTable,
 } from "./render-tables.js";
 
+import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "../config-entry-form.js";
-
-export interface StructuredFormOpts {
-  config: SectionConfigResponse;
-  renderEntries: ConfigEntry[];
-  showAdvanced: boolean;
-  canDelete: boolean;
-}
 
 export function renderPlatformDomainBranch(
   host: ESPHomeDeviceSectionConfig,
@@ -71,8 +63,12 @@ export function renderYamlOnlyBranch(
 
 export function renderStructuredFormBranch(
   host: ESPHomeDeviceSectionConfig,
-  { config, renderEntries, showAdvanced, canDelete }: StructuredFormOpts
+  config: SectionConfigResponse,
+  canDelete: boolean
 ) {
+  // Memoized on its inputs, so this repeat of render()'s call returns the
+  // same reference and the form's .entries identity stays stable.
+  const renderEntries = resolveSectionEntries(host.sectionKey, config.entries);
   return html`
     ${
       isSecuritySection(host.sectionKey)
@@ -113,7 +109,7 @@ export function renderStructuredFormBranch(
       .presentComponents=${host._presentComponents}
       advanced-section
       gate-advanced
-      ?show-advanced=${showAdvanced}
+      ?show-advanced=${host._showAdvanced}
       @value-change=${host._onValueChange}
       @advanced-toggle=${host._onAdvancedToggle}
       @edit-action-field=${host._onEditActionField}
@@ -122,4 +118,27 @@ export function renderStructuredFormBranch(
     ${renderApiActionsTable(host)} ${renderTriggersTable(host)}
     ${renderActionsRow(host, canDelete)}
   `;
+}
+
+/** The info-notice shell shared by the YAML-only and platform-domain
+ *  states; *body* supplies the message and its CTA. */
+function renderNotice(body: TemplateResult) {
+  return html`<div class="yaml-only-notice" role="note">
+    <wa-icon library="mdi" name="information-outline"></wa-icon>
+    <div class="yaml-only-notice-body">${body}</div>
+  </div>`;
+}
+
+function renderActionsRow(host: ESPHomeDeviceSectionConfig, canDelete: boolean) {
+  if (!canDelete) return nothing;
+  return html`<div class="actions">
+    <button
+      class="delete-button"
+      ?disabled=${host._deleting}
+      @click=${() => host._confirmDialog?.open()}
+    >
+      <wa-icon library="mdi" name="delete"></wa-icon>
+      ${host._localize("device.delete_section")}
+    </button>
+  </div>`;
 }

--- a/src/components/device/device-section-config/render-header.ts
+++ b/src/components/device/device-section-config/render-header.ts
@@ -4,35 +4,37 @@
  */
 import { html, nothing } from "lit";
 import { defaultBoardImageUrl, onBoardImageError } from "../../../util/board-image.js";
-import { renderMarkdown } from "../../../util/markdown.js";
+import { isSafeLinkHref, renderMarkdown } from "../../../util/markdown.js";
 import type { ESPHomeDeviceSectionConfig } from "../device-section-config.js";
 import type { SectionConfigResponse } from "./loading.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 
-export interface SectionHeaderOpts {
-  config: SectionConfigResponse;
-  catalogMiss: boolean;
-  headerTitle: string;
-  sectionAlerts: string[];
-}
-
 export function renderSectionHeader(
   host: ESPHomeDeviceSectionConfig,
-  { config, catalogMiss, headerTitle, sectionAlerts }: SectionHeaderOpts
+  config: SectionConfigResponse,
+  sectionAlerts: string[]
 ) {
+  // A catalog miss (external component or bare platform domain) swaps the
+  // title and drops the subtitle-less image header.
+  const catalogMiss = host._isUnknown || host._isPlatformDomain;
+  const headerTitle = host._isUnknown
+    ? host._localize("device.external_component_title")
+    : host._isPlatformDomain
+      ? host._localize("device.platform_section_title")
+      : config.title;
   return html`
     <div class="section-header">
       <div class="section-header-info">
         <div class="section-header-title-row">
           <h3 class="section-title">${headerTitle}</h3>
           ${
-            config.docs_url
+            isSafeLinkHref(config.docs_url)
               ? html`<a
                   class="docs-link"
                   href=${config.docs_url}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                 >
                   ${host._localize("device.docs")}
                   <wa-icon library="mdi" name="open-in-new"></wa-icon>

--- a/src/components/device/device-section-config/render-tables.ts
+++ b/src/components/device/device-section-config/render-tables.ts
@@ -1,29 +1,17 @@
 /**
- * Inline manage-lists (api actions, triggers, component action fields)
- * plus the shared notice shell and the delete actions row.
+ * Inline manage-lists: api actions, triggers, component action fields.
  */
-import { html, nothing, type TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { actionFieldLabel } from "../../../util/action-field-label.js";
 import { parseYamlAutomations, type YamlSection } from "../../../util/yaml-sections.js";
 import type { ESPHomeDeviceSectionConfig } from "../device-section-config.js";
-import { selectActionFieldRows, selectTriggerRows } from "./automation-rows.js";
+import {
+  selectActionFieldRows,
+  selectApiActionRows,
+  selectTriggerRows,
+} from "./automation-rows.js";
 
-import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "../device-section-automation-list.js";
-
-/** The info-notice shell shared by the YAML-only and platform-domain
- *  states; *body* supplies the message and its CTA. */
-export function renderNotice(body: TemplateResult) {
-  return html`<div class="yaml-only-notice" role="note">
-    <wa-icon library="mdi" name="information-outline"></wa-icon>
-    <div class="yaml-only-notice-body">${body}</div>
-  </div>`;
-}
-
-export function renderActionsRow(host: ESPHomeDeviceSectionConfig, canDelete: boolean) {
-  if (!canDelete) return nothing;
-  return html`<div class="actions">${renderDeleteButton(host)}</div>`;
-}
 
 /**
  * Inline manage-list of api_action entries. Rendered only for the
@@ -32,9 +20,7 @@ export function renderActionsRow(host: ESPHomeDeviceSectionConfig, canDelete: bo
  */
 export function renderApiActionsTable(host: ESPHomeDeviceSectionConfig) {
   if (host.sectionKey !== "api") return nothing;
-  const rows = parseYamlAutomations(host.yaml)
-    .filter((s) => s.key.startsWith("automation:api_action:"))
-    .map((s) => ({ key: s.key, label: s.id ?? "" }));
+  const rows = selectApiActionRows(parseYamlAutomations(host.yaml));
   return html`<esphome-section-automation-list
     .heading=${host._localize("device.api_actions_list_title")}
     .rows=${rows}
@@ -102,17 +88,6 @@ export function renderActionFieldsTable(host: ESPHomeDeviceSectionConfig) {
     @edit=${host._onEditRow}
     @delete=${host._onDeleteRow}
   ></esphome-section-automation-list>`;
-}
-
-function renderDeleteButton(host: ESPHomeDeviceSectionConfig) {
-  return html`<button
-    class="delete-button"
-    ?disabled=${host._deleting}
-    @click=${() => host._confirmDialog?.open()}
-  >
-    <wa-icon library="mdi" name="delete"></wa-icon>
-    ${host._localize("device.delete_section")}
-  </button>`;
 }
 
 /** Pretty trigger label for an automations-list row, resolved from

--- a/test/components/device/automation-rows.test.ts
+++ b/test/components/device/automation-rows.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   selectActionFieldRows,
+  selectApiActionRows,
   selectTriggerRows,
 } from "../../../src/components/device/device-section-config/automation-rows.js";
 import type { YamlSection } from "../../../src/util/yaml-sections.js";
@@ -116,5 +117,19 @@ describe("selectActionFieldRows", () => {
   it("returns an empty list when the instance declares no action fields", () => {
     const sections = [section({ key: "trigger", eventKey: "on_press", id: "c1" })];
     expect(selectActionFieldRows(sections, "c1", labelField)).toEqual([]);
+  });
+});
+
+describe("selectApiActionRows", () => {
+  it("keeps only api_action rows, labelled by id", () => {
+    const sections = [
+      section({ key: "automation:api_action:greet", id: "greet" }),
+      section({ key: "automation:trigger:esphome:on_boot", eventKey: "on_boot" }),
+      section({ key: "automation:api_action:anon" }), // no id -> empty label
+    ];
+    expect(selectApiActionRows(sections)).toEqual([
+      { key: "automation:api_action:greet", label: "greet" },
+      { key: "automation:api_action:anon", label: "" },
+    ]);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Follow up cleanup pass over the #1326 split, from a four angle review (reuse, simplification, efficiency, altitude) plus the Copilot comments on that PR. The three one line `_renderXxxBranch` delegates are gone; `render()` calls the branch functions directly, matching how it already called the header and dialogs. The opts objects dissolved into plain signatures: `renderStructuredFormBranch` derives `renderEntries` itself (the memoized `resolveSectionEntries` makes the repeat free and restores the substitutions override test pin to one file), and `render-header.ts` derives `catalogMiss` / `headerTitle` where they are consumed. The notice shell and delete row moved into `render-branches.ts`, their only consumer, so `render-tables.ts` is purely the three manage lists; the api actions table now routes through a new `selectApiActionRows` in `automation-rows.ts` like its two siblings, with a unit test. Five hand rolled bubbling `CustomEvent` dispatches collapsed to the existing `fireEvent` helper, and the stranded `_apiListFlashKey` field moved next to the other non reactive fields.

One deliberate behavior tweak, from the Copilot review on #1326: the docs link is now gated through `isSafeLinkHref` and carries `rel="noopener noreferrer"`, consistent with the other safe link call sites; a catalog `docs_url` without an http(s)/mailto scheme renders no link instead of a live anchor. Everything else is identical, verified in the live dashboard against all three render branches and the dialogs. Main file is 524 lines.

**Related issue or feature (if applicable):**

- follow up to #1326 (issue device-builder-frontend#1325)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
