### PR TITLE
Add a report-an-issue kebab menu to the ESPHome Web header

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1645,7 +1645,9 @@
       "title": "ESPHome Web",
       "subtitle": "Install and manage your devices from the browser",
       "switch_to_pico": "Raspberry Pi",
-      "switch_to_esp": "ESP device"
+      "switch_to_esp": "ESP device",
+      "more_options": "More options",
+      "report_issue": "Report an issue"
     },
     "footer": {
       "tagline": "Runs 100% in your browser — no data leaves your computer."

--- a/src/web/header/esphome-web-header-actions.ts
+++ b/src/web/header/esphome-web-header-actions.ts
@@ -1,0 +1,84 @@
+import { consume } from "@lit/context";
+import { mdiBugOutline, mdiDotsVertical } from "@mdi/js";
+import { html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+
+import type { LocalizeFunc } from "../../common/localize.js";
+import { headerActionsStyles } from "../../components/esphome-header-actions.styles.js";
+import { OverflowMenuElement } from "../../components/overflow-menu-element.js";
+import { localizeContext } from "../../context/index.js";
+import { dropdownMenuStyles } from "../../styles/dropdown-menu.js";
+import { espHomeStyles } from "../../styles/shared.js";
+import { registerMdiIcons } from "../../util/register-icons.js";
+
+import "@home-assistant/webawesome/dist/components/icon/icon.js";
+
+registerMdiIcons({
+  "bug-outline": mdiBugOutline,
+  "dots-vertical": mdiDotsVertical,
+});
+
+const REPORT_ISSUE_URL =
+  "https://github.com/esphome/device-builder-frontend/issues/new?template=web_bug_report.yml";
+
+/**
+ * ESPHome Web's counterpart to the dashboard's header kebab
+ * (``esphome-header-actions``). The web shell has no backend, so instead of the
+ * feedback dialog it links straight to the web.esphome.io issue form.
+ */
+@customElement("esphome-web-header-actions")
+export class ESPHomeWebHeaderActions extends OverflowMenuElement {
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  private _localize: LocalizeFunc = (key) => key;
+
+  static styles = [espHomeStyles, dropdownMenuStyles, headerActionsStyles];
+
+  protected render() {
+    const kebabLabel = this._localize("web.header.more_options");
+    return html`
+      <button
+        type="button"
+        class="menu-btn menu-kebab"
+        @click=${this._toggle}
+        title=${kebabLabel}
+        aria-label=${kebabLabel}
+      >
+        <wa-icon library="mdi" name="dots-vertical"></wa-icon>
+      </button>
+      ${
+        this._open
+          ? html`
+              <div class="backdrop" @click=${this._close}></div>
+              <div
+                class="menu"
+                role="menu"
+                style="position:fixed;top:var(--esphome-header-height, 48px);right:var(--wa-space-s);"
+              >
+                <a
+                  class="menu-item menu-item--link"
+                  role="menuitem"
+                  href=${REPORT_ISSUE_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  @click=${this._close}
+                  @keydown=${this._onItemKeydown}
+                >
+                  <wa-icon library="mdi" name="bug-outline"></wa-icon>
+                  <span class="menu-item-label"
+                    >${this._localize("web.header.report_issue")}</span
+                  >
+                </a>
+              </div>
+            `
+          : nothing
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-web-header-actions": ESPHomeWebHeaderActions;
+  }
+}

--- a/src/web/header/esphome-web-header.ts
+++ b/src/web/header/esphome-web-header.ts
@@ -11,6 +11,7 @@ import { isWebSerialSupported } from "../../util/web-serial.js";
 import { modeUrl, type WebMode } from "../web-mode.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "./esphome-web-header-actions.js";
 
 registerMdiIcons({ "swap-horizontal": mdiSwapHorizontal });
 
@@ -18,7 +19,8 @@ registerMdiIcons({ "swap-horizontal": mdiSwapHorizontal });
  * ESPHome Web top bar, replicating the main builder's ``.app-header`` chrome
  * (``esphome-layout.ts``): the brand-primary bar, the 44px logo box, and the
  * bold on-primary title + subtitle. On the right sits the ESP ⇄ Raspberry Pi
- * device-family switch, hidden entirely on browsers without Web Serial.
+ * device-family switch (hidden entirely on browsers without Web Serial) and
+ * the overflow kebab.
  */
 @customElement("esphome-web-header")
 export class ESPHomeWebHeader extends LitElement {
@@ -72,6 +74,7 @@ export class ESPHomeWebHeader extends LitElement {
               `
             : nothing
         }
+        <esphome-web-header-actions></esphome-web-header-actions>
       </div>
     `;
   }

--- a/test/web/web-header-actions.test.ts
+++ b/test/web/web-header-actions.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The ESPHome Web header kebab: opens on click, its single row is an anchor
+ * pointing at the web.esphome.io issue form, and clicking the row closes the
+ * menu.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/util/register-icons.js", () => ({ registerMdiIcons: vi.fn() }));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomeWebHeaderActions } from "../../src/web/header/esphome-web-header-actions.js";
+import { identityLocalize } from "../_dom.js";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+async function mount(): Promise<ESPHomeWebHeaderActions> {
+  const el = new ESPHomeWebHeaderActions();
+  (el as unknown as { _localize: typeof identityLocalize })._localize = identityLocalize;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+async function openMenu(el: ESPHomeWebHeaderActions): Promise<void> {
+  el.shadowRoot!.querySelector<HTMLElement>(".menu-btn")!.click();
+  await el.updateComplete;
+}
+
+describe("esphome-web-header-actions", () => {
+  it("opens the menu with a report-issue link targeting the web issue form", async () => {
+    const el = await mount();
+    expect(el.shadowRoot!.querySelector(".menu")).toBeNull();
+
+    await openMenu(el);
+
+    const link = el.shadowRoot!.querySelector<HTMLAnchorElement>(".menu-item--link");
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute("href")).toBe(
+      "https://github.com/esphome/device-builder-frontend/issues/new?template=web_bug_report.yml"
+    );
+    expect(link!.getAttribute("target")).toBe("_blank");
+    expect(link!.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(link!.textContent).toContain("web.header.report_issue");
+  });
+
+  it("closes the menu when the report-issue link is clicked", async () => {
+    const el = await mount();
+    await openMenu(el);
+
+    // happy-dom would follow the navigation; the assertion is about _close.
+    const link = el.shadowRoot!.querySelector<HTMLAnchorElement>(".menu-item--link")!;
+    link.addEventListener("click", (e) => e.preventDefault());
+    link.click();
+    await el.updateComplete;
+
+    expect(el.shadowRoot!.querySelector(".menu")).toBeNull();
+  });
+
+  it("closes the menu on backdrop click", async () => {
+    const el = await mount();
+    await openMenu(el);
+
+    el.shadowRoot!.querySelector<HTMLElement>(".backdrop")!.click();
+    await el.updateComplete;
+
+    expect(el.shadowRoot!.querySelector(".menu")).toBeNull();
+  });
+});

--- a/test/web/web-header.test.ts
+++ b/test/web/web-header.test.ts
@@ -60,4 +60,12 @@ describe("esphome-web-header switch target", () => {
 
     expect(el.shadowRoot!.querySelector(".switch-btn")).toBeNull();
   });
+
+  // The kebab stays in minimal mode on purpose: a flash failure in the
+  // receiver popup is exactly when a user needs the report-issue link.
+  it("keeps the kebab in minimal (flash-receiver) mode", async () => {
+    const el = await mount("esp", true);
+
+    expect(el.shadowRoot!.querySelector("esphome-web-header-actions")).not.toBeNull();
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Adds a kebab menu to the ESPHome Web header, mirroring the dashboard's header kebab, with a "Report an issue" entry that opens the web.esphome.io issue form from #1328 in a new tab. The menu reuses the existing OverflowMenuElement base and the shared dropdown and header action styles; two new localization keys in en.json.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1329

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

