### PR TITLE
Fetch ESPHome Web deploy translations in the lokalise environment

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -11,8 +11,8 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Build job just reads the repo and uploads the artifact; the deploy job below
-# gets the Pages-write + OIDC scope.
+# The translations + build jobs only read the repo (contents: read, inherited
+# below); the deploy job alone gets the Pages-write + OIDC scope.
 permissions:
   contents: read
 
@@ -26,8 +26,60 @@ env:
   NODE_VERSION: "24.x"
 
 jobs:
+  translations:
+    name: Download translations from Lokalise
+    runs-on: ubuntu-latest
+    # The Lokalise credentials live in the `lokalise` environment, so the API
+    # token is only ever exposed to this small job — not to the build job,
+    # which runs `npm ci` and the full bundler.
+    environment: lokalise
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download from Lokalise
+        # Non-English locales are gitignored, so pull them before bundling. On
+        # the canonical repo the live site MUST ship translations, so unset
+        # secrets hard-fail rather than silently deploying English-only (a
+        # credential regression would otherwise degrade web.esphome.io behind
+        # an easily-missed ::warning::). On a fork the secrets are unreachable,
+        # so building English-only is the expected, non-fatal outcome.
+        env:
+          LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
+          LOKALISE_PROJECT_ID: ${{ secrets.LOKALISE_PROJECT_ID }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "${LOKALISE_API_TOKEN}" ] || [ -z "${LOKALISE_PROJECT_ID}" ]; then
+            if [ "${REPO}" = "esphome/device-builder-frontend" ]; then
+              echo "::error::Lokalise secrets unset on the canonical repo; the site must ship translations."
+              exit 1
+            fi
+            echo "::warning::Lokalise secrets unset; deploying English-only (fork)."
+            exit 0
+          fi
+          npm run translations:download
+
+      - name: Upload translations artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: translations
+          # en.json is always present, so the artifact stays non-empty even
+          # when no locales were downloaded — the build job's restore step
+          # then never fails on a missing artifact.
+          path: src/translations/
+
   build:
     name: Build site
+    needs: translations
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -41,19 +93,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download translations from Lokalise
-        # Best-effort: the build works English-only without the secrets (the
-        # runtime falls back to English per-key), and non-English locales load
-        # lazily. When the secrets are present we ship every translated locale.
-        env:
-          LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
-          LOKALISE_PROJECT_ID: ${{ secrets.LOKALISE_PROJECT_ID }}
-        run: |
-          if [ -z "${LOKALISE_API_TOKEN}" ] || [ -z "${LOKALISE_PROJECT_ID}" ]; then
-            echo "::warning::Lokalise secrets unset; deploying English-only."
-            exit 0
-          fi
-          npm run translations:download
+      - name: Restore translations
+        # Locale files come from the `translations` job (which holds the
+        # Lokalise credentials); the build job never sees the API token. The
+        # artifact always carries en.json, so this overwrites the checked-out
+        # copy with itself and adds any downloaded locales.
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: translations
+          path: src/translations/
 
       - name: Build ESPHome Web
         run: npm run build:web


### PR DESCRIPTION
# What does this implement/fix?

The `deploy-web.yml` build job read the Lokalise secrets directly, but they live in the `lokalise` GitHub environment, so they resolved empty on every run — the "Lokalise secrets unset; deploying English-only" guard fired and web.esphome.io shipped English-only.

This mirrors the pattern already in `release.yml`: a dedicated `translations` job holds the credentials (`environment: lokalise`), downloads the locales, and hands them to the build job as the `translations` artifact, so the bundler job never sees the API token. `build:web` regenerates the language manifest from the restored `src/translations/`, so every locale ships.

It also tightens the failure mode: on the canonical repo, missing secrets now hard-fail (`::error::` + `exit 1`) instead of silently degrading the live site to English-only; forks still warn and build English-only.

Workflow-only change — no source or backend changes, and the diff vs `main` is just the job split (the Pages action pins bumped by #1321/#1322 are preserved).

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).