### PR TITLE
Show a neutral Disabled badge with a turn-on action while remote build is off

### DIFF
--- a/src/components/settings-dialog/build-server-section.ts
+++ b/src/components/settings-dialog/build-server-section.ts
@@ -346,11 +346,10 @@ export class ESPHomeSettingsBuildServer extends LitElement {
   private _renderListenerBadge(listenerBound: boolean) {
     if (!this._remoteBuildEnabled) {
       return html`
-        <span
-          class="build-server-listener-badge build-server-listener-disabled"
-          role="status"
-        >
-          ${this._localize("settings.remote_build_listener_disabled")}
+        <span class="build-server-listener-badge build-server-listener-disabled">
+          <span role="status">
+            ${this._localize("settings.remote_build_listener_disabled")}
+          </span>
           <button
             class="link-button"
             type="button"

--- a/src/components/settings-dialog/build-server-section.ts
+++ b/src/components/settings-dialog/build-server-section.ts
@@ -22,6 +22,7 @@ import {
   remoteBuildCleanupTtlContext,
   remoteBuildEnabledContext,
 } from "../../context/index.js";
+import { linkButtonStyles } from "../../styles/link-button.js";
 import { pairingAddressStyles } from "../../styles/pairing-address.js";
 import { peerRowStyles } from "../../styles/peer-rows.js";
 import { pinHexStyles } from "../../styles/pin-hex.js";
@@ -101,6 +102,7 @@ export class ESPHomeSettingsBuildServer extends LitElement {
     peerRowStyles,
     buildServerCardStyles,
     cleanupTtlStyles,
+    linkButtonStyles,
   ];
 
   protected updated(changed: Map<string, unknown>) {
@@ -282,18 +284,7 @@ export class ESPHomeSettingsBuildServer extends LitElement {
           <button class="build-server-copy" type="button" @click=${this._onCopyPin}>
             ${this._localize("settings.remote_build_pin_copy")}
           </button>
-          <span
-            class=${`build-server-listener-badge build-server-listener-${
-              identity.listener_bound ? "up" : "down"
-            }`}
-            role="status"
-          >
-            ${
-              identity.listener_bound
-                ? this._localize("settings.remote_build_listener_up")
-                : this._localize("settings.remote_build_listener_down")
-            }
-          </span>
+          ${this._renderListenerBadge(identity.listener_bound)}
         </div>
         <div class="build-server-row">
           <span class="build-server-label">
@@ -346,6 +337,39 @@ export class ESPHomeSettingsBuildServer extends LitElement {
         confirm-label=${this._localize("settings.remote_build_rotate_confirm_confirm")}
         @confirm=${this._onRotateConfirm}
       ></esphome-confirm-dialog>
+    `;
+  }
+
+  // Disabled is intentional state, not a fault: it reads neutral with a
+  // direct turn-on action, so the red "offline" only ever means an enabled
+  // listener that failed to bind.
+  private _renderListenerBadge(listenerBound: boolean) {
+    if (!this._remoteBuildEnabled) {
+      return html`
+        <span
+          class="build-server-listener-badge build-server-listener-disabled"
+          role="status"
+        >
+          ${this._localize("settings.remote_build_listener_disabled")}
+          <button class="link-button" type="button" @click=${this._onToggleEnabled}>
+            ${this._localize("settings.remote_build_listener_turn_on")}
+          </button>
+        </span>
+      `;
+    }
+    return html`
+      <span
+        class=${`build-server-listener-badge build-server-listener-${
+          listenerBound ? "up" : "down"
+        }`}
+        role="status"
+      >
+        ${
+          listenerBound
+            ? this._localize("settings.remote_build_listener_up")
+            : this._localize("settings.remote_build_listener_down")
+        }
+      </span>
     `;
   }
 
@@ -428,7 +452,9 @@ export class ESPHomeSettingsBuildServer extends LitElement {
     this._rotateInFlight = true;
     try {
       this._identityCtrl.set(await this._api.rotateRemoteBuildIdentity());
-      if (this._identityCtrl.identity?.listener_bound) {
+      // An unbound listener is expected while remote build is disabled;
+      // only warn when it should have been up.
+      if (this._identityCtrl.identity?.listener_bound || !this._remoteBuildEnabled) {
         this._toast("success", "settings.remote_build_rotate_success");
       } else {
         this._toast("warning", "settings.remote_build_rotate_listener_down");

--- a/src/components/settings-dialog/build-server-section.ts
+++ b/src/components/settings-dialog/build-server-section.ts
@@ -351,7 +351,12 @@ export class ESPHomeSettingsBuildServer extends LitElement {
           role="status"
         >
           ${this._localize("settings.remote_build_listener_disabled")}
-          <button class="link-button" type="button" @click=${this._onToggleEnabled}>
+          <button
+            class="link-button"
+            type="button"
+            aria-label=${this._localize("settings.remote_build_listener_turn_on_aria")}
+            @click=${this._onToggleEnabled}
+          >
             ${this._localize("settings.remote_build_listener_turn_on")}
           </button>
         </span>

--- a/src/components/settings-dialog/build-server-styles.ts
+++ b/src/components/settings-dialog/build-server-styles.ts
@@ -116,6 +116,12 @@ export const buildServerCardStyles = css`
     background: var(--wa-color-warning-quiet, #fff3cd);
     color: var(--wa-color-warning-on-quiet, #8a6d3b);
   }
+
+  .build-server-listener-disabled {
+    gap: var(--wa-space-2xs);
+    background: color-mix(in srgb, var(--wa-color-neutral-500, #6b7280), transparent 80%);
+    color: var(--wa-color-neutral-500, #6b7280);
+  }
 `;
 
 export const cleanupTtlStyles = css`

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1506,6 +1506,8 @@
     "remote_build_esphome_version_label": "ESPHome version",
     "remote_build_listener_up": "Listener active",
     "remote_build_listener_down": "Listener offline",
+    "remote_build_listener_disabled": "Disabled",
+    "remote_build_listener_turn_on": "Turn on",
     "remote_build_identity_loading": "Loading identity…",
     "remote_build_identity_load_failed": "Could not load this dashboard's identity. Please reopen Settings to retry.",
     "remote_build_rotate": "Rotate identity",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1508,6 +1508,7 @@
     "remote_build_listener_down": "Listener offline",
     "remote_build_listener_disabled": "Disabled",
     "remote_build_listener_turn_on": "Turn on",
+    "remote_build_listener_turn_on_aria": "Turn on remote build",
     "remote_build_identity_loading": "Loading identity…",
     "remote_build_identity_load_failed": "Could not load this dashboard's identity. Please reopen Settings to retry.",
     "remote_build_rotate": "Rotate identity",

--- a/test/components/settings-dialog/build-server-listener-badge.test.ts
+++ b/test/components/settings-dialog/build-server-listener-badge.test.ts
@@ -84,6 +84,10 @@ describe("build-server listener badge", () => {
     expect(badge(el)!.textContent).toContain("settings.remote_build_listener_disabled");
     expect(badge(el)!.textContent).not.toContain("settings.remote_build_listener_down");
     expect(turnOn(el)).not.toBeNull();
+    // The turn-on action must sit outside the live region.
+    const status = badge(el)!.querySelector('[role="status"]')!;
+    expect(status).not.toBeNull();
+    expect(status.querySelector("button")).toBeNull();
   });
 
   it("fires set-remote-build-enabled(true) from the turn-on action", async () => {

--- a/test/components/settings-dialog/build-server-listener-badge.test.ts
+++ b/test/components/settings-dialog/build-server-listener-badge.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The build-server card's listener badge is three-state: a disabled listener
+ * is intentional and reads neutral with an inline turn-on action, so the red
+ * "Listener offline" only ever means an enabled listener that failed to bind.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+// wa-dialog registers form-associated internals happy-dom can't run.
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+
+import { ESPHomeSettingsBuildServer } from "../../../src/components/settings-dialog/build-server-section.js";
+import type { IdentityView } from "../../../src/api/types/remote-build.js";
+
+const IDENTITY: IdentityView = {
+  dashboard_id: "dash-1234",
+  pin_sha256: "ab".repeat(32),
+  server_version: "1.6.9",
+  esphome_version: "2026.7.1",
+  listener_bound: false,
+  listener_host: null,
+  listener_addresses: [],
+  listener_port: null,
+};
+
+async function mount(
+  enabled: boolean,
+  listenerBound: boolean
+): Promise<ESPHomeSettingsBuildServer> {
+  const el = new ESPHomeSettingsBuildServer();
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  (el as any)._remoteBuildEnabled = enabled;
+  (el as any)._api = {
+    getRemoteBuildIdentity: async () => ({
+      ...IDENTITY,
+      listener_bound: listenerBound,
+    }),
+  };
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  document.body.appendChild(el);
+  await el.updateComplete;
+  // The identity controller loads async; flush it and the re-render.
+  await Promise.resolve();
+  await Promise.resolve();
+  await el.updateComplete;
+  return el;
+}
+
+const badge = (el: ESPHomeSettingsBuildServer) =>
+  el.shadowRoot!.querySelector<HTMLSpanElement>(".build-server-listener-badge");
+const turnOn = (el: ESPHomeSettingsBuildServer) =>
+  el.shadowRoot!.querySelector<HTMLButtonElement>(
+    ".build-server-listener-badge .link-button"
+  );
+
+describe("build-server listener badge", () => {
+  it("shows the active badge when enabled and bound", async () => {
+    const el = await mount(true, true);
+    expect(badge(el)!.classList.contains("build-server-listener-up")).toBe(true);
+    expect(badge(el)!.textContent).toContain("settings.remote_build_listener_up");
+    expect(turnOn(el)).toBeNull();
+  });
+
+  it("shows the offline badge when enabled but not bound", async () => {
+    const el = await mount(true, false);
+    expect(badge(el)!.classList.contains("build-server-listener-down")).toBe(true);
+    expect(badge(el)!.textContent).toContain("settings.remote_build_listener_down");
+    expect(turnOn(el)).toBeNull();
+  });
+
+  it("shows a neutral disabled badge with a turn-on action when disabled", async () => {
+    const el = await mount(false, false);
+    expect(badge(el)!.classList.contains("build-server-listener-disabled")).toBe(true);
+    expect(badge(el)!.textContent).toContain("settings.remote_build_listener_disabled");
+    expect(badge(el)!.textContent).not.toContain("settings.remote_build_listener_down");
+    expect(turnOn(el)).not.toBeNull();
+  });
+
+  it("fires set-remote-build-enabled(true) from the turn-on action", async () => {
+    const el = await mount(false, false);
+    const listener = vi.fn();
+    el.addEventListener("set-remote-build-enabled", listener as EventListener);
+
+    turnOn(el)!.click();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect((listener.mock.calls[0][0] as CustomEvent<boolean>).detail).toBe(true);
+  });
+});

--- a/test/components/settings-dialog/build-server-listener-badge.test.ts
+++ b/test/components/settings-dialog/build-server-listener-badge.test.ts
@@ -10,9 +10,17 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 // wa-dialog registers form-associated internals happy-dom can't run.
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("../../../src/util/notify.js", () => ({
+  notify: {
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+  },
+}));
 
 import { ESPHomeSettingsBuildServer } from "../../../src/components/settings-dialog/build-server-section.js";
 import type { IdentityView } from "../../../src/api/types/remote-build.js";
+import { notify } from "../../../src/util/notify.js";
 
 const IDENTITY: IdentityView = {
   dashboard_id: "dash-1234",
@@ -87,5 +95,39 @@ describe("build-server listener badge", () => {
 
     expect(listener).toHaveBeenCalledTimes(1);
     expect((listener.mock.calls[0][0] as CustomEvent<boolean>).detail).toBe(true);
+  });
+
+  it("rotate while disabled reports success, not a listener-down warning", async () => {
+    const el = await mount(false, false);
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    (el as any)._api.rotateRemoteBuildIdentity = async () => ({
+      ...IDENTITY,
+      listener_bound: false,
+    });
+    vi.mocked(notify.success).mockClear();
+    vi.mocked(notify.warning).mockClear();
+
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    await (el as any)._onRotateConfirm();
+
+    expect(notify.success).toHaveBeenCalledTimes(1);
+    expect(notify.warning).not.toHaveBeenCalled();
+  });
+
+  it("rotate while enabled but unbound still warns", async () => {
+    const el = await mount(true, false);
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    (el as any)._api.rotateRemoteBuildIdentity = async () => ({
+      ...IDENTITY,
+      listener_bound: false,
+    });
+    vi.mocked(notify.success).mockClear();
+    vi.mocked(notify.warning).mockClear();
+
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    await (el as any)._onRotateConfirm();
+
+    expect(notify.warning).toHaveBeenCalledTimes(1);
+    expect(notify.success).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The build server card showed the red "Listener offline" badge whenever the listener was not bound, including when the operator simply has remote build switched off. A deliberately disabled listener reading as a fault is what sent the reporter of esphome/device-builder#2280 chasing mDNS captures instead of flipping the toggle at the top of the same section. The badge is now three state: disabled renders a neutral "Disabled" badge with an inline "Turn on" action that fires the existing enable event (the identity refetch on save already flips the badge to green once the listener binds), and the red "Listener offline" now only ever means an enabled listener that failed to bind. Rotating the identity while disabled no longer warns about the listener being down, since that is the expected state.

Verified live against a dev backend: active badge, toggle off shows Disabled with Turn on, clicking it re enables and the badge returns to Listener active.

**Related issue or feature (if applicable):**

- follow-up to esphome/device-builder#2280

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
