### PR TITLE
Parse comment-only values as empty and re-append their comment on edit

### DIFF
--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -27,10 +27,19 @@ export const stripQuotes = (s: string): string => {
  * comment (``true #hides`` → ``{ value: "true", comment: " #hides" }``).
  * A ``#`` only starts a comment when it's whitespace-preceded and
  * outside quotes — ``Bedroom#2`` and ``"a # b"`` keep the ``#`` in the
- * value. ``comment`` retains its leading whitespace (``""`` when none)
- * so the serializer can re-append it verbatim.
+ * value. *openingIsComment* additionally treats a ``#`` that opens the
+ * string as a comment: trimmed callers lost the separating whitespace to
+ * their regex, so ``name: # note`` reaches them as ``# note`` and is an
+ * empty value to the loader (#1385) — while the untrimmed dash-line
+ * caller keeps the default, where a position-0 ``#`` means the source
+ * had no separator (``file:#fragment``) and the ``#`` is value text.
+ * ``comment`` retains its leading whitespace (a string-opening comment
+ * gets a canonical single space) so the serializer can re-append it.
  */
-export const splitInlineComment = (raw: string): { value: string; comment: string } => {
+export const splitInlineComment = (
+  raw: string,
+  openingIsComment = false
+): { value: string; comment: string } => {
   let inSingle = false;
   let inDouble = false;
   for (let i = 0; i < raw.length; i++) {
@@ -48,11 +57,14 @@ export const splitInlineComment = (raw: string): { value: string; comment: strin
       c === "#" &&
       !inSingle &&
       !inDouble &&
-      (raw[i - 1] === " " || raw[i - 1] === "\t")
+      ((i === 0 && openingIsComment) || raw[i - 1] === " " || raw[i - 1] === "\t")
     ) {
       let ws = i;
       while (ws > 0 && (raw[ws - 1] === " " || raw[ws - 1] === "\t")) ws--;
-      return { value: raw.slice(0, ws), comment: raw.slice(ws) };
+      // A string-opening comment lost its separator to the caller's trim;
+      // give it a canonical single space so a re-append stays valid YAML.
+      const comment = i === 0 ? ` ${raw}` : raw.slice(ws);
+      return { value: raw.slice(0, ws), comment };
     }
   }
   return { value: raw, comment: "" };

--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -27,19 +27,11 @@ export const stripQuotes = (s: string): string => {
  * comment (``true #hides`` → ``{ value: "true", comment: " #hides" }``).
  * A ``#`` only starts a comment when it's whitespace-preceded and
  * outside quotes — ``Bedroom#2`` and ``"a # b"`` keep the ``#`` in the
- * value. *openingIsComment* additionally treats a ``#`` that opens the
- * string as a comment: trimmed callers lost the separating whitespace to
- * their regex, so ``name: # note`` reaches them as ``# note`` and is an
- * empty value to the loader (#1385) — while the untrimmed dash-line
- * caller keeps the default, where a position-0 ``#`` means the source
- * had no separator (``file:#fragment``) and the ``#`` is value text.
- * ``comment`` retains its leading whitespace (a string-opening comment
- * gets a canonical single space) so the serializer can re-append it.
+ * value. ``comment`` retains its leading whitespace (``""`` when none)
+ * so the serializer can re-append it verbatim. Callers holding
+ * pre-trimmed input use ``splitTrimmedInlineComment`` instead.
  */
-export const splitInlineComment = (
-  raw: string,
-  openingIsComment = false
-): { value: string; comment: string } => {
+export const splitInlineComment = (raw: string): { value: string; comment: string } => {
   let inSingle = false;
   let inDouble = false;
   for (let i = 0; i < raw.length; i++) {
@@ -57,18 +49,24 @@ export const splitInlineComment = (
       c === "#" &&
       !inSingle &&
       !inDouble &&
-      ((i === 0 && openingIsComment) || raw[i - 1] === " " || raw[i - 1] === "\t")
+      (raw[i - 1] === " " || raw[i - 1] === "\t")
     ) {
       let ws = i;
       while (ws > 0 && (raw[ws - 1] === " " || raw[ws - 1] === "\t")) ws--;
-      // A string-opening comment lost its separator to the caller's trim;
-      // give it a canonical single space so a re-append stays valid YAML.
-      const comment = i === 0 ? ` ${raw}` : raw.slice(ws);
-      return { value: raw.slice(0, ws), comment };
+      return { value: raw.slice(0, ws), comment: raw.slice(ws) };
     }
   }
   return { value: raw, comment: "" };
 };
+
+/** ``splitInlineComment`` for pre-trimmed input, where a string-opening
+ *  ``#`` is a comment over an empty value (``name: # note``, #1385). The
+ *  comment gains a canonical single space so a re-append stays valid —
+ *  the trim ate the source separator. */
+export const splitTrimmedInlineComment = (
+  raw: string
+): { value: string; comment: string } =>
+  raw.startsWith("#") ? { value: "", comment: ` ${raw}` } : splitInlineComment(raw);
 
 // Inline lambda scalar: ``!lambda return x;`` (and the quoted
 // ``!lambda 'return x;'`` form). Recognised as a ``LambdaValue``

--- a/src/util/yaml-section-block-reader.ts
+++ b/src/util/yaml-section-block-reader.ts
@@ -14,7 +14,7 @@ import {
   isEditableLambdaBlock,
   lambdaValueFromBlock,
 } from "./yaml-block-scalar-value.js";
-import { parseFlowList, parseScalar, splitInlineComment } from "./yaml-scalar.js";
+import { parseFlowList, parseScalar, splitTrimmedInlineComment } from "./yaml-scalar.js";
 import {
   _detectListItemChildIndent,
   _leadingIndent,
@@ -402,7 +402,12 @@ function parseNestedBlock(
       continue;
     }
 
-    if (raw === "") {
+    // Strip a trailing line comment before the empty test (a comment-only
+    // ``key: # note`` is an empty value, #1385) and the bracket test —
+    // without the latter ``key: [1, 2] # note`` misses the flow branch
+    // and degrades to the literal string "[1, 2]".
+    const { value: scalar } = splitTrimmedInlineComment(raw);
+    if (scalar === "") {
       const peek = _skipBlankAndCommentLines(lines, i + 1);
       // ``key:`` followed by a block list. Accept both the standard
       // (deeper-indent) and compact (same-indent) forms; the compact
@@ -423,18 +428,18 @@ function parseNestedBlock(
           continue;
         }
       }
+      // Value-less key: structurally ``{key: null}``, same as the
+      // top-level reader; the serializer's null filter keeps it out of
+      // re-emits either way.
+      values[key] = null;
       i++;
       continue;
     }
 
-    // Strip a trailing line comment before the bracket test — the other
-    // flow-list sites do, and without it ``key: [1, 2] # note`` misses
-    // the flow branch and degrades to the literal string "[1, 2]".
-    const { value: scalar } = splitInlineComment(raw);
     if (scalar.startsWith("[") && scalar.endsWith("]")) {
       values[key] = parseFlowList(scalar);
     } else {
-      values[key] = parseScalar(raw);
+      values[key] = parseScalar(scalar);
     }
     i++;
   }

--- a/src/util/yaml-section-list.ts
+++ b/src/util/yaml-section-list.ts
@@ -59,7 +59,7 @@ export const collectBlockListItems = (
     // Strip a trailing inline comment (``- 10 # note``) so the item
     // coerces and the form value isn't polluted with ``# ...`` text —
     // same rule as parseScalar (#1235).
-    const { value: raw, comment } = splitInlineComment(m[1].trim());
+    const { value: raw, comment } = splitInlineComment(m[1].trim(), true);
     items.push(coerceYamlScalar(stripQuotes(raw), isQuotedScalar(raw)));
     itemRanges.push([j, j + 1]);
     inlineComments.push(comment);
@@ -115,17 +115,15 @@ export const parseFlatMappingField = (
   // the caller captures. ``parseScalar("|-")`` would otherwise
   // return the literal string ``"|-"`` (or ``"!lambda |-"``).
   if (parseBlockScalarHeader(raw)) return null;
-  // ``key:`` with no value is structurally ``{key: null}`` in YAML.
-  // Recognising it here is what lets list-of-single-key-mappings
-  // (light ``effects:``, sensor ``filters:``, any registry-shaped
-  // field) round-trip through the section editor instead of
-  // falling back to YamlRawValue. #941.
-  if (raw === "") return { key, value: null };
-  // Flow list inside a list-item mapping (``extras[].glyphs:
-  // ["\U000F058F", ...]``). Strip a trailing comment first so the
-  // ``[...]`` test fires; without this the array reads as a scalar string
-  // and the multi_value field renders empty (device-builder#1232).
-  const { value: scalar } = splitInlineComment(raw);
+  // ``key:`` with no value — bare or comment-only (``ssid: # note``,
+  // #1385) — is structurally ``{key: null}`` in YAML. Recognising it here
+  // is what lets list-of-single-key-mappings (light ``effects:``, sensor
+  // ``filters:``, any registry-shaped field) round-trip through the
+  // section editor instead of falling back to YamlRawValue. #941. The
+  // comment is also stripped before the ``[...]`` test so a flow list
+  // with a trailing comment still reads as an array (device-builder#1232).
+  const { value: scalar } = splitInlineComment(raw, true);
+  if (scalar === "") return { key, value: null };
   if (scalar.startsWith("[") && scalar.endsWith("]")) {
     return { key, value: parseFlowList(scalar) };
   }

--- a/src/util/yaml-section-list.ts
+++ b/src/util/yaml-section-list.ts
@@ -10,7 +10,7 @@ import {
   isQuotedScalar,
   parseFlowList,
   parseScalar,
-  splitInlineComment,
+  splitTrimmedInlineComment,
   stripQuotes,
 } from "./yaml-scalar.js";
 import {
@@ -59,7 +59,7 @@ export const collectBlockListItems = (
     // Strip a trailing inline comment (``- 10 # note``) so the item
     // coerces and the form value isn't polluted with ``# ...`` text —
     // same rule as parseScalar (#1235).
-    const { value: raw, comment } = splitInlineComment(m[1].trim(), true);
+    const { value: raw, comment } = splitTrimmedInlineComment(m[1].trim());
     items.push(coerceYamlScalar(stripQuotes(raw), isQuotedScalar(raw)));
     itemRanges.push([j, j + 1]);
     inlineComments.push(comment);
@@ -122,12 +122,12 @@ export const parseFlatMappingField = (
   // section editor instead of falling back to YamlRawValue. #941. The
   // comment is also stripped before the ``[...]`` test so a flow list
   // with a trailing comment still reads as an array (device-builder#1232).
-  const { value: scalar } = splitInlineComment(raw, true);
+  const { value: scalar } = splitTrimmedInlineComment(raw);
   if (scalar === "") return { key, value: null };
   if (scalar.startsWith("[") && scalar.endsWith("]")) {
     return { key, value: parseFlowList(scalar) };
   }
-  return { key, value: parseScalar(raw) };
+  return { key, value: parseScalar(scalar) };
 };
 
 /**

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -214,7 +214,12 @@ export function parseSectionCore(
       continue;
     }
 
-    if (raw === "") {
+    // Split a trailing inline comment off before the empty test (a
+    // comment-only value ``key: # note`` is an empty value to the loader,
+    // #1385), the flow-list test (`[a, b] # c` doesn't end with `]`), and
+    // scalar parsing — and record it so an edit can re-append it (#1235).
+    const { value: scalar, comment } = splitInlineComment(raw, true);
+    if (scalar === "") {
       const peek = _skipBlankAndCommentLines(lines, i + 1);
       if (peek < lines.length && isChildListItemLine(lines[peek], childIndent)) {
         const { value, endIdx, isEmptyScalarList, listSource } = parseListBlock(
@@ -226,6 +231,7 @@ export function parseSectionCore(
           values[key] = value;
           const meta = recordKey(key, i, endIdx);
           if (listSource) meta.listSource = listSource;
+          if (comment) meta.comment = comment;
           i = endIdx - 1;
         }
         continue;
@@ -242,15 +248,12 @@ export function parseSectionCore(
       const endIdx = result?.endIdx ?? i + 1;
       values[key] =
         result && Object.keys(result.values).length > 0 ? result.values : null;
-      recordKey(key, i, endIdx);
+      const meta = recordKey(key, i, endIdx);
+      if (comment) meta.comment = comment;
       i = endIdx - 1;
       continue;
     }
 
-    // Split a trailing inline comment off before the flow-list test
-    // (`[a, b] # c` doesn't end with `]`) and before scalar parsing,
-    // and record it so an edit can re-append it (#1235).
-    const { value: scalar, comment } = splitInlineComment(raw);
     if (scalar.startsWith("[") && scalar.endsWith("]")) {
       values[key] = parseFlowList(scalar);
       const meta = recordKey(key, i, i + 1);

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -9,7 +9,12 @@
 
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import { blockScalarValue } from "./yaml-block-scalar-value.js";
-import { parseFlowList, parseScalar, splitInlineComment } from "./yaml-scalar.js";
+import {
+  parseFlowList,
+  parseScalar,
+  splitInlineComment,
+  splitTrimmedInlineComment,
+} from "./yaml-scalar.js";
 import { parseListBlock, parseNestedBlock } from "./yaml-section-block-reader.js";
 import {
   _detectSectionChildIndent,
@@ -218,7 +223,7 @@ export function parseSectionCore(
     // comment-only value ``key: # note`` is an empty value to the loader,
     // #1385), the flow-list test (`[a, b] # c` doesn't end with `]`), and
     // scalar parsing — and record it so an edit can re-append it (#1235).
-    const { value: scalar, comment } = splitInlineComment(raw, true);
+    const { value: scalar, comment } = splitTrimmedInlineComment(raw);
     if (scalar === "") {
       const peek = _skipBlankAndCommentLines(lines, i + 1);
       if (peek < lines.length && isChildListItemLine(lines[peek], childIndent)) {

--- a/test/util/yaml-scalar.test.ts
+++ b/test/util/yaml-scalar.test.ts
@@ -49,6 +49,15 @@ describe("stripQuotes", () => {
 });
 
 describe("splitInlineComment", () => {
+  it("treats a string-opening # as a comment with an empty value (#1385)", () => {
+    expect(splitInlineComment("# note", true)).toEqual({ value: "", comment: " # note" });
+    expect(splitInlineComment("# note")).toEqual({ value: "# note", comment: "" });
+  });
+
+  it("keeps a mid-word # in the value", () => {
+    expect(splitInlineComment("Bedroom#2")).toEqual({ value: "Bedroom#2", comment: "" });
+  });
+
   it("splits a whitespace-preceded # into value and comment", () => {
     expect(splitInlineComment("true #hides")).toEqual({
       value: "true",

--- a/test/util/yaml-scalar.test.ts
+++ b/test/util/yaml-scalar.test.ts
@@ -3,6 +3,7 @@ import {
   parseFlowList,
   parseScalar,
   splitInlineComment,
+  splitTrimmedInlineComment,
   stripQuotes,
 } from "../../src/util/yaml-scalar.js";
 
@@ -50,12 +51,11 @@ describe("stripQuotes", () => {
 
 describe("splitInlineComment", () => {
   it("treats a string-opening # as a comment with an empty value (#1385)", () => {
-    expect(splitInlineComment("# note", true)).toEqual({ value: "", comment: " # note" });
+    expect(splitTrimmedInlineComment("# note")).toEqual({
+      value: "",
+      comment: " # note",
+    });
     expect(splitInlineComment("# note")).toEqual({ value: "# note", comment: "" });
-  });
-
-  it("keeps a mid-word # in the value", () => {
-    expect(splitInlineComment("Bedroom#2")).toEqual({ value: "Bedroom#2", comment: "" });
   });
 
   it("splits a whitespace-preceded # into value and comment", () => {

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -3355,10 +3355,29 @@ describe("updateSectionInYaml — comment-only values are empty (#1385)", () => 
     expect(values.networks).toEqual(["", "homenet"]);
   });
 
-  it("keeps a value merely starting with # when quoted, and Bedroom#2 unquoted", () => {
-    const yaml = ["wifi:", '  ssid: "#lounge"', "  ap_name: Bedroom#2", ""].join("\n");
+  it("parses a comment-only value inside a nested mapping as null", () => {
+    const yaml = [
+      "wifi:",
+      "  manual_ip:",
+      "    static_ip: # todo",
+      "    gateway: 10.0.0.1",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    expect(values.manual_ip).toEqual({ static_ip: null, gateway: "10.0.0.1" });
+  });
+
+  it("parses the deeper block under a commented nested key instead of dropping it", () => {
+    const yaml = ["wifi:", "  manual_ip:", "    dns1: # note", "      x: 1", ""].join(
+      "\n"
+    );
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    expect(values.manual_ip).toEqual({ dns1: { x: 1 } });
+  });
+
+  it("keeps a quoted value that merely starts with #", () => {
+    const yaml = ["wifi:", '  ssid: "#lounge"', ""].join("\n");
     const values = parseYamlSectionValues(yaml, "wifi", 1);
     expect(values.ssid).toBe("#lounge");
-    expect(values.ap_name).toBe("Bedroom#2");
   });
 });

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -3367,6 +3367,17 @@ describe("updateSectionInYaml — comment-only values are empty (#1385)", () => 
     expect(values.manual_ip).toEqual({ static_ip: null, gateway: "10.0.0.1" });
   });
 
+  it("parses an all-value-less nested block as an object of nulls", () => {
+    // Deliberate #1385 delta: previously such a block collapsed to null;
+    // per-key nulls match parseFlatMappingField's #941 treatment and the
+    // serializer's null filter keeps re-emits unchanged.
+    const yaml = ["wifi:", "  manual_ip:", "    static_ip:", "    gateway:", ""].join(
+      "\n"
+    );
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    expect(values.manual_ip).toEqual({ static_ip: null, gateway: null });
+  });
+
   it("parses the deeper block under a commented nested key instead of dropping it", () => {
     const yaml = ["wifi:", "  manual_ip:", "    dns1: # note", "      x: 1", ""].join(
       "\n"

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -3290,3 +3290,75 @@ describe("updateSectionInYaml — mapping-list rows keep comments on edit (#1379
     expect(after).toContain("password: changed");
   });
 });
+
+describe("updateSectionInYaml — comment-only values are empty (#1385)", () => {
+  it("parses a comment-only scalar as null, not the literal string", () => {
+    const yaml = ["wifi:", "  domain: # note", "  ssid: home", ""].join("\n");
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    expect(values.domain).toBeNull();
+    expect(values.ssid).toBe("home");
+  });
+
+  it("re-appends the comment when the empty field gains a value", () => {
+    const yaml = ["wifi:", "  domain: # note", "  ssid: home", ""].join("\n");
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    values.domain = ".local";
+    const after = updateSectionInYaml(yaml, "wifi", values, 1);
+    expect(after).toContain("  domain: .local # note\n");
+  });
+
+  it("still parses a nested mapping under a commented key line", () => {
+    const yaml = [
+      "wifi:",
+      "  manual_ip: # static below",
+      "    static_ip: 10.0.0.2",
+      "    gateway: 10.0.0.1",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    expect(values.manual_ip).toEqual({ static_ip: "10.0.0.2", gateway: "10.0.0.1" });
+  });
+
+  it("still parses a list under a commented key line", () => {
+    const yaml = [
+      "wifi:",
+      "  networks: # known nets",
+      "    - homenet",
+      "    - guestnet",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    expect(values.networks).toEqual(["homenet", "guestnet"]);
+  });
+
+  it("parses a comment-only mapping-item field as null", () => {
+    const yaml = [
+      "wifi:",
+      "  networks:",
+      "    - ssid: # pick later",
+      "      password: hunter2",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    expect(values.networks).toEqual([{ ssid: null, password: "hunter2" }]);
+  });
+
+  it("coerces a pathological comment-only list item to the empty string", () => {
+    const yaml = [
+      "wifi:",
+      "  networks:",
+      "    - # placeholder",
+      "    - homenet",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    expect(values.networks).toEqual(["", "homenet"]);
+  });
+
+  it("keeps a value merely starting with # when quoted, and Bedroom#2 unquoted", () => {
+    const yaml = ["wifi:", '  ssid: "#lounge"', "  ap_name: Bedroom#2", ""].join("\n");
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    expect(values.ssid).toBe("#lounge");
+    expect(values.ap_name).toBe("Bedroom#2");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

A comment only value, `name: # note`, parsed as the literal string `"# note"`: the child line regex consumes the whitespace after the colon and the raw is trimmed, so `splitInlineComment` never saw the whitespace before `#` its detection requires. The form showed `# note` as the field value and an edit re serialized it quoted (`name: "# note"`), corrupting the config; the loader reads this shape as an empty value plus comment.

A new `splitTrimmedInlineComment` wrapper (a two line prefix test over the unchanged core scanner) serves callers holding pre trimmed input: the reader's child line site, `parseFlatMappingField`, `collectBlockListItems`, and the nested block reader all treat a string opening `#` as a comment with an empty value, while the untrimmed dash line caller keeps plain `splitInlineComment`, where a position 0 `#` means the source had no separator and stays value text (`file:#fragment`, the pinned semantic). A string opening comment gets a canonical single leading space so the re append emits valid YAML.

Both readers now split before their empty value branch and route on the split value, so `key: # note` behaves exactly like bare `key:` — null value, and a nested mapping or list below the commented key line still parses (previously a commented nested key with a deeper block silently dropped the block). The captured comment lands on the key's `KeyMeta.comment` at the top level, so giving the field a value re appends it through the existing #1235 single line re append. A mapping item field `ssid: # note` now yields null for consistency, a value less nested key records null like the top level reader (an all value less nested block therefore parses to an object of nulls, pinned as deliberate), and a pathological comment only list item coerces to the empty string (pinned as accepted).

Verified in the live editor: a seeded `level: # pick later` renders the level select empty instead of showing `# pick later` as the value, and picking DEBUG emits `level: DEBUG # pick later` with the comment re appended.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1385

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
