### PR TITLE
Lock the GPIO select on board-preconfigured pins

### DIFF
--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -298,6 +298,7 @@ export class ESPHomeAddComponentForm extends LitElement {
           .errors=${this._errors}
           .board=${this.board}
           .yaml=${this.yaml}
+          .sectionKey=${this._sectionKey}
           .presentComponents=${presentComponents}
           ?disabled=${disabled}
           ?required-only=${true}
@@ -475,11 +476,15 @@ export class ESPHomeAddComponentForm extends LitElement {
     if (this._localBlockMessage) this._localBlockMessage = "";
   }
 
+  /** Section key the block resolves to — featured ids are synthetic
+   *  (``featured.<board>.<local>``); the underlying component id keys the
+   *  committed YAML and scopes the board's featured designations. */
+  private get _sectionKey(): string {
+    return resolveFeaturedComponentId(this.component.id, this.board);
+  }
+
   private _generateYamlPreview(): string {
-    // Featured ids are synthetic (`featured.<board>.<local>`); preview the
-    // underlying component the block resolves to, matching the committed YAML.
-    const key = resolveFeaturedComponentId(this.component.id, this.board);
-    const lines: string[] = [`${key}:`];
+    const lines: string[] = [`${this._sectionKey}:`];
     lines.push(...serializeYamlValues(this._values, "  "));
     return lines.join("\n");
   }

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -243,9 +243,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
    *  against the parent component's domain — without it a
    *  binary_sensor's filter picker offers sensor-only filters
    *  and a non-addressable light's effects picker offers
-   *  addressable-only effects. Empty when the form is mounted
-   *  outside a section context (the add-component dialog's
-   *  preview, etc.). */
+   *  addressable-only effects. The add-component dialog passes the
+   *  resolved component id so board featured-component designations
+   *  (pin guard) apply there too; empty only outside any section
+   *  context. */
   @property({ attribute: "section-key" })
   sectionKey = "";
 

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -75,6 +75,7 @@ import "@home-assistant/webawesome/dist/components/radio-group/radio-group.js";
 import "@home-assistant/webawesome/dist/components/radio/radio.js";
 import "@home-assistant/webawesome/dist/components/select/select.js";
 import "@home-assistant/webawesome/dist/components/switch/switch.js";
+import "@home-assistant/webawesome/dist/components/tooltip/tooltip.js";
 import "../mdi-icon-picker.js";
 import "../options-combobox.js";
 import { buildFormRenderPlan } from "./config-entry-form-plan.js";

--- a/src/components/device/pin/renderer.ts
+++ b/src/components/device/pin/renderer.ts
@@ -30,6 +30,7 @@ import {
   renderLabel,
   renderStringField,
   renderSubstitutionHint,
+  type LockedReasonCarrier,
   type RenderCtx,
 } from "../config-entry-renderers-shared.js";
 
@@ -439,6 +440,18 @@ export function renderPinField(
   // active option is already forced into ``visible`` above, so the disabled
   // head still shows the real pin instead of blanking.
   const guarded = boardPresetPin && !fieldDisabled;
+  // Hovering a disabled control shows not-allowed but no native title
+  // tooltip, so the guard's hint rides the label's lock icon (the same
+  // chrome a hard lock gets, retargeted at the YAML editor) plus a
+  // wa-tooltip hung off the select.
+  const labelEntry: ConfigEntry = guarded
+    ? ({
+        ...entry,
+        locked: true,
+        locked_reason_key: "device.pin_wiring_guard_tooltip",
+      } as ConfigEntry & LockedReasonCarrier)
+    : entry;
+  const guardTipId = `pin-guard-tip-${path.join(".")}`;
   const isLongForm = isPlainObject(rawValue);
 
   // Pin-select onChange routes to ``path.number`` when the field is
@@ -459,7 +472,7 @@ export function renderPinField(
 
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(entry, ctx)}
+      ${renderLabel(labelEntry, ctx)}
       <!-- Keyed as the long form's number so the YAML cursor lands on the
            select itself (the whole-field fallback centers mid-panel once
            the wiring disclosure is open). Short form keeps the bare path:
@@ -468,14 +481,21 @@ export function renderPinField(
       <wa-select
         data-no-value-sync
         data-field-key=${fieldKeyAttr(isLongForm ? [...path, "number"] : path)}
+        id=${guarded ? guardTipId : nothing}
         class=${invalid ? "invalid" : ""}
         placeholder=${defaultPlaceholder}
         ?disabled=${fieldDisabled || guarded}
-        title=${guarded ? ctx.localize("device.pin_wiring_guard_tooltip") : nothing}
         @change=${onPinChange}
       >
         ${renderPinOptions(visible, entry, usedPins, ownLockedGpios, value, ctx)}
       </wa-select>
+      ${
+        guarded
+          ? html`<wa-tooltip for=${guardTipId}>
+              ${ctx.localize("device.pin_wiring_guard_tooltip")}
+            </wa-tooltip>`
+          : nothing
+      }
       ${renderFieldError(path, ctx)}
       ${renderPinWiring({
         entry,

--- a/src/components/device/pin/renderer.ts
+++ b/src/components/device/pin/renderer.ts
@@ -434,8 +434,8 @@ export function renderPinField(
     ownLockedGpios.add(valueGpio);
   }
   const fieldDisabled = effectiveDisabled(entry, ctx);
-  // A board-preset pin's GPIO is the board's wiring, not the user's: lock
-  // the select in lockstep with the wiring panel's guard (wiring.ts). The
+  // A board-preset pin's GPIO is the board's wiring, not the user's: the
+  // same guard that view-onlys the wiring panel locks the select. The
   // active option is already forced into ``visible`` above, so the disabled
   // head still shows the real pin instead of blanking.
   const guarded = boardPresetPin && !fieldDisabled;
@@ -483,7 +483,7 @@ export function renderPinField(
         ctx,
         rawValue,
         boardPin,
-        boardPreset: boardPresetPin,
+        guarded,
       })}
     </div>
   `;
@@ -524,6 +524,7 @@ function renderSubstitutionPin(
         (entry.suggestions ?? []).some((s) => boardGpioOf(s, pins) === resolved)
       : designationMatches(boardPins.tokens, resolved) ||
         (entry.suggestions ?? []).some((s) => s === resolved));
+  const guarded = boardPreset && !fieldDisabled;
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
@@ -544,7 +545,7 @@ function renderSubstitutionPin(
         ctx,
         rawValue,
         boardPin: null,
-        boardPreset,
+        guarded,
       })}
     </div>
   `;
@@ -565,6 +566,7 @@ function renderExpanderPin(
   boardPreset: boolean
 ): TemplateResult {
   const [provider, hub, channel] = identity.split(":");
+  const guarded = boardPreset && !effectiveDisabled(entry, ctx);
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
@@ -580,7 +582,7 @@ function renderExpanderPin(
         ctx,
         rawValue,
         boardPin: null,
-        boardPreset,
+        guarded,
       })}
     </div>
   `;

--- a/src/components/device/pin/renderer.ts
+++ b/src/components/device/pin/renderer.ts
@@ -548,6 +548,10 @@ function renderSubstitutionPin(
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
+      <!-- Deliberately not guard-locked: no manifest designates a pin via a
+           substitution, so a \${var} landing on one is the user's own
+           hand-authored setup, and this input edits the reference name, not
+           the wiring the panel below guards. -->
       <input
         type="text"
         autocomplete="off"

--- a/src/components/device/pin/renderer.ts
+++ b/src/components/device/pin/renderer.ts
@@ -434,6 +434,11 @@ export function renderPinField(
     ownLockedGpios.add(valueGpio);
   }
   const fieldDisabled = effectiveDisabled(entry, ctx);
+  // A board-preset pin's GPIO is the board's wiring, not the user's: lock
+  // the select in lockstep with the wiring panel's guard (wiring.ts). The
+  // active option is already forced into ``visible`` above, so the disabled
+  // head still shows the real pin instead of blanking.
+  const guarded = boardPresetPin && !fieldDisabled;
   const isLongForm = isPlainObject(rawValue);
 
   // Pin-select onChange routes to ``path.number`` when the field is
@@ -465,7 +470,8 @@ export function renderPinField(
         data-field-key=${fieldKeyAttr(isLongForm ? [...path, "number"] : path)}
         class=${invalid ? "invalid" : ""}
         placeholder=${defaultPlaceholder}
-        ?disabled=${fieldDisabled}
+        ?disabled=${fieldDisabled || guarded}
+        title=${guarded ? ctx.localize("device.pin_wiring_guard_tooltip") : nothing}
         @change=${onPinChange}
       >
         ${renderPinOptions(visible, entry, usedPins, ownLockedGpios, value, ctx)}

--- a/src/components/device/pin/wiring.ts
+++ b/src/components/device/pin/wiring.ts
@@ -51,9 +51,11 @@ export interface PinWiringOptions {
   ctx: RenderCtx;
   rawValue: unknown;
   boardPin: BoardPin | null;
-  /** The pin sits on a GPIO the board locks to this section — the wiring
-   *  is the board's, shown read-only; changes go through the YAML. */
-  boardPreset: boolean;
+  /** The pin sits on a board designation for this section and isn't
+   *  hard-locked — the wiring is the board's, shown read-only; changes
+   *  go through the YAML. Computed by the caller so the picker's select
+   *  locks in lockstep with this panel. */
+  guarded: boolean;
 }
 
 /**
@@ -77,7 +79,7 @@ export interface PinWiringOptions {
  * bus pins (uart/i2c/adc) and pre-#430 catalogs keep the plain picker.
  */
 export function renderPinWiring(opts: PinWiringOptions): TemplateResult | typeof nothing {
-  const { entry, path, ctx, rawValue, boardPin, boardPreset } = opts;
+  const { entry, path, ctx, rawValue, boardPin, guarded } = opts;
   const isLongForm = isPlainObject(rawValue);
   const fieldDisabled = effectiveDisabled(entry, ctx);
   // The wiring fields (mode + inverted) are not an advanced nicety:
@@ -129,11 +131,6 @@ export function renderPinWiring(opts: PinWiringOptions): TemplateResult | typeof
       ? presetsForPinMode(entry.pin_mode)
       : [];
   const usePresets = presets.length > 0;
-
-  // A board-preset pin carries the board's known-good wiring; the panel
-  // is view-only and the guard row points at the YAML editor for the
-  // rare deliberate change.
-  const guarded = boardPreset && !fieldDisabled;
 
   let state: WiringState = { kind: "default" };
   let labelText: string | undefined;

--- a/test/components/device/add-component-form-section-key.test.ts
+++ b/test/components/device/add-component-form-section-key.test.ts
@@ -9,23 +9,23 @@ import { describe, expect, it } from "vitest";
 import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
 import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+import { buildFeaturedId } from "../../../src/util/featured-id.js";
 import { identityLocalize } from "../../_dom.js";
 import {
   extractAttributeBindings,
   findTemplatesByAnchor,
 } from "../../_lit-template-walker.js";
+import { makeComponentEntry } from "../../util/_make-component-entry.js";
+import { makeTestBoard } from "./_renderer-fixtures.js";
 
-function makeComponent(id: string): ComponentCatalogEntry {
-  return { id, description: "", config_entries: [] } as unknown as ComponentCatalogEntry;
-}
-
-const BOARD = {
-  id: "apollo-esk-1",
-  esphome: { platform: "esp32", board: "esp32dev" },
-  featured_components: [
-    { id: "rgb_leds", component_id: "light.esp32_rmt_led_strip", fields: {} },
-  ],
-} as unknown as BoardCatalogEntry;
+const BOARD = makeTestBoard({
+  overrides: {
+    id: "apollo-esk-1",
+    featured_components: [
+      { id: "rgb_leds", component_id: "light.esp32_rmt_led_strip", fields: {} },
+    ],
+  } as never,
+});
 
 function renderedSectionKey(
   component: ComponentCatalogEntry,
@@ -48,11 +48,16 @@ function renderedSectionKey(
 describe("add-component-form section key", () => {
   it("resolves a featured id to the component it adds", () => {
     expect(
-      renderedSectionKey(makeComponent("featured.apollo-esk-1.rgb_leds"), BOARD)
+      renderedSectionKey(
+        makeComponentEntry(buildFeaturedId("apollo-esk-1", "rgb_leds")),
+        BOARD
+      )
     ).toBe("light.esp32_rmt_led_strip");
   });
 
   it("passes a plain catalog id through", () => {
-    expect(renderedSectionKey(makeComponent("sensor.ags10"), BOARD)).toBe("sensor.ags10");
+    expect(renderedSectionKey(makeComponentEntry("sensor.ags10"), BOARD)).toBe(
+      "sensor.ags10"
+    );
   });
 });

--- a/test/components/device/add-component-form-section-key.test.ts
+++ b/test/components/device/add-component-form-section-key.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The add form threads the resolved section key into the shared form so
+ * board featured-component pin designations guard there like the editor.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
+import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
+import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+import { identityLocalize } from "../../_dom.js";
+import {
+  extractAttributeBindings,
+  findTemplatesByAnchor,
+} from "../../_lit-template-walker.js";
+
+function makeComponent(id: string): ComponentCatalogEntry {
+  return { id, description: "", config_entries: [] } as unknown as ComponentCatalogEntry;
+}
+
+const BOARD = {
+  id: "apollo-esk-1",
+  esphome: { platform: "esp32", board: "esp32dev" },
+  featured_components: [
+    { id: "rgb_leds", component_id: "light.esp32_rmt_led_strip", fields: {} },
+  ],
+} as unknown as BoardCatalogEntry;
+
+function renderedSectionKey(
+  component: ComponentCatalogEntry,
+  board: BoardCatalogEntry | null
+): unknown {
+  const form = new ESPHomeAddComponentForm();
+  const internals = form as unknown as {
+    component: ComponentCatalogEntry;
+    board: BoardCatalogEntry | null;
+    _localize: (key: string) => string;
+    render: () => unknown;
+  };
+  internals.component = component;
+  internals.board = board;
+  internals._localize = identityLocalize;
+  const inner = findTemplatesByAnchor(internals.render(), "<esphome-config-entry-form");
+  return extractAttributeBindings(inner[0])[".sectionKey"];
+}
+
+describe("add-component-form section key", () => {
+  it("resolves a featured id to the component it adds", () => {
+    expect(
+      renderedSectionKey(makeComponent("featured.apollo-esk-1.rgb_leds"), BOARD)
+    ).toBe("light.esp32_rmt_led_strip");
+  });
+
+  it("passes a plain catalog id through", () => {
+    expect(renderedSectionKey(makeComponent("sensor.ags10"), BOARD)).toBe("sensor.ags10");
+  });
+});

--- a/test/components/device/pin/wiring.test.ts
+++ b/test/components/device/pin/wiring.test.ts
@@ -1034,10 +1034,17 @@ describe("pin wiring board-preset guard", () => {
     );
     const select = findElementBindings(result, "wa-select")[0];
     expect(select["?disabled"]).toBe(true);
-    expect(select.title).toBe("device.pin_wiring_guard_tooltip");
     // The active pin's option still renders, so the disabled head isn't blank.
     expect(
       findElementBindings(result, "wa-option").some((o) => o.value === "GPIO2")
+    ).toBe(true);
+    // A disabled control surfaces no native title tooltip, so the hint is
+    // a wa-tooltip anchored on the select plus the label's lock icon.
+    expect(findElementBindings(result, "wa-tooltip")[0]?.for).toBe(select.id);
+    expect(
+      findElementBindings(result, "wa-icon").some(
+        (i) => i.title === "device.pin_wiring_guard_tooltip"
+      )
     ).toBe(true);
   });
 
@@ -1049,7 +1056,13 @@ describe("pin wiring board-preset guard", () => {
     );
     const select = findElementBindings(result, "wa-select")[0];
     expect(select["?disabled"]).toBe(false);
-    expect(select.title).toBe(nothing);
+    expect(select.id).toBe(nothing);
+    expect(findElementBindings(result, "wa-tooltip")).toHaveLength(0);
+    expect(
+      findElementBindings(result, "wa-icon").some(
+        (i) => i.title === "device.pin_wiring_guard_tooltip"
+      )
+    ).toBe(false);
   });
 
   it("locks children of a hard-locked pin carrying wiring values", () => {

--- a/test/components/device/pin/wiring.test.ts
+++ b/test/components/device/pin/wiring.test.ts
@@ -1026,7 +1026,7 @@ describe("pin wiring board-preset guard", () => {
     expect(cardById(result, "ground_switch")?.["aria-disabled"]).toBe("false");
   });
 
-  it("disables the GPIO select on a board-preset pin", () => {
+  it("disables the GPIO select on a board-preset pin, keeping the active option", () => {
     const result = renderPinField(
       wiringPinEntry(PinMode.INPUT),
       ["pin"],
@@ -1035,6 +1035,10 @@ describe("pin wiring board-preset guard", () => {
     const select = findElementBindings(result, "wa-select")[0];
     expect(select["?disabled"]).toBe(true);
     expect(select.title).toBe("device.pin_wiring_guard_tooltip");
+    // The active pin's option still renders, so the disabled head isn't blank.
+    expect(
+      findElementBindings(result, "wa-option").some((o) => o.value === "GPIO2")
+    ).toBe(true);
   });
 
   it("leaves the select editable when the pin is the user's own", () => {
@@ -1046,18 +1050,6 @@ describe("pin wiring board-preset guard", () => {
     const select = findElementBindings(result, "wa-select")[0];
     expect(select["?disabled"]).toBe(false);
     expect(select.title).toBe(nothing);
-  });
-
-  it("keeps the active pin option rendered while the select is disabled", () => {
-    const result = renderPinField(
-      wiringPinEntry(PinMode.INPUT),
-      ["pin"],
-      guardedCtx("GPIO2")
-    );
-    expect(findElementBindings(result, "wa-select")[0]["?disabled"]).toBe(true);
-    expect(
-      findElementBindings(result, "wa-option").some((o) => o.value === "GPIO2")
-    ).toBe(true);
   });
 
   it("locks children of a hard-locked pin carrying wiring values", () => {

--- a/test/components/device/pin/wiring.test.ts
+++ b/test/components/device/pin/wiring.test.ts
@@ -4,6 +4,7 @@
  * looked up by their ``data-preset`` binding; walker and fixtures are
  * shared with the sibling tests.
  */
+import { nothing } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { ConfigEntryType, PinMode } from "../../../../src/api/types/config-entries.js";
 import type { ConfigEntry } from "../../../../src/api/types/config-entries.js";
@@ -1023,6 +1024,40 @@ describe("pin wiring board-preset guard", () => {
     );
     expect(findTemplatesByAnchor(result, "pin-wiring-guard")).toHaveLength(0);
     expect(cardById(result, "ground_switch")?.["aria-disabled"]).toBe("false");
+  });
+
+  it("disables the GPIO select on a board-preset pin", () => {
+    const result = renderPinField(
+      wiringPinEntry(PinMode.INPUT),
+      ["pin"],
+      guardedCtx("GPIO2")
+    );
+    const select = findElementBindings(result, "wa-select")[0];
+    expect(select["?disabled"]).toBe(true);
+    expect(select.title).toBe("device.pin_wiring_guard_tooltip");
+  });
+
+  it("leaves the select editable when the pin is the user's own", () => {
+    const result = renderPinField(
+      wiringPinEntry(PinMode.INPUT),
+      ["pin"],
+      guardedCtx("GPIO33")
+    );
+    const select = findElementBindings(result, "wa-select")[0];
+    expect(select["?disabled"]).toBe(false);
+    expect(select.title).toBe(nothing);
+  });
+
+  it("keeps the active pin option rendered while the select is disabled", () => {
+    const result = renderPinField(
+      wiringPinEntry(PinMode.INPUT),
+      ["pin"],
+      guardedCtx("GPIO2")
+    );
+    expect(findElementBindings(result, "wa-select")[0]["?disabled"]).toBe(true);
+    expect(
+      findElementBindings(result, "wa-option").some((o) => o.value === "GPIO2")
+    ).toBe(true);
   });
 
   it("locks children of a hard-locked pin carrying wiring values", () => {


### PR DESCRIPTION
# What does this implement/fix?

PR #1412 made the wiring section of a board preconfigured pin view only, but the GPIO select itself stayed editable. Moving a preconfigured pin to another GPIO is the same class of mistake as changing its mode flags, so the select now disables in lockstep with the wiring guard. The guard hint is discoverable: hovering a disabled control never shows a native title tooltip, so the select carries a wa-tooltip (the same pattern visit-web-ui-link uses) and the label shows the hard lock's icon chrome retargeted at the YAML editor.

The add-component dialog had the same gap because it never passed a section key to the shared form, so board designations could not match. It now threads the resolved component id through, which arms the pin guard (and the #1412 wiring guard) when adding a featured component like the ESK-1 RGB LEDs whose pin preset is not hard locked. renderPinWiring now receives the computed guarded flag instead of rederiving it, so the select and the panel stay in lockstep by construction.

Hard locked pins are unchanged; a pin the user moved off the board's designation stays fully editable. The renderer already forces the active pin's option into the dropdown, so the disabled select shows the real pin instead of blanking.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1417

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
