### PR TITLE
Route backend list-item errors to the offending row

### DIFF
--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -157,10 +157,9 @@ export function renderMultiValueField(
           raw[i] != null &&
           raw[i] !== "" &&
           Number.isFinite(Number(String(raw[i])));
-        // Errors land per item (``field.0``, #1348); flag and explain only
-        // the offending row. A field-keyed error with rows present is a
-        // list-level message — rendered once below, not painted onto
-        // every row (#1354); required-empty renders zero rows anyway.
+        // Errors land per item (``field.0``); flag only the offending row.
+        // A field-keyed error is list-level — rendered once below, not on
+        // every row (#1354).
         const rowPath = [...path, String(i)];
         const rowInvalid = ctx.errorAt(rowPath) !== null;
         // Edit buffer keeps raw keystrokes on screen while typing;

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -124,7 +124,6 @@ export function renderMultiValueField(
   const items: string[] = numeric
     ? raw.map((v) => String(v ?? ""))
     : raw.map((v) => escapeForInput(String(v)));
-  const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
   const { addItem, removeAt } = arrayItemHandlers(ctx, path, () => "");
   const updateAt = (idx: number, value: string) => {
@@ -159,10 +158,11 @@ export function renderMultiValueField(
           raw[i] !== "" &&
           Number.isFinite(Number(String(raw[i])));
         // Errors land per item (``field.0``, #1348); flag and explain only
-        // the offending row. The field-level ``invalid`` stays for errors
-        // keyed at the field itself (required-empty).
+        // the offending row. A field-keyed error with rows present is a
+        // list-level message — rendered once below, not painted onto
+        // every row (#1354); required-empty renders zero rows anyway.
         const rowPath = [...path, String(i)];
-        const rowInvalid = invalid || ctx.errorAt(rowPath) !== null;
+        const rowInvalid = ctx.errorAt(rowPath) !== null;
         // Edit buffer keeps raw keystrokes on screen while typing;
         // clears on blur.
         const display = intList ? (ctx.getEditingMagnitude(rowPath) ?? item) : item;

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -76,14 +76,14 @@ export function onValueChange(
   // backend error keys ``field.1``, #1354). They reappear on the next lint
   // pass if the value is still invalid.
   const itemPrefix = `${errKey}.`;
-  const staleBackend = [...host.backendErrors.fields.keys()].filter(
-    (k) => (k === errKey || k.startsWith(itemPrefix)) && !host._clearedBackendPaths.has(k)
-  );
-  if (staleBackend.length > 0) {
-    const next = new Set(host._clearedBackendPaths);
-    for (const k of staleBackend) next.add(k);
-    host._clearedBackendPaths = next;
+  let nextCleared: Set<string> | null = null;
+  for (const k of host.backendErrors.fields.keys()) {
+    if ((k === errKey || k.startsWith(itemPrefix)) && !host._clearedBackendPaths.has(k)) {
+      nextCleared ??= new Set(host._clearedBackendPaths);
+      nextCleared.add(k);
+    }
   }
+  if (nextCleared) host._clearedBackendPaths = nextCleared;
   host._scheduleDraftFlush();
 }
 

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -71,10 +71,18 @@ export function onValueChange(
   const errKey = path.join(".");
   const cleared = clearPathErrors(host._fieldErrors, errKey);
   if (cleared) host._fieldErrors = cleared;
-  // Same optimistic clear for the backend error on the edited path — it
-  // reappears on the next lint pass if the value is still invalid.
-  if (host.backendErrors.fields.has(errKey) && !host._clearedBackendPaths.has(errKey)) {
-    host._clearedBackendPaths = new Set(host._clearedBackendPaths).add(errKey);
+  // Same optimistic clear for backend errors on the edited path — per-item
+  // keys under it included (a list edit emits at the field path while the
+  // backend error keys ``field.1``, #1354). They reappear on the next lint
+  // pass if the value is still invalid.
+  const itemPrefix = `${errKey}.`;
+  const staleBackend = [...host.backendErrors.fields.keys()].filter(
+    (k) => (k === errKey || k.startsWith(itemPrefix)) && !host._clearedBackendPaths.has(k)
+  );
+  if (staleBackend.length > 0) {
+    const next = new Set(host._clearedBackendPaths);
+    for (const k of staleBackend) next.add(k);
+    host._clearedBackendPaths = next;
   }
   host._scheduleDraftFlush();
 }

--- a/src/util/backend-field-errors.ts
+++ b/src/util/backend-field-errors.ts
@@ -41,6 +41,21 @@ export function formRelativePath<T extends string | number>(full: readonly T[]):
 }
 
 /**
+ * A mapped error's section-relative form path. A scalar list item's
+ * trailing index maps to a renderable row (``field.0``, the per-item
+ * keys the list renderer reads, #1354), so it survives the reduction;
+ * mapping-item tails still reduce to [] (banner material).
+ */
+export function mappedFormPath(
+  err: Pick<MappedValidationError, "keyPath" | "scalarItemTail">
+): (string | number)[] {
+  const rel = formRelativePath(err.keyPath);
+  if (rel.length > 0 || !err.scalarItemTail) return rel;
+  const parent = formRelativePath(err.keyPath.slice(0, -1));
+  return parent.length > 0 ? [...parent, err.keyPath[err.keyPath.length - 1]] : [];
+}
+
+/**
  * Pin each mapped error on a section instance in the current buffer.
  *
  * The result is the deduped set of user-visible errors: one per field
@@ -58,7 +73,7 @@ export function resolveBackendErrors(
   for (const err of mapped) {
     const section = sectionForCursor(yaml, err.line, err.keyPath);
     if (!section) continue;
-    let rel = formRelativePath(err.keyPath);
+    let rel = mappedFormPath(err);
     // An expanded list instance (- platform: dht) IS the form's root: the
     // navigator already picked the item by fromLine, so the domain-list
     // index the key path carries is redundant — drop it. Nested list

--- a/src/util/yaml-ast.ts
+++ b/src/util/yaml-ast.ts
@@ -219,10 +219,7 @@ export function getKeyPathWithListIndices(
     if (node.name === "Pair") {
       const k = getPairKey(state, node);
       if (k) segs.push(k);
-    } else if (
-      node.name === "Item" &&
-      (node.parent?.name === "BlockSequence" || node.parent?.name === "FlowSequence")
-    ) {
+    } else if (isSequenceItem(node)) {
       let idx = 0;
       for (let s = node.prevSibling; s; s = s.prevSibling) {
         if (s.name === "Item") idx++;
@@ -231,6 +228,19 @@ export function getKeyPathWithListIndices(
     }
   }
   return segs.reverse();
+}
+
+// The one definition of "a sequence item" — the index-contributing check in
+// ``getKeyPathWithListIndices`` and the scalar-item probe below must agree,
+// or a keyPath's trailing index and its scalarItemTail flag drift apart.
+function isSequenceItem(node: {
+  name: string;
+  parent: { name: string } | null;
+}): boolean {
+  return (
+    node.name === "Item" &&
+    (node.parent?.name === "BlockSequence" || node.parent?.name === "FlowSequence")
+  );
 }
 
 /**
@@ -243,11 +253,7 @@ export function isScalarListItemAt(state: EditorState, pos: number): boolean {
   if (!node || (node.name !== "Literal" && node.name !== "QuotedLiteral")) {
     return false;
   }
-  const item = node.parent;
-  return (
-    item?.name === "Item" &&
-    (item.parent?.name === "BlockSequence" || item.parent?.name === "FlowSequence")
-  );
+  return node.parent !== null && isSequenceItem(node.parent);
 }
 
 /**

--- a/src/util/yaml-ast.ts
+++ b/src/util/yaml-ast.ts
@@ -204,10 +204,11 @@ export function getKeyPath(state: EditorState, pos: number): string[] {
 export type YamlPathSegment = string | number;
 
 /**
- * Like ``getKeyPath``, but block-sequence items contribute their
- * numeric index, so a field inside ``esphome: areas: - id:`` yields
- * ``["esphome", "areas", 0, "id"]`` — the shape value paths use for
- * fields nested in list entries.
+ * Like ``getKeyPath``, but sequence items contribute their numeric
+ * index, so a field inside ``esphome: areas: - id:`` yields
+ * ``["esphome", "areas", 0, "id"]`` and an item of ``data: [42, 10]``
+ * yields ``[…, "data", 1]`` — the shape value paths use for fields
+ * nested in list entries.
  */
 export function getKeyPathWithListIndices(
   state: EditorState,
@@ -218,7 +219,10 @@ export function getKeyPathWithListIndices(
     if (node.name === "Pair") {
       const k = getPairKey(state, node);
       if (k) segs.push(k);
-    } else if (node.name === "Item" && node.parent?.name === "BlockSequence") {
+    } else if (
+      node.name === "Item" &&
+      (node.parent?.name === "BlockSequence" || node.parent?.name === "FlowSequence")
+    ) {
       let idx = 0;
       for (let s = node.prevSibling; s; s = s.prevSibling) {
         if (s.name === "Item") idx++;
@@ -227,6 +231,23 @@ export function getKeyPathWithListIndices(
     }
   }
   return segs.reverse();
+}
+
+/**
+ * True when *pos* anchors inside a scalar list item (a ``Literal`` /
+ * ``QuotedLiteral`` directly under a sequence ``Item``) — the one
+ * key-path shape whose trailing index maps to a renderable form row.
+ */
+export function isScalarListItemAt(state: EditorState, pos: number): boolean {
+  const node = resolveAnchoredNode(state, pos);
+  if (!node || (node.name !== "Literal" && node.name !== "QuotedLiteral")) {
+    return false;
+  }
+  const item = node.parent;
+  return (
+    item?.name === "Item" &&
+    (item.parent?.name === "BlockSequence" || item.parent?.name === "FlowSequence")
+  );
 }
 
 /**

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -25,9 +25,9 @@ import { gutterLineClass, GutterMarker, type EditorView } from "@codemirror/view
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { EditorValidateResponse } from "../api/types/editor.js";
 import type { LocalizeFunc } from "../common/localize.js";
-import { formRelativePath } from "./backend-field-errors.js";
+import { mappedFormPath } from "./backend-field-errors.js";
 import { splitTextLinks } from "./markdown.js";
-import { getKeyPathWithListIndices } from "./yaml-ast.js";
+import { getKeyPathWithListIndices, isScalarListItemAt } from "./yaml-ast.js";
 import {
   describeValueTypeCause,
   describeYamlError,
@@ -49,8 +49,12 @@ export interface MappedValidationError {
    *  errors resolve to the right instance. */
   line: number;
   /** Key chain from the top-level section key down to the errored field;
-   *  block-sequence items contribute their numeric index. */
+   *  sequence items contribute their numeric index. */
   keyPath: (string | number)[];
+  /** Set when a numeric-tailed ``keyPath`` ends at a scalar list item —
+   *  the one index tail that maps to a renderable form row (#1354);
+   *  mapping-item tails stay banner material. */
+  scalarItemTail?: boolean;
 }
 
 /** A banner-bound error, optionally carrying a line so the banner can jump to it. */
@@ -447,14 +451,22 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
         ) {
           keyPath = keyPath.slice(0, -1);
         }
+        const scalarItemTail =
+          typeof keyPath[keyPath.length - 1] === "number" &&
+          isScalarListItemAt(view.state, Math.min(anchor.from + 1, anchor.to));
         if (keyPath.length > 0) {
-          mapped.push({ message, line: anchorLine.number, keyPath });
+          mapped.push({
+            message,
+            line: anchorLine.number,
+            keyPath,
+            ...(scalarItemTail ? { scalarItemTail } : {}),
+          });
         }
         // No form field to carry the message (a bare section header, or the
         // AST couldn't place it) — keep it in the banner; a section-level
         // error still badges the navigator through the mapped entry. The
         // anchor line gives the banner its "Go to line" jump.
-        if (formRelativePath(keyPath).length === 0) {
+        if (mappedFormPath({ keyPath, scalarItemTail }).length === 0) {
           bannerErrors.push({
             message,
             line: squiggleLineNum,

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -435,10 +435,8 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
         // item; the enclosing key covers them all). Anchor inside the
         // first token — side -1 at the exact start would resolve to the
         // preceding node.
-        let keyPath = getKeyPathWithListIndices(
-          view.state,
-          Math.min(anchor.from + 1, anchor.to)
-        );
+        const anchorPos = Math.min(anchor.from + 1, anchor.to);
+        let keyPath = getKeyPathWithListIndices(view.state, anchorPos);
         // A multi-line range anchored on a key token is a container-level
         // error: esphome marked a whole mapping, whose range starts at its
         // first key. That key is incidental — attribute the error to the
@@ -451,22 +449,22 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
         ) {
           keyPath = keyPath.slice(0, -1);
         }
-        const scalarItemTail =
-          typeof keyPath[keyPath.length - 1] === "number" &&
-          isScalarListItemAt(view.state, Math.min(anchor.from + 1, anchor.to));
+        const entry: MappedValidationError = {
+          message,
+          line: anchorLine.number,
+          keyPath,
+          scalarItemTail:
+            typeof keyPath[keyPath.length - 1] === "number" &&
+            isScalarListItemAt(view.state, anchorPos),
+        };
         if (keyPath.length > 0) {
-          mapped.push({
-            message,
-            line: anchorLine.number,
-            keyPath,
-            ...(scalarItemTail ? { scalarItemTail } : {}),
-          });
+          mapped.push(entry);
         }
         // No form field to carry the message (a bare section header, or the
         // AST couldn't place it) — keep it in the banner; a section-level
         // error still badges the navigator through the mapped entry. The
         // anchor line gives the banner its "Go to line" jump.
-        if (mappedFormPath({ keyPath, scalarItemTail }).length === 0) {
+        if (mappedFormPath(entry).length === 0) {
           bannerErrors.push({
             message,
             line: squiggleLineNum,

--- a/test/components/device/render-multi-value-field.test.ts
+++ b/test/components/device/render-multi-value-field.test.ts
@@ -204,14 +204,17 @@ describe("renderMultiValueField per-row errors", () => {
     expect(JSON.stringify(rows[0].values)).toContain("validation.not_a_number");
   });
 
-  it("a field-level error still paints every row", () => {
+  it("a field-level error shows once below without painting the rows", () => {
+    // #1354: with rows present a field-keyed error is a list-level backend
+    // message; painting every row misattributed it.
     const ctx = makeRenderCtx({ field: [1, 2] });
     ctx.errorAt = (path: string[]) =>
-      path.join(".") === "field" ? { key: "field", code: "validation.required" } : null;
+      path.join(".") === "field" ? { key: "field", code: "validation.backend" } : null;
     const tpl = renderMultiValueField(makeEntry(ConfigEntryType.INTEGER), ["field"], ctx);
     const rows = rowsOf(tpl);
 
-    expect(rows[0].values).toContain("invalid");
-    expect(rows[1].values).toContain("invalid");
+    expect(rows[0].values).not.toContain("invalid");
+    expect(rows[1].values).not.toContain("invalid");
+    expect(JSON.stringify(tpl)).toContain("validation.backend");
   });
 });

--- a/test/components/device/section-config-backend-errors.test.ts
+++ b/test/components/device/section-config-backend-errors.test.ts
@@ -103,6 +103,24 @@ describe("device-section-config — backend field errors", () => {
     expect(inner._clearedBackendPaths.size).toBe(0);
   });
 
+  it("suppresses per-item backend errors when the list field is edited", () => {
+    // #1354: a list edit emits at the field path while the backend error
+    // keys the offending row (``data.1``); the row's ring must clear
+    // optimistically too.
+    const inner = makeHost(instanceErrors({ "data.1": "value must be at most 31." }));
+    onValueChange(
+      inner,
+      new CustomEvent("value-change", { detail: { path: ["data"], value: [10, 20] } })
+    );
+    expect(inner._clearedBackendPaths.has("data.1")).toBe(true);
+    const merged = inner._mergeErrors(
+      inner.backendErrors.fields,
+      inner._clearedBackendPaths,
+      inner._fieldErrors
+    );
+    expect(merged.has("data.1")).toBe(false);
+  });
+
   it("reveals hidden advanced settings when a backend error lands there", () => {
     const inner = makeHost(instanceErrors({ pin: "pin broken" }));
     expect(inner._showAdvanced).toBe(false);

--- a/test/util/backend-field-errors.test.ts
+++ b/test/util/backend-field-errors.test.ts
@@ -4,6 +4,7 @@ import {
   backendErrorsForInstance,
   formRelativePath,
   instanceKey,
+  mappedFormPath,
   resolveBackendErrors,
   type BackendFieldError,
 } from "../../src/util/backend-field-errors.js";
@@ -215,5 +216,27 @@ describe("backendErrorsForInstance", () => {
     expect(miss.fields.size).toBe(0);
     expect(miss.fieldMessages).toEqual([]);
     expect(miss.sectionMessages).toEqual([]);
+  });
+});
+
+describe("mappedFormPath", () => {
+  it("keeps a scalar item's trailing index (#1354)", () => {
+    expect(
+      mappedFormPath({
+        keyPath: ["display", 0, "user_characters", 0, "data", 1],
+        scalarItemTail: true,
+      })
+    ).toEqual([0, "user_characters", 0, "data", 1]);
+  });
+
+  it("still reduces a mapping-item tail to the banner", () => {
+    expect(mappedFormPath({ keyPath: ["sensor", 1] })).toEqual([]);
+    expect(mappedFormPath({ keyPath: ["esphome", "areas", 0] })).toEqual([]);
+  });
+
+  it("reduces when the parent path itself has no form field", () => {
+    // A scalar item directly under a section list has no parent field to
+    // anchor a row on.
+    expect(mappedFormPath({ keyPath: ["sensor", 1], scalarItemTail: true })).toEqual([]);
   });
 });

--- a/test/util/yaml-ast-keypath.test.ts
+++ b/test/util/yaml-ast-keypath.test.ts
@@ -100,6 +100,18 @@ describe("getKeyPathWithListIndices", () => {
     expect(indexedPathAt(doc, "id: $$")).toEqual(["esphome", "areas", 1, "id"]);
   });
 
+  it("indexes flow-sequence items (#1354)", () => {
+    const doc = "display:\n  - platform: lcd\n    data: [42, 10, 31]\n";
+    expect(indexedPathAt(doc, "42")).toEqual(["display", 0, "data", 0]);
+    expect(indexedPathAt(doc, "10")).toEqual(["display", 0, "data", 1]);
+    expect(indexedPathAt(doc, "31")).toEqual(["display", 0, "data", 2]);
+  });
+
+  it("indexes block-style scalar items", () => {
+    const doc = "display:\n  - platform: lcd\n    data:\n      - 42\n      - 10\n";
+    expect(indexedPathAt(doc, "10")).toEqual(["display", 0, "data", 1]);
+  });
+
   it("indexes top-level platform list items too", () => {
     const doc =
       "sensor:\n  - platform: gpio\n    name: a\n  - platform: dht\n    pin: GPIO4\n";
@@ -136,30 +148,14 @@ describe("isInsideBlockScalar", () => {
   });
 });
 
-describe("flow-sequence items (#1354)", () => {
+describe("isScalarListItemAt", () => {
   const stateFor = (doc: string) => {
     const state = EditorState.create({ doc, extensions: [esphomeYaml()] });
     ensureSyntaxTree(state, state.doc.length);
     return state;
   };
-  const indexedPathAt = (doc: string, token: string): (string | number)[] => {
-    const state = stateFor(doc);
-    return getKeyPathWithListIndices(state, doc.indexOf(token) + 1);
-  };
 
-  it("indexes flow-sequence items", () => {
-    const doc = "display:\n  - platform: lcd\n    data: [42, 10, 31]\n";
-    expect(indexedPathAt(doc, "42")).toEqual(["display", 0, "data", 0]);
-    expect(indexedPathAt(doc, "10")).toEqual(["display", 0, "data", 1]);
-    expect(indexedPathAt(doc, "31")).toEqual(["display", 0, "data", 2]);
-  });
-
-  it("indexes block-style scalar items", () => {
-    const doc = "display:\n  - platform: lcd\n    data:\n      - 42\n      - 10\n";
-    expect(indexedPathAt(doc, "10")).toEqual(["display", 0, "data", 1]);
-  });
-
-  it("isScalarListItemAt is true only for scalar items", () => {
+  it("is true only for scalar items", () => {
     const flow = "display:\n  - platform: lcd\n    data: [42, 10]\n";
     const state = stateFor(flow);
     expect(isScalarListItemAt(state, flow.indexOf("42") + 1)).toBe(true);

--- a/test/util/yaml-ast-keypath.test.ts
+++ b/test/util/yaml-ast-keypath.test.ts
@@ -159,6 +159,8 @@ describe("isScalarListItemAt", () => {
     const flow = "display:\n  - platform: lcd\n    data: [42, 10]\n";
     const state = stateFor(flow);
     expect(isScalarListItemAt(state, flow.indexOf("42") + 1)).toBe(true);
+    const block = "display:\n  - platform: lcd\n    data:\n      - 42\n";
+    expect(isScalarListItemAt(stateFor(block), block.indexOf("42") + 1)).toBe(true);
     // A mapping item (the platform entry) is not a scalar item.
     expect(isScalarListItemAt(state, flow.indexOf("platform") + 1)).toBe(false);
     // A plain mapping value is not a list item at all.

--- a/test/util/yaml-ast-keypath.test.ts
+++ b/test/util/yaml-ast-keypath.test.ts
@@ -6,6 +6,7 @@ import {
   getKeyPath,
   getKeyPathWithListIndices,
   isInsideBlockScalar,
+  isScalarListItemAt,
 } from "../../src/util/yaml-ast.js";
 
 function pathAt(doc: string, token: string): string[] {
@@ -132,5 +133,40 @@ describe("isInsideBlockScalar", () => {
   it("is false on a real empty-value key line", () => {
     const doc = "sensor:\n  - platform: template\n    device_class:\n";
     expect(at(doc, "device_class:")).toBe(false);
+  });
+});
+
+describe("flow-sequence items (#1354)", () => {
+  const stateFor = (doc: string) => {
+    const state = EditorState.create({ doc, extensions: [esphomeYaml()] });
+    ensureSyntaxTree(state, state.doc.length);
+    return state;
+  };
+  const indexedPathAt = (doc: string, token: string): (string | number)[] => {
+    const state = stateFor(doc);
+    return getKeyPathWithListIndices(state, doc.indexOf(token) + 1);
+  };
+
+  it("indexes flow-sequence items", () => {
+    const doc = "display:\n  - platform: lcd\n    data: [42, 10, 31]\n";
+    expect(indexedPathAt(doc, "42")).toEqual(["display", 0, "data", 0]);
+    expect(indexedPathAt(doc, "10")).toEqual(["display", 0, "data", 1]);
+    expect(indexedPathAt(doc, "31")).toEqual(["display", 0, "data", 2]);
+  });
+
+  it("indexes block-style scalar items", () => {
+    const doc = "display:\n  - platform: lcd\n    data:\n      - 42\n      - 10\n";
+    expect(indexedPathAt(doc, "10")).toEqual(["display", 0, "data", 1]);
+  });
+
+  it("isScalarListItemAt is true only for scalar items", () => {
+    const flow = "display:\n  - platform: lcd\n    data: [42, 10]\n";
+    const state = stateFor(flow);
+    expect(isScalarListItemAt(state, flow.indexOf("42") + 1)).toBe(true);
+    // A mapping item (the platform entry) is not a scalar item.
+    expect(isScalarListItemAt(state, flow.indexOf("platform") + 1)).toBe(false);
+    // A plain mapping value is not a list item at all.
+    const map = "esphome:\n  name: test\n";
+    expect(isScalarListItemAt(stateFor(map), map.indexOf("test") + 1)).toBe(false);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

A backend lint error on one item of a numeric list rendered its message once at the field level and painted every row red. Two causes, both fixed: the AST key path walker only indexed block sequence items, and the editor's serializer writes scalar lists flow style, so the derived key path ended at the field with no item index; and even a block style index was reduced away before it could reach the form.

The walker now indexes flow sequence items too, and the lint mapper marks an error whose key path ends at a scalar list item. `mappedFormPath` keeps that trailing index (mapping item tails still reduce to the banner), which lands the error on the exact per item key (`data.1`) the list renderer already reads from #1348, so the offending row rings red with its message beneath it. A field keyed error with rows present is list level and now renders once below without painting the rows. Editing a list also optimistically clears per item backend keys, so fixing the bad value drops the ring immediately instead of waiting a lint round trip.

Verified in the live editor with the issue's screenshot repro (`data: [${glyph_row}, 42, …]`, 42 over the 0-31 bound): only the 42 row flags, with "value must be at most 31." directly beneath it; the substitution row and literal siblings stay clean. The other half of the issue — the catalog shipping `range: null` for these items so the client cannot pre flag before the lint round trip — is a catalog sync question for the backend repo and stays open there.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1354

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
