### PR TITLE
Edit a pin mode substitution shorthand as text

### DIFF
--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -52,7 +52,7 @@ import {
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { nearestScrollContainer } from "../../util/scroll-container.js";
 import { SessionBlobCacheController } from "../../util/session-blob-cache-controller.js";
-import { looksLikeSubstitution, parseSubstitutions } from "../../util/substitutions.js";
+import { isSubstitutionString, parseSubstitutions } from "../../util/substitutions.js";
 import {
   _isStructuralType,
   filterRenderable,
@@ -906,7 +906,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // text so the token round-trips and stays editable mid-keystroke;
     // SECURE_STRING stays masked (#1391).
     const raw = ctx.getAt(path);
-    if (typeof raw === "string" && looksLikeSubstitution(raw)) {
+    if (isSubstitutionString(raw)) {
       const inputType =
         entry.type === ConfigEntryType.SECURE_STRING ? "password" : "text";
       return renderStringField(entry, inputType, path, ctx);

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -576,9 +576,11 @@ function renderLongFormChild(
   const scoped = allowed
     ? scopeModeChildren(child, allowed, presentModeFlags(modeValue))
     : child;
-  // A scalar shorthand (``mode: OUTPUT``) needs the display-expansion wrapper;
+  // A scalar shorthand (``mode: OUTPUT``) needs the display-expansion
+  // wrapper; a ``${var}`` scalar goes through renderEntry so the form's
+  // substitution gate edits it as text with the resolves-to hint (#1343);
   // the object form goes through the normal nested dispatch.
-  return typeof modeValue === "string"
+  return typeof modeValue === "string" && !looksLikeSubstitution(modeValue)
     ? renderPinModeField(scoped, modePath, ctx)
     : ctx.renderEntry(scoped, modePath);
 }

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -13,7 +13,7 @@ import { findUsedPins, sectionEndLine } from "../../util/config-entry-yaml-scan.
 import { isPlainObject, isPrimitiveOrNullish } from "../../util/nested-values.js";
 import { formatPinValue, parseBoardGpio, parsePinGpio } from "../../util/pin-gpio.js";
 import { expandPinModeShorthand } from "../../util/pin-mode.js";
-import { looksLikeSubstitution } from "../../util/substitutions.js";
+import { isSubstitutionString, looksLikeSubstitution } from "../../util/substitutions.js";
 import { renderDisclosure } from "../shared/disclosure.js";
 import {
   effectiveDisabled,
@@ -238,11 +238,7 @@ export function renderPinField(
   // ``number`` as text with the resolves-to hint, mirroring the scalar
   // ${var} gate in ``config-entry-form``. Checked before the boardless
   // fallback, which would bail an object value to the YAML-only shell.
-  if (
-    isPlainObject(rawValue) &&
-    typeof rawValue.number === "string" &&
-    looksLikeSubstitution(rawValue.number)
-  ) {
+  if (isPlainObject(rawValue) && isSubstitutionString(rawValue.number)) {
     return renderSubstitutionPin(entry, path, ctx, rawValue, rawValue.number);
   }
   if (!ctx.board || ctx.board.pins.length === 0) {

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -13,7 +13,7 @@ import { parseHexInt } from "./hex-int.js";
 import { parseIntInput } from "./int-input.js";
 import { asMappingList, asRecord } from "./nested-values.js";
 import { isSecretRef } from "./secret-ref.js";
-import { looksLikeSubstitution } from "./substitutions.js";
+import { isSubstitutionString, looksLikeSubstitution } from "./substitutions.js";
 import { YamlRawValue } from "./yaml-serialize.js";
 
 /**
@@ -225,7 +225,7 @@ export function validateEntry(entry: ConfigEntry, raw: unknown): ValidationError
   // A ${var} reference resolves at build time, so its value is unknowable
   // here; skip all validation (range, options, not-a-number) for the literal
   // or a mid-edit partial (#1391).
-  if (typeof raw === "string" && looksLikeSubstitution(raw)) return null;
+  if (isSubstitutionString(raw)) return null;
 
   if (entry.type === ConfigEntryType.INTEGER && entry.display_format === "hex") {
     // BigInt-route the hex-typed integer check so cv.hex_uint64_t

--- a/src/util/substitutions.ts
+++ b/src/util/substitutions.ts
@@ -64,6 +64,15 @@ export function looksLikeSubstitution(text: string): boolean {
   return SUBSTITUTION_LIKE_RE.test(text);
 }
 
+/**
+ * True when *value* is a string that is (or is becoming) a ``${var}``
+ * reference. The one predicate behind the coupled pair "the form edits it
+ * as text" / "the validator skips typed checks", so the two can't drift.
+ */
+export function isSubstitutionString(value: unknown): value is string {
+  return typeof value === "string" && looksLikeSubstitution(value);
+}
+
 /** Expand ``${name}`` / ``$name`` in *text* against *subs*, leaving
  *  unknown refs literal. Iterates (capped) so chained substitutions
  *  resolve without looping on cycles. */

--- a/test/components/device/config-entry-pin-renderer-runtime.test.ts
+++ b/test/components/device/config-entry-pin-renderer-runtime.test.ts
@@ -201,6 +201,21 @@ describe("renderPinField — mode scalar shorthand expansion", () => {
     // No flag switches; the value falls through to the scalar notice.
     expect(findElementBindings(result, "wa-switch")).toHaveLength(0);
   });
+
+  it("delegates a ${var} mode to renderEntry so the substitution gate edits it", () => {
+    // esphome/device-builder-frontend#1343: the shorthand wrapper can't
+    // expand a substitution reference; routing it through renderEntry gives
+    // the form's scalar ${var} gate (text input + resolves-to hint) instead
+    // of the read-only scalar notice.
+    const ctx = openModeCtx({ number: 0, mode: "${my_mode}" });
+    const result = renderPinField(longFormPinEntry(), ["pin"], ctx);
+
+    expect(findElementBindings(result, "wa-switch")).toHaveLength(0);
+    expect(ctx.renderEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "mode" }),
+      ["pin", "mode"]
+    );
+  });
 });
 
 describe("renderPinField — mode flags scoped to the pin registry", () => {

--- a/test/components/device/config-entry-pin-renderer-runtime.test.ts
+++ b/test/components/device/config-entry-pin-renderer-runtime.test.ts
@@ -208,9 +208,8 @@ describe("renderPinField — mode scalar shorthand expansion", () => {
     // the form's scalar ${var} gate (text input + resolves-to hint) instead
     // of the read-only scalar notice.
     const ctx = openModeCtx({ number: 0, mode: "${my_mode}" });
-    const result = renderPinField(longFormPinEntry(), ["pin"], ctx);
+    renderPinField(longFormPinEntry(), ["pin"], ctx);
 
-    expect(findElementBindings(result, "wa-switch")).toHaveLength(0);
     expect(ctx.renderEntry).toHaveBeenCalledWith(
       expect.objectContaining({ key: "mode" }),
       ["pin", "mode"]

--- a/test/util/substitutions.test.ts
+++ b/test/util/substitutions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   hasSubstitutionReference,
+  isSubstitutionString,
   looksLikeSubstitution,
   parseSubstitutions,
   resolveSubstitutions,
@@ -127,5 +128,16 @@ describe("looksLikeSubstitution", () => {
     expect(looksLikeSubstitution("5$")).toBe(false);
     expect(looksLikeSubstitution("$5.00")).toBe(false);
     expect(looksLikeSubstitution("0.05")).toBe(false);
+  });
+});
+
+describe("isSubstitutionString", () => {
+  it("narrows to substitution-looking strings only", () => {
+    expect(isSubstitutionString("${var}")).toBe(true);
+    expect(isSubstitutionString("${mid-edit")).toBe(true);
+    expect(isSubstitutionString("GPIO5")).toBe(false);
+    expect(isSubstitutionString(5)).toBe(false);
+    expect(isSubstitutionString(undefined)).toBe(false);
+    expect(isSubstitutionString({ number: "${var}" })).toBe(false);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

A long-form pin's scalar `mode: ${my_mode}` rendered as the read-only "value set in YAML" shell in the visual editor. The shorthand expansion wrapper can't expand a substitution reference (`expandPinModeShorthand` returns null), so it fell through to the nested renderer's scalar notice, inconsistent with the editable text treatment `pin.number` got in #1342.

`renderLongFormChild` now excludes substitution looking strings from the shorthand branch, so they take the normal `renderEntry` dispatch where the form's scalar `${var}` gate already renders a text input with the resolves-to hint. Literal shorthands (`mode: OUTPUT`) keep the flag checkbox expansion, unknown ones (`mode: BOGUS`) keep the read-only fallback, and the object form is unchanged. Verified in the live editor: `mode: ${my_mode}` shows an editable text input with the resolved `INPUT_PULLUP` preview, and a literal `mode: INPUT_PULLUP` still shows the Input and Pullup checkboxes ticked.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1343

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
