### PR TITLE
Consolidate per-key section metadata into one KeyMeta record

### DIFF
--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -11,7 +11,6 @@ import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import { blockScalarValue } from "./yaml-block-scalar-value.js";
 import { parseFlowList, parseScalar, splitInlineComment } from "./yaml-scalar.js";
 import { parseListBlock, parseNestedBlock } from "./yaml-section-block-reader.js";
-import type { ListItemSource } from "./yaml-section-list.js";
 import {
   _detectSectionChildIndent,
   _leadingIndent,
@@ -26,7 +25,7 @@ import {
   TOP_LEVEL_KEY_START_RE,
 } from "./yaml-section-lexer.js";
 import { _blockScalarBodyEnd } from "./yaml-section-list.js";
-import { type KeySpan, type ParsedSection } from "./yaml-section-splice.js";
+import { type KeyMeta, type ParsedSection } from "./yaml-section-splice.js";
 
 /**
  * Find the 0-indexed line where the named section begins.
@@ -90,30 +89,18 @@ export function parseSectionCore(
   // would now throw. Use `Object.prototype.hasOwnProperty.call` if
   // you need that check on a downstream consumer.
   const values: Record<string, unknown> = Object.create(null);
-  const spans = new Map<string, KeySpan>();
-  const comments = new Map<string, string>();
-  const listSources = new Map<string, ListItemSource>();
-  const flowListKeys = new Set<string>();
-  // leadStart is finalised by the post-loop pass below.
-  const recordSpan = (key: string, start: number, end: number): void => {
-    spans.set(key, { start, end, leadStart: start });
-    // A duplicate key re-assigns the value; stale list metadata pointing
-    // at the first occurrence must not survive it.
-    listSources.delete(key);
-    flowListKeys.delete(key);
+  const keys = new Map<string, KeyMeta>();
+  // leadStart is finalised by the post-loop pass below. A fresh record per
+  // occurrence: a duplicate key re-assigns the value, and stale comment /
+  // list / flow metadata must not survive it.
+  const recordSpan = (key: string, start: number, end: number): KeyMeta => {
+    const meta: KeyMeta = { span: { start, end, leadStart: start } };
+    keys.set(key, meta);
+    return meta;
   };
   const startIdx = findSectionStart(lines, sectionKey, fromLine);
   if (startIdx < 0) {
-    return {
-      values,
-      spans,
-      comments,
-      listSources,
-      flowListKeys,
-      childIndent: "",
-      isListItem: false,
-      startIdx,
-    };
+    return { values, keys, childIndent: "", isListItem: false, startIdx };
   }
 
   const isListItem = LIST_ITEM_START_RE.test(lines[startIdx]);
@@ -153,10 +140,7 @@ export function parseSectionCore(
       // list through its dedicated LIST_SECTIONS branch.
       return {
         values,
-        spans,
-        comments,
-        listSources,
-        flowListKeys,
+        keys,
         childIndent,
         isListItem,
         startIdx,
@@ -179,7 +163,7 @@ export function parseSectionCore(
       const { value: rawValue, comment } = splitInlineComment(afterColon);
       const scalar = rawValue.trim();
       if (scalar !== "") {
-        if (comment) comments.set(firstMatch[1], comment);
+        if (comment) keys.set(firstMatch[1], { comment });
         values[firstMatch[1]] = parseScalar(scalar);
       } else {
         // No scalar: the key's value is the nested mapping below. It rides on
@@ -246,8 +230,8 @@ export function parseSectionCore(
         );
         if (!isEmptyScalarList) {
           values[key] = value;
-          recordSpan(key, i, endIdx);
-          if (listSource) listSources.set(key, listSource);
+          const meta = recordSpan(key, i, endIdx);
+          if (listSource) meta.listSource = listSource;
           i = endIdx - 1;
         }
         continue;
@@ -273,15 +257,16 @@ export function parseSectionCore(
     // (`[a, b] # c` doesn't end with `]`) and before scalar parsing,
     // and record it so an edit can re-append it (#1235).
     const { value: scalar, comment } = splitInlineComment(raw);
-    if (comment) comments.set(key, comment);
     if (scalar.startsWith("[") && scalar.endsWith("]")) {
       values[key] = parseFlowList(scalar);
-      recordSpan(key, i, i + 1);
-      flowListKeys.add(key);
+      const meta = recordSpan(key, i, i + 1);
+      meta.flowList = true;
+      if (comment) meta.comment = comment;
       continue;
     }
     values[key] = parseScalar(scalar);
-    recordSpan(key, i, i + 1);
+    const meta = recordSpan(key, i, i + 1);
+    if (comment) meta.comment = comment;
   }
 
   // A multi-line value's scanners skip trailing blank / sibling-level
@@ -293,7 +278,8 @@ export function parseSectionCore(
   // with the value so byte-identical no-op saves don't lose it. The
   // indent guard keeps deeper block-scalar literal text in the value
   // (#1227).
-  for (const span of spans.values()) {
+  for (const { span } of keys.values()) {
+    if (!span) continue;
     const low = span.start + 1;
     let runStart = span.end;
     let hasComment = false;
@@ -313,21 +299,13 @@ export function parseSectionCore(
   // partition the body — a verbatim copy then neither drops nor
   // double-counts an inter-key comment.
   let prevEnd = startIdx + 1;
-  for (const span of spans.values()) {
+  for (const { span } of keys.values()) {
+    if (!span) continue;
     let lead = span.start;
     while (lead > prevEnd && isBlankOrCommentLine(lines[lead - 1])) lead--;
     span.leadStart = lead;
     prevEnd = span.end;
   }
 
-  return {
-    values,
-    spans,
-    comments,
-    listSources,
-    flowListKeys,
-    childIndent,
-    isListItem,
-    startIdx,
-  };
+  return { values, keys, childIndent, isListItem, startIdx };
 }

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -93,7 +93,7 @@ export function parseSectionCore(
   // leadStart is finalised by the post-loop pass below. A fresh record per
   // occurrence: a duplicate key re-assigns the value, and stale comment /
   // list / flow metadata must not survive it.
-  const recordSpan = (key: string, start: number, end: number): KeyMeta => {
+  const recordKey = (key: string, start: number, end: number): KeyMeta => {
     const meta: KeyMeta = { span: { start, end, leadStart: start } };
     keys.set(key, meta);
     return meta;
@@ -138,13 +138,7 @@ export function parseSectionCore(
       values[sectionKey] = parseListBlock(lines, startIdx + 1, headerIndent).value;
       // No per-key spans — `updateSectionInYaml` re-emits this whole
       // list through its dedicated LIST_SECTIONS branch.
-      return {
-        values,
-        keys,
-        childIndent,
-        isListItem,
-        startIdx,
-      };
+      return { values, keys, childIndent, isListItem, startIdx };
     }
   }
 
@@ -214,7 +208,7 @@ export function parseSectionCore(
     if (blockHeader) {
       const endIdx = _blockScalarBodyEnd(lines, i + 1, childIndent.length);
       values[key] = blockScalarValue(blockHeader, raw, lines.slice(i + 1, endIdx));
-      recordSpan(key, i, endIdx);
+      recordKey(key, i, endIdx);
       // Auto-increment ``for`` loop: resume so the next ``i++`` lands on endIdx.
       i = endIdx - 1;
       continue;
@@ -230,7 +224,7 @@ export function parseSectionCore(
         );
         if (!isEmptyScalarList) {
           values[key] = value;
-          const meta = recordSpan(key, i, endIdx);
+          const meta = recordKey(key, i, endIdx);
           if (listSource) meta.listSource = listSource;
           i = endIdx - 1;
         }
@@ -248,7 +242,7 @@ export function parseSectionCore(
       const endIdx = result?.endIdx ?? i + 1;
       values[key] =
         result && Object.keys(result.values).length > 0 ? result.values : null;
-      recordSpan(key, i, endIdx);
+      recordKey(key, i, endIdx);
       i = endIdx - 1;
       continue;
     }
@@ -259,13 +253,13 @@ export function parseSectionCore(
     const { value: scalar, comment } = splitInlineComment(raw);
     if (scalar.startsWith("[") && scalar.endsWith("]")) {
       values[key] = parseFlowList(scalar);
-      const meta = recordSpan(key, i, i + 1);
+      const meta = recordKey(key, i, i + 1);
       meta.flowList = true;
       if (comment) meta.comment = comment;
       continue;
     }
     values[key] = parseScalar(scalar);
-    const meta = recordSpan(key, i, i + 1);
+    const meta = recordKey(key, i, i + 1);
     if (comment) meta.comment = comment;
   }
 

--- a/src/util/yaml-section-splice.ts
+++ b/src/util/yaml-section-splice.ts
@@ -31,24 +31,30 @@ export interface KeySpan {
   leadStart: number;
 }
 
+/**
+ * Everything the parser records about one top-level key. One record per
+ * key keeps duplicate-key semantics trivial: re-recording a key replaces
+ * the whole record, so stale side state can't survive a re-assignment.
+ */
+export interface KeyMeta {
+  // Absent only for the inline-on-dash key (list items), whose line the
+  // section header owns — it carries at most a ``comment``.
+  span?: KeySpan;
+  // Trailing inline comment (with its leading whitespace, e.g. ` #hides`)
+  // for a scalar key, re-appended on a single-line re-emit (#1235).
+  comment?: string;
+  // Per-item source fidelity for a block scalar list, so an edited list
+  // splices per item instead of re-emitting every row (#1363).
+  listSource?: ListItemSource;
+  // Authored as a flow list (``key: [a, b]``) — an edit re-emits the same
+  // single-line style (#1378). Never coexists with ``listSource``.
+  flowList?: boolean;
+}
+
 export interface ParsedSection {
   values: Record<string, unknown>;
-  // One span per top-level key, in file order. The inline-on-dash key
-  // (list items) is intentionally absent — it lives on the section
-  // header line, which `updateSectionInYaml` owns directly.
-  spans: Map<string, KeySpan>;
-  // Trailing inline comment (with its leading whitespace, e.g.
-  // ` #hides`) per scalar key that had one, so a re-serialized edit can
-  // re-append it instead of dropping it (#1235).
-  comments: Map<string, string>;
-  // Per-item source fidelity for block scalar list keys, so an edited
-  // list splices per item instead of re-emitting every row (#1363).
-  listSources: Map<string, ListItemSource>;
-  // Keys whose value was authored as a flow list (``key: [a, b]``), so an
-  // edit re-emits the same single-line style — which also lets the
-  // trailing-comment re-append below fire (#1378). Never overlaps
-  // ``listSources``: the two are set in disjoint parse branches.
-  flowListKeys: Set<string>;
+  // One meta per top-level key, in file order.
+  keys: Map<string, KeyMeta>;
   childIndent: string;
   isListItem: boolean;
   // 0-indexed section header / leading-dash line.
@@ -109,12 +115,14 @@ export function buildSplicedBody(
   const bodyLines: string[] = [];
   for (const [key, val] of Object.entries(values)) {
     if (inlineKeys.has(key)) continue;
-    const span = parsed.spans.get(key);
+    const meta = parsed.keys.get(key);
+    const span = meta?.span;
     if (span && yamlValueEqual(val, parsed.values[key])) {
       bodyLines.push(...lines.slice(span.leadStart, span.end));
       continue;
     }
-    const spliced = span && spliceScalarList(lines, span, parsed, key, val);
+    const spliced =
+      span && meta && spliceScalarList(lines, span, meta, parsed.values[key], val);
     if (spliced) {
       bodyLines.push(...spliced);
       continue;
@@ -123,12 +131,11 @@ export function buildSplicedBody(
     // original key — the value line below reformats, the comment stays.
     if (span) bodyLines.push(...lines.slice(span.leadStart, span.start));
     const fresh =
-      flowListLine(parsed, key, val, childIndent) ??
+      flowListLine(meta, key, val, childIndent) ??
       serializeYamlValues({ [key]: val }, childIndent, serializeOptions);
     // Re-append the field's trailing inline comment when it still
     // serializes to a single scalar line, so an edit keeps it (#1235).
-    const comment = parsed.comments.get(key);
-    if (comment && fresh.length === 1) fresh[0] += comment;
+    if (meta?.comment && fresh.length === 1) fresh[0] += meta.comment;
     bodyLines.push(...fresh);
   }
   return bodyLines;
@@ -137,12 +144,12 @@ export function buildSplicedBody(
 /** A flow-authored key re-emits as the same single flow line (an emptied
  *  or non-scalar value falls through to the normal re-emit). */
 function flowListLine(
-  parsed: ParsedSection,
+  meta: KeyMeta | undefined,
   key: string,
   val: unknown,
   childIndent: string
 ): string[] | null {
-  if (!parsed.flowListKeys.has(key)) return null;
+  if (!meta?.flowList) return null;
   if (!Array.isArray(val) || val.length === 0 || !val.every(isScalarItem)) return null;
   return [`${childIndent}${key}: ${formatYamlFlowList(val)}`];
 }
@@ -165,12 +172,11 @@ const isScalarItem = (v: unknown): v is string | number | boolean =>
 function spliceScalarList(
   lines: string[],
   span: KeySpan,
-  parsed: ParsedSection,
-  key: string,
+  meta: KeyMeta,
+  old: unknown,
   val: unknown
 ): string[] | null {
-  const src = parsed.listSources.get(key);
-  const old = parsed.values[key];
+  const src = meta.listSource;
   if (
     !src ||
     !Array.isArray(old) ||

--- a/src/util/yaml-section-splice.ts
+++ b/src/util/yaml-section-splice.ts
@@ -117,12 +117,12 @@ export function buildSplicedBody(
     if (inlineKeys.has(key)) continue;
     const meta = parsed.keys.get(key);
     const span = meta?.span;
-    if (span && yamlValueEqual(val, parsed.values[key])) {
+    const old = parsed.values[key];
+    if (span && yamlValueEqual(val, old)) {
       bodyLines.push(...lines.slice(span.leadStart, span.end));
       continue;
     }
-    const spliced =
-      span && meta && spliceScalarList(lines, span, meta, parsed.values[key], val);
+    const spliced = meta && spliceScalarList(lines, meta, old, val);
     if (spliced) {
       bodyLines.push(...spliced);
       continue;
@@ -171,13 +171,13 @@ const isScalarItem = (v: unknown): v is string | number | boolean =>
  */
 function spliceScalarList(
   lines: string[],
-  span: KeySpan,
   meta: KeyMeta,
   old: unknown,
   val: unknown
 ): string[] | null {
-  const src = meta.listSource;
+  const { span, listSource: src } = meta;
   if (
+    !span ||
     !src ||
     !Array.isArray(old) ||
     !Array.isArray(val) ||

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -189,8 +189,8 @@ export function updateSectionInYaml(
   // mapping deeper than the final value). Use it so the splice boundary
   // and the parse extent agree on every block body.
   let lastContentEnd = -1;
-  for (const span of parsed.spans.values()) {
-    if (span.end > lastContentEnd) lastContentEnd = span.end;
+  for (const { span } of parsed.keys.values()) {
+    if (span && span.end > lastContentEnd) lastContentEnd = span.end;
   }
   if (lastContentEnd >= 0) spliceEnd = lastContentEnd;
 
@@ -261,7 +261,7 @@ export function updateSectionInYaml(
             // that invariant local.
             const dashPrefixMatch = dashLine.match(/^(\s*)-(\s+)/)!;
             const dashPrefix = `${dashPrefixMatch[1]}-${dashPrefixMatch[2]}`;
-            const comment = parsed.comments.get(inlineKey) ?? "";
+            const comment = parsed.keys.get(inlineKey)?.comment ?? "";
             dashLine = `${dashPrefix}${inlineKey}: ${formatYamlScalar(values[inlineKey])}${comment}`;
           }
         } else {

--- a/test/util/yaml-section-splice.test.ts
+++ b/test/util/yaml-section-splice.test.ts
@@ -87,16 +87,18 @@ const LINES = [
 ];
 
 function makeParsed(comments: Map<string, string> = new Map()): ParsedSection {
+  const keys = new Map([
+    ["name", { span: { leadStart: 0, start: 0, end: 1 } }],
+    ["brightness", { span: { leadStart: 1, start: 2, end: 3 } }],
+    ["color", { span: { leadStart: 3, start: 3, end: 4 } }],
+  ]);
+  for (const [key, comment] of comments) {
+    const meta = keys.get(key);
+    if (meta) (meta as { comment?: string }).comment = comment;
+  }
   return {
     values: { name: "Living Room", brightness: 50, color: "red" },
-    spans: new Map([
-      ["name", { leadStart: 0, start: 0, end: 1 }],
-      ["brightness", { leadStart: 1, start: 2, end: 3 }],
-      ["color", { leadStart: 3, start: 3, end: 4 }],
-    ]),
-    comments,
-    listSources: new Map(),
-    flowListKeys: new Set(),
+    keys,
     childIndent: "  ",
     isListItem: false,
     startIdx: 0,

--- a/test/util/yaml-section-splice.test.ts
+++ b/test/util/yaml-section-splice.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildSplicedBody,
   yamlValueEqual,
+  type KeyMeta,
   type ParsedSection,
 } from "../../src/util/yaml-section-splice.js";
 import { YamlRawValue } from "../../src/util/yaml-serialize.js";
@@ -87,14 +88,13 @@ const LINES = [
 ];
 
 function makeParsed(comments: Map<string, string> = new Map()): ParsedSection {
-  const keys = new Map([
+  const keys = new Map<string, KeyMeta>([
     ["name", { span: { leadStart: 0, start: 0, end: 1 } }],
     ["brightness", { span: { leadStart: 1, start: 2, end: 3 } }],
     ["color", { span: { leadStart: 3, start: 3, end: 4 } }],
   ]);
   for (const [key, comment] of comments) {
-    const meta = keys.get(key);
-    if (meta) (meta as { comment?: string }).comment = comment;
+    keys.get(key)!.comment = comment;
   }
   return {
     values: { name: "Living Room", brightness: 50, color: "red" },


### PR DESCRIPTION
# What does this implement/fix?

Behavior free refactor preparing the #1379 mapping list work. `ParsedSection` had accreted four parallel per key side structures (`spans`, `comments`, `listSources`, `flowListKeys`), each kept duplicate key consistent by hand inside `recordSpan` — the #1377 and #1380 reviews both flagged that the next per key marker should trigger a consolidation before the drift is forgotten.

They are now one `keys: Map<string, KeyMeta>` with `span`, `comment`, `listSource`, and `flowList` fields. `recordKey` (né `recordSpan`) creates a fresh record per occurrence, so a duplicate key dropping stale metadata falls out of construction instead of relying on a growing list of hand rolled deletes. `span` is optional only for the inline on dash key, which has no span of its own and carries at most a comment for the dash line rewrite. Consumers swap accessor shape only; `spliceScalarList` and `flowListLine` now take the meta directly instead of re deriving it from the section.

No behavior change on valid YAML: the full suite passes with zero test content edits beyond the `makeParsed` factory. One invalid input delta worth naming: the old `recordSpan` cleared list and flow metadata on a duplicate key but never cleared `comments`, so a duplicate scalar key could resurrect the first occurrence's stale inline comment on edit; the fresh record drops it, which was plainly the old deletes' intent (duplicate top level keys are invalid YAML the editor parses pre validation; untested either way).

**Related issue or feature (if applicable):**

- part of the groundwork for https://github.com/esphome/device-builder-frontend/issues/1379

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
