### PR TITLE
Splice mapping lists per item so row comments survive edits

### DIFF
--- a/src/util/yaml-section-block-reader.ts
+++ b/src/util/yaml-section-block-reader.ts
@@ -104,11 +104,7 @@ const parseListBlock = (
         isEmptyScalarList: false,
         listSource:
           mapping.items.length > 0
-            ? {
-                itemRanges: mapping.itemRanges,
-                inlineComments: mapping.items.map(() => ""),
-                dashIndent,
-              }
+            ? { itemRanges: mapping.itemRanges, dashIndent }
             : undefined,
       };
     }

--- a/src/util/yaml-section-block-reader.ts
+++ b/src/util/yaml-section-block-reader.ts
@@ -102,6 +102,14 @@ const parseListBlock = (
         value: mapping.items,
         endIdx: mapping.endIdx,
         isEmptyScalarList: false,
+        listSource:
+          mapping.items.length > 0
+            ? {
+                itemRanges: mapping.itemRanges,
+                inlineComments: mapping.items.map(() => ""),
+                dashIndent,
+              }
+            : undefined,
       };
     }
     return {
@@ -119,7 +127,7 @@ const parseListBlock = (
   const {
     items,
     endIdx: scalarEndIdx,
-    itemLineIdxs,
+    itemRanges,
     inlineComments,
   } = collectBlockListItems(
     lines,
@@ -131,7 +139,7 @@ const parseListBlock = (
     value: items,
     endIdx: scalarEndIdx,
     isEmptyScalarList: items.length === 0,
-    listSource: { itemLineIdxs, inlineComments, dashIndent },
+    listSource: { itemRanges, inlineComments, dashIndent },
   };
 };
 
@@ -225,7 +233,11 @@ const collectBlockListMappings = (
   startIdx: number,
   dashIndent: string,
   childIndent: string
-): { items: Record<string, unknown>[]; endIdx: number } | null => {
+): {
+  items: Record<string, unknown>[];
+  endIdx: number;
+  itemRanges: [number, number][];
+} | null => {
   const headerRe = new RegExp(`^${dashIndent}-\\s+(${KEY_PATTERN}):\\s*(.*)$`);
   const childRe = new RegExp(`^${childIndent}(${KEY_PATTERN}):\\s*(.*)$`);
 
@@ -325,6 +337,7 @@ const collectBlockListMappings = (
   };
 
   const items: Record<string, unknown>[] = [];
+  const itemRanges: [number, number][] = [];
   let j = startIdx;
   while (j < lines.length) {
     if (isBlankOrCommentLine(lines[j])) {
@@ -335,9 +348,10 @@ const collectBlockListMappings = (
     const parsed = parseItem(j);
     if (!parsed) return null;
     items.push(parsed.item);
+    itemRanges.push([j, parsed.endIdx]);
     j = parsed.endIdx;
   }
-  return { items, endIdx: j };
+  return { items, endIdx: j, itemRanges };
 };
 
 /** Recursively parse a nested YAML block at the given indent. */

--- a/src/util/yaml-section-block-reader.ts
+++ b/src/util/yaml-section-block-reader.ts
@@ -344,7 +344,15 @@ const collectBlockListMappings = (
     const parsed = parseItem(j);
     if (!parsed) return null;
     items.push(parsed.item);
-    itemRanges.push([j, parsed.endIdx]);
+    // The sub-key walk resumes past trailing blank/comment lines; trim the
+    // recorded range back to the last content line so an inter-row comment
+    // belongs to the FOLLOWING row's group (scalar-path semantics) and
+    // survives an edit of the row above it.
+    let contentEnd = parsed.endIdx;
+    while (contentEnd > j + 1 && isBlankOrCommentLine(lines[contentEnd - 1])) {
+      contentEnd--;
+    }
+    itemRanges.push([j, contentEnd]);
     j = parsed.endIdx;
   }
   return { items, endIdx: j, itemRanges };

--- a/src/util/yaml-section-list.ts
+++ b/src/util/yaml-section-list.ts
@@ -31,7 +31,8 @@ import {
  *  (#1363/#1379). */
 export interface ListItemSource {
   itemRanges: [number, number][];
-  inlineComments: string[];
+  // Scalar rows only; mapping-list sources omit it.
+  inlineComments?: string[];
   dashIndent: string;
 }
 

--- a/src/util/yaml-section-list.ts
+++ b/src/util/yaml-section-list.ts
@@ -23,13 +23,14 @@ import {
   parseBlockScalarHeader,
 } from "./yaml-section-lexer.js";
 
-/** Source fidelity for a block scalar list: each item's 0-indexed source
- *  line (into the same array the splice writer receives), its trailing
- *  inline comment (leading whitespace kept, "" when none), and the dash
- *  column the parse detected — so a per-item splice keeps unchanged rows
- *  verbatim and re-emits edited rows without re-deriving anything (#1363). */
+/** Source fidelity for a block list: each item's half-open 0-indexed
+ *  source-line range (into the same array the splice writer receives),
+ *  its trailing inline comment (scalar rows only; "" otherwise), and the
+ *  dash column the parse detected — so a per-item splice keeps unchanged
+ *  rows verbatim and re-emits edited rows without re-deriving anything
+ *  (#1363/#1379). */
 export interface ListItemSource {
-  itemLineIdxs: number[];
+  itemRanges: [number, number][];
   inlineComments: string[];
   dashIndent: string;
 }
@@ -42,11 +43,11 @@ export const collectBlockListItems = (
 ): {
   items: (string | number | boolean)[];
   endIdx: number;
-  itemLineIdxs: number[];
+  itemRanges: [number, number][];
   inlineComments: string[];
 } => {
   const items: (string | number | boolean)[] = [];
-  const itemLineIdxs: number[] = [];
+  const itemRanges: [number, number][] = [];
   const inlineComments: string[] = [];
   let j = startIdx;
   for (; j < lines.length; j++) {
@@ -59,10 +60,10 @@ export const collectBlockListItems = (
     // same rule as parseScalar (#1235).
     const { value: raw, comment } = splitInlineComment(m[1].trim());
     items.push(coerceYamlScalar(stripQuotes(raw), isQuotedScalar(raw)));
-    itemLineIdxs.push(j);
+    itemRanges.push([j, j + 1]);
     inlineComments.push(comment);
   }
-  return { items, endIdx: j, itemLineIdxs, inlineComments };
+  return { items, endIdx: j, itemRanges, inlineComments };
 };
 
 /**

--- a/src/util/yaml-section-splice.ts
+++ b/src/util/yaml-section-splice.ts
@@ -217,16 +217,16 @@ function spliceListItems(
   // mapping row would land misaligned beside verbatim siblings — bail to
   // the full re-emit, which is consistently canonical.
   const canonicalDash = `${childIndent}${options.indentStep ?? ESPHOME_YAML_INDENT}`;
-  if (
-    dashIndent !== canonicalDash &&
-    val.some((v, i) => !isScalarItem(v) && !yamlValueEqual(old[i], v))
-  ) {
-    return null;
-  }
   // Each row's group runs from just past the previous row's last line (the
   // key line for the first row), carrying the whole-line comments above it.
   const groupStart = (i: number): number => (i === 0 ? span.start + 1 : ranges[i - 1][1]);
   const inPlace = old.length === val.length;
+  if (dashIndent !== canonicalDash) {
+    for (let k = prefix; k < val.length - suffix; k++) {
+      const verbatim = inPlace && yamlValueEqual(old[k], val[k]);
+      if (!verbatim && !isScalarItem(val[k])) return null;
+    }
+  }
   const out: string[] = [];
   // Groups tile contiguously, so the lead + key line + prefix rows are one
   // slice, and the suffix rows + whatever the span still owns past the

--- a/src/util/yaml-section-splice.ts
+++ b/src/util/yaml-section-splice.ts
@@ -8,6 +8,7 @@
  * with this concern.
  */
 
+import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import { isPlainObject, isPrimitiveOrNullish } from "./nested-values.js";
 import type { ListItemSource } from "./yaml-section-list.js";
 import {
@@ -123,22 +124,8 @@ export function buildSplicedBody(
       bodyLines.push(...lines.slice(span.leadStart, span.end));
       continue;
     }
-<<<<<<< HEAD
-    const spliced = meta && spliceScalarList(lines, meta, old, val);
-=======
     const spliced =
-      span &&
-      meta &&
-      spliceListItems(
-        lines,
-        span,
-        meta,
-        parsed.values[key],
-        val,
-        childIndent,
-        serializeOptions
-      );
->>>>>>> 7b0f32f9 (Splice mapping lists per item so row comments survive edits)
+      meta && spliceListItems(lines, meta, old, val, childIndent, serializeOptions);
     if (spliced) {
       bodyLines.push(...spliced);
       continue;
@@ -175,9 +162,7 @@ function flowListLine(
 const isScalarItem = (v: unknown): v is string | number | boolean =>
   isPrimitiveOrNullish(v) && v != null;
 
-// The item shapes the per-item splice can re-emit: scalars via the dash
-// line below, plain mappings via ``serializeListItem``. Anything else
-// (nulls, nested arrays) falls through to the full re-emit.
+// Scalars and plain mappings; anything else falls through to the full re-emit.
 const isSpliceableItem = (v: unknown): boolean => isScalarItem(v) || isPlainObject(v);
 
 /**
@@ -206,7 +191,6 @@ function spliceListItems(
     !Array.isArray(old) ||
     !Array.isArray(val) ||
     val.length === 0 ||
-    !old.every(isSpliceableItem) ||
     !val.every(isSpliceableItem)
   ) {
     return null;
@@ -227,7 +211,18 @@ function spliceListItems(
   ) {
     suffix++;
   }
-  const { itemRanges: ranges, inlineComments, dashIndent } = src;
+  const { itemRanges: ranges, dashIndent } = src;
+  // ``serializeListItem`` derives its dash column as indent + step; when the
+  // authored column differs (compact same-column dashes), a re-emitted
+  // mapping row would land misaligned beside verbatim siblings — bail to
+  // the full re-emit, which is consistently canonical.
+  const canonicalDash = `${childIndent}${options.indentStep ?? ESPHOME_YAML_INDENT}`;
+  if (
+    dashIndent !== canonicalDash &&
+    val.some((v, i) => !isScalarItem(v) && !yamlValueEqual(old[i], v))
+  ) {
+    return null;
+  }
   // Each row's group runs from just past the previous row's last line (the
   // key line for the first row), carrying the whole-line comments above it.
   const groupStart = (i: number): number => (i === 0 ? span.start + 1 : ranges[i - 1][1]);
@@ -250,12 +245,11 @@ function spliceListItems(
     }
     if (inPlace) out.push(...lines.slice(groupStart(k), ranges[k][0]));
     if (isScalarItem(val[k])) {
-      out.push(
-        `${dashIndent}- ${formatYamlScalar(val[k])}${inPlace ? inlineComments[k] : ""}`
-      );
+      const comment = inPlace ? (src.inlineComments?.[k] ?? "") : "";
+      out.push(`${dashIndent}- ${formatYamlScalar(val[k])}${comment}`);
     } else {
       // A changed mapping row re-emits canonically; its own comments are
-      // unknowable per field. The unchanged rows' bytes are the win.
+      // unknowable per field.
       out.push(...serializeListItem(val[k], childIndent, options));
     }
   }

--- a/src/util/yaml-section-splice.ts
+++ b/src/util/yaml-section-splice.ts
@@ -13,6 +13,7 @@ import type { ListItemSource } from "./yaml-section-list.js";
 import {
   formatYamlFlowList,
   formatYamlScalar,
+  serializeListItem,
   serializeYamlValues,
   YamlRawValue,
   type SerializeYamlOptions,
@@ -122,7 +123,22 @@ export function buildSplicedBody(
       bodyLines.push(...lines.slice(span.leadStart, span.end));
       continue;
     }
+<<<<<<< HEAD
     const spliced = meta && spliceScalarList(lines, meta, old, val);
+=======
+    const spliced =
+      span &&
+      meta &&
+      spliceListItems(
+        lines,
+        span,
+        meta,
+        parsed.values[key],
+        val,
+        childIndent,
+        serializeOptions
+      );
+>>>>>>> 7b0f32f9 (Splice mapping lists per item so row comments survive edits)
     if (spliced) {
       bodyLines.push(...spliced);
       continue;
@@ -159,21 +175,29 @@ function flowListLine(
 const isScalarItem = (v: unknown): v is string | number | boolean =>
   isPrimitiveOrNullish(v) && v != null;
 
+// The item shapes the per-item splice can re-emit: scalars via the dash
+// line below, plain mappings via ``serializeListItem``. Anything else
+// (nulls, nested arrays) falls through to the full re-emit.
+const isSpliceableItem = (v: unknown): boolean => isScalarItem(v) || isPlainObject(v);
+
 /**
- * Per-item splice for a changed block scalar list (#1363): rows unchanged
+ * Per-item splice for a changed block list (#1363/#1379): rows unchanged
  * at the same position (longest common prefix + suffix) keep their source
  * lines — inline comments, preceding whole-line comments, exact quoting —
- * and only the middle re-emits. An in-place edit (equal lengths) also
- * re-attaches each edited row's own inline comment. Returns ``null`` when
- * the key isn't a block scalar list on both sides (caller falls through to
+ * and only the middle re-emits. An in-place edit (equal lengths) keeps each
+ * edited row's preceding whole-line comments, and a scalar row also
+ * re-attaches its own inline comment. Returns ``null`` when the key isn't
+ * a block list of spliceable items on both sides (caller falls through to
  * the full re-emit), or when the new list is empty (the re-emit path owns
  * the drop-the-key semantic).
  */
-function spliceScalarList(
+function spliceListItems(
   lines: string[],
   meta: KeyMeta,
   old: unknown,
-  val: unknown
+  val: unknown,
+  childIndent: string,
+  options: SerializeYamlOptions
 ): string[] | null {
   const { span, listSource: src } = meta;
   if (
@@ -182,27 +206,31 @@ function spliceScalarList(
     !Array.isArray(old) ||
     !Array.isArray(val) ||
     val.length === 0 ||
-    !old.every(isScalarItem) ||
-    !val.every(isScalarItem)
+    !old.every(isSpliceableItem) ||
+    !val.every(isSpliceableItem)
   ) {
     return null;
   }
   let prefix = 0;
-  while (prefix < old.length && prefix < val.length && old[prefix] === val[prefix]) {
+  while (
+    prefix < old.length &&
+    prefix < val.length &&
+    yamlValueEqual(old[prefix], val[prefix])
+  ) {
     prefix++;
   }
   let suffix = 0;
   while (
     suffix < old.length - prefix &&
     suffix < val.length - prefix &&
-    old[old.length - 1 - suffix] === val[val.length - 1 - suffix]
+    yamlValueEqual(old[old.length - 1 - suffix], val[val.length - 1 - suffix])
   ) {
     suffix++;
   }
-  const { itemLineIdxs: idxs, inlineComments, dashIndent } = src;
-  // Each row's group runs from just past the previous row's line (the key
-  // line for the first row), carrying the whole-line comments above it.
-  const groupStart = (i: number): number => (i === 0 ? span.start + 1 : idxs[i - 1] + 1);
+  const { itemRanges: ranges, inlineComments, dashIndent } = src;
+  // Each row's group runs from just past the previous row's last line (the
+  // key line for the first row), carrying the whole-line comments above it.
+  const groupStart = (i: number): number => (i === 0 ? span.start + 1 : ranges[i - 1][1]);
   const inPlace = old.length === val.length;
   const out: string[] = [];
   // Groups tile contiguously, so the lead + key line + prefix rows are one
@@ -211,19 +239,25 @@ function spliceScalarList(
   out.push(...lines.slice(span.leadStart, groupStart(prefix)));
   for (let k = prefix; k < val.length - suffix; k++) {
     // A row unchanged between two edits keeps its bytes; an in-place edit
-    // keeps the row's preceding comments and re-attaches its inline
-    // comment — deliberately, even when the comment described the old
-    // value: row comments label the row's role far more often than its
-    // literal value. With add/remove the middle alignment is ambiguous,
-    // so new middle rows emit plain.
-    if (inPlace && old[k] === val[k]) {
-      out.push(...lines.slice(groupStart(k), idxs[k] + 1));
+    // keeps the row's preceding comments and re-attaches a scalar row's
+    // inline comment — deliberately, even when the comment described the
+    // old value: row comments label the row's role far more often than
+    // its literal value. With add/remove the middle alignment is
+    // ambiguous, so new middle rows emit plain.
+    if (inPlace && yamlValueEqual(old[k], val[k])) {
+      out.push(...lines.slice(groupStart(k), ranges[k][1]));
       continue;
     }
-    if (inPlace) out.push(...lines.slice(groupStart(k), idxs[k]));
-    out.push(
-      `${dashIndent}- ${formatYamlScalar(val[k])}${inPlace ? inlineComments[k] : ""}`
-    );
+    if (inPlace) out.push(...lines.slice(groupStart(k), ranges[k][0]));
+    if (isScalarItem(val[k])) {
+      out.push(
+        `${dashIndent}- ${formatYamlScalar(val[k])}${inPlace ? inlineComments[k] : ""}`
+      );
+    } else {
+      // A changed mapping row re-emits canonically; its own comments are
+      // unknowable per field. The unchanged rows' bytes are the win.
+      out.push(...serializeListItem(val[k], childIndent, options));
+    }
   }
   out.push(...lines.slice(groupStart(old.length - suffix), span.end));
   return out;

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -217,7 +217,7 @@ export interface SerializeYamlOptions {
  * ``YamlRawValue`` values inside an item are emitted with the
  * same inline-header / body shape as the top-level branch.
  */
-function serializeListItem(
+export function serializeListItem(
   item: unknown,
   indent: string,
   options: SerializeYamlOptions

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -3118,6 +3118,26 @@ describe("updateSectionInYaml — mapping-list rows keep comments on edit (#1379
     expect(after).toContain("ssid: homenet");
   });
 
+  it("still splices a non-canonical dash list when no mapping row re-emits", () => {
+    // A pure removal re-emits nothing: the remaining rows are verbatim
+    // copies, so the compact dash column can't be corrupted and the bail
+    // must not fire (it would needlessly drop the surviving comments).
+    const compact = [
+      "wifi:",
+      "  networks:",
+      "  - ssid: homenet #primary",
+      "    password: hunter2",
+      "  - ssid: guestnet",
+      "    password: opensesame",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(compact, "wifi", 1);
+    values.networks = [(values.networks as Record<string, unknown>[])[1]];
+    const after = updateSectionInYaml(compact, "wifi", values, 1);
+    expect(after).toContain("  - ssid: guestnet\n    password: opensesame\n");
+    expect(after).not.toContain("homenet");
+  });
+
   it("keeps a 4-space source's unchanged rows verbatim while the edited row canonicalizes", () => {
     const wide = [
       "wifi:",

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2027,11 +2027,12 @@ sensor:
     const devices = values.devices as Record<string, unknown>[];
     devices[0].name = "Front Entry";
     const after = updateSectionInYaml(yaml, "esphome", values);
-    // Both items survive; only the first item's name changed.
+    // Both items survive; only the first item's name changed. The
+    // unchanged item keeps its authored quoting byte-for-byte (#1379).
     expect(after).toContain("- id: front_door");
     expect(after).toContain("name: Front Entry");
     expect(after).toContain("- id: kitchen");
-    expect(after).toContain("name: Kitchen");
+    expect(after).toContain('name: "Kitchen"');
     // No double-quoted dotted-key corruption.
     expect(after).not.toMatch(/"id":/);
   });
@@ -3053,5 +3054,78 @@ describe("updateSectionInYaml — flow list edits keep flow style (#1378)", () =
     const after = updateSectionInYaml(before, "display", values, 1);
     expect(after).not.toContain("data:");
     expect(after).toContain("size: 20");
+  });
+});
+
+describe("updateSectionInYaml — mapping-list rows keep comments on edit (#1379)", () => {
+  const yaml = [
+    "wifi:",
+    "  networks:",
+    "    - ssid: homenet #primary",
+    "      password: hunter2",
+    "    # guest network below",
+    "    - ssid: guestnet",
+    "      password: opensesame",
+    "  domain: .local",
+    "",
+  ].join("\n");
+
+  it("keeps an untouched row's inline and whole-line comments through a sibling row edit", () => {
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    (values.networks as Record<string, unknown>[])[1].password = "changed";
+    const after = updateSectionInYaml(yaml, "wifi", values, 1);
+    expect(after).toContain("    - ssid: homenet #primary\n      password: hunter2\n");
+    expect(after).toContain("    # guest network below\n");
+    expect(after).toContain("password: changed");
+  });
+
+  it("keeps remaining rows verbatim when a row is removed", () => {
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    values.networks = [(values.networks as Record<string, unknown>[])[0]];
+    const after = updateSectionInYaml(yaml, "wifi", values, 1);
+    expect(after).toContain("    - ssid: homenet #primary\n      password: hunter2\n");
+    expect(after).not.toContain("guestnet");
+  });
+
+  it("keeps existing rows verbatim when a row is appended", () => {
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    (values.networks as Record<string, unknown>[]).push({ ssid: "iot" });
+    const after = updateSectionInYaml(yaml, "wifi", values, 1);
+    expect(after).toContain("    - ssid: homenet #primary\n");
+    expect(after).toContain("    # guest network below\n    - ssid: guestnet\n");
+    expect(after).toContain("    - ssid: iot\n");
+  });
+
+  it("keeps a 4-space source's unchanged rows verbatim while the edited row canonicalizes", () => {
+    const wide = [
+      "wifi:",
+      "    networks:",
+      "        - ssid: homenet #primary",
+      "          password: hunter2",
+      "        - ssid: guestnet",
+      "          password: opensesame",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(wide, "wifi", 1);
+    (values.networks as Record<string, unknown>[])[1].password = "changed";
+    const after = updateSectionInYaml(wide, "wifi", values, 1);
+    expect(after).toContain(
+      "        - ssid: homenet #primary\n          password: hunter2\n"
+    );
+    expect(after).toContain("ssid: guestnet");
+    expect(after).toContain("password: changed");
+  });
+
+  it("still round-trips a bailing shape (lambda field) via YamlRawValue untouched", () => {
+    const withLambda = [
+      "sensor:",
+      "  filters:",
+      "    - lambda: |-",
+      "        return x;",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(withLambda, "sensor", 1);
+    const after = updateSectionInYaml(withLambda, "sensor", values, 1);
+    expect(after).toBe(withLambda);
   });
 });

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -3079,12 +3079,12 @@ describe("updateSectionInYaml — mapping-list rows keep comments on edit (#1379
     expect(after).toContain("password: changed");
   });
 
-  it("keeps remaining rows verbatim when a row is removed", () => {
+  it("keeps the remaining multi-line row verbatim when the first row is removed", () => {
     const values = parseYamlSectionValues(yaml, "wifi", 1);
-    values.networks = [(values.networks as Record<string, unknown>[])[0]];
+    values.networks = [(values.networks as Record<string, unknown>[])[1]];
     const after = updateSectionInYaml(yaml, "wifi", values, 1);
-    expect(after).toContain("    - ssid: homenet #primary\n      password: hunter2\n");
-    expect(after).not.toContain("guestnet");
+    expect(after).toContain("    - ssid: guestnet\n      password: opensesame\n");
+    expect(after).not.toContain("homenet");
   });
 
   it("keeps existing rows verbatim when a row is appended", () => {
@@ -3094,6 +3094,28 @@ describe("updateSectionInYaml — mapping-list rows keep comments on edit (#1379
     expect(after).toContain("    - ssid: homenet #primary\n");
     expect(after).toContain("    # guest network below\n    - ssid: guestnet\n");
     expect(after).toContain("    - ssid: iot\n");
+  });
+
+  it("falls back to a consistent full re-emit when the dash column is non-canonical", () => {
+    // Compact same-column dashes: a spliced mapping row would land two
+    // columns deeper than its verbatim siblings, so the splice bails.
+    const compact = [
+      "wifi:",
+      "  networks:",
+      "  - ssid: homenet #primary",
+      "    password: hunter2",
+      "  - ssid: guestnet",
+      "    password: opensesame",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(compact, "wifi", 1);
+    (values.networks as Record<string, unknown>[])[1].password = "changed";
+    const after = updateSectionInYaml(compact, "wifi", values, 1);
+    // Every dash lands at one column — no mixed-column corruption.
+    const dashCols = [...after.matchAll(/^( *)- ssid/gm)].map((m) => m[1].length);
+    expect(new Set(dashCols).size).toBe(1);
+    expect(after).toContain("password: changed");
+    expect(after).toContain("ssid: homenet");
   });
 
   it("keeps a 4-space source's unchanged rows verbatim while the edited row canonicalizes", () => {
@@ -3114,18 +3136,5 @@ describe("updateSectionInYaml — mapping-list rows keep comments on edit (#1379
     );
     expect(after).toContain("ssid: guestnet");
     expect(after).toContain("password: changed");
-  });
-
-  it("still round-trips a bailing shape (lambda field) via YamlRawValue untouched", () => {
-    const withLambda = [
-      "sensor:",
-      "  filters:",
-      "    - lambda: |-",
-      "        return x;",
-      "",
-    ].join("\n");
-    const values = parseYamlSectionValues(withLambda, "sensor", 1);
-    const after = updateSectionInYaml(withLambda, "sensor", values, 1);
-    expect(after).toBe(withLambda);
   });
 });

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -3079,6 +3079,15 @@ describe("updateSectionInYaml — mapping-list rows keep comments on edit (#1379
     expect(after).toContain("password: changed");
   });
 
+  it("keeps an inter-row comment when the row ABOVE it is edited", () => {
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    (values.networks as Record<string, unknown>[])[0].password = "changed";
+    const after = updateSectionInYaml(yaml, "wifi", values, 1);
+    expect(after).toContain("    # guest network below\n    - ssid: guestnet\n");
+    expect(after).toContain("password: changed");
+    expect(after).toContain("password: opensesame");
+  });
+
   it("keeps the remaining multi-line row verbatim when the first row is removed", () => {
     const values = parseYamlSectionValues(yaml, "wifi", 1);
     values.networks = [(values.networks as Record<string, unknown>[])[1]];

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -3105,6 +3105,129 @@ describe("updateSectionInYaml — mapping-list rows keep comments on edit (#1379
     expect(after).toContain("    - ssid: iot\n");
   });
 
+  it("keeps a sandwiched unchanged mapping row byte-identical between two edited rows", () => {
+    const three = [
+      "wifi:",
+      "  networks:",
+      "    - ssid: alpha",
+      "      password: aaa",
+      "    # beta stays",
+      "    - ssid: beta #vip",
+      "      password: bbb",
+      "    - ssid: gamma",
+      "      password: ccc",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(three, "wifi", 1);
+    const nets = values.networks as Record<string, unknown>[];
+    nets[0].password = "aaa2";
+    nets[2].password = "ccc2";
+    const after = updateSectionInYaml(three, "wifi", values, 1);
+    expect(after).toContain(
+      "    # beta stays\n    - ssid: beta #vip\n      password: bbb\n"
+    );
+    expect(after).toContain("password: aaa2");
+    expect(after).toContain("password: ccc2");
+  });
+
+  it("keeps a comment between the key line and the first row through a first-row edit", () => {
+    const led = [
+      "wifi:",
+      "  networks:",
+      "    # primary first",
+      "    - ssid: homenet",
+      "      password: hunter2",
+      "    - ssid: guestnet",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(led, "wifi", 1);
+    (values.networks as Record<string, unknown>[])[0].password = "changed";
+    const after = updateSectionInYaml(led, "wifi", values, 1);
+    expect(after).toContain("  networks:\n    # primary first\n");
+    expect(after).toContain("password: changed");
+    expect(after).toContain("- ssid: guestnet");
+  });
+
+  it("keeps a trailing comment after the last row through a last-row edit", () => {
+    const trail = [
+      "wifi:",
+      "  networks:",
+      "    - ssid: homenet",
+      "      password: hunter2",
+      "    - ssid: guestnet",
+      "      password: opensesame",
+      "    # end of networks",
+      "  domain: .local",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(trail, "wifi", 1);
+    (values.networks as Record<string, unknown>[])[1].password = "changed";
+    const after = updateSectionInYaml(trail, "wifi", values, 1);
+    expect(after).toContain("password: changed");
+    expect(after).toContain("    # end of networks\n  domain: .local");
+    expect(after).toContain("- ssid: homenet\n      password: hunter2");
+  });
+
+  it("keeps a blank line between rows through a sibling edit", () => {
+    const blanky = [
+      "wifi:",
+      "  networks:",
+      "    - ssid: homenet",
+      "",
+      "    - ssid: guestnet #open",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(blanky, "wifi", 1);
+    (values.networks as Record<string, unknown>[])[0].ssid = "homenet2";
+    const after = updateSectionInYaml(blanky, "wifi", values, 1);
+    expect(after).toContain("- ssid: homenet2\n\n    - ssid: guestnet #open\n");
+  });
+
+  it("keeps an unchanged row with a lambda field verbatim through a sibling edit", () => {
+    const lam = [
+      "sensor:",
+      "  filters:",
+      "    - offset: 1.5 #cal",
+      "    - lambda: !lambda |-",
+      "        return x * 2;",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(lam, "sensor", 1);
+    (values.filters as Record<string, unknown>[])[0].offset = 2.5;
+    const after = updateSectionInYaml(lam, "sensor", values, 1);
+    expect(after).toContain("offset: 2.5");
+    expect(after).toContain("    - lambda: !lambda |-\n        return x * 2;\n");
+  });
+
+  it("keeps outer rows verbatim when the middle row of three is removed", () => {
+    const three = [
+      "wifi:",
+      "  networks:",
+      "    - ssid: alpha #one",
+      "      password: aaa",
+      "    - ssid: beta",
+      "      password: bbb",
+      "    - ssid: gamma #three",
+      "      password: ccc",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(three, "wifi", 1);
+    const nets = values.networks as Record<string, unknown>[];
+    values.networks = [nets[0], nets[2]];
+    const after = updateSectionInYaml(three, "wifi", values, 1);
+    expect(after).toContain("    - ssid: alpha #one\n      password: aaa\n");
+    expect(after).toContain("    - ssid: gamma #three\n      password: ccc\n");
+    expect(after).not.toContain("beta");
+  });
+
+  it("re-emits a row replaced in place by a scalar without touching siblings", () => {
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    (values.networks as unknown[])[1] = "guest-preset";
+    const after = updateSectionInYaml(yaml, "wifi", values, 1);
+    expect(after).toContain("    - ssid: homenet #primary\n      password: hunter2\n");
+    expect(after).toContain("- guest-preset");
+  });
+
   it("falls back to a consistent full re-emit when the dash column is non-canonical", () => {
     // Compact same-column dashes: a spliced mapping row would land two
     // columns deeper than its verbatim siblings, so the splice bails.


### PR DESCRIPTION
# What does this implement/fix?

Editing any row of a mapping list (wifi `networks`, `esphome.devices`/`areas`, registry lists) re emitted the whole key from plain record values, dropping every row's inline field comments (`ssid: home #main`, discarded by the field parser) and the whole line comments between rows. #1377 fixed this for scalar lists; mapping items span multiple lines, which its single line index model could not represent.

`ListItemSource` now carries half open per item line ranges instead of single line indices (scalar items are one line ranges, so the #1377 group math ports mechanically), and `collectBlockListMappings` records the per item boundaries it already computed internally and previously discarded. The splice generalizes (`spliceScalarList` → `spliceListItems`) to lists whose items are all scalars or all plain mappings, comparing per item with the existing `yamlValueEqual` deep equality: unchanged rows keep their source bytes, inline field comments, whole line comments, and authored quoting included; only changed rows re emit, a scalar row with its inline comment re attached, a mapping row canonically through the exported `serializeListItem` (its own comments are unknowable per field; the unchanged rows are the win). Bailing shapes still round trip via `YamlRawValue` untouched.

One existing expectation updated: the `esphome.devices` round trip pin asserted the old wholesale re emit's quote stripping on the untouched row; the unchanged row now keeps its authored `"Kitchen"` quoting byte for byte, which is the point of the fix.

Verified in the live editor: editing one device row's name in the devices editor kept the sibling row's `#entry sensor` inline comment and the `# kitchen zone` whole line comment byte identical. New pins cover the sibling row edit, first row removal (the multi line suffix geometry), append alignment, 4 space sources (unchanged rows verbatim, edited row canonical), and the compact dash column fallback.

Deliberate scope, named for the record: a changed row's own comments are dropped (per field inline comments and its dash header comment alike, unknowable after the form round trip); the `globals` LIST_SECTIONS path still re emits wholesale (it never reaches the splice); and a mapping edit in a list whose dash column is not the canonical child indent plus step bails to the consistent full re emit rather than emitting a misaligned row beside verbatim siblings (pinned with a compact same column fixture).

Stacked on #1382 (the `KeyMeta` consolidation this builds on).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1379

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
