### PR TITLE
Validate scalar multi_value lists per item

### DIFF
--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -14,7 +14,11 @@ import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js"
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { ComponentNameResolverController } from "../../util/component-name-resolver-controller.js";
-import { validateEntries, type ValidationError } from "../../util/config-validation.js";
+import {
+  clearPathErrors,
+  validateEntries,
+  type ValidationError,
+} from "../../util/config-validation.js";
 import { resolveFeaturedComponentId } from "../../util/featured-id.js";
 import { fireEvent } from "../../util/fire-event.js";
 import { renderMarkdown } from "../../util/markdown.js";
@@ -462,22 +466,12 @@ export class ESPHomeAddComponentForm extends LitElement {
     const { path, value } = e.detail;
     this._values = setIn(this._values, path, value);
     // Clear any error on the path the user just edited — including
-    // per-item keys under it (``codes.0``, #1348): a multi_value edit
-    // emits the whole array at the field path, so the offending row's
-    // error would otherwise stick until the next submit. Same for the
-    // hidden-validation block message: any user input is a fresh
-    // signal that supersedes the previous bail; the next submit
-    // attempt re-evaluates from scratch.
-    const errKey = path.join(".");
-    const itemPrefix = `${errKey}.`;
-    const stale = [...this._errors.keys()].filter(
-      (k) => k === errKey || k.startsWith(itemPrefix)
-    );
-    if (stale.length > 0) {
-      const next = new Map(this._errors);
-      for (const k of stale) next.delete(k);
-      this._errors = next;
-    }
+    // per-item keys under it, or the offending row's error sticks until
+    // the next submit. Same for the hidden-validation block message: any
+    // user input is a fresh signal that supersedes the previous bail;
+    // the next submit attempt re-evaluates from scratch.
+    const cleared = clearPathErrors(this._errors, path.join("."));
+    if (cleared) this._errors = cleared;
     if (this._localBlockMessage) this._localBlockMessage = "";
   }
 

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -461,15 +461,21 @@ export class ESPHomeAddComponentForm extends LitElement {
   private _onValueChange(e: CustomEvent<ConfigEntryValueChange>) {
     const { path, value } = e.detail;
     this._values = setIn(this._values, path, value);
-    // Clear any error on the path the user just edited so the
-    // red ring disappears as they type. Same for the
+    // Clear any error on the path the user just edited — including
+    // per-item keys under it (``codes.0``, #1348): a multi_value edit
+    // emits the whole array at the field path, so the offending row's
+    // error would otherwise stick until the next submit. Same for the
     // hidden-validation block message: any user input is a fresh
     // signal that supersedes the previous bail; the next submit
     // attempt re-evaluates from scratch.
     const errKey = path.join(".");
-    if (this._errors.has(errKey)) {
+    const itemPrefix = `${errKey}.`;
+    const stale = [...this._errors.keys()].filter(
+      (k) => k === errKey || k.startsWith(itemPrefix)
+    );
+    if (stale.length > 0) {
       const next = new Map(this._errors);
-      next.delete(errKey);
+      for (const k of stale) next.delete(k);
       this._errors = next;
     }
     if (this._localBlockMessage) this._localBlockMessage = "";

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -305,7 +305,10 @@ export function collectRenderablePaths(
     }
     // Scalar multi_value errors are keyed per item (``codes.0``, #1348);
     // emit the index paths of the rendered rows so those errors count as
-    // visible too.
+    // visible too. Deliberately ``values`` only — the list renderer never
+    // renders a required entry's array default as rows, so per-item errors
+    // from an invalid catalog default are correctly treated as hidden and
+    // routed to the block message.
     if (entry.multi_value && Array.isArray(values[entry.key])) {
       (values[entry.key] as unknown[]).forEach((_item, idx) => {
         out.add([...pathPrefix, entry.key, String(idx)].join("."));

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -305,10 +305,9 @@ export function collectRenderablePaths(
     }
     // Scalar multi_value errors are keyed per item (``codes.0``, #1348);
     // emit the index paths of the rendered rows so those errors count as
-    // visible too. Deliberately ``values`` only — the list renderer never
-    // renders a required entry's array default as rows, so per-item errors
-    // from an invalid catalog default are correctly treated as hidden and
-    // routed to the block message.
+    // visible too. Deliberately ``values`` only — the renderer never shows
+    // an array default as rows, so errors on an invalid catalog default
+    // stay hidden (block message).
     if (entry.multi_value && Array.isArray(values[entry.key])) {
       (values[entry.key] as unknown[]).forEach((_item, idx) => {
         out.add([...pathPrefix, entry.key, String(idx)].join("."));

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -303,6 +303,14 @@ export function collectRenderablePaths(
       out.add([...pathPrefix, entry.key].join("."));
       continue;
     }
+    // Scalar multi_value errors are keyed per item (``codes.0``, #1348);
+    // emit the index paths of the rendered rows so those errors count as
+    // visible too.
+    if (entry.multi_value && Array.isArray(values[entry.key])) {
+      (values[entry.key] as unknown[]).forEach((_item, idx) => {
+        out.add([...pathPrefix, entry.key, String(idx)].join("."));
+      });
+    }
     out.add([...pathPrefix, entry.key].join("."));
   }
   return out;

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -143,6 +143,11 @@ export function renderMultiValueField(
         // A ${var} item can't drive a number input (the browser blanks a
         // non-numeric value); edit it as text so the reference round-trips.
         const rowNumeric = numeric && !isSubstitutionString(raw[i]);
+        // Errors land per item (``field.0``, #1348); flag and explain only
+        // the offending row. The field-level ``invalid`` stays for errors
+        // keyed at the field itself (required-empty).
+        const rowPath = [...path, String(i)];
+        const rowInvalid = invalid || ctx.errorAt(rowPath) !== null;
         return html`
           <div class="multi-row">
             <div class="multi-value-cell">
@@ -155,7 +160,7 @@ export function renderMultiValueField(
                       : "1"
                     : nothing
                 }
-                class="multi-input ${invalid ? "invalid" : ""}"
+                class="multi-input ${rowInvalid ? "invalid" : ""}"
                 .value=${item}
                 ?disabled=${disabled}
                 @input=${(e: Event) => updateAt(i, (e.target as HTMLInputElement).value)}
@@ -169,6 +174,7 @@ export function renderMultiValueField(
                   ctx.localize
                 )
               }
+              ${renderFieldError(rowPath, ctx)}
             </div>
             ${renderListRemoveButton(ctx, disabled, () => removeAt(i))}
           </div>

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -1,4 +1,4 @@
-import { validateEntries } from "../../../util/config-validation.js";
+import { clearPathErrors, validateEntries } from "../../../util/config-validation.js";
 import { fireEvent } from "../../../util/fire-event.js";
 import { formatApiError } from "../../../util/format-api-error.js";
 import { setIn } from "../../../util/nested-values.js";
@@ -69,11 +69,8 @@ export function onValueChange(
   host._values = setIn(host._values, path, value);
   host._setDirty(true);
   const errKey = path.join(".");
-  if (host._fieldErrors.has(errKey)) {
-    const next = new Map(host._fieldErrors);
-    next.delete(errKey);
-    host._fieldErrors = next;
-  }
+  const cleared = clearPathErrors(host._fieldErrors, errKey);
+  if (cleared) host._fieldErrors = cleared;
   // Same optimistic clear for the backend error on the edited path — it
   // reappears on the next lint pass if the value is still invalid.
   if (host.backendErrors.fields.has(errKey) && !host._clearedBackendPaths.has(errKey)) {

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -478,6 +478,35 @@ function _validateEntriesRecursive(
       continue;
     }
 
+    // A scalar multi_value list validates per item, mirroring the NESTED
+    // item walk above: each item gets the full scalar rulebook (numeric
+    // parsing, ranges, options, the ${var} skip) with an array-index
+    // path segment, so one bad row doesn't paint its siblings. The whole
+    // array must never reach validateEntry — it stringifies to "3,5" and
+    // every multi-item numeric list flags not_a_number (#1348). An empty
+    // or blank row is mid-edit, not an error. Non-array values (a bare
+    // scalar cv.ensure_list accepts, an unset field, a YamlRawValue
+    // block) keep the generic field-level path below.
+    if (entry.multi_value && Array.isArray(values[entry.key])) {
+      const items = values[entry.key] as readonly unknown[];
+      if (items.length === 0) {
+        if (entry.required) {
+          const fullPath = [...pathPrefix, entry.key].join(".");
+          errors.set(fullPath, { key: fullPath, code: "validation.required" });
+        }
+        continue;
+      }
+      items.forEach((item, idx) => {
+        if (!isValuePresent(item)) return;
+        const err = validateEntry(entry, item);
+        if (err) {
+          const fullPath = [...pathPrefix, entry.key, String(idx)].join(".");
+          errors.set(fullPath, { ...err, key: fullPath });
+        }
+      });
+      continue;
+    }
+
     // Optional defaults aren't sent to the backend (``_coerceFields``
     // strips empties from the API payload), so validating against
     // them is wrong by design — only fall back to ``default_value``

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -125,6 +125,23 @@ export interface ValidationError {
   params?: Record<string, string | number>;
 }
 
+/**
+ * *errors* without *pathKey* and its per-item descendants (``codes`` also
+ * clears ``codes.0`` — a multi_value edit emits at the field path, #1348),
+ * or ``null`` when nothing matched so callers can skip the state write.
+ */
+export function clearPathErrors(
+  errors: ReadonlyMap<string, ValidationError>,
+  pathKey: string
+): Map<string, ValidationError> | null {
+  const prefix = `${pathKey}.`;
+  const stale = [...errors.keys()].filter((k) => k === pathKey || k.startsWith(prefix));
+  if (stale.length === 0) return null;
+  const next = new Map(errors);
+  for (const k of stale) next.delete(k);
+  return next;
+}
+
 /* Mirrors esphome's ``ALLOWED_NAME_CHARS`` (const.py) — what
    ``esphome rename`` and the YAML ``name:`` validator both accept.
    Underscore is included because plenty of existing configs already

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -484,12 +484,21 @@ function _validateEntriesRecursive(
     // path segment, so one bad row doesn't paint its siblings. The whole
     // array must never reach validateEntry — it stringifies to "3,5" and
     // every multi-item numeric list flags not_a_number (#1348). A blank
-    // row is mid-edit, not an error. An empty list and non-array values
+    // row beside a real value is mid-edit, not an error. Non-array values
     // (a bare scalar cv.ensure_list accepts, an unset field, a
-    // YamlRawValue block) keep the generic field-level path below, so
-    // required-empty and the hidden-field rule stay validateEntry's.
+    // YamlRawValue block) keep the generic field-level path below.
     const list: unknown = values[entry.key];
-    if (entry.multi_value && Array.isArray(list) && list.length > 0) {
+    if (entry.multi_value && Array.isArray(list)) {
+      if (!list.some(isValuePresent)) {
+        // Empty, or only blank rows: required-and-unsatisfied either way.
+        // An unset hidden field isn't rendered, so never block on it
+        // (validateEntry's rule).
+        if (entry.required && !entry.hidden) {
+          const fullPath = [...pathPrefix, entry.key].join(".");
+          errors.set(fullPath, { key: fullPath, code: "validation.required" });
+        }
+        continue;
+      }
       // A list-of-dicts the schema bundle couldn't type as nested renders
       // YAML-only (the renderer's whole-field bail); per-item scalar
       // checks would flag rows the form never shows. ESPHome's own

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -496,23 +496,25 @@ function _validateEntriesRecursive(
       continue;
     }
 
-    // A scalar multi_value list validates per item, mirroring the NESTED
-    // item walk above: each item gets the full scalar rulebook (numeric
-    // parsing, ranges, options, the ${var} skip) with an array-index
-    // path segment, so one bad row doesn't paint its siblings. The whole
-    // array must never reach validateEntry — it stringifies to "3,5" and
-    // every multi-item numeric list flags not_a_number (#1348). A blank
-    // row beside a real value is mid-edit, not an error. Non-array values
-    // (a bare scalar cv.ensure_list accepts, an unset field, a
-    // YamlRawValue block) keep the generic field-level path below.
-    // Same required-default fallback as the generic path below, so a
-    // required list falling back to an array default is still walked per
-    // item instead of stringifying in validateEntry.
-    const list: unknown = entry.required
+    // Optional defaults aren't sent to the backend (``_coerceFields``
+    // strips empties from the API payload), so validating against
+    // them is wrong by design — only fall back to ``default_value``
+    // for required entries, where an unset value would otherwise
+    // surface as ``validation.required`` even though the catalog
+    // pre-supplies a valid value.
+    const raw = entry.required
       ? (values[entry.key] ?? entry.default_value)
       : values[entry.key];
-    if (entry.multi_value && Array.isArray(list)) {
-      if (!list.some(isValuePresent)) {
+
+    // A scalar multi_value list validates per item with array-index path
+    // segments, so one bad row doesn't paint its siblings — the whole array
+    // must never reach validateEntry, where it stringifies ("3,5" →
+    // not_a_number on every multi-item numeric list, #1348). A blank row
+    // beside a real value is mid-edit, not an error. Non-array values (a
+    // bare scalar cv.ensure_list accepts, an unset field, a YamlRawValue
+    // block) keep the generic field-level path below.
+    if (entry.multi_value && Array.isArray(raw)) {
+      if (!raw.some(isValuePresent)) {
         // Empty, or only blank rows: required-and-unsatisfied either way.
         // An unset hidden field isn't rendered, so never block on it
         // (validateEntry's rule).
@@ -526,8 +528,8 @@ function _validateEntriesRecursive(
       // YAML-only (the renderer's whole-field bail); per-item scalar
       // checks would flag rows the form never shows. ESPHome's own
       // validate_yaml owns those, same as MAP values.
-      if (list.every(isPrimitiveOrNullish)) {
-        list.forEach((item, idx) => {
+      if (raw.every(isPrimitiveOrNullish)) {
+        raw.forEach((item, idx) => {
           if (!isValuePresent(item)) return;
           const err = validateEntry(entry, item);
           if (err) {
@@ -539,15 +541,6 @@ function _validateEntriesRecursive(
       continue;
     }
 
-    // Optional defaults aren't sent to the backend (``_coerceFields``
-    // strips empties from the API payload), so validating against
-    // them is wrong by design — only fall back to ``default_value``
-    // for required entries, where an unset value would otherwise
-    // surface as ``validation.required`` even though the catalog
-    // pre-supplies a valid value.
-    const raw = entry.required
-      ? (values[entry.key] ?? entry.default_value)
-      : values[entry.key];
     const err = validateEntry(entry, raw);
     if (err) {
       const fullPath = [...pathPrefix, entry.key].join(".");

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -11,7 +11,7 @@ import {
 import { parseFloatWithUnit } from "./float-with-unit.js";
 import { parseHexInt } from "./hex-int.js";
 import { parseIntInput } from "./int-input.js";
-import { asMappingList, asRecord } from "./nested-values.js";
+import { asMappingList, asRecord, isPrimitiveOrNullish } from "./nested-values.js";
 import { isSecretRef } from "./secret-ref.js";
 import { isSubstitutionString, looksLikeSubstitution } from "./substitutions.js";
 import { YamlRawValue } from "./yaml-serialize.js";
@@ -483,27 +483,27 @@ function _validateEntriesRecursive(
     // parsing, ranges, options, the ${var} skip) with an array-index
     // path segment, so one bad row doesn't paint its siblings. The whole
     // array must never reach validateEntry — it stringifies to "3,5" and
-    // every multi-item numeric list flags not_a_number (#1348). An empty
-    // or blank row is mid-edit, not an error. Non-array values (a bare
-    // scalar cv.ensure_list accepts, an unset field, a YamlRawValue
-    // block) keep the generic field-level path below.
-    if (entry.multi_value && Array.isArray(values[entry.key])) {
-      const items = values[entry.key] as readonly unknown[];
-      if (items.length === 0) {
-        if (entry.required) {
-          const fullPath = [...pathPrefix, entry.key].join(".");
-          errors.set(fullPath, { key: fullPath, code: "validation.required" });
-        }
-        continue;
+    // every multi-item numeric list flags not_a_number (#1348). A blank
+    // row is mid-edit, not an error. An empty list and non-array values
+    // (a bare scalar cv.ensure_list accepts, an unset field, a
+    // YamlRawValue block) keep the generic field-level path below, so
+    // required-empty and the hidden-field rule stay validateEntry's.
+    const list: unknown = values[entry.key];
+    if (entry.multi_value && Array.isArray(list) && list.length > 0) {
+      // A list-of-dicts the schema bundle couldn't type as nested renders
+      // YAML-only (the renderer's whole-field bail); per-item scalar
+      // checks would flag rows the form never shows. ESPHome's own
+      // validate_yaml owns those, same as MAP values.
+      if (list.every(isPrimitiveOrNullish)) {
+        list.forEach((item, idx) => {
+          if (!isValuePresent(item)) return;
+          const err = validateEntry(entry, item);
+          if (err) {
+            const fullPath = [...pathPrefix, entry.key, String(idx)].join(".");
+            errors.set(fullPath, { ...err, key: fullPath });
+          }
+        });
       }
-      items.forEach((item, idx) => {
-        if (!isValuePresent(item)) return;
-        const err = validateEntry(entry, item);
-        if (err) {
-          const fullPath = [...pathPrefix, entry.key, String(idx)].join(".");
-          errors.set(fullPath, { ...err, key: fullPath });
-        }
-      });
       continue;
     }
 

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -504,7 +504,12 @@ function _validateEntriesRecursive(
     // row beside a real value is mid-edit, not an error. Non-array values
     // (a bare scalar cv.ensure_list accepts, an unset field, a
     // YamlRawValue block) keep the generic field-level path below.
-    const list: unknown = values[entry.key];
+    // Same required-default fallback as the generic path below, so a
+    // required list falling back to an array default is still walked per
+    // item instead of stringifying in validateEntry.
+    const list: unknown = entry.required
+      ? (values[entry.key] ?? entry.default_value)
+      : values[entry.key];
     if (entry.multi_value && Array.isArray(list)) {
       if (!list.some(isValuePresent)) {
         // Empty, or only blank rows: required-and-unsatisfied either way.

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -126,9 +126,10 @@ export interface ValidationError {
 }
 
 /**
- * *errors* without *pathKey* and its per-item descendants (``codes`` also
- * clears ``codes.0`` — a multi_value edit emits at the field path, #1348),
- * or ``null`` when nothing matched so callers can skip the state write.
+ * Return a copy of *errors* without *pathKey* and its per-item descendants
+ * (``codes`` also clears ``codes.0`` — a multi_value edit emits at the field
+ * path, #1348), or ``null`` when nothing matched so callers can skip the
+ * state write.
  */
 export function clearPathErrors(
   errors: ReadonlyMap<string, ValidationError>,

--- a/test/components/device/add-component-form-error-clear.test.ts
+++ b/test/components/device/add-component-form-error-clear.test.ts
@@ -33,15 +33,4 @@ describe("esphome-add-component-form error clearing", () => {
     expect(form._errors.has("codes.1")).toBe(false);
     expect(form._errors.has("other")).toBe(true);
   });
-
-  it("does not clear a sibling whose key shares a prefix string", () => {
-    const form = new ESPHomeAddComponentForm() as unknown as ErrorClearView;
-    form._errors = new Map([
-      ["codes_extra", { key: "codes_extra", code: "validation.required" }],
-    ]);
-
-    form._onValueChange(changeEvent(["codes"], [3]));
-
-    expect(form._errors.has("codes_extra")).toBe(true);
-  });
 });

--- a/test/components/device/add-component-form-error-clear.test.ts
+++ b/test/components/device/add-component-form-error-clear.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+
+import "../../_mock-webawesome.js";
+
+import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+
+/**
+ * Pins that editing a field clears its per-item error keys too (#1348):
+ * a multi_value edit emits the whole array at the field path, so ``codes.0``
+ * must not survive as a stale red ring.
+ */
+interface ErrorClearView {
+  _errors: Map<string, { key: string; code: string }>;
+  _onValueChange(e: CustomEvent): void;
+}
+
+const changeEvent = (path: string[], value: unknown) =>
+  new CustomEvent("value-change", { detail: { path, value } });
+
+describe("esphome-add-component-form error clearing", () => {
+  it("clears per-item keys under the edited field path", () => {
+    const form = new ESPHomeAddComponentForm() as unknown as ErrorClearView;
+    form._errors = new Map([
+      ["codes.0", { key: "codes.0", code: "validation.not_a_number" }],
+      ["codes.1", { key: "codes.1", code: "validation.max" }],
+      ["other", { key: "other", code: "validation.required" }],
+    ]);
+
+    form._onValueChange(changeEvent(["codes"], [3, 5]));
+
+    expect(form._errors.has("codes.0")).toBe(false);
+    expect(form._errors.has("codes.1")).toBe(false);
+    expect(form._errors.has("other")).toBe(true);
+  });
+
+  it("does not clear a sibling whose key shares a prefix string", () => {
+    const form = new ESPHomeAddComponentForm() as unknown as ErrorClearView;
+    form._errors = new Map([
+      ["codes_extra", { key: "codes_extra", code: "validation.required" }],
+    ]);
+
+    form._onValueChange(changeEvent(["codes"], [3]));
+
+    expect(form._errors.has("codes_extra")).toBe(true);
+  });
+});

--- a/test/components/device/config-entry-render-filter.test.ts
+++ b/test/components/device/config-entry-render-filter.test.ts
@@ -944,3 +944,17 @@ describe("renderFilterOptions board-implied variant seeding", () => {
     expect(sramVisible(source({ board: null, values: { variant: "ESP32" } }))).toBe(true);
   });
 });
+
+describe("collectRenderablePaths — scalar multi_value index paths (#1348)", () => {
+  it("emits an index path per rendered row so per-item errors count as visible", () => {
+    const entries = [
+      makeEntry({ key: "codes", type: ConfigEntryType.INTEGER, multi_value: true }),
+    ];
+    const paths = collectRenderablePaths(
+      entries,
+      { codes: [3, "abc"] },
+      { requiredOnly: false, showAdvanced: false }
+    );
+    expect([...paths].sort()).toEqual(["codes", "codes.0", "codes.1"]);
+  });
+});

--- a/test/components/device/render-multi-value-field.test.ts
+++ b/test/components/device/render-multi-value-field.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from "vitest";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { renderMultiValueField } from "../../../src/components/device/config-entry-renderers.js";
+import { findTemplatesByAnchor } from "../../_lit-template-walker.js";
 import { findElementBindings, makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
 
 function fireInput(binding: Record<string, unknown>, value: string): void {
@@ -100,5 +101,39 @@ describe("renderMultiValueField numeric substitution rows", () => {
 
     fireInput(inputs[1], "7");
     expect(ctx.emitChange).toHaveBeenCalledWith(["field"], ["${ch}", 7]);
+  });
+});
+
+describe("renderMultiValueField per-row errors", () => {
+  // #1348: item errors land at ``field.<idx>``; only the offending row is
+  // flagged and explained, siblings stay clean. The class binding is
+  // mid-attribute (walker skips it by name), so assert on each row
+  // template's expression values.
+  const rowsOf = (tpl: unknown) => findTemplatesByAnchor(tpl, "multi-row");
+
+  it("flags and explains only the row whose path carries the error", () => {
+    const ctx = makeRenderCtx({ field: ["abc", 5] });
+    ctx.errorAt = (path: string[]) =>
+      path.join(".") === "field.0"
+        ? { key: "field.0", code: "validation.not_a_number" }
+        : null;
+    const tpl = renderMultiValueField(makeEntry(ConfigEntryType.INTEGER), ["field"], ctx);
+    const rows = rowsOf(tpl);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].values).toContain("invalid");
+    expect(rows[1].values).not.toContain("invalid");
+    expect(JSON.stringify(rows[0].values)).toContain("validation.not_a_number");
+  });
+
+  it("a field-level error still paints every row", () => {
+    const ctx = makeRenderCtx({ field: [1, 2] });
+    ctx.errorAt = (path: string[]) =>
+      path.join(".") === "field" ? { key: "field", code: "validation.required" } : null;
+    const tpl = renderMultiValueField(makeEntry(ConfigEntryType.INTEGER), ["field"], ctx);
+    const rows = rowsOf(tpl);
+
+    expect(rows[0].values).toContain("invalid");
+    expect(rows[1].values).toContain("invalid");
   });
 });

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -860,7 +860,7 @@ describe("validateEntries — scalar multi_value lists (#1348)", () => {
   });
 
   it("walks a required entry's array default per item, not stringified", () => {
-    const entry = intList({ required: true, default_value: [3, 5] as never });
+    const entry = intList({ required: true, default_value: [3, 5] });
     expect(validateEntries([entry], {}).size).toBe(0);
   });
 

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { ConfigValueOption } from "../../src/api/types/config-entries.js";
 import { ConfigEntryType } from "../../src/api/types/config-entries.js";
 import {
+  clearPathErrors,
   getDeviceNameWarning,
   isEntryVisible,
   nearCanonicalOption,
@@ -887,5 +888,24 @@ describe("validateEntries — multi_value lists the form can't itemize", () => {
       hidden: true,
     });
     expect(validateEntries([entry], { codes: [] }).size).toBe(0);
+  });
+});
+
+describe("clearPathErrors", () => {
+  const errs = () =>
+    new Map([
+      ["codes", { key: "codes", code: "validation.required" }],
+      ["codes.0", { key: "codes.0", code: "validation.not_a_number" }],
+      ["codes_extra", { key: "codes_extra", code: "validation.required" }],
+    ]);
+
+  it("clears the key and its per-item descendants, not prefix-string siblings", () => {
+    const next = clearPathErrors(errs(), "codes");
+    expect(next).not.toBeNull();
+    expect([...next!.keys()]).toEqual(["codes_extra"]);
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(clearPathErrors(errs(), "other")).toBeNull();
   });
 });

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -859,6 +859,11 @@ describe("validateEntries — scalar multi_value lists (#1348)", () => {
     expect(validateEntries([required], { codes: [3, ""] }).size).toBe(0);
   });
 
+  it("walks a required entry's array default per item, not stringified", () => {
+    const entry = intList({ required: true, default_value: [3, 5] as never });
+    expect(validateEntries([entry], {}).size).toBe(0);
+  });
+
   it("flags a required list holding only blank rows", () => {
     const required = intList({ required: true });
     expect(validateEntries([required], { codes: ["", ""] }).get("codes")?.code).toBe(

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -846,7 +846,7 @@ describe("validateEntries — scalar multi_value lists (#1348)", () => {
     expect(errors.has("codes.0")).toBe(false);
   });
 
-  it("flags a bad single-item list (String([v]) no longer masks the walk)", () => {
+  it("keys a single-item list's error at index 0", () => {
     const errors = validateEntries([intList()], { codes: ["abc"] });
     expect(errors.get("codes.0")?.code).toBe("validation.not_a_number");
   });
@@ -871,6 +871,11 @@ describe("validateEntries — scalar multi_value lists (#1348)", () => {
     );
     expect(validateEntries([intList()], { codes: ["", ""] }).size).toBe(0);
   });
+
+  it("never blocks on a hidden list of blank rows", () => {
+    const entry = intList({ required: true, hidden: true });
+    expect(validateEntries([entry], { codes: ["", ""] }).size).toBe(0);
+  });
 });
 
 describe("validateEntries — multi_value lists the form can't itemize", () => {
@@ -882,17 +887,6 @@ describe("validateEntries — multi_value lists the form can't itemize", () => {
     });
     const errors = validateEntries([entry], { segments: [{ from: 1 }, { from: 2 }] });
     expect(errors.size).toBe(0);
-  });
-
-  it("honours the hidden-field rule for an empty required list", () => {
-    const entry = makeEntry({
-      key: "codes",
-      type: ConfigEntryType.INTEGER,
-      multi_value: true,
-      required: true,
-      hidden: true,
-    });
-    expect(validateEntries([entry], { codes: [] }).size).toBe(0);
   });
 });
 

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -858,3 +858,26 @@ describe("validateEntries — scalar multi_value lists (#1348)", () => {
     expect(validateEntries([required], { codes: [3, ""] }).size).toBe(0);
   });
 });
+
+describe("validateEntries — multi_value lists the form can't itemize", () => {
+  it("skips per-item checks for a list of mappings (YAML-only shape)", () => {
+    const entry = makeEntry({
+      key: "segments",
+      type: ConfigEntryType.INTEGER,
+      multi_value: true,
+    });
+    const errors = validateEntries([entry], { segments: [{ from: 1 }, { from: 2 }] });
+    expect(errors.size).toBe(0);
+  });
+
+  it("honours the hidden-field rule for an empty required list", () => {
+    const entry = makeEntry({
+      key: "codes",
+      type: ConfigEntryType.INTEGER,
+      multi_value: true,
+      required: true,
+      hidden: true,
+    });
+    expect(validateEntries([entry], { codes: [] }).size).toBe(0);
+  });
+});

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -857,6 +857,14 @@ describe("validateEntries — scalar multi_value lists (#1348)", () => {
     );
     expect(validateEntries([required], { codes: [3, ""] }).size).toBe(0);
   });
+
+  it("flags a required list holding only blank rows", () => {
+    const required = intList({ required: true });
+    expect(validateEntries([required], { codes: ["", ""] }).get("codes")?.code).toBe(
+      "validation.required"
+    );
+    expect(validateEntries([intList()], { codes: ["", ""] }).size).toBe(0);
+  });
 });
 
 describe("validateEntries — multi_value lists the form can't itemize", () => {

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -815,3 +815,46 @@ describe("platformSupported", () => {
     expect(platformSupported(["esp32", "esp8266"], "esp8266")).toBe(true);
   });
 });
+
+describe("validateEntries — scalar multi_value lists (#1348)", () => {
+  const intList = (extra: Record<string, unknown> = {}) =>
+    makeEntry({
+      key: "codes",
+      type: ConfigEntryType.INTEGER,
+      multi_value: true,
+      ...extra,
+    });
+
+  it("passes a list of valid integers", () => {
+    expect(validateEntries([intList()], { codes: [3, 5] }).size).toBe(0);
+  });
+
+  it("flags only the offending item, keyed by index", () => {
+    const errors = validateEntries([intList()], { codes: ["abc", 5] });
+    expect(errors.size).toBe(1);
+    expect(errors.get("codes.0")?.code).toBe("validation.not_a_number");
+  });
+
+  it("skips a ${var} item (resolves at build time)", () => {
+    expect(validateEntries([intList()], { codes: ["${ch}", 5] }).size).toBe(0);
+  });
+
+  it("range-checks per item", () => {
+    const errors = validateEntries([intList({ range: [0, 31] })], { codes: [10, 300] });
+    expect(errors.get("codes.1")?.code).toBe("validation.max");
+    expect(errors.has("codes.0")).toBe(false);
+  });
+
+  it("flags a bad single-item list (String([v]) no longer masks the walk)", () => {
+    const errors = validateEntries([intList()], { codes: ["abc"] });
+    expect(errors.get("codes.0")?.code).toBe("validation.not_a_number");
+  });
+
+  it("keeps required-empty at the field path and skips blank rows", () => {
+    const required = intList({ required: true });
+    expect(validateEntries([required], { codes: [] }).get("codes")?.code).toBe(
+      "validation.required"
+    );
+    expect(validateEntries([required], { codes: [3, ""] }).size).toBe(0);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

`validateEntry` had no scalar `multi_value` handling, so a populated numeric list was validated as one value: the whole array reached the INTEGER branch, stringified to `"3,5"`, and the field flagged `validation.not_a_number` for any multi item numeric list, valid literals included. `String([3])` masks single item lists, so the error confusingly appeared only once a second (valid) row was added, and the `${var}` skip never fired for arrays, so the reference rows #1347 makes editable sat in a red field.

`_validateEntriesRecursive` now walks scalar `multi_value` arrays per item, mirroring the NESTED item walk: each item gets the full scalar rulebook (numeric parsing, ranges, options, the substitution skip) with an array index path segment (`codes.0`), a blank row is treated as mid edit rather than an error, and required plus empty stays one error at the field path. Non array values (the bare scalar `cv.ensure_list` accepts, an unset field, a `YamlRawValue` block) keep the generic field level path. The list renderer reads the per item errors: only the offending row gets the `invalid` class and an inline message; a field level error still paints every row. Verified in the live editor: a list holding `${glyph_row}` plus literals shows no error, and planting `abc` in one row flags just that row with "Must be a number".

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1348

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
