### PR TITLE
Mirror the single-value numeric widgets in list rows

### DIFF
--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -1066,6 +1066,13 @@ export class ESPHomeConfigEntryForm extends LitElement {
       clearEditingMagnitude: (path) => {
         this._editingMagnitudes.delete(path.join("."));
       },
+      clearEditingMagnitudesUnder: (path) => {
+        const key = path.join(".");
+        const prefix = `${key}.`;
+        for (const k of [...this._editingMagnitudes.keys()]) {
+          if (k === key || k.startsWith(prefix)) this._editingMagnitudes.delete(k);
+        }
+      },
       getClusterChoice: (clusterId) => this._constraintClusters.getChoice(clusterId),
       setClusterChoice: (clusterId, altId) =>
         this._constraintClusters.setChoice(clusterId, altId),

--- a/src/components/device/config-entry-renderers-types.ts
+++ b/src/components/device/config-entry-renderers-types.ts
@@ -103,6 +103,10 @@ export interface RenderCtx {
   getEditingMagnitude: (path: string[]) => string | undefined;
   setEditingMagnitude: (path: string[], text: string) => void;
   clearEditingMagnitude: (path: string[]) => void;
+  /** Drop every edit buffer at or under *path*. List-row buffers embed the
+   *  row index, so removing a row must invalidate them — the indices shift
+   *  and an un-blurred buffer would paint (and commit) over the wrong row. */
+  clearEditingMagnitudesUnder: (path: string[]) => void;
   /**
    * Either/or constraint cluster (radio chooser) UI state, off-config like
    * the unit/magnitude stashes above. ``ClusterChoice`` is the selected

--- a/src/components/device/config-entry-renderers-types.ts
+++ b/src/components/device/config-entry-renderers-types.ts
@@ -92,13 +92,12 @@ export interface RenderCtx {
   getPendingUnit: (path: string[]) => string | undefined;
   setPendingUnit: (path: string[], unit: string) => void;
   /**
-   * FLOAT_WITH_UNIT-only: transient editing buffer for the numeric
-   * input. `<input type="number">` reads `""` from `.value` while
-   * the user is typing intermediate states (`"-"`, `"1e"`, `"1."`),
-   * which would round-trip through serialize and reset the field
-   * mid-typing. Renderers stash the raw text here and read it on
-   * the next paint so partial input survives until the user types a
-   * parseable value (or blurs the field).
+   * Transient editing buffer for numeric inputs (float-with-unit, int,
+   * hex, and INTEGER list rows). Committing an intermediate typing state
+   * (`"-"`, `"1e"`, `"0042"`) would round-trip through serialize and
+   * reset or reformat the field mid-typing. Renderers stash the raw text
+   * here and read it on the next paint so partial input survives until
+   * the user types a parseable value (or blurs the field).
    */
   getEditingMagnitude: (path: string[]) => string | undefined;
   setEditingMagnitude: (path: string[], text: string) => void;

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -3,7 +3,6 @@ import { isLambdaValue } from "../../../api/types/automations.js";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../../api/types/config-entries.js";
 import { asMappingList, isPrimitiveOrNullish } from "../../../util/nested-values.js";
-import { isSubstitutionString } from "../../../util/substitutions.js";
 import { escapeForInput, unescapeForInput } from "../../../util/yaml-escape.js";
 import { YamlRawValue } from "../../../util/yaml-serialize.js";
 import {
@@ -106,13 +105,12 @@ export function renderMultiValueField(
   // must stay unconditional too — a freshly added row is empty, so a typed
   // ``\U…`` has to decode without a prior escape-worthy value to gate on.
   // INTEGER / FLOAT lists (lcd user-characters data, microphone channels,
-  // ...) get number inputs and coerce each item back to a number on edit, so
-  // the YAML serializer emits them unquoted; numeric items are plain
-  // stringified numbers and skip the glyph escaping above. Hex-display
-  // integers (modbus custom_command, sync_value) stay text: <input
-  // type="number"> rejects 0x.. literals and Number("0x76") would both lose
-  // the canonical hex form and overflow 64-bit values, same reason the
-  // single-value number renderer hands hex off to its own text parser.
+  // ...) coerce each item back to a number on edit, so the YAML serializer
+  // emits them unquoted; numeric items are plain stringified numbers and
+  // skip the glyph escaping above. Hex-display integers (modbus
+  // custom_command, sync_value) stay on the text path with hex kept
+  // verbatim, same reason the single-value number renderer hands hex off
+  // to its own text parser.
   const numeric =
     (entry.type === ConfigEntryType.INTEGER || entry.type === ConfigEntryType.FLOAT) &&
     entry.display_format !== "hex";
@@ -140,30 +138,46 @@ export function renderMultiValueField(
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)} ${renderListEmptyHint(items, ctx)}
       ${items.map((item, i) => {
-        // A ${var} item can't drive a number input (the browser blanks a
-        // non-numeric value); edit it as text so the reference round-trips.
-        const rowNumeric = numeric && !isSubstitutionString(raw[i]);
+        // Row widget mirrors the single-value renderers (#1349): INTEGER
+        // rows are text — a number input can't show the 0x literals,
+        // >2^53 decimals, or ${var} references cv.int_ accepts, and
+        // blanks-then-clobbers them. FLOAT rows keep the native spinner
+        // except when the stored value is a non-finite string (junk or a
+        // ${var} reference), which edits as text with its per-item error.
+        const rowNumeric =
+          numeric &&
+          entry.type === ConfigEntryType.FLOAT &&
+          (raw[i] == null || Number.isFinite(Number(String(raw[i]))));
+        const intRow = numeric && entry.type === ConfigEntryType.INTEGER;
         // Errors land per item (``field.0``, #1348); flag and explain only
         // the offending row. The field-level ``invalid`` stays for errors
         // keyed at the field itself (required-empty).
         const rowPath = [...path, String(i)];
         const rowInvalid = invalid || ctx.errorAt(rowPath) !== null;
+        // INTEGER rows keep raw keystrokes on screen while typing so the
+        // committed value's reformatting (``0042`` → ``42``) doesn't
+        // fight the cursor; the buffer clears on blur (renderIntField's
+        // discipline).
+        const display = intRow ? (ctx.getEditingMagnitude(rowPath) ?? item) : item;
         return html`
           <div class="multi-row">
             <div class="multi-value-cell">
               <input
                 type=${rowNumeric ? "number" : "text"}
-                step=${
-                  rowNumeric
-                    ? entry.type === ConfigEntryType.FLOAT
-                      ? "any"
-                      : "1"
-                    : nothing
-                }
+                autocomplete="off"
+                spellcheck="false"
+                step=${rowNumeric ? "any" : nothing}
                 class="multi-input ${rowInvalid ? "invalid" : ""}"
-                .value=${item}
+                .value=${display}
                 ?disabled=${disabled}
-                @input=${(e: Event) => updateAt(i, (e.target as HTMLInputElement).value)}
+                @input=${(e: Event) => {
+                  const value = (e.target as HTMLInputElement).value;
+                  if (intRow) ctx.setEditingMagnitude(rowPath, value);
+                  updateAt(i, value);
+                }}
+                @blur=${() => {
+                  if (intRow) ctx.clearEditingMagnitude(rowPath);
+                }}
               />
               ${
                 // Resolve against the stored value, not the escaped display

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -32,11 +32,16 @@ function arrayItemHandlers(
   path: string[],
   makeNewItem: () => unknown
 ): { addItem: () => void; removeAt: (idx: number) => void } {
-  const removeAt = (idx: number) =>
+  const removeAt = (idx: number) => {
+    // Row edit buffers are keyed by index; a removal shifts the indices,
+    // so an un-blurred buffer would paint (and commit) over the row that
+    // slides into its slot.
+    ctx.clearEditingMagnitudesUnder(path);
     ctx.emitChange(
       path,
       readArrayAt(ctx, path).filter((_, i) => i !== idx)
     );
+  };
   const addItem = () => ctx.emitChange(path, [...readArrayAt(ctx, path), makeNewItem()]);
   return { addItem, removeAt };
 }
@@ -114,6 +119,8 @@ export function renderMultiValueField(
   const numeric =
     (entry.type === ConfigEntryType.INTEGER || entry.type === ConfigEntryType.FLOAT) &&
     entry.display_format !== "hex";
+  const intList = numeric && entry.type === ConfigEntryType.INTEGER;
+  const floatList = numeric && entry.type === ConfigEntryType.FLOAT;
   const items: string[] = numeric
     ? raw.map((v) => String(v ?? ""))
     : raw.map((v) => escapeForInput(String(v)));
@@ -138,27 +145,22 @@ export function renderMultiValueField(
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)} ${renderListEmptyHint(items, ctx)}
       ${items.map((item, i) => {
-        // Row widget mirrors the single-value renderers (#1349): INTEGER
+        // Row widgets match the single-value renderers (#1349): INTEGER
         // rows are text — a number input can't show the 0x literals,
         // >2^53 decimals, or ${var} references cv.int_ accepts, and
         // blanks-then-clobbers them. FLOAT rows keep the native spinner
         // except when the stored value is a non-finite string (junk or a
         // ${var} reference), which edits as text with its per-item error.
         const rowNumeric =
-          numeric &&
-          entry.type === ConfigEntryType.FLOAT &&
-          (raw[i] == null || Number.isFinite(Number(String(raw[i]))));
-        const intRow = numeric && entry.type === ConfigEntryType.INTEGER;
+          floatList && (raw[i] == null || Number.isFinite(Number(String(raw[i]))));
         // Errors land per item (``field.0``, #1348); flag and explain only
         // the offending row. The field-level ``invalid`` stays for errors
         // keyed at the field itself (required-empty).
         const rowPath = [...path, String(i)];
         const rowInvalid = invalid || ctx.errorAt(rowPath) !== null;
-        // INTEGER rows keep raw keystrokes on screen while typing so the
-        // committed value's reformatting (``0042`` → ``42``) doesn't
-        // fight the cursor; the buffer clears on blur (renderIntField's
-        // discipline).
-        const display = intRow ? (ctx.getEditingMagnitude(rowPath) ?? item) : item;
+        // Edit buffer keeps raw keystrokes on screen while typing;
+        // clears on blur.
+        const display = intList ? (ctx.getEditingMagnitude(rowPath) ?? item) : item;
         return html`
           <div class="multi-row">
             <div class="multi-value-cell">
@@ -172,11 +174,11 @@ export function renderMultiValueField(
                 ?disabled=${disabled}
                 @input=${(e: Event) => {
                   const value = (e.target as HTMLInputElement).value;
-                  if (intRow) ctx.setEditingMagnitude(rowPath, value);
+                  if (intList) ctx.setEditingMagnitude(rowPath, value);
                   updateAt(i, value);
                 }}
                 @blur=${() => {
-                  if (intRow) ctx.clearEditingMagnitude(rowPath);
+                  if (intList) ctx.clearEditingMagnitude(rowPath);
                 }}
               />
               ${

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -149,10 +149,15 @@ export function renderMultiValueField(
         // rows are text — a number input can't show the 0x literals,
         // >2^53 decimals, or ${var} references cv.int_ accepts, and
         // blanks-then-clobbers them. FLOAT rows keep the native spinner
-        // except when the stored value is a non-finite string (junk or a
-        // ${var} reference), which edits as text with its per-item error.
+        // for stored finite numbers; empty rows and non-finite strings
+        // (junk or a ${var} reference) edit as text, so a reference is
+        // typeable into a fresh row and the row turns numeric once a
+        // finite value is committed.
         const rowNumeric =
-          floatList && (raw[i] == null || Number.isFinite(Number(String(raw[i]))));
+          floatList &&
+          raw[i] != null &&
+          raw[i] !== "" &&
+          Number.isFinite(Number(String(raw[i])));
         // Errors land per item (``field.0``, #1348); flag and explain only
         // the offending row. The field-level ``invalid`` stays for errors
         // keyed at the field itself (required-empty).

--- a/test/components/device/_renderer-fixtures.ts
+++ b/test/components/device/_renderer-fixtures.ts
@@ -118,6 +118,7 @@ export function makeRenderCtx(
     getEditingMagnitude: () => undefined,
     setEditingMagnitude: vi.fn(),
     clearEditingMagnitude: vi.fn(),
+    clearEditingMagnitudesUnder: vi.fn(),
     reactiveConstraintKeys: new Set<string>(),
     getClusterChoice: () => undefined,
     setClusterChoice: vi.fn(),

--- a/test/components/device/render-multi-value-field.test.ts
+++ b/test/components/device/render-multi-value-field.test.ts
@@ -39,6 +39,15 @@ describe("renderMultiValueField numeric coercion", () => {
     expect(inputs[0][".value"]).toBe("0x10");
     fireInput(inputs[0], "0x20");
     expect(ctx.emitChange).toHaveBeenCalledWith(["field"], ["0x20", "9007199254740993"]);
+
+    // Editing the 64-bit row itself commits the string, never a rounded
+    // double (the Number.isSafeInteger guard in coerceIntFieldValue).
+    expect(inputs[1][".value"]).toBe("9007199254740993");
+    fireInput(inputs[1], "18446744073709551615");
+    expect(ctx.emitChange).toHaveBeenCalledWith(
+      ["field"],
+      ["0x10", "18446744073709551615"]
+    );
   });
 
   it("routes INTEGER row edits through the editing buffer", () => {

--- a/test/components/device/render-multi-value-field.test.ts
+++ b/test/components/device/render-multi-value-field.test.ts
@@ -1,10 +1,11 @@
 /**
  * Targeted tests for renderMultiValueField numeric handling.
  *
- * INTEGER / FLOAT lists (remote_receiver raw codes via the backend,
- * modbus custom_command, lcd user-characters data) must render number
- * inputs and coerce edits back to numbers, so the YAML serializer emits
- * them unquoted; STRING lists keep text inputs and string values.
+ * INTEGER lists render text rows (0x literals, >2^53 decimals, and
+ * ${var} references must display and stay typeable, #1349); FLOAT lists
+ * keep number spinners on finite rows. Edits coerce back to numbers so
+ * the YAML serializer emits them unquoted; STRING lists keep text
+ * inputs and string values.
  */
 import { describe, expect, it } from "vitest";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
@@ -48,6 +49,30 @@ describe("renderMultiValueField numeric coercion", () => {
     fireInput(inputs[0], "0042");
     expect(ctx.setEditingMagnitude).toHaveBeenCalledWith(["field", "0"], "0042");
     expect(ctx.emitChange).toHaveBeenCalledWith(["field"], [42]);
+
+    (inputs[0]["@blur"] as () => void)();
+    expect(ctx.clearEditingMagnitude).toHaveBeenCalledWith(["field", "0"]);
+  });
+
+  it("shows the edit buffer verbatim while it is set", () => {
+    const ctx = makeRenderCtx(
+      { field: [42] },
+      { overrides: { getEditingMagnitude: () => "0042" } }
+    );
+    const tpl = renderMultiValueField(makeEntry(ConfigEntryType.INTEGER), ["field"], ctx);
+    const inputs = findElementBindings(tpl, "input");
+
+    expect(inputs[0][".value"]).toBe("0042");
+  });
+
+  it("invalidates row edit buffers when a row is removed", () => {
+    const ctx = makeRenderCtx({ field: [1, 2] });
+    const tpl = renderMultiValueField(makeEntry(ConfigEntryType.INTEGER), ["field"], ctx);
+    const removeButtons = findElementBindings(tpl, "button");
+
+    (removeButtons[0]["@click"] as () => void)();
+    expect(ctx.clearEditingMagnitudesUnder).toHaveBeenCalledWith(["field"]);
+    expect(ctx.emitChange).toHaveBeenCalledWith(["field"], [2]);
   });
 
   it("keeps FLOAT literal rows on the number spinner, junk rows on text", () => {
@@ -58,6 +83,9 @@ describe("renderMultiValueField numeric coercion", () => {
     expect(inputs[0].type).toBe("number");
     expect(inputs[1].type).toBe("text");
     expect(inputs[1][".value"]).toBe("abc");
+
+    fireInput(inputs[1], "xyz");
+    expect(ctx.emitChange).toHaveBeenCalledWith(["field"], [1.5, "xyz"]);
   });
 
   it("uses step=any for a FLOAT list", () => {

--- a/test/components/device/render-multi-value-field.test.ts
+++ b/test/components/device/render-multi-value-field.test.ts
@@ -88,6 +88,16 @@ describe("renderMultiValueField numeric coercion", () => {
     expect(ctx.emitChange).toHaveBeenCalledWith(["field"], [1.5, "xyz"]);
   });
 
+  it("renders a fresh empty FLOAT row as text so a reference is typeable", () => {
+    const ctx = makeRenderCtx({ field: [""] });
+    const tpl = renderMultiValueField(makeEntry(ConfigEntryType.FLOAT), ["field"], ctx);
+    const inputs = findElementBindings(tpl, "input");
+
+    expect(inputs[0].type).toBe("text");
+    fireInput(inputs[0], "${gain}");
+    expect(ctx.emitChange).toHaveBeenCalledWith(["field"], ["${gain}"]);
+  });
+
   it("uses step=any for a FLOAT list", () => {
     const ctx = makeRenderCtx({ field: [1.5] });
     const tpl = renderMultiValueField(makeEntry(ConfigEntryType.FLOAT), ["field"], ctx);

--- a/test/components/device/render-multi-value-field.test.ts
+++ b/test/components/device/render-multi-value-field.test.ts
@@ -17,16 +17,47 @@ function fireInput(binding: Record<string, unknown>, value: string): void {
 }
 
 describe("renderMultiValueField numeric coercion", () => {
-  it("renders number inputs and emits numbers for an INTEGER list", () => {
+  it("renders text inputs and emits numbers for an INTEGER list", () => {
+    // Text, not number: mirrors renderIntField (#1349) so 0x literals,
+    // >2^53 decimals, and ${var} references display and stay typeable.
     const ctx = makeRenderCtx({ field: [1, 2] });
     const tpl = renderMultiValueField(makeEntry(ConfigEntryType.INTEGER), ["field"], ctx);
     const inputs = findElementBindings(tpl, "input");
 
-    expect(inputs[0].type).toBe("number");
-    expect(inputs[0].step).toBe("1");
+    expect(inputs[0].type).toBe("text");
 
     fireInput(inputs[1], "5");
     expect(ctx.emitChange).toHaveBeenCalledWith(["field"], [1, 5]);
+  });
+
+  it("keeps 0x literals and >2^53 decimals verbatim in INTEGER rows", () => {
+    const ctx = makeRenderCtx({ field: ["0x10", "9007199254740993"] });
+    const tpl = renderMultiValueField(makeEntry(ConfigEntryType.INTEGER), ["field"], ctx);
+    const inputs = findElementBindings(tpl, "input");
+
+    expect(inputs[0][".value"]).toBe("0x10");
+    fireInput(inputs[0], "0x20");
+    expect(ctx.emitChange).toHaveBeenCalledWith(["field"], ["0x20", "9007199254740993"]);
+  });
+
+  it("routes INTEGER row edits through the editing buffer", () => {
+    const ctx = makeRenderCtx({ field: [42] });
+    const tpl = renderMultiValueField(makeEntry(ConfigEntryType.INTEGER), ["field"], ctx);
+    const inputs = findElementBindings(tpl, "input");
+
+    fireInput(inputs[0], "0042");
+    expect(ctx.setEditingMagnitude).toHaveBeenCalledWith(["field", "0"], "0042");
+    expect(ctx.emitChange).toHaveBeenCalledWith(["field"], [42]);
+  });
+
+  it("keeps FLOAT literal rows on the number spinner, junk rows on text", () => {
+    const ctx = makeRenderCtx({ field: [1.5, "abc"] });
+    const tpl = renderMultiValueField(makeEntry(ConfigEntryType.FLOAT), ["field"], ctx);
+    const inputs = findElementBindings(tpl, "input");
+
+    expect(inputs[0].type).toBe("number");
+    expect(inputs[1].type).toBe("text");
+    expect(inputs[1][".value"]).toBe("abc");
   });
 
   it("uses step=any for a FLOAT list", () => {
@@ -75,9 +106,9 @@ describe("renderMultiValueField numeric substitution rows", () => {
   // esphome/device-builder-frontend#1346: a ${var} item can't drive a number
   // input (the browser blanks it) and Number() on edit clobbered the
   // reference. The row edits as text and round-trips the string.
-  it("renders the ${var} row as text while sibling literals stay numeric", () => {
+  it("renders a FLOAT ${var} row as text while sibling literals stay numeric", () => {
     const ctx = makeRenderCtx({ field: ["${ch}", 5] });
-    const tpl = renderMultiValueField(makeEntry(ConfigEntryType.INTEGER), ["field"], ctx);
+    const tpl = renderMultiValueField(makeEntry(ConfigEntryType.FLOAT), ["field"], ctx);
     const inputs = findElementBindings(tpl, "input");
 
     expect(inputs[0].type).toBe("text");


### PR DESCRIPTION
# What does this implement/fix?

Numeric multi value list rows used `<input type="number">` per row, while the single value INTEGER renderer deliberately uses text plus `coerceIntFieldValue` because a number input cannot represent everything `cv.int_` accepts. That left list rows with the blank and clobber class #1347 fixed only for substitutions: an `abc` or `50Hz` row, a `0x10` literal in a non hex INTEGER list, and >2^53 decimals all blanked in the number input and the first keystroke overwrote them, and a `${var}` reference could not be typed into a fresh row at all.

INTEGER rows now render as text and reuse the editing magnitude buffer so commit time reformatting (`0042` to `42`) does not fight the cursor; FLOAT rows keep the native spinner except when the stored item is a non finite string (junk or a reference), which edits as text with its per item error from #1348. The write side was already correct via `coerceValueToEntryType`. The per row substitution gate from #1347 is subsumed by the finite check. Removing a row now also invalidates the index keyed edit buffers; without that, on browsers that do not blur on button click (Safari, Firefox on macOS) a mid edit removal painted, and could commit, a stale buffer over the row that shifted into its slot; the same fix retires the identical pre existing hazard for nested list numeric children.

One deliberate divergence from the single value renderers: a non finite FLOAT row edits as text instead of the read only YAML only shell, since a per row read only shell would strand the user while the per item error already explains the problem inline.

Verified in the live editor: an `lcd_pcf8574` `user_characters.data` list renders every row as editable text, a `0x10` edit displays and round trips to unquoted hex in the YAML, and the `${glyph_row}` reference stays editable with its resolved hint. Editing a row rewrites sibling literals as quoted strings; that is a pre existing serializer behaviour reproduced byte for byte on main and out of scope here.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1349

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
