### PR TITLE
Carry nested flow-list style and comment on the value via YamlFlowList

### DIFF
--- a/src/util/yaml-section-block-reader.ts
+++ b/src/util/yaml-section-block-reader.ts
@@ -38,7 +38,7 @@ import {
   type ListItemSource,
   parseFlatMappingField,
 } from "./yaml-section-list.js";
-import { YamlRawValue } from "./yaml-serialize.js";
+import { YamlFlowList, YamlRawValue } from "./yaml-serialize.js";
 
 /**
  * Dispatch a YAML list block (``key:\n  - …``) into the right
@@ -406,7 +406,7 @@ function parseNestedBlock(
     // ``key: # note`` is an empty value, #1385) and the bracket test —
     // without the latter ``key: [1, 2] # note`` misses the flow branch
     // and degrades to the literal string "[1, 2]".
-    const { value: scalar } = splitTrimmedInlineComment(raw);
+    const { value: scalar, comment } = splitTrimmedInlineComment(raw);
     if (scalar === "") {
       const peek = _skipBlankAndCommentLines(lines, i + 1);
       // ``key:`` followed by a block list. Accept both the standard
@@ -437,7 +437,7 @@ function parseNestedBlock(
     }
 
     if (scalar.startsWith("[") && scalar.endsWith("]")) {
-      values[key] = parseFlowList(scalar);
+      values[key] = YamlFlowList.wrap(parseFlowList(scalar), comment);
     } else {
       values[key] = parseScalar(scalar);
     }

--- a/src/util/yaml-section-list.ts
+++ b/src/util/yaml-section-list.ts
@@ -22,6 +22,7 @@ import {
   LIST_ITEM_DICT_KEY_RE,
   parseBlockScalarHeader,
 } from "./yaml-section-lexer.js";
+import { YamlFlowList } from "./yaml-serialize.js";
 
 /** Source fidelity for a block list: each item's half-open 0-indexed
  *  source-line range (into the same array the splice writer receives),
@@ -122,10 +123,10 @@ export const parseFlatMappingField = (
   // section editor instead of falling back to YamlRawValue. #941. The
   // comment is also stripped before the ``[...]`` test so a flow list
   // with a trailing comment still reads as an array (device-builder#1232).
-  const { value: scalar } = splitTrimmedInlineComment(raw);
+  const { value: scalar, comment } = splitTrimmedInlineComment(raw);
   if (scalar === "") return { key, value: null };
   if (scalar.startsWith("[") && scalar.endsWith("]")) {
-    return { key, value: parseFlowList(scalar) };
+    return { key, value: YamlFlowList.wrap(parseFlowList(scalar), comment) };
   }
   return { key, value: parseScalar(scalar) };
 };

--- a/src/util/yaml-section-splice.ts
+++ b/src/util/yaml-section-splice.ts
@@ -49,7 +49,9 @@ export interface KeyMeta {
   // splices per item instead of re-emitting every row (#1363).
   listSource?: ListItemSource;
   // Authored as a flow list (``key: [a, b]``) — an edit re-emits the same
-  // single-line style (#1378). Never coexists with ``listSource``.
+  // single-line style (#1378). Never coexists with ``listSource``. The
+  // nested-depth counterpart is the value-carried ``YamlFlowList``, which
+  // deliberately does NOT survive list edits — don't unify the two.
   flowList?: boolean;
 }
 

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -88,31 +88,6 @@ function emitYamlRawValueLines(key: string, indent: string, raw: YamlRawValue): 
  * reference through ``{...obj}`` spread, so the class identity
  * survives form mutations.
  */
-/**
- * A flow-authored scalar list inside a nested mapping or list-item field
- * (``data: [1, 2] # note``), so a sibling-field edit re-emits the same
- * single flow line with its trailing comment (#1381). An ``Array``
- * subclass so every array consumer works unchanged; a form edit of the
- * list itself writes a plain array back, which re-emits canonically.
- */
-export class YamlFlowList extends Array<string | number | boolean> {
-  // Non-enumerable (set in ``wrap``) so deep-equality, JSON, and spreads
-  // see a plain array of items; only the serializer reads it.
-  declare comment: string | undefined;
-
-  /** ``new Array(n)`` semantics make the constructor a trap; build via
-   *  push instead. */
-  static wrap(
-    items: readonly (string | number | boolean)[],
-    comment: string
-  ): YamlFlowList {
-    const list = new YamlFlowList();
-    list.push(...items);
-    Object.defineProperty(list, "comment", { value: comment, enumerable: false });
-    return list;
-  }
-}
-
 export class YamlRawValue {
   constructor(
     public readonly lines: readonly string[],
@@ -193,6 +168,41 @@ export class YamlRawValue {
     const indent = original.indent;
     const lines = body.split("\n").map((line) => (line === "" ? "" : `${indent}${line}`));
     return new YamlRawValue(lines, original.inlineHeader);
+  }
+}
+
+/**
+ * A flow-authored scalar list inside a nested mapping or list-item field
+ * (``data: [1, 2] # note``), so a sibling-field edit re-emits the same
+ * single flow line with its trailing comment (#1381). An ``Array``
+ * subclass so every array consumer works unchanged; a form edit of the
+ * list itself writes a plain array back, which re-emits canonically.
+ * Top-level flow keys use ``KeyMeta.flowList`` instead (key-sticky:
+ * style survives list edits there) — don't unify the two.
+ */
+export class YamlFlowList extends Array<string | number | boolean> {
+  // Derived arrays (filter/map/slice) come back plain, keeping the
+  // "form edits write plain arrays back" contract uniform — without this
+  // a removeAt filter minted a comment-less wrapper that kept flow style
+  // but silently dropped the comment.
+  static get [Symbol.species](): ArrayConstructor {
+    return Array;
+  }
+
+  // Non-enumerable (set in ``wrap``) so deep-equality, JSON, and spreads
+  // see a plain array of items; only the serializer reads it.
+  declare comment: string | undefined;
+
+  /** ``new Array(n)`` semantics make the constructor a trap; build via
+   *  push instead. */
+  static wrap(
+    items: readonly (string | number | boolean)[],
+    comment: string
+  ): YamlFlowList {
+    const list = new YamlFlowList();
+    list.push(...items);
+    Object.defineProperty(list, "comment", { value: comment, enumerable: false });
+    return list;
   }
 }
 

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -88,6 +88,31 @@ function emitYamlRawValueLines(key: string, indent: string, raw: YamlRawValue): 
  * reference through ``{...obj}`` spread, so the class identity
  * survives form mutations.
  */
+/**
+ * A flow-authored scalar list inside a nested mapping or list-item field
+ * (``data: [1, 2] # note``), so a sibling-field edit re-emits the same
+ * single flow line with its trailing comment (#1381). An ``Array``
+ * subclass so every array consumer works unchanged; a form edit of the
+ * list itself writes a plain array back, which re-emits canonically.
+ */
+export class YamlFlowList extends Array<string | number | boolean> {
+  // Non-enumerable (set in ``wrap``) so deep-equality, JSON, and spreads
+  // see a plain array of items; only the serializer reads it.
+  declare comment: string | undefined;
+
+  /** ``new Array(n)`` semantics make the constructor a trap; build via
+   *  push instead. */
+  static wrap(
+    items: readonly (string | number | boolean)[],
+    comment: string
+  ): YamlFlowList {
+    const list = new YamlFlowList();
+    list.push(...items);
+    Object.defineProperty(list, "comment", { value: comment, enumerable: false });
+    return list;
+  }
+}
+
 export class YamlRawValue {
   constructor(
     public readonly lines: readonly string[],
@@ -274,7 +299,8 @@ export function serializeListItem(
           (it) => !isPlainObject(it) && !Array.isArray(it) && !isLambdaValue(it)
         );
         if (scalarItems) {
-          lines.push(`${prefix}${k}: ${formatYamlFlowList(v)}`);
+          const comment = v instanceof YamlFlowList ? (v.comment ?? "") : "";
+          lines.push(`${prefix}${k}: ${formatYamlFlowList(v)}${comment}`);
           return;
         }
         lines.push(`${prefix}${k}:`);
@@ -358,6 +384,10 @@ export function serializeYamlValues(
     }
     if (Array.isArray(val)) {
       if (val.length === 0) continue;
+      if (val instanceof YamlFlowList) {
+        lines.push(`${indent}${key}: ${formatYamlFlowList(val)}${val.comment ?? ""}`);
+        continue;
+      }
       lines.push(`${indent}${key}:`);
       for (const item of val) {
         const itemLines = serializeListItem(item, indent, options);

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -3399,12 +3399,19 @@ describe("updateSectionInYaml — nested flow lists keep style and comment (#138
   );
 
   it("keeps the flow line and comment when a sibling field in the nested mapping changes", () => {
-    const values = parseYamlSectionValues(yaml, "display", 1);
+    const quoted = [
+      "display:",
+      "  foo:",
+      '    data: ["${row}", 2] # note',
+      "    size: 20",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(quoted, "display", 1);
     (values.foo as Record<string, unknown>).size = 22;
-    const after = updateSectionInYaml(yaml, "display", values, 1);
-    expect(after).toContain("    data: [1, 2] # note\n");
+    const after = updateSectionInYaml(quoted, "display", values, 1);
+    expect(after).toContain('    data: ["${row}", 2] # note\n');
     expect(after).toContain("size: 22");
-    expect(after).not.toContain("- 1");
+    expect(after).not.toContain("- 2");
   });
 
   it("keeps a comment-less nested flow list flow-styled through a sibling edit", () => {
@@ -3417,6 +3424,18 @@ describe("updateSectionInYaml — nested flow lists keep style and comment (#138
     expect(after).toContain("    data: [1, 2]\n");
   });
 
+  it("re-emits canonically when a row is removed via filter (no stale flow/comment)", () => {
+    // ``removeAt`` filters the array; Symbol.species keeps the result a
+    // plain array so the mutation canonicalizes like every other edit.
+    const values = parseYamlSectionValues(yaml, "display", 1);
+    const data = (values.foo as Record<string, unknown>).data as unknown[];
+    (values.foo as Record<string, unknown>).data = data.filter((_, i) => i !== 0);
+    const after = updateSectionInYaml(yaml, "display", values, 1);
+    expect(after).not.toContain("# note");
+    expect(after).not.toContain("[");
+    expect(after).toContain("data:");
+  });
+
   it("re-emits canonically with no stale comment when the list itself is edited", () => {
     const values = parseYamlSectionValues(yaml, "display", 1);
     (values.foo as Record<string, unknown>).data = [1, 3];
@@ -3424,20 +3443,6 @@ describe("updateSectionInYaml — nested flow lists keep style and comment (#138
     expect(after).not.toContain("# note");
     expect(after).toContain("data:");
     expect(after).toContain("size: 20");
-  });
-
-  it("keeps protective quoting for substitutions inside the preserved flow line", () => {
-    const sub = [
-      "display:",
-      "  foo:",
-      '    data: ["${row}", 2] # glyphs',
-      "    size: 20",
-      "",
-    ].join("\n");
-    const values = parseYamlSectionValues(sub, "display", 1);
-    (values.foo as Record<string, unknown>).size = 22;
-    const after = updateSectionInYaml(sub, "display", values, 1);
-    expect(after).toContain('    data: ["${row}", 2] # glyphs\n');
   });
 
   it("keeps a mapping-list item's flow sub-list comment when a sibling field is edited", () => {

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -3392,3 +3392,69 @@ describe("updateSectionInYaml — comment-only values are empty (#1385)", () => 
     expect(values.ssid).toBe("#lounge");
   });
 });
+
+describe("updateSectionInYaml — nested flow lists keep style and comment (#1381)", () => {
+  const yaml = ["display:", "  foo:", "    data: [1, 2] # note", "    size: 20", ""].join(
+    "\n"
+  );
+
+  it("keeps the flow line and comment when a sibling field in the nested mapping changes", () => {
+    const values = parseYamlSectionValues(yaml, "display", 1);
+    (values.foo as Record<string, unknown>).size = 22;
+    const after = updateSectionInYaml(yaml, "display", values, 1);
+    expect(after).toContain("    data: [1, 2] # note\n");
+    expect(after).toContain("size: 22");
+    expect(after).not.toContain("- 1");
+  });
+
+  it("keeps a comment-less nested flow list flow-styled through a sibling edit", () => {
+    const bare = ["display:", "  foo:", "    data: [1, 2]", "    size: 20", ""].join(
+      "\n"
+    );
+    const values = parseYamlSectionValues(bare, "display", 1);
+    (values.foo as Record<string, unknown>).size = 22;
+    const after = updateSectionInYaml(bare, "display", values, 1);
+    expect(after).toContain("    data: [1, 2]\n");
+  });
+
+  it("re-emits canonically with no stale comment when the list itself is edited", () => {
+    const values = parseYamlSectionValues(yaml, "display", 1);
+    (values.foo as Record<string, unknown>).data = [1, 3];
+    const after = updateSectionInYaml(yaml, "display", values, 1);
+    expect(after).not.toContain("# note");
+    expect(after).toContain("data:");
+    expect(after).toContain("size: 20");
+  });
+
+  it("keeps protective quoting for substitutions inside the preserved flow line", () => {
+    const sub = [
+      "display:",
+      "  foo:",
+      '    data: ["${row}", 2] # glyphs',
+      "    size: 20",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(sub, "display", 1);
+    (values.foo as Record<string, unknown>).size = 22;
+    const after = updateSectionInYaml(sub, "display", values, 1);
+    expect(after).toContain('    data: ["${row}", 2] # glyphs\n');
+  });
+
+  it("keeps a mapping-list item's flow sub-list comment when a sibling field is edited", () => {
+    const items = [
+      "font:",
+      "  extras:",
+      "    - file: a.ttf",
+      "      glyphs: [x, y] # icons",
+      "    - file: b.ttf",
+      "      glyphs: [z]",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(items, "font", 1);
+    (values.extras as Record<string, unknown>[])[0].file = "c.ttf";
+    const after = updateSectionInYaml(items, "font", values, 1);
+    expect(after).toContain("glyphs: [x, y] # icons");
+    expect(after).toContain("file: c.ttf");
+    expect(after).toContain("glyphs: [z]");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

A flow list inside a nested mapping (`display:` → `foo:` → `data: [1, 2] # note`) flipped to block style and dropped its trailing comment whenever any sibling field in that mapping changed: the whole key re emits through `serializeYamlValues`, whose array branch was block only and comment blind. Flow lists inside mapping list items kept their style through a row re emit but still lost the comment.

Threading per path style metadata through the generic serializer would need path tracking it does not have, so the fix rides the value instead, the same pattern as `YamlRawValue`: a new `YamlFlowList` is an `Array` subclass carrying a non enumerable `comment`, created by the nested block reader and the mapping item field parser at their flow branches. Every array consumer works unchanged (deep equality, JSON, spreads, and `setIn` copies see a plain array of items), and only the serializer looks at it — `serializeYamlValues` re emits the single flow line with the comment, and `serializeListItem`'s sub list branch appends the comment to the flow line it already produced. Top level flow lists stay on the #1380 `KeyMeta` path — the two mechanisms are deliberately distinct and cross referenced in the code: the key sticky meta keeps flow style even through a list edit at the top level, while the value carried wrapper cannot at nested depth, so a direct edit of the nested list writes a plain array back and re emits canonically with no stale comment (pinned as accepted, matching #1383's changed row scope). A `Symbol.species` override keeps derived arrays (a row removal's filter) plain too, so every list mutation canonicalizes uniformly instead of a filtered copy keeping flow style while silently dropping the comment.

Verified in the live editor on the display `user_characters` item: editing the sibling `position` field keeps `data: ["${glyph_row}", …] # glyph bytes` as one flow line with the protective quoting and the comment intact. Pinned for the sibling edit with and without a comment, the substitution quoting, the direct edit canonicalization, and the mapping item sub list comment.

This closes the last item of the round trip fidelity arc.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1381

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
