### PR TITLE
Show substitution references in long-form pin fields

### DIFF
--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -13,6 +13,7 @@ import { findUsedPins, sectionEndLine } from "../../util/config-entry-yaml-scan.
 import { isPlainObject, isPrimitiveOrNullish } from "../../util/nested-values.js";
 import { formatPinValue, parseBoardGpio, parsePinGpio } from "../../util/pin-gpio.js";
 import { expandPinModeShorthand } from "../../util/pin-mode.js";
+import { looksLikeSubstitution } from "../../util/substitutions.js";
 import { renderDisclosure } from "../shared/disclosure.js";
 import {
   effectiveDisabled,
@@ -20,6 +21,7 @@ import {
   renderFieldError,
   renderLabel,
   renderStringField,
+  renderSubstitutionHint,
   type RenderCtx,
 } from "./config-entry-renderers-shared.js";
 import { renderNestedField } from "./config-entry-renderers/nested.js";
@@ -229,6 +231,20 @@ export function renderPinField(
   path: string[],
   ctx: RenderCtx
 ): TemplateResult {
+  const rawValue = ctx.getAt(path);
+  // A long-form pin whose ``number`` is a ``${var}`` reference can't drive
+  // the board-GPIO picker — no option matches, so the select rendered blank
+  // (#2268) — and a pick would clobber the reference with a literal. Edit
+  // ``number`` as text with the resolves-to hint, mirroring the scalar
+  // ${var} gate in ``config-entry-form``. Checked before the boardless
+  // fallback, which would bail an object value to the YAML-only shell.
+  if (
+    isPlainObject(rawValue) &&
+    typeof rawValue.number === "string" &&
+    looksLikeSubstitution(rawValue.number)
+  ) {
+    return renderSubstitutionPin(entry, path, ctx, rawValue);
+  }
   if (!ctx.board || ctx.board.pins.length === 0) {
     return renderStringField(entry, "text", path, ctx);
   }
@@ -238,7 +254,6 @@ export function renderPinField(
   // The wa-option values are the platform's value form (`GPIOn`, or `P0.x`
   // for nRF52), so normalise before comparing or the disabled select renders
   // blank.
-  const rawValue = ctx.getAt(path);
   const identity = parsePinGpio(rawValue);
   if (typeof identity === "string") {
     // An I/O-expander pin is a `provider:hub:channel` channel, never a board
@@ -372,6 +387,38 @@ export function renderPinField(
       </wa-select>
       ${renderFieldError(path, ctx)}
       ${renderPinAdvanced(entry, path, ctx, rawValue, isLongForm, fieldDisabled)}
+    </div>
+  `;
+}
+
+/** Long-form pin with a ``${var}`` ``number``: a text input for the
+ *  reference (edits route to ``path.number``, so mode / inverted are
+ *  preserved) plus the Advanced disclosure the normal path renders. */
+function renderSubstitutionPin(
+  entry: ConfigEntry,
+  path: string[],
+  ctx: RenderCtx,
+  rawValue: Record<string, unknown>
+): TemplateResult {
+  const number = rawValue.number as string;
+  const numberPath = [...path, "number"];
+  const invalid = ctx.errorAt(numberPath) !== null;
+  const fieldDisabled = effectiveDisabled(entry, ctx);
+  return html`
+    <div class="field" data-field-key=${fieldKeyAttr(path)}>
+      ${renderLabel(entry, ctx)}
+      <input
+        type="text"
+        autocomplete="off"
+        class=${invalid ? "invalid" : ""}
+        .value=${number}
+        ?disabled=${fieldDisabled}
+        @input=${(e: Event) =>
+          ctx.emitChange(numberPath, (e.target as HTMLInputElement).value)}
+      />
+      ${renderSubstitutionHint(number, ctx.substitutions, ctx.localize)}
+      ${renderFieldError(numberPath, ctx)}
+      ${renderPinAdvanced(entry, path, ctx, rawValue, true, fieldDisabled)}
     </div>
   `;
 }

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -243,7 +243,7 @@ export function renderPinField(
     typeof rawValue.number === "string" &&
     looksLikeSubstitution(rawValue.number)
   ) {
-    return renderSubstitutionPin(entry, path, ctx, rawValue);
+    return renderSubstitutionPin(entry, path, ctx, rawValue, rawValue.number);
   }
   if (!ctx.board || ctx.board.pins.length === 0) {
     return renderStringField(entry, "text", path, ctx);
@@ -398,9 +398,9 @@ function renderSubstitutionPin(
   entry: ConfigEntry,
   path: string[],
   ctx: RenderCtx,
-  rawValue: Record<string, unknown>
+  rawValue: Record<string, unknown>,
+  number: string
 ): TemplateResult {
-  const number = rawValue.number as string;
   const numberPath = [...path, "number"];
   const invalid = ctx.errorAt(numberPath) !== null;
   const fieldDisabled = effectiveDisabled(entry, ctx);

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -875,7 +875,6 @@ describe("renderPinField long-form substitution number", () => {
     );
     const result = renderPinField(subEntry(), ["pin"], ctx);
     const hint = findTemplatesByAnchor(result, "substitution-note")[0];
-    expect(hint).toBeDefined();
     expect(hint.values).toContain("GPIO10");
   });
 

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -841,3 +841,53 @@ describe("renderPinField on an I/O-expander pin", () => {
     expect(findTemplatesByAnchor(result, "<wa-select").length).toBe(0);
   });
 });
+
+describe("renderPinField long-form substitution number", () => {
+  // esphome/device-builder#2268: `pin: { number: ${testpin1}, inverted: true }`
+  // rendered a blank board picker — no option matches a ${var}, and a pick
+  // would clobber the reference. The number edits as text instead, like the
+  // scalar ${var} gate in config-entry-form.
+  const subEntry = () =>
+    makeEntry(ConfigEntryType.PIN, { key: "pin", required: true, pin_features: [] });
+
+  it("renders a text input for the reference instead of the picker", () => {
+    const ctx = makeRenderCtx({ pin: { number: "${testpin1}", inverted: true } });
+    const result = renderPinField(subEntry(), ["pin"], ctx);
+    expect(findTemplatesByAnchor(result, "<wa-select").length).toBe(0);
+    const input = findElementBindings(result, "input")[0];
+    expect(input[".value"]).toBe("${testpin1}");
+  });
+
+  it("routes edits to path.number, preserving the other long-form keys", () => {
+    const ctx = makeRenderCtx({ pin: { number: "${testpin1}", inverted: true } });
+    const result = renderPinField(subEntry(), ["pin"], ctx);
+    const input = findTemplatesByAnchor(result, "<input")[0];
+    const onInput = extractAttributeBindings(input)["@input"] as (e: Event) => void;
+    onInput({ target: { value: "${testpin2}" } } as never);
+    expect(ctx.emitChange).toHaveBeenCalledWith(["pin", "number"], "${testpin2}");
+  });
+
+  it("previews the resolved value from the file's substitutions", () => {
+    const yaml = "substitutions:\n  testpin1: GPIO10\n";
+    const ctx = makeRenderCtx(
+      { pin: { number: "${testpin1}", inverted: true } },
+      { overrides: { yaml } }
+    );
+    const result = renderPinField(subEntry(), ["pin"], ctx);
+    const hint = findTemplatesByAnchor(result, "substitution-note")[0];
+    expect(hint).toBeDefined();
+    expect(hint.values).toContain("GPIO10");
+  });
+
+  it("marks an unresolvable reference as external", () => {
+    const ctx = makeRenderCtx({ pin: { number: "${from_package}" } });
+    const result = renderPinField(subEntry(), ["pin"], ctx);
+    expect(findTemplatesByAnchor(result, "substitution-note--external").length).toBe(1);
+  });
+
+  it("still renders the board picker for a literal long-form number", () => {
+    const ctx = makeRenderCtx({ pin: { number: "GPIO5", inverted: true } });
+    const result = renderPinField(subEntry(), ["pin"], ctx);
+    expect(findTemplatesByAnchor(result, "<wa-select").length).toBe(1);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

With the advanced pin schema (`pin: { number: ${testpin1}, inverted: true }`) the visual editor's pin field rendered blank. A scalar `pin: ${testpin1}` already works because the form's leaf gate edits any `${var}` scalar as text, but the long form is an object, so it lands in the pin renderer, where a `${var}` in `number` parses to no board GPIO and the picker selects nothing.

The picker cannot represent a substitution reference, and resolving it into the dropdown would let one pick clobber the reference with a literal. So the pin renderer now catches a long-form pin whose `number` looks like a substitution and edits `number` as text, with the same resolves-to hint the scalar path shows (previewing `GPIO10` from the file's `substitutions:`, or the resolved-at-build-time marker for package defined ones). Edits route to `pin.number` so `mode` and `inverted` are preserved, and the Advanced disclosure renders unchanged. Verified in the live editor with the issue's exact config: both `binary_sensor.gpio` and `output.gpio` now show the reference plus its resolved pin, and a long-form pin with a literal `number` still gets the board picker.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2268

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
