### PR TITLE
Move toasts to the bottom-right corner

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -421,9 +421,11 @@ export class ESPHomeApp extends LitElement {
   private async _init() {
     toast.config({
       toastOptions: {
-        // bottom-left keeps toasts clear of the editor's bottom-right
-        // Install/Validate/Save FAB cluster (#921, prior fix #171).
-        position: "bottom-left",
+        // bottom-right by maintainer preference. Known trade-off: a toast
+        // can briefly cover the editor's bottom-right Install/Validate/Save
+        // cluster (#921 moved it left for that reason) — toasts auto-dismiss
+        // and carry a close button, so the overlap is transient.
+        position: "bottom-right",
         richColors: true,
         duration: 4000,
         closeButton: true,

--- a/src/web/esphome-web-app.ts
+++ b/src/web/esphome-web-app.ts
@@ -57,7 +57,8 @@ export class ESPHomeWebApp extends LitElement {
   private async _init(): Promise<void> {
     toast.config({
       toastOptions: {
-        position: "bottom-left",
+        // Mirrors the dashboard's toaster position (app-shell.ts).
+        position: "bottom-right",
         richColors: true,
         duration: 4000,
         closeButton: true,


### PR DESCRIPTION
# What does this implement/fix?

Moves the sonner toaster from the bottom-left to the **bottom-right** corner, on both surfaces that configure it: the wheel dashboard (`app-shell.ts`) and ESPHome Web (`esphome-web-app.ts`), keeping the two consistent.

Heads-up for review — this knowingly reverses the placement chosen when fixing esphome/device-builder#921 ("Popup covering buttons"): a toast at bottom-right can briefly overlap the editor's bottom-right Install/Validate/Save cluster. Maintainer decision was to accept that trade-off (toasts auto-dismiss after 4s and carry a close button, so the overlap is transient); the code comment at the config site now records exactly that instead of the stale bottom-left rationale.

Verified live in the dev server: the rendered toaster carries `data-position="bottom-right"` and a fired toast measures 24px from the right and bottom viewport edges.

**Related issue or feature (if applicable):**

- Reverses the placement introduced for esphome/device-builder#921 (accepted trade-off, see above)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
