### PR TITLE
Splice block scalar lists per item so comments survive edits

### DIFF
--- a/src/util/yaml-section-block-reader.ts
+++ b/src/util/yaml-section-block-reader.ts
@@ -35,6 +35,7 @@ import {
   _matchFlatMappingField,
   _scanValueBlock,
   collectBlockListItems,
+  type ListItemSource,
   parseFlatMappingField,
 } from "./yaml-section-list.js";
 import { YamlRawValue } from "./yaml-serialize.js";
@@ -67,6 +68,7 @@ const parseListBlock = (
   value: YamlRawValue | Record<string, unknown>[] | (string | number | boolean)[];
   endIdx: number;
   isEmptyScalarList: boolean;
+  listSource?: ListItemSource;
 } => {
   const canonicalDashIndent = `${parentIndent}${ESPHOME_YAML_INDENT}`;
   const { dashIndent, firstDashIdx } = _detectFirstDashIndent(
@@ -114,7 +116,11 @@ const parseListBlock = (
   // ``dashIndent`` so 4-space user YAMLs round-trip — the older
   // ``listItemRegexFor(parentIndent)`` hardcoded the canonical
   // 2-space step and silently dropped scalar lists otherwise.
-  const { items, endIdx: scalarEndIdx } = collectBlockListItems(
+  const {
+    items,
+    endIdx: scalarEndIdx,
+    source,
+  } = collectBlockListItems(
     lines,
     startIdx,
     `${dashIndent}- `,
@@ -124,6 +130,7 @@ const parseListBlock = (
     value: items,
     endIdx: scalarEndIdx,
     isEmptyScalarList: items.length === 0,
+    listSource: items.length > 0 ? source : undefined,
   };
 };
 

--- a/src/util/yaml-section-block-reader.ts
+++ b/src/util/yaml-section-block-reader.ts
@@ -119,7 +119,8 @@ const parseListBlock = (
   const {
     items,
     endIdx: scalarEndIdx,
-    source,
+    itemLineIdxs,
+    inlineComments,
   } = collectBlockListItems(
     lines,
     startIdx,
@@ -130,7 +131,7 @@ const parseListBlock = (
     value: items,
     endIdx: scalarEndIdx,
     isEmptyScalarList: items.length === 0,
-    listSource: items.length > 0 ? source : undefined,
+    listSource: { itemLineIdxs, inlineComments, dashIndent },
   };
 };
 

--- a/src/util/yaml-section-list.ts
+++ b/src/util/yaml-section-list.ts
@@ -24,13 +24,14 @@ import {
 } from "./yaml-section-lexer.js";
 
 /** Source fidelity for a block scalar list: each item's 0-indexed source
- *  line (into the same array the splice writer receives) and its trailing
- *  inline comment (leading whitespace kept, "" when none), so a per-item
- *  splice can keep unchanged rows verbatim and re-attach an edited row's
- *  comment (#1363). */
+ *  line (into the same array the splice writer receives), its trailing
+ *  inline comment (leading whitespace kept, "" when none), and the dash
+ *  column the parse detected — so a per-item splice keeps unchanged rows
+ *  verbatim and re-emits edited rows without re-deriving anything (#1363). */
 export interface ListItemSource {
   itemLineIdxs: number[];
   inlineComments: string[];
+  dashIndent: string;
 }
 
 export const collectBlockListItems = (
@@ -38,7 +39,12 @@ export const collectBlockListItems = (
   startIdx: number,
   prefix: string,
   itemRegex: RegExp
-): { items: (string | number | boolean)[]; endIdx: number; source: ListItemSource } => {
+): {
+  items: (string | number | boolean)[];
+  endIdx: number;
+  itemLineIdxs: number[];
+  inlineComments: string[];
+} => {
   const items: (string | number | boolean)[] = [];
   const itemLineIdxs: number[] = [];
   const inlineComments: string[] = [];
@@ -50,14 +56,13 @@ export const collectBlockListItems = (
     if (!m) break;
     // Strip a trailing inline comment (``- 10 # note``) so the item
     // coerces and the form value isn't polluted with ``# ...`` text —
-    // same rule as parseScalar (#1235). The comment is kept aside so the
-    // per-item splice can re-append it on an in-place edit (#1363).
+    // same rule as parseScalar (#1235).
     const { value: raw, comment } = splitInlineComment(m[1].trim());
     items.push(coerceYamlScalar(stripQuotes(raw), isQuotedScalar(raw)));
     itemLineIdxs.push(j);
     inlineComments.push(comment);
   }
-  return { items, endIdx: j, source: { itemLineIdxs, inlineComments } };
+  return { items, endIdx: j, itemLineIdxs, inlineComments };
 };
 
 /**

--- a/src/util/yaml-section-list.ts
+++ b/src/util/yaml-section-list.ts
@@ -23,13 +23,25 @@ import {
   parseBlockScalarHeader,
 } from "./yaml-section-lexer.js";
 
+/** Source fidelity for a block scalar list: each item's 0-indexed source
+ *  line (into the same array the splice writer receives) and its trailing
+ *  inline comment (leading whitespace kept, "" when none), so a per-item
+ *  splice can keep unchanged rows verbatim and re-attach an edited row's
+ *  comment (#1363). */
+export interface ListItemSource {
+  itemLineIdxs: number[];
+  inlineComments: string[];
+}
+
 export const collectBlockListItems = (
   lines: string[],
   startIdx: number,
   prefix: string,
   itemRegex: RegExp
-): { items: (string | number | boolean)[]; endIdx: number } => {
+): { items: (string | number | boolean)[]; endIdx: number; source: ListItemSource } => {
   const items: (string | number | boolean)[] = [];
+  const itemLineIdxs: number[] = [];
+  const inlineComments: string[] = [];
   let j = startIdx;
   for (; j < lines.length; j++) {
     if (isBlankOrCommentLine(lines[j])) continue;
@@ -38,13 +50,14 @@ export const collectBlockListItems = (
     if (!m) break;
     // Strip a trailing inline comment (``- 10 # note``) so the item
     // coerces and the form value isn't polluted with ``# ...`` text —
-    // same rule as parseScalar (#1235). An edited list re-emits without
-    // the comment; keeping it in the value corrupted it into the string
-    // ``"10 # note"`` instead.
-    const { value: raw } = splitInlineComment(m[1].trim());
+    // same rule as parseScalar (#1235). The comment is kept aside so the
+    // per-item splice can re-append it on an in-place edit (#1363).
+    const { value: raw, comment } = splitInlineComment(m[1].trim());
     items.push(coerceYamlScalar(stripQuotes(raw), isQuotedScalar(raw)));
+    itemLineIdxs.push(j);
+    inlineComments.push(comment);
   }
-  return { items, endIdx: j };
+  return { items, endIdx: j, source: { itemLineIdxs, inlineComments } };
 };
 
 /**

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -96,10 +96,21 @@ export function parseSectionCore(
   // leadStart is finalised by the post-loop pass below.
   const recordSpan = (key: string, start: number, end: number): void => {
     spans.set(key, { start, end, leadStart: start });
+    // A duplicate key re-assigns the value; a stale list source pointing
+    // at the first occurrence's lines must not survive it.
+    listSources.delete(key);
   };
   const startIdx = findSectionStart(lines, sectionKey, fromLine);
   if (startIdx < 0) {
-    return { values, spans, comments, childIndent: "", isListItem: false, startIdx };
+    return {
+      values,
+      spans,
+      comments,
+      listSources,
+      childIndent: "",
+      isListItem: false,
+      startIdx,
+    };
   }
 
   const isListItem = LIST_ITEM_START_RE.test(lines[startIdx]);
@@ -137,7 +148,7 @@ export function parseSectionCore(
       values[sectionKey] = parseListBlock(lines, startIdx + 1, headerIndent).value;
       // No per-key spans — `updateSectionInYaml` re-emits this whole
       // list through its dedicated LIST_SECTIONS branch.
-      return { values, spans, comments, childIndent, isListItem, startIdx };
+      return { values, spans, comments, listSources, childIndent, isListItem, startIdx };
     }
   }
 

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -11,6 +11,7 @@ import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import { blockScalarValue } from "./yaml-block-scalar-value.js";
 import { parseFlowList, parseScalar, splitInlineComment } from "./yaml-scalar.js";
 import { parseListBlock, parseNestedBlock } from "./yaml-section-block-reader.js";
+import type { ListItemSource } from "./yaml-section-list.js";
 import {
   _detectSectionChildIndent,
   _leadingIndent,
@@ -91,6 +92,7 @@ export function parseSectionCore(
   const values: Record<string, unknown> = Object.create(null);
   const spans = new Map<string, KeySpan>();
   const comments = new Map<string, string>();
+  const listSources = new Map<string, ListItemSource>();
   // leadStart is finalised by the post-loop pass below.
   const recordSpan = (key: string, start: number, end: number): void => {
     spans.set(key, { start, end, leadStart: start });
@@ -214,7 +216,7 @@ export function parseSectionCore(
     if (raw === "") {
       const peek = _skipBlankAndCommentLines(lines, i + 1);
       if (peek < lines.length && isChildListItemLine(lines[peek], childIndent)) {
-        const { value, endIdx, isEmptyScalarList } = parseListBlock(
+        const { value, endIdx, isEmptyScalarList, listSource } = parseListBlock(
           lines,
           i + 1,
           childIndent
@@ -222,6 +224,7 @@ export function parseSectionCore(
         if (!isEmptyScalarList) {
           values[key] = value;
           recordSpan(key, i, endIdx);
+          if (listSource) listSources.set(key, listSource);
           i = endIdx - 1;
         }
         continue;
@@ -293,5 +296,5 @@ export function parseSectionCore(
     prevEnd = span.end;
   }
 
-  return { values, spans, comments, childIndent, isListItem, startIdx };
+  return { values, spans, comments, listSources, childIndent, isListItem, startIdx };
 }

--- a/src/util/yaml-section-splice.ts
+++ b/src/util/yaml-section-splice.ts
@@ -9,7 +9,9 @@
  */
 
 import { isPlainObject } from "./nested-values.js";
+import type { ListItemSource } from "./yaml-section-list.js";
 import {
+  formatYamlScalar,
   serializeYamlValues,
   YamlRawValue,
   type SerializeYamlOptions,
@@ -38,6 +40,10 @@ export interface ParsedSection {
   // ` #hides`) per scalar key that had one, so a re-serialized edit can
   // re-append it instead of dropping it (#1235).
   comments: Map<string, string>;
+  // Per-item source fidelity for block scalar list keys, so an edited
+  // list splices per item instead of re-emitting every row (#1363).
+  // Absent when the section carried no such list.
+  listSources?: Map<string, ListItemSource>;
   childIndent: string;
   isListItem: boolean;
   // 0-indexed section header / leading-dash line.
@@ -103,6 +109,12 @@ export function buildSplicedBody(
       bodyLines.push(...lines.slice(span.leadStart, span.end));
       continue;
     }
+    const spliced =
+      span && spliceScalarList(lines, span, parsed, key, val, serializeOptions);
+    if (spliced) {
+      bodyLines.push(...spliced);
+      continue;
+    }
     // Changed / added key. Keep any standalone-comment run that led the
     // original key — the value line below reformats, the comment stays.
     if (span) bodyLines.push(...lines.slice(span.leadStart, span.start));
@@ -114,4 +126,79 @@ export function buildSplicedBody(
     bodyLines.push(...fresh);
   }
   return bodyLines;
+}
+
+const isScalarItem = (v: unknown): v is string | number | boolean =>
+  typeof v === "string" || typeof v === "number" || typeof v === "boolean";
+
+/**
+ * Per-item splice for a changed block scalar list (#1363): rows unchanged
+ * at the same position (longest common prefix + suffix) keep their source
+ * lines — inline comments, preceding whole-line comments, exact quoting —
+ * and only the middle re-emits. An in-place edit (equal lengths) also
+ * re-attaches each edited row's own inline comment. Returns ``null`` when
+ * the key isn't a block scalar list on both sides (caller falls through to
+ * the full re-emit), or when the new list is empty (the re-emit path owns
+ * the drop-the-key semantic).
+ */
+function spliceScalarList(
+  lines: string[],
+  span: KeySpan,
+  parsed: ParsedSection,
+  key: string,
+  val: unknown,
+  options: SerializeYamlOptions
+): string[] | null {
+  const src = parsed.listSources?.get(key);
+  const old = parsed.values[key];
+  if (
+    !src ||
+    src.itemLineIdxs.length === 0 ||
+    !Array.isArray(old) ||
+    !Array.isArray(val) ||
+    val.length === 0 ||
+    !old.every(isScalarItem) ||
+    !val.every(isScalarItem)
+  ) {
+    return null;
+  }
+  let prefix = 0;
+  while (prefix < old.length && prefix < val.length && old[prefix] === val[prefix]) {
+    prefix++;
+  }
+  let suffix = 0;
+  while (
+    suffix < old.length - prefix &&
+    suffix < val.length - prefix &&
+    old[old.length - 1 - suffix] === val[val.length - 1 - suffix]
+  ) {
+    suffix++;
+  }
+  const idxs = src.itemLineIdxs;
+  // Each row's group runs from just past the previous row's line (the key
+  // line for the first row), carrying the whole-line comments above it.
+  const groupStart = (i: number): number => (i === 0 ? span.start + 1 : idxs[i - 1] + 1);
+  const dashIndent = /^( *)-/.exec(lines[idxs[0]])?.[1] ?? "";
+  const inPlace = old.length === val.length;
+  const out: string[] = [];
+  out.push(...lines.slice(span.leadStart, span.start + 1));
+  for (let i = 0; i < prefix; i++) {
+    out.push(...lines.slice(groupStart(i), idxs[i] + 1));
+  }
+  for (let k = prefix; k < val.length - suffix; k++) {
+    // An in-place edit keeps the row's own preceding comments and inline
+    // comment; with add/remove the middle alignment is ambiguous, so new
+    // middle rows emit plain.
+    if (inPlace) out.push(...lines.slice(groupStart(k), idxs[k]));
+    out.push(
+      `${dashIndent}- ${formatYamlScalar(val[k])}${inPlace ? src.inlineComments[k] : ""}`
+    );
+  }
+  for (let i = old.length - suffix; i < old.length; i++) {
+    out.push(...lines.slice(groupStart(i), idxs[i] + 1));
+  }
+  // Whatever the span still owns past the last row (trailing comment
+  // lines the lead-repartition left with this key) rides along verbatim.
+  out.push(...lines.slice(idxs[old.length - 1] + 1, span.end));
+  return out;
 }

--- a/src/util/yaml-section-splice.ts
+++ b/src/util/yaml-section-splice.ts
@@ -185,8 +185,10 @@ function spliceScalarList(
   for (let k = prefix; k < val.length - suffix; k++) {
     // A row unchanged between two edits keeps its bytes; an in-place edit
     // keeps the row's preceding comments and re-attaches its inline
-    // comment. With add/remove the middle alignment is ambiguous, so new
-    // middle rows emit plain.
+    // comment — deliberately, even when the comment described the old
+    // value: row comments label the row's role far more often than its
+    // literal value. With add/remove the middle alignment is ambiguous,
+    // so new middle rows emit plain.
     if (inPlace && old[k] === val[k]) {
       out.push(...lines.slice(groupStart(k), idxs[k] + 1));
       continue;

--- a/src/util/yaml-section-splice.ts
+++ b/src/util/yaml-section-splice.ts
@@ -8,7 +8,7 @@
  * with this concern.
  */
 
-import { isPlainObject } from "./nested-values.js";
+import { isPlainObject, isPrimitiveOrNullish } from "./nested-values.js";
 import type { ListItemSource } from "./yaml-section-list.js";
 import {
   formatYamlScalar,
@@ -42,8 +42,7 @@ export interface ParsedSection {
   comments: Map<string, string>;
   // Per-item source fidelity for block scalar list keys, so an edited
   // list splices per item instead of re-emitting every row (#1363).
-  // Absent when the section carried no such list.
-  listSources?: Map<string, ListItemSource>;
+  listSources: Map<string, ListItemSource>;
   childIndent: string;
   isListItem: boolean;
   // 0-indexed section header / leading-dash line.
@@ -109,8 +108,7 @@ export function buildSplicedBody(
       bodyLines.push(...lines.slice(span.leadStart, span.end));
       continue;
     }
-    const spliced =
-      span && spliceScalarList(lines, span, parsed, key, val, serializeOptions);
+    const spliced = span && spliceScalarList(lines, span, parsed, key, val);
     if (spliced) {
       bodyLines.push(...spliced);
       continue;
@@ -128,8 +126,10 @@ export function buildSplicedBody(
   return bodyLines;
 }
 
+// Deliberately stricter than ``isPrimitiveOrNullish``: a nullish item must
+// fall through to the full re-emit, not reach ``formatYamlScalar``.
 const isScalarItem = (v: unknown): v is string | number | boolean =>
-  typeof v === "string" || typeof v === "number" || typeof v === "boolean";
+  isPrimitiveOrNullish(v) && v != null;
 
 /**
  * Per-item splice for a changed block scalar list (#1363): rows unchanged
@@ -146,14 +146,12 @@ function spliceScalarList(
   span: KeySpan,
   parsed: ParsedSection,
   key: string,
-  val: unknown,
-  options: SerializeYamlOptions
+  val: unknown
 ): string[] | null {
-  const src = parsed.listSources?.get(key);
+  const src = parsed.listSources.get(key);
   const old = parsed.values[key];
   if (
     !src ||
-    src.itemLineIdxs.length === 0 ||
     !Array.isArray(old) ||
     !Array.isArray(val) ||
     val.length === 0 ||
@@ -174,31 +172,30 @@ function spliceScalarList(
   ) {
     suffix++;
   }
-  const idxs = src.itemLineIdxs;
+  const { itemLineIdxs: idxs, inlineComments, dashIndent } = src;
   // Each row's group runs from just past the previous row's line (the key
   // line for the first row), carrying the whole-line comments above it.
   const groupStart = (i: number): number => (i === 0 ? span.start + 1 : idxs[i - 1] + 1);
-  const dashIndent = /^( *)-/.exec(lines[idxs[0]])?.[1] ?? "";
   const inPlace = old.length === val.length;
   const out: string[] = [];
-  out.push(...lines.slice(span.leadStart, span.start + 1));
-  for (let i = 0; i < prefix; i++) {
-    out.push(...lines.slice(groupStart(i), idxs[i] + 1));
-  }
+  // Groups tile contiguously, so the lead + key line + prefix rows are one
+  // slice, and the suffix rows + whatever the span still owns past the
+  // last row (trailing comments) are another.
+  out.push(...lines.slice(span.leadStart, groupStart(prefix)));
   for (let k = prefix; k < val.length - suffix; k++) {
-    // An in-place edit keeps the row's own preceding comments and inline
-    // comment; with add/remove the middle alignment is ambiguous, so new
+    // A row unchanged between two edits keeps its bytes; an in-place edit
+    // keeps the row's preceding comments and re-attaches its inline
+    // comment. With add/remove the middle alignment is ambiguous, so new
     // middle rows emit plain.
+    if (inPlace && old[k] === val[k]) {
+      out.push(...lines.slice(groupStart(k), idxs[k] + 1));
+      continue;
+    }
     if (inPlace) out.push(...lines.slice(groupStart(k), idxs[k]));
     out.push(
-      `${dashIndent}- ${formatYamlScalar(val[k])}${inPlace ? src.inlineComments[k] : ""}`
+      `${dashIndent}- ${formatYamlScalar(val[k])}${inPlace ? inlineComments[k] : ""}`
     );
   }
-  for (let i = old.length - suffix; i < old.length; i++) {
-    out.push(...lines.slice(groupStart(i), idxs[i] + 1));
-  }
-  // Whatever the span still owns past the last row (trailing comment
-  // lines the lead-repartition left with this key) rides along verbatim.
-  out.push(...lines.slice(idxs[old.length - 1] + 1, span.end));
+  out.push(...lines.slice(groupStart(old.length - suffix), span.end));
   return out;
 }

--- a/test/util/yaml-section-splice.test.ts
+++ b/test/util/yaml-section-splice.test.ts
@@ -95,6 +95,7 @@ function makeParsed(comments: Map<string, string> = new Map()): ParsedSection {
       ["color", { leadStart: 3, start: 3, end: 4 }],
     ]),
     comments,
+    listSources: new Map(),
     childIndent: "  ",
     isListItem: false,
     startIdx: 0,

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1397,6 +1397,24 @@ describe("updateSectionInYaml — preserves untouched field byte layout (#1227)"
     );
   });
 
+  it("keeps a sandwiched unchanged row byte-identical between two edited rows", () => {
+    const before = [
+      "display:",
+      "  glyphs:",
+      "    - 1 #a",
+      '    - "${glyph_row}" #keep',
+      "    - 3 #c",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "display", 1);
+    (values.glyphs as unknown[])[0] = 10;
+    (values.glyphs as unknown[])[2] = 30;
+    const after = updateSectionInYaml(before, "display", values, 1);
+    expect(after).toContain(
+      '  glyphs:\n    - 10 #a\n    - "${glyph_row}" #keep\n    - 30 #c\n'
+    );
+  });
+
   it("re-emits plain on a wholesale list replacement (no stale comments)", () => {
     const before = ["wifi:", "  networks:", "    - a #one", "    - b #two", ""].join(
       "\n"

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1326,6 +1326,103 @@ describe("updateSectionInYaml — preserves untouched field byte layout (#1227)"
     expect(after).toContain("ssid: office");
   });
 
+  it("keeps other items' comments when one list row is edited in place (#1363)", () => {
+    const before = [
+      "wifi:",
+      "  networks:",
+      "    - homenet #primary",
+      "    # fallback network",
+      "    - guestnet #open",
+      "    - iot",
+      "  ssid: home",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "wifi", 1);
+    (values.networks as unknown[])[2] = "iot2";
+    const after = updateSectionInYaml(before, "wifi", values, 1);
+    expect(after).toContain(
+      "  networks:\n    - homenet #primary\n    # fallback network\n    - guestnet #open\n    - iot2\n"
+    );
+  });
+
+  it("re-attaches the edited row's own inline comment on an in-place edit", () => {
+    const before = ["display:", "  glyphs:", "    - 10 #ten", "    - 12", ""].join("\n");
+    const values = parseYamlSectionValues(before, "display", 1);
+    (values.glyphs as unknown[])[0] = 11;
+    const after = updateSectionInYaml(before, "display", values, 1);
+    expect(after).toContain("  glyphs:\n    - 11 #ten\n    - 12\n");
+  });
+
+  it("keeps remaining rows' comments when a middle row is removed", () => {
+    const before = [
+      "wifi:",
+      "  networks:",
+      "    - homenet #primary",
+      "    - dead",
+      "    - guestnet #open",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "wifi", 1);
+    values.networks = ["homenet", "guestnet"];
+    const after = updateSectionInYaml(before, "wifi", values, 1);
+    expect(after).toContain(
+      "  networks:\n    - homenet #primary\n    - guestnet #open\n"
+    );
+    expect(after).not.toContain("- dead");
+  });
+
+  it("keeps existing rows verbatim when a row is appended", () => {
+    const before = ["wifi:", "  networks:", "    - homenet #primary", ""].join("\n");
+    const values = parseYamlSectionValues(before, "wifi", 1);
+    values.networks = ["homenet", "extra"];
+    const after = updateSectionInYaml(before, "wifi", values, 1);
+    expect(after).toContain("  networks:\n    - homenet #primary\n    - extra\n");
+  });
+
+  it("keeps a trailing comment after the last row through an edit", () => {
+    const before = [
+      "wifi:",
+      "  networks:",
+      "    - homenet",
+      "    - guestnet #open",
+      "    # end of networks",
+      "  ssid: home",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "wifi", 1);
+    (values.networks as unknown[])[0] = "homenet2";
+    const after = updateSectionInYaml(before, "wifi", values, 1);
+    expect(after).toContain(
+      "  networks:\n    - homenet2\n    - guestnet #open\n    # end of networks\n  ssid: home"
+    );
+  });
+
+  it("re-emits plain on a wholesale list replacement (no stale comments)", () => {
+    const before = ["wifi:", "  networks:", "    - a #one", "    - b #two", ""].join(
+      "\n"
+    );
+    const values = parseYamlSectionValues(before, "wifi", 1);
+    values.networks = ["x", "y", "z"];
+    const after = updateSectionInYaml(before, "wifi", values, 1);
+    expect(after).toContain("  networks:\n    - x\n    - y\n    - z\n");
+    expect(after).not.toContain("#one");
+    expect(after).not.toContain("#two");
+  });
+
+  it("keeps protective quoting on an untouched substitution row through a sibling edit", () => {
+    const before = [
+      "display:",
+      "  glyphs:",
+      '    - "${glyph_row}" #from subst',
+      "    - 10",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "display", 1);
+    (values.glyphs as unknown[])[1] = 12;
+    const after = updateSectionInYaml(before, "display", values, 1);
+    expect(after).toContain('    - "${glyph_row}" #from subst\n    - 12\n');
+  });
+
   it("keeps an inter-key comment when editing the multi-line value above it", () => {
     // Copilot review: a block scalar's span absorbs the trailing
     // sibling-level comment the scanner skipped, so editing that key


### PR DESCRIPTION
# What does this implement/fix?

Editing any row of a block scalar list dropped every item's comments: the parsed section stores list keys as bare scalar arrays (`collectBlockListItems` discards the comment half of `splitInlineComment`), and the splice writer had only two paths, byte verbatim when the whole array is unchanged, else a full re emit from scalars. Any edit to any row defeated the verbatim path, losing inline comments, whole line comments between items, and exact quoting in one stroke.

This pushes the #1227 diff and splice philosophy one level down. The collector now records each item's source line index and inline comment in a `listSources` side map on `ParsedSection` (the values stay plain scalar arrays, so renderers, `setIn`/`getIn`, and validation are untouched). When a changed key is a block scalar list on both sides, `buildSplicedBody` splices per item: rows unchanged at the same position (longest common prefix plus suffix) keep their source lines verbatim, comments, quoting, and the whole line comments above them included, and only the middle re emits. An in place edit (equal lengths) also keeps each edited row's own preceding comments and re attaches its inline comment. Trailing comments after the last row ride along verbatim. Anything else, mapping lists, flow lists, a wholesale replacement, an emptied list, falls through to today's re emit, so no stale comments are ever smeared onto new values.

Seven new round trip pins cover the in place edit, the edited row's own comment, remove and append alignment, trailing comments, the wholesale replacement fallback, and protective quoting on substitution rows. Verified in the live editor on an `esphome.libraries` list: editing one row kept the other row's `#i2c bus` inline comment and the `# display driver` whole line comment byte identical.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1363

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
