### PR TITLE
Route both wa-select emit paths through coerceValueToEntryType

### DIFF
--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -470,12 +470,11 @@ export function renderStringField(
 
 /**
  * Render a closed `<wa-select>` for entries carrying a `suggestions`
- * list (featured components only). Mirrors the strict-select branch of
- * `renderSelectField` in `config-entry-renderers.ts` but lives in the
- * shared module so the simple-field renderer can reuse it without
+ * list (featured components only). Lives in the shared module so the
+ * simple-field renderer and `renderSelectField` can both use it without
  * importing the barrel.
  */
-function renderSuggestionSelect(
+export function renderSuggestionSelect(
   entry: ConfigEntry,
   path: string[],
   value: string,

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -146,7 +146,13 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
           ?disabled=${disabled}
           placeholder=${String(entry.default_value ?? "")}
           @change=${(e: Event) =>
-            ctx.emitChange(path, (e.target as unknown as { value: string }).value)}
+            ctx.emitChange(
+              path,
+              coerceValueToEntryType(
+                entry,
+                (e.target as unknown as { value: string }).value
+              )
+            )}
         >
           ${entry.suggestions.map((s) => {
             const v = String(s);
@@ -220,7 +226,13 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
         .withClear=${clearable}
         placeholder=${placeholder}
         @change=${(e: Event) =>
-          ctx.emitChange(path, (e.target as unknown as { value: string }).value)}
+          ctx.emitChange(
+            path,
+            coerceValueToEntryType(
+              entry,
+              (e.target as unknown as { value: string }).value
+            )
+          )}
       >
         ${
           clearable

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -13,6 +13,7 @@ import {
   renderFieldError,
   renderHelpLink,
   renderLabel,
+  renderSuggestionSelect,
   renderUnparseableScalarField,
   renderYamlOnlyFallbackIfNonPrimitive,
   type RenderCtx,
@@ -132,38 +133,17 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
   const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
   if (bail) return bail;
   const value = String(raw ?? "");
+  const onSelectChange = (e: Event) =>
+    ctx.emitChange(
+      path,
+      coerceValueToEntryType(entry, (e.target as unknown as { value: string }).value)
+    );
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
   // Featured suggestions override options — board author narrowed the choice.
   // Always strict select; suggestions are a closed set.
   if (entry.suggestions && entry.suggestions.length > 0) {
-    const valueLower = value.toLowerCase();
-    return html`
-      <div class="field" data-field-key=${fieldKeyAttr(path)}>
-        ${renderLabel(entry, ctx)}
-        <wa-select
-          class=${invalid ? "invalid" : ""}
-          ?disabled=${disabled}
-          placeholder=${String(entry.default_value ?? "")}
-          @change=${(e: Event) =>
-            ctx.emitChange(
-              path,
-              coerceValueToEntryType(
-                entry,
-                (e.target as unknown as { value: string }).value
-              )
-            )}
-        >
-          ${entry.suggestions.map((s) => {
-            const v = String(s);
-            return html`<wa-option value=${v} ?selected=${v.toLowerCase() === valueLower}
-              >${v}</wa-option
-            >`;
-          })}
-        </wa-select>
-        ${renderFieldError(path, ctx)}
-      </div>
-    `;
+    return renderSuggestionSelect(entry, path, value, invalid, disabled, ctx);
   }
   // The device's ESP32 variant, used to filter per-variant options (and derive
   // the esp32 variant default below); resolved once per render.
@@ -225,14 +205,7 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
         ?disabled=${disabled}
         .withClear=${clearable}
         placeholder=${placeholder}
-        @change=${(e: Event) =>
-          ctx.emitChange(
-            path,
-            coerceValueToEntryType(
-              entry,
-              (e.target as unknown as { value: string }).value
-            )
-          )}
+        @change=${onSelectChange}
       >
         ${
           clearable

--- a/test/components/device/config-entry-select-emit-coerce.test.ts
+++ b/test/components/device/config-entry-select-emit-coerce.test.ts
@@ -26,7 +26,7 @@ function emitFor(
   return emitChange.mock.calls[0][1];
 }
 
-describe("renderSelectField — emits coerce to the entry's type", () => {
+describe("renderSelectField — emits values coerced to the entry's type", () => {
   it("strict select: integer options emit numbers, booleans emit booleans", () => {
     expect(
       emitFor(ConfigEntryType.INTEGER, { options: asOptions(["0", "90"]) }, "90")
@@ -44,9 +44,15 @@ describe("renderSelectField — emits coerce to the entry's type", () => {
         "energy"
       )
     ).toBe("energy");
-    expect(
-      emitFor(ConfigEntryType.INTEGER, { options: asOptions(["0", "90"]) }, "")
-    ).toBe("");
+    // An empty-value option is what makes the select clearable; prove the
+    // clear path is live before firing it.
+    const clearable = [...asOptions(["0", "90"]), { value: "", label: "(none)" }];
+    const entry = makeEntry(ConfigEntryType.INTEGER, { options: clearable });
+    const { ctx, emitChange } = makeEmitCtx({ field: "90" });
+    const tpl = renderSelectField(entry, ["field"], ctx);
+    expect(findElementBindings(tpl, "wa-select")[0][".withClear"]).toBe(true);
+    fireChange(tpl, "");
+    expect(emitChange).toHaveBeenCalledWith(["field"], "");
   });
 
   it("suggestions select: integer suggestions emit numbers", () => {

--- a/test/components/device/config-entry-select-emit-coerce.test.ts
+++ b/test/components/device/config-entry-select-emit-coerce.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Pins that both wa-select emit paths (suggestions and strict select)
+ * commit through ``coerceValueToEntryType``, so a typed entry modeled
+ * as options emits its declared type and the YAML stays bare (#1372).
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { ConfigValueOption } from "../../../src/api/types/config-entries.js";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { renderSelectField } from "../../../src/components/device/config-entry-renderers/primitives.js";
+import { makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
+import { findElementBindings } from "./_renderer-fixtures.js";
+
+const asOptions = (values: string[]): ConfigValueOption[] =>
+  values.map((v) => ({ value: v, label: v }));
+
+function fireChange(tpl: unknown, value: string): void {
+  const handler = findElementBindings(tpl, "wa-select")[0]["@change"] as (
+    e: unknown
+  ) => void;
+  handler({ target: { value } });
+}
+
+function emitFor(
+  type: ConfigEntryType,
+  extra: Record<string, unknown>,
+  picked: string
+): unknown {
+  const emitChange = vi.fn();
+  const entry = makeEntry(type, extra);
+  const ctx = makeRenderCtx({ field: "" }, { board: null, overrides: { emitChange } });
+  fireChange(renderSelectField(entry, ["field"], ctx), picked);
+  return emitChange.mock.calls[0][1];
+}
+
+describe("renderSelectField — emits coerce to the entry's type", () => {
+  it("strict select: integer options emit numbers, booleans emit booleans", () => {
+    expect(
+      emitFor(ConfigEntryType.INTEGER, { options: asOptions(["0", "90"]) }, "90")
+    ).toBe(90);
+    expect(
+      emitFor(ConfigEntryType.BOOLEAN, { options: asOptions(["true", "false"]) }, "true")
+    ).toBe(true);
+  });
+
+  it("strict select: string options and the clearable's empty pass through", () => {
+    expect(
+      emitFor(
+        ConfigEntryType.SELECT,
+        { options: asOptions(["energy", "power"]) },
+        "energy"
+      )
+    ).toBe("energy");
+    expect(
+      emitFor(ConfigEntryType.INTEGER, { options: asOptions(["0", "90"]) }, "")
+    ).toBe("");
+  });
+
+  it("suggestions select: integer suggestions emit numbers", () => {
+    expect(emitFor(ConfigEntryType.INTEGER, { suggestions: ["11", "13"] }, "13")).toBe(
+      13
+    );
+    expect(
+      emitFor(ConfigEntryType.SELECT, { suggestions: ["fast", "slow"] }, "fast")
+    ).toBe("fast");
+  });
+});

--- a/test/components/device/config-entry-select-emit-coerce.test.ts
+++ b/test/components/device/config-entry-select-emit-coerce.test.ts
@@ -1,14 +1,9 @@
-/**
- * Pins that both wa-select emit paths (suggestions and strict select)
- * commit through ``coerceValueToEntryType``, so a typed entry modeled
- * as options emits its declared type and the YAML stays bare (#1372).
- */
-import { describe, expect, it, vi } from "vitest";
+/** Pins that both wa-select emit paths coerce through coerceValueToEntryType (#1372). */
+import { describe, expect, it } from "vitest";
 import type { ConfigValueOption } from "../../../src/api/types/config-entries.js";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { renderSelectField } from "../../../src/components/device/config-entry-renderers/primitives.js";
-import { makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
-import { findElementBindings } from "./_renderer-fixtures.js";
+import { findElementBindings, makeEmitCtx, makeEntry } from "./_renderer-fixtures.js";
 
 const asOptions = (values: string[]): ConfigValueOption[] =>
   values.map((v) => ({ value: v, label: v }));
@@ -25,9 +20,8 @@ function emitFor(
   extra: Record<string, unknown>,
   picked: string
 ): unknown {
-  const emitChange = vi.fn();
   const entry = makeEntry(type, extra);
-  const ctx = makeRenderCtx({ field: "" }, { board: null, overrides: { emitChange } });
+  const { ctx, emitChange } = makeEmitCtx({ field: "" });
   fireChange(renderSelectField(entry, ["field"], ctx), picked);
   return emitChange.mock.calls[0][1];
 }


### PR DESCRIPTION
# What does this implement/fix?

`renderSelectField` has four emit paths and two of them, the featured suggestions select and the plain strict select (including its clear), emitted the control's raw string while the combobox branch and the shared suggestion select already coerce through `coerceValueToEntryType`. The form dispatch routes any entry with `options` or `suggestions` to this renderer before the per type cases, so an INTEGER or BOOLEAN entry modeled as options emitted `"90"` or `"true"` as strings, which the serializer then quotes, re typing the YAML; the churn class #1364 through #1370 closed everywhere else.

Both emits now route through `coerceValueToEntryType`. The coercer is a no op for string entries and maps empty to empty, so string selects and the clearable's clear are unchanged; pinned for both branches with integer, boolean, string, and clear cases.

Reachability today is narrow but real: `speaker.resampler.bits_per_sample` and `esp32_camera.jpeg_quality` are integer typed strict selects (the common `uart`/`logger` baud rates use the combobox branch, which already coerced), plus any board featured suggestion list on a numeric entry. Verified in the live editor that a string strict select (`esp32.framework.type`) still round trips bare; the numeric cases are pinned by the new unit tests since neither numeric strict select component is practical to stand up in the scratch config.

While auditing reachability I found ~76 catalog fields whose option values are all integers but which the schema sync types as `string` (`sensor.ina226` averaging, `sensor.ads1115` oversampling, and friends); those stay quoted after this fix because coercion is keyed on the entry's declared type. That is a catalog typing gap in the backend sync script, filed separately.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1372

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
