### PR TITLE
Gate experience_level off the remote-builder onboarding path

### DIFF
--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -179,9 +179,11 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
 
   /** Ordered screens for the current environment. */
   private get _screens(): WizardScreen[] {
-    // existing_server sits after experience (index 1). While the user is still
-    // on Welcome or experience the tail can grow as mDNS hosts arrive; freeze it
-    // once they advance past experience so a late host can't shift the flow.
+    // existing_server can appear only in the non-desktop flow, where experience
+    // is index 1 (wizardScreens ignores the flag when the usage screen shows).
+    // While the user is still on Welcome or experience the tail can grow as
+    // mDNS hosts arrive; freeze it once they advance past experience so a late
+    // host can't shift the flow.
     const showExistingServer =
       this._index <= 1 ? this._computeShowExistingServer() : this._existingServerPinned;
     return wizardScreens({
@@ -384,6 +386,24 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     `;
   }
 
+  /** Discovered-host names localized through *key* ({name}) or, past the
+   *  display cap, *overflowKey* ({name}, {count}); null when none are known.
+   *  The cap keeps a busy network from blowing up the copy. */
+  private _localizeDiscoveredHosts(key: string, overflowKey: string): string | null {
+    const names = this._discoveredHosts
+      ? [...new Set([...this._discoveredHosts.values()].map(remoteBuildPeerName))]
+      : [];
+    if (!names.length) return null;
+    const shown = names.slice(0, 3);
+    const extra = names.length - shown.length;
+    const joined = new Intl.ListFormat(activeLocale(), {
+      type: extra > 0 ? "unit" : "conjunction",
+    }).format(shown);
+    return extra > 0
+      ? this._localize(overflowKey, { name: joined, count: extra })
+      : this._localize(key, { name: joined });
+  }
+
   /** Banner atop the experience screen when the user picked a standalone
    *  setup even though another Device Builder was discovered. Reads the
    *  live host map on purpose: a host that appears mid-flow should still
@@ -392,12 +412,16 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
    *  preselected, so Continue there completes the switch. */
   private _renderExistingNotice() {
     if (!this._showUsage || this._usage !== "standalone") return nothing;
-    if (!this._discoveredHosts?.size) return nothing;
+    const notice = this._localizeDiscoveredHosts(
+      "onboarding.wizard.experience.existing_notice",
+      "onboarding.wizard.experience.existing_notice_overflow"
+    );
+    if (!notice) return nothing;
     return html`
       <div class="existing-notice" role="status">
         <wa-icon library="mdi" name="alert-outline" aria-hidden="true"></wa-icon>
         <span>
-          ${this._localize("onboarding.wizard.experience.existing_notice")}
+          ${notice}
           <button type="button" class="notice-link" @click=${this._switchToRemoteBuild}>
             ${this._localize("onboarding.wizard.experience.existing_notice_link")}
           </button>
@@ -412,26 +436,14 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
   };
 
   private _renderExistingServer() {
-    const names = this._discoveredHosts
-      ? [...new Set([...this._discoveredHosts.values()].map(remoteBuildPeerName))]
-      : [];
-    // Cap the named list so a busy network can't push the switch off-screen.
-    const shown = names.slice(0, 3);
-    const extra = names.length - shown.length;
-    const joined = new Intl.ListFormat(activeLocale(), {
-      type: extra > 0 ? "unit" : "conjunction",
-    }).format(shown);
-    const foundLabel =
-      extra > 0
-        ? this._localize("onboarding.wizard.existing_server.found_overflow", {
-            name: joined,
-            count: extra,
-          })
-        : this._localize("onboarding.wizard.existing_server.found", { name: joined });
+    const foundLabel = this._localizeDiscoveredHosts(
+      "onboarding.wizard.existing_server.found",
+      "onboarding.wizard.existing_server.found_overflow"
+    );
     return html`
       <div class="existing-server">
         <wa-icon library="mdi" name="server-network" class="tour-offer-icon"></wa-icon>
-        ${names.length ? html`<p class="tour-ready">${foundLabel}</p>` : nothing}
+        ${foundLabel ? html`<p class="tour-ready">${foundLabel}</p>` : nothing}
         <p class="intro">${this._localize("onboarding.wizard.existing_server.intro")}</p>
         <label class="remote-toggle">
           <span class="remote-toggle-text">
@@ -609,7 +621,10 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     const remoteBuilder = this._usage === "remote_builder";
     try {
       await this._api.updatePreferences({
-        experience_level: this._experience,
+        // The remote-builder path ends before the experience screen, so
+        // persisting the default would silently downgrade a returning
+        // EXPERT/ADVANCED user on an onboarding re-run.
+        ...(remoteBuilder ? {} : { experience_level: this._experience }),
         remote_compute_only: remoteBuilder || this._remoteCompute,
         // Only the desktop usage question decides this: a remote builder
         // hides the Device builder entirely (the dashboard shows just the

--- a/src/components/onboarding/wizard-screens.ts
+++ b/src/components/onboarding/wizard-screens.ts
@@ -9,7 +9,8 @@ export type UsageChoice = "standalone" | "remote_builder";
 /**
  * The ordered onboarding-wizard screens for the current environment.
  *
- * Welcome and experience are always mandatory. On the desktop app a usage
+ * Welcome is always mandatory; experience is too except on the remote-builder
+ * exit below. On the desktop app a usage
  * question comes right after Welcome: picking "standalone" continues the
  * normal flow, while "remote builder" ends the wizard there — the app
  * switches to remote-build mode and its own pairing onboarding takes over,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1066,7 +1066,8 @@
       "experience": {
         "title": "Choose your experience",
         "intro": "You can change this any time in Settings.",
-        "existing_notice": "We have detected an existing instance of ESPHome Device Builder on your network.",
+        "existing_notice": "We have detected an existing instance of ESPHome Device Builder on your network: {name}.",
+        "existing_notice_overflow": "We have detected existing instances of ESPHome Device Builder on your network: {name}, and {count} more.",
         "existing_notice_link": "Would you like to change to remote build mode?",
         "beginner_title": "New to ESPHome",
         "beginner_desc": "Start with a simple, guided interface.",

--- a/test/components/onboarding/onboarding-existing-server.test.ts
+++ b/test/components/onboarding/onboarding-existing-server.test.ts
@@ -7,6 +7,7 @@ vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}));
 
+import { ExperienceLevel } from "../../../src/api/types/system.js";
 import type { LocalizeFunc } from "../../../src/common/localize.js";
 import { ESPHomeOnboardingWizardDialog } from "../../../src/components/onboarding/onboarding-wizard-dialog.js";
 
@@ -119,7 +120,10 @@ describe("onboarding existing-server orientation", () => {
 
     expect(state._screen).toBe("tour");
     expect(state._api.updatePreferences).toHaveBeenCalledWith(
-      expect.objectContaining({ remote_compute_only: true })
+      expect.objectContaining({
+        experience_level: ExperienceLevel.BEGINNER,
+        remote_compute_only: true,
+      })
     );
   });
 

--- a/test/components/onboarding/onboarding-usage.test.ts
+++ b/test/components/onboarding/onboarding-usage.test.ts
@@ -7,6 +7,7 @@ vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}));
 
+import { ExperienceLevel } from "../../../src/api/types/system.js";
 import type { LocalizeFunc } from "../../../src/common/localize.js";
 import {
   DESKTOP_ONBOARDING_PARAM,
@@ -121,6 +122,7 @@ describe("desktop usage question", () => {
     expect(state._screens).not.toContain("existing_server");
     expect(state._api.updatePreferences).toHaveBeenCalledWith(
       expect.objectContaining({
+        experience_level: ExperienceLevel.BEGINNER,
         remote_compute_only: false,
         hide_device_builder: false,
       })
@@ -140,6 +142,10 @@ describe("desktop usage question", () => {
         hide_device_builder: true,
       })
     );
+    // The experience screen was never shown, so the default must not
+    // overwrite a returning user's stored level.
+    const prefs = state._api.updatePreferences.mock.calls[0][0];
+    expect("experience_level" in prefs).toBe(false);
     expect(state._api.markOnboardingAcknowledged).toHaveBeenCalledOnce();
     expect(state._open).toBe(false);
   });
@@ -171,6 +177,21 @@ describe("desktop usage question", () => {
 
     expect(state._screen).toBe("experience");
     expect(wizard.shadowRoot?.querySelector(".existing-notice")).not.toBeNull();
+  });
+
+  it("names the detected install in the banner", async () => {
+    const { wizard, state } = openDesktopWizard();
+    document.body.appendChild(wizard);
+    state._localize = ((key, params) =>
+      params ? `${key} ${Object.values(params).join(" ")}` : key) as LocalizeFunc;
+    state._discoveredHosts = hosts("living-room");
+    await state._onContinue(); // welcome -> usage
+    state._usage = "standalone";
+    await state._onContinue(); // usage -> experience
+    await wizard.updateComplete;
+
+    const notice = wizard.shadowRoot?.querySelector(".existing-notice");
+    expect(notice?.textContent).toContain("living-room");
   });
 
   it("returns to the usage screen with remote preselected via the banner link", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Completing onboarding on the desktop remote builder path persisted `experience_level: BEGINNER` even though the experience screen was never shown; `open()` resets the field and `_persistChoices` always sent it, so re running onboarding to switch into remote build mode silently downgraded a returning EXPERT user out of expert mode. The field is now omitted on that path, the same gate shape `hide_device_builder` already uses; the standalone and non desktop flows keep sending the chosen level. Verified in the live editor: with a stored `expert` level, completing the remote builder path wrote `remote_compute_only` and `hide_device_builder` and left the level untouched.

This also sweeps the other unaddressed review threads from #1337: the standalone warning banner now names the discovered install(s), reusing the existing_server screen's name formatting through one hoisted helper (unique names, cap of three, overflow count); the `wizard-screens.ts` docstring no longer claims experience is always mandatory; and the `_screens` freeze guard comment now says why index 1 is correct, the step only exists in the non desktop flow where experience sits at index 1 (verified, no logic change needed).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1390

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
