### PR TITLE
Ship non-finite float-with-unit input verbatim and keep junk strings editable

### DIFF
--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -296,6 +296,20 @@ export function renderYamlOnlyFallbackIfNonPrimitive(
   return renderYamlOnlyField(entry, path, ctx);
 }
 
+/** Fallback for a primitive a numeric widget can't represent: a string (a
+ *  ${substitution}, junk, a stored "1e309") stays editable as text with its
+ *  validation error in place; any other primitive gets the YAML-only shell. */
+export function renderUnparseableScalarField(
+  entry: ConfigEntry,
+  path: string[],
+  ctx: RenderCtx,
+  raw: unknown
+) {
+  return typeof raw === "string"
+    ? renderStringField(entry, "text", path, ctx)
+    : renderYamlOnlyField(entry, path, ctx);
+}
+
 /** The "this value can only be edited in YAML" field shell — shown when a
  *  value's shape (a mapping, or a list whose items are mappings) can't be
  *  driven by the scalar/multi-value inputs. */

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -296,7 +296,7 @@ export function renderYamlOnlyFallbackIfNonPrimitive(
   return renderYamlOnlyField(entry, path, ctx);
 }
 
-/** Fallback for a primitive a numeric widget can't represent: a string (a
+/** Fallback for a primitive a typed widget can't represent: a string (a
  *  ${substitution}, junk, a stored "1e309") stays editable as text with its
  *  validation error in place; any other primitive gets the YAML-only shell. */
 export function renderUnparseableScalarField(

--- a/src/components/device/config-entry-renderers/primitives-numeric.ts
+++ b/src/components/device/config-entry-renderers/primitives-numeric.ts
@@ -10,10 +10,12 @@ import {
   serializeFloatWithUnit,
   visibleUnitOptions,
 } from "../../../util/float-with-unit.js";
-import { coerceValueToEntryType } from "../../../util/coerce-entry-value.js";
+import {
+  coerceFloatFieldValue,
+  coerceValueToEntryType,
+} from "../../../util/coerce-entry-value.js";
 import { formatHexInt, parseHexInt } from "../../../util/hex-int.js";
 import { coerceIntFieldValue } from "../../../util/int-input.js";
-import { looksLikeSubstitution } from "../../../util/substitutions.js";
 import {
   parseTimePeriodScalar,
   serializeTimePeriod,
@@ -27,8 +29,8 @@ import {
   renderFieldShell,
   renderLabel,
   renderStringField,
+  renderUnparseableScalarField,
   renderYamlOnlyFallbackIfNonPrimitive,
-  renderYamlOnlyField,
   type RenderCtx,
 } from "../config-entry-renderers-shared.js";
 
@@ -50,13 +52,9 @@ export function renderNumberField(entry: ConfigEntry, path: string[], ctx: Rende
     return renderIntField(entry, path, ctx);
   }
   // An unparseable primitive blanks inside <input type="number"> and reads
-  // as unset. A string (a ${substitution}, junk, a stored "1e309") stays
-  // editable as text with its validation error in place; only a non-string
-  // primitive gets the read-only YAML-only shell.
+  // as unset; bail to the shared junk-scalar fallback.
   if (raw != null && !Number.isFinite(Number(String(raw)))) {
-    return typeof raw === "string"
-      ? renderStringField(entry, "text", path, ctx)
-      : renderYamlOnlyField(entry, path, ctx);
+    return renderUnparseableScalarField(entry, path, ctx, raw);
   }
   // FLOAT keeps the native number spinner — floats don't take 0x… literals.
   const value = String(raw ?? "");
@@ -277,18 +275,16 @@ export function renderFloatWithUnitField(
   // the parser turns into null/"". Cleared on blur and on entries change.
   const editingText = ctx.getEditingMagnitude(path);
   // A present value the parser can't split ("21C", "inf") would render as an
-  // empty magnitude + unit picker and read as unset. Bail visibly unless the
-  // user is mid-edit — the buffer legitimately holds partial input — with the
-  // same editable-text carve-out for a ${substitution} value (#2056).
+  // empty magnitude + unit picker and read as unset. Bail to the shared
+  // junk-scalar fallback unless the user is mid-edit — the buffer
+  // legitimately holds partial input.
   if (
     parsed.value === null &&
     editingText == null &&
     rawValue != null &&
     String(rawValue).trim() !== ""
   ) {
-    return looksLikeSubstitution(String(rawValue))
-      ? renderStringField(entry, "text", path, ctx)
-      : renderYamlOnlyField(entry, path, ctx);
+    return renderUnparseableScalarField(entry, path, ctx, rawValue);
   }
   const numberValue = editingText ?? (parsed.value === null ? "" : String(parsed.value));
   const unit = chooseDisplayUnit(
@@ -331,8 +327,14 @@ export function renderFloatWithUnitField(
             // Clearing magnitude drops the unit (`{null, kHz}` serializes to "");
             // stash the unit so the next render's fallback doesn't snap back to canonical.
             if (raw === "") ctx.setPendingUnit(path, unit);
-            const next = raw === "" ? null : Number(raw);
-            emit({ value: Number.isFinite(next) ? next : null, unit });
+            const next = coerceFloatFieldValue(raw);
+            if (typeof next === "string" && next !== "") {
+              // Non-finite input ships verbatim so the validator flags it
+              // instead of the serializer silently clearing the value (#1365).
+              ctx.emitChange(path, next);
+            } else {
+              emit({ value: next === "" ? null : next, unit });
+            }
           }}
           @blur=${() => ctx.clearEditingMagnitude(path)}
         />

--- a/src/components/device/config-entry-renderers/primitives-numeric.ts
+++ b/src/components/device/config-entry-renderers/primitives-numeric.ts
@@ -193,10 +193,11 @@ export function renderTimePeriodField(
   const parsed = parseTimePeriodScalar(raw);
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
-  // Compound / unparseable strings fall through to a plain text
-  // input so the user can keep editing the raw form they pasted.
+  // Compound / unparseable values fall through to the shared fallback: a
+  // string (a pasted "1h30m") stays editable as text; a non-string
+  // primitive gets the YAML-only shell instead of a type-clobbering input.
   if (!parsed.parseable) {
-    return renderStringField(entry, "text", path, ctx);
+    return renderUnparseableScalarField(entry, path, ctx, raw);
   }
   // Split the catalog's default ("5s") into its numeric prefix
   // for the placeholder — the magnitude input shows only the
@@ -324,16 +325,20 @@ export function renderFloatWithUnitField(
           @input=${(e: Event) => {
             const raw = (e.target as HTMLInputElement).value;
             ctx.setEditingMagnitude(path, raw);
-            // Clearing magnitude drops the unit (`{null, kHz}` serializes to "");
-            // stash the unit so the next render's fallback doesn't snap back to canonical.
-            if (raw === "") ctx.setPendingUnit(path, unit);
+            if (raw === "") {
+              // Clearing magnitude drops the unit (`{null, kHz}` serializes to "");
+              // stash the unit so the next render's fallback doesn't snap back to canonical.
+              ctx.setPendingUnit(path, unit);
+              emit({ value: null, unit });
+              return;
+            }
             const next = coerceFloatFieldValue(raw);
-            if (typeof next === "string" && next !== "") {
+            if (typeof next === "number") {
+              emit({ value: next, unit });
+            } else {
               // Non-finite input ships verbatim so the validator flags it
               // instead of the serializer silently clearing the value (#1365).
               ctx.emitChange(path, next);
-            } else {
-              emit({ value: next === "" ? null : next, unit });
             }
           }}
           @blur=${() => ctx.clearEditingMagnitude(path)}

--- a/src/components/device/config-entry-renderers/primitives-numeric.ts
+++ b/src/components/device/config-entry-renderers/primitives-numeric.ts
@@ -325,15 +325,13 @@ export function renderFloatWithUnitField(
           @input=${(e: Event) => {
             const raw = (e.target as HTMLInputElement).value;
             ctx.setEditingMagnitude(path, raw);
-            if (raw === "") {
+            const next = coerceFloatFieldValue(raw);
+            if (next === "") {
               // Clearing magnitude drops the unit (`{null, kHz}` serializes to "");
               // stash the unit so the next render's fallback doesn't snap back to canonical.
               ctx.setPendingUnit(path, unit);
               emit({ value: null, unit });
-              return;
-            }
-            const next = coerceFloatFieldValue(raw);
-            if (typeof next === "number") {
+            } else if (typeof next === "number") {
               emit({ value: next, unit });
             } else {
               // Non-finite input ships verbatim so the validator flags it

--- a/src/components/device/config-entry-renderers/primitives-numeric.ts
+++ b/src/components/device/config-entry-renderers/primitives-numeric.ts
@@ -336,7 +336,10 @@ export function renderFloatWithUnitField(
             } else {
               // Non-finite input ships verbatim so the validator flags it
               // instead of the serializer silently clearing the value (#1365).
-              ctx.emitChange(path, next);
+              // The picked unit rides along: parseFloatWithUnit falls back to
+              // the canonical unit on junk, so a bare "1e" would snap a kHz
+              // field to Hz for the corrective keystroke that follows.
+              ctx.emitChange(path, next + unit);
             }
           }}
           @blur=${() => ctx.clearEditingMagnitude(path)}

--- a/test/components/device/_renderer-fixtures.ts
+++ b/test/components/device/_renderer-fixtures.ts
@@ -174,3 +174,24 @@ export function findElementBindings(
 ): Record<string, unknown>[] {
   return findTemplatesByAnchor(template, `<${tag}`).map(extractAttributeBindings);
 }
+
+/** Fire the first rendered ``<input>``'s ``@input`` handler with *value*. */
+export function fireInput(template: unknown, value: string): void {
+  const handler = findElementBindings(template, "input")[0]["@input"] as (
+    e: unknown
+  ) => void;
+  handler({ target: { value } });
+}
+
+/** A boardless RenderCtx plus its ``emitChange`` spy, for commit tests. */
+export function makeEmitCtx(
+  values: unknown,
+  overrides: Partial<RenderCtx> = {}
+): { ctx: RenderCtx; emitChange: ReturnType<typeof vi.fn> } {
+  const emitChange = vi.fn();
+  const ctx = makeRenderCtx(values, {
+    board: null,
+    overrides: { emitChange, ...overrides },
+  });
+  return { ctx, emitChange };
+}

--- a/test/components/device/render-float-with-unit-emit.test.ts
+++ b/test/components/device/render-float-with-unit-emit.test.ts
@@ -34,10 +34,12 @@ describe("renderFloatWithUnitField — magnitude commit", () => {
     expect(emitChange).toHaveBeenCalledWith(["frequency"], "75kHz");
   });
 
-  it("still clears on empty input", () => {
+  it("still clears on empty and whitespace-only input", () => {
     const { ctx, emitChange } = makeEmitCtx({ frequency: "50kHz" });
     fireInput(renderFloatWithUnitField(withUnitEntry(), ["frequency"], ctx), "");
     expect(emitChange).toHaveBeenCalledWith(["frequency"], "");
+    fireInput(renderFloatWithUnitField(withUnitEntry(), ["frequency"], ctx), "  ");
+    expect(emitChange).toHaveBeenLastCalledWith(["frequency"], "");
   });
 
   it("ships non-finite input verbatim instead of clearing", () => {

--- a/test/components/device/render-float-with-unit-emit.test.ts
+++ b/test/components/device/render-float-with-unit-emit.test.ts
@@ -3,20 +3,14 @@
  * ``<value><unit>``, clearing still clears, and non-finite input ships
  * verbatim instead of silently clearing the stored value (#1365).
  */
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   type ConfigEntry,
   ConfigEntryType,
 } from "../../../src/api/types/config-entries.js";
-import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
 import { renderFloatWithUnitField } from "../../../src/components/device/config-entry-renderers/primitives.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
-import { findElementBindings, makeRenderCtx } from "./_renderer-fixtures.js";
-
-function fireInput(tpl: unknown, value: string): void {
-  const handler = findElementBindings(tpl, "input")[0]["@input"] as (e: unknown) => void;
-  handler({ target: { value } });
-}
+import { fireInput, makeEmitCtx } from "./_renderer-fixtures.js";
 
 function withUnitEntry(): ConfigEntry {
   return makeConfigEntry({
@@ -27,36 +21,27 @@ function withUnitEntry(): ConfigEntry {
   });
 }
 
-function makeCtx(values: Record<string, unknown>): {
-  ctx: RenderCtx;
-  emitChange: ReturnType<typeof vi.fn>;
-} {
-  const emitChange = vi.fn();
-  const ctx = makeRenderCtx(values, { board: null, overrides: { emitChange } });
-  return { ctx, emitChange };
-}
-
 describe("renderFloatWithUnitField — magnitude commit", () => {
   it("serializes finite input with the display unit", () => {
-    const { ctx, emitChange } = makeCtx({ frequency: "" });
+    const { ctx, emitChange } = makeEmitCtx({ frequency: "" });
     fireInput(renderFloatWithUnitField(withUnitEntry(), ["frequency"], ctx), "50");
     expect(emitChange).toHaveBeenCalledWith(["frequency"], "50Hz");
   });
 
   it("keeps the stored value's unit on edit", () => {
-    const { ctx, emitChange } = makeCtx({ frequency: "50kHz" });
+    const { ctx, emitChange } = makeEmitCtx({ frequency: "50kHz" });
     fireInput(renderFloatWithUnitField(withUnitEntry(), ["frequency"], ctx), "75");
     expect(emitChange).toHaveBeenCalledWith(["frequency"], "75kHz");
   });
 
   it("still clears on empty input", () => {
-    const { ctx, emitChange } = makeCtx({ frequency: "50kHz" });
+    const { ctx, emitChange } = makeEmitCtx({ frequency: "50kHz" });
     fireInput(renderFloatWithUnitField(withUnitEntry(), ["frequency"], ctx), "");
     expect(emitChange).toHaveBeenCalledWith(["frequency"], "");
   });
 
   it("ships non-finite input verbatim instead of clearing", () => {
-    const { ctx, emitChange } = makeCtx({ frequency: "50kHz" });
+    const { ctx, emitChange } = makeEmitCtx({ frequency: "50kHz" });
     fireInput(renderFloatWithUnitField(withUnitEntry(), ["frequency"], ctx), "1e309");
     expect(emitChange).toHaveBeenCalledWith(["frequency"], "1e309");
   });

--- a/test/components/device/render-float-with-unit-emit.test.ts
+++ b/test/components/device/render-float-with-unit-emit.test.ts
@@ -42,9 +42,20 @@ describe("renderFloatWithUnitField — magnitude commit", () => {
     expect(emitChange).toHaveBeenLastCalledWith(["frequency"], "");
   });
 
-  it("ships non-finite input verbatim instead of clearing", () => {
+  it("ships non-finite input verbatim with the picked unit instead of clearing", () => {
     const { ctx, emitChange } = makeEmitCtx({ frequency: "50kHz" });
     fireInput(renderFloatWithUnitField(withUnitEntry(), ["frequency"], ctx), "1e309");
-    expect(emitChange).toHaveBeenCalledWith(["frequency"], "1e309");
+    expect(emitChange).toHaveBeenCalledWith(["frequency"], "1e309kHz");
+  });
+
+  it("keeps the unit across a junk intermediate and its correction", () => {
+    // "50kHz" → mid-edit "1e" stores "1ekHz"; the corrective keystroke
+    // must serialize back to kHz, not snap to the canonical Hz.
+    const { ctx, emitChange } = makeEmitCtx(
+      { frequency: "1ekHz" },
+      { getEditingMagnitude: () => "1e" }
+    );
+    fireInput(renderFloatWithUnitField(withUnitEntry(), ["frequency"], ctx), "75");
+    expect(emitChange).toHaveBeenCalledWith(["frequency"], "75kHz");
   });
 });

--- a/test/components/device/render-float-with-unit-emit.test.ts
+++ b/test/components/device/render-float-with-unit-emit.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Pins the float-with-unit magnitude commit: finite input serializes
+ * ``<value><unit>``, clearing still clears, and non-finite input ships
+ * verbatim instead of silently clearing the stored value (#1365).
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ConfigEntry,
+  ConfigEntryType,
+} from "../../../src/api/types/config-entries.js";
+import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
+import { renderFloatWithUnitField } from "../../../src/components/device/config-entry-renderers/primitives.js";
+import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+import { findElementBindings, makeRenderCtx } from "./_renderer-fixtures.js";
+
+function fireInput(tpl: unknown, value: string): void {
+  const handler = findElementBindings(tpl, "input")[0]["@input"] as (e: unknown) => void;
+  handler({ target: { value } });
+}
+
+function withUnitEntry(): ConfigEntry {
+  return makeConfigEntry({
+    key: "frequency",
+    type: ConfigEntryType.FLOAT_WITH_UNIT,
+    label: "Frequency",
+    unit_options: ["Hz", "kHz", "MHz"],
+  });
+}
+
+function makeCtx(values: Record<string, unknown>): {
+  ctx: RenderCtx;
+  emitChange: ReturnType<typeof vi.fn>;
+} {
+  const emitChange = vi.fn();
+  const ctx = makeRenderCtx(values, { board: null, overrides: { emitChange } });
+  return { ctx, emitChange };
+}
+
+describe("renderFloatWithUnitField — magnitude commit", () => {
+  it("serializes finite input with the display unit", () => {
+    const { ctx, emitChange } = makeCtx({ frequency: "" });
+    fireInput(renderFloatWithUnitField(withUnitEntry(), ["frequency"], ctx), "50");
+    expect(emitChange).toHaveBeenCalledWith(["frequency"], "50Hz");
+  });
+
+  it("keeps the stored value's unit on edit", () => {
+    const { ctx, emitChange } = makeCtx({ frequency: "50kHz" });
+    fireInput(renderFloatWithUnitField(withUnitEntry(), ["frequency"], ctx), "75");
+    expect(emitChange).toHaveBeenCalledWith(["frequency"], "75kHz");
+  });
+
+  it("still clears on empty input", () => {
+    const { ctx, emitChange } = makeCtx({ frequency: "50kHz" });
+    fireInput(renderFloatWithUnitField(withUnitEntry(), ["frequency"], ctx), "");
+    expect(emitChange).toHaveBeenCalledWith(["frequency"], "");
+  });
+
+  it("ships non-finite input verbatim instead of clearing", () => {
+    const { ctx, emitChange } = makeCtx({ frequency: "50kHz" });
+    fireInput(renderFloatWithUnitField(withUnitEntry(), ["frequency"], ctx), "1e309");
+    expect(emitChange).toHaveBeenCalledWith(["frequency"], "1e309");
+  });
+});

--- a/test/components/device/render-int-field.test.ts
+++ b/test/components/device/render-int-field.test.ts
@@ -14,7 +14,12 @@ import type { RenderCtx } from "../../../src/components/device/config-entry-rend
 import { renderNumberField } from "../../../src/components/device/config-entry-renderers/primitives.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
 import { findTemplatesByAnchor } from "../../_lit-template-walker.js";
-import { findElementBindings, makeRenderCtx } from "./_renderer-fixtures.js";
+import {
+  findElementBindings,
+  fireInput,
+  makeEmitCtx,
+  makeRenderCtx,
+} from "./_renderer-fixtures.js";
 
 /** The literal HTML of the rendered ``<input>`` (static strings, real quotes). */
 const inputHtml = (tpl: unknown): string =>
@@ -23,12 +28,6 @@ const inputHtml = (tpl: unknown): string =>
 /** The ``.value`` property bound on the rendered input. */
 const inputValue = (tpl: unknown): unknown =>
   findElementBindings(tpl, "input")[0][".value"];
-
-/** Fire the input's ``@input`` handler with *value*. */
-function fireInput(tpl: unknown, value: string): void {
-  const handler = findElementBindings(tpl, "input")[0]["@input"] as (e: unknown) => void;
-  handler({ target: { value } });
-}
 
 function intEntry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
   return makeConfigEntry({
@@ -39,49 +38,40 @@ function intEntry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
   });
 }
 
-function makeCtx(values: Record<string, unknown>): {
-  ctx: RenderCtx;
-  emitChange: ReturnType<typeof vi.fn>;
-} {
-  const emitChange = vi.fn();
-  const ctx = makeRenderCtx(values, { board: null, overrides: { emitChange } });
-  return { ctx, emitChange };
-}
-
 describe("renderNumberField — integer fields accept decimal or hex", () => {
   it("renders a text input (not a number spinner) for integers", () => {
-    const { ctx } = makeCtx({ address: "0x1111" });
+    const { ctx } = makeEmitCtx({ address: "0x1111" });
     const html = inputHtml(renderNumberField(intEntry(), ["address"], ctx));
     expect(html).toContain('type="text"');
     expect(html).not.toContain('type="number"');
   });
 
   it("displays the stored value verbatim — hex stays hex", () => {
-    const { ctx } = makeCtx({ address: "0x1111" });
+    const { ctx } = makeEmitCtx({ address: "0x1111" });
     expect(inputValue(renderNumberField(intEntry(), ["address"], ctx))).toBe("0x1111");
   });
 
   it("emits decimal input as a number (so YAML stays bare, not quoted)", () => {
-    const { ctx, emitChange } = makeCtx({ address: "" });
+    const { ctx, emitChange } = makeEmitCtx({ address: "" });
     fireInput(renderNumberField(intEntry(), ["address"], ctx), "434343");
     expect(emitChange).toHaveBeenCalledWith(["address"], 434343);
   });
 
   it("emits hex input verbatim as a string (no canonicalization)", () => {
-    const { ctx, emitChange } = makeCtx({ address: "" });
+    const { ctx, emitChange } = makeEmitCtx({ address: "" });
     fireInput(renderNumberField(intEntry(), ["address"], ctx), "0x2A");
     expect(emitChange).toHaveBeenCalledWith(["address"], "0x2A");
   });
 
   it("emits a negative decimal as a number (stays bare, not quoted)", () => {
-    const { ctx, emitChange } = makeCtx({ offset: "" });
+    const { ctx, emitChange } = makeEmitCtx({ offset: "" });
     const entry = intEntry({ key: "offset" });
     fireInput(renderNumberField(entry, ["offset"], ctx), "-5");
     expect(emitChange).toHaveBeenCalledWith(["offset"], -5);
   });
 
   it("trims surrounding whitespace and emits empty for a blank value", () => {
-    const { ctx, emitChange } = makeCtx({ address: "" });
+    const { ctx, emitChange } = makeEmitCtx({ address: "" });
     fireInput(renderNumberField(intEntry(), ["address"], ctx), "  4369  ");
     expect(emitChange).toHaveBeenCalledWith(["address"], 4369);
     fireInput(renderNumberField(intEntry(), ["address"], ctx), "");
@@ -107,13 +97,13 @@ describe("renderNumberField — integer fields accept decimal or hex", () => {
   });
 
   it("keeps a 64-bit decimal as a string (precision past 2^53)", () => {
-    const { ctx, emitChange } = makeCtx({ address: "" });
+    const { ctx, emitChange } = makeEmitCtx({ address: "" });
     fireInput(renderNumberField(intEntry(), ["address"], ctx), "18446744073709551615");
     expect(emitChange).toHaveBeenCalledWith(["address"], "18446744073709551615");
   });
 
   it("leaves the display_format:hex path canonicalizing", () => {
-    const { ctx, emitChange } = makeCtx({ rom: "" });
+    const { ctx, emitChange } = makeEmitCtx({ rom: "" });
     const entry = intEntry({ key: "rom", display_format: "hex" });
     fireInput(renderNumberField(entry, ["rom"], ctx), "118");
     expect(emitChange).toHaveBeenCalledWith(["rom"], "0x76");
@@ -129,7 +119,7 @@ describe("renderNumberField — float fields", () => {
     });
 
   it("keeps the native number input and coerces to a number", () => {
-    const { ctx, emitChange } = makeCtx({ gain: "1.5" });
+    const { ctx, emitChange } = makeEmitCtx({ gain: "1.5" });
     const tpl = renderNumberField(floatEntry(), ["gain"], ctx);
     expect(inputHtml(tpl)).toContain('type="number"');
     fireInput(tpl, "2.5");
@@ -137,7 +127,7 @@ describe("renderNumberField — float fields", () => {
   });
 
   it("keeps non-finite input verbatim (never Infinity)", () => {
-    const { ctx, emitChange } = makeCtx({ gain: "" });
+    const { ctx, emitChange } = makeEmitCtx({ gain: "" });
     fireInput(renderNumberField(floatEntry(), ["gain"], ctx), "1e309");
     expect(emitChange).toHaveBeenCalledWith(["gain"], "1e309");
     fireInput(renderNumberField(floatEntry(), ["gain"], ctx), "");
@@ -151,7 +141,7 @@ describe("renderNumberField — float fields", () => {
   });
 
   it("coerces a corrected value from the junk-value text field back to a number", () => {
-    const { ctx, emitChange } = makeCtx({ gain: "1e309" });
+    const { ctx, emitChange } = makeEmitCtx({ gain: "1e309" });
     const tpl = renderNumberField(floatEntry(), ["gain"], ctx);
     fireInput(tpl, "50");
     expect(emitChange).toHaveBeenCalledWith(["gain"], 50);

--- a/test/components/device/render-int-field.test.ts
+++ b/test/components/device/render-int-field.test.ts
@@ -135,7 +135,7 @@ describe("renderNumberField — float fields", () => {
   });
 
   it("treats whitespace-only input as blank, not 0", () => {
-    const { ctx, emitChange } = makeCtx({ gain: "" });
+    const { ctx, emitChange } = makeEmitCtx({ gain: "" });
     fireInput(renderNumberField(floatEntry(), ["gain"], ctx), "   ");
     expect(emitChange).toHaveBeenCalledWith(["gain"], "");
   });

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -24,7 +24,7 @@ import {
 } from "../../../src/components/device/config-entry-renderers/primitives.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
 import { YamlRawValue } from "../../../src/util/yaml-serialize.js";
-import { makeRenderCtx } from "./_renderer-fixtures.js";
+import { makeEmitCtx, makeRenderCtx } from "./_renderer-fixtures.js";
 
 function makeStringEntry(): ConfigEntry {
   return makeConfigEntry({
@@ -38,12 +38,7 @@ function makeCtx(values: Record<string, unknown>): {
   ctx: RenderCtx;
   emitChange: ReturnType<typeof vi.fn>;
 } {
-  const emitChange = vi.fn();
-  const ctx = makeRenderCtx(values, {
-    board: null,
-    overrides: { emitChange, renderEntry: () => "<rendered>" },
-  });
-  return { ctx, emitChange };
+  return makeEmitCtx(values, { renderEntry: () => "<rendered>" });
 }
 
 /** The bail branch is the only one that emits a ``<p class="field-description">``
@@ -150,6 +145,31 @@ describe("renderTimePeriodField / renderFloatWithUnitField — bail on non-primi
     const tpl = renderTimePeriodField(entry, ["delay"], ctx);
     const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
     expect(rendersBailBranch(json)).toBe(true);
+  });
+
+  it("bails on a boolean under a time-period field", () => {
+    const entry = makeConfigEntry({
+      key: "delay",
+      type: ConfigEntryType.TIME_PERIOD,
+      label: "Delay",
+    });
+    const { ctx } = makeCtx({ delay: true });
+    const tpl = renderTimePeriodField(entry, ["delay"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(true);
+  });
+
+  it("keeps a compound duration string editable as text", () => {
+    const entry = makeConfigEntry({
+      key: "delay",
+      type: ConfigEntryType.TIME_PERIOD,
+      label: "Delay",
+    });
+    const { ctx } = makeCtx({ delay: "1h30m" });
+    const tpl = renderTimePeriodField(entry, ["delay"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(false);
+    expect(json).toContain("1h30m");
   });
 
   it("renders the editable time-period UI for an actual scalar", () => {
@@ -280,18 +300,6 @@ describe("renderNumberField / renderFloatWithUnitField — bail on unparseable p
     const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
     expect(rendersBailBranch(json)).toBe(false);
     expect(json).toContain("21X");
-  });
-
-  it("renders editable text for a stored non-finite string under a float-with-unit field", () => {
-    const { ctx } = makeCtx({ default_target_temperature: "1e309" });
-    const tpl = renderFloatWithUnitField(
-      withUnitEntry(),
-      ["default_target_temperature"],
-      ctx
-    );
-    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
-    expect(rendersBailBranch(json)).toBe(false);
-    expect(json).toContain("1e309");
   });
 
   it("bails on a boolean under a float-with-unit field", () => {

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -270,8 +270,32 @@ describe("renderNumberField / renderFloatWithUnitField — bail on unparseable p
     expect(rendersEditableBranch(json)).toBe(true);
   });
 
-  it("bails on a malformed unit string under a float-with-unit field", () => {
+  it("renders editable text for a malformed unit string under a float-with-unit field", () => {
     const { ctx } = makeCtx({ default_target_temperature: "21X" });
+    const tpl = renderFloatWithUnitField(
+      withUnitEntry(),
+      ["default_target_temperature"],
+      ctx
+    );
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(false);
+    expect(json).toContain("21X");
+  });
+
+  it("renders editable text for a stored non-finite string under a float-with-unit field", () => {
+    const { ctx } = makeCtx({ default_target_temperature: "1e309" });
+    const tpl = renderFloatWithUnitField(
+      withUnitEntry(),
+      ["default_target_temperature"],
+      ctx
+    );
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(false);
+    expect(json).toContain("1e309");
+  });
+
+  it("bails on a boolean under a float-with-unit field", () => {
+    const { ctx } = makeCtx({ default_target_temperature: true });
     const tpl = renderFloatWithUnitField(
       withUnitEntry(),
       ["default_target_temperature"],


### PR DESCRIPTION
# What does this implement/fix?

The float with unit magnitude input was the last numeric emit path on the old policy, and it failed in both directions. On emit, non finite input mapped to `null`, which `serializeFloatWithUnit` turns into an empty string; the stored YAML value was silently cleared while the user's typed text stayed on screen. On read, the unparseable bail still used the substitution only carve out, so a stored junk string like `21X` or `1e309` was stranded in the read only YAML notice.

The magnitude commit now routes through `coerceFloatFieldValue` from #1364: finite input serializes `<value><unit>` as before, empty still clears through the pending unit stash, and non finite input ships verbatim so the existing FLOAT_WITH_UNIT validation flags it. The bail policy is hoisted into a shared `renderUnparseableScalarField` in `config-entry-renderers-shared.ts` (string becomes editable text, any other primitive keeps the YAML only shell), used by the plain FLOAT renderer (a behavior free swap of #1364's inline ternary), the float with unit renderer, and the time period renderer. For time period the string half matches its long standing editable text fall through; the non string half is a small deliberate tightening, since a boolean under a duration field previously rendered as an editable `true` text input where one keystroke would clobber the YAML type, and now gets the YAML only shell instead (pinned by a new test).

Stacked on #1364 since it reuses the shared float coercer.

Verified in the live editor on the i2c `frequency` field: a stored `21X` renders editable text, a junk edit keeps the value verbatim in the YAML with "Must be a number" showing, and correcting it to `100kHz` restores the split magnitude and unit widget with `frequency: 100kHz` serialized cleanly.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1365

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

