### PR TITLE
Mention Firefox in the web.esphome.io unsupported-browser message

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1730,7 +1730,7 @@
       "status": "Unsupported",
       "heading": "Web Serial unavailable",
       "insecure": "ESPHome Web needs a secure connection. Reopen this page over https (or on localhost) to connect to a device.",
-      "browser": "ESPHome Web requires a browser that supports Web Serial. Open this site on a desktop using Google Chrome, Microsoft Edge, or another Chromium-based browser."
+      "browser": "ESPHome Web requires a browser that supports Web Serial. Open this site on a desktop using Google Chrome, Microsoft Edge, another Chromium-based browser, or Firefox 151 or newer. Safari does not support Web Serial, and Firefox managed by an organization may have it disabled by policy."
     },
     "logs": {
       "title_named": "{name} logs",


### PR DESCRIPTION
# What does this implement/fix?

The web.esphome.io unsupported browser card still told users to open the site in "Google Chrome, Microsoft Edge, or another Chromium-based browser". Firefox 151 and newer ship Web Serial on desktop, and the sibling string `install_method_usb_local_unsupported` plus the issue form from #1330 already say so; this card was the one place left with the stale copy, and it is exactly the message the reporter saw.

This rewords `web.unsupported.browser` to include Firefox 151 or newer, note that Safari does not support Web Serial, and mention that Firefox managed by an organization may have it disabled by policy. That last part covers the reporter's own case: they were on Firefox 152 and still saw the card, which matches enterprise policy managed Firefox where Web Serial is off by default. Detection is capability based (`"serial" in navigator`) so no code change is needed; copy only.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1332

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
