### PR TITLE
Link the remote build pairing issue form from the feedback dialog

### DIFF
--- a/src/components/feedback-dialog.ts
+++ b/src/components/feedback-dialog.ts
@@ -10,6 +10,7 @@ import {
   mdiLightbulbOutline,
   mdiMagnify,
   mdiOpenInNew,
+  mdiServerNetwork,
 } from "@mdi/js";
 import { LitElement, css, html, type PropertyValues } from "lit";
 import { customElement, state } from "lit/decorators.js";
@@ -38,6 +39,7 @@ registerMdiIcons({
   "lightbulb-outline": mdiLightbulbOutline,
   magnify: mdiMagnify,
   "open-in-new": mdiOpenInNew,
+  "server-network": mdiServerNetwork,
 });
 
 const SURVEY_LINK = {
@@ -92,6 +94,13 @@ const BUG_LINKS: ReadonlyArray<FeedbackLink> = [
     labelKey: "feedback.bug_status",
     descKey: "feedback.bug_status_desc",
     href: "https://github.com/esphome/device-builder/issues/new?template=device_status.yml",
+    versionSource: "dashboard",
+  },
+  {
+    icon: "server-network",
+    labelKey: "feedback.bug_remote_build",
+    descKey: "feedback.bug_remote_build_desc",
+    href: "https://github.com/esphome/device-builder/issues/new?template=remote_build.yml",
     versionSource: "dashboard",
   },
   {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1190,6 +1190,8 @@
     "bug_builder_desc": "A problem with Device Builder itself (UI, backend, or install).",
     "bug_status": "Device status looks wrong",
     "bug_status_desc": "Online/offline, sync, or detection state doesn't match reality.",
+    "bug_remote_build": "Remote build pairing problem",
+    "bug_remote_build_desc": "Two dashboards can't discover each other, pair, stay connected, or run builds for each other.",
     "bug_esphome": "ESPHome firmware or compile issue",
     "bug_esphome_desc": "Compile errors, firmware crashes, boot loops, or component bugs in ESPHome itself; these belong in the core repo, not Device Builder.",
     "browse_features": "Browse feature requests",


### PR DESCRIPTION
# What does this implement/fix?

Adds a row for the new remote_build.yml issue form in the feedback dialog's report list, next to the device status row; the dashboard version is prefilled like the other Device Builder rows.

Companion backend PR: esphome/device-builder#2263 (adds the form).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2260

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
