### PR TITLE
Honor board-locked presets across the form surfaces

### DIFF
--- a/src/components/device/config-entry-form-plan.ts
+++ b/src/components/device/config-entry-form-plan.ts
@@ -5,8 +5,10 @@ import {
 } from "./config-entry-render-filter.js";
 import {
   buildConstraintClusters,
+  isRadioCluster,
   type ConstraintCluster,
 } from "./config-entry-renderers/constraint-cluster.js";
+import { choicePinned } from "../../util/config-entry-tree.js";
 import { orderExclusiveGroups } from "./config-entry-renderers/exclusive-group.js";
 
 /**
@@ -63,9 +65,20 @@ export function planNeedsUserInput(
 ): boolean {
   const anyActionable = (entries: ConfigEntry[]): boolean =>
     entries.some((e) => !e.locked && isVisible(e));
+  // A pinned selector (group dropdown, exactly_one radios) is disabled, so
+  // an unlocked member behind it is unreachable — don't let it hold the
+  // form open. Box clusters paint their members directly and stay gated on
+  // anyActionable alone.
   return (
     anyActionable([...plan.visible]) ||
-    plan.clusters.some((cluster) => anyActionable(cluster.members)) ||
-    plan.ordered.some((item) => Array.isArray(item) && anyActionable(item))
+    plan.clusters.some(
+      (cluster) =>
+        anyActionable(cluster.members) &&
+        !(isRadioCluster(cluster) && choicePinned(cluster.members, isVisible))
+    ) ||
+    plan.ordered.some(
+      (item) =>
+        Array.isArray(item) && anyActionable(item) && !choicePinned(item, isVisible)
+    )
   );
 }

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -41,6 +41,7 @@ import {
 import { isEntryVisible, type ValidationError } from "../../util/config-validation.js";
 import { resolveDeviceName } from "../../util/device-name.js";
 import { getErrorMessage } from "../../util/error-message.js";
+import { overlayBoardLockedPresets } from "../../util/featured-locks.js";
 import { fetchAllComponents } from "../../util/fetch-all-components.js";
 import { fireEvent } from "../../util/fire-event.js";
 import { getIn, isPrimitiveOrNullish } from "../../util/nested-values.js";
@@ -367,11 +368,20 @@ export class ESPHomeConfigEntryForm extends LitElement {
 
   protected render() {
     const ctx = this._buildCtx();
+    // Board-locked featured presets render read-only wherever the form is
+    // mounted — the add dialog's entries arrive pre-locked, but the editor's
+    // plain schema needs the value-dependent overlay.
+    const withLocks = overlayBoardLockedPresets(
+      this.entries,
+      this.board,
+      this.sectionKey,
+      this.values
+    );
     // In the add-component dialog, float required entries above optional
     // ones (stable, so each keeps its catalog order) so the user fills the
     // mandatory fields first. The section editor mirrors the on-disk YAML
     // order, so it's left untouched.
-    const entries = this.requiredOnly ? floatRequiredFirst(this.entries) : this.entries;
+    const entries = this.requiredOnly ? floatRequiredFirst(withLocks) : withLocks;
     return this.advancedSection
       ? this._renderWithAdvancedSection(entries, ctx)
       : this._renderFlat(entries, ctx);

--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -144,7 +144,7 @@ export function renderIdReferenceField(
   if (empty) {
     return html`
       <div class="field" data-field-key=${fieldKeyAttr(path)}>
-        ${renderLabel(entry, ctx)}
+        ${renderLabel(entry, ctx, { path })}
         <wa-select
           class=${fieldError ? "invalid" : ""}
           ?disabled=${effectiveDisabled(entry, ctx)}
@@ -174,7 +174,7 @@ export function renderIdReferenceField(
 
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(entry, ctx)}
+      ${renderLabel(entry, ctx, { path })}
       <wa-select
         class=${invalid ? "invalid" : ""}
         ?disabled=${effectiveDisabled(entry, ctx)}

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -103,6 +103,12 @@ export function effectiveDisabled(entry: ConfigEntry, ctx: RenderCtx): boolean {
  *  the round-trip back to a path in ``parseFieldKey``. */
 export const fieldKeyAttr = (path: string[]): string => JSON.stringify(path);
 
+/** Collision-free tooltip anchor id for *path* under *prefix* — JSON keeps
+ *  dotted map keys distinct from nested paths; URI-encoding keeps the id
+ *  whitespace-free. */
+export const tooltipAnchorId = (prefix: string, path: string[]): string =>
+  `${prefix}-${encodeURIComponent(fieldKeyAttr(path))}`;
+
 /** Recover a field path from a ``data-field-key`` attribute. Non-JSON
  *  values (the pin-advanced toggle key) fall back to dot-splitting. */
 export const parseFieldKey = (attr: string): string[] => {
@@ -236,7 +242,7 @@ export function renderLabel(
  *  (native title tooltips don't surface reliably). */
 function renderLockIcon(entry: ConfigEntry, ctx: RenderCtx, path: string[]) {
   const reason = ctx.localize(lockedReasonKey(entry));
-  const tipId = `lock-tip-${path.join(".")}`;
+  const tipId = tooltipAnchorId("lock-tip", path);
   return html`<wa-icon
       id=${tipId}
       class="lock-icon"

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -248,6 +248,9 @@ function renderLockIcon(entry: ConfigEntry, ctx: RenderCtx, path: string[]) {
       class="lock-icon"
       library="mdi"
       name="lock-outline"
+      tabindex="0"
+      role="img"
+      aria-label=${reason}
     ></wa-icon>
     <wa-tooltip for=${tipId}>${reason}</wa-tooltip>`;
 }

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -211,6 +211,9 @@ const lockedReasonKey = (entry: ConfigEntry): string =>
 
 export interface RenderLabelOptions {
   includeHelpLink?: boolean;
+  /** Field path; keys the lock icon's wa-tooltip anchor. Without it the
+   *  icon falls back to a native title, which many UAs won't surface. */
+  path?: string[];
 }
 
 export function renderLabel(
@@ -218,25 +221,38 @@ export function renderLabel(
   ctx: RenderCtx,
   options: RenderLabelOptions = {}
 ) {
-  const { includeHelpLink = true } = options;
+  const { includeHelpLink = true, path } = options;
   return html`
     <label class="field-label">
       ${labelFor(entry, ctx)}
       ${entry.required ? html`<span class="required">*</span>` : nothing}
-      ${
-        entry.locked
-          ? html`<wa-icon
-              class="lock-icon"
-              library="mdi"
-              name="lock-outline"
-              title=${ctx.localize(lockedReasonKey(entry))}
-            ></wa-icon>`
-          : nothing
-      }
+      ${entry.locked ? renderLockIcon(entry, ctx, path) : nothing}
       ${includeHelpLink && entry.help_link ? renderHelpLink(entry, ctx) : nothing}
     </label>
     ${_fieldDescription(entry, ctx)}
   `;
+}
+
+/** The label's lock icon; *path* keys a wa-tooltip anchor id (native
+ *  title tooltips are unreliable, so pass it whenever available). */
+function renderLockIcon(entry: ConfigEntry, ctx: RenderCtx, path?: string[]) {
+  const reason = ctx.localize(lockedReasonKey(entry));
+  if (!path) {
+    return html`<wa-icon
+      class="lock-icon"
+      library="mdi"
+      name="lock-outline"
+      title=${reason}
+    ></wa-icon>`;
+  }
+  const tipId = `lock-tip-${path.join(".")}`;
+  return html`<wa-icon
+      id=${tipId}
+      class="lock-icon"
+      library="mdi"
+      name="lock-outline"
+    ></wa-icon>
+    <wa-tooltip for=${tipId}>${reason}</wa-tooltip>`;
 }
 
 /** The field's description, with the backend's baked constraint-prose paragraph
@@ -285,7 +301,8 @@ export function renderFieldShell(
 ) {
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(entry, ctx)} ${input} ${trailing} ${renderFieldError(path, ctx)}
+      ${renderLabel(entry, ctx, { path })} ${input} ${trailing}
+      ${renderFieldError(path, ctx)}
     </div>
   `;
 }
@@ -327,7 +344,7 @@ export function renderUnparseableScalarField(
 export function renderYamlOnlyField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(entry, ctx)}
+      ${renderLabel(entry, ctx, { path })}
       <p class="field-description">${ctx.localize("device.value_yaml_only")}</p>
       ${renderFieldError(path, ctx)}
     </div>
@@ -443,7 +460,7 @@ export function renderStringField(
     ></esphome-password-input>`;
     return html`
       <div class="field" data-field-key=${fieldKeyAttr(path)}>
-        ${renderLabel(entry, ctx)} ${withPicker(passwordInput)} ${secretHint}
+        ${renderLabel(entry, ctx, { path })} ${withPicker(passwordInput)} ${secretHint}
         ${renderFieldError(path, ctx)}
       </div>
     `;
@@ -473,8 +490,8 @@ export function renderStringField(
   />`;
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(entry, ctx)} ${withPicker(textInput)} ${secretHint} ${subHint}
-      ${renderFieldError(path, ctx)}
+      ${renderLabel(entry, ctx, { path })} ${withPicker(textInput)} ${secretHint}
+      ${subHint} ${renderFieldError(path, ctx)}
     </div>
   `;
 }
@@ -497,7 +514,7 @@ export function renderSuggestionSelect(
   const placeholder = String(entry.default_value ?? "");
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(entry, ctx)}
+      ${renderLabel(entry, ctx, { path })}
       <wa-select
         class=${invalid ? "invalid" : ""}
         ?disabled=${disabled}

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -211,15 +211,14 @@ const lockedReasonKey = (entry: ConfigEntry): string =>
 
 export interface RenderLabelOptions {
   includeHelpLink?: boolean;
-  /** Field path; keys the lock icon's wa-tooltip anchor. Without it the
-   *  icon falls back to a native title, which many UAs won't surface. */
-  path?: string[];
+  /** Field path; keys the lock icon's wa-tooltip anchor. */
+  path: string[];
 }
 
 export function renderLabel(
   entry: ConfigEntry,
   ctx: RenderCtx,
-  options: RenderLabelOptions = {}
+  options: RenderLabelOptions
 ) {
   const { includeHelpLink = true, path } = options;
   return html`
@@ -233,18 +232,10 @@ export function renderLabel(
   `;
 }
 
-/** The label's lock icon; *path* keys a wa-tooltip anchor id (native
- *  title tooltips are unreliable, so pass it whenever available). */
-function renderLockIcon(entry: ConfigEntry, ctx: RenderCtx, path?: string[]) {
+/** The label's lock icon, its reason on a wa-tooltip anchored per *path*
+ *  (native title tooltips don't surface reliably). */
+function renderLockIcon(entry: ConfigEntry, ctx: RenderCtx, path: string[]) {
   const reason = ctx.localize(lockedReasonKey(entry));
-  if (!path) {
-    return html`<wa-icon
-      class="lock-icon"
-      library="mdi"
-      name="lock-outline"
-      title=${reason}
-    ></wa-icon>`;
-  }
   const tipId = `lock-tip-${path.join(".")}`;
   return html`<wa-icon
       id=${tipId}

--- a/src/components/device/config-entry-renderers/constraint-cluster.ts
+++ b/src/components/device/config-entry-renderers/constraint-cluster.ts
@@ -214,8 +214,12 @@ export function renderConstraintRadioField(cluster: ConstraintCluster, ctx: Rend
 
   const visibleMembers = (selected?.members ?? []).filter(isRenderable);
   // A board-locked member means the board made the cluster choice; switching
-  // sides would clear the locked value, so the radios pin to it.
-  const pinned = choicePinned(alternatives.flatMap((a) => a.members));
+  // sides would clear the locked value, so the radios pin to it. Gated on
+  // renderable members, matching the dropdown's options and the plan gate.
+  const pinned = choicePinned(
+    alternatives.flatMap((a) => a.members),
+    isRenderable
+  );
   return html`
     <div
       class="nested-group constraint-cluster"

--- a/src/components/device/config-entry-renderers/constraint-cluster.ts
+++ b/src/components/device/config-entry-renderers/constraint-cluster.ts
@@ -212,6 +212,9 @@ export function renderConstraintRadioField(cluster: ConstraintCluster, ctx: Rend
   const headerId = `constraint-cluster-${clusterId}`;
 
   const visibleMembers = (selected?.members ?? []).filter(isRenderable);
+  // A board-locked member means the board made the cluster choice; switching
+  // sides would clear the locked value, so the radios pin to it.
+  const pinned = alternatives.some((a) => a.members.some((m) => m.locked));
   return html`
     <div
       class="nested-group constraint-cluster"
@@ -224,7 +227,7 @@ export function renderConstraintRadioField(cluster: ConstraintCluster, ctx: Rend
         class="constraint-cluster-radios"
         aria-labelledby=${headerId}
         .value=${selectedId ?? ""}
-        ?disabled=${ctx.disabled}
+        ?disabled=${ctx.disabled || pinned}
         @change=${(e: Event) =>
           selectClusterAlternative(
             cluster,

--- a/src/components/device/config-entry-renderers/constraint-cluster.ts
+++ b/src/components/device/config-entry-renderers/constraint-cluster.ts
@@ -1,6 +1,7 @@
 import { html, nothing } from "lit";
 import type { ConfigEntry, RequiredGroup } from "../../../api/types/config-entries.js";
 import { isEntryVisible, isValuePresent } from "../../../util/config-validation.js";
+import { choicePinned } from "../../../util/config-entry-tree.js";
 import { evaluateGroup } from "../../../util/constraint-groups.js";
 import {
   fieldKeyAttr,
@@ -214,7 +215,7 @@ export function renderConstraintRadioField(cluster: ConstraintCluster, ctx: Rend
   const visibleMembers = (selected?.members ?? []).filter(isRenderable);
   // A board-locked member means the board made the cluster choice; switching
   // sides would clear the locked value, so the radios pin to it.
-  const pinned = alternatives.some((a) => a.members.some((m) => m.locked));
+  const pinned = choicePinned(alternatives.flatMap((a) => a.members));
   return html`
     <div
       class="nested-group constraint-cluster"

--- a/src/components/device/config-entry-renderers/exclusive-group.ts
+++ b/src/components/device/config-entry-renderers/exclusive-group.ts
@@ -64,11 +64,11 @@ export function renderExclusiveGroupField(members: ConfigEntry[], ctx: RenderCtx
       )
   );
 
-  // Every *rendered* option board-locked → the choice is fixed; render the
-  // dropdown read-only so it matches `planNeedsUserInput` treating it as
-  // non-actionable. Use options, not all members: a hidden unlocked member
+  // Any *rendered* option board-locked → the choice is fixed: the board's
+  // preset picked this member, and switching away would clear the locked
+  // value. Use options, not all members: a hidden unlocked member
   // (e.g. platform-incompatible) isn't selectable and shouldn't keep it live.
-  const disabled = ctx.disabled || options.every((m) => m.locked);
+  const disabled = ctx.disabled || options.some((m) => m.locked);
 
   // Clear only the members actually present (avoids ~N redundant events and
   // stray key: undefined state); scaffold {} only for an absent choice, so

--- a/src/components/device/config-entry-renderers/exclusive-group.ts
+++ b/src/components/device/config-entry-renderers/exclusive-group.ts
@@ -1,6 +1,7 @@
 import { html, nothing } from "lit";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { isEntryVisible } from "../../../util/config-validation.js";
+import { choicePinned } from "../../../util/config-entry-tree.js";
 import {
   fieldKeyAttr,
   labelFor,
@@ -68,7 +69,7 @@ export function renderExclusiveGroupField(members: ConfigEntry[], ctx: RenderCtx
   // preset picked this member, and switching away would clear the locked
   // value. Use options, not all members: a hidden unlocked member
   // (e.g. platform-incompatible) isn't selectable and shouldn't keep it live.
-  const disabled = ctx.disabled || options.some((m) => m.locked);
+  const disabled = ctx.disabled || choicePinned(options);
 
   // Clear only the members actually present (avoids ~N redundant events and
   // stray key: undefined state); scaffold {} only for an absent choice, so

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -142,7 +142,7 @@ export function renderMultiValueField(
 
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(entry, ctx)} ${renderListEmptyHint(items, ctx)}
+      ${renderLabel(entry, ctx, { path })} ${renderListEmptyHint(items, ctx)}
       ${items.map((item, i) => {
         // Row widgets match the single-value renderers (#1349): INTEGER
         // rows are text — a number input can't show the 0x literals,
@@ -310,7 +310,7 @@ export function renderMapField(entry: ConfigEntry, path: string[], ctx: RenderCt
 
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(entry, ctx)}
+      ${renderLabel(entry, ctx, { path })}
       ${
         keys.length === 0
           ? html`<p class="field-description">${ctx.localize("device.map_empty")}</p>`
@@ -349,7 +349,7 @@ export function renderNestedListField(
   if (raw instanceof YamlRawValue) {
     return html`
       <div class="nested-list" data-field-key=${fieldKeyAttr(path)}>
-        ${renderLabel(entry, ctx)}
+        ${renderLabel(entry, ctx, { path })}
         <p class="field-description">${ctx.localize("device.multi_value_yaml_only")}</p>
         ${renderFieldError(path, ctx)}
       </div>
@@ -364,7 +364,7 @@ export function renderNestedListField(
 
   return html`
     <div class="nested-list" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(entry, ctx)} ${renderListEmptyHint(items, ctx)}
+      ${renderLabel(entry, ctx, { path })} ${renderListEmptyHint(items, ctx)}
       ${items.map((item, i) => {
         const itemPath = [...path, String(i)];
         const renderableChildren = ctx.filterRenderable(childrenSchema, item);

--- a/src/components/device/config-entry-renderers/nested.ts
+++ b/src/components/device/config-entry-renderers/nested.ts
@@ -47,7 +47,7 @@ export function renderNestedField(entry: ConfigEntry, path: string[], ctx: Rende
   ) {
     return html`
       <div class="field" data-field-key=${fieldKeyAttr(path)}>
-        ${renderLabel(entry, ctx)}
+        ${renderLabel(entry, ctx, { path })}
         <p class="field-description">
           ${ctx.localize("device.value_set_in_yaml", { value: String(raw) })}
         </p>

--- a/src/components/device/config-entry-renderers/primitives-numeric.ts
+++ b/src/components/device/config-entry-renderers/primitives-numeric.ts
@@ -219,7 +219,7 @@ export function renderTimePeriodField(
         : parsed.unit;
   return html`
     <div class="field time-period" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(entry, ctx)}
+      ${renderLabel(entry, ctx, { path })}
       <div class="time-period-inputs">
         <input
           type="text"
@@ -311,7 +311,7 @@ export function renderFloatWithUnitField(
     ctx.emitChange(path, serializeFloatWithUnit(next));
   return html`
     <div class="field float-with-unit" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(entry, ctx)}
+      ${renderLabel(entry, ctx, { path })}
       <div class="float-with-unit-inputs">
         <input
           type="number"

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -69,7 +69,9 @@ export function renderBooleanField(entry: ConfigEntry, path: string[], ctx: Rend
   const checked = (raw == null ? parseYamlBoolean(entry.default_value) : parsed) === true;
   return html`
     <div class="switch-field" data-field-key=${fieldKeyAttr(path)}>
-      <div class="field-info">${renderLabel(entry, ctx, { includeHelpLink: false })}</div>
+      <div class="field-info">
+        ${renderLabel(entry, ctx, { includeHelpLink: false, path })}
+      </div>
       ${renderHelpLink(entry, ctx)}
       <wa-switch
         ?checked=${checked}
@@ -171,7 +173,7 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
     // chrome of its own, so this isn't a duplicate visible label.
     return html`
       <div class="field" data-field-key=${fieldKeyAttr(path)}>
-        ${renderLabel(entry, ctx)}
+        ${renderLabel(entry, ctx, { path })}
         <esphome-options-combobox
           .options=${filterOptionsByVariant(entry.options, variant, value)}
           .value=${value}
@@ -212,7 +214,7 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
   const shownOptions = filterOptionsByVariant(visibleOptions, variant, value);
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(entry, ctx)}
+      ${renderLabel(entry, ctx, { path })}
       <wa-select
         class=${invalid ? "invalid" : ""}
         ?disabled=${disabled}
@@ -272,7 +274,7 @@ export function renderTextareaField(entry: ConfigEntry, path: string[], ctx: Ren
   const invalid = ctx.errorAt(path) !== null;
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(entry, ctx)}
+      ${renderLabel(entry, ctx, { path })}
       <textarea
         class="textarea-field ${invalid ? "invalid" : ""}"
         rows="4"
@@ -297,7 +299,7 @@ export function renderIconField(entry: ConfigEntry, path: string[], ctx: RenderC
   const invalid = ctx.errorAt(path) !== null;
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(entry, ctx)}
+      ${renderLabel(entry, ctx, { path })}
       <esphome-mdi-icon-picker
         .value=${value}
         .invalid=${invalid}

--- a/src/components/device/config-entry-renderers/registry-list.ts
+++ b/src/components/device/config-entry-renderers/registry-list.ts
@@ -201,7 +201,7 @@ export class ESPHomeRegistryList extends LitElement {
       // stand-in catalog.
       return html`
         <div class="field" data-field-key=${fieldKeyAttr(this.path)}>
-          ${renderLabel(this.entry, this.ctx)}
+          ${renderLabel(this.entry, this.ctx, { path: this.path })}
           <p class="registry-list-fallback">
             ${this.ctx.localize("device.registry_list_unsupported")}
           </p>
@@ -218,7 +218,7 @@ export class ESPHomeRegistryList extends LitElement {
     if (raw instanceof YamlRawValue || (raw !== undefined && !Array.isArray(raw))) {
       return html`
         <div class="field" data-field-key=${fieldKeyAttr(this.path)}>
-          ${renderLabel(this.entry, this.ctx)}
+          ${renderLabel(this.entry, this.ctx, { path: this.path })}
           <p class="field-description">
             ${this.ctx.localize("device.multi_value_yaml_only")}
           </p>
@@ -286,8 +286,8 @@ export class ESPHomeRegistryList extends LitElement {
     const addDisabled = disabled || catalog.length === 0;
     return html`
       <div class="field" data-field-key=${fieldKeyAttr(this.path)}>
-        ${renderLabel(this.entry, this.ctx)} ${renderListEmptyHint(items, this.ctx)}
-        ${statusHint}
+        ${renderLabel(this.entry, this.ctx, { path: this.path })}
+        ${renderListEmptyHint(items, this.ctx)} ${statusHint}
         ${items.map((item, i) =>
           this._renderRow(item, i, catalog, items, disabled, ops.dedupByTypeId)
         )}

--- a/src/components/device/pin/renderer.ts
+++ b/src/components/device/pin/renderer.ts
@@ -30,6 +30,7 @@ import {
   renderLabel,
   renderStringField,
   renderSubstitutionHint,
+  tooltipAnchorId,
   type LockedReasonCarrier,
   type RenderCtx,
 } from "../config-entry-renderers-shared.js";
@@ -451,7 +452,7 @@ export function renderPinField(
         locked_reason_key: "device.pin_wiring_guard_tooltip",
       } as ConfigEntry & LockedReasonCarrier)
     : entry;
-  const guardTipId = `pin-guard-tip-${path.join(".")}`;
+  const guardTipId = tooltipAnchorId("pin-guard-tip", path);
   const isLongForm = isPlainObject(rawValue);
 
   // Pin-select onChange routes to ``path.number`` when the field is

--- a/src/components/device/pin/renderer.ts
+++ b/src/components/device/pin/renderer.ts
@@ -472,7 +472,7 @@ export function renderPinField(
 
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(labelEntry, ctx)}
+      ${renderLabel(labelEntry, ctx, { path })}
       <!-- Keyed as the long form's number so the YAML cursor lands on the
            select itself (the whole-field fallback centers mid-panel once
            the wiring disclosure is open). Short form keeps the bare path:
@@ -547,7 +547,7 @@ function renderSubstitutionPin(
   const guarded = boardPreset && !fieldDisabled;
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(entry, ctx)}
+      ${renderLabel(entry, ctx, { path })}
       <!-- Deliberately not guard-locked: no manifest designates a pin via a
            substitution, so a \${var} landing on one is the user's own
            hand-authored setup, and this input edits the reference name, not
@@ -593,7 +593,7 @@ function renderExpanderPin(
   const guarded = boardPreset && !effectiveDisabled(entry, ctx);
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
-      ${renderLabel(entry, ctx)}
+      ${renderLabel(entry, ctx, { path })}
       <input
         type="text"
         readonly

--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -10,6 +10,17 @@ import type { ValidationError } from "./config-validation.js";
 import { isIndexSegment } from "./nested-values.js";
 import { PIN_WIRING_KEYS } from "./pin/wiring-presets.js";
 
+/** A pick-one group/cluster with any visible board-locked member is the
+ *  board's choice: switching away would clear the locked value. Single
+ *  source for the selector paint (dropdown/radios disable) and the
+ *  add-form gate (the whole choice is non-actionable). */
+export function choicePinned(
+  members: ConfigEntry[],
+  isVisible: (entry: ConfigEntry) => boolean = () => true
+): boolean {
+  return members.some((m) => m.locked && isVisible(m));
+}
+
 /** True when `entries` contains any advanced entry, recursively. Drives whether
  *  the advanced-settings control shows at all: a nested advanced field reveals
  *  in place (it can't move to the bottom section), so the control must surface

--- a/src/util/featured-id.ts
+++ b/src/util/featured-id.ts
@@ -1,3 +1,5 @@
+import type { BoardCatalogEntry, FeaturedComponent } from "../api/types/boards.js";
+
 /** The `featured.<board>.<local>` id prefix marking a board-curated preset entry. */
 export const FEATURED_ID_PREFIX = "featured.";
 
@@ -15,6 +17,26 @@ export function buildFeaturedId(boardId: string, localId: string): string {
 /** True when a catalog id carries the `featured.` prefix; only the prefix is checked, not the full shape. */
 export function isFeaturedId(id: string): boolean {
   return id.startsWith(FEATURED_ID_PREFIX);
+}
+
+/**
+ * The featured entry a YAML instance materializes, or null.
+
+ * Matches by section (``component_id``) plus the instance's emitted
+ * ``id`` against the entry's ``id`` preset — the per-instance
+ * counterpart to the pin guard's physical per-GPIO matching.
+ */
+export function featuredEntryForInstance(
+  board: BoardCatalogEntry | null,
+  sectionKey: string,
+  instanceId: unknown
+): FeaturedComponent | null {
+  if (!board || !sectionKey || typeof instanceId !== "string") return null;
+  return (
+    board.featured_components?.find(
+      (fc) => fc.component_id === sectionKey && fc.fields.id?.value === instanceId
+    ) ?? null
+  );
 }
 
 /** Resolve a featured catalog id to the component it actually adds; non-featured or unknown ids pass through. */

--- a/src/util/featured-locks.ts
+++ b/src/util/featured-locks.ts
@@ -31,8 +31,14 @@ export function overlayBoardLockedPresets(
   return entries.map((entry) => {
     // Pins keep their own value-dependent guard (the picker's
     // board-preset lock); stamping ``locked`` would demote it to the
-    // hard-lock chrome and hide the wiring guard row.
-    if (!lockedKeys.has(entry.key) || entry.type === ConfigEntryType.PIN) {
+    // hard-lock chrome and hide the wiring guard row. An already-locked
+    // entry (the add dialog's server-hydrated featured schema) keeps its
+    // own lock and reason verbatim.
+    if (
+      !lockedKeys.has(entry.key) ||
+      entry.locked ||
+      entry.type === ConfigEntryType.PIN
+    ) {
       return entry;
     }
     let copy = lockedCopies.get(entry);

--- a/src/util/featured-locks.ts
+++ b/src/util/featured-locks.ts
@@ -13,6 +13,8 @@
 import type { BoardCatalogEntry } from "../api/types/boards.js";
 import type { ConfigEntry } from "../api/types/config-entries.js";
 import { ConfigEntryType } from "../api/types/config-entries.js";
+import type { LockedReasonCarrier } from "../components/device/config-entry-renderers-shared.js";
+import { featuredEntryForInstance } from "./featured-id.js";
 
 // Stable locked copies so re-renders hand the form identical entry
 // references (same rationale as the pin wiring's lock cache).
@@ -39,7 +41,7 @@ export function overlayBoardLockedPresets(
         ...entry,
         locked: true,
         locked_reason_key: "device.pin_wiring_guard_tooltip",
-      } as ConfigEntry & { locked_reason_key?: string };
+      } as ConfigEntry & LockedReasonCarrier;
       lockedCopies.set(entry, copy);
     }
     return copy;
@@ -54,14 +56,11 @@ function boardLockedPresetKeys(
   values: Record<string, unknown>
 ): Set<string> {
   const out = new Set<string>();
-  if (!sectionKey || values.id === undefined) return out;
-  for (const fc of board?.featured_components ?? []) {
-    if (fc.component_id !== sectionKey) continue;
-    if (fc.fields.id?.value !== values.id) continue;
-    for (const [key, preset] of Object.entries(fc.fields)) {
-      if (preset.locked && presetValueMatches(values[key], preset.value)) {
-        out.add(key);
-      }
+  const fc = featuredEntryForInstance(board, sectionKey, values.id);
+  if (!fc) return out;
+  for (const [key, preset] of Object.entries(fc.fields)) {
+    if (preset.locked && presetValueMatches(values[key], preset.value)) {
+      out.add(key);
     }
   }
   return out;

--- a/src/util/featured-locks.ts
+++ b/src/util/featured-locks.ts
@@ -1,0 +1,80 @@
+/**
+ * Value-dependent board-lock overlay for a section instance.
+ *
+ * The add dialog receives ``locked`` on the server-hydrated featured
+ * entries, but the editor renders the plain component schema, so a
+ * board-locked preset (the ESK-1 module's ``num_leds``) arrived
+ * editable there. Overlay ``locked`` onto entries whose instance still
+ * sits on the locked preset — matched to the featured entry by the
+ * instance's ``id``, and released once the user moves the value off
+ * the preset in YAML (their own config, like the pin guard).
+ */
+
+import type { BoardCatalogEntry } from "../api/types/boards.js";
+import type { ConfigEntry } from "../api/types/config-entries.js";
+import { ConfigEntryType } from "../api/types/config-entries.js";
+
+// Stable locked copies so re-renders hand the form identical entry
+// references (same rationale as the pin wiring's lock cache).
+const lockedCopies = new WeakMap<ConfigEntry, ConfigEntry>();
+
+export function overlayBoardLockedPresets(
+  entries: ConfigEntry[],
+  board: BoardCatalogEntry | null,
+  sectionKey: string,
+  values: Record<string, unknown>
+): ConfigEntry[] {
+  const lockedKeys = boardLockedPresetKeys(board, sectionKey, values);
+  if (lockedKeys.size === 0) return entries;
+  return entries.map((entry) => {
+    // Pins keep their own value-dependent guard (the picker's
+    // board-preset lock); stamping ``locked`` would demote it to the
+    // hard-lock chrome and hide the wiring guard row.
+    if (!lockedKeys.has(entry.key) || entry.type === ConfigEntryType.PIN) {
+      return entry;
+    }
+    let copy = lockedCopies.get(entry);
+    if (!copy) {
+      copy = {
+        ...entry,
+        locked: true,
+        locked_reason_key: "device.pin_wiring_guard_tooltip",
+      } as ConfigEntry & { locked_reason_key?: string };
+      lockedCopies.set(entry, copy);
+    }
+    return copy;
+  });
+}
+
+/** Keys of *sectionKey*'s board-locked presets the instance in *values*
+ *  still holds, matched to the featured entry by its ``id`` preset. */
+function boardLockedPresetKeys(
+  board: BoardCatalogEntry | null,
+  sectionKey: string,
+  values: Record<string, unknown>
+): Set<string> {
+  const out = new Set<string>();
+  if (!sectionKey || values.id === undefined) return out;
+  for (const fc of board?.featured_components ?? []) {
+    if (fc.component_id !== sectionKey) continue;
+    if (fc.fields.id?.value !== values.id) continue;
+    for (const [key, preset] of Object.entries(fc.fields)) {
+      if (preset.locked && presetValueMatches(values[key], preset.value)) {
+        out.add(key);
+      }
+    }
+  }
+  return out;
+}
+
+/** Loose scalar match (YAML round-trips ``48`` and ``"48"``); lists via
+ *  JSON. Mapping presets never match — their only locked use is pins,
+ *  which the overlay skips anyway. */
+function presetValueMatches(current: unknown, preset: unknown): boolean {
+  if (current === undefined || current === null || preset === null) return false;
+  if (Array.isArray(preset) || Array.isArray(current)) {
+    return JSON.stringify(current) === JSON.stringify(preset);
+  }
+  if (typeof preset === "object" || typeof current === "object") return false;
+  return String(current) === String(preset);
+}

--- a/test/components/device/add-component-form-filter.test.ts
+++ b/test/components/device/add-component-form-filter.test.ts
@@ -47,12 +47,14 @@ describe("addFormNeedsUserInput", () => {
     expect(addFormNeedsUserInput(entries, {}, [], null, NONE)).toBe(false);
   });
 
-  it("shows the form when an exclusive group still has an unlocked choice", () => {
+  it("skips an exclusive group pinned by one locked member", () => {
+    // The dropdown disables when any rendered option is locked (the board
+    // made the choice), so the unlocked sibling is unreachable.
     const entries = [
       makeConfigEntry({ key: "i2c", exclusive_group: "bus", locked: true }),
       makeConfigEntry({ key: "spi", exclusive_group: "bus", locked: false }),
     ];
-    expect(addFormNeedsUserInput(entries, {}, [], null, NONE)).toBe(true);
+    expect(addFormNeedsUserInput(entries, {}, [], null, NONE)).toBe(false);
   });
 
   it("skips a fully board-locked constraint cluster (every member read-only)", () => {

--- a/test/components/device/config-entry-form-constraint-cluster.test.ts
+++ b/test/components/device/config-entry-form-constraint-cluster.test.ts
@@ -19,7 +19,14 @@ import {
   renderConstraintRadioField,
   selectClusterAlternative,
 } from "../../../src/components/device/config-entry-renderers/constraint-cluster.js";
+import {
+  extractAttributeBindings,
+  findTemplatesByAnchor,
+} from "../../_lit-template-walker.js";
 import { makeConfigEntry } from "../../util/_make-config-entry.js";
+
+const radioGroupBindings = (tpl: unknown) =>
+  extractAttributeBindings(findTemplatesByAnchor(tpl, "<wa-radio-group")[0]);
 
 const ENTRIES: ConfigEntry[] = [
   makeConfigEntry({ key: "rgb_order", type: ConfigEntryType.STRING, label: "RGB Order" }),
@@ -312,6 +319,25 @@ describe("renderConstraintRadioField", () => {
     const out = serialize(renderConstraintRadioField(cluster, ctxFor({})));
     expect(out).not.toContain("wa-radio-group");
     expect(out).toContain("nested-group");
+  });
+
+  it("pins the radios when an alternative member is board-locked", () => {
+    // The board's preset picked the chipset side; switching to manual timings
+    // would clear the locked value.
+    const lockedChipset = ENTRIES.map((e) =>
+      e.key === "chipset" ? { ...e, locked: true } : e
+    );
+    const [locked] = buildConstraintClusters(lockedChipset, REQUIRED_GROUPS).clusters;
+    const tpl = renderConstraintRadioField(
+      locked,
+      statefulCtx({ chipset: "WS2812" }).ctx
+    );
+    expect(radioGroupBindings(tpl)["?disabled"]).toBe(true);
+  });
+
+  it("keeps the radios live when no member is locked", () => {
+    const tpl = renderConstraintRadioField(cluster, statefulCtx({}).ctx);
+    expect(radioGroupBindings(tpl)["?disabled"]).toBe(false);
   });
 });
 

--- a/test/components/device/constraint-prose-scope.test.ts
+++ b/test/components/device/constraint-prose-scope.test.ts
@@ -30,14 +30,14 @@ describe("constraint-prose strip scoping", () => {
       {},
       { overrides: { reactiveConstraintKeys: new Set(["client_certificate"]) } }
     );
-    const out = serialize(renderLabel(entry, ctx));
+    const out = serialize(renderLabel(entry, ctx, { path: ["client_certificate"] }));
     expect(out).toContain("The real description.");
     expect(out).not.toContain("Set together");
   });
 
   it("keeps the prose for a member the form doesn't reactively render", () => {
     const ctx = makeRenderCtx({}, { overrides: { reactiveConstraintKeys: new Set() } });
-    const out = serialize(renderLabel(entry, ctx));
+    const out = serialize(renderLabel(entry, ctx, { path: ["client_certificate"] }));
     expect(out).toContain("Set together");
   });
 });

--- a/test/components/device/pin/wiring.test.ts
+++ b/test/components/device/pin/wiring.test.ts
@@ -1040,10 +1040,12 @@ describe("pin wiring board-preset guard", () => {
     ).toBe(true);
     // A disabled control surfaces no native title tooltip, so the hint is
     // a wa-tooltip anchored on the select plus the label's lock icon.
-    expect(findElementBindings(result, "wa-tooltip")[0]?.for).toBe(select.id);
+    const tooltips = findElementBindings(result, "wa-tooltip");
+    expect(tooltips.some((t) => t.for === select.id)).toBe(true);
+    // The label's lock icon carries its own tooltip anchor.
     expect(
       findElementBindings(result, "wa-icon").some(
-        (i) => i.title === "device.pin_wiring_guard_tooltip"
+        (i) => typeof i.id === "string" && tooltips.some((t) => t.for === i.id)
       )
     ).toBe(true);
   });
@@ -1058,11 +1060,6 @@ describe("pin wiring board-preset guard", () => {
     expect(select["?disabled"]).toBe(false);
     expect(select.id).toBe(nothing);
     expect(findElementBindings(result, "wa-tooltip")).toHaveLength(0);
-    expect(
-      findElementBindings(result, "wa-icon").some(
-        (i) => i.title === "device.pin_wiring_guard_tooltip"
-      )
-    ).toBe(false);
   });
 
   it("locks children of a hard-locked pin carrying wiring values", () => {

--- a/test/components/device/render-exclusive-group-field.test.ts
+++ b/test/components/device/render-exclusive-group-field.test.ts
@@ -88,11 +88,13 @@ describe("renderExclusiveGroupField", () => {
     expect(findElementBindings(tpl, "wa-select")[0]["?disabled"]).toBe(true);
   });
 
-  it("keeps the dropdown enabled when a member is still unlocked", () => {
+  it("disables the dropdown when any member is board-locked", () => {
+    // The board's preset picked the locked member; switching away would
+    // clear its locked value.
     const ctx = makeRenderCtx({ raw: { code: "x" } });
     const [a, b] = members();
     const tpl = renderExclusiveGroupField([{ ...a, locked: true }, b], ctx);
-    expect(findElementBindings(tpl, "wa-select")[0]["?disabled"]).toBe(false);
+    expect(findElementBindings(tpl, "wa-select")[0]["?disabled"]).toBe(true);
   });
 
   it("disables when every visible option is locked, ignoring a hidden unlocked member", () => {

--- a/test/util/featured-locks.test.ts
+++ b/test/util/featured-locks.test.ts
@@ -77,6 +77,18 @@ describe("overlayBoardLockedPresets", () => {
     expect(out.find((e) => e.key === "pin")!.locked).toBeFalsy();
   });
 
+  it("passes an already-locked entry through with its own reason", () => {
+    // The add dialog's server-hydrated entries arrive locked; the overlay
+    // must not re-stamp them with the guard reason.
+    const serverLocked = makeConfigEntry({
+      key: "chipset",
+      type: ConfigEntryType.STRING,
+      locked: true,
+    });
+    const out = overlayBoardLockedPresets([serverLocked], BOARD, SECTION, VALUES);
+    expect(out[0]).toBe(serverLocked);
+  });
+
   it("returns the input array untouched outside the section", () => {
     expect(overlayBoardLockedPresets(ENTRIES, BOARD, "switch.gpio", VALUES)).toBe(
       ENTRIES

--- a/test/util/featured-locks.test.ts
+++ b/test/util/featured-locks.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import type { BoardCatalogEntry } from "../../src/api/types/boards.js";
+import { ConfigEntryType } from "../../src/api/types/config-entries.js";
+import { overlayBoardLockedPresets } from "../../src/util/featured-locks.js";
+import { makeConfigEntry } from "./_make-config-entry.js";
+
+const preset = (value: unknown, locked = true) => ({ value, locked, suggestions: null });
+
+const BOARD = {
+  id: "apollo-esk-1",
+  featured_components: [
+    {
+      id: "onboard_rgb_led",
+      component_id: "light.esp32_rmt_led_strip",
+      fields: {
+        id: preset("onboard_rgb_led", false),
+        name: preset("Onboard RGB LED", false),
+        pin: preset(5),
+        chipset: preset("WS2812"),
+        num_leds: preset(1),
+      },
+    },
+  ],
+} as unknown as BoardCatalogEntry;
+
+const ENTRIES = [
+  makeConfigEntry({ key: "chipset", type: ConfigEntryType.STRING }),
+  makeConfigEntry({ key: "num_leds", type: ConfigEntryType.INTEGER }),
+  makeConfigEntry({ key: "name", type: ConfigEntryType.STRING }),
+  makeConfigEntry({ key: "pin", type: ConfigEntryType.PIN }),
+];
+
+const SECTION = "light.esp32_rmt_led_strip";
+
+const VALUES = { id: "onboard_rgb_led", chipset: "WS2812", num_leds: 1, pin: 5 };
+
+describe("overlayBoardLockedPresets", () => {
+  it("locks a matching instance's locked presets with the guard reason", () => {
+    const out = overlayBoardLockedPresets(ENTRIES, BOARD, SECTION, VALUES);
+    const chipset = out.find((e) => e.key === "chipset")!;
+    expect(chipset.locked).toBe(true);
+    expect((chipset as { locked_reason_key?: string }).locked_reason_key).toBe(
+      "device.pin_wiring_guard_tooltip"
+    );
+    // Soft preset stays editable.
+    expect(out.find((e) => e.key === "name")!.locked).toBeFalsy();
+  });
+
+  it("matches a scalar loosely across YAML round-trips", () => {
+    const out = overlayBoardLockedPresets(ENTRIES, BOARD, SECTION, {
+      ...VALUES,
+      num_leds: "1",
+    });
+    expect(out.find((e) => e.key === "num_leds")!.locked).toBe(true);
+  });
+
+  it("releases a value the user moved off the preset", () => {
+    const out = overlayBoardLockedPresets(ENTRIES, BOARD, SECTION, {
+      ...VALUES,
+      num_leds: 30,
+    });
+    expect(out.find((e) => e.key === "num_leds")!.locked).toBeFalsy();
+    expect(out.find((e) => e.key === "chipset")!.locked).toBe(true);
+  });
+
+  it("ignores an instance whose id doesn't match the featured entry", () => {
+    const out = overlayBoardLockedPresets(ENTRIES, BOARD, SECTION, {
+      ...VALUES,
+      id: "my_own_strip",
+    });
+    expect(out).toBe(ENTRIES);
+  });
+
+  it("never stamps a PIN entry (the picker guard owns pins)", () => {
+    const out = overlayBoardLockedPresets(ENTRIES, BOARD, SECTION, VALUES);
+    expect(out.find((e) => e.key === "pin")!.locked).toBeFalsy();
+  });
+
+  it("returns the input array untouched outside the section", () => {
+    expect(overlayBoardLockedPresets(ENTRIES, BOARD, "switch.gpio", VALUES)).toBe(
+      ENTRIES
+    );
+  });
+
+  it("hands back stable locked copies across renders", () => {
+    const a = overlayBoardLockedPresets(ENTRIES, BOARD, SECTION, VALUES);
+    const b = overlayBoardLockedPresets(ENTRIES, BOARD, SECTION, VALUES);
+    expect(a.find((e) => e.key === "chipset")).toBe(b.find((e) => e.key === "chipset"));
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#2296, which marks fixed hardware presets (the ESK-1 module's chipset, num_leds, rgb_order) as locked in the board manifests. Three gaps kept locked presets escapable or invisible:

The "Set exactly one of" cluster radios and the exclusive group dropdown ignored locked members, so a user could switch the ESK-1 LED strip from the board's locked chipset to manual timings, clearing the locked value on the way. Any rendered locked member now pins the choice; the radios and dropdown disable.

Lock icons relied on native title tooltips, which never surface on hover in practice, so a locked field gave no reason. renderLabel now anchors a wa-tooltip on the icon (the pattern visit-web-ui-link established), keyed by field path so nested duplicates don't collide. Every renderer passes its path through.

The editor rendered the plain component schema, so a board locked preset arrived fully editable after add, and only the pin showed locked. A new value dependent overlay matches the instance to its featured entry by id and stamps locked (with the "Preconfigured for this board" reason) onto fields still holding a locked preset. A value the user moved off the preset in YAML is theirs and stays editable, and pins keep their own picker guard.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
