### PR TITLE
Name featured section headers like the recommended cards

### DIFF
--- a/src/components/device/device-section-config/render-header.ts
+++ b/src/components/device/device-section-config/render-header.ts
@@ -38,6 +38,15 @@ export function renderSectionHeader(
         : config.title;
   const description = featured?.description ?? config.description;
   const imageUrl = featured?.image_url || config.image_url;
+  // A featured name replaces the component's identity, so surface what
+  // the section actually is ("ESP32 RMT LED Strip") as the subtitle —
+  // skipped when the title already carries it (the "Title (id)" form).
+  // A catalog miss keeps its raw section key there instead.
+  const subtitle = catalogMiss
+    ? host.sectionKey
+    : headerTitle.includes(config.title)
+      ? null
+      : config.title;
   return html`
     <div class="section-header">
       <div class="section-header-info">
@@ -57,9 +66,7 @@ export function renderSectionHeader(
               : nothing
           }
         </div>
-        ${
-          catalogMiss ? html`<p class="section-subtitle">${host.sectionKey}</p>` : nothing
-        }
+        ${subtitle ? html`<p class="section-subtitle">${subtitle}</p>` : nothing}
         ${
           description
             ? html`<p class="section-desc">${renderMarkdown(description)}</p>`

--- a/src/components/device/device-section-config/render-header.ts
+++ b/src/components/device/device-section-config/render-header.ts
@@ -4,7 +4,10 @@
  */
 import { html, nothing } from "lit";
 import { defaultBoardImageUrl, onBoardImageError } from "../../../util/board-image.js";
-import { featuredEntryForInstance } from "../../../util/featured-id.js";
+import {
+  featuredDisplayName,
+  featuredEntryForInstance,
+} from "../../../util/featured-id.js";
 import { isSafeLinkHref, renderMarkdown } from "../../../util/markdown.js";
 import type { ESPHomeDeviceSectionConfig } from "../device-section-config.js";
 import type { SectionConfigResponse } from "./loading.js";
@@ -30,7 +33,9 @@ export function renderSectionHeader(
     ? host._localize("device.external_component_title")
     : host._isPlatformDomain
       ? host._localize("device.platform_section_title")
-      : (featured?.name ?? config.title);
+      : featured
+        ? featuredDisplayName(featured, config.title)
+        : config.title;
   const description = featured?.description ?? config.description;
   const imageUrl = featured?.image_url || config.image_url;
   return html`

--- a/src/components/device/device-section-config/render-header.ts
+++ b/src/components/device/device-section-config/render-header.ts
@@ -33,20 +33,19 @@ export function renderSectionHeader(
     ? host._localize("device.external_component_title")
     : host._isPlatformDomain
       ? host._localize("device.platform_section_title")
-      : featured
-        ? featuredDisplayName(featured, config.title)
-        : config.title;
+      : config.title;
   const description = featured?.description ?? config.description;
   const imageUrl = featured?.image_url || config.image_url;
-  // A featured name replaces the component's identity, so surface what
-  // the section actually is ("ESP32 RMT LED Strip") as the subtitle —
-  // skipped when the title already carries it (the "Title (id)" form).
-  // A catalog miss keeps its raw section key there instead.
+  // The title keeps the component's identity ("ESP32 RMT LED Strip");
+  // the featured entry's name ("RGB LEDs (module)") rides the subtitle,
+  // named like the recommended card. A catalog miss keeps its raw
+  // section key there instead.
+  const featuredName = featured ? featuredDisplayName(featured, config.title) : null;
   const subtitle = catalogMiss
     ? host.sectionKey
-    : headerTitle.includes(config.title)
-      ? null
-      : config.title;
+    : featuredName !== config.title
+      ? featuredName
+      : null;
   return html`
     <div class="section-header">
       <div class="section-header-info">

--- a/src/util/featured-id.ts
+++ b/src/util/featured-id.ts
@@ -39,6 +39,21 @@ export function featuredEntryForInstance(
   );
 }
 
+/**
+ * Display name for a featured entry, mirroring the backend's
+ * ``_featured_display_name`` so every surface names the entry the same
+ * way: manifest ``name`` override, preset entity name (``fields.name``),
+ * then *fallback* suffixed with the preset id ("SPI Bus (lcd_spi)").
+ */
+export function featuredDisplayName(fc: FeaturedComponent, fallback: string): string {
+  if (fc.name) return fc.name;
+  const namePreset = fc.fields.name?.value;
+  if (typeof namePreset === "string" && namePreset) return namePreset;
+  const idPreset = fc.fields.id?.value;
+  if (typeof idPreset === "string" && idPreset) return `${fallback} (${idPreset})`;
+  return fallback;
+}
+
 /** Resolve a featured catalog id to the component it actually adds; non-featured or unknown ids pass through. */
 export function resolveFeaturedComponentId(
   id: string,

--- a/test/components/device/section-header-featured.test.ts
+++ b/test/components/device/section-header-featured.test.ts
@@ -75,16 +75,15 @@ const imgSrc = (tpl: unknown): unknown =>
   extractAttributeBindings(findTemplatesByAnchor(tpl, "<img")[0]).src;
 
 describe("section header featured presentation", () => {
-  it("uses the matching featured entry's name, description, and image", () => {
+  it("keeps the component title and subtitles the featured entry's name", () => {
     const tpl = renderSectionHeader(makeHost({ id: "rgb_leds" }), CONFIG, []);
     const out = serialize(tpl);
+    // Component identity stays the title; the module name rides below.
+    expect(out).toContain("ESP32 RMT LED Strip");
+    expect(out).toContain("section-subtitle");
     expect(out).toContain("RGB LEDs (module)");
     expect(out).toContain("The 10 RGB LEDs by themselves.");
     expect(imgSrc(tpl)).toBe("https://cdn.example/led_module.png");
-    // The featured name hides what the section is; the catalog title
-    // stays visible as the subtitle.
-    expect(out).toContain("section-subtitle");
-    expect(out).toContain("ESP32 RMT LED Strip");
   });
 
   it("falls back to the catalog image when the featured entry has none", () => {

--- a/test/components/device/section-header-featured.test.ts
+++ b/test/components/device/section-header-featured.test.ts
@@ -7,7 +7,6 @@
  */
 import { describe, expect, it } from "vitest";
 
-import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
 import { renderSectionHeader } from "../../../src/components/device/device-section-config/render-header.js";
 import type { ESPHomeDeviceSectionConfig } from "../../../src/components/device/device-section-config.js";
 import type { SectionConfigResponse } from "../../../src/components/device/device-section-config/loading.js";
@@ -15,27 +14,40 @@ import {
   extractAttributeBindings,
   findTemplatesByAnchor,
 } from "../../_lit-template-walker.js";
+import { makeTestBoard } from "./_renderer-fixtures.js";
 
-const BOARD = {
-  id: "apollo-esk-1",
-  featured_components: [
-    {
-      id: "rgb_leds",
-      component_id: "light.esp32_rmt_led_strip",
-      name: "RGB LEDs (module)",
-      description: "The 10 RGB LEDs by themselves.",
-      image_url: "https://cdn.example/led_module.png",
-      fields: { id: { value: "rgb_leds", locked: false, suggestions: null } },
-    },
-    {
-      id: "onboard_rgb_led",
-      component_id: "light.esp32_rmt_led_strip",
-      name: "Onboard RGB LED",
-      description: "The onboard RGB LED.",
-      fields: { id: { value: "onboard_rgb_led", locked: false, suggestions: null } },
-    },
-  ],
-} as unknown as BoardCatalogEntry;
+const BOARD = makeTestBoard({
+  overrides: {
+    id: "apollo-esk-1",
+    featured_components: [
+      {
+        id: "rgb_leds",
+        component_id: "light.esp32_rmt_led_strip",
+        name: "RGB LEDs (module)",
+        description: "The 10 RGB LEDs by themselves.",
+        image_url: "https://cdn.example/led_module.png",
+        fields: { id: { value: "rgb_leds" } },
+      },
+      {
+        id: "onboard_rgb_led",
+        component_id: "light.esp32_rmt_led_strip",
+        name: "Onboard RGB LED",
+        description: "The onboard RGB LED.",
+        fields: { id: { value: "onboard_rgb_led" } },
+      },
+      {
+        id: "relay_1",
+        component_id: "light.esp32_rmt_led_strip",
+        name: null,
+        description: null,
+        fields: {
+          id: { value: "relay_1" },
+          name: { value: "Relay 1" },
+        },
+      },
+    ],
+  } as never,
+});
 
 const CONFIG = {
   section_key: "light.esp32_rmt_led_strip",
@@ -75,6 +87,13 @@ describe("section header featured presentation", () => {
     const tpl = renderSectionHeader(makeHost({ id: "onboard_rgb_led" }), CONFIG, []);
     expect(serialize(tpl)).toContain("Onboard RGB LED");
     expect(imgSrc(tpl)).toBe("https://cdn.example/generic.png");
+  });
+
+  it("names an unnamed entry from its name preset, like the add card", () => {
+    // Mirrors the backend's _featured_display_name chain so the header
+    // and the recommended card never disagree on the entry's name.
+    const tpl = renderSectionHeader(makeHost({ id: "relay_1" }), CONFIG, []);
+    expect(serialize(tpl)).toContain("Relay 1");
   });
 
   it("keeps the catalog presentation for a hand-authored instance", () => {

--- a/test/components/device/section-header-featured.test.ts
+++ b/test/components/device/section-header-featured.test.ts
@@ -81,6 +81,10 @@ describe("section header featured presentation", () => {
     expect(out).toContain("RGB LEDs (module)");
     expect(out).toContain("The 10 RGB LEDs by themselves.");
     expect(imgSrc(tpl)).toBe("https://cdn.example/led_module.png");
+    // The featured name hides what the section is; the catalog title
+    // stays visible as the subtitle.
+    expect(out).toContain("section-subtitle");
+    expect(out).toContain("ESP32 RMT LED Strip");
   });
 
   it("falls back to the catalog image when the featured entry has none", () => {
@@ -102,5 +106,7 @@ describe("section header featured presentation", () => {
     expect(out).toContain("ESP32 RMT LED Strip");
     expect(out).toContain("Generic catalog description.");
     expect(imgSrc(tpl)).toBe("https://cdn.example/generic.png");
+    // No featured override, no subtitle.
+    expect(out).not.toContain("section-subtitle");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Follow up from the #1423 simplify review, which landed after that PR merged.

The section header resolved a featured entry's name as `featured.name ?? config.title`, a fork of the backend's `_featured_display_name` chain the recommended cards use (manifest name, then the `fields.name` preset, then the underlying name suffixed with the preset id). A manifest that leaves `name` null but presets `fields.name` would show one name on the add card and another in the header for the same entity. A new `featuredDisplayName` helper mirrors the backend rule in one client spot and the header uses it.

Also converts the header test's hand rolled board literal to `makeTestBoard`, matching the sibling tests, and pins the name preset case.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
