### PR TITLE
Correct the Web Serial browser support note

### DIFF
--- a/.github/ISSUE_TEMPLATE/web_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/web_bug_report.yml
@@ -10,9 +10,10 @@ body:
         Thanks for reporting! 🙏 A couple of checks before filing:
 
 
-        - **Web Serial only works in Chromium browsers** (Chrome, Edge,
-        Opera). Firefox and Safari cannot connect to serial devices by
-        browser design — that's a browser limitation, not a bug we can fix.
+        - **Your browser must support Web Serial** — Chromium browsers
+        (Chrome, Edge, Opera) and recent Firefox work; Safari cannot
+        connect to serial devices — that's a browser limitation, not a
+        bug we can fix.
 
         - **Firmware / compile / component problems** belong in the
         [esphome repo](https://github.com/esphome/esphome/issues/new/choose)


### PR DESCRIPTION
# What does this implement/fix?

The web.esphome.io issue form from #1328 claimed Web Serial is Chromium only; Firefox supports it now. Reword the note so the requirement is Web Serial support itself, with Safari as the one that cannot connect.

**Related issue or feature (if applicable):**

- follows up #1328

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
