### PR TITLE
Guard the remaining numeric emit paths against non-finite and prefix-parsed input

### DIFF
--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -38,8 +38,8 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
+import { coerceParamValue } from "../../../util/coerce-entry-value.js";
 import { fireEvent } from "../../../util/fire-event.js";
-import { coerceIntFieldValue } from "../../../util/int-input.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import "../config-entry-form.js";
@@ -69,19 +69,6 @@ import type {
   CatalogPickedDetail,
   ESPHomeCatalogPickerDialog,
 } from "./catalog-picker-dialog.js";
-
-/** Script-parameter commit coercion: ints via ``coerceIntFieldValue`` (no
- *  prefix parsing; hex / 64-bit decimals stay verbatim), floats
- *  finite-or-verbatim so Infinity can't reach the JSON wire as null. */
-export function coerceParamValue(type: string, raw: string): string | number {
-  if (raw === "") return "";
-  if (type === "int") return coerceIntFieldValue(raw);
-  if (type === "float") {
-    const n = Number(raw);
-    return Number.isFinite(n) ? n : raw;
-  }
-  return raw;
-}
 import { applyParamChange } from "./serialise.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -366,10 +353,6 @@ export class ESPHomeAutomationActionNode extends LitElement {
               .value=${String(this.value.params[p.name] ?? "")}
               @input=${(e: Event) => {
                 const raw = (e.target as HTMLInputElement).value;
-                // Strict coercion (#1361): parseInt prefix-parsed junk
-                // ("1e309" became 1) and an unguarded Number() could put
-                // Infinity into params, which JSON-serializes to null on
-                // the wire. Unparseable input ships verbatim instead.
                 this._patchParams({ [p.name]: coerceParamValue(p.type, raw) });
               }}
             />`

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -39,6 +39,7 @@ import { localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
 import { fireEvent } from "../../../util/fire-event.js";
+import { coerceIntFieldValue } from "../../../util/int-input.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import "../config-entry-form.js";
@@ -68,6 +69,19 @@ import type {
   CatalogPickedDetail,
   ESPHomeCatalogPickerDialog,
 } from "./catalog-picker-dialog.js";
+
+/** Script-parameter commit coercion: ints via ``coerceIntFieldValue`` (no
+ *  prefix parsing; hex / 64-bit decimals stay verbatim), floats
+ *  finite-or-verbatim so Infinity can't reach the JSON wire as null. */
+export function coerceParamValue(type: string, raw: string): string | number {
+  if (raw === "") return "";
+  if (type === "int") return coerceIntFieldValue(raw);
+  if (type === "float") {
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : raw;
+  }
+  return raw;
+}
 import { applyParamChange } from "./serialise.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -352,17 +366,11 @@ export class ESPHomeAutomationActionNode extends LitElement {
               .value=${String(this.value.params[p.name] ?? "")}
               @input=${(e: Event) => {
                 const raw = (e.target as HTMLInputElement).value;
-                const next =
-                  p.type === "int"
-                    ? raw === ""
-                      ? ""
-                      : parseInt(raw, 10)
-                    : p.type === "float"
-                      ? raw === ""
-                        ? ""
-                        : Number(raw)
-                      : raw;
-                this._patchParams({ [p.name]: next });
+                // Strict coercion (#1361): parseInt prefix-parsed junk
+                // ("1e309" became 1) and an unguarded Number() could put
+                // Infinity into params, which JSON-serializes to null on
+                // the wire. Unparseable input ships verbatim instead.
+                this._patchParams({ [p.name]: coerceParamValue(p.type, raw) });
               }}
             />`
       )}

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -439,7 +439,11 @@ export function renderStringField(
     placeholder=${placeholder}
     @input=${(e: Event) => {
       const raw = (e.target as HTMLInputElement).value;
-      ctx.emitChange(path, escapeMode ? unescapeControlForInput(raw) : raw);
+      // Numeric entries land here when the stored value is a substitution
+      // or junk (the FLOAT bail); a corrected plain number must go back
+      // as a number or the YAML re-emits it quoted (#1361).
+      const text = escapeMode ? unescapeControlForInput(raw) : raw;
+      ctx.emitChange(path, coerceValueToEntryType(entry, text));
     }}
   />`;
   return html`

--- a/src/components/device/config-entry-renderers/primitives-numeric.ts
+++ b/src/components/device/config-entry-renderers/primitives-numeric.ts
@@ -10,6 +10,7 @@ import {
   serializeFloatWithUnit,
   visibleUnitOptions,
 } from "../../../util/float-with-unit.js";
+import { coerceValueToEntryType } from "../../../util/coerce-entry-value.js";
 import { formatHexInt, parseHexInt } from "../../../util/hex-int.js";
 import { coerceIntFieldValue } from "../../../util/int-input.js";
 import { looksLikeSubstitution } from "../../../util/substitutions.js";
@@ -50,12 +51,14 @@ export function renderNumberField(entry: ConfigEntry, path: string[], ctx: Rende
   }
   // An unparseable primitive ("250 steps/s", a stray boolean) blanks inside
   // <input type="number"> and reads as unset — and an edit would write a bare
-  // number over the original value. Bail visibly instead; a ${substitution}
-  // stays editable as text, matching the validator's carve-out (#2056).
-  // Number(String(raw)) mirrors validateEntry's coercion, tightened to
-  // isFinite: Infinity also blanks in a number input, so it bails too.
+  // number over the original value. Bail visibly instead. A string (a
+  // ${substitution}, junk, a stored "1e309") edits as text with its
+  // validation error in place — a read-only shell would strand the user,
+  // the call #1352 settled for list rows; only a non-string primitive
+  // keeps the YAML-only shell. Number(String(raw)) mirrors validateEntry's
+  // coercion; Infinity also blanks in a number input, so it bails too.
   if (raw != null && !Number.isFinite(Number(String(raw)))) {
-    return looksLikeSubstitution(String(raw))
+    return typeof raw === "string"
       ? renderStringField(entry, "text", path, ctx)
       : renderYamlOnlyField(entry, path, ctx);
   }
@@ -80,7 +83,10 @@ export function renderNumberField(entry: ConfigEntry, path: string[], ctx: Rende
       placeholder=${String(entry.default_value ?? "")}
       @input=${(e: Event) => {
         const raw = (e.target as HTMLInputElement).value;
-        ctx.emitChange(path, raw === "" ? "" : Number(raw));
+        // Non-finite input (a typed 1e309) ships verbatim, not Infinity —
+        // the serializer would write a bare ``Infinity`` the loader reads
+        // as a string (#1361).
+        ctx.emitChange(path, coerceValueToEntryType(entry, raw));
       }}
     />`
   );

--- a/src/components/device/config-entry-renderers/primitives-numeric.ts
+++ b/src/components/device/config-entry-renderers/primitives-numeric.ts
@@ -49,14 +49,10 @@ export function renderNumberField(entry: ConfigEntry, path: string[], ctx: Rende
   if (entry.type === ConfigEntryType.INTEGER) {
     return renderIntField(entry, path, ctx);
   }
-  // An unparseable primitive ("250 steps/s", a stray boolean) blanks inside
-  // <input type="number"> and reads as unset — and an edit would write a bare
-  // number over the original value. Bail visibly instead. A string (a
-  // ${substitution}, junk, a stored "1e309") edits as text with its
-  // validation error in place — a read-only shell would strand the user,
-  // the call #1352 settled for list rows; only a non-string primitive
-  // keeps the YAML-only shell. Number(String(raw)) mirrors validateEntry's
-  // coercion; Infinity also blanks in a number input, so it bails too.
+  // An unparseable primitive blanks inside <input type="number"> and reads
+  // as unset. A string (a ${substitution}, junk, a stored "1e309") stays
+  // editable as text with its validation error in place; only a non-string
+  // primitive gets the read-only YAML-only shell.
   if (raw != null && !Number.isFinite(Number(String(raw)))) {
     return typeof raw === "string"
       ? renderStringField(entry, "text", path, ctx)
@@ -83,9 +79,6 @@ export function renderNumberField(entry: ConfigEntry, path: string[], ctx: Rende
       placeholder=${String(entry.default_value ?? "")}
       @input=${(e: Event) => {
         const raw = (e.target as HTMLInputElement).value;
-        // Non-finite input (a typed 1e309) ships verbatim, not Infinity —
-        // the serializer would write a bare ``Infinity`` the loader reads
-        // as a string (#1361).
         ctx.emitChange(path, coerceValueToEntryType(entry, raw));
       }}
     />`

--- a/src/util/coerce-entry-value.ts
+++ b/src/util/coerce-entry-value.ts
@@ -18,13 +18,15 @@ export function coerceValueToEntryType(entry: ConfigEntry, raw: string): string 
   return raw;
 }
 
-/** Finite input becomes a number; empty and non-finite input (a typed
- *  ``1e309``) ship verbatim so the validator flags them instead of the
- *  serializer writing a bare ``Infinity`` (#1361). */
+/** Finite input becomes a number; blank and non-finite input (a typed
+ *  ``1e309``) ship as ""/verbatim so the validator flags them instead of
+ *  the serializer writing a bare ``Infinity`` (#1361). Trims like
+ *  ``coerceIntFieldValue`` so whitespace-only input stays blank, not 0. */
 export function coerceFloatFieldValue(raw: string): string | number {
-  if (raw === "") return "";
-  const n = Number(raw);
-  return Number.isFinite(n) ? n : raw;
+  const v = raw.trim();
+  if (v === "") return "";
+  const n = Number(v);
+  return Number.isFinite(n) ? n : v;
 }
 
 /** Script-parameter variant keyed on the param's type token; ints never

--- a/src/util/coerce-entry-value.ts
+++ b/src/util/coerce-entry-value.ts
@@ -14,7 +14,24 @@ import { coerceIntFieldValue } from "./int-input.js";
  */
 export function coerceValueToEntryType(entry: ConfigEntry, raw: string): string | number {
   if (entry.type === ConfigEntryType.INTEGER) return coerceIntFieldValue(raw);
-  if (entry.type !== ConfigEntryType.FLOAT || raw === "") return raw;
+  if (entry.type === ConfigEntryType.FLOAT) return coerceFloatFieldValue(raw);
+  return raw;
+}
+
+/** Finite input becomes a number; empty and non-finite input (a typed
+ *  ``1e309``) ship verbatim so the validator flags them instead of the
+ *  serializer writing a bare ``Infinity`` (#1361). */
+export function coerceFloatFieldValue(raw: string): string | number {
+  if (raw === "") return "";
   const n = Number(raw);
   return Number.isFinite(n) ? n : raw;
+}
+
+/** Script-parameter variant keyed on the param's type token; ints never
+ *  prefix-parse (``parseInt`` read ``1e309`` as 1) and floats never
+ *  commit Infinity, which JSON-serializes to null on the WS wire. */
+export function coerceParamValue(type: string, raw: string): string | number {
+  if (type === "int") return coerceIntFieldValue(raw);
+  if (type === "float") return coerceFloatFieldValue(raw);
+  return raw;
 }

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -308,7 +308,9 @@ export function validateEntry(entry: ConfigEntry, raw: unknown): ValidationError
     }
   } else if (entry.type === ConfigEntryType.FLOAT) {
     const num = typeof raw === "number" ? raw : Number(String(raw));
-    if (Number.isNaN(num)) {
+    // isFinite, not just NaN: a stored "1e309"/"Infinity" is no float the
+    // backend accepts, and the text field it renders in needs the error.
+    if (!Number.isFinite(num)) {
       return { key: entry.key, code: "validation.not_a_number" };
     }
     if (entry.range) {

--- a/test/components/device/automation-editor/automation-action-node-param-coerce.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-param-coerce.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the script-parameter commit coercion: ints never prefix-parse
+ * (the old ``parseInt`` read ``1e309`` as 1) and floats never commit
+ * Infinity, which JSON-serializes to null on the WS wire (#1361).
+ */
+import { describe, expect, it } from "vitest";
+import { coerceParamValue } from "../../../../src/components/device/automation-editor/automation-action-node.js";
+
+describe("coerceParamValue", () => {
+  it("commits decimal int input as a number", () => {
+    expect(coerceParamValue("int", "42")).toBe(42);
+    expect(coerceParamValue("int", "-5")).toBe(-5);
+  });
+
+  it("ships non-decimal int input verbatim instead of prefix-parsing", () => {
+    expect(coerceParamValue("int", "1e309")).toBe("1e309");
+    expect(coerceParamValue("int", "0x10")).toBe("0x10");
+    expect(coerceParamValue("int", "18446744073709551615")).toBe("18446744073709551615");
+  });
+
+  it("commits finite float input as a number, non-finite verbatim", () => {
+    expect(coerceParamValue("float", "2.5")).toBe(2.5);
+    expect(coerceParamValue("float", "1e309")).toBe("1e309");
+  });
+
+  it("passes empty input and non-numeric param types through", () => {
+    expect(coerceParamValue("int", "")).toBe("");
+    expect(coerceParamValue("float", "")).toBe("");
+    expect(coerceParamValue("string", "abc")).toBe("abc");
+  });
+});

--- a/test/components/device/render-int-field.test.ts
+++ b/test/components/device/render-int-field.test.ts
@@ -144,6 +144,12 @@ describe("renderNumberField — float fields", () => {
     expect(emitChange).toHaveBeenCalledWith(["gain"], "");
   });
 
+  it("treats whitespace-only input as blank, not 0", () => {
+    const { ctx, emitChange } = makeCtx({ gain: "" });
+    fireInput(renderNumberField(floatEntry(), ["gain"], ctx), "   ");
+    expect(emitChange).toHaveBeenCalledWith(["gain"], "");
+  });
+
   it("coerces a corrected value from the junk-value text field back to a number", () => {
     const { ctx, emitChange } = makeCtx({ gain: "1e309" });
     const tpl = renderNumberField(floatEntry(), ["gain"], ctx);

--- a/test/components/device/render-int-field.test.ts
+++ b/test/components/device/render-int-field.test.ts
@@ -112,51 +112,44 @@ describe("renderNumberField — integer fields accept decimal or hex", () => {
     expect(emitChange).toHaveBeenCalledWith(["address"], "18446744073709551615");
   });
 
-  it("keeps the native number input for float fields", () => {
-    const { ctx, emitChange } = makeCtx({ gain: "1.5" });
-    const entry = makeConfigEntry({
-      key: "gain",
-      type: ConfigEntryType.FLOAT,
-      label: "Gain",
-    });
-    const tpl = renderNumberField(entry, ["gain"], ctx);
-    expect(inputHtml(tpl)).toContain('type="number"');
-    // The float path coerces to a number rather than preserving a string.
-    fireInput(tpl, "2.5");
-    expect(emitChange).toHaveBeenCalledWith(["gain"], 2.5);
-  });
-
-  it("keeps non-finite float input verbatim (never Infinity)", () => {
-    const { ctx, emitChange } = makeCtx({ gain: "" });
-    const entry = makeConfigEntry({
-      key: "gain",
-      type: ConfigEntryType.FLOAT,
-      label: "Gain",
-    });
-    fireInput(renderNumberField(entry, ["gain"], ctx), "1e309");
-    expect(emitChange).toHaveBeenCalledWith(["gain"], "1e309");
-    fireInput(renderNumberField(entry, ["gain"], ctx), "");
-    expect(emitChange).toHaveBeenCalledWith(["gain"], "");
-  });
-
-  it("coerces a corrected value from the junk-float text field back to a number", () => {
-    const { ctx, emitChange } = makeCtx({ gain: "1e309" });
-    const entry = makeConfigEntry({
-      key: "gain",
-      type: ConfigEntryType.FLOAT,
-      label: "Gain",
-    });
-    const tpl = renderNumberField(entry, ["gain"], ctx);
-    fireInput(tpl, "50");
-    expect(emitChange).toHaveBeenCalledWith(["gain"], 50);
-    fireInput(tpl, "${speed}");
-    expect(emitChange).toHaveBeenCalledWith(["gain"], "${speed}");
-  });
-
   it("leaves the display_format:hex path canonicalizing", () => {
     const { ctx, emitChange } = makeCtx({ rom: "" });
     const entry = intEntry({ key: "rom", display_format: "hex" });
     fireInput(renderNumberField(entry, ["rom"], ctx), "118");
     expect(emitChange).toHaveBeenCalledWith(["rom"], "0x76");
+  });
+});
+
+describe("renderNumberField — float fields", () => {
+  const floatEntry = (): ConfigEntry =>
+    makeConfigEntry({
+      key: "gain",
+      type: ConfigEntryType.FLOAT,
+      label: "Gain",
+    });
+
+  it("keeps the native number input and coerces to a number", () => {
+    const { ctx, emitChange } = makeCtx({ gain: "1.5" });
+    const tpl = renderNumberField(floatEntry(), ["gain"], ctx);
+    expect(inputHtml(tpl)).toContain('type="number"');
+    fireInput(tpl, "2.5");
+    expect(emitChange).toHaveBeenCalledWith(["gain"], 2.5);
+  });
+
+  it("keeps non-finite input verbatim (never Infinity)", () => {
+    const { ctx, emitChange } = makeCtx({ gain: "" });
+    fireInput(renderNumberField(floatEntry(), ["gain"], ctx), "1e309");
+    expect(emitChange).toHaveBeenCalledWith(["gain"], "1e309");
+    fireInput(renderNumberField(floatEntry(), ["gain"], ctx), "");
+    expect(emitChange).toHaveBeenCalledWith(["gain"], "");
+  });
+
+  it("coerces a corrected value from the junk-value text field back to a number", () => {
+    const { ctx, emitChange } = makeCtx({ gain: "1e309" });
+    const tpl = renderNumberField(floatEntry(), ["gain"], ctx);
+    fireInput(tpl, "50");
+    expect(emitChange).toHaveBeenCalledWith(["gain"], 50);
+    fireInput(tpl, "${speed}");
+    expect(emitChange).toHaveBeenCalledWith(["gain"], "${speed}");
   });
 });

--- a/test/components/device/render-int-field.test.ts
+++ b/test/components/device/render-int-field.test.ts
@@ -126,6 +126,33 @@ describe("renderNumberField — integer fields accept decimal or hex", () => {
     expect(emitChange).toHaveBeenCalledWith(["gain"], 2.5);
   });
 
+  it("keeps non-finite float input verbatim (never Infinity)", () => {
+    const { ctx, emitChange } = makeCtx({ gain: "" });
+    const entry = makeConfigEntry({
+      key: "gain",
+      type: ConfigEntryType.FLOAT,
+      label: "Gain",
+    });
+    fireInput(renderNumberField(entry, ["gain"], ctx), "1e309");
+    expect(emitChange).toHaveBeenCalledWith(["gain"], "1e309");
+    fireInput(renderNumberField(entry, ["gain"], ctx), "");
+    expect(emitChange).toHaveBeenCalledWith(["gain"], "");
+  });
+
+  it("coerces a corrected value from the junk-float text field back to a number", () => {
+    const { ctx, emitChange } = makeCtx({ gain: "1e309" });
+    const entry = makeConfigEntry({
+      key: "gain",
+      type: ConfigEntryType.FLOAT,
+      label: "Gain",
+    });
+    const tpl = renderNumberField(entry, ["gain"], ctx);
+    fireInput(tpl, "50");
+    expect(emitChange).toHaveBeenCalledWith(["gain"], 50);
+    fireInput(tpl, "${speed}");
+    expect(emitChange).toHaveBeenCalledWith(["gain"], "${speed}");
+  });
+
   it("leaves the display_format:hex path canonicalizing", () => {
     const { ctx, emitChange } = makeCtx({ rom: "" });
     const entry = intEntry({ key: "rom", display_format: "hex" });

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -227,11 +227,22 @@ describe("renderNumberField / renderFloatWithUnitField — bail on unparseable p
       unit_options: ["°C", "°F", "K"],
     });
 
-  it("bails on a unit-suffixed string under a FLOAT field", () => {
+  it("renders editable text for a unit-suffixed string under a FLOAT field", () => {
+    // A junk string edits in place with its validation error rather than
+    // locking behind the YAML-only shell (#1352's call for list rows).
     const { ctx } = makeCtx({ max_speed: "250 steps/s" });
     const tpl = renderNumberField(floatEntry(), ["max_speed"], ctx);
     const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
-    expect(rendersBailBranch(json)).toBe(true);
+    expect(rendersBailBranch(json)).toBe(false);
+    expect(json).toContain("250 steps/s");
+  });
+
+  it("renders editable text for a stored non-finite string under a FLOAT field", () => {
+    const { ctx } = makeCtx({ max_speed: "1e309" });
+    const tpl = renderNumberField(floatEntry(), ["max_speed"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(false);
+    expect(json).toContain("1e309");
   });
 
   it("bails on a boolean under a FLOAT field", () => {

--- a/test/util/coerce-param-value.test.ts
+++ b/test/util/coerce-param-value.test.ts
@@ -26,6 +26,7 @@ describe("coerceParamValue", () => {
   it("passes empty input and non-numeric param types through", () => {
     expect(coerceParamValue("int", "")).toBe("");
     expect(coerceParamValue("float", "")).toBe("");
+    expect(coerceParamValue("float", "  ")).toBe("");
     expect(coerceParamValue("string", "abc")).toBe("abc");
   });
 });

--- a/test/util/coerce-param-value.test.ts
+++ b/test/util/coerce-param-value.test.ts
@@ -1,12 +1,10 @@
 /**
- * @vitest-environment happy-dom
- *
  * Pins the script-parameter commit coercion: ints never prefix-parse
  * (the old ``parseInt`` read ``1e309`` as 1) and floats never commit
  * Infinity, which JSON-serializes to null on the WS wire (#1361).
  */
 import { describe, expect, it } from "vitest";
-import { coerceParamValue } from "../../../../src/components/device/automation-editor/automation-action-node.js";
+import { coerceParamValue } from "../../src/util/coerce-entry-value.js";
 
 describe("coerceParamValue", () => {
   it("commits decimal int input as a number", () => {

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -279,6 +279,13 @@ describe("validateEntry", () => {
     expect(validateEntry(entry, 3.5)).toBeNull();
   });
 
+  it("flags non-finite text on FLOAT fields", () => {
+    const entry = makeEntry({ type: ConfigEntryType.FLOAT });
+    expect(validateEntry(entry, "1e309")?.code).toBe("validation.not_a_number");
+    expect(validateEntry(entry, "Infinity")?.code).toBe("validation.not_a_number");
+    expect(validateEntry(entry, "1e308")).toBeNull();
+  });
+
   it("validates the numeric portion of FLOAT_WITH_UNIT entries", () => {
     const entry = makeEntry({
       type: ConfigEntryType.FLOAT_WITH_UNIT,


### PR DESCRIPTION
# What does this implement/fix?

The two emit paths #1359's sweep flagged still carried the old coercion bugs. The FLOAT field committed `Number(raw)` unguarded, so an overflowing input stored `Infinity` and the serializer wrote a bare `Infinity` the loader reads back as a string. Script parameters were worse: `parseInt` prefix parses, so `1e309` silently became `1`, and the float branch could put `Infinity` into params that ship over the JSON wire, where it serializes to `null`.

Both now route through the strict coercers: the FLOAT field commits via `coerceValueToEntryType` (finite becomes a number, anything else ships verbatim), and script params get a small `coerceParamValue` using `coerceIntFieldValue` for ints and a finite guarded `Number` for floats.

Storing the junk verbatim needed two companions. The FLOAT renderer's unparseable bail previously locked any such value behind the read only YAML notice; a string now renders as editable text (the call #1352 settled for list rows), with only non string primitives keeping the shell. And `validateEntry`'s FLOAT check tightened from `isNaN` to `!isFinite`, so a stored `1e309` actually flags "Must be a number" instead of passing silently. The plain text emit also coerces through the same helper, so correcting a junk float writes a bare number rather than a quoted string.

Verified in the live editor with a template number: a stored `max_value: 1e309` renders editable text, a junk edit flags "Must be a number", and correcting it to `50` flips the field back to the number spinner with `max_value: 50` bare in the YAML.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1361

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
