### PR TITLE
Treat a string-opening hash as a comment only when the colon had a separator

### DIFF
--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -68,6 +68,15 @@ export const splitTrimmedInlineComment = (
 ): { value: string; comment: string } =>
   raw.startsWith("#") ? { value: "", comment: ` ${raw}` } : splitInlineComment(raw);
 
+/** The #1385/#1388 rule in one place: a string-opening ``#`` is a comment
+ *  only when the source had separator whitespace after the colon; with no
+ *  separator it stays value text. */
+export const splitValueComment = (
+  raw: string,
+  hadSeparator: boolean
+): { value: string; comment: string } =>
+  hadSeparator ? splitTrimmedInlineComment(raw) : splitInlineComment(raw);
+
 // Inline lambda scalar: ``!lambda return x;`` (and the quoted
 // ``!lambda 'return x;'`` form). Recognised as a ``LambdaValue``
 // so a templatable field shows the lambda editor instead of a

--- a/src/util/yaml-section-block-reader.ts
+++ b/src/util/yaml-section-block-reader.ts
@@ -269,6 +269,13 @@ const collectBlockListMappings = (
       const headerKey = headerMatch[1];
       const headerHadSep = headerMatch[2].length > 0;
       const headerRaw = headerMatch[3].trim();
+      // A non-empty header without a post-colon separator is a scalar
+      // item to the loader (``- ssid:#odd``), not a mapping field —
+      // bail to the whole-list ``YamlRawValue`` fallback rather than
+      // coercing it into an object (matches ``LIST_ITEM_DICT_KEY_RE``'s
+      // ``:(?:\s|$)`` mapping signal). A bare ``- key:`` stays a valid
+      // single-null-key item.
+      if (!headerHadSep && headerRaw !== "") return null;
       // ``- multiply: !lambda |-``: the body sits on the following
       // deeper-indented lines, so capture it here rather than letting
       // ``parseFlatMappingField`` mis-read the lone header as a scalar

--- a/src/util/yaml-section-block-reader.ts
+++ b/src/util/yaml-section-block-reader.ts
@@ -14,12 +14,7 @@ import {
   isEditableLambdaBlock,
   lambdaValueFromBlock,
 } from "./yaml-block-scalar-value.js";
-import {
-  parseFlowList,
-  parseScalar,
-  splitInlineComment,
-  splitTrimmedInlineComment,
-} from "./yaml-scalar.js";
+import { parseFlowList, parseScalar, splitValueComment } from "./yaml-scalar.js";
 import {
   _detectListItemChildIndent,
   _leadingIndent,
@@ -269,12 +264,11 @@ const collectBlockListMappings = (
       const headerKey = headerMatch[1];
       const headerHadSep = headerMatch[2].length > 0;
       const headerRaw = headerMatch[3].trim();
-      // A non-empty header without a post-colon separator is a scalar
-      // item to the loader (``- ssid:#odd``), not a mapping field —
-      // bail to the whole-list ``YamlRawValue`` fallback rather than
-      // coercing it into an object (matches ``LIST_ITEM_DICT_KEY_RE``'s
-      // ``:(?:\s|$)`` mapping signal). A bare ``- key:`` stays a valid
-      // single-null-key item.
+      // ``- ssid:#odd`` is a VALID scalar item to the loader (no
+      // ``:(?:\s|$)`` mapping signal, cf. LIST_ITEM_DICT_KEY_RE), so
+      // coercing it to a mapping would rewrite a valid doc — bail. Child
+      // lines stay lenient: separator-less there is invalid YAML, so
+      // repair can't misread a valid doc.
       if (!headerHadSep && headerRaw !== "") return null;
       // ``- multiply: !lambda |-``: the body sits on the following
       // deeper-indented lines, so capture it here rather than letting
@@ -420,9 +414,7 @@ function parseNestedBlock(
     // ``key: # note`` is an empty value, #1385) and the bracket test —
     // without the latter ``key: [1, 2] # note`` misses the flow branch
     // and degrades to the literal string "[1, 2]".
-    const { value: scalar, comment } = hadSeparator
-      ? splitTrimmedInlineComment(raw)
-      : splitInlineComment(raw);
+    const { value: scalar, comment } = splitValueComment(raw, hadSeparator);
     if (scalar === "") {
       const peek = _skipBlankAndCommentLines(lines, i + 1);
       // ``key:`` followed by a block list. Accept both the standard

--- a/src/util/yaml-section-block-reader.ts
+++ b/src/util/yaml-section-block-reader.ts
@@ -14,7 +14,12 @@ import {
   isEditableLambdaBlock,
   lambdaValueFromBlock,
 } from "./yaml-block-scalar-value.js";
-import { parseFlowList, parseScalar, splitTrimmedInlineComment } from "./yaml-scalar.js";
+import {
+  parseFlowList,
+  parseScalar,
+  splitInlineComment,
+  splitTrimmedInlineComment,
+} from "./yaml-scalar.js";
 import {
   _detectListItemChildIndent,
   _leadingIndent,
@@ -234,8 +239,8 @@ const collectBlockListMappings = (
   endIdx: number;
   itemRanges: [number, number][];
 } | null => {
-  const headerRe = new RegExp(`^${dashIndent}-\\s+(${KEY_PATTERN}):\\s*(.*)$`);
-  const childRe = new RegExp(`^${childIndent}(${KEY_PATTERN}):\\s*(.*)$`);
+  const headerRe = new RegExp(`^${dashIndent}-\\s+(${KEY_PATTERN}):(\\s*)(.*)$`);
+  const childRe = new RegExp(`^${childIndent}(${KEY_PATTERN}):(\\s*)(.*)$`);
 
   /**
    * Parse one list item starting at *at* (the dash line). Returns
@@ -262,7 +267,8 @@ const collectBlockListMappings = (
       const headerMatch = lines[at].match(headerRe);
       if (!headerMatch) return null;
       const headerKey = headerMatch[1];
-      const headerRaw = headerMatch[2].trim();
+      const headerHadSep = headerMatch[2].length > 0;
+      const headerRaw = headerMatch[3].trim();
       // ``- multiply: !lambda |-``: the body sits on the following
       // deeper-indented lines, so capture it here rather than letting
       // ``parseFlatMappingField`` mis-read the lone header as a scalar
@@ -294,7 +300,7 @@ const collectBlockListMappings = (
         item[headerKey] = lambdaValueFromBlock(lines.slice(at + 1, endIdx));
         return { item, endIdx };
       }
-      const header = parseFlatMappingField(headerKey, headerRaw);
+      const header = parseFlatMappingField(headerKey, headerRaw, headerHadSep);
       if (!header) return null;
       item[header.key] = header.value;
       // ``- effect_id:`` with no value may be a polymorphic single-
@@ -383,7 +389,8 @@ function parseNestedBlock(
       continue;
     }
     const key = match[1];
-    const raw = match[2].trim();
+    const hadSeparator = match[2].length > 0;
+    const raw = match[3].trim();
 
     // Direct block scalar at nested indent (same shape as the
     // top-level parser's branch — see comment there). A nested
@@ -406,7 +413,9 @@ function parseNestedBlock(
     // ``key: # note`` is an empty value, #1385) and the bracket test —
     // without the latter ``key: [1, 2] # note`` misses the flow branch
     // and degrades to the literal string "[1, 2]".
-    const { value: scalar, comment } = splitTrimmedInlineComment(raw);
+    const { value: scalar, comment } = hadSeparator
+      ? splitTrimmedInlineComment(raw)
+      : splitInlineComment(raw);
     if (scalar === "") {
       const peek = _skipBlankAndCommentLines(lines, i + 1);
       // ``key:`` followed by a block list. Accept both the standard

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -170,8 +170,9 @@ export const LIST_ITEM_DICT_KEY_RE = /^\s*-\s+[a-zA-Z_][\w.]*:(?:\s|$)/;
 
 export const childRegexFor = (indent: string) =>
   // Group 2 captures the post-colon separator: ``key:#fragment`` (no
-  // whitespace) keeps the ``#`` as value text, matching the dash-line
-  // leniency, while ``key: # note`` is a comment-only empty value (#1388).
+  // whitespace) keeps the ``#`` as value text (#1388), matching the
+  // dash-line leniency, while ``key: # note`` stays a comment-only empty
+  // value (#1385).
   new RegExp(`^${indent}(${KEY_PATTERN}):(\\s*)(.*)$`);
 
 // Intentionally permissive — the body after `- ` can be any

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -169,7 +169,10 @@ export const LIST_ITEM_INLINE_KEY_PREFIX_RE = /^(\s*-\s*)\S/;
 export const LIST_ITEM_DICT_KEY_RE = /^\s*-\s+[a-zA-Z_][\w.]*:(?:\s|$)/;
 
 export const childRegexFor = (indent: string) =>
-  new RegExp(`^${indent}(${KEY_PATTERN}):\\s*(.*)$`);
+  // Group 2 captures the post-colon separator: ``key:#fragment`` (no
+  // whitespace) keeps the ``#`` as value text, matching the dash-line
+  // leniency, while ``key: # note`` is a comment-only empty value (#1388).
+  new RegExp(`^${indent}(${KEY_PATTERN}):(\\s*)(.*)$`);
 
 // Intentionally permissive — the body after `- ` can be any
 // scalar (string with spaces, number, !secret reference) and we

--- a/src/util/yaml-section-list.ts
+++ b/src/util/yaml-section-list.ts
@@ -10,6 +10,7 @@ import {
   isQuotedScalar,
   parseFlowList,
   parseScalar,
+  splitInlineComment,
   splitTrimmedInlineComment,
   stripQuotes,
 } from "./yaml-scalar.js";
@@ -103,7 +104,8 @@ export const _detectFirstDashIndent = (
  */
 export const parseFlatMappingField = (
   key: string,
-  raw: string
+  raw: string,
+  hadSeparator = true
 ): { key: string; value: unknown } | null => {
   // Dotted keys (``logger.log:``, ``switch.turn_on:``) are
   // automation-action shorthand — not flat-mapping fields. Bail
@@ -123,7 +125,9 @@ export const parseFlatMappingField = (
   // section editor instead of falling back to YamlRawValue. #941. The
   // comment is also stripped before the ``[...]`` test so a flow list
   // with a trailing comment still reads as an array (device-builder#1232).
-  const { value: scalar, comment } = splitTrimmedInlineComment(raw);
+  const { value: scalar, comment } = hadSeparator
+    ? splitTrimmedInlineComment(raw)
+    : splitInlineComment(raw);
   if (scalar === "") return { key, value: null };
   if (scalar.startsWith("[") && scalar.endsWith("]")) {
     return { key, value: YamlFlowList.wrap(parseFlowList(scalar), comment) };
@@ -146,7 +150,7 @@ export const _matchFlatMappingField = (
   re: RegExp
 ): { key: string; value: unknown } | null => {
   const m = line.match(re);
-  return m ? parseFlatMappingField(m[1], m[2].trim()) : null;
+  return m ? parseFlatMappingField(m[1], m[3].trim(), m[2].length > 0) : null;
 };
 
 /**

--- a/src/util/yaml-section-list.ts
+++ b/src/util/yaml-section-list.ts
@@ -10,8 +10,8 @@ import {
   isQuotedScalar,
   parseFlowList,
   parseScalar,
-  splitInlineComment,
   splitTrimmedInlineComment,
+  splitValueComment,
   stripQuotes,
 } from "./yaml-scalar.js";
 import {
@@ -105,7 +105,7 @@ export const _detectFirstDashIndent = (
 export const parseFlatMappingField = (
   key: string,
   raw: string,
-  hadSeparator = true
+  hadSeparator: boolean
 ): { key: string; value: unknown } | null => {
   // Dotted keys (``logger.log:``, ``switch.turn_on:``) are
   // automation-action shorthand — not flat-mapping fields. Bail
@@ -125,9 +125,7 @@ export const parseFlatMappingField = (
   // section editor instead of falling back to YamlRawValue. #941. The
   // comment is also stripped before the ``[...]`` test so a flow list
   // with a trailing comment still reads as an array (device-builder#1232).
-  const { value: scalar, comment } = hadSeparator
-    ? splitTrimmedInlineComment(raw)
-    : splitInlineComment(raw);
+  const { value: scalar, comment } = splitValueComment(raw, hadSeparator);
   if (scalar === "") return { key, value: null };
   if (scalar.startsWith("[") && scalar.endsWith("]")) {
     return { key, value: YamlFlowList.wrap(parseFlowList(scalar), comment) };

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -199,7 +199,8 @@ export function parseSectionCore(
     const match = line.match(childRegex);
     if (!match) continue;
     const key = match[1];
-    const raw = match[2].trim();
+    const hadSeparator = match[2].length > 0;
+    const raw = match[3].trim();
 
     // Direct block scalar: `key: |-` (or `|`, `>`, `>-`, `|+`,
     // `>+`), optionally tagged (`key: !lambda |-`). The header sits
@@ -223,7 +224,9 @@ export function parseSectionCore(
     // comment-only value ``key: # note`` is an empty value to the loader,
     // #1385), the flow-list test (`[a, b] # c` doesn't end with `]`), and
     // scalar parsing — and record it so an edit can re-append it (#1235).
-    const { value: scalar, comment } = splitTrimmedInlineComment(raw);
+    const { value: scalar, comment } = hadSeparator
+      ? splitTrimmedInlineComment(raw)
+      : splitInlineComment(raw);
     if (scalar === "") {
       const peek = _skipBlankAndCommentLines(lines, i + 1);
       if (peek < lines.length && isChildListItemLine(lines[peek], childIndent)) {

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -13,7 +13,7 @@ import {
   parseFlowList,
   parseScalar,
   splitInlineComment,
-  splitTrimmedInlineComment,
+  splitValueComment,
 } from "./yaml-scalar.js";
 import { parseListBlock, parseNestedBlock } from "./yaml-section-block-reader.js";
 import {
@@ -157,6 +157,10 @@ export function parseSectionCore(
       // ``\s*`` drops it) so ``splitInlineComment`` can tell a real comment
       // (``#`` after whitespace) from a value that merely starts with ``#``
       // (``- file:#fragment``). The first ``:`` after the dash is the key's.
+      // The loader reads a separator-less ``- key:#x`` as a scalar item;
+      // this path still shows it as a field, but the serializer's
+      // ``yamlValueEqual`` guard keeps untouched saves byte-verbatim, so
+      // only a deliberate edit of the field rewrites it.
       const head = lines[startIdx];
       const afterColon = head.slice(head.indexOf(":", head.indexOf("-")) + 1);
       const { value: rawValue, comment } = splitInlineComment(afterColon);
@@ -224,9 +228,7 @@ export function parseSectionCore(
     // comment-only value ``key: # note`` is an empty value to the loader,
     // #1385), the flow-list test (`[a, b] # c` doesn't end with `]`), and
     // scalar parsing — and record it so an edit can re-append it (#1235).
-    const { value: scalar, comment } = hadSeparator
-      ? splitTrimmedInlineComment(raw)
-      : splitInlineComment(raw);
+    const { value: scalar, comment } = splitValueComment(raw, hadSeparator);
     if (scalar === "") {
       const peek = _skipBlankAndCommentLines(lines, i + 1);
       if (peek < lines.length && isChildListItemLine(lines[peek], childIndent)) {

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -3406,6 +3406,23 @@ describe("updateSectionInYaml — comment-only values are empty (#1385)", () => 
     expect(values.manual_ip).toEqual({ static_ip: "#odd", gateway: "10.0.0.1" });
   });
 
+  it("bails a mixed list with a separator-less dash header to YamlRawValue", () => {
+    // ``- ssid:#odd`` is a scalar item to the loader; coercing it into a
+    // mapping field would silently rewrite it on save. The conservative
+    // fallback keeps the block byte-verbatim.
+    const yaml = [
+      "wifi:",
+      "  networks:",
+      "    - ssid: home",
+      "      password: x",
+      "    - ssid:#odd",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    const after = updateSectionInYaml(yaml, "wifi", values, 1);
+    expect(after).toBe(yaml);
+  });
+
   it("keeps colon-adjacent # as value text in a mapping-item field", () => {
     const yaml = [
       "wifi:",

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -3386,6 +3386,38 @@ describe("updateSectionInYaml — comment-only values are empty (#1385)", () => 
     expect(values.manual_ip).toEqual({ dns1: { x: 1 } });
   });
 
+  it("keeps colon-adjacent # as value text when no separator follows the colon (#1388)", () => {
+    // Matches the dash-line ``- file:#fragment`` leniency: with no
+    // whitespace after the colon there was never a comment separator.
+    const yaml = ["wifi:", "  ssid:#fragment", "  domain: .local", ""].join("\n");
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    expect(values.ssid).toBe("#fragment");
+  });
+
+  it("keeps colon-adjacent # as value text inside a nested mapping", () => {
+    const yaml = [
+      "wifi:",
+      "  manual_ip:",
+      "    static_ip:#odd",
+      "    gateway: 10.0.0.1",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    expect(values.manual_ip).toEqual({ static_ip: "#odd", gateway: "10.0.0.1" });
+  });
+
+  it("keeps colon-adjacent # as value text in a mapping-item field", () => {
+    const yaml = [
+      "wifi:",
+      "  networks:",
+      "    - ssid: home",
+      "      password:#odd",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(yaml, "wifi", 1);
+    expect(values.networks).toEqual([{ ssid: "home", password: "#odd" }]);
+  });
+
   it("keeps a quoted value that merely starts with #", () => {
     const yaml = ["wifi:", '  ssid: "#lounge"', ""].join("\n");
     const values = parseYamlSectionValues(yaml, "wifi", 1);


### PR DESCRIPTION
# What does this implement/fix?

Late Copilot catch on the merged #1386: the key value regexes allow zero whitespace after the colon, so `key:#fragment` matched with a raw of `#fragment` and the new trimmed comment split treated it as a comment only empty value, while the dash line path deliberately keeps colon adjacent `#` as value text (the pinned `- file:#fragment` leniency). The two readers disagreed on the same tolerated shape.

The key value regexes (`childRegexFor` and the mapping item header/child pair) now capture the post colon separator, and the comment only interpretation applies only when the source actually had whitespace after the colon; with no separator, the plain splitter keeps a position 0 `#` in the value. Covers the section reader child lines, the nested block reader, and mapping item fields through `parseFlatMappingField`'s new `hadSeparator` parameter. `key: # note` with a separator keeps its #1385 behavior (empty value plus preserved comment), pinned already; the three no separator surfaces gain their own pins. One nuance the pinning surfaced: a dash header without a separator (`- ssid:#odd`) is classified as a scalar item by the complexity scanner, which matches the loader (no separator means no mapping), so the mapping item pin uses a child line.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1388

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
