### PR TITLE
Add a web.esphome.io issue form and route the chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
-# With `blank_issues_enabled: false` and no issue templates defined,
-# the new-issue chooser shows nothing but these contact links — users
-# are funnelled straight to the right channel. Maintainers can still
-# open issues directly via the /issues/new URL when needed.
+# web.esphome.io bugs are filed here (this repo deploys the site);
+# dashboard bugs are funnelled to the backend tracker so triage stays
+# in one place. `blank_issues_enabled: false` removes the blank-issue
+# escape hatch.
 blank_issues_enabled: false
 contact_links:
   - name: 📋 Check the backlog first
@@ -11,11 +11,19 @@ contact_links:
       filing — saves duplicates and gives you a feel for the
       direction the project is heading.
 
-  - name: 🐛 Report a bug
+  - name: 🐛 Report a Device Builder dashboard bug
     url: https://github.com/esphome/device-builder/issues/new?template=bug_report.yml
     about: |
-      All bug reports — UI included — go on the backend tracker
-      so we can triage in one place.
+      Dashboard bug reports — UI included — go on the backend
+      tracker so we can triage in one place. Only web.esphome.io
+      reports are filed here.
+
+  - name: 🐛 ESPHome compilation / firmware / component issues
+    url: https://github.com/esphome/esphome/issues/new/choose
+    about: |
+      Compile errors, runtime problems on the device, and component
+      behaviour live in the esphome core repo — web.esphome.io only
+      delivers the firmware to the device.
 
   - name: 💡 Request / discuss a feature
     url: https://github.com/orgs/esphome/discussions

--- a/.github/ISSUE_TEMPLATE/web_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/web_bug_report.yml
@@ -1,0 +1,86 @@
+name: 🌐 web.esphome.io bug report
+description: Report a problem with the web.esphome.io site (flashing, Wi-Fi provisioning, logs).
+title: "[web.esphome.io] "
+type: "Bug"
+labels: ["web.esphome.io"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for reporting! 🙏 A couple of checks before filing:
+
+
+        - **Web Serial only works in Chromium browsers** (Chrome, Edge,
+        Opera). Firefox and Safari cannot connect to serial devices by
+        browser design — that's a browser limitation, not a bug we can fix.
+
+        - **Firmware / compile / component problems** belong in the
+        [esphome repo](https://github.com/esphome/esphome/issues/new/choose)
+        — web.esphome.io only delivers the firmware to the device.
+
+        - **Device Builder dashboard problems** (the ESPHome dashboard you
+        run yourself) go on the
+        [device-builder tracker](https://github.com/esphome/device-builder/issues/new?template=bug_report.yml).
+
+        - **Quick questions** land faster in the
+        [Discord channel](https://discord.gg/Rf2jWGVjaK).
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: |
+        A clear description of the problem. Include reproduction steps
+        — "I clicked X, expected Y, got Z" is ideal.
+      placeholder: |
+        1. Open web.esphome.io and click "Connect"
+        2. Pick the USB serial port
+        3. ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: action
+    attributes:
+      label: What were you trying to do?
+      multiple: false
+      options:
+        - Connect to the device / select the serial port
+        - Install / flash firmware
+        - Provision Wi-Fi (Improv)
+        - View logs
+        - Something else
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and operating system
+      description: Browser with its version, and the OS it runs on.
+      placeholder: "e.g. Chrome 138 on macOS 15"
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device / board
+      description: The board or chip you were connecting to.
+      placeholder: "e.g. ESP32-S3-DevKitC-1"
+
+  - type: textarea
+    id: console
+    attributes:
+      label: Console / log output
+      description: |
+        Open the browser devtools console (F12), reproduce the problem, and
+        paste any errors here. For log-viewing problems, include the
+        on-screen device log too.
+      render: shell
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Screenshots or anything else that might help us reproduce.


### PR DESCRIPTION
# What does this implement/fix?

web.esphome.io now deploys from this repo, but the issue chooser had no way to report a problem with it; the only bug card redirected to the backend tracker, whose required fields (dashboard version, install method) don't fit a browser only site. This adds a web.esphome.io issue form with fields that do fit (browser and OS, what you were doing, device, console output), auto labeled `web.esphome.io`. The chooser comment and the dashboard bug card are updated so the two bug paths read clearly side by side, and an esphome core off ramp is added so firmware and compile problems don't land on the web form for lack of anywhere else to go.

**Related issue or feature (if applicable):**

- reported on Discord; web.esphome.io reports had no fitting template

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
