### PR TITLE
Round-trip substitution references in numeric list rows

### DIFF
--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -575,7 +575,9 @@ function renderLongFormChild(
   // A scalar shorthand (``mode: OUTPUT``) needs the display-expansion
   // wrapper; a ``${var}`` scalar goes through renderEntry so the form's
   // substitution gate edits it as text with the resolves-to hint (#1343);
-  // the object form goes through the normal nested dispatch.
+  // the object form goes through the normal nested dispatch. Deliberately
+  // ``looksLikeSubstitution``, not ``isSubstitutionString`` — the typeof
+  // guard is load-bearing (an object mode must not hit the wrapper).
   return typeof modeValue === "string" && !looksLikeSubstitution(modeValue)
     ? renderPinModeField(scoped, modePath, ctx)
     : ctx.renderEntry(scoped, modePath);

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -7,6 +7,7 @@ import { isSubstitutionString } from "../../../util/substitutions.js";
 import { escapeForInput, unescapeForInput } from "../../../util/yaml-escape.js";
 import { YamlRawValue } from "../../../util/yaml-serialize.js";
 import {
+  coerceValueToEntryType,
   effectiveDisabled,
   fieldKeyAttr,
   labelFor,
@@ -121,21 +122,16 @@ export function renderMultiValueField(
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
   const { addItem, removeAt } = arrayItemHandlers(ctx, path, () => "");
-  const updateAt = (idx: number, value: string, rowNumeric: boolean) => {
+  const updateAt = (idx: number, value: string) => {
     const current = [...readArrayAt(ctx, path)];
-    // Empty stays "" so a half-typed or cleared row round-trips instead of
-    // becoming NaN, matching the single-value number renderer. A ${var} row
-    // in a numeric list round-trips the string verbatim — no coercion — so
-    // an edit can't clobber the reference with a number (#1346); dropping
-    // the $ flips the row numeric on the next render, same transient
-    // string-typed number the single-value ${var} gates write.
-    current[idx] = rowNumeric
-      ? value === ""
-        ? ""
-        : Number(value)
-      : numeric
-        ? value
-        : unescapeForInput(value);
+    // Numeric rows coerce through the shared helper: decimals become
+    // numbers; "" and unparseable input — a ${var} reference (#1346), a
+    // 0x literal, a >2^53 decimal — pass through verbatim, so an edit
+    // can't clobber a reference and 64-bit precision survives, matching
+    // the single-value number renderers.
+    current[idx] = numeric
+      ? coerceValueToEntryType(entry, value)
+      : unescapeForInput(value);
     ctx.emitChange(path, current);
   };
 
@@ -161,8 +157,7 @@ export function renderMultiValueField(
                 class="multi-input ${invalid ? "invalid" : ""}"
                 .value=${item}
                 ?disabled=${disabled}
-                @input=${(e: Event) =>
-                  updateAt(i, (e.target as HTMLInputElement).value, rowNumeric)}
+                @input=${(e: Event) => updateAt(i, (e.target as HTMLInputElement).value)}
               />
               ${
                 // Resolve against the stored value, not the escaped display

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -124,11 +124,12 @@ export function renderMultiValueField(
   const { addItem, removeAt } = arrayItemHandlers(ctx, path, () => "");
   const updateAt = (idx: number, value: string) => {
     const current = [...readArrayAt(ctx, path)];
-    // Numeric rows coerce through the shared helper: decimals become
-    // numbers; "" and unparseable input — a ${var} reference (#1346), a
-    // 0x literal, a >2^53 decimal — pass through verbatim, so an edit
-    // can't clobber a reference and 64-bit precision survives, matching
-    // the single-value number renderers.
+    // Numeric rows coerce through the shared helper: parseable input
+    // becomes a number; "" and unparseable input — notably a ${var}
+    // reference (#1346) — pass through verbatim so an edit can't clobber
+    // it. INTEGER rows additionally keep 0x literals and >2^53 decimals
+    // as strings (coerceIntFieldValue), matching the single-value
+    // renderers; FLOAT coercion is plain Number().
     current[idx] = numeric
       ? coerceValueToEntryType(entry, value)
       : unescapeForInput(value);

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -3,6 +3,7 @@ import { isLambdaValue } from "../../../api/types/automations.js";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../../api/types/config-entries.js";
 import { asMappingList, isPrimitiveOrNullish } from "../../../util/nested-values.js";
+import { isSubstitutionString } from "../../../util/substitutions.js";
 import { escapeForInput, unescapeForInput } from "../../../util/yaml-escape.js";
 import { YamlRawValue } from "../../../util/yaml-serialize.js";
 import {
@@ -120,34 +121,48 @@ export function renderMultiValueField(
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
   const { addItem, removeAt } = arrayItemHandlers(ctx, path, () => "");
-  const updateAt = (idx: number, value: string) => {
+  const updateAt = (idx: number, value: string, rowNumeric: boolean) => {
     const current = [...readArrayAt(ctx, path)];
     // Empty stays "" so a half-typed or cleared row round-trips instead of
-    // becoming NaN, matching the single-value number renderer.
-    current[idx] = numeric
+    // becoming NaN, matching the single-value number renderer. A ${var} row
+    // in a numeric list round-trips the string verbatim — no coercion — so
+    // an edit can't clobber the reference with a number (#1346); dropping
+    // the $ flips the row numeric on the next render, same transient
+    // string-typed number the single-value ${var} gates write.
+    current[idx] = rowNumeric
       ? value === ""
         ? ""
         : Number(value)
-      : unescapeForInput(value);
+      : numeric
+        ? value
+        : unescapeForInput(value);
     ctx.emitChange(path, current);
   };
 
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)} ${renderListEmptyHint(items, ctx)}
-      ${items.map(
-        (item, i) => html`
+      ${items.map((item, i) => {
+        // A ${var} item can't drive a number input (the browser blanks a
+        // non-numeric value); edit it as text so the reference round-trips.
+        const rowNumeric = numeric && !isSubstitutionString(raw[i]);
+        return html`
           <div class="multi-row">
             <div class="multi-value-cell">
               <input
-                type=${numeric ? "number" : "text"}
+                type=${rowNumeric ? "number" : "text"}
                 step=${
-                  numeric ? (entry.type === ConfigEntryType.FLOAT ? "any" : "1") : nothing
+                  rowNumeric
+                    ? entry.type === ConfigEntryType.FLOAT
+                      ? "any"
+                      : "1"
+                    : nothing
                 }
                 class="multi-input ${invalid ? "invalid" : ""}"
                 .value=${item}
                 ?disabled=${disabled}
-                @input=${(e: Event) => updateAt(i, (e.target as HTMLInputElement).value)}
+                @input=${(e: Event) =>
+                  updateAt(i, (e.target as HTMLInputElement).value, rowNumeric)}
               />
               ${
                 // Resolve against the stored value, not the escaped display
@@ -161,8 +176,8 @@ export function renderMultiValueField(
             </div>
             ${renderListRemoveButton(ctx, disabled, () => removeAt(i))}
           </div>
-        `
-      )}
+        `;
+      })}
       ${renderListAddButton(ctx, disabled, addItem)} ${renderFieldError(path, ctx)}
     </div>
   `;

--- a/test/components/device/render-multi-value-field-substitution.test.ts
+++ b/test/components/device/render-multi-value-field-substitution.test.ts
@@ -66,3 +66,18 @@ describe("renderMultiValueField — substitution preview", () => {
     expect(json).toContain("substitution-warn");
   });
 });
+
+describe("renderMultiValueField — numeric list substitution preview", () => {
+  it("previews the resolved value for a ${var} row in an INTEGER list", () => {
+    const yaml = 'substitutions:\n  ch: "3"\n';
+    const ctx = makeRenderCtx(
+      { codes: ["${ch}", 5] },
+      { overrides: { sectionKey: "remote_receiver", yaml } }
+    );
+    const json = serialize(
+      renderMultiValueField(makeEntry(ConfigEntryType.INTEGER), ["codes"], ctx)
+    );
+    expect(json).toContain("substitution-note");
+    expect(json).toContain('"3"');
+  });
+});

--- a/test/components/device/render-multi-value-field.test.ts
+++ b/test/components/device/render-multi-value-field.test.ts
@@ -69,3 +69,36 @@ describe("renderMultiValueField numeric coercion", () => {
     expect(inputs[0].type).toBe("text");
   });
 });
+
+describe("renderMultiValueField numeric substitution rows", () => {
+  // esphome/device-builder-frontend#1346: a ${var} item can't drive a number
+  // input (the browser blanks it) and Number() on edit clobbered the
+  // reference. The row edits as text and round-trips the string.
+  it("renders the ${var} row as text while sibling literals stay numeric", () => {
+    const ctx = makeRenderCtx({ field: ["${ch}", 5] });
+    const tpl = renderMultiValueField(makeEntry(ConfigEntryType.INTEGER), ["field"], ctx);
+    const inputs = findElementBindings(tpl, "input");
+
+    expect(inputs[0].type).toBe("text");
+    expect(inputs[0][".value"]).toBe("${ch}");
+    expect(inputs[1].type).toBe("number");
+  });
+
+  it("round-trips the reference string on edit, no Number coercion", () => {
+    const ctx = makeRenderCtx({ field: ["${ch}", 5] });
+    const tpl = renderMultiValueField(makeEntry(ConfigEntryType.INTEGER), ["field"], ctx);
+    const inputs = findElementBindings(tpl, "input");
+
+    fireInput(inputs[0], "${chan}");
+    expect(ctx.emitChange).toHaveBeenCalledWith(["field"], ["${chan}", 5]);
+  });
+
+  it("sibling literal edits still coerce to numbers", () => {
+    const ctx = makeRenderCtx({ field: ["${ch}", 5] });
+    const tpl = renderMultiValueField(makeEntry(ConfigEntryType.INTEGER), ["field"], ctx);
+    const inputs = findElementBindings(tpl, "input");
+
+    fireInput(inputs[1], "7");
+    expect(ctx.emitChange).toHaveBeenCalledWith(["field"], ["${ch}", 7]);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

A `${var}` item in an INTEGER or FLOAT multi value list fed `<input type="number">`, which blanks a non numeric value, and the edit handler wrote `Number(value)` back, so the first keystroke clobbered the reference. Text typed lists already handled substitutions per row.

The numeric decision is now per row: an item that looks like a substitution renders as a text input and round trips the string verbatim on edit, no coercion; the per row resolves-to hint the list renderer already carries starts showing for it. Sibling literal rows keep the number input and numeric coercion, and dropping the `$` flips the row back to numeric on the next render, the same transient string typed number the single value `${var}` gates write. Verified in the live editor with an `lcd_pcf8574` `user_characters.data` list: the `${glyph_row}` row is editable text with the resolved preview while the literal rows stay number inputs.

Builds on the `isSubstitutionString` predicate #1344 added (now merged, so this targets `main` directly).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1346

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
