### PR TITLE
Ask desktop installs how they'll be used before the experience step

### DIFF
--- a/src/components/onboarding/choice-card-styles.ts
+++ b/src/components/onboarding/choice-card-styles.ts
@@ -77,6 +77,12 @@ export const choiceCardStyles = css`
     flex-shrink: 0;
   }
 
+  /* Image variant (brand logo) sized to match the mdi glyph box. */
+  .choice-image {
+    width: 24px;
+    height: 24px;
+  }
+
   .choice-text {
     display: flex;
     flex-direction: column;

--- a/src/components/onboarding/choice-card.ts
+++ b/src/components/onboarding/choice-card.ts
@@ -1,8 +1,12 @@
 import { type TemplateResult, html, nothing } from "lit";
 
 export interface ChoiceCardProps {
-  /** mdi icon name; the caller is responsible for registering it. */
-  icon: string;
+  /** mdi icon name; the caller is responsible for registering it.
+   *  Ignored when ``imageSrc`` is set. */
+  icon?: string;
+  /** Image URL rendered instead of the mdi icon (e.g. a brand logo that
+   *  has no mdi glyph). */
+  imageSrc?: string;
   title: string;
   description: string;
   selected: boolean;
@@ -35,7 +39,15 @@ export function renderChoiceCard(props: ChoiceCardProps): TemplateResult {
       ?disabled=${props.disabled ?? false}
       @click=${props.onSelect}
     >
-      <wa-icon library="mdi" name=${props.icon} class="choice-icon"></wa-icon>
+      ${
+        props.imageSrc
+          ? html`<img class="choice-icon choice-image" src=${props.imageSrc} alt="" />`
+          : html`<wa-icon
+              library="mdi"
+              name=${props.icon ?? ""}
+              class="choice-icon"
+            ></wa-icon>`
+      }
       <span class="choice-text">
         <span class="choice-title">${props.title}</span>
         <span class="choice-desc">${props.description}</span>

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -1,9 +1,11 @@
 import { consume } from "@lit/context";
 import {
+  mdiAlertOutline,
   mdiCodeBraces,
   mdiCompassOutline,
   mdiHandshake,
   mdiMemory,
+  mdiMonitorDashboard,
   mdiServerNetwork,
   mdiSprout,
 } from "@mdi/js";
@@ -16,6 +18,7 @@ import { activeLocale, type LocalizeFunc } from "../../common/localize.js";
 import {
   apiContext,
   buildOffloadDiscoveredHostsContext,
+  desktopVersionContext,
   isHaAddonContext,
   localizeContext,
 } from "../../context/index.js";
@@ -37,7 +40,7 @@ import { REMOTE_COMPUTE_FEATURES, renderFeatureList } from "../shared/feature-li
 import { choiceCardStyles } from "./choice-card-styles.js";
 import { onChoiceGroupKeydown, renderChoiceCard, rovingTabbable } from "./choice-card.js";
 import { onboardingWizardStyles } from "./onboarding-wizard-styles.js";
-import { wizardScreens, type WizardScreen } from "./wizard-screens.js";
+import { wizardScreens, type UsageChoice, type WizardScreen } from "./wizard-screens.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/switch/switch.js";
@@ -52,9 +55,11 @@ function viewportSupportsTour(): boolean {
 }
 
 registerMdiIcons({
+  "alert-outline": mdiAlertOutline,
   "code-braces": mdiCodeBraces,
   "compass-outline": mdiCompassOutline,
   handshake: mdiHandshake,
+  "monitor-dashboard": mdiMonitorDashboard,
   "server-network": mdiServerNetwork,
   sprout: mdiSprout,
   memory: mdiMemory,
@@ -71,6 +76,13 @@ registerMdiIcons({
  * choices closes the wizard straight onto the dashboard. Wi-Fi is
  * intentionally absent: the first Wi-Fi device that needs shared credentials
  * collects them.
+ *
+ * Under the desktop app a usage question follows Welcome: "standalone"
+ * continues the flow above (minus the orientation step, which the question
+ * subsumes), while "use as remote builder" persists remote_compute_only +
+ * hide_device_builder and ends the wizard on the spot — the dashboard
+ * reacts to the preference flip and lands on the remote-build pairing
+ * onboarding instead of the device builder.
  *
  * ``?resetOnboarding=1`` reopens a clean default run for frontend development.
  * It does not reset data before opening; completing the choices writes them
@@ -93,6 +105,12 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
   @state()
   private _isHaAddon = false;
 
+  /** Desktop wrapper version from the handshake; non-empty ⇒ running under
+   *  the ESPHome Desktop app (the repo-wide "is desktop" signal). */
+  @consume({ context: desktopVersionContext, subscribe: true })
+  @state()
+  private _desktopVersion = "";
+
   @state() private _open = false;
   @state() private _saving = false;
   @state() private _error: string | null = null;
@@ -104,6 +122,14 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
   // insert/remove the existing-server screen under the user.
   @state() private _existingServerPinned = false;
   @state() private _showTour = viewportSupportsTour();
+  // Frozen at open() like _showTour, so a reconnect can't add or remove the
+  // usage screen mid-flow.
+  @state() private _showUsage = false;
+  @state() private _usage: UsageChoice | null = null;
+  // The detection-based default, pinned when the usage screen is first
+  // entered so a host discovered mid-screen can't flip the badge and the
+  // preselection under the user. The warning banner stays live on purpose.
+  @state() private _usageRecommended: UsageChoice | null = null;
 
   private _startTourAfterClose = false;
   private _enter = new EnterController(this, () => {
@@ -131,6 +157,9 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     this._experience = ExperienceLevel.BEGINNER;
     this._existingServerPinned = false;
     this._showTour = viewportSupportsTour();
+    this._showUsage = Boolean(this._desktopVersion);
+    this._usage = null;
+    this._usageRecommended = null;
     this._startTourAfterClose = false;
     this._enter.set(true);
   }
@@ -151,7 +180,12 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     // once they advance past experience so a late host can't shift the flow.
     const showExistingServer =
       this._index <= 1 ? this._computeShowExistingServer() : this._existingServerPinned;
-    return wizardScreens({ showExistingServer, showTour: this._showTour });
+    return wizardScreens({
+      showUsage: this._showUsage,
+      usage: this._usage,
+      showExistingServer,
+      showTour: this._showTour,
+    });
   }
 
   /** Offer the orientation step only off the HA add-on, and only when another
@@ -179,6 +213,8 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     switch (this._screen) {
       case "welcome":
         return true;
+      case "usage":
+        return this._usage !== null;
       case "existing_server":
         return true;
       case "experience":
@@ -271,6 +307,8 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     switch (this._screen) {
       case "welcome":
         return this._renderWelcome();
+      case "usage":
+        return this._renderUsage();
       case "existing_server":
         return this._renderExistingServer();
       case "experience":
@@ -289,6 +327,76 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
           alt=""
         />
         <p class="intro">${this._localize("onboarding.wizard.welcome.intro")}</p>
+      </div>
+    `;
+  }
+
+  /** Usage options in display order with their card icons. */
+  private static readonly USAGE_OPTIONS: ReadonlyArray<[UsageChoice, string, string]> = [
+    ["standalone", "monitor-dashboard", "standalone"],
+    ["remote_builder", "server-network", "remote"],
+  ];
+
+  private _renderUsage() {
+    return html`
+      <p class="intro">${this._localize("onboarding.wizard.usage.intro")}</p>
+      <div
+        class="choices"
+        role="radiogroup"
+        aria-label=${this._localize("onboarding.wizard.usage.title")}
+        @keydown=${onChoiceGroupKeydown}
+      >
+        ${ESPHomeOnboardingWizardDialog.USAGE_OPTIONS.map(
+          ([choice, icon, keyPrefix], index) =>
+            renderChoiceCard({
+              icon,
+              title: this._localize(`onboarding.wizard.usage.${keyPrefix}_title`),
+              description: this._localize(`onboarding.wizard.usage.${keyPrefix}_desc`),
+              selected: this._usage === choice,
+              tabbable: rovingTabbable(
+                this._usage === choice,
+                this._usage !== null,
+                index
+              ),
+              badge:
+                choice === this._usageRecommended
+                  ? this._localize("onboarding.wizard.recommended")
+                  : undefined,
+              disabled: this._saving,
+              onSelect: () => {
+                this._usage = choice;
+              },
+            })
+        )}
+      </div>
+      ${this._renderUsageWarning()}
+    `;
+  }
+
+  /** Caution note under the cards when the user insists on a standalone
+   *  setup even though another Device Builder was discovered. Reads the
+   *  live host map on purpose: a host that appears mid-screen should still
+   *  raise the flag even though the badge/preselection stay pinned. */
+  private _renderUsageWarning() {
+    if (this._usage !== "standalone" || !this._discoveredHosts?.size) return nothing;
+    const names = [
+      ...new Set([...this._discoveredHosts.values()].map(remoteBuildPeerName)),
+    ].filter(Boolean);
+    const joined = new Intl.ListFormat(activeLocale(), { type: "conjunction" }).format(
+      names.slice(0, 3)
+    );
+    return html`
+      <div class="usage-warning" role="status">
+        <wa-icon library="mdi" name="alert-outline" aria-hidden="true"></wa-icon>
+        <span>
+          ${
+            joined
+              ? this._localize("onboarding.wizard.usage.existing_warning", {
+                  name: joined,
+                })
+              : this._localize("onboarding.wizard.usage.existing_warning_unnamed")
+          }
+        </span>
       </div>
     `;
   }
@@ -425,12 +533,31 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     this._error = null;
     switch (this._screen) {
       case "welcome":
+        if (this._showUsage && this._usage === null) {
+          // Pin the detection-based default the moment the question is
+          // asked: existing install found ⇒ remote builder, else standalone.
+          this._usageRecommended = this._discoveredHosts?.size
+            ? "remote_builder"
+            : "standalone";
+          this._usage = this._usageRecommended;
+        }
+        this._index += 1;
+        return;
+      case "usage":
+        if (this._usage === "remote_builder") {
+          // Onboarding ends here; the dashboard flips to remote-build mode
+          // (pairing onboarding first) as soon as the preference lands.
+          await this._completeSetup();
+          return;
+        }
         this._index += 1;
         return;
       case "experience":
         // Freeze whether the orientation step follows, now that mDNS has had
-        // Welcome + this screen to report.
-        this._existingServerPinned = this._computeShowExistingServer();
+        // Welcome + this screen to report. The usage screen subsumes the
+        // orientation step, so it never pins on desktop.
+        this._existingServerPinned =
+          !this._showUsage && this._computeShowExistingServer();
         if (this._existingServerPinned) {
           this._index += 1;
           return;
@@ -458,7 +585,9 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     this._emitAcknowledged();
     this._saving = false;
 
-    if (this._showTour) {
+    // A remote builder never gets the tour offer — the remote-build pairing
+    // onboarding takes over the dashboard the moment the preference lands.
+    if (this._showTour && this._usage !== "remote_builder") {
       this._index += 1;
     } else {
       this._open = false;
@@ -466,10 +595,16 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
   }
 
   private async _persistChoices(): Promise<boolean> {
+    const remoteBuilder = this._usage === "remote_builder";
     try {
       await this._api.updatePreferences({
         experience_level: this._experience,
-        remote_compute_only: this._remoteCompute,
+        remote_compute_only: remoteBuilder || this._remoteCompute,
+        // Only the desktop usage question decides this: a remote builder
+        // hides the Device builder entirely (the dashboard shows just the
+        // remote-build screens), and a standalone pick resets it so a
+        // re-run of onboarding can back out of a previous remote setup.
+        ...(this._showUsage ? { hide_device_builder: remoteBuilder } : {}),
       });
       return true;
     } catch (err) {

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -46,6 +46,9 @@ import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/switch/switch.js";
 
 export const RESET_ONBOARDING_PARAM = "resetOnboarding";
+/** Companion to ``resetOnboarding``: ``&desktop=1`` previews the desktop-only
+ *  usage screen on a dev backend that isn't the desktop wrapper. */
+export const DESKTOP_ONBOARDING_PARAM = "desktop";
 
 function viewportSupportsTour(): boolean {
   return !(
@@ -86,7 +89,8 @@ registerMdiIcons({
  *
  * ``?resetOnboarding=1`` reopens a clean default run for frontend development.
  * It does not reset data before opening; completing the choices writes them
- * through the same API path as first-run onboarding.
+ * through the same API path as first-run onboarding. Add ``&desktop=1`` to
+ * preview the desktop-only usage screen on a non-desktop dev backend.
  */
 @customElement("esphome-onboarding-wizard-dialog")
 export class ESPHomeOnboardingWizardDialog extends LitElement {
@@ -652,12 +656,19 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     const params = new URLSearchParams(window.location.search);
     if (params.get(RESET_ONBOARDING_PARAM) !== "1") return;
 
+    const forceDesktop = params.get(DESKTOP_ONBOARDING_PARAM) === "1";
     params.delete(RESET_ONBOARDING_PARAM);
+    params.delete(DESKTOP_ONBOARDING_PARAM);
     const query = params.toString();
     const cleaned =
       window.location.pathname + (query ? `?${query}` : "") + window.location.hash;
     window.history.replaceState(window.history.state, "", cleaned);
     this.open();
+    // The dev backend is never the desktop wrapper, so ``&desktop=1``
+    // previews the desktop-only usage screen anyway. Applied after open()
+    // (which derives the flag from the handshake) rather than by faking
+    // _desktopVersion, which the context provider would overwrite.
+    if (forceDesktop) this._showUsage = true;
   }
 }
 

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -2,10 +2,10 @@ import { consume } from "@lit/context";
 import {
   mdiAlertOutline,
   mdiCodeBraces,
+  mdiCogTransferOutline,
   mdiCompassOutline,
   mdiHandshake,
   mdiMemory,
-  mdiMonitorDashboard,
   mdiServerNetwork,
   mdiSprout,
 } from "@mdi/js";
@@ -60,9 +60,9 @@ function viewportSupportsTour(): boolean {
 registerMdiIcons({
   "alert-outline": mdiAlertOutline,
   "code-braces": mdiCodeBraces,
+  "cog-transfer-outline": mdiCogTransferOutline,
   "compass-outline": mdiCompassOutline,
   handshake: mdiHandshake,
-  "monitor-dashboard": mdiMonitorDashboard,
   "server-network": mdiServerNetwork,
   sprout: mdiSprout,
   memory: mdiMemory,
@@ -237,7 +237,7 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
         @request-close=${this._onRequestClose}
         @after-hide=${this._onAfterHide}
       >
-        <div class="body">
+        <div class="body${this._showUsage ? " body--usage-flow" : ""}">
           ${this._renderScreen()}
           ${this._error ? html`<p class="error" role="alert">${this._error}</p>` : nothing}
         </div>
@@ -335,10 +335,18 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     `;
   }
 
-  /** Usage options in display order with their card icons. */
-  private static readonly USAGE_OPTIONS: ReadonlyArray<[UsageChoice, string, string]> = [
-    ["standalone", "monitor-dashboard", "standalone"],
-    ["remote_builder", "server-network", "remote"],
+  /** Usage options in display order. The standalone card carries the blue
+   *  ESPHome logo (no mdi glyph exists for it); remote build keeps an mdi
+   *  icon. */
+  private static readonly USAGE_OPTIONS: ReadonlyArray<
+    [UsageChoice, { icon?: string; imageSrc?: string }, string]
+  > = [
+    [
+      "standalone",
+      { imageSrc: withBase("/assets/logo/esphome-favicon.svg") },
+      "standalone",
+    ],
+    ["remote_builder", { icon: "cog-transfer-outline" }, "remote"],
   ];
 
   private _renderUsage() {
@@ -351,9 +359,9 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
         @keydown=${onChoiceGroupKeydown}
       >
         ${ESPHomeOnboardingWizardDialog.USAGE_OPTIONS.map(
-          ([choice, icon, keyPrefix], index) =>
+          ([choice, visual, keyPrefix], index) =>
             renderChoiceCard({
-              icon,
+              ...visual,
               title: this._localize(`onboarding.wizard.usage.${keyPrefix}_title`),
               description: this._localize(`onboarding.wizard.usage.${keyPrefix}_desc`),
               selected: this._usage === choice,
@@ -373,37 +381,35 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
             })
         )}
       </div>
-      ${this._renderUsageWarning()}
     `;
   }
 
-  /** Caution note under the cards when the user insists on a standalone
+  /** Banner atop the experience screen when the user picked a standalone
    *  setup even though another Device Builder was discovered. Reads the
-   *  live host map on purpose: a host that appears mid-screen should still
-   *  raise the flag even though the badge/preselection stay pinned. */
-  private _renderUsageWarning() {
-    if (this._usage !== "standalone" || !this._discoveredHosts?.size) return nothing;
-    const names = [
-      ...new Set([...this._discoveredHosts.values()].map(remoteBuildPeerName)),
-    ].filter(Boolean);
-    const joined = new Intl.ListFormat(activeLocale(), { type: "conjunction" }).format(
-      names.slice(0, 3)
-    );
+   *  live host map on purpose: a host that appears mid-flow should still
+   *  raise the flag even though the badge/preselection stay pinned. The
+   *  link takes the user back to the usage screen with remote build
+   *  preselected, so Continue there completes the switch. */
+  private _renderExistingNotice() {
+    if (!this._showUsage || this._usage !== "standalone") return nothing;
+    if (!this._discoveredHosts?.size) return nothing;
     return html`
-      <div class="usage-warning" role="status">
+      <div class="existing-notice" role="status">
         <wa-icon library="mdi" name="alert-outline" aria-hidden="true"></wa-icon>
         <span>
-          ${
-            joined
-              ? this._localize("onboarding.wizard.usage.existing_warning", {
-                  name: joined,
-                })
-              : this._localize("onboarding.wizard.usage.existing_warning_unnamed")
-          }
+          ${this._localize("onboarding.wizard.experience.existing_notice")}
+          <button type="button" class="notice-link" @click=${this._switchToRemoteBuild}>
+            ${this._localize("onboarding.wizard.experience.existing_notice_link")}
+          </button>
         </span>
       </div>
     `;
   }
+
+  private _switchToRemoteBuild = () => {
+    this._usage = "remote_builder";
+    this._index = this._screens.indexOf("usage");
+  };
 
   private _renderExistingServer() {
     const names = this._discoveredHosts
@@ -495,6 +501,7 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
   private _renderExperience() {
     return html`
       <p class="intro">${this._localize("onboarding.wizard.experience.intro")}</p>
+      ${this._renderExistingNotice()}
       <div
         class="choices"
         role="radiogroup"

--- a/src/components/onboarding/onboarding-wizard-styles.ts
+++ b/src/components/onboarding/onboarding-wizard-styles.ts
@@ -53,6 +53,30 @@ export const onboardingWizardStyles = css`
     margin-top: var(--wa-space-xs);
   }
 
+  /* Caution note on the usage screen when the user picks a standalone
+     setup while another Device Builder was discovered on the network. */
+  .usage-warning {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--wa-space-s);
+    margin-top: var(--wa-space-s);
+    padding: var(--wa-space-s) var(--wa-space-m);
+    background: color-mix(in srgb, var(--esphome-warning, #f59e0b), transparent 90%);
+    border: 1px solid color-mix(in srgb, var(--esphome-warning, #f59e0b), transparent 65%);
+    border-radius: var(--wa-border-radius-m);
+    font-size: var(--wa-font-size-s);
+    line-height: 1.5;
+    color: var(--wa-color-text-normal);
+    text-align: left;
+  }
+
+  .usage-warning wa-icon {
+    flex-shrink: 0;
+    margin-top: 2px;
+    font-size: 18px;
+    color: var(--esphome-warning, #f59e0b);
+  }
+
   .welcome-logo {
     width: 88px;
     height: 88px;

--- a/src/components/onboarding/onboarding-wizard-styles.ts
+++ b/src/components/onboarding/onboarding-wizard-styles.ts
@@ -28,6 +28,13 @@ export const onboardingWizardStyles = css`
     overflow-y: auto;
   }
 
+  /* The desktop flow's tallest screen is the usage question (two cards
+     with multi-line copy), so every step of that flow shares its height.
+     Non-desktop flows never show it and keep the shorter base above. */
+  .body--usage-flow {
+    min-height: 320px;
+  }
+
   /* The existing-server step carries the toggle plus the always-visible
      explainer; give it enough height that the explainer isn't below the
      fold on desktop (viewport-capped so short screens still fit). */
@@ -53,13 +60,12 @@ export const onboardingWizardStyles = css`
     margin-top: var(--wa-space-xs);
   }
 
-  /* Caution note on the usage screen when the user picks a standalone
+  /* Banner atop the experience screen when the user picked a standalone
      setup while another Device Builder was discovered on the network. */
-  .usage-warning {
+  .existing-notice {
     display: flex;
     align-items: flex-start;
     gap: var(--wa-space-s);
-    margin-top: var(--wa-space-s);
     padding: var(--wa-space-s) var(--wa-space-m);
     background: color-mix(in srgb, var(--esphome-warning, #f59e0b), transparent 90%);
     border: 1px solid color-mix(in srgb, var(--esphome-warning, #f59e0b), transparent 65%);
@@ -70,11 +76,27 @@ export const onboardingWizardStyles = css`
     text-align: left;
   }
 
-  .usage-warning wa-icon {
+  .existing-notice wa-icon {
     flex-shrink: 0;
     margin-top: 2px;
     font-size: 18px;
     color: var(--esphome-warning, #f59e0b);
+  }
+
+  /* In-sentence action; a bare styled button keeps the banner one
+     paragraph instead of adding a second action row to the dialog. */
+  .notice-link {
+    padding: 0;
+    border: none;
+    background: none;
+    font: inherit;
+    color: var(--esphome-primary);
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .notice-link:hover {
+    color: var(--esphome-primary-hover, var(--esphome-primary));
   }
 
   .welcome-logo {

--- a/src/components/onboarding/wizard-screens.ts
+++ b/src/components/onboarding/wizard-screens.ts
@@ -1,22 +1,48 @@
-export type WizardScreen = "welcome" | "experience" | "existing_server" | "tour";
+export type WizardScreen =
+  "welcome" | "usage" | "experience" | "existing_server" | "tour";
+
+/** The desktop app's answer to "How do you want to use this installation?".
+ *  null until the user reaches the usage screen (or on non-desktop installs,
+ *  where the question is never asked). */
+export type UsageChoice = "standalone" | "remote_builder";
 
 /**
  * The ordered onboarding-wizard screens for the current environment.
  *
- * Welcome and experience are always mandatory. When another Device Builder is
- * on the network (non-add-on installs only), an orientation step follows
- * experience — it's the only place the remote-build-server choice is offered,
- * since there's nothing to build for otherwise. The optional-tour offer closes
- * the flow on viewports that can run the guided tour; on phones it's dropped
- * and completing the choices lands straight on the dashboard. Wi-Fi is
- * deliberately not part of onboarding.
+ * Welcome and experience are always mandatory. On the desktop app a usage
+ * question comes right after Welcome: picking "standalone" continues the
+ * normal flow, while "remote builder" ends the wizard there — the app
+ * switches to remote-build mode and its own pairing onboarding takes over,
+ * so experience/tour would be dead weight. The usage screen also subsumes
+ * the existing-server orientation step (its remote-only switch asks the
+ * same question), so that step never shows alongside it.
+ *
+ * Off the desktop app the flow is unchanged: when another Device Builder is
+ * on the network (non-add-on installs only), the orientation step follows
+ * experience — it's the only place the remote-build-server choice is
+ * offered, since there's nothing to build for otherwise. The optional-tour
+ * offer closes the flow on viewports that can run the guided tour; on
+ * phones it's dropped and completing the choices lands straight on the
+ * dashboard. Wi-Fi is deliberately not part of onboarding.
  */
 export function wizardScreens(opts: {
+  showUsage: boolean;
+  usage: UsageChoice | null;
   showExistingServer: boolean;
   showTour: boolean;
 }): WizardScreen[] {
-  const screens: WizardScreen[] = ["welcome", "experience"];
-  if (opts.showExistingServer) screens.push("existing_server");
+  const screens: WizardScreen[] = ["welcome"];
+  if (opts.showUsage) {
+    screens.push("usage");
+    // The wizard ends at the usage screen for a remote builder; while the
+    // choice is still standalone (the default) or unset, the tail shows the
+    // standalone flow so the step dots reflect what's ahead.
+    if (opts.usage === "remote_builder") return screens;
+    screens.push("experience");
+  } else {
+    screens.push("experience");
+    if (opts.showExistingServer) screens.push("existing_server");
+  }
   if (opts.showTour) screens.push("tour");
   return screens;
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1047,14 +1047,12 @@
         "intro": "We’ll help you tailor your ESPHome experience in a few quick steps."
       },
       "usage": {
-        "title": "How do you want to use this installation?",
-        "intro": "You can change this any time in Settings.",
-        "standalone_title": "Standalone installation",
-        "standalone_desc": "A full ESPHome Device Builder on this machine — recommended if you don't already have an ESPHome installation.",
-        "remote_title": "Use as remote builder",
-        "remote_desc": "Pair with your existing ESPHome Device Builder and lend this machine's compute power to build device firmware.",
-        "existing_warning": "We found an existing installation on your network: {name}. A standalone setup here creates a second, separate Device Builder — continue only if that's what you want.",
-        "existing_warning_unnamed": "We found an existing installation on your network. A standalone setup here creates a second, separate Device Builder — continue only if that's what you want."
+        "title": "How will you use the ESPHome Desktop app?",
+        "intro": "Please tell us how you intend to use the ESPHome Desktop app. This helps tailor the dashboard to what you need.",
+        "standalone_title": "Installation of the ESPHome Device Builder",
+        "standalone_desc": "I want to create, configure, build, flash and manage ESPHome devices, from this device/computer.",
+        "remote_title": "Remote build",
+        "remote_desc": "Recommended for existing users of ESPHome Device Builder to use this app for compute power to build your device firmware."
       },
       "existing_server": {
         "title": "You already have ESPHome Device Builder",
@@ -1065,8 +1063,10 @@
         "remote_only_desc": "Lead with pairing and the build queue when you open this dashboard. Device creation stays available; the builder section just starts collapsed."
       },
       "experience": {
-        "title": "Choose your experience level",
+        "title": "Choose your experience",
         "intro": "You can change this any time in Settings.",
+        "existing_notice": "We have detected an existing instance of ESPHome Device Builder on your network.",
+        "existing_notice_link": "Would you like to change to remote build mode?",
         "beginner_title": "New to ESPHome",
         "beginner_desc": "Start with a simple, guided interface.",
         "expert_title": "Expert",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1046,6 +1046,16 @@
         "title": "Welcome to ESPHome Device Builder",
         "intro": "We’ll help you tailor your ESPHome experience in a few quick steps."
       },
+      "usage": {
+        "title": "How do you want to use this installation?",
+        "intro": "You can change this any time in Settings.",
+        "standalone_title": "Standalone installation",
+        "standalone_desc": "A full ESPHome Device Builder on this machine — recommended if you don't already have an ESPHome installation.",
+        "remote_title": "Use as remote builder",
+        "remote_desc": "Pair with your existing ESPHome Device Builder and lend this machine's compute power to build device firmware.",
+        "existing_warning": "We found an existing installation on your network: {name}. A standalone setup here creates a second, separate Device Builder — continue only if that's what you want.",
+        "existing_warning_unnamed": "We found an existing installation on your network. A standalone setup here creates a second, separate Device Builder — continue only if that's what you want."
+      },
       "existing_server": {
         "title": "You already have ESPHome Device Builder",
         "found": "Found on your network: {name}",

--- a/test/components/onboarding/onboarding-usage.test.ts
+++ b/test/components/onboarding/onboarding-usage.test.ts
@@ -1,0 +1,180 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}));
+
+import type { LocalizeFunc } from "../../../src/common/localize.js";
+import { ESPHomeOnboardingWizardDialog } from "../../../src/components/onboarding/onboarding-wizard-dialog.js";
+import type { UsageChoice } from "../../../src/components/onboarding/wizard-screens.js";
+
+interface WizardInternals {
+  _api: {
+    updatePreferences: ReturnType<typeof vi.fn>;
+    markOnboardingAcknowledged: ReturnType<typeof vi.fn>;
+  };
+  _open: boolean;
+  _index: number;
+  _screen: string;
+  _screens: string[];
+  _desktopVersion: string;
+  _showUsage: boolean;
+  _usage: UsageChoice | null;
+  _usageRecommended: UsageChoice | null;
+  _discoveredHosts: Map<string, { friendly_name: string; name: string }> | null;
+  _isHaAddon: boolean;
+  _localize: LocalizeFunc;
+  _onContinue(): Promise<void>;
+}
+
+const internals = (wizard: ESPHomeOnboardingWizardDialog) =>
+  wizard as unknown as WizardInternals;
+
+const hosts = (...names: string[]) =>
+  new Map(names.map((name, i) => [`h${i}`, { friendly_name: "", name }]));
+
+const stubApi = (state: WizardInternals) => {
+  state._api = {
+    updatePreferences: vi.fn().mockResolvedValue(undefined),
+    markOnboardingAcknowledged: vi.fn().mockResolvedValue(undefined),
+  };
+};
+
+/** A wizard opened under the desktop app (handshake reported a version). */
+const openDesktopWizard = () => {
+  const wizard = new ESPHomeOnboardingWizardDialog();
+  const state = internals(wizard);
+  state._desktopVersion = "1.4.0";
+  wizard.open();
+  stubApi(state);
+  return { wizard, state };
+};
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("desktop usage question", () => {
+  it("is asked right after welcome only under the desktop app", () => {
+    const { state } = openDesktopWizard();
+    expect(state._screens).toEqual(["welcome", "usage", "experience", "tour"]);
+
+    const web = new ESPHomeOnboardingWizardDialog();
+    web.open();
+    expect(internals(web)._screens).not.toContain("usage");
+  });
+
+  it("defaults to standalone with the badge when nothing is detected", async () => {
+    const { state } = openDesktopWizard();
+    state._discoveredHosts = null;
+
+    await state._onContinue(); // welcome -> usage
+
+    expect(state._screen).toBe("usage");
+    expect(state._usage).toBe("standalone");
+    expect(state._usageRecommended).toBe("standalone");
+  });
+
+  it("defaults to remote builder with the badge when an install is detected", async () => {
+    const { state } = openDesktopWizard();
+    state._discoveredHosts = hosts("living-room");
+
+    await state._onContinue(); // welcome -> usage
+
+    expect(state._usage).toBe("remote_builder");
+    expect(state._usageRecommended).toBe("remote_builder");
+  });
+
+  it("keeps the pinned default when a host arrives mid-screen", async () => {
+    const { state } = openDesktopWizard();
+    state._discoveredHosts = null;
+    await state._onContinue(); // welcome -> usage
+
+    state._discoveredHosts = hosts("late-arrival"); // mDNS lands late
+
+    expect(state._usage).toBe("standalone");
+    expect(state._usageRecommended).toBe("standalone");
+  });
+
+  it("continues the standalone flow without the orientation step", async () => {
+    const { state } = openDesktopWizard();
+    // A detected host must not re-insert existing_server on desktop: the
+    // usage question already asked it.
+    state._discoveredHosts = hosts("living-room");
+    await state._onContinue(); // welcome -> usage
+    state._usage = "standalone";
+
+    await state._onContinue(); // usage -> experience
+    expect(state._screen).toBe("experience");
+
+    await state._onContinue(); // experience -> tour (persists)
+    expect(state._screen).toBe("tour");
+    expect(state._screens).not.toContain("existing_server");
+    expect(state._api.updatePreferences).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remote_compute_only: false,
+        hide_device_builder: false,
+      })
+    );
+  });
+
+  it("ends onboarding at the usage screen for a remote builder", async () => {
+    const { state } = openDesktopWizard();
+    state._discoveredHosts = hosts("living-room");
+    await state._onContinue(); // welcome -> usage (remote preselected)
+
+    await state._onContinue(); // completes setup, no tour offer
+
+    expect(state._api.updatePreferences).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remote_compute_only: true,
+        hide_device_builder: true,
+      })
+    );
+    expect(state._api.markOnboardingAcknowledged).toHaveBeenCalledOnce();
+    expect(state._open).toBe(false);
+  });
+
+  it("never writes hide_device_builder off the desktop app", async () => {
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    wizard.open();
+    const state = internals(wizard);
+    stubApi(state);
+    state._index = 1; // experience, nothing detected
+
+    await state._onContinue();
+
+    const prefs = state._api.updatePreferences.mock.calls[0][0];
+    expect("hide_device_builder" in prefs).toBe(false);
+  });
+
+  it("warns when standalone is picked despite a detected install", async () => {
+    const { wizard, state } = openDesktopWizard();
+    document.body.appendChild(wizard);
+    state._localize = ((key, values) =>
+      values?.name !== undefined ? String(values.name) : key) as LocalizeFunc;
+    state._discoveredHosts = hosts("living-room");
+    await state._onContinue(); // welcome -> usage, remote preselected
+    await wizard.updateComplete;
+    expect(wizard.shadowRoot?.querySelector(".usage-warning")).toBeNull();
+
+    state._usage = "standalone";
+    await wizard.updateComplete;
+    const warning = wizard.shadowRoot?.querySelector(".usage-warning");
+    expect(warning).not.toBeNull();
+    expect(warning?.textContent).toContain("living-room");
+  });
+
+  it("shows no warning for standalone when nothing was detected", async () => {
+    const { wizard, state } = openDesktopWizard();
+    document.body.appendChild(wizard);
+    state._discoveredHosts = null;
+    await state._onContinue(); // welcome -> usage, standalone preselected
+    await wizard.updateComplete;
+
+    expect(wizard.shadowRoot?.querySelector(".usage-warning")).toBeNull();
+  });
+});

--- a/test/components/onboarding/onboarding-usage.test.ts
+++ b/test/components/onboarding/onboarding-usage.test.ts
@@ -8,7 +8,11 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}));
 
 import type { LocalizeFunc } from "../../../src/common/localize.js";
-import { ESPHomeOnboardingWizardDialog } from "../../../src/components/onboarding/onboarding-wizard-dialog.js";
+import {
+  DESKTOP_ONBOARDING_PARAM,
+  ESPHomeOnboardingWizardDialog,
+  RESET_ONBOARDING_PARAM,
+} from "../../../src/components/onboarding/onboarding-wizard-dialog.js";
 import type { UsageChoice } from "../../../src/components/onboarding/wizard-screens.js";
 
 interface WizardInternals {
@@ -55,6 +59,8 @@ const openDesktopWizard = () => {
 
 afterEach(() => {
   document.body.replaceChildren();
+  window.history.replaceState(null, "", "/");
+  delete (globalThis as { __DEV__?: boolean }).__DEV__;
 });
 
 describe("desktop usage question", () => {
@@ -166,6 +172,24 @@ describe("desktop usage question", () => {
     const warning = wizard.shadowRoot?.querySelector(".usage-warning");
     expect(warning).not.toBeNull();
     expect(warning?.textContent).toContain("living-room");
+  });
+
+  it("previews the usage screen via the dev reset query on a non-desktop backend", async () => {
+    (globalThis as { __DEV__?: boolean }).__DEV__ = true;
+    window.history.replaceState(
+      null,
+      "",
+      `/?${RESET_ONBOARDING_PARAM}=1&${DESKTOP_ONBOARDING_PARAM}=1`
+    );
+    const wizard = new ESPHomeOnboardingWizardDialog();
+    document.body.appendChild(wizard);
+    await wizard.updateComplete;
+
+    const state = internals(wizard);
+    expect(state._open).toBe(true);
+    expect(state._showUsage).toBe(true);
+    expect(state._screens).toContain("usage");
+    expect(window.location.search).toBe("");
   });
 
   it("shows no warning for standalone when nothing was detected", async () => {

--- a/test/components/onboarding/onboarding-usage.test.ts
+++ b/test/components/onboarding/onboarding-usage.test.ts
@@ -157,21 +157,38 @@ describe("desktop usage question", () => {
     expect("hide_device_builder" in prefs).toBe(false);
   });
 
-  it("warns when standalone is picked despite a detected install", async () => {
+  it("banners the experience screen when standalone won over a detected install", async () => {
     const { wizard, state } = openDesktopWizard();
     document.body.appendChild(wizard);
-    state._localize = ((key, values) =>
-      values?.name !== undefined ? String(values.name) : key) as LocalizeFunc;
     state._discoveredHosts = hosts("living-room");
     await state._onContinue(); // welcome -> usage, remote preselected
     await wizard.updateComplete;
-    expect(wizard.shadowRoot?.querySelector(".usage-warning")).toBeNull();
+    expect(wizard.shadowRoot?.querySelector(".existing-notice")).toBeNull();
 
     state._usage = "standalone";
+    await state._onContinue(); // usage -> experience
     await wizard.updateComplete;
-    const warning = wizard.shadowRoot?.querySelector(".usage-warning");
-    expect(warning).not.toBeNull();
-    expect(warning?.textContent).toContain("living-room");
+
+    expect(state._screen).toBe("experience");
+    expect(wizard.shadowRoot?.querySelector(".existing-notice")).not.toBeNull();
+  });
+
+  it("returns to the usage screen with remote preselected via the banner link", async () => {
+    const { wizard, state } = openDesktopWizard();
+    document.body.appendChild(wizard);
+    state._discoveredHosts = hosts("living-room");
+    await state._onContinue(); // welcome -> usage
+    state._usage = "standalone";
+    await state._onContinue(); // usage -> experience
+    await wizard.updateComplete;
+
+    wizard.shadowRoot
+      ?.querySelector<HTMLButtonElement>(".existing-notice .notice-link")
+      ?.click();
+    await wizard.updateComplete;
+
+    expect(state._screen).toBe("usage");
+    expect(state._usage).toBe("remote_builder");
   });
 
   it("previews the usage screen via the dev reset query on a non-desktop backend", async () => {
@@ -192,13 +209,24 @@ describe("desktop usage question", () => {
     expect(window.location.search).toBe("");
   });
 
-  it("shows no warning for standalone when nothing was detected", async () => {
+  it("shows no banner when nothing was detected or off the desktop app", async () => {
     const { wizard, state } = openDesktopWizard();
     document.body.appendChild(wizard);
     state._discoveredHosts = null;
     await state._onContinue(); // welcome -> usage, standalone preselected
+    await state._onContinue(); // usage -> experience
     await wizard.updateComplete;
+    expect(wizard.shadowRoot?.querySelector(".existing-notice")).toBeNull();
 
-    expect(wizard.shadowRoot?.querySelector(".usage-warning")).toBeNull();
+    // Non-desktop installs keep the orientation-step flow instead.
+    const web = new ESPHomeOnboardingWizardDialog();
+    document.body.appendChild(web);
+    web.open();
+    const webState = internals(web);
+    webState._discoveredHosts = hosts("living-room");
+    await webState._onContinue(); // welcome -> experience
+    await web.updateComplete;
+    expect(webState._screen).toBe("experience");
+    expect(web.shadowRoot?.querySelector(".existing-notice")).toBeNull();
   });
 });

--- a/test/components/onboarding/wizard-screens.test.ts
+++ b/test/components/onboarding/wizard-screens.test.ts
@@ -1,17 +1,20 @@
 import { describe, expect, it } from "vitest";
 import { wizardScreens } from "../../../src/components/onboarding/wizard-screens.js";
 
+const base = {
+  showUsage: false,
+  usage: null,
+  showExistingServer: false,
+  showTour: true,
+} as const;
+
 describe("wizardScreens", () => {
   it("is welcome, experience, tour with nothing detected", () => {
-    expect(wizardScreens({ showExistingServer: false, showTour: true })).toEqual([
-      "welcome",
-      "experience",
-      "tour",
-    ]);
+    expect(wizardScreens({ ...base })).toEqual(["welcome", "experience", "tour"]);
   });
 
   it("inserts the existing-server step after experience when detected", () => {
-    expect(wizardScreens({ showExistingServer: true, showTour: true })).toEqual([
+    expect(wizardScreens({ ...base, showExistingServer: true })).toEqual([
       "welcome",
       "experience",
       "existing_server",
@@ -20,23 +23,48 @@ describe("wizardScreens", () => {
   });
 
   it("drops the tour offer on viewports that can't run the tour", () => {
-    expect(wizardScreens({ showExistingServer: false, showTour: false })).toEqual([
+    expect(wizardScreens({ ...base, showTour: false })).toEqual([
       "welcome",
       "experience",
     ]);
-    expect(wizardScreens({ showExistingServer: true, showTour: false })).toEqual([
+    expect(wizardScreens({ ...base, showExistingServer: true, showTour: false })).toEqual(
+      ["welcome", "experience", "existing_server"]
+    );
+  });
+
+  it("asks the usage question right after welcome on the desktop app", () => {
+    expect(wizardScreens({ ...base, showUsage: true })).toEqual([
       "welcome",
+      "usage",
       "experience",
-      "existing_server",
+      "tour",
     ]);
   });
 
+  it("keeps the standalone flow while standalone is picked", () => {
+    expect(wizardScreens({ ...base, showUsage: true, usage: "standalone" })).toEqual([
+      "welcome",
+      "usage",
+      "experience",
+      "tour",
+    ]);
+  });
+
+  it("ends the flow at the usage screen for a remote builder", () => {
+    expect(wizardScreens({ ...base, showUsage: true, usage: "remote_builder" })).toEqual([
+      "welcome",
+      "usage",
+    ]);
+  });
+
+  it("never shows the orientation step alongside the usage question", () => {
+    expect(
+      wizardScreens({ ...base, showUsage: true, showExistingServer: true })
+    ).not.toContain("existing_server");
+  });
+
   it("never includes Wi-Fi setup", () => {
-    expect(wizardScreens({ showExistingServer: true, showTour: true })).not.toContain(
-      "wifi"
-    );
-    expect(wizardScreens({ showExistingServer: false, showTour: false })).not.toContain(
-      "wifi"
-    );
+    expect(wizardScreens({ ...base, showExistingServer: true })).not.toContain("wifi");
+    expect(wizardScreens({ ...base, showUsage: true })).not.toContain("wifi");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Implements the desktop-app onboarding changes agreed on the call: under the ESPHome Desktop app (detected via the handshake's `desktop_version`, the repo-wide "is desktop" signal), the wizard asks **"How do you want to use this installation?"** right after Welcome, before the experience-level question.

- **Standalone installation** — continues the flow as-is (experience level, tour offer). The old existing-server orientation step is subsumed by this question, so it no longer shows on desktop; non-desktop installs keep it unchanged.
- **Use as remote builder** — onboarding ends on the spot: the wizard persists `remote_compute_only: true` + `hide_device_builder: true` and closes. The dashboard reacts to the preference flip (no reload) and shows only the remote-building screens, with the pairing wizard first — verified live end-to-end in the dev server.

Detection-driven defaults, per the spec:

- No existing installation found on the network → **Standalone** preselected with the RECOMMENDED badge.
- Existing installation found (mDNS-discovered Device Builder) → **Use as remote builder** preselected with the badge.
- The default + badge are pinned when the screen is entered (same philosophy as the existing-server freeze) so a host arriving mid-choice can't flip them under the user.
- Picking **Standalone while an installation was detected** shows a warning banner naming the found install ("…creates a second, separate Device Builder — continue only if that's what you want"). The banner reads the live host map on purpose, so a host discovered mid-screen still raises the flag.

A standalone pick also writes `hide_device_builder: false`, so re-running onboarding (version bump) can back out of a previous remote-builder setup. `hide_device_builder` is only ever written when the usage question was shown.

New copy lives under `onboarding.wizard.usage.*` in `en.json` only, per the translations policy.

No backend changes needed — the flow uses the existing `config/set_preferences` fields (`remote_compute_only`, `hide_device_builder`) and the existing remote-build dashboard mode.

**Related issue or feature (if applicable):**

- N/A (spec from maintainer call)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
