### PR TITLE
Freeze collision checks while the create is in flight

### DIFF
--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -27,6 +27,11 @@ import "@home-assistant/webawesome/dist/components/checkbox/checkbox.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 import "../shared/device-name-inputs.js";
 
+// While createDevice is in flight the devices push announcing the new device
+// arrives before the dialog closes; checking against it would flash a
+// collides-with-itself error on the name being created.
+const _EMPTY_TAKEN: ReadonlySet<string> = new Set();
+
 @customElement("esphome-wizard-step-setup")
 export class ESPHomeWizardStepSetup extends LitElement {
   @consume({ context: localizeContext, subscribe: true })
@@ -461,7 +466,7 @@ export class ESPHomeWizardStepSetup extends LitElement {
                   })
                 : ""
             }
-            .takenHostnames=${this.takenHostnames}
+            .takenHostnames=${this.submitting ? _EMPTY_TAKEN : this.takenHostnames}
             @device-name-changed=${() => this.requestUpdate()}
           ></esphome-device-name-inputs>
         </div>

--- a/test/components/wizard/wizard-step-setup.test.ts
+++ b/test/components/wizard/wizard-step-setup.test.ts
@@ -293,6 +293,20 @@ describe("wizard-step-setup", () => {
     expect(inputs.hostname).toBe("kitchen-plug");
   });
 
+  it("ignores the just-created device's push while submitting", async () => {
+    // createDevice's success push announces the new device before the
+    // dialog closes; flagging it would flash a self-collision error.
+    const el = await mount(noWifiBoard());
+    await setName(el, "Kitchen Plug");
+    el.submitting = true;
+    el.takenHostnames = new Set(["kitchen-plug"]);
+    await el.updateComplete;
+    const inputs = await deviceNameInputsOf(el);
+    await inputs.updateComplete;
+    expect(inputs.validity.err).toBeNull();
+    expect(inputs.canSubmit).toBe(true);
+  });
+
   it("a collision push on the Wi-Fi stage blocks Finish", async () => {
     // The name was valid when the user advanced; a devices push landing
     // afterwards must still gate the finish button.


### PR DESCRIPTION
# What does this implement/fix?

Follow-up visual fix to #1411: submitting the create wizard flashed a red self-collision error on the hostname field for a moment before the dialog closed.

`createDevice`'s success is announced by a devices push that lands while the dialog is still open, so the live collision check (added in #1411) briefly flagged the name being created as "already exists". The setup step now passes an empty taken-hostnames set to the name inputs while `submitting` is true, so the in-flight create can't collide with itself; the real set returns if the create fails and the dialog stays open.

Test pins it: with `submitting` set, a push containing the device's own slug produces no error and leaves `canSubmit` true.

**Related issue or feature (if applicable):**

- visual regression from the live collision detection in #1411, observed on first real device create

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
