### PR TITLE
Run the leave guard before Escape pops history in the device editor

### DIFF
--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -15,7 +15,7 @@ import { espHomeStyles } from "../styles/shared.js";
 import { textStyles } from "../styles/text.js";
 import { stripBase, withBase } from "../util/base-path.js";
 import { deviceBuilderChannel } from "../util/device-builder-channel.js";
-import { navigate, runLeaveGuard } from "../util/navigation.js";
+import { goBackOrHome } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import {
   desktopDocsUrl,
@@ -343,24 +343,7 @@ export class ESPHomeLayout extends LitElement {
   ];
 
   private async _goHome() {
-    // Prefer popping the history stack so the previous URL — and
-    // therefore the dashboard's filter / search state encoded in
-    // its query string — is restored verbatim. ``history.state`` is
-    // set to ``{}`` by our own ``navigate()`` helper on every
-    // pushState; ``null`` means we landed on this route via a fresh
-    // page load (deep link / refresh) so there's nothing useful to
-    // pop and we fall back to ``navigate("/")`` to stay inside the
-    // SPA instead of exiting to the previous site.
-    if (window.history.state !== null && typeof window.history.state === "object") {
-      // history.back() fires a raw popstate the router commits (unmounting the
-      // page) before the device editor's popstate guard can veto it, so honour
-      // the leave guard here — same gate navigate() applies. navigate("/") runs
-      // the guard itself, so the fallback isn't double-prompted.
-      if (!(await runLeaveGuard())) return;
-      window.history.back();
-      return;
-    }
-    navigate("/");
+    await goBackOrHome();
   }
 
   protected render() {

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -48,7 +48,7 @@ import { showPendingChanges, showUpdateAvailable } from "../util/device-sync.js"
 import { deviceLayoutToPref, prefToDeviceLayout } from "../util/editor-layout.js";
 import { followActiveJob } from "../util/firmware-job-display.js";
 import { consumeJustCreated } from "../util/just-created.js";
-import { navigate, setLeaveGuard } from "../util/navigation.js";
+import { goBackOrHome, navigate, setLeaveGuard } from "../util/navigation.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { isTypingTarget } from "../util/typing-target.js";
@@ -572,10 +572,13 @@ export class ESPHomePageDevice extends LitElement {
       this._drawerOpen = false;
       return;
     }
-    /* Otherwise leave the editor — same path as the back button, so
-       the unsaved-changes guard runs via popstate. */
+    /* Otherwise leave the editor via the header back arrow's guarded
+       path. A raw history.back() here loses the dirty buffer: the
+       router's popstate listener commits the leave before this page's
+       ``_onPopState`` can veto it, so the unsaved-changes prompt must
+       run before the navigation, not after. */
     e.preventDefault();
-    window.history.back();
+    void goBackOrHome();
   };
 
   updated(changedProperties: Map<string, unknown>) {

--- a/src/util/navigation.ts
+++ b/src/util/navigation.ts
@@ -24,3 +24,24 @@ export async function navigate(url: string): Promise<void> {
 export async function runLeaveGuard(): Promise<boolean> {
   return activeGuard ? activeGuard() : true;
 }
+
+/**
+ * Leave the current page the way the header back arrow does. Prefer popping
+ * the history stack so the previous URL — and therefore the dashboard's
+ * filter / search state encoded in its query string — is restored verbatim.
+ * ``history.state`` is set to ``{}`` by ``navigate()`` on every pushState;
+ * ``null`` means a fresh page load (deep link / refresh) so there's nothing
+ * useful to pop and we fall back to ``navigate("/")`` to stay inside the SPA.
+ */
+export async function goBackOrHome(): Promise<void> {
+  if (window.history.state !== null && typeof window.history.state === "object") {
+    // history.back() fires a raw popstate the router commits (unmounting the
+    // page) before the device editor's popstate guard can veto it, so honour
+    // the leave guard here — same gate navigate() applies. navigate("/") runs
+    // the guard itself, so the fallback isn't double-prompted.
+    if (!(await runLeaveGuard())) return;
+    window.history.back();
+    return;
+  }
+  await navigate("/");
+}

--- a/test/pages/device-escape-leave.test.ts
+++ b/test/pages/device-escape-leave.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { ESPHomePageDevice } from "../../src/pages/device.js";
+import { setLeaveGuard } from "../../src/util/navigation.js";
+
+/**
+ * Pin the Escape-to-leave path against esphome/device-builder#2259: with a
+ * dirty buffer, Escape must run the unsaved-changes guard BEFORE popping
+ * history. The old raw ``history.back()`` lost the buffer to the router's
+ * popstate listener, which unmounts the page before the device page's own
+ * popstate guard can veto.
+ */
+
+interface EscapeView {
+  id: string;
+  _yaml: string;
+  _savedYaml: string;
+  _drawerOpen: boolean;
+  _onKeydown(e: KeyboardEvent): void;
+  _onUnsavedDiscard(): void;
+  _onUnsavedCancel(): void;
+  _confirmLeave(): Promise<boolean>;
+}
+
+function makePage(): { page: EscapeView; dialogOpen: ReturnType<typeof vi.fn> } {
+  const page = new ESPHomePageDevice() as unknown as EscapeView;
+  page.id = "kitchen";
+  page._yaml = "esphome:\n  name: kitchen\n  friendly_name: edited\n";
+  page._savedYaml = "esphome:\n  name: kitchen\n";
+  const dialogOpen = vi.fn();
+  // ``_unsavedDialog`` is a @query getter on the prototype; shadow it so the
+  // guard's ``open`` lands on the spy without mounting the component tree.
+  Object.defineProperty(page, "_unsavedDialog", { value: { open: dialogOpen } });
+  // Mirror connectedCallback's registration — the piece of mounting the
+  // Escape path actually depends on.
+  setLeaveGuard(page._confirmLeave);
+  return { page, dialogOpen };
+}
+
+function escapeEvent(
+  target: EventTarget = document.body,
+  defaultPrevented = false
+): KeyboardEvent {
+  return {
+    key: "Escape",
+    defaultPrevented,
+    preventDefault: vi.fn(),
+    composedPath: () => [target],
+  } as unknown as KeyboardEvent;
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("esphome-page-device Escape leave guard", () => {
+  let backSpy: ReturnType<typeof vi.fn<() => void>>;
+
+  beforeEach(() => {
+    // A non-null object history.state marks an in-SPA history entry, the
+    // shape ``navigate()`` pushes — the branch that pops history.
+    window.history.pushState({}, "", "/device/kitchen");
+    backSpy = vi.fn<() => void>();
+    vi.spyOn(window.history, "back").mockImplementation(backSpy);
+  });
+
+  afterEach(() => {
+    setLeaveGuard(null);
+    vi.restoreAllMocks();
+  });
+
+  test("dirty buffer: Escape opens the prompt and holds the navigation", async () => {
+    const { page, dialogOpen } = makePage();
+    const ev = escapeEvent();
+
+    page._onKeydown(ev);
+    await flush();
+
+    expect(ev.preventDefault).toHaveBeenCalledTimes(1);
+    expect(dialogOpen).toHaveBeenCalledTimes(1);
+    expect(backSpy).not.toHaveBeenCalled();
+
+    page._onUnsavedDiscard();
+    await flush();
+    expect(backSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("Cancel keeps the page: no history pop", async () => {
+    const { page, dialogOpen } = makePage();
+
+    page._onKeydown(escapeEvent());
+    await flush();
+    expect(dialogOpen).toHaveBeenCalledTimes(1);
+
+    page._onUnsavedCancel();
+    await flush();
+    expect(backSpy).not.toHaveBeenCalled();
+  });
+
+  test("clean buffer: Escape leaves immediately without the prompt", async () => {
+    const { page, dialogOpen } = makePage();
+    page._savedYaml = page._yaml;
+
+    page._onKeydown(escapeEvent());
+    await flush();
+
+    expect(dialogOpen).not.toHaveBeenCalled();
+    expect(backSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("Escape in a typing target is left to the editor", async () => {
+    const { page, dialogOpen } = makePage();
+    const ev = escapeEvent(document.createElement("input"));
+
+    page._onKeydown(ev);
+    await flush();
+
+    expect(ev.preventDefault).not.toHaveBeenCalled();
+    expect(dialogOpen).not.toHaveBeenCalled();
+    expect(backSpy).not.toHaveBeenCalled();
+  });
+
+  test("an Escape a deeper handler already claimed is ignored", async () => {
+    const { page, dialogOpen } = makePage();
+
+    page._onKeydown(escapeEvent(document.body, true));
+    await flush();
+
+    expect(dialogOpen).not.toHaveBeenCalled();
+    expect(backSpy).not.toHaveBeenCalled();
+  });
+
+  test("Escape closes the drawer before it means leave", async () => {
+    const { page, dialogOpen } = makePage();
+    page._drawerOpen = true;
+
+    page._onKeydown(escapeEvent());
+    await flush();
+
+    expect(page._drawerOpen).toBe(false);
+    expect(dialogOpen).not.toHaveBeenCalled();
+    expect(backSpy).not.toHaveBeenCalled();
+  });
+});

--- a/test/util/navigation.test.ts
+++ b/test/util/navigation.test.ts
@@ -31,7 +31,12 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { navigate, runLeaveGuard, setLeaveGuard } from "../../src/util/navigation.js";
+import {
+  goBackOrHome,
+  navigate,
+  runLeaveGuard,
+  setLeaveGuard,
+} from "../../src/util/navigation.js";
 
 /* The vitest config runs in the ``node`` environment, which has
  * no ``window``. ``navigation.ts`` reaches for ``window.history``
@@ -242,5 +247,97 @@ describe("runLeaveGuard", () => {
     setLeaveGuard(null);
     await expect(runLeaveGuard()).resolves.toBe(true);
     expect(stale).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * ``goBackOrHome`` is the shared header-back-arrow / Escape-key leave path.
+ * It must run the guard BEFORE ``history.back()`` — issue
+ * esphome/device-builder#2259 was Escape calling raw ``history.back()`` and
+ * losing the dirty buffer to the router's popstate listener.
+ */
+describe("goBackOrHome", () => {
+  let pushStateSpy: ReturnType<typeof vi.fn>;
+  let backSpy: ReturnType<typeof vi.fn>;
+  let historyState: unknown;
+
+  const stubWindow = () => {
+    (globalThis as Record<string, unknown>).window = {
+      history: {
+        pushState: pushStateSpy,
+        back: backSpy,
+        get state() {
+          return historyState;
+        },
+      },
+      dispatchEvent: vi.fn(),
+    };
+    (globalThis as Record<string, unknown>).PopStateEvent = Event;
+  };
+
+  beforeEach(() => {
+    pushStateSpy = vi.fn();
+    backSpy = vi.fn();
+    historyState = {};
+    stubWindow();
+  });
+
+  afterEach(() => {
+    setLeaveGuard(null);
+    delete (globalThis as Record<string, unknown>).window;
+    delete (globalThis as Record<string, unknown>).PopStateEvent;
+    vi.restoreAllMocks();
+  });
+
+  it("runs the guard before popping history", async () => {
+    const guard = vi.fn(() => Promise.resolve(true));
+    setLeaveGuard(guard);
+
+    await goBackOrHome();
+
+    expect(guard).toHaveBeenCalledTimes(1);
+    expect(backSpy).toHaveBeenCalledTimes(1);
+    expect(guard.mock.invocationCallOrder[0]).toBeLessThan(
+      backSpy.mock.invocationCallOrder[0]
+    );
+    expect(pushStateSpy).not.toHaveBeenCalled();
+  });
+
+  it("blocks the back-pop when the guard resolves false", async () => {
+    const guard = vi.fn(() => Promise.resolve(false));
+    setLeaveGuard(guard);
+
+    await goBackOrHome();
+
+    expect(backSpy).not.toHaveBeenCalled();
+    expect(pushStateSpy).not.toHaveBeenCalled();
+  });
+
+  it("pops history unconditionally when no guard is registered", async () => {
+    await goBackOrHome();
+    expect(backSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to navigate('/') on a fresh page load (null history.state)", async () => {
+    historyState = null;
+    const guard = vi.fn(() => Promise.resolve(true));
+    setLeaveGuard(guard);
+
+    await goBackOrHome();
+
+    expect(backSpy).not.toHaveBeenCalled();
+    // navigate() owns the guard on this branch — exactly one prompt.
+    expect(guard).toHaveBeenCalledTimes(1);
+    expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/");
+  });
+
+  it("fallback navigation honours a blocking guard", async () => {
+    historyState = null;
+    setLeaveGuard(vi.fn(() => Promise.resolve(false)));
+
+    await goBackOrHome();
+
+    expect(backSpy).not.toHaveBeenCalled();
+    expect(pushStateSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Pressing Escape in the device editor with focus outside the YAML surface called raw `window.history.back()`, relying on the page's popstate listener to intercept and show the unsaved changes prompt. That listener never wins; popstate handlers fire in registration order, so the router (registered first) commits the navigation and unmounts the page before the veto runs, discarding the dirty buffer with no prompt. The header back arrow already handles this by running the leave guard before popping history.

This extracts that guarded back navigation into a shared `goBackOrHome()` in `util/navigation.ts` and routes both the header back arrow and the Escape handler through it. Escape now shows the same Cancel / Discard / Save prompt as the back button, and Escape on a deep linked editor (null `history.state`) falls back to `navigate("/")` instead of leaving the site. Verified in the live dashboard: dirty buffer plus Escape opens the prompt, Cancel keeps the buffer, Discard leaves, and Escape inside the CodeMirror search box still just closes the search panel.

Also checked the secrets page per the issue triage: it is not affected. It registers no Escape handler at all, so there is no bypass path; its back arrow and in-app navigation already run the guard (re-verified in the browser after this refactor).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2259

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
