### PR TITLE
Keep unparseable boolean values editable instead of clobbering on toggle

### DIFF
--- a/src/components/device/add-component-form-coerce.ts
+++ b/src/components/device/add-component-form-coerce.ts
@@ -3,7 +3,6 @@ import { ConfigEntryType } from "../../api/types/config-entries.js";
 import { coerceValueToEntryType } from "../../util/coerce-entry-value.js";
 import { coerceIntFieldValue } from "../../util/int-input.js";
 import { asMappingList, asRecord } from "../../util/nested-values.js";
-import { parseYamlBoolean } from "../../util/yaml-serialize.js";
 
 /**
  * Coerce raw form values for the WS payload: numbers / booleans to
@@ -63,10 +62,10 @@ export function coerceFields(
           ? raw
           : coerceValueToEntryType(entry, String(raw));
     } else if (entry.type === ConfigEntryType.BOOLEAN) {
-      // parseYamlBoolean's null (junk, a ${var} reference) ships verbatim
-      // so the backend resolves or rejects the real value — `=== true`
-      // flattened it to false (#1356).
-      out[entry.key] = parseYamlBoolean(raw) ?? raw;
+      // Junk and ${var} references ship verbatim so the backend resolves
+      // or rejects the real value — `=== true` flattened it to false (#1356).
+      out[entry.key] =
+        typeof raw === "boolean" ? raw : coerceValueToEntryType(entry, String(raw));
     } else {
       out[entry.key] = raw;
     }

--- a/src/components/device/add-component-form-coerce.ts
+++ b/src/components/device/add-component-form-coerce.ts
@@ -64,8 +64,9 @@ export function coerceFields(
     } else if (entry.type === ConfigEntryType.BOOLEAN) {
       // Junk and ${var} references ship verbatim so the backend resolves
       // or rejects the real value — `=== true` flattened it to false (#1356).
-      out[entry.key] =
-        typeof raw === "boolean" ? raw : coerceValueToEntryType(entry, String(raw));
+      // Non-string primitives (a stored `1`) also ship verbatim; String()
+      // would change their YAML type.
+      out[entry.key] = typeof raw === "string" ? coerceValueToEntryType(entry, raw) : raw;
     } else {
       out[entry.key] = raw;
     }

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -13,6 +13,7 @@ import {
   renderFieldError,
   renderHelpLink,
   renderLabel,
+  renderUnparseableScalarField,
   renderYamlOnlyFallbackIfNonPrimitive,
   type RenderCtx,
 } from "../config-entry-renderers-shared.js";
@@ -59,6 +60,11 @@ export function renderBooleanField(entry: ConfigEntry, path: string[], ctx: Rend
   // Bail to the YAML-only notice instead.
   const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
   if (bail) return bail;
+  // A primitive parseYamlBoolean can't read (a ${substitution}, junk, a
+  // stray number) renders unchecked and the first toggle clobbers it (#1368).
+  if (raw != null && String(raw).trim() !== "" && parseYamlBoolean(raw) === null) {
+    return renderUnparseableScalarField(entry, path, ctx, raw);
+  }
   const effective = raw === undefined || raw === null ? entry.default_value : raw;
   const checked = parseYamlBoolean(effective) === true;
   return html`

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -1,7 +1,7 @@
 import { html, nothing } from "lit";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { chipNameToVariant } from "../../../util/chip-variant.js";
-import { nearCanonicalOption } from "../../../util/config-validation.js";
+import { isValuePresent, nearCanonicalOption } from "../../../util/config-validation.js";
 import { renderOptionStack } from "../../../util/option-stack.js";
 import { parseYamlBoolean, YamlRawValue } from "../../../util/yaml-serialize.js";
 import { coerceValueToEntryType } from "../../../util/coerce-entry-value.js";
@@ -54,19 +54,16 @@ export {
 // YAML editor reflects ON in the form view (issue device-builder#923).
 export function renderBooleanField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   const raw = ctx.getAt(path);
-  // A list / mapping under a boolean-shaped catalog field renders
-  // unchecked (``parseYamlBoolean`` returns null), but the first
-  // user toggle emits ``true`` and clobbers the YAML structure.
-  // Bail to the YAML-only notice instead.
+  // Anything ``parseYamlBoolean`` can't read renders unchecked and the
+  // first toggle clobbers it: non-primitive shapes get the YAML-only
+  // notice, unparseable primitives stay editable text (#1368).
   const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
   if (bail) return bail;
-  // A primitive parseYamlBoolean can't read (a ${substitution}, junk, a
-  // stray number) renders unchecked and the first toggle clobbers it (#1368).
-  if (raw != null && String(raw).trim() !== "" && parseYamlBoolean(raw) === null) {
+  const parsed = parseYamlBoolean(raw);
+  if (parsed === null && isValuePresent(raw)) {
     return renderUnparseableScalarField(entry, path, ctx, raw);
   }
-  const effective = raw === undefined || raw === null ? entry.default_value : raw;
-  const checked = parseYamlBoolean(effective) === true;
+  const checked = (raw == null ? parseYamlBoolean(entry.default_value) : parsed) === true;
   return html`
     <div class="switch-field" data-field-key=${fieldKeyAttr(path)}>
       <div class="field-info">${renderLabel(entry, ctx, { includeHelpLink: false })}</div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1008,6 +1008,7 @@
     "max_length": "Must be at most {max} characters",
     "not_a_number": "Must be a number",
     "not_an_integer": "Must be a whole number",
+    "not_a_boolean": "Must be true or false",
     "invalid_option": "Not a valid option",
     "invalid_encryption_key": "Must be a 32-byte base64 key",
     "backend": "{message}",

--- a/src/util/coerce-entry-value.ts
+++ b/src/util/coerce-entry-value.ts
@@ -21,8 +21,12 @@ export function coerceValueToEntryType(
   if (entry.type === ConfigEntryType.INTEGER) return coerceIntFieldValue(raw);
   if (entry.type === ConfigEntryType.FLOAT) return coerceFloatFieldValue(raw);
   // Spellings emit as booleans so a corrected value serializes bare
-  // (`false`, not `"false"`).
-  if (entry.type === ConfigEntryType.BOOLEAN) return parseYamlBoolean(raw) ?? raw;
+  // (`false`, not `"false"`); blank stays blank and junk ships trimmed,
+  // mirroring the int/float coercers.
+  if (entry.type === ConfigEntryType.BOOLEAN) {
+    const v = raw.trim();
+    return v === "" ? "" : (parseYamlBoolean(v) ?? v);
+  }
   return raw;
 }
 

--- a/src/util/coerce-entry-value.ts
+++ b/src/util/coerce-entry-value.ts
@@ -1,6 +1,7 @@
 import type { ConfigEntry } from "../api/types/config-entries.js";
 import { ConfigEntryType } from "../api/types/config-entries.js";
 import { coerceIntFieldValue } from "./int-input.js";
+import { parseYamlBoolean } from "./yaml-serialize.js";
 
 /**
  * Coerce a control's string value back to the entry's declared numeric
@@ -9,12 +10,19 @@ import { coerceIntFieldValue } from "./int-input.js";
  * validation (and the backend's locked-value compare) rejects it. INTEGER
  * goes through ``coerceIntFieldValue`` so a >2^53 decimal stays a string
  * (64-bit precision, #378/#944) and a ``0x…`` literal isn't truncated.
- * Non-numeric entries, an empty string, and unparseable input pass through
- * unchanged so the inline validator can flag them.
+ * BOOLEAN spellings coerce through ``parseYamlBoolean``. Other entries,
+ * an empty string, and unparseable input pass through unchanged so the
+ * inline validator can flag them.
  */
-export function coerceValueToEntryType(entry: ConfigEntry, raw: string): string | number {
+export function coerceValueToEntryType(
+  entry: ConfigEntry,
+  raw: string
+): string | number | boolean {
   if (entry.type === ConfigEntryType.INTEGER) return coerceIntFieldValue(raw);
   if (entry.type === ConfigEntryType.FLOAT) return coerceFloatFieldValue(raw);
+  // Boolean spellings emit as booleans so a corrected value serializes
+  // bare (`false`, not `"false"`); junk/substitutions ship verbatim.
+  if (entry.type === ConfigEntryType.BOOLEAN) return parseYamlBoolean(raw) ?? raw;
   return raw;
 }
 

--- a/src/util/coerce-entry-value.ts
+++ b/src/util/coerce-entry-value.ts
@@ -20,8 +20,8 @@ export function coerceValueToEntryType(
 ): string | number | boolean {
   if (entry.type === ConfigEntryType.INTEGER) return coerceIntFieldValue(raw);
   if (entry.type === ConfigEntryType.FLOAT) return coerceFloatFieldValue(raw);
-  // Boolean spellings emit as booleans so a corrected value serializes
-  // bare (`false`, not `"false"`); junk/substitutions ship verbatim.
+  // Spellings emit as booleans so a corrected value serializes bare
+  // (`false`, not `"false"`).
   if (entry.type === ConfigEntryType.BOOLEAN) return parseYamlBoolean(raw) ?? raw;
   return raw;
 }

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -14,7 +14,7 @@ import { parseIntInput } from "./int-input.js";
 import { asMappingList, asRecord, isPrimitiveOrNullish } from "./nested-values.js";
 import { isSecretRef } from "./secret-ref.js";
 import { isSubstitutionString, looksLikeSubstitution } from "./substitutions.js";
-import { YamlRawValue } from "./yaml-serialize.js";
+import { parseYamlBoolean, YamlRawValue } from "./yaml-serialize.js";
 
 /**
  * Whether an entry restricted to ``supportedPlatforms`` is allowed on the
@@ -321,6 +321,10 @@ export function validateEntry(entry: ConfigEntry, raw: unknown): ValidationError
       if (num > max) {
         return { key: entry.key, code: "validation.max", params: { max } };
       }
+    }
+  } else if (entry.type === ConfigEntryType.BOOLEAN) {
+    if (parseYamlBoolean(raw) === null) {
+      return { key: entry.key, code: "validation.not_a_boolean" };
     }
   }
 

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -547,7 +547,9 @@ const YAML_FALSE_VALUES = new Set(["false", "no", "off", "disable"]);
 export function parseYamlBoolean(v: unknown): boolean | null {
   if (typeof v === "boolean") return v;
   if (typeof v === "string") {
-    const lower = v.toLowerCase();
+    // Trim like the int/float coercers: YAML plain scalars never carry
+    // surrounding whitespace, but form input can.
+    const lower = v.trim().toLowerCase();
     if (YAML_TRUE_VALUES.has(lower)) return true;
     if (YAML_FALSE_VALUES.has(lower)) return false;
   }

--- a/test/components/device/add-component-form-coerce.test.ts
+++ b/test/components/device/add-component-form-coerce.test.ts
@@ -168,4 +168,8 @@ describe("BOOLEAN coercion", () => {
       enabled: "maybe",
     });
   });
+
+  test("ships a non-string primitive verbatim without stringifying", () => {
+    expect(coerceFields([enabled], { enabled: 1 })).toEqual({ enabled: 1 });
+  });
 });

--- a/test/components/device/config-entry-boolean-renderer.test.ts
+++ b/test/components/device/config-entry-boolean-renderer.test.ts
@@ -52,11 +52,12 @@ describe("renderBooleanField default-value fallback", () => {
     // that lands the catalog default into a single intermediate
     // (commonly named ``effective``) before the boolean coercion.
     //
-    // Accept either of the two shapes likely to be used:
+    // Accept the shapes likely to be used:
     //
     //   const <name> = raw === undefined || raw === null
     //     ? entry.default_value : raw;
     //   const <name> = raw ?? entry.default_value;
+    //   ... (raw == null ? parseYamlBoolean(entry.default_value) : parsed) ...
     //
     // The ``checked`` line below must then derive from that
     // intermediate (or from ``entry.default_value`` directly), so
@@ -65,7 +66,9 @@ describe("renderBooleanField default-value fallback", () => {
     const fallbackShape =
       /=\s*raw\s*===\s*undefined\s*\|\|\s*raw\s*===\s*null\s*\?\s*entry\.default_value\s*:\s*raw/.test(
         fnSrc
-      ) || /=\s*raw\s*\?\?\s*entry\.default_value/.test(fnSrc);
+      ) ||
+      /=\s*raw\s*\?\?\s*entry\.default_value/.test(fnSrc) ||
+      /raw\s*==\s*null\s*\?\s*parseYamlBoolean\(entry\.default_value\)/.test(fnSrc);
     expect(
       fallbackShape,
       "renderBooleanField must compute an intermediate that falls " +

--- a/test/components/device/config-entry-boolean-renderer.test.ts
+++ b/test/components/device/config-entry-boolean-renderer.test.ts
@@ -1,144 +1,63 @@
 /**
- * Source-scan tests for ``renderBooleanField``. The renderer
- * imports Lit decorators that need DOM globals (vitest runs in
- * ``node``), so we can't render it here. Instead pin the
- * default-value contract by inspecting the source — a future
- * refactor that drops the ``default_value`` fallback would
- * silently regress the
- * ``esp32_ble_tracker.software_coexistence`` case where the
- * catalog ships ``default_value: true`` and the YAML omits the
- * field, so the toggle should render ON.
+ * Rendered-output pins for ``renderBooleanField``: the default-value
+ * fallback that drives ``checked`` (an omitted
+ * ``esp32_ble_tracker.software_coexistence`` with catalog
+ * ``default_value: true`` must render ON), the lenient spelling
+ * parse (#923), and the switch's accessible name.
  */
 import { describe, expect, it } from "vitest";
+import {
+  type ConfigEntry,
+  ConfigEntryType,
+} from "../../../src/api/types/config-entries.js";
+import { renderBooleanField } from "../../../src/components/device/config-entry-renderers/primitives.js";
+import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+import { findElementBindings, makeRenderCtx } from "./_renderer-fixtures.js";
 
-describe("renderBooleanField default-value fallback", () => {
-  it("treats undefined / null raw as ``entry.default_value`` when computing checked state", async () => {
-    // tsconfig restricts `types` to @types/w3c-web-serial, so node
-    // module specifiers don't type-check; vitest resolves them fine.
-    // @ts-ignore — node-only module
-    const fs = await import("node:fs");
-    // @ts-ignore — node-only module
-    const path = await import("node:path");
-    // @ts-ignore — node-only module
-    const url = await import("node:url");
-    const here = path.dirname(url.fileURLToPath(import.meta.url));
-    const sourcePath = path.resolve(
-      here,
-      "../../../src/components/device/config-entry-renderers/primitives.ts"
+function entry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
+  return makeConfigEntry({
+    key: "enabled",
+    type: ConfigEntryType.BOOLEAN,
+    label: "Enabled",
+    ...overrides,
+  });
+}
+
+function switchBindings(
+  values: Record<string, unknown>,
+  overrides: Partial<ConfigEntry> = {}
+): Record<string, unknown> {
+  const ctx = makeRenderCtx(values, { board: null });
+  const tpl = renderBooleanField(entry(overrides), ["enabled"], ctx);
+  return findElementBindings(tpl, "wa-switch")[0];
+}
+
+describe("renderBooleanField — checked state", () => {
+  it("falls back to entry.default_value when the YAML omits the field", () => {
+    expect(switchBindings({}, { default_value: true })["?checked"]).toBe(true);
+    expect(switchBindings({ enabled: null }, { default_value: true })["?checked"]).toBe(
+      true
     );
-    const src = fs.readFileSync(sourcePath, "utf-8");
-
-    // Carve out just ``renderBooleanField`` so we don't accidentally
-    // match a fallback in another renderer. The function is short
-    // but its rationale comment is long, so slice up to the next
-    // ``export function`` boundary instead of a fixed offset.
-    const startIdx = src.indexOf("export function renderBooleanField");
-    expect(startIdx).toBeGreaterThan(-1);
-    // When ``renderBooleanField`` is the last export in the file
-    // there's no next-export sentinel; slice to end-of-file rather
-    // than a fixed window so a future implementation that grows
-    // past a hard-coded byte budget (extra comments, more guard
-    // branches) still produces a complete carve-out instead of a
-    // false failure when an assertion's anchor falls past the
-    // truncation boundary.
-    const nextExportIdx = src.indexOf("export function ", startIdx + 1);
-    const fnSrc = src.slice(startIdx, nextExportIdx > 0 ? nextExportIdx : src.length);
-
-    // The renderer must consult ``entry.default_value`` when
-    // computing the value that drives ``checked`` — a bare reference
-    // somewhere in the function body would pass even if ``checked``
-    // were computed off ``raw`` alone (with ``entry.default_value``
-    // mentioned in an unrelated expression). Pin a fallback shape
-    // that lands the catalog default into a single intermediate
-    // (commonly named ``effective``) before the boolean coercion.
-    //
-    // Accept the shapes likely to be used:
-    //
-    //   const <name> = raw === undefined || raw === null
-    //     ? entry.default_value : raw;
-    //   const <name> = raw ?? entry.default_value;
-    //   ... (raw == null ? parseYamlBoolean(entry.default_value) : parsed) ...
-    //
-    // The ``checked`` line below must then derive from that
-    // intermediate (or from ``entry.default_value`` directly), so
-    // any future refactor that disconnects the two surfaces fails
-    // this test.
-    const fallbackShape =
-      /=\s*raw\s*===\s*undefined\s*\|\|\s*raw\s*===\s*null\s*\?\s*entry\.default_value\s*:\s*raw/.test(
-        fnSrc
-      ) ||
-      /=\s*raw\s*\?\?\s*entry\.default_value/.test(fnSrc) ||
-      /raw\s*==\s*null\s*\?\s*parseYamlBoolean\(entry\.default_value\)/.test(fnSrc);
-    expect(
-      fallbackShape,
-      "renderBooleanField must compute an intermediate that falls " +
-        "back from raw to entry.default_value — default-true fields " +
-        "otherwise render OFF when the YAML omits them"
-    ).toBe(true);
-
-    // The ``checked`` computation must depend on whichever value
-    // wins the fallback (not just the raw). The renderer routes the
-    // value through ``parseYamlBoolean`` so every ESPHome YAML
-    // truthy spelling (``True`` / ``yes`` / ``on`` / ``enable``)
-    // collapses to the boolean primitive before the strict-equality
-    // compare — pin that shape so a stray refactor that drops the
-    // lenient parser silently regresses the case where the form
-    // value (or backend-supplied default) arrived as the uppercase
-    // string ``"True"``.
-    expect(
-      /parseYamlBoolean\(.*\)\s*===\s*true\b/.test(fnSrc),
-      "checked must route the fallback value through parseYamlBoolean " +
-        "so all ESPHome YAML boolean spellings (True / yes / on / enable) " +
-        "collapse to the boolean primitive — issue device-builder#923"
-    ).toBe(true);
-
-    // ``checked`` must be derived from the same value that consulted
-    // ``entry.default_value`` — pin that the strict-equality check
-    // doesn't operate on a bare ``raw``. Use a non-greedy span to
-    // confirm there's at least one ``=== true`` after the
-    // fallback intermediate's assignment, and confirm none of the
-    // ``=== true`` lines compare against ``raw`` directly.
-    expect(
-      /raw\s*===\s*true\b/.test(fnSrc),
-      "checked must be computed from the fallback intermediate, not raw directly"
-    ).toBe(false);
+    expect(switchBindings({}, { default_value: false })["?checked"]).toBe(false);
   });
 
-  it("gives the ``wa-switch`` an accessible name via ``aria-label``", async () => {
-    // Same node-only source-scan approach as above: the renderer
-    // can't mount without DOM globals, so pin the a11y contract by
-    // inspecting the carved-out function source. The visible label
-    // lives in a sibling ``.field-info`` div with no ``for``/wrapping
-    // association, so the switch has no accessible name unless one is
-    // set explicitly — a screen reader otherwise announces a bare
-    // "switch" with no context (see CLAUDE.md ARIA / a11y).
-    // @ts-ignore — node-only module
-    const fs = await import("node:fs");
-    // @ts-ignore — node-only module
-    const path = await import("node:path");
-    // @ts-ignore — node-only module
-    const url = await import("node:url");
-    const here = path.dirname(url.fileURLToPath(import.meta.url));
-    const sourcePath = path.resolve(
-      here,
-      "../../../src/components/device/config-entry-renderers/primitives.ts"
+  it("lets a present value win over the default", () => {
+    expect(switchBindings({ enabled: false }, { default_value: true })["?checked"]).toBe(
+      false
     );
-    const src = fs.readFileSync(sourcePath, "utf-8");
+  });
 
-    const startIdx = src.indexOf("export function renderBooleanField");
-    expect(startIdx).toBeGreaterThan(-1);
-    const nextExportIdx = src.indexOf("export function ", startIdx + 1);
-    const fnSrc = src.slice(startIdx, nextExportIdx > 0 ? nextExportIdx : src.length);
+  it("collapses YAML truthy spellings through parseYamlBoolean", () => {
+    expect(switchBindings({ enabled: "True" })["?checked"]).toBe(true);
+    expect(switchBindings({ enabled: "off" })["?checked"]).toBe(false);
+  });
+});
 
-    // The switch must carry an ``aria-label`` derived from the field's
-    // resolved label (``labelFor``), mirroring the proven pattern in
-    // ``nested.ts``. A bare ``aria-label`` constant, or none at all,
-    // would leave the toggle unnamed for assistive tech.
-    expect(
-      /aria-label=\$\{labelFor\(/.test(fnSrc),
-      "the boolean-field wa-switch must set aria-label=${labelFor(...)} " +
-        "so assistive tech announces the field name — the sibling " +
-        "label is not programmatically associated with the switch"
-    ).toBe(true);
+describe("renderBooleanField — accessibility", () => {
+  it("gives the wa-switch an accessible name from the field label", () => {
+    // The visible label lives in a sibling ``.field-info`` div with no
+    // ``for``/wrapping association, so without an explicit aria-label a
+    // screen reader announces a bare "switch" with no context.
+    expect(switchBindings({ enabled: true })["aria-label"]).toBe("Enabled");
   });
 });

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -468,6 +468,17 @@ describe("renderBooleanField — bail branches", () => {
     expect(emitChange).toHaveBeenCalledWith(["enabled"], false);
     handler({ target: { value: "maybe" } });
     expect(emitChange).toHaveBeenCalledWith(["enabled"], "maybe");
+    handler({ target: { value: " off " } });
+    expect(emitChange).toHaveBeenCalledWith(["enabled"], false);
+    handler({ target: { value: "  " } });
+    expect(emitChange).toHaveBeenCalledWith(["enabled"], "");
+  });
+
+  it("renders the switch for a whitespace-padded spelling", () => {
+    const { ctx } = makeCtx({ enabled: " yes " });
+    const tpl = renderBooleanField(entry(), ["enabled"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(json).toContain("wa-switch");
   });
 
   it("keeps the switch for quoted boolean spellings and empty placeholder", () => {

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -24,7 +24,7 @@ import {
 } from "../../../src/components/device/config-entry-renderers/primitives.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
 import { YamlRawValue } from "../../../src/util/yaml-serialize.js";
-import { makeEmitCtx, makeRenderCtx } from "./_renderer-fixtures.js";
+import { findElementBindings, makeEmitCtx, makeRenderCtx } from "./_renderer-fixtures.js";
 
 function makeStringEntry(): ConfigEntry {
   return makeConfigEntry({
@@ -436,5 +436,45 @@ describe("renderBooleanField — bail on non-primitive", () => {
     const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
     expect(rendersBailBranch(json)).toBe(false);
     expect(json).toContain("wa-switch");
+  });
+
+  it("renders editable text for a substitution or junk string (no switch to clobber it)", () => {
+    for (const value of ["${my_mode}", "maybe"]) {
+      const { ctx } = makeCtx({ enabled: value });
+      const tpl = renderBooleanField(entry(), ["enabled"], ctx);
+      const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+      expect(rendersBailBranch(json)).toBe(false);
+      expect(json).not.toContain("wa-switch");
+      expect(json).toContain(value);
+    }
+  });
+
+  it("bails on a stray number under a boolean field", () => {
+    const { ctx } = makeCtx({ enabled: 1 });
+    const tpl = renderBooleanField(entry(), ["enabled"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(true);
+    expect(json).not.toContain("wa-switch");
+  });
+
+  it("coerces a corrected boolean spelling back to a real boolean on emit", () => {
+    const { ctx, emitChange } = makeCtx({ enabled: "${my_mode}" });
+    const tpl = renderBooleanField(entry(), ["enabled"], ctx);
+    const handler = findElementBindings(tpl, "input")[0]["@input"] as (
+      e: unknown
+    ) => void;
+    handler({ target: { value: "false" } });
+    expect(emitChange).toHaveBeenCalledWith(["enabled"], false);
+    handler({ target: { value: "maybe" } });
+    expect(emitChange).toHaveBeenCalledWith(["enabled"], "maybe");
+  });
+
+  it("keeps the switch for quoted boolean spellings and empty placeholder", () => {
+    for (const value of ["off", "Yes", ""]) {
+      const { ctx } = makeCtx({ enabled: value });
+      const tpl = renderBooleanField(entry(), ["enabled"], ctx);
+      const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+      expect(json).toContain("wa-switch");
+    }
   });
 });

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -414,11 +414,12 @@ describe("renderMultiValueField — bail when items are mappings", () => {
   });
 });
 
-// ``parseYamlBoolean`` returns null for non-boolean/non-string inputs,
-// so a list / mapping under a boolean field renders unchecked. The
-// first user toggle would then write ``true`` back and clobber the
-// YAML structure. Pin both halves.
-describe("renderBooleanField — bail on non-primitive", () => {
+// ``parseYamlBoolean`` returns null for anything but a boolean or a
+// boolean spelling, and the first toggle of an unchecked switch would
+// write ``true`` over the stored value. Pin every bail branch: lists /
+// mappings and stray numbers to the YAML-only notice, substitution and
+// junk strings to editable text (#1368).
+describe("renderBooleanField — bail branches", () => {
   const entry = (): ConfigEntry =>
     makeConfigEntry({ key: "enabled", type: ConfigEntryType.BOOLEAN, label: "Enabled" });
 
@@ -470,7 +471,7 @@ describe("renderBooleanField — bail on non-primitive", () => {
   });
 
   it("keeps the switch for quoted boolean spellings and empty placeholder", () => {
-    for (const value of ["off", "Yes", ""]) {
+    for (const value of ["off", ""]) {
       const { ctx } = makeCtx({ enabled: value });
       const tpl = renderBooleanField(entry(), ["enabled"], ctx);
       const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -286,6 +286,7 @@ describe("validateEntry", () => {
     expect(validateEntry(entry, true)).toBeNull();
     expect(validateEntry(entry, "yes")).toBeNull();
     expect(validateEntry(entry, "OFF")).toBeNull();
+    expect(validateEntry(entry, " true ")).toBeNull();
     expect(validateEntry(entry, "${use_dhcp}")).toBeNull();
     expect(validateEntry(entry, "")).toBeNull();
   });

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -279,6 +279,17 @@ describe("validateEntry", () => {
     expect(validateEntry(entry, 3.5)).toBeNull();
   });
 
+  it("flags values parseYamlBoolean can't read on BOOLEAN fields", () => {
+    const entry = makeEntry({ type: ConfigEntryType.BOOLEAN });
+    expect(validateEntry(entry, "maybe")?.code).toBe("validation.not_a_boolean");
+    expect(validateEntry(entry, 1)?.code).toBe("validation.not_a_boolean");
+    expect(validateEntry(entry, true)).toBeNull();
+    expect(validateEntry(entry, "yes")).toBeNull();
+    expect(validateEntry(entry, "OFF")).toBeNull();
+    expect(validateEntry(entry, "${use_dhcp}")).toBeNull();
+    expect(validateEntry(entry, "")).toBeNull();
+  });
+
   it("flags non-finite text on FLOAT fields", () => {
     const entry = makeEntry({ type: ConfigEntryType.FLOAT });
     expect(validateEntry(entry, "1e309")?.code).toBe("validation.not_a_number");

--- a/test/util/yaml-serialize.test.ts
+++ b/test/util/yaml-serialize.test.ts
@@ -77,6 +77,12 @@ describe("parseYamlBoolean", () => {
     }
   });
 
+  it("trims surrounding whitespace before matching", () => {
+    expect(parseYamlBoolean(" true ")).toBe(true);
+    expect(parseYamlBoolean("off\n")).toBe(false);
+    expect(parseYamlBoolean("  ")).toBeNull();
+  });
+
   it("returns null for non-boolean strings and non-strings", () => {
     expect(parseYamlBoolean("maybe")).toBeNull();
     expect(parseYamlBoolean(1)).toBeNull();


### PR DESCRIPTION
# What does this implement/fix?

The boolean field bails on non primitives, but any primitive `parseYamlBoolean` cannot read, notably a `${substitution}` reference or a junk string, rendered as an unchecked switch; the first toggle emitted `true` and silently replaced the stored value. Same data loss class as #1365.

The renderer now bails such values to `renderUnparseableScalarField` from #1367: a string stays editable as text, a stray number gets the YAML only shell. Two companions make the editable path whole. `validateEntry` gains a BOOLEAN branch (there was none), flagging anything `parseYamlBoolean` rejects with a new "Must be true or false" message; substitutions and empties keep their existing skips. And `coerceValueToEntryType` gains the BOOLEAN branch `add-component-form-coerce` already had, so correcting the text to a boolean spelling emits a real boolean; without it the fix up wrote a quoted `"false"` string that the serializer then had to quote forever. Quoted spellings like `"off"` still parse and keep the switch; an empty value keeps the unchecked placeholder switch.

Verified in the live editor: a seeded `optimistic: maybe` renders editable text, a junk edit flags "Must be true or false", and correcting it to `yes` restores the switch with `optimistic: true` bare in the YAML. A pin `inverted: ${my_mode}` renders editable text instead of a switch, and junk under the pin sub schema still gets its row error from the backend lint pass (frontend validation deliberately does not recurse into PIN schemas).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1368

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
