### PR TITLE
Coerce scalar-field numerics and normalize the visibility gates

### DIFF
--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -107,21 +107,19 @@ export function isEntryVisible(
     ? values[entry.depends_on]
     : rootValues?.[entry.depends_on];
   depValue ??= siblings?.find((s) => s.key === entry.depends_on)?.default_value;
-  // Type-insensitive compares: the parser hands back numbers/booleans for
-  // plain scalars (#1360) while catalog gate values may be strings (or the
-  // reverse for seeded defaults). Nullish depValue keeps today's semantics:
-  // never equal, so `value` hides and `value_not` shows.
+  // Type-insensitive: the parser hands back numbers/booleans for plain
+  // scalars (#1360) while catalog gate values may be strings. Nullish
+  // depValue never matches, so `value` hides and `value_not` shows.
+  const gateMatches = (gate: ConfigPrimitive): boolean =>
+    depValue != null && String(depValue) === String(gate);
   if (entry.depends_on_value !== null && entry.depends_on_value !== undefined) {
-    return depValue != null && String(depValue) === String(entry.depends_on_value);
+    return gateMatches(entry.depends_on_value);
   }
   if (entry.depends_on_value_not !== null && entry.depends_on_value_not !== undefined) {
-    return depValue == null || String(depValue) !== String(entry.depends_on_value_not);
+    return !gateMatches(entry.depends_on_value_not);
   }
   if (entry.depends_on_value_any != null) {
-    return (
-      depValue != null &&
-      entry.depends_on_value_any.some((v) => String(v) === String(depValue))
-    );
+    return entry.depends_on_value_any.some(gateMatches);
   }
   return true;
 }

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -107,14 +107,21 @@ export function isEntryVisible(
     ? values[entry.depends_on]
     : rootValues?.[entry.depends_on];
   depValue ??= siblings?.find((s) => s.key === entry.depends_on)?.default_value;
+  // Type-insensitive compares: the parser hands back numbers/booleans for
+  // plain scalars (#1360) while catalog gate values may be strings (or the
+  // reverse for seeded defaults). Nullish depValue keeps today's semantics:
+  // never equal, so `value` hides and `value_not` shows.
   if (entry.depends_on_value !== null && entry.depends_on_value !== undefined) {
-    return depValue === entry.depends_on_value;
+    return depValue != null && String(depValue) === String(entry.depends_on_value);
   }
   if (entry.depends_on_value_not !== null && entry.depends_on_value_not !== undefined) {
-    return depValue !== entry.depends_on_value_not;
+    return depValue == null || String(depValue) !== String(entry.depends_on_value_not);
   }
   if (entry.depends_on_value_any != null) {
-    return entry.depends_on_value_any.includes(depValue as ConfigPrimitive);
+    return (
+      depValue != null &&
+      entry.depends_on_value_any.some((v) => String(v) === String(depValue))
+    );
   }
   return true;
 }

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -109,7 +109,9 @@ export function isEntryVisible(
   depValue ??= siblings?.find((s) => s.key === entry.depends_on)?.default_value;
   // Type-insensitive: the parser hands back numbers/booleans for plain
   // scalars (#1360) while catalog gate values may be strings. Nullish
-  // depValue never matches, so `value` hides and `value_not` shows.
+  // depValue never matches, so `value` hides and `value_not` shows. The
+  // compare is canonical-form, not lexical — a string gate "1.0" misses a
+  // numeric 1 (fails closed; gate values are integer or token shaped).
   const gateMatches = (gate: ConfigPrimitive): boolean =>
     depValue != null && String(depValue) === String(gate);
   if (entry.depends_on_value !== null && entry.depends_on_value !== undefined) {

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -107,13 +107,18 @@ export function isEntryVisible(
     ? values[entry.depends_on]
     : rootValues?.[entry.depends_on];
   depValue ??= siblings?.find((s) => s.key === entry.depends_on)?.default_value;
-  // Type-insensitive: the parser hands back numbers/booleans for plain
-  // scalars (#1360) while catalog gate values may be strings. Nullish
-  // depValue never matches, so `value` hides and `value_not` shows. The
-  // compare is canonical-form, not lexical — a string gate "1.0" misses a
-  // numeric 1 (fails closed; gate values are integer or token shaped).
+  // Type-insensitive across primitives: the parser hands back numbers /
+  // booleans for plain scalars (#1360) while catalog gate values may be
+  // strings. A non-primitive (or nullish) depValue never matches — so
+  // `value` hides and `value_not` shows, and an array can't stringify
+  // into a spurious match. The compare is canonical-form, not lexical —
+  // a string gate "1.0" misses a numeric 1 (fails closed; gate values
+  // are integer or token shaped).
   const gateMatches = (gate: ConfigPrimitive): boolean =>
-    depValue != null && String(depValue) === String(gate);
+    (typeof depValue === "string" ||
+      typeof depValue === "number" ||
+      typeof depValue === "boolean") &&
+    String(depValue) === String(gate);
   if (entry.depends_on_value !== null && entry.depends_on_value !== undefined) {
     return gateMatches(entry.depends_on_value);
   }

--- a/src/util/hex-int.ts
+++ b/src/util/hex-int.ts
@@ -160,7 +160,8 @@ export function normalizeHexValues(
       // depends on us not allocating a copy here.
       if (CANONICAL_HEX_RE.test(v)) continue;
       // The `parseYamlSectionValues` parser hands hex literals back
-      // as strings (`parseScalar` only special-cases true/false), so
+      // as strings (`parseScalar` coerces only plain decimals and
+      // booleans; hex is deliberately excluded, #1360), so
       // this is the live path for fresh YAML loads. Canonicalising
       // here is what makes `address: 0xBE030C9794184728` (uppercase)
       // round-trip losslessly through the visual editor — without

--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -78,18 +78,12 @@ const parseInlineLambda = (scalar: string): LambdaValue | null => {
 // field that happens to hold ``"on"`` / ``"yes"`` would silently
 // flip to boolean ``true`` on round-trip.
 export const parseScalar = (raw: string): unknown => {
-  // Strip a trailing inline comment so a boolean coerces and no field
+  // Strip a trailing inline comment so plain scalars coerce and no field
   // value is polluted with `# ...` text (#1235).
   const { value: scalar } = splitInlineComment(raw);
   const lambda = parseInlineLambda(scalar);
   if (lambda !== null) return lambda;
-  const wasQuoted = isQuotedScalar(scalar);
-  const v = stripQuotes(scalar);
-  if (!wasQuoted) {
-    const bool = parseYamlBoolean(v);
-    if (bool !== null) return bool;
-  }
-  return v;
+  return coerceYamlScalar(stripQuotes(scalar), isQuotedScalar(scalar));
 };
 
 // Plain-decimal forms only: unambiguous across YAML versions. Hex stays a
@@ -111,15 +105,15 @@ export const isQuotedScalar = (s: string): boolean =>
   ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'")));
 
 /**
- * A list item's parsed value: unquoted plain decimals become numbers and
- * truthy/falsy spellings become booleans (``parseYamlBoolean``, the same
- * rule ``parseScalar`` applies to fields), so the serializer re-emits
- * them bare — string-typed ``10`` would re-quote every sibling when the
- * list re-serializes (#1353), and a string ``on`` would re-emit quoted
- * where the loader had read a boolean. A >2^53 decimal stays a string
- * (Number() would silently rewrite the digits, #378/#944).
+ * A plain scalar's parsed value — fields and list items share this rule.
+ * Unquoted plain decimals become numbers and truthy/falsy spellings
+ * become booleans, so the serializer re-emits them bare — string-typed
+ * ``10`` re-quoted on every re-serialize (#1353/#1360), and a string
+ * ``on`` re-emitted quoted where the loader had read a boolean. A >2^53
+ * decimal stays a string (Number() would silently rewrite the digits,
+ * #378/#944).
  */
-export const coerceListScalar = (
+export const coerceYamlScalar = (
   text: string,
   wasQuoted: boolean
 ): string | number | boolean => {
@@ -158,6 +152,6 @@ export const parseFlowList = (raw: string): (string | number | boolean)[] => {
     if (t.length >= 2 && t.startsWith('"') && t.endsWith('"')) {
       return unescapeYamlDoubleQuoted(t.slice(1, -1));
     }
-    return coerceListScalar(stripQuotes(t), isQuotedScalar(t));
+    return coerceYamlScalar(stripQuotes(t), isQuotedScalar(t));
   });
 };

--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -71,12 +71,8 @@ const parseInlineLambda = (scalar: string): LambdaValue | null => {
   return m ? { _lambda: stripQuotes(m[1].trim()), _tag: "!lambda" } : null;
 };
 
-// Quoting in YAML is the explicit "treat me as a string" signal —
-// ``key: "on"`` must stay the literal ``"on"`` even though ``on`` is
-// a truthy spelling. Detect the quotes BEFORE stripping so we only
-// run the boolean coercion on plain scalars; otherwise a string
-// field that happens to hold ``"on"`` / ``"yes"`` would silently
-// flip to boolean ``true`` on round-trip.
+// ``isQuotedScalar`` must see the scalar BEFORE ``stripQuotes`` — the
+// quotes are the signal that suppresses coercion.
 export const parseScalar = (raw: string): unknown => {
   // Strip a trailing inline comment so plain scalars coerce and no field
   // value is polluted with `# ...` text (#1235).

--- a/src/util/yaml-section-list.ts
+++ b/src/util/yaml-section-list.ts
@@ -6,7 +6,7 @@
  */
 
 import {
-  coerceListScalar,
+  coerceYamlScalar,
   isQuotedScalar,
   parseFlowList,
   parseScalar,
@@ -42,7 +42,7 @@ export const collectBlockListItems = (
     // the comment; keeping it in the value corrupted it into the string
     // ``"10 # note"`` instead.
     const { value: raw } = splitInlineComment(m[1].trim());
-    items.push(coerceListScalar(stripQuotes(raw), isQuotedScalar(raw)));
+    items.push(coerceYamlScalar(stripQuotes(raw), isQuotedScalar(raw)));
   }
   return { items, endIdx: j };
 };

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -405,6 +405,29 @@ describe("validateEntries", () => {
     expect(errors.size).toBe(0);
   });
 
+  it("matches depends_on gates across value types (#1360)", () => {
+    // The parser hands back numbers for plain scalars while catalog gate
+    // values may be strings; the compare is type-insensitive either way.
+    const eq = makeEntry({ key: "a", depends_on: "mode", depends_on_value: "1" });
+    expect(isEntryVisible(eq, { mode: 1 })).toBe(true);
+    expect(isEntryVisible(eq, { mode: 2 })).toBe(false);
+    expect(isEntryVisible(eq, {})).toBe(false);
+
+    const ne = makeEntry({ key: "b", depends_on: "mode", depends_on_value_not: 1 });
+    expect(isEntryVisible(ne, { mode: "1" })).toBe(false);
+    expect(isEntryVisible(ne, { mode: "2" })).toBe(true);
+    expect(isEntryVisible(ne, {})).toBe(true);
+
+    const any = makeEntry({
+      key: "c",
+      depends_on: "mode",
+      depends_on_value_any: ["1", "3"],
+    });
+    expect(isEntryVisible(any, { mode: 3 })).toBe(true);
+    expect(isEntryVisible(any, { mode: 2 })).toBe(false);
+    expect(isEntryVisible(any, {})).toBe(false);
+  });
+
   it("skips required entries gated out by depends_on_value_any", () => {
     const entries = [
       makeEntry({ key: "type", required: true }),

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -426,6 +426,9 @@ describe("validateEntries", () => {
     expect(isEntryVisible(any, { mode: 3 })).toBe(true);
     expect(isEntryVisible(any, { mode: 2 })).toBe(false);
     expect(isEntryVisible(any, {})).toBe(false);
+    // A non-primitive never matches — String(["1"]) is "1" but an array
+    // depValue must not stringify into a spurious gate hit.
+    expect(isEntryVisible(eq, { mode: ["1"] })).toBe(false);
   });
 
   it("skips required entries gated out by depends_on_value_any", () => {

--- a/test/util/yaml-scalar.test.ts
+++ b/test/util/yaml-scalar.test.ts
@@ -141,8 +141,14 @@ describe("parseScalar", () => {
     expect(parseScalar("hello")).toBe("hello");
   });
 
-  it("does not coerce a numeric scalar (boolean-only coercion)", () => {
-    expect(parseScalar("42")).toBe("42");
+  it("coerces plain numeric scalars; quotes and ambiguous forms stay strings", () => {
+    // Same bounds as list items (#1360): plain decimals coerce, hex /
+    // octal-looking / exponent forms keep the authored text.
+    expect(parseScalar("42")).toBe(42);
+    expect(parseScalar('"42"')).toBe("42");
+    expect(parseScalar("0x76")).toBe("0x76");
+    expect(parseScalar("010")).toBe("010");
+    expect(parseScalar("1e3")).toBe("1e3");
   });
 
   it("parses an inline lambda into a LambdaValue", () => {

--- a/test/util/yaml-section-reader-nested-list.test.ts
+++ b/test/util/yaml-section-reader-nested-list.test.ts
@@ -22,8 +22,8 @@ describe("parseYamlSectionValues — list item whose first field is a nested map
 `;
     const v = parseYamlSectionValues(yaml, "font", 2);
     expect(v.id).toBe("my_font");
-    expect(v.size).toBe("20");
-    expect(v.file).toEqual({ type: "gfonts", family: "Roboto", weight: "300" });
+    expect(v.size).toBe(20);
+    expect(v.file).toEqual({ type: "gfonts", family: "Roboto", weight: 300 });
   });
 
   it("captures a local nested mapping (path)", () => {
@@ -49,7 +49,7 @@ describe("parseYamlSectionValues — list item whose first field is a nested map
     const v = parseYamlSectionValues(yaml, "font", 2);
     expect(v.file).toEqual({ type: "web", url: "https://example.com/x.ttf" });
     expect(v.id).toBe("f");
-    expect(v.size).toBe("12");
+    expect(v.size).toBe(12);
   });
 
   it("handles 4-space user indentation", () => {
@@ -74,7 +74,7 @@ describe("parseYamlSectionValues — list item whose first field is a nested map
 `;
     const v = parseYamlSectionValues(yaml, "font", 2);
     expect(v.id).toBe("my_font");
-    expect(v.size).toBe("20");
+    expect(v.size).toBe(20);
     expect(v.file).toEqual({ type: "gfonts", family: "Roboto" });
   });
 
@@ -90,7 +90,7 @@ describe("parseYamlSectionValues — list item whose first field is a nested map
     expect(v).toEqual({
       id: "f",
       file: { type: "gfonts", family: "Roboto" },
-      size: "18",
+      size: 18,
     });
   });
 });
@@ -107,12 +107,12 @@ describe("updateSectionInYaml — list item whose first field is a nested mappin
 
   it("preserves the nested block when a sibling field is edited", () => {
     const values = parseYamlSectionValues(START, "font", 2);
-    values.size = "24";
+    values.size = 24;
     const after = updateSectionInYaml(START, "font", values, 2);
     const v = parseYamlSectionValues(after, "font", 2);
-    expect(v.size).toBe("24");
+    expect(v.size).toBe(24);
     expect(v.id).toBe("my_font");
-    expect(v.file).toEqual({ type: "gfonts", family: "Roboto", weight: "300" });
+    expect(v.file).toEqual({ type: "gfonts", family: "Roboto", weight: 300 });
   });
 
   it("round-trips an unchanged save without dropping or duplicating keys", () => {
@@ -126,10 +126,10 @@ describe("updateSectionInYaml — list item whose first field is a nested mappin
 
   it("writes an edited nested field back into the block", () => {
     const values = parseYamlSectionValues(START, "font", 2);
-    (values.file as Record<string, unknown>).weight = "700";
+    (values.file as Record<string, unknown>).weight = 700;
     const after = updateSectionInYaml(START, "font", values, 2);
     const v = parseYamlSectionValues(after, "font", 2);
-    expect((v.file as Record<string, unknown>).weight).toBe("700");
+    expect((v.file as Record<string, unknown>).weight).toBe(700);
     expect((v.file as Record<string, unknown>).family).toBe("Roboto");
     expect(v.id).toBe("my_font");
   });
@@ -183,7 +183,7 @@ describe("parseYamlSectionValues — nested-under-a-key list item with a txt map
       {
         service: "aioesphome._tcp.local.",
         protocol: "_tcp",
-        port: "0",
+        port: 0,
         txt: { new_1: "fdfd" },
       },
     ]);

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1621,7 +1621,7 @@ describe("parseYamlSectionValues — list-of-mappings (multi_value=true)", () =>
       {
         to_ntc_resistance: {
           calibration: ["10.0kOhm -> 25°C", "27.219kOhm -> 0°C"],
-          b_constant: "3950",
+          b_constant: 3950,
         },
       },
     ]);
@@ -1755,7 +1755,7 @@ describe("parseYamlSectionValues — list-of-mappings (multi_value=true)", () =>
           delta: 0.5
 `;
     const values = parseYamlSectionValues(yaml, "sensor.template", 2);
-    expect(values.triggers).toEqual([{ id: "my_trigger", filters: { delta: "0.5" } }]);
+    expect(values.triggers).toEqual([{ id: "my_trigger", filters: { delta: 0.5 } }]);
     expect(updateSectionInYaml(yaml, "sensor.template", values, 2)).toBe(yaml);
   });
 
@@ -1818,7 +1818,7 @@ sensor:
     const sensorLine =
       yaml.split("\n").findIndex((l) => l.startsWith("  - platform: template")) + 1;
     const sensorValues = parseYamlSectionValues(yaml, "sensor.template", sensorLine);
-    expect(sensorValues.filters).toEqual([{ delta: "0.1" }, { multiply: "2.0" }]);
+    expect(sensorValues.filters).toEqual([{ delta: 0.1 }, { multiply: 2 }]);
   });
 
   it("parses light effects (single-key empty mappings) as an array (#941)", () => {
@@ -2769,5 +2769,9 @@ describe("numeric list items parse as numbers (#1353)", () => {
     chars[0].data[1] = 11;
     const after = updateSectionInYaml(yaml, "display", values, from);
     expect(after).toContain('data: ["${glyph_row}", 11, 10]');
+    // The sibling scalar field re-emits bare too (#1360) — it parsed as a
+    // number, so the re-serialized item can't re-quote it.
+    expect(after).toContain("position: 0");
+    expect(after).not.toContain('position: "0"');
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The scalar field half of the #1353 churn: editing any field inside a list item re serialized the whole item, and a numeric field parsed as a string re emitted quoted (`position: 0` became `position: "0"`). The root is the same type lie #1359 fixed for list items, but scalar fields were deliberately left out there because `parseScalar` feeds the `depends_on_value` visibility gates, which compared with raw strict equality and would break on number typed values.

This lands the two halves in order. The three gates in `isEntryVisible` now compare type insensitively through one `gateMatches` helper (`String()` both sides, nullish never matches, preserving today's hide and show semantics exactly) — a robustness fix on its own, since number typed seeded defaults could already mismatch string gates. With the gates safe, `parseScalar` routes through the same `coerceYamlScalar` (renamed from `coerceListScalar`) that #1359 landed, so scalar fields inherit every bound: plain decimals and loader boolean spellings coerce, quotes win, hex, octal looking, exponent, >2^53 and overflow forms keep the authored text. An independent consumer sweep confirmed every other reader of parsed values already `String()` normalizes or type guards, and unchanged fields keep byte verbatim preservation since the splice compares two parses of the same shape.

Verified in the live editor: editing a `data` row now flushes the item with `position: 0` bare, and the gated `esp32` section renders its `depends_on` driven fields unchanged. Fixture expectations that pinned the old string typed numerics (`size: "20"`, `port: "0"`, `weight: "300"`) are updated to the loader true types; quoted forms staying strings remain pinned at every level.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1360

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
