### PR TITLE
Re-emit edited flow lists in flow style with their trailing comment

### DIFF
--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -93,12 +93,14 @@ export function parseSectionCore(
   const spans = new Map<string, KeySpan>();
   const comments = new Map<string, string>();
   const listSources = new Map<string, ListItemSource>();
+  const flowListKeys = new Set<string>();
   // leadStart is finalised by the post-loop pass below.
   const recordSpan = (key: string, start: number, end: number): void => {
     spans.set(key, { start, end, leadStart: start });
-    // A duplicate key re-assigns the value; a stale list source pointing
-    // at the first occurrence's lines must not survive it.
+    // A duplicate key re-assigns the value; stale list metadata pointing
+    // at the first occurrence must not survive it.
     listSources.delete(key);
+    flowListKeys.delete(key);
   };
   const startIdx = findSectionStart(lines, sectionKey, fromLine);
   if (startIdx < 0) {
@@ -107,6 +109,7 @@ export function parseSectionCore(
       spans,
       comments,
       listSources,
+      flowListKeys,
       childIndent: "",
       isListItem: false,
       startIdx,
@@ -148,7 +151,16 @@ export function parseSectionCore(
       values[sectionKey] = parseListBlock(lines, startIdx + 1, headerIndent).value;
       // No per-key spans — `updateSectionInYaml` re-emits this whole
       // list through its dedicated LIST_SECTIONS branch.
-      return { values, spans, comments, listSources, childIndent, isListItem, startIdx };
+      return {
+        values,
+        spans,
+        comments,
+        listSources,
+        flowListKeys,
+        childIndent,
+        isListItem,
+        startIdx,
+      };
     }
   }
 
@@ -265,6 +277,7 @@ export function parseSectionCore(
     if (scalar.startsWith("[") && scalar.endsWith("]")) {
       values[key] = parseFlowList(scalar);
       recordSpan(key, i, i + 1);
+      flowListKeys.add(key);
       continue;
     }
     values[key] = parseScalar(scalar);
@@ -307,5 +320,14 @@ export function parseSectionCore(
     prevEnd = span.end;
   }
 
-  return { values, spans, comments, listSources, childIndent, isListItem, startIdx };
+  return {
+    values,
+    spans,
+    comments,
+    listSources,
+    flowListKeys,
+    childIndent,
+    isListItem,
+    startIdx,
+  };
 }

--- a/src/util/yaml-section-splice.ts
+++ b/src/util/yaml-section-splice.ts
@@ -11,6 +11,7 @@
 import { isPlainObject, isPrimitiveOrNullish } from "./nested-values.js";
 import type { ListItemSource } from "./yaml-section-list.js";
 import {
+  formatYamlFlowScalar,
   formatYamlScalar,
   serializeYamlValues,
   YamlRawValue,
@@ -43,6 +44,10 @@ export interface ParsedSection {
   // Per-item source fidelity for block scalar list keys, so an edited
   // list splices per item instead of re-emitting every row (#1363).
   listSources: Map<string, ListItemSource>;
+  // Keys whose value was authored as a flow list (``key: [a, b]``), so an
+  // edit re-emits the same single-line style — which also lets the
+  // trailing-comment re-append below fire (#1378).
+  flowListKeys: Set<string>;
   childIndent: string;
   isListItem: boolean;
   // 0-indexed section header / leading-dash line.
@@ -116,7 +121,13 @@ export function buildSplicedBody(
     // Changed / added key. Keep any standalone-comment run that led the
     // original key — the value line below reformats, the comment stays.
     if (span) bodyLines.push(...lines.slice(span.leadStart, span.start));
-    const fresh = serializeYamlValues({ [key]: val }, childIndent, serializeOptions);
+    const fresh =
+      parsed.flowListKeys.has(key) &&
+      Array.isArray(val) &&
+      val.length > 0 &&
+      val.every(isScalarItem)
+        ? [`${childIndent}${key}: [${val.map(formatYamlFlowScalar).join(", ")}]`]
+        : serializeYamlValues({ [key]: val }, childIndent, serializeOptions);
     // Re-append the field's trailing inline comment when it still
     // serializes to a single scalar line, so an edit keeps it (#1235).
     const comment = parsed.comments.get(key);

--- a/src/util/yaml-section-splice.ts
+++ b/src/util/yaml-section-splice.ts
@@ -11,7 +11,7 @@
 import { isPlainObject, isPrimitiveOrNullish } from "./nested-values.js";
 import type { ListItemSource } from "./yaml-section-list.js";
 import {
-  formatYamlFlowScalar,
+  formatYamlFlowList,
   formatYamlScalar,
   serializeYamlValues,
   YamlRawValue,
@@ -46,7 +46,8 @@ export interface ParsedSection {
   listSources: Map<string, ListItemSource>;
   // Keys whose value was authored as a flow list (``key: [a, b]``), so an
   // edit re-emits the same single-line style — which also lets the
-  // trailing-comment re-append below fire (#1378).
+  // trailing-comment re-append below fire (#1378). Never overlaps
+  // ``listSources``: the two are set in disjoint parse branches.
   flowListKeys: Set<string>;
   childIndent: string;
   isListItem: boolean;
@@ -122,12 +123,8 @@ export function buildSplicedBody(
     // original key — the value line below reformats, the comment stays.
     if (span) bodyLines.push(...lines.slice(span.leadStart, span.start));
     const fresh =
-      parsed.flowListKeys.has(key) &&
-      Array.isArray(val) &&
-      val.length > 0 &&
-      val.every(isScalarItem)
-        ? [`${childIndent}${key}: [${val.map(formatYamlFlowScalar).join(", ")}]`]
-        : serializeYamlValues({ [key]: val }, childIndent, serializeOptions);
+      flowListLine(parsed, key, val, childIndent) ??
+      serializeYamlValues({ [key]: val }, childIndent, serializeOptions);
     // Re-append the field's trailing inline comment when it still
     // serializes to a single scalar line, so an edit keeps it (#1235).
     const comment = parsed.comments.get(key);
@@ -135,6 +132,19 @@ export function buildSplicedBody(
     bodyLines.push(...fresh);
   }
   return bodyLines;
+}
+
+/** A flow-authored key re-emits as the same single flow line (an emptied
+ *  or non-scalar value falls through to the normal re-emit). */
+function flowListLine(
+  parsed: ParsedSection,
+  key: string,
+  val: unknown,
+  childIndent: string
+): string[] | null {
+  if (!parsed.flowListKeys.has(key)) return null;
+  if (!Array.isArray(val) || val.length === 0 || !val.every(isScalarItem)) return null;
+  return [`${childIndent}${key}: ${formatYamlFlowList(val)}`];
 }
 
 // Deliberately stricter than ``isPrimitiveOrNullish``: a nullish item must

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -523,7 +523,7 @@ export function formatYamlScalar(v: unknown): string {
  * (``,`` ``[`` ``]`` ``{`` ``}``) must be quoted on top of
  * ``formatYamlScalar``'s rules, or the list mis-splits.
  */
-function formatYamlFlowScalar(v: unknown): string {
+export function formatYamlFlowScalar(v: unknown): string {
   if (typeof v === "string" && /[,[\]{}]/.test(v)) return yamlDoubleQuote(v);
   return formatYamlScalar(v);
 }

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -274,7 +274,7 @@ function serializeListItem(
           (it) => !isPlainObject(it) && !Array.isArray(it) && !isLambdaValue(it)
         );
         if (scalarItems) {
-          lines.push(`${prefix}${k}: [${v.map(formatYamlFlowScalar).join(", ")}]`);
+          lines.push(`${prefix}${k}: ${formatYamlFlowList(v)}`);
           return;
         }
         lines.push(`${prefix}${k}:`);
@@ -523,9 +523,14 @@ export function formatYamlScalar(v: unknown): string {
  * (``,`` ``[`` ``]`` ``{`` ``}``) must be quoted on top of
  * ``formatYamlScalar``'s rules, or the list mis-splits.
  */
-export function formatYamlFlowScalar(v: unknown): string {
+function formatYamlFlowScalar(v: unknown): string {
   if (typeof v === "string" && /[,[\]{}]/.test(v)) return yamlDoubleQuote(v);
   return formatYamlScalar(v);
+}
+
+/** The ``[a, b]`` body of a flow list — the one owner of flow-list grammar. */
+export function formatYamlFlowList(items: readonly unknown[]): string {
+  return `[${items.map(formatYamlFlowScalar).join(", ")}]`;
 }
 
 // ESPHome's YAML loader accepts the YAML 1.1 truthy/falsy spellings

--- a/test/util/yaml-section-splice.test.ts
+++ b/test/util/yaml-section-splice.test.ts
@@ -96,6 +96,7 @@ function makeParsed(comments: Map<string, string> = new Map()): ParsedSection {
     ]),
     comments,
     listSources: new Map(),
+    flowListKeys: new Set(),
     childIndent: "  ",
     isListItem: false,
     startIdx: 0,

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1415,32 +1415,6 @@ describe("updateSectionInYaml — preserves untouched field byte layout (#1227)"
     );
   });
 
-  it("keeps flow style and the trailing comment when a flow list is edited (#1378)", () => {
-    const before = ["display:", "  data: [10, 12] # note", "  size: 20", ""].join("\n");
-    const values = parseYamlSectionValues(before, "display", 1);
-    (values.data as unknown[])[1] = 13;
-    const after = updateSectionInYaml(before, "display", values, 1);
-    expect(after).toContain("  data: [10, 13] # note\n");
-    expect(after).not.toContain("- 10");
-  });
-
-  it("keeps flow-indicator quoting on substitution items through a flow edit", () => {
-    const before = ["display:", '  data: ["${glyph_row}", 10] # glyphs', ""].join("\n");
-    const values = parseYamlSectionValues(before, "display", 1);
-    (values.data as unknown[])[1] = 11;
-    const after = updateSectionInYaml(before, "display", values, 1);
-    expect(after).toContain('  data: ["${glyph_row}", 11] # glyphs\n');
-  });
-
-  it("drops the key when a flow list is emptied", () => {
-    const before = ["display:", "  data: [10, 12] # note", "  size: 20", ""].join("\n");
-    const values = parseYamlSectionValues(before, "display", 1);
-    values.data = [];
-    const after = updateSectionInYaml(before, "display", values, 1);
-    expect(after).not.toContain("data:");
-    expect(after).toContain("size: 20");
-  });
-
   it("re-emits plain on a wholesale list replacement (no stale comments)", () => {
     const before = ["wifi:", "  networks:", "    - a #one", "    - b #two", ""].join(
       "\n"
@@ -3051,5 +3025,33 @@ describe("bare child keys — hand-typed `key:` with no value", () => {
     expect(after).toContain("rotation: 180");
     // The second platform item is untouched and still follows the first.
     expect(after.indexOf("rotation: 180")).toBeLessThan(after.indexOf("ili9xxx"));
+  });
+});
+
+describe("updateSectionInYaml — flow list edits keep flow style (#1378)", () => {
+  it("keeps flow style and the trailing comment when a flow list is edited (#1378)", () => {
+    const before = ["display:", "  data: [10, 12] # note", "  size: 20", ""].join("\n");
+    const values = parseYamlSectionValues(before, "display", 1);
+    (values.data as unknown[])[1] = 13;
+    const after = updateSectionInYaml(before, "display", values, 1);
+    expect(after).toContain("  data: [10, 13] # note\n");
+    expect(after).not.toContain("- 10");
+  });
+
+  it("keeps flow-indicator quoting on substitution items through a flow edit", () => {
+    const before = ["display:", '  data: ["${glyph_row}", 10] # glyphs', ""].join("\n");
+    const values = parseYamlSectionValues(before, "display", 1);
+    (values.data as unknown[])[1] = 11;
+    const after = updateSectionInYaml(before, "display", values, 1);
+    expect(after).toContain('  data: ["${glyph_row}", 11] # glyphs\n');
+  });
+
+  it("drops the key when a flow list is emptied", () => {
+    const before = ["display:", "  data: [10, 12] # note", "  size: 20", ""].join("\n");
+    const values = parseYamlSectionValues(before, "display", 1);
+    values.data = [];
+    const after = updateSectionInYaml(before, "display", values, 1);
+    expect(after).not.toContain("data:");
+    expect(after).toContain("size: 20");
   });
 });

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1415,6 +1415,32 @@ describe("updateSectionInYaml — preserves untouched field byte layout (#1227)"
     );
   });
 
+  it("keeps flow style and the trailing comment when a flow list is edited (#1378)", () => {
+    const before = ["display:", "  data: [10, 12] # note", "  size: 20", ""].join("\n");
+    const values = parseYamlSectionValues(before, "display", 1);
+    (values.data as unknown[])[1] = 13;
+    const after = updateSectionInYaml(before, "display", values, 1);
+    expect(after).toContain("  data: [10, 13] # note\n");
+    expect(after).not.toContain("- 10");
+  });
+
+  it("keeps flow-indicator quoting on substitution items through a flow edit", () => {
+    const before = ["display:", '  data: ["${glyph_row}", 10] # glyphs', ""].join("\n");
+    const values = parseYamlSectionValues(before, "display", 1);
+    (values.data as unknown[])[1] = 11;
+    const after = updateSectionInYaml(before, "display", values, 1);
+    expect(after).toContain('  data: ["${glyph_row}", 11] # glyphs\n');
+  });
+
+  it("drops the key when a flow list is emptied", () => {
+    const before = ["display:", "  data: [10, 12] # note", "  size: 20", ""].join("\n");
+    const values = parseYamlSectionValues(before, "display", 1);
+    values.data = [];
+    const after = updateSectionInYaml(before, "display", values, 1);
+    expect(after).not.toContain("data:");
+    expect(after).toContain("size: 20");
+  });
+
   it("re-emits plain on a wholesale list replacement (no stale comments)", () => {
     const before = ["wifi:", "  networks:", "    - a #one", "    - b #two", ""].join(
       "\n"


### PR DESCRIPTION
# What does this implement/fix?

A flow list's trailing comment is captured at parse (`data: [10, 12] # note` splits before the bracket test), but an edited flow list re serialized through the array branch as multi line block style: the authored style silently flipped and, because the re emit was no longer a single line, the #1235 comment re append never fired, so the comment dropped too.

The reader now records flow authored keys in a `flowListKeys` set on `ParsedSection` (cleared on duplicate key re assignment, the same hygiene #1377 established for `listSources`). When such a key changes and the new value is a non empty all scalar array, the splice re emits it as the same single flow line via the existing `formatYamlFlowScalar` (now exported; it is the flow indicator aware quoter that keeps `"${glyph_row}"` protected), and the existing single line comment re append restores the trailing comment with no further code. An emptied list still drops the key, and non scalar values fall through to the normal re emit.

Verified in the live editor: editing one row of a seeded `libraries: [Wire, SPI] # deps` keeps the single flow line and the comment. Pinned for the edit, the substitution quoting, and the emptied list drop; the unchanged flow list byte verbatim pin and the #1377 block list pins stay green.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1378

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
