### PR TITLE
Fall through to the flag group when a nested scalar shorthand is cleared

### DIFF
--- a/src/components/device/config-entry-renderers/nested.ts
+++ b/src/components/device/config-entry-renderers/nested.ts
@@ -37,9 +37,12 @@ function _enableStash(ctx: RenderCtx): Map<string, Record<string, unknown>> {
 export function renderNestedField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   // A scalar at a NESTED key (an unmodellable shorthand the user set in
   // YAML) renders read-only with its value, not as an empty flag group.
+  // Empty string is a cleared value, not a shorthand — fall through to the
+  // flag-group editor or the notice strands the group until reload (#1373).
   const raw = ctx.getAt(path);
   if (
     !entry.multi_value &&
+    raw !== "" &&
     (typeof raw === "string" || typeof raw === "number" || typeof raw === "boolean")
   ) {
     return html`

--- a/src/components/device/config-entry-renderers/nested.ts
+++ b/src/components/device/config-entry-renderers/nested.ts
@@ -37,12 +37,12 @@ function _enableStash(ctx: RenderCtx): Map<string, Record<string, unknown>> {
 export function renderNestedField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   // A scalar at a NESTED key (an unmodellable shorthand the user set in
   // YAML) renders read-only with its value, not as an empty flag group.
-  // Empty string is a cleared value, not a shorthand — fall through to the
-  // flag-group editor or the notice strands the group until reload (#1373).
+  // Only a scalar that actually serializes gets the notice — a cleared ""
+  // never lands in YAML, so it falls through to the flag-group editor.
   const raw = ctx.getAt(path);
   if (
     !entry.multi_value &&
-    raw !== "" &&
+    hasSerializableValue(raw) &&
     (typeof raw === "string" || typeof raw === "number" || typeof raw === "boolean")
   ) {
     return html`
@@ -69,7 +69,7 @@ export function renderNestedField(entry: ConfigEntry, path: string[], ctx: Rende
   // an explicit enable switch; plain nested forms (platform_type === null)
   // and required groups keep the bare collapsible header.
   const isOptionalEntity = entry.platform_type != null && !entry.required;
-  const enabled = isOptionalEntity && hasSerializableValue(ctx.getAt(path));
+  const enabled = isOptionalEntity && hasSerializableValue(raw);
   const label = labelFor(entry, ctx);
   const enableLabel = ctx.localize("device.enable_entity", { name: label });
   return html`

--- a/test/components/device/render-nested-field-scalar-notice.test.ts
+++ b/test/components/device/render-nested-field-scalar-notice.test.ts
@@ -1,7 +1,8 @@
 /**
- * A scalar at a NESTED key (a shorthand the visual editor can't model
- * with its flag group, e.g. a pin ``mode: OUTPUT``) renders as a
- * read-only notice showing the value, not an empty collapsible group.
+ * A non-empty scalar at a NESTED key (a shorthand the visual editor
+ * can't model with its flag group, e.g. a pin ``mode: OUTPUT``) renders
+ * as a read-only notice showing the value, not an empty collapsible
+ * group; a cleared "" falls through to the group.
  */
 import { describe, expect, it } from "vitest";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
@@ -35,8 +36,6 @@ describe("renderNestedField — scalar value", () => {
   });
 
   it("renders the flag group for a cleared (empty-string) value, not the notice", () => {
-    // Clearing the shorthand text field leaves "" in the form values; the
-    // notice would strand the group read-only until reload (#1373).
     const tpl = renderNestedField(modeEntry(), ["mode"], makeRenderCtx({ mode: "" }));
     expect(findTemplatesByAnchor(tpl, "nested-toggle")).not.toHaveLength(0);
     expect(findTemplatesByAnchor(tpl, "field-description")).toHaveLength(0);

--- a/test/components/device/render-nested-field-scalar-notice.test.ts
+++ b/test/components/device/render-nested-field-scalar-notice.test.ts
@@ -33,4 +33,12 @@ describe("renderNestedField — scalar value", () => {
     expect(findTemplatesByAnchor(tpl, "nested-toggle")).not.toHaveLength(0);
     expect(findTemplatesByAnchor(tpl, "field-description")).toHaveLength(0);
   });
+
+  it("renders the flag group for a cleared (empty-string) value, not the notice", () => {
+    // Clearing the shorthand text field leaves "" in the form values; the
+    // notice would strand the group read-only until reload (#1373).
+    const tpl = renderNestedField(modeEntry(), ["mode"], makeRenderCtx({ mode: "" }));
+    expect(findTemplatesByAnchor(tpl, "nested-toggle")).not.toHaveLength(0);
+    expect(findTemplatesByAnchor(tpl, "field-description")).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Clearing a nested scalar shorthand's text field (a pin `mode: ${my_mode}` made editable by #1344) correctly drops the key from the YAML, but the form's in memory values keep the empty string, and `renderNestedField`'s scalar shorthand branch treated any string as an unmodellable shorthand. The user saw the read only notice with a blank interpolation, "Set to  in YAML; edit it in the YAML pane on the right.", and the group was stranded until a reload re parsed the YAML.

The scalar branch now excludes the empty string, so a cleared value falls through to the normal collapsible flag group, matching what a reload already produced. An audit of the other editable text fallbacks (FLOAT, float with unit, time period, boolean, pin number) confirmed they all already recover from a cleared value; this branch was the only read only notice reachable from an in memory empty string.

Verified in the live editor: clearing the mode field's `${my_mode}` now renders the flag group immediately instead of the stranded notice.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1373

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
