### PR TITLE
Ship unrecognised BOOLEAN values verbatim from the add-component coercer

### DIFF
--- a/src/components/device/add-component-form-coerce.ts
+++ b/src/components/device/add-component-form-coerce.ts
@@ -63,7 +63,9 @@ export function coerceFields(
           ? raw
           : coerceValueToEntryType(entry, String(raw));
     } else if (entry.type === ConfigEntryType.BOOLEAN) {
-      out[entry.key] = parseYamlBoolean(raw) === true;
+      // parseYamlBoolean's null (junk, a ${var} reference) ships verbatim
+      // so the backend flags it — `=== true` flattened it to false (#1356).
+      out[entry.key] = parseYamlBoolean(raw) ?? raw;
     } else {
       out[entry.key] = raw;
     }

--- a/src/components/device/add-component-form-coerce.ts
+++ b/src/components/device/add-component-form-coerce.ts
@@ -64,7 +64,8 @@ export function coerceFields(
           : coerceValueToEntryType(entry, String(raw));
     } else if (entry.type === ConfigEntryType.BOOLEAN) {
       // parseYamlBoolean's null (junk, a ${var} reference) ships verbatim
-      // so the backend flags it — `=== true` flattened it to false (#1356).
+      // so the backend resolves or rejects the real value — `=== true`
+      // flattened it to false (#1356).
       out[entry.key] = parseYamlBoolean(raw) ?? raw;
     } else {
       out[entry.key] = raw;

--- a/test/components/device/add-component-form-coerce.test.ts
+++ b/test/components/device/add-component-form-coerce.test.ts
@@ -147,3 +147,25 @@ describe("FLOAT coercion", () => {
     expect(coerceFields([gain], { gain: "0x10" })).toEqual({ gain: 16 });
   });
 });
+
+describe("BOOLEAN coercion", () => {
+  const enabled = makeConfigEntry({ key: "enabled", type: ConfigEntryType.BOOLEAN });
+
+  test("passes booleans through and coerces YAML spellings", () => {
+    expect(coerceFields([enabled], { enabled: true })).toEqual({ enabled: true });
+    expect(coerceFields([enabled], { enabled: "yes" })).toEqual({ enabled: true });
+    expect(coerceFields([enabled], { enabled: "off" })).toEqual({ enabled: false });
+  });
+
+  test("ships a ${var} reference verbatim instead of false", () => {
+    expect(coerceFields([enabled], { enabled: "${enable_foo}" })).toEqual({
+      enabled: "${enable_foo}",
+    });
+  });
+
+  test("ships junk verbatim instead of false", () => {
+    expect(coerceFields([enabled], { enabled: "maybe" })).toEqual({
+      enabled: "maybe",
+    });
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The add component payload coercer's BOOLEAN branch did `parseYamlBoolean(raw) === true`, flattening the parser's `null` (junk, or a `${var}` reference) to `false` — a silent value rewrite, the same class #1355 fixed for FLOAT. It bites because the pre submit validator deliberately skips substitution strings for every type, so `${enable_foo}` passes validation and then shipped as `false`.

The branch now honours `parseYamlBoolean`'s own documented contract ("callers treat null as not a boolean, leave the value as-is"): real booleans and YAML spellings (`yes`, `off`, …) coerce as before, and anything unrecognised ships verbatim so the backend flags the real value at validate time, mirroring the INTEGER and FLOAT branches. Tests cover the pass throughs, both YAML spellings, and the reference and junk round trips.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1356

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
