### PR TITLE
Parse plain numeric list items as numbers

### DIFF
--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -78,8 +78,8 @@ const parseInlineLambda = (scalar: string): LambdaValue | null => {
 // field that happens to hold ``"on"`` / ``"yes"`` would silently
 // flip to boolean ``true`` on round-trip.
 export const parseScalar = (raw: string): unknown => {
-  // Strip a trailing inline comment so a boolean/number field coerces
-  // and the form value isn't polluted with `# ...` text (#1235).
+  // Strip a trailing inline comment so a boolean coerces and no field
+  // value is polluted with `# ...` text (#1235).
   const { value: scalar } = splitInlineComment(raw);
   const lambda = parseInlineLambda(scalar);
   if (lambda !== null) return lambda;

--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -95,7 +95,11 @@ export const parseScalar = (raw: string): unknown => {
 // Plain-decimal forms only: unambiguous across YAML versions. Hex stays a
 // string (the i2c-address round-trip keeps ``0x76`` verbatim), and a leading
 // zero (``010``) or exponent stays a string too — YAML 1.1 reads ``010`` as
-// octal 8, so Number() would silently rewrite it.
+// octal 8, so Number() would silently rewrite it. Deliberately narrower
+// than yaml-serialize's YAML_INT/YAML_FLOAT recognition sets (which decide
+// quoting, so must match every form the loader re-types) and int-input's
+// DECIMAL_INT_RE (form input, leading zeros fine): coerce only what
+// Number() provably reads the same as the loader.
 const PLAIN_INT_RE = /^-?(?:0|[1-9]\d*)$/;
 const PLAIN_FLOAT_RE = /^-?(?:(?:0|[1-9]\d*)\.\d+|\.\d+)$/;
 

--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -107,19 +107,20 @@ export const isQuotedScalar = (s: string): boolean =>
 
 /**
  * A list item's parsed value: unquoted plain decimals become numbers and
- * bare ``true``/``false`` become booleans, so the serializer re-emits
+ * truthy/falsy spellings become booleans (``parseYamlBoolean``, the same
+ * rule ``parseScalar`` applies to fields), so the serializer re-emits
  * them bare — string-typed ``10`` would re-quote every sibling when the
- * list re-serializes (#1353). A >2^53 decimal stays a string (Number()
- * would silently rewrite the digits, #378/#944); other YAML truthy
- * spellings (``on``/``yes``) stay strings so the authored form survives.
+ * list re-serializes (#1353), and a string ``on`` would re-emit quoted
+ * where the loader had read a boolean. A >2^53 decimal stays a string
+ * (Number() would silently rewrite the digits, #378/#944).
  */
 export const coerceListScalar = (
   text: string,
   wasQuoted: boolean
 ): string | number | boolean => {
   if (wasQuoted) return text;
-  if (text === "true") return true;
-  if (text === "false") return false;
+  const bool = parseYamlBoolean(text);
+  if (bool !== null) return bool;
   if (PLAIN_INT_RE.test(text)) {
     const n = Number(text);
     return Number.isSafeInteger(n) ? n : text;

--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -124,6 +124,9 @@ export const coerceListScalar = (
     const n = Number(text);
     return Number.isSafeInteger(n) ? n : text;
   }
+  // Floats trade text fidelity for the loader's value: ``1.50`` re-emits
+  // as ``1.5`` and extra precision truncates to the same double PyYAML
+  // hands the backend anyway.
   if (PLAIN_FLOAT_RE.test(text)) return Number(text);
   return text;
 };

--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -100,8 +100,9 @@ export const parseScalar = (raw: string): unknown => {
 // quoting, so must match every form the loader re-types) and int-input's
 // DECIMAL_INT_RE (form input, leading zeros fine): coerce only what
 // Number() provably reads the same as the loader.
-const PLAIN_INT_RE = /^[-+]?(?:0|[1-9]\d*)$/;
-const PLAIN_FLOAT_RE = /^[-+]?(?:(?:0|[1-9]\d*)\.\d*|\.\d+)$/;
+const PLAIN_INT_RE = /^[-+]?(?:0|[1-9]\d*(?:_\d+)*)$/;
+const PLAIN_FLOAT_RE =
+  /^[-+]?(?:(?:0|[1-9]\d*(?:_\d+)*)\.(?:\d+(?:_\d+)*)?|\.\d+(?:_\d+)*)$/;
 
 /** Quoting in YAML is the explicit "treat me as a string" signal; the
  *  scalar and list-item readers share one definition of "quoted". */
@@ -125,8 +126,11 @@ export const coerceListScalar = (
   if (wasQuoted) return text;
   const bool = parseYamlBoolean(text);
   if (bool !== null) return bool;
+  // Underscore digit separators (``1_000``) are loader numerics; strip
+  // them for Number() once the shape matched (between digits only, a
+  // strict subset of the resolver's grammar).
   if (PLAIN_INT_RE.test(text)) {
-    const n = Number(text);
+    const n = Number(text.replace(/_/g, ""));
     return Number.isSafeInteger(n) ? n : text;
   }
   // Floats trade text fidelity for the loader's value: ``1.50`` re-emits
@@ -135,7 +139,7 @@ export const coerceListScalar = (
   // the serializer would emit a bare ``Infinity``, which YAML reads as
   // a plain string anyway.
   if (PLAIN_FLOAT_RE.test(text)) {
-    const n = Number(text);
+    const n = Number(text.replace(/_/g, ""));
     return Number.isFinite(n) ? n : text;
   }
   return text;

--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -94,7 +94,26 @@ export const parseScalar = (raw: string): unknown => {
   return v;
 };
 
-export const parseFlowList = (raw: string): string[] => {
+// Plain-decimal forms only: unambiguous across YAML versions. Hex stays a
+// string (the i2c-address round-trip keeps ``0x76`` verbatim), and a leading
+// zero (``010``) or exponent stays a string too — YAML 1.1 reads ``010`` as
+// octal 8, so Number() would silently rewrite it.
+const PLAIN_INT_RE = /^-?(?:0|[1-9]\d*)$/;
+const PLAIN_FLOAT_RE = /^-?(?:0|[1-9]\d*)\.\d+$/;
+
+/**
+ * A list item's parsed value: unquoted plain decimals become numbers so
+ * the serializer re-emits them bare — string-typed ``10`` would re-quote
+ * every sibling when the list re-serializes (#1353). Quotes are the
+ * explicit "treat me as a string" signal, same rule as ``parseScalar``.
+ */
+export const coerceListScalar = (text: string, wasQuoted: boolean): string | number => {
+  if (wasQuoted) return text;
+  if (PLAIN_INT_RE.test(text) || PLAIN_FLOAT_RE.test(text)) return Number(text);
+  return text;
+};
+
+export const parseFlowList = (raw: string): (string | number)[] => {
   const inner = raw.slice(1, -1).trim();
   if (inner === "") return [];
   // Quote-aware split: a quoted element may itself contain a comma (the
@@ -104,8 +123,10 @@ export const parseFlowList = (raw: string): string[] => {
   // literal backslash text (device-builder#1232).
   return splitTopLevelCommas(inner).map((p) => {
     const t = p.trim();
-    return t.length >= 2 && t.startsWith('"') && t.endsWith('"')
-      ? unescapeYamlDoubleQuoted(t.slice(1, -1))
-      : stripQuotes(t);
+    if (t.length >= 2 && t.startsWith('"') && t.endsWith('"')) {
+      return unescapeYamlDoubleQuoted(t.slice(1, -1));
+    }
+    const wasQuoted = t.length >= 2 && t.startsWith("'") && t.endsWith("'");
+    return coerceListScalar(stripQuotes(t), wasQuoted);
   });
 };

--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -131,8 +131,13 @@ export const coerceListScalar = (
   }
   // Floats trade text fidelity for the loader's value: ``1.50`` re-emits
   // as ``1.5`` and extra precision truncates to the same double PyYAML
-  // hands the backend anyway.
-  if (PLAIN_FLOAT_RE.test(text)) return Number(text);
+  // hands the backend anyway. An overflowing mantissa stays a string —
+  // the serializer would emit a bare ``Infinity``, which YAML reads as
+  // a plain string anyway.
+  if (PLAIN_FLOAT_RE.test(text)) {
+    const n = Number(text);
+    return Number.isFinite(n) ? n : text;
+  }
   return text;
 };
 

--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -100,8 +100,8 @@ export const parseScalar = (raw: string): unknown => {
 // quoting, so must match every form the loader re-types) and int-input's
 // DECIMAL_INT_RE (form input, leading zeros fine): coerce only what
 // Number() provably reads the same as the loader.
-const PLAIN_INT_RE = /^-?(?:0|[1-9]\d*)$/;
-const PLAIN_FLOAT_RE = /^-?(?:(?:0|[1-9]\d*)\.\d+|\.\d+)$/;
+const PLAIN_INT_RE = /^[-+]?(?:0|[1-9]\d*)$/;
+const PLAIN_FLOAT_RE = /^[-+]?(?:(?:0|[1-9]\d*)\.\d*|\.\d+)$/;
 
 /** Quoting in YAML is the explicit "treat me as a string" signal; the
  *  scalar and list-item readers share one definition of "quoted". */

--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -83,9 +83,7 @@ export const parseScalar = (raw: string): unknown => {
   const { value: scalar } = splitInlineComment(raw);
   const lambda = parseInlineLambda(scalar);
   if (lambda !== null) return lambda;
-  const wasQuoted =
-    (scalar.startsWith('"') && scalar.endsWith('"')) ||
-    (scalar.startsWith("'") && scalar.endsWith("'"));
+  const wasQuoted = isQuotedScalar(scalar);
   const v = stripQuotes(scalar);
   if (!wasQuoted) {
     const bool = parseYamlBoolean(v);
@@ -99,21 +97,38 @@ export const parseScalar = (raw: string): unknown => {
 // zero (``010``) or exponent stays a string too — YAML 1.1 reads ``010`` as
 // octal 8, so Number() would silently rewrite it.
 const PLAIN_INT_RE = /^-?(?:0|[1-9]\d*)$/;
-const PLAIN_FLOAT_RE = /^-?(?:0|[1-9]\d*)\.\d+$/;
+const PLAIN_FLOAT_RE = /^-?(?:(?:0|[1-9]\d*)\.\d+|\.\d+)$/;
+
+/** Quoting in YAML is the explicit "treat me as a string" signal; the
+ *  scalar and list-item readers share one definition of "quoted". */
+export const isQuotedScalar = (s: string): boolean =>
+  s.length >= 2 &&
+  ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'")));
 
 /**
- * A list item's parsed value: unquoted plain decimals become numbers so
- * the serializer re-emits them bare — string-typed ``10`` would re-quote
- * every sibling when the list re-serializes (#1353). Quotes are the
- * explicit "treat me as a string" signal, same rule as ``parseScalar``.
+ * A list item's parsed value: unquoted plain decimals become numbers and
+ * bare ``true``/``false`` become booleans, so the serializer re-emits
+ * them bare — string-typed ``10`` would re-quote every sibling when the
+ * list re-serializes (#1353). A >2^53 decimal stays a string (Number()
+ * would silently rewrite the digits, #378/#944); other YAML truthy
+ * spellings (``on``/``yes``) stay strings so the authored form survives.
  */
-export const coerceListScalar = (text: string, wasQuoted: boolean): string | number => {
+export const coerceListScalar = (
+  text: string,
+  wasQuoted: boolean
+): string | number | boolean => {
   if (wasQuoted) return text;
-  if (PLAIN_INT_RE.test(text) || PLAIN_FLOAT_RE.test(text)) return Number(text);
+  if (text === "true") return true;
+  if (text === "false") return false;
+  if (PLAIN_INT_RE.test(text)) {
+    const n = Number(text);
+    return Number.isSafeInteger(n) ? n : text;
+  }
+  if (PLAIN_FLOAT_RE.test(text)) return Number(text);
   return text;
 };
 
-export const parseFlowList = (raw: string): (string | number)[] => {
+export const parseFlowList = (raw: string): (string | number | boolean)[] => {
   const inner = raw.slice(1, -1).trim();
   if (inner === "") return [];
   // Quote-aware split: a quoted element may itself contain a comma (the
@@ -126,7 +141,6 @@ export const parseFlowList = (raw: string): (string | number)[] => {
     if (t.length >= 2 && t.startsWith('"') && t.endsWith('"')) {
       return unescapeYamlDoubleQuoted(t.slice(1, -1));
     }
-    const wasQuoted = t.length >= 2 && t.startsWith("'") && t.endsWith("'");
-    return coerceListScalar(stripQuotes(t), wasQuoted);
+    return coerceListScalar(stripQuotes(t), isQuotedScalar(t));
   });
 };

--- a/src/util/yaml-section-block-reader.ts
+++ b/src/util/yaml-section-block-reader.ts
@@ -64,7 +64,7 @@ const parseListBlock = (
   startIdx: number,
   parentIndent: string
 ): {
-  value: YamlRawValue | Record<string, unknown>[] | (string | number)[];
+  value: YamlRawValue | Record<string, unknown>[] | (string | number | boolean)[];
   endIdx: number;
   isEmptyScalarList: boolean;
 } => {

--- a/src/util/yaml-section-block-reader.ts
+++ b/src/util/yaml-section-block-reader.ts
@@ -14,7 +14,7 @@ import {
   isEditableLambdaBlock,
   lambdaValueFromBlock,
 } from "./yaml-block-scalar-value.js";
-import { parseFlowList, parseScalar } from "./yaml-scalar.js";
+import { parseFlowList, parseScalar, splitInlineComment } from "./yaml-scalar.js";
 import {
   _detectListItemChildIndent,
   _leadingIndent,
@@ -401,8 +401,12 @@ function parseNestedBlock(
       continue;
     }
 
-    if (raw.startsWith("[") && raw.endsWith("]")) {
-      values[key] = parseFlowList(raw);
+    // Strip a trailing line comment before the bracket test — the other
+    // flow-list sites do, and without it ``key: [1, 2] # note`` misses
+    // the flow branch and degrades to the literal string "[1, 2]".
+    const { value: scalar } = splitInlineComment(raw);
+    if (scalar.startsWith("[") && scalar.endsWith("]")) {
+      values[key] = parseFlowList(scalar);
     } else {
       values[key] = parseScalar(raw);
     }

--- a/src/util/yaml-section-block-reader.ts
+++ b/src/util/yaml-section-block-reader.ts
@@ -43,8 +43,8 @@ import { YamlRawValue } from "./yaml-serialize.js";
  * Dispatch a YAML list block (``key:\n  - …``) into the right
  * value shape: structured array of mappings for editor-friendly
  * lists (``esphome.devices`` / ``esphome.areas``), ``YamlRawValue``
- * for complex automation triggers, or scalar items (numbers /
- * strings) for scalar lists. Shared between the top-level and nested-block parsers
+ * for complex automation triggers, or scalar items (numbers,
+ * booleans, strings) for scalar lists. Shared between the top-level and nested-block parsers
  * so both surfaces agree on the dispatch.
  *
  * ``parentIndent`` is the indent of the parent KEY (the one whose

--- a/src/util/yaml-section-block-reader.ts
+++ b/src/util/yaml-section-block-reader.ts
@@ -43,8 +43,8 @@ import { YamlRawValue } from "./yaml-serialize.js";
  * Dispatch a YAML list block (``key:\n  - …``) into the right
  * value shape: structured array of mappings for editor-friendly
  * lists (``esphome.devices`` / ``esphome.areas``), ``YamlRawValue``
- * for complex automation triggers, or ``string[]`` for scalar
- * lists. Shared between the top-level and nested-block parsers
+ * for complex automation triggers, or scalar items (numbers /
+ * strings) for scalar lists. Shared between the top-level and nested-block parsers
  * so both surfaces agree on the dispatch.
  *
  * ``parentIndent`` is the indent of the parent KEY (the one whose
@@ -64,7 +64,7 @@ const parseListBlock = (
   startIdx: number,
   parentIndent: string
 ): {
-  value: YamlRawValue | Record<string, unknown>[] | string[];
+  value: YamlRawValue | Record<string, unknown>[] | (string | number)[];
   endIdx: number;
   isEmptyScalarList: boolean;
 } => {

--- a/src/util/yaml-section-list.ts
+++ b/src/util/yaml-section-list.ts
@@ -6,10 +6,11 @@
  */
 
 import {
+  coerceListScalar,
+  isQuotedScalar,
   parseFlowList,
   parseScalar,
   splitInlineComment,
-  coerceListScalar,
   stripQuotes,
 } from "./yaml-scalar.js";
 import {
@@ -27,8 +28,8 @@ export const collectBlockListItems = (
   startIdx: number,
   prefix: string,
   itemRegex: RegExp
-): { items: (string | number)[]; endIdx: number } => {
-  const items: (string | number)[] = [];
+): { items: (string | number | boolean)[]; endIdx: number } => {
+  const items: (string | number | boolean)[] = [];
   let j = startIdx;
   for (; j < lines.length; j++) {
     if (isBlankOrCommentLine(lines[j])) continue;
@@ -36,10 +37,7 @@ export const collectBlockListItems = (
     const m = lines[j].match(itemRegex);
     if (!m) break;
     const raw = m[1].trim();
-    const wasQuoted =
-      (raw.startsWith('"') && raw.endsWith('"')) ||
-      (raw.startsWith("'") && raw.endsWith("'"));
-    items.push(coerceListScalar(stripQuotes(raw), wasQuoted));
+    items.push(coerceListScalar(stripQuotes(raw), isQuotedScalar(raw)));
   }
   return { items, endIdx: j };
 };

--- a/src/util/yaml-section-list.ts
+++ b/src/util/yaml-section-list.ts
@@ -36,7 +36,12 @@ export const collectBlockListItems = (
     if (!lines[j].startsWith(prefix)) break;
     const m = lines[j].match(itemRegex);
     if (!m) break;
-    const raw = m[1].trim();
+    // Strip a trailing inline comment (``- 10 # note``) so the item
+    // coerces and the form value isn't polluted with ``# ...`` text —
+    // same rule as parseScalar (#1235). An edited list re-emits without
+    // the comment; keeping it in the value corrupted it into the string
+    // ``"10 # note"`` instead.
+    const { value: raw } = splitInlineComment(m[1].trim());
     items.push(coerceListScalar(stripQuotes(raw), isQuotedScalar(raw)));
   }
   return { items, endIdx: j };

--- a/src/util/yaml-section-list.ts
+++ b/src/util/yaml-section-list.ts
@@ -9,6 +9,7 @@ import {
   parseFlowList,
   parseScalar,
   splitInlineComment,
+  coerceListScalar,
   stripQuotes,
 } from "./yaml-scalar.js";
 import {
@@ -26,15 +27,19 @@ export const collectBlockListItems = (
   startIdx: number,
   prefix: string,
   itemRegex: RegExp
-): { items: string[]; endIdx: number } => {
-  const items: string[] = [];
+): { items: (string | number)[]; endIdx: number } => {
+  const items: (string | number)[] = [];
   let j = startIdx;
   for (; j < lines.length; j++) {
     if (isBlankOrCommentLine(lines[j])) continue;
     if (!lines[j].startsWith(prefix)) break;
     const m = lines[j].match(itemRegex);
     if (!m) break;
-    items.push(stripQuotes(m[1].trim()));
+    const raw = m[1].trim();
+    const wasQuoted =
+      (raw.startsWith('"') && raw.endsWith('"')) ||
+      (raw.startsWith("'") && raw.endsWith("'"));
+    items.push(coerceListScalar(stripQuotes(raw), wasQuoted));
   }
   return { items, endIdx: j };
 };

--- a/test/util/yaml-scalar.test.ts
+++ b/test/util/yaml-scalar.test.ts
@@ -236,6 +236,10 @@ describe("coerceListScalar via parseFlowList (#1353)", () => {
     expect(parseFlowList("[.5, -1.5]")).toEqual([0.5, -1.5]);
   });
 
+  it("coerces plus-signed and trailing-dot forms the loader reads as numbers", () => {
+    expect(parseFlowList("[+1, 1., +2.5]")).toEqual([1, 1, 2.5]);
+  });
+
   it("keeps an overflowing float mantissa as a string", () => {
     const huge = `${"9".repeat(400)}.5`;
     expect(parseFlowList(`[${huge}]`)).toEqual([huge]);

--- a/test/util/yaml-scalar.test.ts
+++ b/test/util/yaml-scalar.test.ts
@@ -235,4 +235,9 @@ describe("coerceListScalar via parseFlowList (#1353)", () => {
   it("coerces a leading-dot float and negative floats", () => {
     expect(parseFlowList("[.5, -1.5]")).toEqual([0.5, -1.5]);
   });
+
+  it("keeps an overflowing float mantissa as a string", () => {
+    const huge = `${"9".repeat(400)}.5`;
+    expect(parseFlowList(`[${huge}]`)).toEqual([huge]);
+  });
 });

--- a/test/util/yaml-scalar.test.ts
+++ b/test/util/yaml-scalar.test.ts
@@ -205,10 +205,31 @@ describe("coerceListScalar via parseFlowList (#1353)", () => {
     // 0x76 round-trips bare through the serializer's hex carve-out; 010 is
     // octal 8 in YAML 1.1 so Number() would silently rewrite it; 1e3 keeps
     // the authored form.
-    expect(parseFlowList("[0x76, 1e3, 010, .5]")).toEqual(["0x76", "1e3", "010", ".5"]);
+    expect(parseFlowList("[0x76, 1e3, 010]")).toEqual(["0x76", "1e3", "010"]);
   });
 
   it("leaves substitution references and words alone", () => {
     expect(parseFlowList("[${ch}, abc]")).toEqual(["${ch}", "abc"]);
+  });
+
+  it("keeps a >2^53 decimal as a string (no silent digit rewrite)", () => {
+    expect(parseFlowList("[18446744073709551615, 1]")).toEqual([
+      "18446744073709551615",
+      1,
+    ]);
+  });
+
+  it("coerces bare true/false but keeps other truthy spellings", () => {
+    expect(parseFlowList("[true, false, on, yes, 'true']")).toEqual([
+      true,
+      false,
+      "on",
+      "yes",
+      "true",
+    ]);
+  });
+
+  it("coerces a leading-dot float and negative floats", () => {
+    expect(parseFlowList("[.5, -1.5]")).toEqual([0.5, -1.5]);
   });
 });

--- a/test/util/yaml-scalar.test.ts
+++ b/test/util/yaml-scalar.test.ts
@@ -240,6 +240,15 @@ describe("coerceListScalar via parseFlowList (#1353)", () => {
     expect(parseFlowList("[+1, 1., +2.5]")).toEqual([1, 1, 2.5]);
   });
 
+  it("coerces underscore-separated numerics; words with underscores stay strings", () => {
+    expect(parseFlowList("[1_000, 1_0.5, foo_bar, 1_]")).toEqual([
+      1000,
+      10.5,
+      "foo_bar",
+      "1_",
+    ]);
+  });
+
   it("keeps an overflowing float mantissa as a string", () => {
     const huge = `${"9".repeat(400)}.5`;
     expect(parseFlowList(`[${huge}]`)).toEqual([huge]);

--- a/test/util/yaml-scalar.test.ts
+++ b/test/util/yaml-scalar.test.ts
@@ -219,12 +219,15 @@ describe("coerceListScalar via parseFlowList (#1353)", () => {
     ]);
   });
 
-  it("coerces bare true/false but keeps other truthy spellings", () => {
-    expect(parseFlowList("[true, false, on, yes, 'true']")).toEqual([
+  it("coerces every YAML boolean spelling; quotes keep strings", () => {
+    // Same rule parseScalar applies to fields: a bare ``on`` is a boolean
+    // to the loader, so keeping it a string re-emits it quoted and
+    // changes the loaded type.
+    expect(parseFlowList("[true, FALSE, on, yes, 'true']")).toEqual([
       true,
       false,
-      "on",
-      "yes",
+      true,
+      true,
       "true",
     ]);
   });

--- a/test/util/yaml-scalar.test.ts
+++ b/test/util/yaml-scalar.test.ts
@@ -191,3 +191,24 @@ describe("parseFlowList", () => {
     expect(parseFlowList('["\\U000F058F", plain]')).toEqual([MDI, "plain"]);
   });
 });
+
+describe("coerceListScalar via parseFlowList (#1353)", () => {
+  it("coerces unquoted plain decimals and floats to numbers", () => {
+    expect(parseFlowList("[10, -3, 1.5, 0]")).toEqual([10, -3, 1.5, 0]);
+  });
+
+  it("keeps quoted numerics as strings", () => {
+    expect(parseFlowList("['10', \"3\"]")).toEqual(["10", "3"]);
+  });
+
+  it("keeps hex, exponent, and leading-zero forms as strings", () => {
+    // 0x76 round-trips bare through the serializer's hex carve-out; 010 is
+    // octal 8 in YAML 1.1 so Number() would silently rewrite it; 1e3 keeps
+    // the authored form.
+    expect(parseFlowList("[0x76, 1e3, 010, .5]")).toEqual(["0x76", "1e3", "010", ".5"]);
+  });
+
+  it("leaves substitution references and words alone", () => {
+    expect(parseFlowList("[${ch}, abc]")).toEqual(["${ch}", "abc"]);
+  });
+});

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2733,6 +2733,13 @@ describe("numeric list items parse as numbers (#1353)", () => {
     - 11
 `;
     expect(parseYamlSectionValues(single, "wifi").channels).toEqual(["10", 11]);
+
+    const commented = `wifi:
+  channels:
+    - 10 # primary
+    - "6" # quoted
+`;
+    expect(parseYamlSectionValues(commented, "wifi").channels).toEqual([10, "6"]);
   });
 
   it("re-emits sibling numerics bare when one flow-list item changes", () => {

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2705,3 +2705,45 @@ describe("parseYamlSectionValues — flow list with comma-containing items", () 
     expect(values.items).toEqual(["a", "b"]);
   });
 });
+
+describe("numeric list items parse as numbers (#1353)", () => {
+  it("parses unquoted plain decimals in flow and block lists as numbers", () => {
+    const flow = `display:
+  data: [10, 1.5, 0x76, "3", \${glyph_row}]
+`;
+    expect(parseYamlSectionValues(flow, "display").data).toEqual([
+      10,
+      1.5,
+      "0x76",
+      "3",
+      "${glyph_row}",
+    ]);
+
+    const block = `wifi:
+  channels:
+    - 1
+    - "6"
+    - 11
+`;
+    expect(parseYamlSectionValues(block, "wifi").channels).toEqual([1, "6", 11]);
+  });
+
+  it("re-emits sibling numerics bare when one flow-list item changes", () => {
+    // The #1353 repro shape: a flow list inside a list-item mapping
+    // (lcd_pcf8574 user_characters.data). Numeric siblings must come back
+    // bare; only the substitution keeps the protective quoting.
+    const yaml = `display:
+  - platform: lcd_pcf8574
+    user_characters:
+      - position: 0
+        data: [\${glyph_row}, 10, 10]
+`;
+    const from = firstListItemLine(yaml, "display");
+    const values = parseYamlSectionValues(yaml, "display", from);
+    const chars = values.user_characters as { data: (string | number)[] }[];
+    expect(chars[0].data).toEqual(["${glyph_row}", 10, 10]);
+    chars[0].data[1] = 11;
+    const after = updateSectionInYaml(yaml, "display", values, from);
+    expect(after).toContain('data: ["${glyph_row}", 11, 10]');
+  });
+});

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2740,6 +2740,16 @@ describe("numeric list items parse as numbers (#1353)", () => {
     - "6" # quoted
 `;
     expect(parseYamlSectionValues(commented, "wifi").channels).toEqual([10, "6"]);
+
+    // Nested-block flow lists strip the trailing line comment before the
+    // bracket test — without it the value degraded to the string "[1, 2]".
+    const nestedFlow = `mysect:
+  sub:
+    vals: [1, 2] # note
+`;
+    expect(parseYamlSectionValues(nestedFlow, "mysect").sub).toEqual({
+      vals: [1, 2],
+    });
   });
 
   it("re-emits sibling numerics bare when one flow-list item changes", () => {

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2726,6 +2726,13 @@ describe("numeric list items parse as numbers (#1353)", () => {
     - 11
 `;
     expect(parseYamlSectionValues(block, "wifi").channels).toEqual([1, "6", 11]);
+
+    const single = `wifi:
+  channels:
+    - '10'
+    - 11
+`;
+    expect(parseYamlSectionValues(single, "wifi").channels).toEqual(["10", 11]);
   });
 
   it("re-emits sibling numerics bare when one flow-list item changes", () => {


### PR DESCRIPTION
# What does this implement/fix?

Editing one row of a numeric list rewrote the sibling literals quoted: `data: [${glyph_row}, 10, 10]` came back as `data: ["${glyph_row}", "10", 11, …]`. The serializer was right and the type was the lie: both list readers returned every item as a string, and `yamlNeedsQuoting` must quote a string `"10"` or it would re type on reload. The per key splice from #1227 confines the churn to the edited list key, but that key re emits every element.

The list readers (`parseFlowList` and the block reader's `collectBlockListItems`) now coerce unquoted items: plain decimal ints and floats become numbers, and truthy or falsy spellings become booleans through the same `parseYamlBoolean` rule `parseScalar` applies to fields (a bare `on` is a boolean to the loader, so keeping it a string re-emitted it quoted and changed the loaded type). Everything else stays a string, and the bounds are deliberate: quoted items keep their explicit string signal (the readers now share one `isQuotedScalar` definition with `parseScalar`), hex stays a string so `0x76` keeps its bare round trip, leading zero forms stay strings (YAML 1.1 reads `010` as octal 8), exponents keep their authored form, a >2^53 decimal stays a string so `Number()` cannot silently rewrite its digits, and an overflowing float mantissa stays a string rather than becoming `Infinity`. Block items also strip trailing inline comments before coercion (the parseScalar rule), so an edited list no longer corrupts `10 # note` into a literal string. Scalar mapping fields are intentionally untouched — coercing `parseScalar` would change the values the `depends_on_value` visibility gates compare with raw equality.

Verified in the live editor: editing one `user_characters.data` row now flushes `data: ["${glyph_row}", 10, 12, 10, …]` with every numeric bare (only the substitution keeps its protective quoting, since `{` opens a flow mapping in strict YAML), and a typed `0x10` round trips bare. Flat scalar siblings inside a changed list item (`position: 0` re quoting) are a separate residual with the depends_on constraint attached; filed as a follow up.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1353

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
