### PR TITLE
Wrap long dialog titles instead of ellipsizing them

### DIFF
--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -6,7 +6,6 @@ import { customElement, property, state } from "lit/decorators.js";
 
 import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { centeredMobileDialog } from "../styles/dialog-mobile.js";
-import { textStyles } from "../styles/text.js";
 import { EnterController } from "../util/enter-controller.js";
 
 /** Wrappers currently open, maintained by the class below. Backs
@@ -325,8 +324,7 @@ export class ESPHomeBaseDialog extends LitElement {
         @wa-after-hide=${this._onWaAfterHide}
       >
         <header slot="label" part="label-row">
-          <slot name="header-prefix"></slot
-          ><span class="truncate" part="title-text">${this.label}</span
+          <slot name="header-prefix"></slot><span part="title-text">${this.label}</span
           ><slot name="header-suffix"></slot>
         </header>
         <slot></slot>
@@ -340,7 +338,6 @@ export class ESPHomeBaseDialog extends LitElement {
     // Mobile default: centered, dvh-capped. Heavy dialogs override with
     // fullscreenMobileDialog (their outer-tree ::part rule wins).
     centeredMobileDialog("wa-dialog"),
-    textStyles,
     css`
       :host {
         display: contents;
@@ -391,10 +388,14 @@ export class ESPHomeBaseDialog extends LitElement {
          flex-shrink: 0)] but gives .title no min-width, so its default
          min-width:auto (= min-content) lets a long unbroken title grow
          the header past the dialog's right edge and shove the close
-         button off-screen (worst on a narrow / mobile viewport). Letting
-         the title column shrink to 0 and ellipsize fixes it for every
-         dialog built on this wrapper. The header-suffix (e.g. a status
-         chip) stays beside the truncated title via the label-row flex. */
+         button off-screen (worst on a narrow / mobile viewport). The
+         min-width: 0 chain lets the title column shrink instead, and
+         overflow-wrap breaks even an unbroken token so long / localized
+         titles wrap to extra lines rather than ellipsize away (#1331).
+         Fixed-height header bars (dialog-header.ts / dialog-chrome.ts)
+         opt back into single-line ellipsis on ::part(title-text). The
+         header-suffix (e.g. a status chip) stays beside the title via
+         the label-row flex. */
       wa-dialog::part(title) {
         min-width: 0;
       }
@@ -405,6 +406,7 @@ export class ESPHomeBaseDialog extends LitElement {
       }
       [part="title-text"] {
         min-width: 0;
+        overflow-wrap: anywhere;
       }
     `,
   ];

--- a/src/components/command-dialog/styles.ts
+++ b/src/components/command-dialog/styles.ts
@@ -28,6 +28,13 @@ export const commandDialogStyles = css`
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);
   }
+  /* The band height is fixed, so a wrapped title would clip against it;
+     keep the title single-line (base-dialog wraps by default). */
+  esphome-base-dialog::part(title-text) {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
   esphome-base-dialog::part(body) {
     padding: 0;
     background: var(--term-bg);

--- a/src/components/firmware-install-dialog/styles.ts
+++ b/src/components/firmware-install-dialog/styles.ts
@@ -42,6 +42,13 @@ export const firmwareInstallDialogStyles = css`
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);
   }
+  /* The band height is fixed, so a wrapped title would clip against it;
+     keep the title single-line (base-dialog wraps by default). */
+  esphome-base-dialog::part(title-text) {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
   esphome-base-dialog::part(body) {
     padding: var(--wa-space-l) var(--wa-space-xl);
   }

--- a/src/components/onboarding/onboarding-wizard-styles.ts
+++ b/src/components/onboarding/onboarding-wizard-styles.ts
@@ -5,12 +5,6 @@ export const onboardingWizardStyles = css`
     --width: min(520px, calc(100vw - 24px));
   }
 
-  /* Let the longer step titles wrap instead of truncating (the base dialog
-     ellipsizes by default), so nothing is chopped on a narrow / mobile sheet. */
-  esphome-base-dialog::part(title-text) {
-    white-space: normal;
-  }
-
   esphome-base-dialog::part(close-button) {
     display: none;
   }

--- a/src/styles/dialog-chrome.ts
+++ b/src/styles/dialog-chrome.ts
@@ -84,6 +84,14 @@ export const primaryHeaderDialogStyles = css`
     font-weight: var(--wa-font-weight-bold);
   }
 
+  /* The band height is fixed, so a wrapped title would clip against it;
+     keep these titles single-line (base-dialog wraps by default). */
+  esphome-base-dialog::part(title-text) {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   esphome-base-dialog::part(close-button__base) {
     background: transparent;
     border: none;

--- a/src/styles/dialog-header.ts
+++ b/src/styles/dialog-header.ts
@@ -31,4 +31,12 @@ export const primaryDialogHeaderStyles = css`
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);
   }
+
+  /* The band height is fixed, so a wrapped title would clip against it;
+     keep these titles single-line (base-dialog wraps by default). */
+  esphome-base-dialog::part(title-text) {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 `;

--- a/test/components/base-dialog-title-wrap.test.ts
+++ b/test/components/base-dialog-title-wrap.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment happy-dom
+import { describe, expect, test } from "vitest";
+
+// Stub the real wa-dialog (happy-dom can't run its form-associated close
+// button); this test only exercises the wrapper's own header markup.
+import { vi } from "vitest";
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+
+import { ESPHomeBaseDialog } from "../../src/components/base-dialog.js";
+import { mount } from "../_dom.js";
+
+/**
+ * Pins that the default dialog title wraps instead of ellipsizing
+ * (esphome/device-builder-frontend#1331): the title span must not carry the
+ * single-line ``.truncate`` class. Fixed-height header bars re-add nowrap via
+ * ``::part(title-text)`` in dialog-header.ts / dialog-chrome.ts.
+ */
+describe("esphome-base-dialog title wrapping", () => {
+  test("title span does not carry the truncate class", async () => {
+    const el = await mount(new ESPHomeBaseDialog(), {
+      label: "Prepare your Raspberry Pi Pico W for first use",
+    });
+    const title = el.shadowRoot!.querySelector('[part="title-text"]')!;
+    expect(title.classList.contains("truncate")).toBe(false);
+  });
+});

--- a/test/components/base-dialog-title-wrap.test.ts
+++ b/test/components/base-dialog-title-wrap.test.ts
@@ -1,10 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, expect, test } from "vitest";
 
-// Stub the real wa-dialog (happy-dom can't run its form-associated close
-// button); this test only exercises the wrapper's own header markup.
-import { vi } from "vitest";
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+import "../_mock-webawesome.js";
 
 import { ESPHomeBaseDialog } from "../../src/components/base-dialog.js";
 import { mount } from "../_dom.js";

--- a/test/components/base-dialog-title-wrap.test.ts
+++ b/test/components/base-dialog-title-wrap.test.ts
@@ -4,6 +4,10 @@ import { describe, expect, test } from "vitest";
 import "../_mock-webawesome.js";
 
 import { ESPHomeBaseDialog } from "../../src/components/base-dialog.js";
+import { commandDialogStyles } from "../../src/components/command-dialog/styles.js";
+import { firmwareInstallDialogStyles } from "../../src/components/firmware-install-dialog/styles.js";
+import { primaryHeaderDialogStyles } from "../../src/styles/dialog-chrome.js";
+import { primaryDialogHeaderStyles } from "../../src/styles/dialog-header.js";
 import { mount } from "../_dom.js";
 
 /**
@@ -19,5 +23,25 @@ describe("esphome-base-dialog title wrapping", () => {
     });
     const title = el.shadowRoot!.querySelector('[part="title-text"]')!;
     expect(title.classList.contains("truncate")).toBe(false);
+  });
+});
+
+/**
+ * Every fixed-height 40px header band must opt its title back into
+ * single-line ellipsis, or a wrapped title clips against the band. happy-dom
+ * does no layout, so pin the rule's presence in each fragment's CSS text —
+ * this is the half of the #1331 fix that shipped incomplete the first time
+ * (the two inline bands were missed).
+ */
+describe("fixed-height header bands keep titles single-line", () => {
+  const bands = [
+    ["primaryDialogHeaderStyles", primaryDialogHeaderStyles],
+    ["primaryHeaderDialogStyles", primaryHeaderDialogStyles],
+    ["commandDialogStyles", commandDialogStyles],
+    ["firmwareInstallDialogStyles", firmwareInstallDialogStyles],
+  ] as const;
+
+  test.each(bands)("%s re-adds nowrap on ::part(title-text)", (_name, styles) => {
+    expect(styles.cssText).toMatch(/::part\(title-text\)\s*\{[^}]*white-space:\s*nowrap/);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Every dialog built on `esphome-base-dialog` rendered its title as a single line with `.truncate`, so a long title ellipsized away; the adoptable install dialog's "Prepare your Raspberry Pi Pico W for first use" clipped, and the reporter notes German titles clip in other dialogs too since the translations run longer. The truncate was added to keep the close button reachable when a long unbroken title would push it off screen, but the `min-width: 0` chain is what actually prevents that; the ellipsis was collateral.

This drops the truncate from the shared title span so titles wrap to extra lines, and adds `overflow-wrap: anywhere` so even an unbroken token breaks instead of shoving the close button off screen. The two fixed height 40px header bar fragments (`primaryDialogHeaderStyles` used by settings, logs, install method and firmware jobs; `primaryHeaderDialogStyles` used by the create wizard and add component dialog) opt back into single line ellipsis via `::part(title-text)`, since a wrapped line would clip against the fixed band and their titles are short chrome or device names. Verified in the live dashboard at 500px width: the issue's exact title wraps to two lines with the close button in place, and the logs dialog's fixed bar still ellipsizes on one line.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1331

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
