### PR TITLE
Reveal the fresh clone: clear the search and highlight the new device

### DIFF
--- a/src/components/dashboard/actions-ui.ts
+++ b/src/components/dashboard/actions-ui.ts
@@ -60,9 +60,10 @@ export async function executeClone(
   const device = host._actionDevice;
   if (!device) return;
   const { newName, newFriendlyName } = e.detail;
+  let result: Awaited<ReturnType<ESPHomeAPI["cloneDevice"]>>;
   try {
     const friendly = newFriendlyName.length > 0 ? newFriendlyName : undefined;
-    await host._api.cloneDevice(device.configuration, newName, friendly);
+    result = await host._api.cloneDevice(device.configuration, newName, friendly);
   } catch (err) {
     const reason = getErrorMessage(err);
     notifyError(
@@ -74,6 +75,7 @@ export async function executeClone(
     return;
   }
   notifySuccess(host._localize("dashboard.action_clone_success", { name: newName }));
+  host._onCloned(result.configuration);
 }
 
 export async function executeRename(

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -415,7 +415,6 @@ export class ESPHomePageDashboard extends LitElement {
     const pending = consumePendingHighlight();
     if (pending !== null) {
       this._highlightFreshDevice(pending);
-      this._tryConsumePendingScroll();
     }
     // USB "Set it up" actioned from another route stashes the port and
     // navigates here. Defer to first render so _createDialog (@query)
@@ -769,11 +768,16 @@ export class ESPHomePageDashboard extends LitElement {
     };
   }
 
+  /** Clear the search term and resync YAML mode, without touching focus. */
+  private _resetSearch(): void {
+    this._search = "";
+    this._syncYamlSearch();
+  }
+
   /** Clear just the search box (facets untouched) and refocus it so the
    *  user can retype. Wired to the in-input × control (#1160). */
   _clearSearch = () => {
-    this._search = "";
-    this._syncYamlSearch();
+    this._resetSearch();
     refocusSearchInput(this);
   };
 
@@ -782,13 +786,12 @@ export class ESPHomePageDashboard extends LitElement {
    *  ``_hasActiveFilters`` — so this is always doing something
    *  visible from the user's perspective. */
   _clearAllFilters = () => {
-    this._search = "";
+    this._resetSearch();
     this._selectedLabels = [];
     this._selectedAreas = [];
     this._selectedPlatforms = [];
     this._selectedStates = [];
     this._selectedUpdateStatus = [];
-    this._syncYamlSearch();
   };
 
   /** Apply every active facet filter to the device list. Labels and
@@ -907,6 +910,10 @@ export class ESPHomePageDashboard extends LitElement {
       this._recentlyAdopted = null;
       this._adoptHighlightTimer = null;
     }, 4000);
+    // The device may already be in _devices (an ADDED push beating the
+    // command reply), in which case updated()'s _devices gate never
+    // fires — scroll now; otherwise the pending scroll stays armed.
+    this._tryConsumePendingScroll();
   }
 
   _onAdopted = (e: CustomEvent<{ name: string; friendlyName: string }>) => {
@@ -915,14 +922,10 @@ export class ESPHomePageDashboard extends LitElement {
 
   /** Post-clone reveal (#2246): the search that matched the source would
    *  hide the fresh clone, so clear it (no refocus — attention belongs on
-   *  the new card; facets stay, adopt parity). The rescan's ADDED push can
-   *  beat the command reply, so try the scroll now; otherwise
-   *  _pendingAdoptScroll stays armed for updated(). */
+   *  the new card; facets stay, adopt parity). */
   _onCloned = (configuration: string) => {
-    this._search = "";
-    this._syncYamlSearch();
+    this._resetSearch();
     this._highlightFreshDevice(configuration);
-    this._tryConsumePendingScroll();
   };
 
   private _tryConsumePendingScroll(): void {

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -913,6 +913,18 @@ export class ESPHomePageDashboard extends LitElement {
     this._highlightFreshDevice(`${e.detail.name}.yaml`);
   };
 
+  /** Post-clone reveal (#2246): the search that matched the source would
+   *  hide the fresh clone, so clear it (no refocus — attention belongs on
+   *  the new card; facets stay, adopt parity). The rescan's ADDED push can
+   *  beat the command reply, so try the scroll now; otherwise
+   *  _pendingAdoptScroll stays armed for updated(). */
+  _onCloned = (configuration: string) => {
+    this._search = "";
+    this._syncYamlSearch();
+    this._highlightFreshDevice(configuration);
+    this._tryConsumePendingScroll();
+  };
+
   private _tryConsumePendingScroll(): void {
     if (this._pendingAdoptScroll === null) return;
     const target = this._pendingAdoptScroll;

--- a/test/components/dashboard/actions-ui.test.ts
+++ b/test/components/dashboard/actions-ui.test.ts
@@ -4,6 +4,7 @@ import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
 import { DeviceState } from "../../../src/api/types/devices.js";
 import type { LocalizeFunc } from "../../../src/common/localize.js";
 import {
+  executeClone,
   executeRename,
   openLogsWithMethod,
 } from "../../../src/components/dashboard/actions-ui.js";
@@ -154,6 +155,78 @@ describe("executeRename", () => {
 
     expect(toastError).toHaveBeenCalledTimes(1);
     expect(toastError.mock.calls[0][0]).toContain(reason);
+  });
+});
+
+describe("executeClone", () => {
+  beforeEach(() => {
+    toastError.mockClear();
+    toastSuccess.mockClear();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  function makeCloneHost(cloneDevice: ESPHomeAPI["cloneDevice"]): {
+    host: ESPHomePageDashboard;
+    onCloned: ReturnType<typeof vi.fn>;
+  } {
+    const onCloned = vi.fn();
+    const host = makeDashboardHost({
+      _actionDevice: makeConfiguredDevice({
+        name: "kitchen",
+        configuration: "kitchen.yaml",
+      }),
+      _api: { cloneDevice } as unknown as ESPHomeAPI,
+      _localize: localize,
+      _onCloned: onCloned,
+    });
+    return { host, onCloned };
+  }
+
+  function cloneEvent(
+    newName: string,
+    newFriendlyName = ""
+  ): CustomEvent<{ newName: string; newFriendlyName: string }> {
+    return new CustomEvent("clone-confirm", { detail: { newName, newFriendlyName } });
+  }
+
+  it("reveals the fresh clone on success (empty friendly name maps to undefined)", async () => {
+    const cloneDevice = vi.fn(async () => ({ configuration: "bedroom-bulb.yaml" }));
+    const { host, onCloned } = makeCloneHost(
+      cloneDevice as unknown as ESPHomeAPI["cloneDevice"]
+    );
+
+    await executeClone(host, cloneEvent("bedroom-bulb"));
+
+    expect(cloneDevice).toHaveBeenCalledWith("kitchen.yaml", "bedroom-bulb", undefined);
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(onCloned).toHaveBeenCalledExactlyOnceWith("bedroom-bulb.yaml");
+  });
+
+  it("forwards a non-empty friendly name", async () => {
+    const cloneDevice = vi.fn(async () => ({ configuration: "bedroom-bulb.yaml" }));
+    const { host } = makeCloneHost(cloneDevice as unknown as ESPHomeAPI["cloneDevice"]);
+
+    await executeClone(host, cloneEvent("bedroom-bulb", "Bedroom Bulb"));
+
+    expect(cloneDevice).toHaveBeenCalledWith(
+      "kitchen.yaml",
+      "bedroom-bulb",
+      "Bedroom Bulb"
+    );
+  });
+
+  it("keeps the list untouched on failure and surfaces the reason", async () => {
+    const reason = "A device named bedroom-bulb.yaml already exists";
+    const cloneDevice = vi.fn(async () => {
+      throw new Error(`invalid_args: ${reason}`);
+    }) as unknown as ESPHomeAPI["cloneDevice"];
+    const { host, onCloned } = makeCloneHost(cloneDevice);
+
+    await executeClone(host, cloneEvent("bedroom-bulb"));
+
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastError.mock.calls[0][0]).toContain(reason);
+    expect(onCloned).not.toHaveBeenCalled();
   });
 });
 

--- a/test/pages/dashboard-clone-reveal.test.ts
+++ b/test/pages/dashboard-clone-reveal.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins ESPHomePageDashboard._onCloned: clears the search (which matched the
+ * source device and would hide the clone), leaves facets intact, and arms the
+ * adopt-style highlight + deferred scroll for the fresh clone (issue
+ * device-builder#2246).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomePageDashboard } from "../../src/pages/dashboard.js";
+
+describe("_onCloned", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("clears the search, keeps facets, and arms the highlight for the clone", () => {
+    vi.useFakeTimers();
+    const page = new ESPHomePageDashboard();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Object.assign(page as any, {
+      _search: "kitchen",
+      _selectedAreas: ["living"],
+      _devices: [],
+    });
+    const sync = vi.spyOn(page, "_syncYamlSearch").mockImplementation(() => {});
+
+    page._onCloned("bedroom-bulb.yaml");
+
+    expect(page._search).toBe("");
+    expect(sync).toHaveBeenCalledOnce();
+    expect(page._selectedAreas).toEqual(["living"]);
+    expect(page._recentlyAdopted).toBe("bedroom-bulb.yaml");
+    // The clone isn't in _devices yet, so the scroll stays armed for the
+    // ADDED push that updated() consumes.
+    expect(page._pendingAdoptScroll).toBe("bedroom-bulb.yaml");
+
+    vi.advanceTimersByTime(4000);
+    expect(page._recentlyAdopted).toBeNull();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

After a clone, the dashboard kept the search that matched the source device, so the user landed back on the filtered list with the original device instead of the new one. The clone response already carries the new configuration filename; `executeClone` was discarding it.

Now a successful clone hands the returned configuration to a new `_onCloned` on the dashboard page: it clears the search (which by definition matched the source, not the clone), leaves facet filters alone (parity with the adopt flow), and arms the same highlight plus deferred scroll adopt uses. The scroll is also tried immediately because the rescan's ADDED push can land before the command reply. The search box is deliberately not refocused; attention belongs on the new card. Failures keep the old behavior, the search stays put.

Verified live in both card and table view: search cleared, list scrolled to the clone, 4 second highlight ring shown.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2246

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
