### PR TITLE
Fix duplicate key when filling a hand-typed bare key in the structured editor

### DIFF
--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -213,33 +213,44 @@ export function parseSectionCore(
 
     if (raw === "") {
       const peek = _skipBlankAndCommentLines(lines, i + 1);
-      if (peek >= lines.length) continue;
-      const peekLine = lines[peek];
+      if (peek < lines.length) {
+        const peekLine = lines[peek];
 
-      if (isChildListItemLine(peekLine, childIndent)) {
-        const { value, endIdx, isEmptyScalarList } = parseListBlock(
-          lines,
-          i + 1,
-          childIndent
-        );
-        if (!isEmptyScalarList) {
-          values[key] = value;
-          recordSpan(key, i, endIdx);
-          i = endIdx - 1;
+        if (isChildListItemLine(peekLine, childIndent)) {
+          const { value, endIdx, isEmptyScalarList } = parseListBlock(
+            lines,
+            i + 1,
+            childIndent
+          );
+          if (!isEmptyScalarList) {
+            values[key] = value;
+            recordSpan(key, i, endIdx);
+            i = endIdx - 1;
+          }
+          continue;
         }
-        continue;
-      }
 
-      // Nested mapping under ``key:`` (deeper indent read from the block
-      // itself so a user-typed 4-space file recurses correctly).
-      const result = readNestedMappingAfter(i + 1);
-      if (result) {
-        if (Object.keys(result.values).length > 0) {
-          values[key] = result.values;
+        // Nested mapping under ``key:`` (deeper indent read from the block
+        // itself so a user-typed 4-space file recurses correctly). A
+        // comment-only block parses to zero keys; treat it like the bare
+        // key below, spanning the whole run so the comments ride along.
+        const result = readNestedMappingAfter(i + 1);
+        if (result) {
+          const hasKeys = Object.keys(result.values).length > 0;
+          values[key] = hasKeys ? result.values : null;
           recordSpan(key, i, result.endIdx);
+          i = result.endIdx - 1;
+          continue;
         }
-        i = result.endIdx - 1;
       }
+
+      // Bare ``key:`` with nothing under it (a hand-typed key the user is
+      // about to fill in). Record it as null WITH a span: dropped, the
+      // source line is invisible to the splice writer, which then appends
+      // a second ``key:`` when the form supplies the value while the
+      // original line — outside every span — survives the splice.
+      values[key] = null;
+      recordSpan(key, i, i + 1);
       continue;
     }
 

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -213,44 +213,33 @@ export function parseSectionCore(
 
     if (raw === "") {
       const peek = _skipBlankAndCommentLines(lines, i + 1);
-      if (peek < lines.length) {
-        const peekLine = lines[peek];
-
-        if (isChildListItemLine(peekLine, childIndent)) {
-          const { value, endIdx, isEmptyScalarList } = parseListBlock(
-            lines,
-            i + 1,
-            childIndent
-          );
-          if (!isEmptyScalarList) {
-            values[key] = value;
-            recordSpan(key, i, endIdx);
-            i = endIdx - 1;
-          }
-          continue;
+      if (peek < lines.length && isChildListItemLine(lines[peek], childIndent)) {
+        const { value, endIdx, isEmptyScalarList } = parseListBlock(
+          lines,
+          i + 1,
+          childIndent
+        );
+        if (!isEmptyScalarList) {
+          values[key] = value;
+          recordSpan(key, i, endIdx);
+          i = endIdx - 1;
         }
-
-        // Nested mapping under ``key:`` (deeper indent read from the block
-        // itself so a user-typed 4-space file recurses correctly). A
-        // comment-only block parses to zero keys; treat it like the bare
-        // key below, spanning the whole run so the comments ride along.
-        const result = readNestedMappingAfter(i + 1);
-        if (result) {
-          const hasKeys = Object.keys(result.values).length > 0;
-          values[key] = hasKeys ? result.values : null;
-          recordSpan(key, i, result.endIdx);
-          i = result.endIdx - 1;
-          continue;
-        }
+        continue;
       }
 
-      // Bare ``key:`` with nothing under it (a hand-typed key the user is
-      // about to fill in). Record it as null WITH a span: dropped, the
-      // source line is invisible to the splice writer, which then appends
-      // a second ``key:`` when the form supplies the value while the
-      // original line — outside every span — survives the splice.
-      values[key] = null;
-      recordSpan(key, i, i + 1);
+      // Nested mapping under ``key:`` (deeper indent read from the block
+      // itself so a user-typed 4-space file recurses correctly). No block
+      // — or a comment-only one — parses to null, recorded WITH a span:
+      // dropped instead, a hand-typed bare ``key:`` is invisible to the
+      // splice writer, which then appends a second ``key:`` when the form
+      // supplies the value while the original line — outside every span —
+      // survives the splice.
+      const result = readNestedMappingAfter(i + 1);
+      const endIdx = result?.endIdx ?? i + 1;
+      values[key] =
+        result && Object.keys(result.values).length > 0 ? result.values : null;
+      recordSpan(key, i, endIdx);
+      i = endIdx - 1;
       continue;
     }
 

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -229,11 +229,11 @@ export function parseSectionCore(
 
       // Nested mapping under ``key:`` (deeper indent read from the block
       // itself so a user-typed 4-space file recurses correctly). No block
-      // — or a comment-only one — parses to null, recorded WITH a span:
-      // dropped instead, a hand-typed bare ``key:`` is invisible to the
-      // splice writer, which then appends a second ``key:`` when the form
-      // supplies the value while the original line — outside every span —
-      // survives the splice.
+      // — or a comment-only one — parses to null but is still recorded
+      // WITH a span. If the bare key were dropped instead, its source
+      // line would be invisible to the splice writer, which would then
+      // append a second ``key:`` when the form supplies the value while
+      // the original line — outside every span — survives the splice.
       const result = readNestedMappingAfter(i + 1);
       const endIdx = result?.endIdx ?? i + 1;
       values[key] =

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2775,3 +2775,69 @@ describe("numeric list items parse as numbers (#1353)", () => {
     expect(after).not.toContain('position: "0"');
   });
 });
+
+describe("bare child keys — hand-typed `key:` with no value", () => {
+  // The device-builder#2271 repro shape: the user types a bare
+  // `rotation:` under a platform item, then fills the field in the
+  // structured editor. The parser must surface the key (as null, with
+  // a span) or the splice writer appends a second `rotation:` while
+  // the original line, outside every span, survives the splice.
+  const before =
+    "display:\n" +
+    "  - platform: mipi_rgb\n" +
+    "    model: GUITION-4848S040\n" +
+    "    rotation:\n";
+
+  it("parses a bare trailing child key as null", () => {
+    const from = firstListItemLine(before, "display");
+    expect(parseYamlSectionValues(before, "display", from)).toEqual({
+      platform: "mipi_rgb",
+      model: "GUITION-4848S040",
+      rotation: null,
+    });
+  });
+
+  it("fills the bare key in place instead of appending a duplicate", () => {
+    const from = firstListItemLine(before, "display");
+    const values = parseYamlSectionValues(before, "display", from);
+    values.rotation = 90;
+    const after = updateSectionInYaml(before, "display", values, from);
+    expect(after.match(/rotation:/g)).toHaveLength(1);
+    expect(after).toContain("rotation: 90");
+  });
+
+  it("keeps the bare key line verbatim when a sibling field changes", () => {
+    const from = firstListItemLine(before, "display");
+    const values = parseYamlSectionValues(before, "display", from);
+    values.model = "OTHER";
+    const after = updateSectionInYaml(before, "display", values, from);
+    expect(after).toContain("model: OTHER");
+    expect(after.match(/rotation:/g)).toHaveLength(1);
+    expect(after).toContain("\n    rotation:\n");
+  });
+
+  it("parses a bare key followed by a sibling key as null", () => {
+    const yaml = "wifi:\n  ssid:\n  password: x\n";
+    expect(parseYamlSectionValues(yaml, "wifi")).toEqual({
+      ssid: null,
+      password: "x",
+    });
+  });
+
+  it("fills a bare key that a sibling list item follows", () => {
+    const yaml =
+      "display:\n" +
+      "  - platform: mipi_rgb\n" +
+      "    rotation:\n" +
+      "  - platform: ili9xxx\n";
+    const from = firstListItemLine(yaml, "display");
+    const values = parseYamlSectionValues(yaml, "display", from);
+    expect(values).toEqual({ platform: "mipi_rgb", rotation: null });
+    values.rotation = 180;
+    const after = updateSectionInYaml(yaml, "display", values, from);
+    expect(after.match(/rotation:/g)).toHaveLength(1);
+    expect(after).toContain("rotation: 180");
+    // The second platform item is untouched and still follows the first.
+    expect(after.indexOf("rotation: 180")).toBeLessThan(after.indexOf("ili9xxx"));
+  });
+});

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2835,6 +2835,31 @@ describe("bare child keys — hand-typed `key:` with no value", () => {
     expect(after).toContain("password: y");
   });
 
+  it("keeps a comment under a bare key when the key itself is filled", () => {
+    // The deeper comment is not part of the bare key's span (the
+    // nested-block peek skips comment lines), so filling the key
+    // rewrites only the key line and the note survives.
+    const yaml = "wifi:\n  ssid:\n    # note\n  password: x\n";
+    const values = parseYamlSectionValues(yaml, "wifi");
+    expect(values).toEqual({ ssid: null, password: "x" });
+    values.ssid = 1;
+    const after = updateSectionInYaml(yaml, "wifi", values);
+    expect(after.match(/ssid:/g)).toHaveLength(1);
+    expect(after).toContain("ssid: 1");
+    expect(after).toContain("# note");
+  });
+
+  it("keeps a trailing comment under a bare key filled at section end", () => {
+    const yaml = "wifi:\n  ssid:\n    # note\n";
+    const values = parseYamlSectionValues(yaml, "wifi");
+    expect(values).toEqual({ ssid: null });
+    values.ssid = 1;
+    const after = updateSectionInYaml(yaml, "wifi", values);
+    expect(after.match(/ssid:/g)).toHaveLength(1);
+    expect(after).toContain("ssid: 1");
+    expect(after).toContain("# note");
+  });
+
   it("parses a bare key over an unreadable deeper block as null", () => {
     // A deeper line the child regex can't read (quoted key) parses to a
     // zero-key nested block; the key records null with a span over the

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2822,6 +2822,32 @@ describe("bare child keys — hand-typed `key:` with no value", () => {
     });
   });
 
+  it("keeps a comment under a bare key when a sibling changes", () => {
+    // The comment is not a nested block (the peek skips it), so the
+    // bare key parses through the no-block arm; the comment folds into
+    // the next key's lead run and must ride through the splice.
+    const yaml = "wifi:\n  ssid:\n    # fill me in later\n  password: x\n";
+    const values = parseYamlSectionValues(yaml, "wifi");
+    expect(values).toEqual({ ssid: null, password: "x" });
+    values.password = "y";
+    const after = updateSectionInYaml(yaml, "wifi", values);
+    expect(after).toContain("  ssid:\n    # fill me in later\n");
+    expect(after).toContain("password: y");
+  });
+
+  it("parses a bare key over an unreadable deeper block as null", () => {
+    // A deeper line the child regex can't read (quoted key) parses to a
+    // zero-key nested block; the key records null with a span over the
+    // run, so an unrelated edit keeps both lines byte-for-byte.
+    const yaml = 'mysect:\n  wrapper:\n    "quoted key": x\n  other: y\n';
+    const values = parseYamlSectionValues(yaml, "mysect");
+    expect(values).toEqual({ wrapper: null, other: "y" });
+    values.other = "z";
+    const after = updateSectionInYaml(yaml, "mysect", values);
+    expect(after).toContain('  wrapper:\n    "quoted key": x\n');
+    expect(after).toContain("other: z");
+  });
+
   it("fills a bare key that a sibling list item follows", () => {
     const yaml =
       "display:\n" +

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2873,6 +2873,28 @@ describe("bare child keys — hand-typed `key:` with no value", () => {
     expect(after).toContain("other: z");
   });
 
+  it("fills a bare sole inline key through the dash rewrite", () => {
+    // A bare key riding the dash line (`- rotation:`) deliberately does
+    // NOT get the null-with-span treatment: the dash line has no span
+    // by design and the form is authoritative there, so the writer
+    // rewrites the dash in place (a null form value would instead
+    // collapse the dash and drop the key on a no-op save).
+    const yaml = "display:\n  - rotation:\n";
+    const from = firstListItemLine(yaml, "display");
+    expect(parseYamlSectionValues(yaml, "display", from)).toEqual({});
+    const after = updateSectionInYaml(yaml, "display", { rotation: 90 }, from);
+    expect(after.match(/rotation:/g)).toHaveLength(1);
+    expect(after).toContain("- rotation: 90");
+  });
+
+  it("keeps a bare sole inline key verbatim on an untouched save", () => {
+    const yaml = "display:\n  - rotation:\n";
+    const from = firstListItemLine(yaml, "display");
+    const values = parseYamlSectionValues(yaml, "display", from);
+    const after = updateSectionInYaml(yaml, "display", values, from);
+    expect(after).toContain("- rotation:");
+  });
+
   it("fills a bare key that a sibling list item follows", () => {
     const yaml =
       "display:\n" +

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2787,9 +2787,9 @@ describe("bare child keys — hand-typed `key:` with no value", () => {
     "  - platform: mipi_rgb\n" +
     "    model: GUITION-4848S040\n" +
     "    rotation:\n";
+  const from = firstListItemLine(before, "display");
 
   it("parses a bare trailing child key as null", () => {
-    const from = firstListItemLine(before, "display");
     expect(parseYamlSectionValues(before, "display", from)).toEqual({
       platform: "mipi_rgb",
       model: "GUITION-4848S040",
@@ -2798,7 +2798,6 @@ describe("bare child keys — hand-typed `key:` with no value", () => {
   });
 
   it("fills the bare key in place instead of appending a duplicate", () => {
-    const from = firstListItemLine(before, "display");
     const values = parseYamlSectionValues(before, "display", from);
     values.rotation = 90;
     const after = updateSectionInYaml(before, "display", values, from);
@@ -2807,7 +2806,6 @@ describe("bare child keys — hand-typed `key:` with no value", () => {
   });
 
   it("keeps the bare key line verbatim when a sibling field changes", () => {
-    const from = firstListItemLine(before, "display");
     const values = parseYamlSectionValues(before, "display", from);
     values.model = "OTHER";
     const after = updateSectionInYaml(before, "display", values, from);


### PR DESCRIPTION
# What does this implement/fix?

When a user hand-types a bare key like `rotation:` under a platform entry and then fills the field in the structured editor, a second `rotation:` line was inserted instead of the existing one being edited, producing a duplicate key error. The section parser dropped a bare child key entirely, so the splice writer treated the typed value as a new key and the original line survived outside the splice window. The parser now records a bare key as null with a real source span; an untouched bare key round-trips byte for byte, and a filled in value replaces the line in place.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2271

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
