### PR TITLE
Ship unparseable FLOAT values verbatim from the add-component coercer

### DIFF
--- a/src/components/device/add-component-form-coerce.ts
+++ b/src/components/device/add-component-form-coerce.ts
@@ -55,9 +55,13 @@ export function coerceFields(
       // Strict coercion: unparseable input (a ${var} reference, junk like
       // "50Hz") ships verbatim so the backend flags it — parseFloat's
       // prefix parsing silently rewrote "50Hz" to 50, and the NaN branch
-      // silently dropped the field from the payload (#1350).
+      // silently dropped the field from the payload (#1350). Non-finite
+      // numbers (a typed 1e309 becomes Infinity) stringify too: JSON has
+      // no Infinity/NaN and they'd ship as null.
       out[entry.key] =
-        typeof raw === "number" ? raw : coerceValueToEntryType(entry, String(raw));
+        typeof raw === "number" && Number.isFinite(raw)
+          ? raw
+          : coerceValueToEntryType(entry, String(raw));
     } else if (entry.type === ConfigEntryType.BOOLEAN) {
       out[entry.key] = parseYamlBoolean(raw) === true;
     } else {

--- a/src/components/device/add-component-form-coerce.ts
+++ b/src/components/device/add-component-form-coerce.ts
@@ -1,5 +1,6 @@
 import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../api/types/config-entries.js";
+import { coerceValueToEntryType } from "../../util/coerce-entry-value.js";
 import { coerceIntFieldValue } from "../../util/int-input.js";
 import { asMappingList, asRecord } from "../../util/nested-values.js";
 import { parseYamlBoolean } from "../../util/yaml-serialize.js";
@@ -51,8 +52,12 @@ export function coerceFields(
     if (entry.type === ConfigEntryType.INTEGER && entry.display_format !== "hex") {
       out[entry.key] = coerceIntFieldValue(raw);
     } else if (entry.type === ConfigEntryType.FLOAT) {
-      const n = typeof raw === "number" ? raw : Number.parseFloat(String(raw));
-      if (!Number.isNaN(n)) out[entry.key] = n;
+      // Strict coercion: unparseable input (a ${var} reference, junk like
+      // "50Hz") ships verbatim so the backend flags it — parseFloat's
+      // prefix parsing silently rewrote "50Hz" to 50, and the NaN branch
+      // silently dropped the field from the payload (#1350).
+      out[entry.key] =
+        typeof raw === "number" ? raw : coerceValueToEntryType(entry, String(raw));
     } else if (entry.type === ConfigEntryType.BOOLEAN) {
       out[entry.key] = parseYamlBoolean(raw) === true;
     } else {

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -27,7 +27,7 @@ import {
 } from "../../util/api-encryption-key.js";
 import { stripConstraintProse } from "../../util/constraint-groups.js";
 import { resolveEntryLabel } from "../../util/entry-label.js";
-import { coerceIntFieldValue } from "../../util/int-input.js";
+import { coerceValueToEntryType } from "../../util/coerce-entry-value.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { isPrimitiveOrNullish } from "../../util/nested-values.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -97,22 +97,10 @@ export function effectiveDisabled(entry: ConfigEntry, ctx: RenderCtx): boolean {
   return ctx.disabled || entry.locked;
 }
 
-/**
- * Coerce a control's string value back to the entry's declared numeric
- * type before emitting. A wa-select / combo box always hands back a
- * string, but an INTEGER/FLOAT field's YAML must be a number or downstream
- * validation (and the backend's locked-value compare) rejects it. INTEGER
- * goes through ``coerceIntFieldValue`` so a >2^53 decimal stays a string
- * (64-bit precision, #378/#944) and a ``0x…`` literal isn't truncated.
- * Non-numeric entries, an empty string, and unparseable input pass through
- * unchanged so the inline validator can flag them.
- */
-export function coerceValueToEntryType(entry: ConfigEntry, raw: string): string | number {
-  if (entry.type === ConfigEntryType.INTEGER) return coerceIntFieldValue(raw);
-  if (entry.type !== ConfigEntryType.FLOAT || raw === "") return raw;
-  const n = Number(raw);
-  return Number.isFinite(n) ? n : raw;
-}
+// ``coerceValueToEntryType`` moved to ``util/coerce-entry-value.ts`` so
+// Lit-free modules (the add-component payload coercer) can share it;
+// re-exported to keep this module's long-standing import surface.
+export { coerceValueToEntryType };
 
 /** Serialize a field path into the ``data-field-key`` attribute. JSON
  *  (not ``path.join(".")``) so a user-supplied map key that itself

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -97,11 +97,6 @@ export function effectiveDisabled(entry: ConfigEntry, ctx: RenderCtx): boolean {
   return ctx.disabled || entry.locked;
 }
 
-// ``coerceValueToEntryType`` moved to ``util/coerce-entry-value.ts`` so
-// Lit-free modules (the add-component payload coercer) can share it;
-// re-exported to keep this module's long-standing import surface.
-export { coerceValueToEntryType };
-
 /** Serialize a field path into the ``data-field-key`` attribute. JSON
  *  (not ``path.join(".")``) so a user-supplied map key that itself
  *  contains a dot (a ``logger.logs`` row keyed ``i2c.idf``) survives

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -5,8 +5,8 @@ import { ConfigEntryType } from "../../../api/types/config-entries.js";
 import { asMappingList, isPrimitiveOrNullish } from "../../../util/nested-values.js";
 import { escapeForInput, unescapeForInput } from "../../../util/yaml-escape.js";
 import { YamlRawValue } from "../../../util/yaml-serialize.js";
+import { coerceValueToEntryType } from "../../../util/coerce-entry-value.js";
 import {
-  coerceValueToEntryType,
   effectiveDisabled,
   fieldKeyAttr,
   labelFor,

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -4,9 +4,9 @@ import { chipNameToVariant } from "../../../util/chip-variant.js";
 import { nearCanonicalOption } from "../../../util/config-validation.js";
 import { renderOptionStack } from "../../../util/option-stack.js";
 import { parseYamlBoolean, YamlRawValue } from "../../../util/yaml-serialize.js";
+import { coerceValueToEntryType } from "../../../util/coerce-entry-value.js";
 import type { OptionsComboboxValueChange } from "../../options-combobox-event.js";
 import {
-  coerceValueToEntryType,
   effectiveDisabled,
   fieldKeyAttr,
   labelFor,

--- a/src/util/coerce-entry-value.ts
+++ b/src/util/coerce-entry-value.ts
@@ -1,0 +1,20 @@
+import type { ConfigEntry } from "../api/types/config-entries.js";
+import { ConfigEntryType } from "../api/types/config-entries.js";
+import { coerceIntFieldValue } from "./int-input.js";
+
+/**
+ * Coerce a control's string value back to the entry's declared numeric
+ * type before emitting. A wa-select / combo box always hands back a
+ * string, but an INTEGER/FLOAT field's YAML must be a number or downstream
+ * validation (and the backend's locked-value compare) rejects it. INTEGER
+ * goes through ``coerceIntFieldValue`` so a >2^53 decimal stays a string
+ * (64-bit precision, #378/#944) and a ``0x…`` literal isn't truncated.
+ * Non-numeric entries, an empty string, and unparseable input pass through
+ * unchanged so the inline validator can flag them.
+ */
+export function coerceValueToEntryType(entry: ConfigEntry, raw: string): string | number {
+  if (entry.type === ConfigEntryType.INTEGER) return coerceIntFieldValue(raw);
+  if (entry.type !== ConfigEntryType.FLOAT || raw === "") return raw;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : raw;
+}

--- a/test/components/device/add-component-form-coerce.test.ts
+++ b/test/components/device/add-component-form-coerce.test.ts
@@ -135,6 +135,12 @@ describe("FLOAT coercion", () => {
 
   test("ships non-finite input verbatim instead of a JSON-null Infinity", () => {
     expect(coerceFields([gain], { gain: "Infinity" })).toEqual({ gain: "Infinity" });
+    // A number input accepts 1e309, so the stored value can be a numeric
+    // Infinity/NaN — those must stringify too, not JSON-serialize to null.
+    expect(coerceFields([gain], { gain: Number.POSITIVE_INFINITY })).toEqual({
+      gain: "Infinity",
+    });
+    expect(coerceFields([gain], { gain: Number.NaN })).toEqual({ gain: "NaN" });
   });
 
   test("coerces a 0x literal through strict Number, not parseFloat's 0", () => {

--- a/test/components/device/add-component-form-coerce.test.ts
+++ b/test/components/device/add-component-form-coerce.test.ts
@@ -132,4 +132,12 @@ describe("FLOAT coercion", () => {
     // and flag the real value.
     expect(coerceFields([gain], { gain: "50Hz" })).toEqual({ gain: "50Hz" });
   });
+
+  test("ships non-finite input verbatim instead of a JSON-null Infinity", () => {
+    expect(coerceFields([gain], { gain: "Infinity" })).toEqual({ gain: "Infinity" });
+  });
+
+  test("coerces a 0x literal through strict Number, not parseFloat's 0", () => {
+    expect(coerceFields([gain], { gain: "0x10" })).toEqual({ gain: 16 });
+  });
 });

--- a/test/components/device/add-component-form-coerce.test.ts
+++ b/test/components/device/add-component-form-coerce.test.ts
@@ -112,3 +112,24 @@ describe("coerceFields multi_value nested list (usb_uart channels)", () => {
     expect(coerceFields([channels], { channels: [{}] })).toEqual({});
   });
 });
+
+describe("FLOAT coercion", () => {
+  const gain = makeConfigEntry({ key: "gain", type: ConfigEntryType.FLOAT });
+
+  test("coerces a finite string to a number and passes numbers through", () => {
+    expect(coerceFields([gain], { gain: "1.5" })).toEqual({ gain: 1.5 });
+    expect(coerceFields([gain], { gain: 2.5 })).toEqual({ gain: 2.5 });
+  });
+
+  test("ships a ${var} reference verbatim instead of dropping the field", () => {
+    expect(coerceFields([gain], { gain: "${mic_gain}" })).toEqual({
+      gain: "${mic_gain}",
+    });
+  });
+
+  test("ships junk verbatim instead of prefix-parsing it", () => {
+    // parseFloat("50Hz") is 50 — a silent rewrite; the backend should see
+    // and flag the real value.
+    expect(coerceFields([gain], { gain: "50Hz" })).toEqual({ gain: "50Hz" });
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The add component payload coercer's FLOAT branch dropped the key entirely when `Number.parseFloat` yielded NaN, so a `${var}` reference or junk string in a FLOAT field silently vanished from the WS payload while the INTEGER branch preserved verbatim strings. It also prefix parsed, so `50Hz` silently became `50`, and `Infinity` shipped as a JSON null. Since #1352 made a typed reference reachable in FLOAT list rows, the silent drop was live.

The branch now routes through `coerceValueToEntryType`, the same strict contract the visual editor's emit paths already use: finite strings become numbers, numbers pass through, everything else ships verbatim so the backend flags the real value at validate time. The helper moved from the Lit heavy `config-entry-renderers-shared` module to a pure `util/coerce-entry-value.ts` (the payload coercer and its node side tests stay Lit free), with the two renderer importers pointed at the new home. Tests pin the reference and junk round trips plus the behaviour deltas (`0x10` now coerces to 16 through strict `Number`, `Infinity` ships verbatim instead of a JSON null).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1350

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
