### PR TITLE
Resync the hostname input after a one-step clear

### DIFF
--- a/src/components/shared/device-name-field.ts
+++ b/src/components/shared/device-name-field.ts
@@ -1,4 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
+import { live } from "lit/directives/live.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import {
   getDeviceNameWarning,
@@ -56,7 +57,7 @@ export function renderDeviceNameField(o: DeviceNameFieldOptions): TemplateResult
         type="text"
         ?autofocus=${o.autofocus ?? true}
         class=${err ? "invalid" : ""}
-        .value=${o.value}
+        .value=${live(o.value)}
         placeholder=${o.placeholder ?? nothing}
         @input=${(e: Event) => o.onInput((e.target as HTMLInputElement).value)}
       />

--- a/src/components/shared/device-name-inputs.ts
+++ b/src/components/shared/device-name-inputs.ts
@@ -272,6 +272,10 @@ export class ESPHomeDeviceNameInputs extends LitElement {
                 // once the edit clears the error that force-opened it, or
                 // the field unmounts mid-keystroke.
                 this._open = true;
+                // Select-all + delete restores a value identical to the last
+                // committed one, so no @state changes; force a render so the
+                // live() binding can resync the visually emptied DOM input.
+                this.requestUpdate();
                 this._notify();
               },
               id: "device-hostname",

--- a/test/components/shared/device-name-inputs.test.ts
+++ b/test/components/shared/device-name-inputs.test.ts
@@ -84,6 +84,21 @@ describe("device-name-inputs derivation", () => {
     expect(el.friendlyName).toBe("Dining Room AC 2");
   });
 
+  it("a one-step select-all clear resyncs the DOM input with the restored value", async () => {
+    // Clearing an un-edited override restores a value identical to the last
+    // committed one: no state changes, and a plain .value binding would be
+    // dirty-checked away, leaving the field visually empty while the
+    // component reports the derived hostname.
+    const el = await mountInputs();
+    await typeFriendly(el, "Office Fan");
+    const input = await hostnameInput(el);
+    input.value = "";
+    input.dispatchEvent(new Event("input"));
+    await el.updateComplete;
+    expect(el.hostname).toBe("office-fan");
+    expect(input.value).toBe("office-fan");
+  });
+
   it("clearing the hostname restores the derived value immediately", async () => {
     const el = await mountInputs();
     await typeFriendly(el, "Office Fan");


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #1411, closing the late review finding there: select-all + delete on an **un-edited** hostname override left the field visually empty while the component still reported (and would submit) the derived value.

The sequence defeats both layers of Lit's rendering: restoring the derived hostname produces a value identical to the last committed one, so no `@state` changes and no render is scheduled — and even when one is, a plain `.value` binding dirty-checks against the last committed value and skips the DOM write, leaving the browser's cleared input as-is.

Two-part fix:

- `renderDeviceNameField` binds `.value=${live(o.value)}` so renders compare against the live DOM value instead of the last committed one — the canonical controlled-input use of `live()`. The rename dialog (the other consumer) gets the same robustness.
- The hostname input handler calls `requestUpdate()` explicitly, since the restore-to-identical-value path schedules no render on its own for `live()` to act in.

Test pins the exact repro: derive `office-fan`, clear the field in one step, and assert both the component state **and the DOM input** read `office-fan`.

**Related issue or feature (if applicable):**

- late review finding on #1411 (merged): https://github.com/esphome/device-builder-frontend/pull/1411#issuecomment-5065242968

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
