### PR TITLE
Bail color fields to editable text when the value is not #rrggbb

### DIFF
--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -94,6 +94,7 @@ import {
   renderMultiValueField,
   renderNestedField,
   renderNestedListField,
+  renderColorField,
   renderNumberField,
   renderPinField,
   renderRegistryListField,
@@ -966,7 +967,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
       case ConfigEntryType.PIN:
         return renderPinField(entry, path, ctx);
       case ConfigEntryType.COLOR:
-        return renderStringField(entry, "color", path, ctx);
+        return renderColorField(entry, path, ctx);
       case ConfigEntryType.MAC_ADDRESS:
         return renderStringField(entry, "text", path, ctx);
       case ConfigEntryType.LAMBDA:

--- a/src/components/device/config-entry-renderers.ts
+++ b/src/components/device/config-entry-renderers.ts
@@ -21,6 +21,7 @@ export { renderPinField } from "./config-entry-pin-renderer.js";
 export {
   renderBooleanField,
   renderFloatWithUnitField,
+  renderColorField,
   renderIconField,
   renderNumberField,
   renderSelectField,

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { chipNameToVariant } from "../../../util/chip-variant.js";
 import { isValuePresent, nearCanonicalOption } from "../../../util/config-validation.js";
+import { isHexColor } from "../../../util/label-style.js";
 import { renderOptionStack } from "../../../util/option-stack.js";
 import { parseYamlBoolean, YamlRawValue } from "../../../util/yaml-serialize.js";
 import { coerceValueToEntryType } from "../../../util/coerce-entry-value.js";
@@ -132,11 +133,9 @@ function boardDerivedVariantDefault(
 // <input type="color"> represents only #rrggbb; the browser normalizes any
 // other value to #000000, so a named color or ${substitution} would render
 // as a plausible black swatch and the first pick would clobber it (#1371).
-const HEX_COLOR_RE = /^#[0-9a-f]{6}$/i;
-
 export function renderColorField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   const raw = ctx.getAt(path);
-  if (isValuePresent(raw) && !HEX_COLOR_RE.test(String(raw))) {
+  if (isValuePresent(raw) && !isHexColor(String(raw))) {
     return renderUnparseableScalarField(entry, path, ctx, raw);
   }
   return renderStringField(entry, "color", path, ctx);

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -13,6 +13,7 @@ import {
   renderFieldError,
   renderHelpLink,
   renderLabel,
+  renderStringField,
   renderSuggestionSelect,
   renderUnparseableScalarField,
   renderYamlOnlyFallbackIfNonPrimitive,
@@ -126,6 +127,19 @@ function boardDerivedVariantDefault(
   return entry.options?.some((o) => o.value.toLowerCase() === variant)
     ? variant
     : undefined;
+}
+
+// <input type="color"> represents only #rrggbb; the browser normalizes any
+// other value to #000000, so a named color or ${substitution} would render
+// as a plausible black swatch and the first pick would clobber it (#1371).
+const HEX_COLOR_RE = /^#[0-9a-f]{6}$/i;
+
+export function renderColorField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
+  const raw = ctx.getAt(path);
+  if (isValuePresent(raw) && !HEX_COLOR_RE.test(String(raw))) {
+    return renderUnparseableScalarField(entry, path, ctx, raw);
+  }
+  return renderStringField(entry, "color", path, ctx);
 }
 
 export function renderSelectField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {

--- a/src/util/label-style.ts
+++ b/src/util/label-style.ts
@@ -27,8 +27,11 @@ const NEUTRAL_STYLE: LabelChipStyle = {
 /** ``#rrggbb`` validator. The backend lower-cases on save, but a
  *  hand-edited sidecar could still surface uppercase or a malformed
  *  string — fall back to the neutral palette in that case rather
- *  than throwing. */
+ *  than throwing. Shared with the COLOR field renderer, whose
+ *  ``<input type="color">`` can represent exactly this form. */
 const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+export const isHexColor = (value: string): boolean => HEX_RE.test(value);
 
 /** Pick the contrasting foreground for a hex color using a
  *  relative-luminance heuristic. The cutoff is biased toward

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -17,6 +17,7 @@ import { renderStringField } from "../../../src/components/device/config-entry-r
 import { renderMultiValueField } from "../../../src/components/device/config-entry-renderers/lists.js";
 import {
   renderBooleanField,
+  renderColorField,
   renderFloatWithUnitField,
   renderNumberField,
   renderTextareaField,
@@ -488,5 +489,41 @@ describe("renderBooleanField — bail branches", () => {
       const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
       expect(json).toContain("wa-switch");
     }
+  });
+});
+
+// <input type="color"> silently normalizes anything but #rrggbb to
+// #000000, so a named color or substitution would render as a black
+// swatch and the first pick would clobber it. Pin all three branches.
+describe("renderColorField — bail on values a color input can't show", () => {
+  const entry = (): ConfigEntry =>
+    makeConfigEntry({ key: "color", type: ConfigEntryType.COLOR, label: "Color" });
+
+  it("renders editable text for named colors and substitutions", () => {
+    for (const value of ["red", "${accent}"]) {
+      const { ctx } = makeCtx({ color: value });
+      const tpl = renderColorField(entry(), ["color"], ctx);
+      const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+      expect(rendersBailBranch(json)).toBe(false);
+      expect(json).not.toContain('"color"');
+      expect(json).toContain(value);
+    }
+  });
+
+  it("keeps the color input for #rrggbb and for unset/empty", () => {
+    for (const values of [{ color: "#ff0000" }, { color: "" }, {}]) {
+      const { ctx } = makeCtx(values);
+      const tpl = renderColorField(entry(), ["color"], ctx);
+      const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+      expect(rendersBailBranch(json)).toBe(false);
+      expect(json).toContain('"color"');
+    }
+  });
+
+  it("bails to the YAML-only shell for a non-string value", () => {
+    const { ctx } = makeCtx({ color: [255, 0, 0] });
+    const tpl = renderColorField(entry(), ["color"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(true);
   });
 });

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -492,9 +492,6 @@ describe("renderBooleanField — bail branches", () => {
   });
 });
 
-// <input type="color"> silently normalizes anything but #rrggbb to
-// #000000, so a named color or substitution would render as a black
-// swatch and the first pick would clobber it. Pin all three branches.
 describe("renderColorField — bail on values a color input can't show", () => {
   const entry = (): ConfigEntry =>
     makeConfigEntry({ key: "color", type: ConfigEntryType.COLOR, label: "Color" });
@@ -505,7 +502,7 @@ describe("renderColorField — bail on values a color input can't show", () => {
       const tpl = renderColorField(entry(), ["color"], ctx);
       const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
       expect(rendersBailBranch(json)).toBe(false);
-      expect(json).not.toContain('"color"');
+      expect(findElementBindings(tpl, "input")[0].type).toBe("text");
       expect(json).toContain(value);
     }
   });
@@ -516,7 +513,7 @@ describe("renderColorField — bail on values a color input can't show", () => {
       const tpl = renderColorField(entry(), ["color"], ctx);
       const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
       expect(rendersBailBranch(json)).toBe(false);
-      expect(json).toContain('"color"');
+      expect(findElementBindings(tpl, "input")[0].type).toBe("color");
     }
   });
 


### PR DESCRIPTION
# What does this implement/fix?

The COLOR entry type routed straight to a `<input type="color">`, which can only represent `#rrggbb`; the browser normalizes anything else to `#000000`, so a named color or `${substitution}` would render as a plausible looking black swatch and the first pick would silently replace it. Same data loss class as #1365/#1368, without even the unchecked switch tell.

A new `renderColorField` bails any present value that is not `#rrggbb` to `renderUnparseableScalarField` from #1367: named colors, substitutions, short hex, and junk stay editable as text, a non string value gets the YAML only shell, and `#rrggbb` and empty keep the native picker. The dispatch case calls the new renderer; nothing else changes.

No catalog field carries `type: color` today (noted on the issue), so this is not reachable in app to demo; the guard exists so the first schema sync that emits the type does not ship the clobber. All three branches are pinned in the bail suite.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1371

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
