### PR TITLE
Auto-reconnect the web logs terminal after a re-enumeration

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1804,7 +1804,10 @@
       "open_failed": "Could not open the serial port: {error}",
       "reset_failed": "Could not reset the device.",
       "port_busy": "The device is busy with another operation. Close it and try again.",
-      "terminal_disconnected": "Terminal disconnected"
+      "terminal_disconnected": "Terminal disconnected",
+      "reconnecting": "Waiting for the device to come back…",
+      "reconnected": "Reconnected",
+      "reconnect_failed": "The device did not come back. Close the logs and reconnect it."
     },
     "dashboard_hint": {
       "logs": "Connect your device below, then click Logs to view its output.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1807,7 +1807,8 @@
       "terminal_disconnected": "Terminal disconnected",
       "reconnecting": "Waiting for the device to come back…",
       "reconnected": "Reconnected",
-      "reconnect_failed": "The device did not come back. Close the logs and reconnect it."
+      "reconnect_failed": "The device did not come back. Close the logs and reconnect it.",
+      "reconnect_gave_up": "Stopped reconnecting — no output after several attempts. Close the logs and reconnect."
     },
     "dashboard_hint": {
       "logs": "Connect your device below, then click Logs to view its output.",

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -5,8 +5,8 @@ import { OTA_PORT } from "../components/logs-session.js";
 import { resolveLogBaudRate } from "./log-baud-rate.js";
 import { notifyError } from "./notify.js";
 import {
-  grantedHandlesFor,
   isPortPickerCancel,
+  openLiveSerialPort,
   SERIAL_REOPEN_TIMEOUT_MS,
 } from "./web-serial.js";
 
@@ -160,60 +160,6 @@ export function postInstallShowLogsHandler(
 }
 
 /**
- * Open the live SerialPort for a device the post-install hard-reset just
- * closed, retrying through the native-USB re-enumeration window. Returns the
- * open port, or ``null`` if none opened inside ``timeoutMs``.
- *
- * ESP32-S3 / C3 / C6 (USB-Serial/JTAG) drop their USB device after the reset
- * and re-enumerate. On Chrome the *cached* handle esptool used stays dead
- * (``open()`` throws ``NetworkError`` forever) while ``navigator.serial.
- * getPorts()`` returns a fresh, openable handle for the same authorized
- * device — so each attempt prefers a live granted port, falling back to the
- * cached handle (which Firefox and non-re-enumerating UART bridges reopen
- * directly). No re-prompt: every candidate is already permitted.
- */
-async function openLiveSerialPort(
-  cachedPort: SerialPort,
-  baudRate: number,
-  timeoutMs: number
-): Promise<SerialPort | null> {
-  const deadline = Date.now() + timeoutMs;
-  let lastErr: unknown = null;
-  while (true) {
-    // Prefer a freshly-granted handle for the same device (Chrome's live
-    // re-enumerated port), then the cached handle (Firefox / UART bridges
-    // reopen it in place), probed even when getPorts() omits it: the open()
-    // attempt below is the real liveness test here.
-    const { fresh } = await grantedHandlesFor(cachedPort);
-    const candidates = [...fresh, cachedPort];
-    for (const p of candidates) {
-      if (p.readable) return p; // already open (a reset race left it usable)
-      try {
-        await p.open({ baudRate });
-        return p;
-      } catch (err) {
-        lastErr = err;
-        const name = err instanceof DOMException ? err.name : "";
-        const message = err instanceof Error ? err.message : "";
-        // Already open (a reset race / another candidate) — usable as-is.
-        if (name === "InvalidStateError" && /already open/i.test(message)) {
-          return p;
-        }
-        // Unusable this round — still re-enumerating (NetworkError), claimed by
-        // another app, or a transient driver / security error. Fall through to
-        // the next candidate (including the cached handle this function exists
-        // to fall back to) and only give up at the deadline below.
-      }
-    }
-    if (Date.now() >= deadline) {
-      console.error("[Web Serial] Failed to reopen port for logs:", lastErr);
-      return null;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 200));
-  }
-}
-
-/**
  * Start a Web Serial read loop and hand the dialog its port + loop-cancel.
  * Begins a passive session (user-initiated logs, post-install hand-off, or
  * the dialog's reconnect-after-failure). A closed port is reopened through the
@@ -228,7 +174,10 @@ export async function attachSerialLogStream(
   baudRate: number
 ): Promise<void> {
   if (!port.readable) {
-    const live = await openLiveSerialPort(port, baudRate, SERIAL_REOPEN_TIMEOUT_MS);
+    const live = await openLiveSerialPort(port, {
+      baudRate,
+      timeoutMs: SERIAL_REOPEN_TIMEOUT_MS,
+    });
     if (!live) {
       const message = localize("dashboard.logs_port_reopen_failed", {
         port: formatSerialPortLabel(port),

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -250,6 +250,64 @@ export async function reacquirePort(
 }
 
 /**
+ * Open a live handle for a possibly re-enumerating device, retrying through
+ * the re-enumeration window. Returns the OPEN port, or ``null`` past
+ * ``timeoutMs`` / on cancel.
+ *
+ * Presence in ``getPorts()`` isn't enough — a device can be enumerated but
+ * not yet openable (Chrome throws ``NetworkError`` in that window) — so the
+ * ``open()`` attempt is the real liveness test. Each round prefers a
+ * freshly-granted handle (Chrome's re-enumerated port), then the cached
+ * handle (Firefox / UART bridges reopen it in place).
+ */
+export async function openLiveSerialPort(
+  cachedPort: SerialPort,
+  options: {
+    baudRate: number;
+    bufferSize?: number;
+    timeoutMs?: number;
+    cancelled?: () => boolean;
+  }
+): Promise<SerialPort | null> {
+  const {
+    baudRate,
+    bufferSize,
+    timeoutMs = SERIAL_REOPEN_TIMEOUT_MS,
+    cancelled = () => false,
+  } = options;
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown = null;
+  while (!cancelled()) {
+    const { fresh } = await grantedHandlesFor(cachedPort);
+    const candidates = [...fresh, cachedPort];
+    for (const p of candidates) {
+      if (p.readable) return p; // already open (a reset race left it usable)
+      try {
+        await p.open(bufferSize ? { baudRate, bufferSize } : { baudRate });
+        return p;
+      } catch (err) {
+        lastErr = err;
+        const name = err instanceof DOMException ? err.name : "";
+        const message = err instanceof Error ? err.message : "";
+        // Already open (a reset race / another candidate) — usable as-is.
+        if (name === "InvalidStateError" && /already open/i.test(message)) {
+          return p;
+        }
+        // Unusable this round — still re-enumerating (NetworkError), claimed
+        // by another app, or a transient driver / security error. Fall
+        // through to the next candidate and only give up at the deadline.
+      }
+    }
+    if (Date.now() >= deadline) {
+      console.error("[Web Serial] Failed to reopen port:", lastErr);
+      return null;
+    }
+    await sleep(200);
+  }
+  return null;
+}
+
+/**
  * Open an already-authorized serial port and detect the connected chip.
  *
  * Used for both first-time detect (via ``detectChip`` after the

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -281,7 +281,16 @@ export async function openLiveSerialPort(
     const { fresh } = await grantedHandlesFor(cachedPort);
     const candidates = [...fresh, cachedPort];
     for (const p of candidates) {
-      if (p.readable) return p; // already open (a reset race left it usable)
+      if (p.readable) {
+        // Open but locked by an existing reader → unusable: the caller's
+        // getReader() would throw "already locked". Skip it and try the
+        // next candidate (mirrors live-log-port's candidate walk).
+        if (p.readable.locked) {
+          lastErr = new Error("port stream already locked");
+          continue;
+        }
+        return p; // already open (a reset race left it usable)
+      }
       try {
         await p.open(bufferSize ? { baudRate, bufferSize } : { baudRate });
         return p;
@@ -289,8 +298,15 @@ export async function openLiveSerialPort(
         lastErr = err;
         const name = err instanceof DOMException ? err.name : "";
         const message = err instanceof Error ? err.message : "";
-        // Already open (a reset race / another candidate) — usable as-is.
-        if (name === "InvalidStateError" && /already open/i.test(message)) {
+        // Already open (a reset race / another candidate) — usable as-is,
+        // unless its stream is held by another reader. Re-read readable:
+        // the failed open() invalidates the null the loop head narrowed to.
+        const readableNow = p.readable as ReadableStream<Uint8Array> | null;
+        if (
+          name === "InvalidStateError" &&
+          /already open/i.test(message) &&
+          !readableNow?.locked
+        ) {
           return p;
         }
         // Unusable this round — still re-enumerating (NetworkError), claimed

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -298,14 +298,17 @@ export async function openLiveSerialPort(
         lastErr = err;
         const name = err instanceof DOMException ? err.name : "";
         const message = err instanceof Error ? err.message : "";
-        // Already open (a reset race / another candidate) — usable as-is,
-        // unless its stream is held by another reader. Re-read readable:
-        // the failed open() invalidates the null the loop head narrowed to.
+        // Already open (a reset race / another candidate) — usable only
+        // with an actual unlocked stream: a fatal read error leaves a port
+        // open with readable null, and returning that would just throw at
+        // getReader(). Re-read readable: the failed open() invalidates the
+        // null the loop head narrowed to.
         const readableNow = p.readable as ReadableStream<Uint8Array> | null;
         if (
           name === "InvalidStateError" &&
           /already open/i.test(message) &&
-          !readableNow?.locked
+          readableNow &&
+          !readableNow.locked
         ) {
           return p;
         }
@@ -318,6 +321,9 @@ export async function openLiveSerialPort(
       console.error("[Web Serial] Failed to reopen port:", lastErr);
       return null;
     }
+    // Re-check before the inter-round sleep so a teardown that landed
+    // mid-round short-circuits instead of napping on it.
+    if (cancelled()) return null;
     await sleep(200);
   }
   return null;

--- a/src/web/dashboard/esphome-web-esp-connect-card.ts
+++ b/src/web/dashboard/esphome-web-esp-connect-card.ts
@@ -42,11 +42,20 @@ export class ESPHomeWebEspConnectCard extends LitElement {
     () => (this._port = undefined)
   );
 
+  // The logs dialog recovered a live handle from a read-error disconnect
+  // the watcher never saw (no DOM disconnect event fires for those); fold
+  // it in so the card's other actions use the live handle too.
+  private _onPortReplaced = (e: CustomEvent<SerialPort>): void => {
+    this._port = e.detail;
+    this._watcher.watch(e.detail);
+  };
+
   protected render() {
     if (this._port) {
       return html`<esphome-web-esp-device-card
         .port=${this._port}
         @close=${this._handleClose}
+        @port-replaced=${this._onPortReplaced}
       ></esphome-web-esp-device-card>`;
     }
 

--- a/src/web/dashboard/esphome-web-esp-connect-card.ts
+++ b/src/web/dashboard/esphome-web-esp-connect-card.ts
@@ -42,20 +42,12 @@ export class ESPHomeWebEspConnectCard extends LitElement {
     () => (this._port = undefined)
   );
 
-  // The logs dialog recovered a live handle from a read-error disconnect
-  // the watcher never saw (no DOM disconnect event fires for those); fold
-  // it in so the card's other actions use the live handle too.
-  private _onPortReplaced = (e: CustomEvent<SerialPort>): void => {
-    this._port = e.detail;
-    this._watcher.watch(e.detail);
-  };
-
   protected render() {
     if (this._port) {
       return html`<esphome-web-esp-device-card
         .port=${this._port}
         @close=${this._handleClose}
-        @port-replaced=${this._onPortReplaced}
+        @port-replaced=${(e: CustomEvent<SerialPort>) => this._watcher.adopt(e.detail)}
       ></esphome-web-esp-device-card>`;
     }
 

--- a/src/web/dashboard/esphome-web-pico-connect-card.ts
+++ b/src/web/dashboard/esphome-web-pico-connect-card.ts
@@ -46,11 +46,20 @@ export class ESPHomeWebPicoConnectCard extends LitElement {
     () => (this._port = undefined)
   );
 
+  // The logs dialog recovered a live handle from a read-error disconnect
+  // the watcher never saw (no DOM disconnect event fires for those); fold
+  // it in so the card's other actions use the live handle too.
+  private _onPortReplaced = (e: CustomEvent<SerialPort>): void => {
+    this._port = e.detail;
+    this._watcher.watch(e.detail);
+  };
+
   protected render() {
     if (this._port) {
       return html`<esphome-web-pico-device-card
         .port=${this._port}
         @close=${this._handleClose}
+        @port-replaced=${this._onPortReplaced}
       ></esphome-web-pico-device-card>`;
     }
 

--- a/src/web/dashboard/esphome-web-pico-connect-card.ts
+++ b/src/web/dashboard/esphome-web-pico-connect-card.ts
@@ -46,20 +46,12 @@ export class ESPHomeWebPicoConnectCard extends LitElement {
     () => (this._port = undefined)
   );
 
-  // The logs dialog recovered a live handle from a read-error disconnect
-  // the watcher never saw (no DOM disconnect event fires for those); fold
-  // it in so the card's other actions use the live handle too.
-  private _onPortReplaced = (e: CustomEvent<SerialPort>): void => {
-    this._port = e.detail;
-    this._watcher.watch(e.detail);
-  };
-
   protected render() {
     if (this._port) {
       return html`<esphome-web-pico-device-card
         .port=${this._port}
         @close=${this._handleClose}
-        @port-replaced=${this._onPortReplaced}
+        @port-replaced=${(e: CustomEvent<SerialPort>) => this._watcher.adopt(e.detail)}
       ></esphome-web-pico-device-card>`;
     }
 

--- a/src/web/logs/esphome-web-logs-dialog.ts
+++ b/src/web/logs/esphome-web-logs-dialog.ts
@@ -287,9 +287,12 @@ export class ESPHomeWebLogsDialog extends LitElement {
   }
 
   // Recovery failed ⇒ the handle is released and the spinner is down.
+  // Release, not just clear: a sync throw in _streamFrom lands here with
+  // the freshly-opened handle already recorded as _activePort, and the
+  // already-closed old port on the !live path rejects harmlessly.
   private _failReconnect(): void {
     this._streaming = false;
-    this._activePort = undefined;
+    this._releaseActivePort();
     this._enqueueLine(this._localize("web.logs.reconnect_failed"));
     this._flushPending();
   }

--- a/src/web/logs/esphome-web-logs-dialog.ts
+++ b/src/web/logs/esphome-web-logs-dialog.ts
@@ -218,87 +218,105 @@ export class ESPHomeWebLogsDialog extends LitElement {
       // The reader is gone and _cancel is cleared, so nothing else will
       // release the handle — an open Web Serial port locks the device
       // away from every other tool for the tab's lifetime.
-      this._activePort = undefined;
-      void port?.close().catch(() => {});
+      this._releaseActivePort();
       this._flushPending();
       return;
     }
     this._enqueueLine(this._localize("web.logs.reconnecting"));
     this._flushPending();
     const generation = ++this._reacquireGeneration;
-    void (async () => {
-      // Close the dead stream's port first: the reacquired handle is often
-      // this very one (a UART bridge, or Firefox after a re-enum), and
-      // reopening a still-open port would re-read the dead stream and loop.
-      // The dead reader already released its lock, so close() can proceed;
-      // a UA that closed it on device loss rejects harmlessly. A real
-      // failure is logged — it means the cached handle may come back dead.
-      await port.close().catch((err) => {
-        console.error("[Web Serial] Failed to close the dead logs port:", err);
-      });
-      const live = await openLiveSerialPort(port, {
-        baudRate: LOG_BAUD_RATE,
-        bufferSize: LOG_BUFFER_SIZE,
-        cancelled: () => generation !== this._reacquireGeneration,
-      });
-      if (generation !== this._reacquireGeneration) {
-        // Superseded after the open — reclaim the handle we just opened.
-        if (live) {
-          void live.close().catch((err) => {
-            console.error("[Web Serial] Failed to release superseded port:", err);
-          });
-        }
-        return;
-      }
-      if (!live) {
-        this._enqueueLine(this._localize("web.logs.reconnect_failed"));
-        this._flushPending();
-        return;
-      }
-      this._enqueueLine(this._localize("web.logs.reconnected"));
-      this._enqueueLine("");
-      // Honour a Stop pressed before the reset: the reader drains either
-      // way, so the display stays paused instead of force-resuming.
-      this._streaming = !wasPaused;
-      this._paused = wasPaused;
-      this._streamFrom(live);
-      // Hand the recovered handle to the parent card: a read-error-only
-      // disconnect fires no DOM disconnect event, so the card's watcher
-      // may still hold the dead one for the other actions.
-      this.dispatchEvent(
-        new CustomEvent("port-replaced", {
-          detail: live,
-          bubbles: true,
-          composed: true,
-        })
-      );
-    })().catch((err) => {
-      // A synchronous throw in the resume tail (a locked readable slipping
-      // through) must not strand the spinner on a dead stream.
+    void this._resumeAfterDisconnect(port, generation, wasPaused).catch((err) => {
+      // A throw in the resume tail (a locked readable slipping through)
+      // must not strand the spinner on a dead stream.
       console.error("[Web Serial] Logs reconnect failed:", err);
       if (generation !== this._reacquireGeneration) return;
-      this._streaming = false;
-      this._enqueueLine(this._localize("web.logs.reconnect_failed"));
-      this._flushPending();
+      this._failReconnect();
     });
+  }
+
+  private async _resumeAfterDisconnect(
+    port: SerialPort,
+    generation: number,
+    wasPaused: boolean
+  ): Promise<void> {
+    // Close the dead stream's port first: the reacquired handle is often
+    // this very one (a UART bridge, or Firefox after a re-enum), and
+    // reopening a still-open port would re-read the dead stream and loop.
+    // The dead reader already released its lock, so close() can proceed;
+    // a UA that closed it on device loss rejects harmlessly. A real
+    // failure is logged — it means the cached handle may come back dead.
+    await port.close().catch((err) => {
+      console.error("[Web Serial] Failed to close the dead logs port:", err);
+    });
+    const live = await openLiveSerialPort(port, {
+      baudRate: LOG_BAUD_RATE,
+      bufferSize: LOG_BUFFER_SIZE,
+      cancelled: () => generation !== this._reacquireGeneration,
+    });
+    if (generation !== this._reacquireGeneration) {
+      // Superseded after the open — reclaim the handle we just opened.
+      // Logged loudly: a failure here is a genuinely leaked open port.
+      if (live) {
+        void live.close().catch((err) => {
+          console.error("[Web Serial] Failed to release superseded port:", err);
+        });
+      }
+      return;
+    }
+    if (!live) {
+      this._failReconnect();
+      return;
+    }
+    this._enqueueLine(this._localize("web.logs.reconnected"));
+    this._enqueueLine("");
+    // Honour a Stop pressed before the reset: the reader drains either
+    // way, so the display stays paused instead of force-resuming.
+    this._streaming = !wasPaused;
+    this._paused = wasPaused;
+    this._streamFrom(live);
+    // Hand the recovered handle to the parent card: a read-error-only
+    // disconnect fires no DOM disconnect event, so the card's watcher
+    // may still hold the dead one for the other actions.
+    this.dispatchEvent(
+      new CustomEvent("port-replaced", {
+        detail: live,
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  // Recovery failed ⇒ the handle is released and the spinner is down.
+  private _failReconnect(): void {
+    this._streaming = false;
+    this._activePort = undefined;
+    this._enqueueLine(this._localize("web.logs.reconnect_failed"));
+    this._flushPending();
+  }
+
+  // Null-and-close the abandoned active handle in one step: the paired
+  // invariant on every reader-already-dead path.
+  private _releaseActivePort(): void {
+    const active = this._activePort;
+    this._activePort = undefined;
+    void active?.close().catch(() => {});
   }
 
   private _stop(): void {
     this._reacquireGeneration++;
     this._streaming = false;
     this._paused = false;
-    const active = this._activePort;
-    this._activePort = undefined;
     this._resetPending();
     const cancel = this._cancel;
     this._cancel = undefined;
     if (cancel) {
+      this._activePort = undefined;
       cancel();
     } else {
       // A dead-stream path already dropped the cancel closure; release
       // whatever handle the reconnect flow last held (a no-op when the
       // UA closed it with the device).
-      void active?.close().catch(() => {});
+      this._releaseActivePort();
     }
   }
 

--- a/src/web/logs/esphome-web-logs-dialog.ts
+++ b/src/web/logs/esphome-web-logs-dialog.ts
@@ -213,7 +213,9 @@ export class ESPHomeWebLogsDialog extends LitElement {
     const port = this._activePort;
     if (!this.open || !port || ++this._silentReconnects > MAX_SILENT_RECONNECTS) {
       if (this.open && port) {
-        this._enqueueLine(this._localize("web.logs.reconnect_failed"));
+        // The cap case: every reopen succeeded but nothing readable ever
+        // arrived — a different diagnosis than "did not come back".
+        this._enqueueLine(this._localize("web.logs.reconnect_gave_up"));
       }
       // The reader is gone and _cancel is cleared, so nothing else will
       // release the handle — an open Web Serial port locks the device
@@ -292,6 +294,9 @@ export class ESPHomeWebLogsDialog extends LitElement {
   // already-closed old port on the !live path rejects harmlessly.
   private _failReconnect(): void {
     this._streaming = false;
+    // The .catch path lands here after _paused was restored for the resume;
+    // a Start button over a released port would strand the spinner.
+    this._paused = false;
     this._releaseActivePort();
     this._enqueueLine(this._localize("web.logs.reconnect_failed"));
     this._flushPending();

--- a/src/web/logs/esphome-web-logs-dialog.ts
+++ b/src/web/logs/esphome-web-logs-dialog.ts
@@ -150,14 +150,15 @@ export class ESPHomeWebLogsDialog extends LitElement {
     this._resetLines();
     this._paused = false;
     this._streaming = true;
-    this._activePort = this.port;
     this._streamFrom(this.port);
   }
 
   // Shared reader: same ESPHome log formatting / timestamps / garbage
   // filtering as the dashboard's post-install serial logs. The cancel it
-  // returns also closes the port.
+  // returns also closes the port. Single place the live handle is recorded,
+  // so "streaming ⇒ _activePort set" holds by construction.
   private _streamFrom(port: SerialPort): void {
+    this._activePort = port;
     this._cancel = streamSerialLines(port, {
       // Stop pauses only the display — the reader keeps draining the port so a
       // Start resumes without a reopen (which would DTR/RTS-reset the device).
@@ -208,7 +209,6 @@ export class ESPHomeWebLogsDialog extends LitElement {
       if (generation !== this._reacquireGeneration) return;
       if (live && (await openPortForLogs(live, this._localize))) {
         if (generation !== this._reacquireGeneration) return;
-        this._activePort = live;
         this._enqueueLine(this._localize("web.logs.reconnected"));
         this._enqueueLine("");
         this._streaming = true;

--- a/src/web/logs/esphome-web-logs-dialog.ts
+++ b/src/web/logs/esphome-web-logs-dialog.ts
@@ -215,6 +215,11 @@ export class ESPHomeWebLogsDialog extends LitElement {
       if (this.open && port) {
         this._enqueueLine(this._localize("web.logs.reconnect_failed"));
       }
+      // The reader is gone and _cancel is cleared, so nothing else will
+      // release the handle — an open Web Serial port locks the device
+      // away from every other tool for the tab's lifetime.
+      this._activePort = undefined;
+      void port?.close().catch(() => {});
       this._flushPending();
       return;
     }
@@ -226,8 +231,11 @@ export class ESPHomeWebLogsDialog extends LitElement {
       // this very one (a UART bridge, or Firefox after a re-enum), and
       // reopening a still-open port would re-read the dead stream and loop.
       // The dead reader already released its lock, so close() can proceed;
-      // a UA that closed it on device loss rejects harmlessly.
-      await port.close().catch(() => {});
+      // a UA that closed it on device loss rejects harmlessly. A real
+      // failure is logged — it means the cached handle may come back dead.
+      await port.close().catch((err) => {
+        console.error("[Web Serial] Failed to close the dead logs port:", err);
+      });
       const live = await openLiveSerialPort(port, {
         baudRate: LOG_BAUD_RATE,
         bufferSize: LOG_BUFFER_SIZE,
@@ -235,7 +243,11 @@ export class ESPHomeWebLogsDialog extends LitElement {
       });
       if (generation !== this._reacquireGeneration) {
         // Superseded after the open — reclaim the handle we just opened.
-        if (live) void live.close().catch(() => {});
+        if (live) {
+          void live.close().catch((err) => {
+            console.error("[Web Serial] Failed to release superseded port:", err);
+          });
+        }
         return;
       }
       if (!live) {
@@ -250,18 +262,44 @@ export class ESPHomeWebLogsDialog extends LitElement {
       this._streaming = !wasPaused;
       this._paused = wasPaused;
       this._streamFrom(live);
-    })();
+      // Hand the recovered handle to the parent card: a read-error-only
+      // disconnect fires no DOM disconnect event, so the card's watcher
+      // may still hold the dead one for the other actions.
+      this.dispatchEvent(
+        new CustomEvent("port-replaced", {
+          detail: live,
+          bubbles: true,
+          composed: true,
+        })
+      );
+    })().catch((err) => {
+      // A synchronous throw in the resume tail (a locked readable slipping
+      // through) must not strand the spinner on a dead stream.
+      console.error("[Web Serial] Logs reconnect failed:", err);
+      if (generation !== this._reacquireGeneration) return;
+      this._streaming = false;
+      this._enqueueLine(this._localize("web.logs.reconnect_failed"));
+      this._flushPending();
+    });
   }
 
   private _stop(): void {
     this._reacquireGeneration++;
     this._streaming = false;
     this._paused = false;
+    const active = this._activePort;
     this._activePort = undefined;
     this._resetPending();
     const cancel = this._cancel;
     this._cancel = undefined;
-    cancel?.();
+    if (cancel) {
+      cancel();
+    } else {
+      // A dead-stream path already dropped the cancel closure; release
+      // whatever handle the reconnect flow last held (a no-op when the
+      // UA closed it with the device).
+      void active?.close().catch(() => {});
+    }
   }
 
   // Buffer a streamed line; flush on the next animation frame so a log flood

--- a/src/web/logs/esphome-web-logs-dialog.ts
+++ b/src/web/logs/esphome-web-logs-dialog.ts
@@ -17,7 +17,7 @@ import { downloadAnsiText } from "../../util/download-text.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { streamSerialLines } from "../../util/serial-log-stream.js";
 import { sleep } from "../../util/sleep.js";
-import { reacquirePort } from "../../util/web-serial.js";
+import { openLiveSerialPort } from "../../util/web-serial.js";
 
 import "../../components/base-dialog.js";
 import "../../components/process-terminal/process-terminal.js";
@@ -39,6 +39,14 @@ const MAX_LOG_LINES = 10000;
 // default is all that applies.
 const LOG_BAUD_RATE = 115200;
 
+// 8k buffer (vs Chrome's 255-byte default) so a burst of boot logs in a
+// throttled/backgrounded tab doesn't overrun — matches the legacy site.
+const LOG_BUFFER_SIZE = 8192;
+
+// Consecutive reconnect cycles that produced no log lines before giving up:
+// a flapping bridge or a device stuck resetting must not churn forever.
+const MAX_SILENT_RECONNECTS = 3;
+
 /**
  * Open a port for the logs view before showing the dialog. Returns ``true`` if
  * the port is ready to stream. Opening here (in the caller's click gesture)
@@ -51,9 +59,7 @@ export async function openPortForLogs(
   localize: LocalizeFunc
 ): Promise<boolean> {
   try {
-    // 8k buffer (vs Chrome's 255-byte default) so a burst of boot logs in a
-    // throttled/backgrounded tab doesn't overrun — matches the legacy site.
-    await port.open({ baudRate: LOG_BAUD_RATE, bufferSize: 8192 });
+    await port.open({ baudRate: LOG_BAUD_RATE, bufferSize: LOG_BUFFER_SIZE });
   } catch (err) {
     // ``InvalidStateError`` means the port is already open. That's fine ONLY if
     // nothing else holds its reader — streamSerialLines() calls getReader(), so
@@ -82,6 +88,8 @@ export async function openPortForLogs(
  * plain Web Serial reader instead of the backend logs WS — no ``apiContext``,
  * no OTA source. The parent opens the port (via ``openPortForLogs``) before
  * showing the dialog; the dialog streams it and closes it on ``after-hide``.
+ * After a mid-stream disconnect the dialog owns recovery: it closes the
+ * dead handle and reopens a live one itself (``openLiveSerialPort``).
  */
 @customElement("esphome-web-logs-dialog")
 export class ESPHomeWebLogsDialog extends LitElement {
@@ -120,6 +128,9 @@ export class ESPHomeWebLogsDialog extends LitElement {
   private _activePort?: SerialPort;
   // Supersedes stale reacquire attempts (close, a newer disconnect).
   private _reacquireGeneration = 0;
+  // Consecutive reconnects that have produced no log lines yet; reset by
+  // the first line after a resume, checked against MAX_SILENT_RECONNECTS.
+  private _silentReconnects = 0;
   // Batched line buffer flushed on the next animation frame, matching the
   // dashboard logs dialog (logs-dialog.ts): a flooding device would otherwise
   // trigger a Lit render per line. Flushed early on teardown / clear / download.
@@ -144,12 +155,14 @@ export class ESPHomeWebLogsDialog extends LitElement {
   }
 
   // The parent opens the port (openPortForLogs) before showing the dialog, so
-  // here we just stream it. Defensive guard: a closed port has no readable.
+  // the initial stream reads it as-is; reconnect reopens are this dialog's
+  // own (_onDisconnect). Defensive guard: a closed port has no readable.
   private _start(): void {
     if (!this.port?.readable || this._cancel) return;
     this._resetLines();
     this._paused = false;
     this._streaming = true;
+    this._silentReconnects = 0;
     this._streamFrom(this.port);
   }
 
@@ -163,6 +176,7 @@ export class ESPHomeWebLogsDialog extends LitElement {
       // Stop pauses only the display — the reader keeps draining the port so a
       // Start resumes without a reopen (which would DTR/RTS-reset the device).
       onLine: (line) => {
+        this._silentReconnects = 0;
         if (!this._paused) this._enqueueLine(line);
       },
       onDisconnect: (error) => this._onDisconnect(error),
@@ -191,38 +205,52 @@ export class ESPHomeWebLogsDialog extends LitElement {
     this._enqueueLine("");
     const base = this._localize("web.logs.terminal_disconnected");
     this._enqueueLine(error ? `${base}: ${String(error)}` : base);
-    // Reader ended: no Stop/Start button (neither streaming nor paused).
-    // Dropping the cancel closure without calling it is deliberate — the
-    // dead reader already released its lock (the stream helper's finally),
-    // the UA auto-closes the port on real device loss, and a port that
-    // survived its stream stays tolerated by openPortForLogs' already-open
-    // path when the resume reopens it.
+    // Reader ended: no Stop/Start button until the resume decides.
     this._cancel = undefined;
     this._streaming = false;
+    const wasPaused = this._paused;
     this._paused = false;
     const port = this._activePort;
-    if (!this.open || !port) {
+    if (!this.open || !port || ++this._silentReconnects > MAX_SILENT_RECONNECTS) {
+      if (this.open && port) {
+        this._enqueueLine(this._localize("web.logs.reconnect_failed"));
+      }
       this._flushPending();
       return;
     }
     this._enqueueLine(this._localize("web.logs.reconnecting"));
     this._flushPending();
     const generation = ++this._reacquireGeneration;
-    void reacquirePort(port, {
-      cancelled: () => generation !== this._reacquireGeneration,
-    }).then(async (live) => {
-      if (generation !== this._reacquireGeneration) return;
-      if (live && (await openPortForLogs(live, this._localize))) {
-        if (generation !== this._reacquireGeneration) return;
-        this._enqueueLine(this._localize("web.logs.reconnected"));
-        this._enqueueLine("");
-        this._streaming = true;
-        this._streamFrom(live);
-      } else {
+    void (async () => {
+      // Close the dead stream's port first: the reacquired handle is often
+      // this very one (a UART bridge, or Firefox after a re-enum), and
+      // reopening a still-open port would re-read the dead stream and loop.
+      // The dead reader already released its lock, so close() can proceed;
+      // a UA that closed it on device loss rejects harmlessly.
+      await port.close().catch(() => {});
+      const live = await openLiveSerialPort(port, {
+        baudRate: LOG_BAUD_RATE,
+        bufferSize: LOG_BUFFER_SIZE,
+        cancelled: () => generation !== this._reacquireGeneration,
+      });
+      if (generation !== this._reacquireGeneration) {
+        // Superseded after the open — reclaim the handle we just opened.
+        if (live) void live.close().catch(() => {});
+        return;
+      }
+      if (!live) {
         this._enqueueLine(this._localize("web.logs.reconnect_failed"));
         this._flushPending();
+        return;
       }
-    });
+      this._enqueueLine(this._localize("web.logs.reconnected"));
+      this._enqueueLine("");
+      // Honour a Stop pressed before the reset: the reader drains either
+      // way, so the display stays paused instead of force-resuming.
+      this._streaming = !wasPaused;
+      this._paused = wasPaused;
+      this._streamFrom(live);
+    })();
   }
 
   private _stop(): void {

--- a/src/web/logs/esphome-web-logs-dialog.ts
+++ b/src/web/logs/esphome-web-logs-dialog.ts
@@ -17,6 +17,7 @@ import { downloadAnsiText } from "../../util/download-text.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { streamSerialLines } from "../../util/serial-log-stream.js";
 import { sleep } from "../../util/sleep.js";
+import { reacquirePort } from "../../util/web-serial.js";
 
 import "../../components/base-dialog.js";
 import "../../components/process-terminal/process-terminal.js";
@@ -112,6 +113,13 @@ export class ESPHomeWebLogsDialog extends LitElement {
   @state() private _paused = false;
 
   private _cancel?: () => void;
+  // Handle currently streamed. Starts as ``port`` and is replaced when a
+  // native-USB re-enumeration hands back a fresh handle; the parent's own
+  // ``PortDisconnectWatcher`` swap can't be relied on here — Firefox keeps
+  // the same handle, so no property change ever reaches this dialog.
+  private _activePort?: SerialPort;
+  // Supersedes stale reacquire attempts (close, a newer disconnect).
+  private _reacquireGeneration = 0;
   // Batched line buffer flushed on the next animation frame, matching the
   // dashboard logs dialog (logs-dialog.ts): a flooding device would otherwise
   // trigger a Lit render per line. Flushed early on teardown / clear / download.
@@ -128,6 +136,13 @@ export class ESPHomeWebLogsDialog extends LitElement {
     }
   }
 
+  // A genuine unplug collapses the whole device card (the connect card's
+  // watcher), unmounting this dialog mid-reacquire — cancel it.
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._stop();
+  }
+
   // The parent opens the port (openPortForLogs) before showing the dialog, so
   // here we just stream it. Defensive guard: a closed port has no readable.
   private _start(): void {
@@ -135,10 +150,15 @@ export class ESPHomeWebLogsDialog extends LitElement {
     this._resetLines();
     this._paused = false;
     this._streaming = true;
-    // Shared reader: same ESPHome log formatting / timestamps / garbage
-    // filtering as the dashboard's post-install serial logs. The cancel it
-    // returns also closes the port.
-    this._cancel = streamSerialLines(this.port, {
+    this._activePort = this.port;
+    this._streamFrom(this.port);
+  }
+
+  // Shared reader: same ESPHome log formatting / timestamps / garbage
+  // filtering as the dashboard's post-install serial logs. The cancel it
+  // returns also closes the port.
+  private _streamFrom(port: SerialPort): void {
+    this._cancel = streamSerialLines(port, {
       // Stop pauses only the display — the reader keeps draining the port so a
       // Start resumes without a reopen (which would DTR/RTS-reset the device).
       onLine: (line) => {
@@ -162,22 +182,49 @@ export class ESPHomeWebLogsDialog extends LitElement {
   }
 
   // The device dropped the stream on its own (unplugged / reset). Print a
-  // "Terminal disconnected" line and drop the spinner, matching legacy — the
-  // terminal would otherwise look stuck streaming forever.
+  // "Terminal disconnected" line, then ride out a native-USB re-enumeration
+  // the way the connect cards do: reacquire the handle, reopen, and resume
+  // streaming. Only a device that stays gone ends the terminal for good.
   private _onDisconnect(error?: unknown): void {
     this._enqueueLine("");
     this._enqueueLine("");
     const base = this._localize("web.logs.terminal_disconnected");
     this._enqueueLine(error ? `${base}: ${String(error)}` : base);
-    this._flushPending();
     // Reader ended: no Stop/Start button (neither streaming nor paused).
+    this._cancel = undefined;
     this._streaming = false;
     this._paused = false;
+    const port = this._activePort;
+    if (!this.open || !port) {
+      this._flushPending();
+      return;
+    }
+    this._enqueueLine(this._localize("web.logs.reconnecting"));
+    this._flushPending();
+    const generation = ++this._reacquireGeneration;
+    void reacquirePort(port, {
+      cancelled: () => generation !== this._reacquireGeneration,
+    }).then(async (live) => {
+      if (generation !== this._reacquireGeneration) return;
+      if (live && (await openPortForLogs(live, this._localize))) {
+        if (generation !== this._reacquireGeneration) return;
+        this._activePort = live;
+        this._enqueueLine(this._localize("web.logs.reconnected"));
+        this._enqueueLine("");
+        this._streaming = true;
+        this._streamFrom(live);
+      } else {
+        this._enqueueLine(this._localize("web.logs.reconnect_failed"));
+        this._flushPending();
+      }
+    });
   }
 
   private _stop(): void {
+    this._reacquireGeneration++;
     this._streaming = false;
     this._paused = false;
+    this._activePort = undefined;
     this._resetPending();
     const cancel = this._cancel;
     this._cancel = undefined;
@@ -224,10 +271,12 @@ export class ESPHomeWebLogsDialog extends LitElement {
   // 1s settle for the device to come back up. Best-effort — some USB bridges
   // don't wire the reset lines.
   private async _resetDevice(): Promise<void> {
-    if (!this.port) return;
+    // The reacquired handle after a re-enumeration, never the stale one.
+    const port = this._activePort ?? this.port;
+    if (!port) return;
     try {
-      await this.port.setSignals({ dataTerminalReady: false, requestToSend: true });
-      await this.port.setSignals({ dataTerminalReady: false, requestToSend: false });
+      await port.setSignals({ dataTerminalReady: false, requestToSend: true });
+      await port.setSignals({ dataTerminalReady: false, requestToSend: false });
       await sleep(1000);
     } catch {
       toast.error(this._localize("web.logs.reset_failed"));

--- a/src/web/logs/esphome-web-logs-dialog.ts
+++ b/src/web/logs/esphome-web-logs-dialog.ts
@@ -192,6 +192,11 @@ export class ESPHomeWebLogsDialog extends LitElement {
     const base = this._localize("web.logs.terminal_disconnected");
     this._enqueueLine(error ? `${base}: ${String(error)}` : base);
     // Reader ended: no Stop/Start button (neither streaming nor paused).
+    // Dropping the cancel closure without calling it is deliberate — the
+    // dead reader already released its lock (the stream helper's finally),
+    // the UA auto-closes the port on real device loss, and a port that
+    // survived its stream stays tolerated by openPortForLogs' already-open
+    // path when the resume reopens it.
     this._cancel = undefined;
     this._streaming = false;
     this._paused = false;

--- a/src/web/util/port-disconnect-watcher.ts
+++ b/src/web/util/port-disconnect-watcher.ts
@@ -32,6 +32,15 @@ export class PortDisconnectWatcher implements ReactiveController {
     port.addEventListener("disconnect", this._handleDisconnect);
   }
 
+  /** Fold in a live handle another recovery path produced (the logs
+   *  dialog's read-error resume): report it and move the watch — which
+   *  also supersedes any reacquire in flight for the same physical
+   *  disconnect. */
+  adopt(port: SerialPort): void {
+    this.watch(port);
+    this._onReplace(port);
+  }
+
   /** Stop watching (explicit disconnect); no callbacks fire after. */
   unwatch(): void {
     this._generation++;

--- a/test/util/web-serial-reacquire.test.ts
+++ b/test/util/web-serial-reacquire.test.ts
@@ -149,6 +149,22 @@ describe("openLiveSerialPort", () => {
     });
   });
 
+  it("never returns an already-open port whose readable is null", async () => {
+    // A fatal read error leaves a port open with readable null; handing it
+    // back would just throw at getReader(). The loop must keep retrying.
+    const cached = fakePort({
+      readable: null,
+      open: vi.fn(async () => {
+        throw Object.assign(new DOMException("Port already open", "InvalidStateError"));
+      }),
+    });
+    stubGetPorts(async () => []);
+
+    expect(await openLiveSerialPort(cached, { baudRate: 115200, timeoutMs: 1 })).toBe(
+      null
+    );
+  });
+
   it("stops polling when cancelled", async () => {
     let rounds = 0;
     const cached = fakePort({

--- a/test/util/web-serial-reacquire.test.ts
+++ b/test/util/web-serial-reacquire.test.ts
@@ -133,4 +133,41 @@ describe("openLiveSerialPort", () => {
       null
     );
   });
+
+  it("forwards bufferSize to open (the 8k logs buffer must survive the reopen)", async () => {
+    const cached = fakePort({ readable: null, open: vi.fn(async () => {}) });
+    stubGetPorts(async () => []);
+
+    await openLiveSerialPort(cached, {
+      baudRate: 115200,
+      bufferSize: 8192,
+      timeoutMs: 500,
+    });
+    expect((cached as any).open).toHaveBeenCalledWith({
+      baudRate: 115200,
+      bufferSize: 8192,
+    });
+  });
+
+  it("stops polling when cancelled", async () => {
+    let rounds = 0;
+    const cached = fakePort({
+      readable: null,
+      open: vi.fn(async () => {
+        throw new DOMException("not ready", "NetworkError");
+      }),
+    });
+    stubGetPorts(async () => {
+      rounds++;
+      return [];
+    });
+
+    const got = await openLiveSerialPort(cached, {
+      baudRate: 115200,
+      timeoutMs: 60000,
+      cancelled: () => rounds >= 2,
+    });
+    expect(got).toBe(null);
+    expect(rounds).toBeLessThanOrEqual(3);
+  });
 });

--- a/test/util/web-serial-reacquire.test.ts
+++ b/test/util/web-serial-reacquire.test.ts
@@ -8,7 +8,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { reacquirePort } from "../../src/util/web-serial.js";
+import { openLiveSerialPort, reacquirePort } from "../../src/util/web-serial.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -94,5 +94,43 @@ describe("reacquirePort", () => {
       await reacquirePort(cached, { timeoutMs: 1000, cancelled: () => true })
     ).toBeNull();
     expect(getPorts).not.toHaveBeenCalled();
+  });
+});
+
+describe("openLiveSerialPort", () => {
+  it("skips an open candidate whose stream is locked and opens the next", async () => {
+    const cached = fakePort({
+      readable: null,
+      open: vi.fn(async () => {}),
+    });
+    const locked = fakePort({ readable: { locked: true } });
+    stubGetPorts(async () => [locked, cached]);
+
+    const got = await openLiveSerialPort(cached, { baudRate: 115200, timeoutMs: 500 });
+    expect(got).toBe(cached);
+    expect((cached as any).open).toHaveBeenCalledWith({ baudRate: 115200 });
+  });
+
+  it("returns an open unlocked candidate without reopening it", async () => {
+    const cached = fakePort({ readable: null, open: vi.fn(async () => {}) });
+    const openUnlocked = fakePort({ readable: { locked: false } });
+    stubGetPorts(async () => [openUnlocked]);
+
+    const got = await openLiveSerialPort(cached, { baudRate: 115200, timeoutMs: 500 });
+    expect(got).toBe(openUnlocked);
+  });
+
+  it("gives up past the deadline when every candidate stays unopenable", async () => {
+    const cached = fakePort({
+      readable: null,
+      open: vi.fn(async () => {
+        throw new DOMException("not ready", "NetworkError");
+      }),
+    });
+    stubGetPorts(async () => []);
+
+    expect(await openLiveSerialPort(cached, { baudRate: 115200, timeoutMs: 1 })).toBe(
+      null
+    );
   });
 });

--- a/test/web/esp-connect-card.test.ts
+++ b/test/web/esp-connect-card.test.ts
@@ -76,6 +76,25 @@ describe("esphome-web-esp-connect-card disconnect resilience", () => {
     return el;
   }
 
+  it("folds a dialog-recovered handle in via port-replaced (composed hop)", async () => {
+    const port = makeDisconnectPort();
+    const live = makeDisconnectPort();
+    const el = await connected(port);
+    document.body.appendChild(el);
+    await (el as any).updateComplete;
+
+    // The logs dialog dispatches from inside the device card's shadow root;
+    // composed: true is what lets it reach the connect card's binding.
+    const device = el.shadowRoot!.querySelector("esphome-web-esp-device-card")!;
+    device.dispatchEvent(
+      new CustomEvent("port-replaced", { detail: live, bubbles: true, composed: true })
+    );
+
+    expect((el as any)._port).toBe(live);
+    expect(live.listenerCount()).toBe(1);
+    el.remove();
+  });
+
   it("keeps the device card through a re-enum blip, rebinding the live handle (#1410)", async () => {
     const port = makeDisconnectPort();
     const fresh = makeDisconnectPort();

--- a/test/web/esp-connect-card.test.ts
+++ b/test/web/esp-connect-card.test.ts
@@ -83,10 +83,13 @@ describe("esphome-web-esp-connect-card disconnect resilience", () => {
     document.body.appendChild(el);
     await (el as any).updateComplete;
 
-    // The logs dialog dispatches from inside the device card's shadow root;
-    // composed: true is what lets it reach the connect card's binding.
+    // The logs dialog dispatches from inside the device card's shadow
+    // root; give the stubbed card one so the event genuinely crosses a
+    // shadow boundary — composed: true is what carries it out.
     const device = el.shadowRoot!.querySelector("esphome-web-esp-device-card")!;
-    device.dispatchEvent(
+    const inner = document.createElement("div");
+    device.attachShadow({ mode: "open" }).appendChild(inner);
+    inner.dispatchEvent(
       new CustomEvent("port-replaced", { detail: live, bubbles: true, composed: true })
     );
 

--- a/test/web/logs-dialog.test.ts
+++ b/test/web/logs-dialog.test.ts
@@ -7,11 +7,13 @@ vi.mock("../../src/util/register-icons.js", () => ({ registerMdiIcons: vi.fn() }
 vi.mock("../../src/util/serial-log-stream.js", () => ({ streamSerialLines: vi.fn() }));
 vi.mock("../../src/util/download-text.js", () => ({ downloadAnsiText: vi.fn() }));
 vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+vi.mock("../../src/util/web-serial.js", () => ({ reacquirePort: vi.fn() }));
 
 const sleep = vi.fn((_ms?: number) => Promise.resolve());
 vi.mock("../../src/util/sleep.js", () => ({ sleep: (ms: number) => sleep(ms) }));
 
 import { streamSerialLines } from "../../src/util/serial-log-stream.js";
+import { reacquirePort } from "../../src/util/web-serial.js";
 import { ESPHomeWebLogsDialog } from "../../src/web/logs/esphome-web-logs-dialog.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -84,6 +86,60 @@ describe("esphome-web-logs-dialog", () => {
     expect((el as any)._paused).toBe(false);
     await el.updateComplete;
     expect(toolbarLabels(el)).not.toContain("dashboard.logs_start");
+  });
+
+  it("reacquires and resumes streaming after a native-USB re-enumeration", async () => {
+    const el = await mount();
+    const live = { open: vi.fn(async () => {}), readable: {} };
+    (reacquirePort as any).mockResolvedValue(live);
+    el.open = true;
+    (el as any)._activePort = { fake: "stale" };
+
+    (el as any)._onDisconnect();
+    expect((el as any)._lines).toContain("web.logs.reconnecting");
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(live.open).toHaveBeenCalled();
+    expect((el as any)._activePort).toBe(live);
+    expect((el as any)._streaming).toBe(true);
+    expect(streamSerialLines).toHaveBeenLastCalledWith(live, expect.anything());
+    (el as any)._flushPending();
+    expect((el as any)._lines).toContain("web.logs.reconnected");
+  });
+
+  it("ends the terminal when the device stays gone", async () => {
+    const el = await mount();
+    (reacquirePort as any).mockResolvedValue(null);
+    el.open = true;
+    (el as any)._activePort = { fake: "stale" };
+
+    (el as any)._onDisconnect();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect((el as any)._streaming).toBe(false);
+    expect((el as any)._lines).toContain("web.logs.reconnect_failed");
+  });
+
+  it("a close during the reacquire window cancels the resume", async () => {
+    const el = await mount();
+    let resolve: (v: unknown) => void;
+    (reacquirePort as any).mockReturnValue(new Promise((r) => (resolve = r)));
+    el.open = true;
+    (el as any)._activePort = { fake: "stale" };
+
+    (el as any)._onDisconnect();
+    (el as any)._stop();
+    resolve!({ open: vi.fn(async () => {}), readable: {} });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect((el as any)._streaming).toBe(false);
+    (el as any)._flushPending();
+    expect((el as any)._lines).not.toContain("web.logs.reconnected");
   });
 
   it("renders a Clear label and toggles Stop ⇄ Start", async () => {

--- a/test/web/logs-dialog.test.ts
+++ b/test/web/logs-dialog.test.ts
@@ -110,6 +110,9 @@ describe("esphome-web-logs-dialog", () => {
     el.open = true;
     (el as any)._activePort = stale;
 
+    const replaced = vi.fn();
+    el.addEventListener("port-replaced", (e) => replaced((e as CustomEvent).detail));
+
     (el as any)._onDisconnect();
     expect((el as any)._lines).toContain("web.logs.reconnecting");
     await vi.waitFor(() => expect((el as any)._activePort).toBe(live));
@@ -118,6 +121,8 @@ describe("esphome-web-logs-dialog", () => {
     expect(order).toEqual(["close", "reopen"]);
     expect((el as any)._streaming).toBe(true);
     expect(streamSerialLines).toHaveBeenLastCalledWith(live, expect.anything());
+    // The recovered handle is announced to the parent card.
+    await vi.waitFor(() => expect(replaced).toHaveBeenCalledWith(live));
     (el as any)._flushPending();
     expect((el as any)._lines).toContain("web.logs.reconnected");
   });
@@ -177,19 +182,6 @@ describe("esphome-web-logs-dialog", () => {
     expect((el as any)._activePort).toBeUndefined();
     (el as any)._flushPending();
     expect((el as any)._lines).toContain("web.logs.reconnect_failed");
-  });
-
-  it("hands the recovered handle to the parent via port-replaced", async () => {
-    const el = await mount();
-    const live = { readable: {}, close: vi.fn(async () => {}) };
-    (openLiveSerialPort as any).mockResolvedValue(live);
-    el.open = true;
-    (el as any)._activePort = { close: vi.fn(async () => {}) };
-    const replaced = vi.fn();
-    el.addEventListener("port-replaced", (e) => replaced((e as CustomEvent).detail));
-
-    (el as any)._onDisconnect();
-    await vi.waitFor(() => expect(replaced).toHaveBeenCalledWith(live));
   });
 
   it("a throw in the resume tail ends as reconnect_failed, not a stuck spinner", async () => {

--- a/test/web/logs-dialog.test.ts
+++ b/test/web/logs-dialog.test.ts
@@ -97,11 +97,7 @@ describe("esphome-web-logs-dialog", () => {
 
     (el as any)._onDisconnect();
     expect((el as any)._lines).toContain("web.logs.reconnecting");
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(live.open).toHaveBeenCalled();
+    await vi.waitFor(() => expect(live.open).toHaveBeenCalled());
     expect((el as any)._activePort).toBe(live);
     expect((el as any)._streaming).toBe(true);
     expect(streamSerialLines).toHaveBeenLastCalledWith(live, expect.anything());
@@ -116,11 +112,10 @@ describe("esphome-web-logs-dialog", () => {
     (el as any)._activePort = { fake: "stale" };
 
     (el as any)._onDisconnect();
-    await Promise.resolve();
-    await Promise.resolve();
-
+    await vi.waitFor(() =>
+      expect((el as any)._lines).toContain("web.logs.reconnect_failed")
+    );
     expect((el as any)._streaming).toBe(false);
-    expect((el as any)._lines).toContain("web.logs.reconnect_failed");
   });
 
   it("a close during the reacquire window cancels the resume", async () => {
@@ -132,11 +127,13 @@ describe("esphome-web-logs-dialog", () => {
 
     (el as any)._onDisconnect();
     (el as any)._stop();
-    resolve!({ open: vi.fn(async () => {}), readable: {} });
+    const live = { open: vi.fn(async () => {}), readable: {} };
+    resolve!(live);
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
 
+    expect(live.open).not.toHaveBeenCalled();
     expect((el as any)._streaming).toBe(false);
     (el as any)._flushPending();
     expect((el as any)._lines).not.toContain("web.logs.reconnected");

--- a/test/web/logs-dialog.test.ts
+++ b/test/web/logs-dialog.test.ts
@@ -7,13 +7,13 @@ vi.mock("../../src/util/register-icons.js", () => ({ registerMdiIcons: vi.fn() }
 vi.mock("../../src/util/serial-log-stream.js", () => ({ streamSerialLines: vi.fn() }));
 vi.mock("../../src/util/download-text.js", () => ({ downloadAnsiText: vi.fn() }));
 vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
-vi.mock("../../src/util/web-serial.js", () => ({ reacquirePort: vi.fn() }));
+vi.mock("../../src/util/web-serial.js", () => ({ openLiveSerialPort: vi.fn() }));
 
 const sleep = vi.fn((_ms?: number) => Promise.resolve());
 vi.mock("../../src/util/sleep.js", () => ({ sleep: (ms: number) => sleep(ms) }));
 
 import { streamSerialLines } from "../../src/util/serial-log-stream.js";
-import { reacquirePort } from "../../src/util/web-serial.js";
+import { openLiveSerialPort } from "../../src/util/web-serial.js";
 import { ESPHomeWebLogsDialog } from "../../src/web/logs/esphome-web-logs-dialog.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -41,8 +41,12 @@ function resetButtons(el: ESPHomeWebLogsDialog): Element[] {
 
 afterEach(() => {
   document.body.innerHTML = "";
-  vi.clearAllMocks();
+  // resetAllMocks (not clearAllMocks): per-test mockResolvedValue
+  // implementations must not leak into later tests.
+  vi.resetAllMocks();
 });
+
+const drainMacrotasks = () => new Promise((r) => setTimeout(r, 0));
 
 describe("esphome-web-logs-dialog", () => {
   it("pulses RTS high→low then settles 1s (legacy ewt-console reset shape)", async () => {
@@ -88,28 +92,49 @@ describe("esphome-web-logs-dialog", () => {
     expect(toolbarLabels(el)).not.toContain("dashboard.logs_start");
   });
 
-  it("reacquires and resumes streaming after a native-USB re-enumeration", async () => {
+  it("closes the dead port, reopens, and resumes streaming", async () => {
     const el = await mount();
-    const live = { open: vi.fn(async () => {}), readable: {} };
-    (reacquirePort as any).mockResolvedValue(live);
+    const order: string[] = [];
+    const stale = { close: vi.fn(async () => order.push("close")) };
+    const live = { readable: {} };
+    (openLiveSerialPort as any).mockImplementation(async () => {
+      order.push("reopen");
+      return live;
+    });
     el.open = true;
-    (el as any)._activePort = { fake: "stale" };
+    (el as any)._activePort = stale;
 
     (el as any)._onDisconnect();
     expect((el as any)._lines).toContain("web.logs.reconnecting");
-    await vi.waitFor(() => expect(live.open).toHaveBeenCalled());
-    expect((el as any)._activePort).toBe(live);
+    await vi.waitFor(() => expect((el as any)._activePort).toBe(live));
+
+    // The dead handle is closed before any reopen attempt.
+    expect(order).toEqual(["close", "reopen"]);
     expect((el as any)._streaming).toBe(true);
     expect(streamSerialLines).toHaveBeenLastCalledWith(live, expect.anything());
     (el as any)._flushPending();
     expect((el as any)._lines).toContain("web.logs.reconnected");
   });
 
+  it("keeps the display paused across an auto-reconnect", async () => {
+    const el = await mount();
+    (openLiveSerialPort as any).mockResolvedValue({ readable: {} });
+    el.open = true;
+    (el as any)._activePort = { close: vi.fn(async () => {}) };
+    (el as any)._paused = true;
+
+    (el as any)._onDisconnect();
+    await vi.waitFor(() => expect((el as any)._lines).toContain("web.logs.reconnected"));
+
+    expect((el as any)._paused).toBe(true);
+    expect((el as any)._streaming).toBe(false);
+  });
+
   it("ends the terminal when the device stays gone", async () => {
     const el = await mount();
-    (reacquirePort as any).mockResolvedValue(null);
+    (openLiveSerialPort as any).mockResolvedValue(null);
     el.open = true;
-    (el as any)._activePort = { fake: "stale" };
+    (el as any)._activePort = { close: vi.fn(async () => {}) };
 
     (el as any)._onDisconnect();
     await vi.waitFor(() =>
@@ -118,23 +143,61 @@ describe("esphome-web-logs-dialog", () => {
     expect((el as any)._streaming).toBe(false);
   });
 
+  it("gives up after consecutive reconnects that never produce a line", async () => {
+    const el = await mount();
+    (openLiveSerialPort as any).mockResolvedValue({ readable: {} });
+    el.open = true;
+
+    for (let i = 0; i < 3; i++) {
+      (el as any)._activePort = { close: vi.fn(async () => {}) };
+      (el as any)._onDisconnect();
+      await vi.waitFor(() => expect((el as any)._streaming).toBe(true));
+    }
+    (openLiveSerialPort as any).mockClear();
+    (el as any)._activePort = { close: vi.fn(async () => {}) };
+    (el as any)._onDisconnect();
+    await drainMacrotasks();
+
+    expect(openLiveSerialPort).not.toHaveBeenCalled();
+    (el as any)._flushPending();
+    expect((el as any)._lines).toContain("web.logs.reconnect_failed");
+  });
+
+  it("a line arriving after a resume resets the give-up counter", async () => {
+    const el = await mount();
+    let hooks: any;
+    (streamSerialLines as any).mockImplementation((_p: unknown, h: unknown) => {
+      hooks = h;
+      return vi.fn();
+    });
+    (openLiveSerialPort as any).mockResolvedValue({ readable: {} });
+    el.open = true;
+    (el as any)._activePort = { close: vi.fn(async () => {}) };
+
+    (el as any)._onDisconnect();
+    await vi.waitFor(() => expect((el as any)._streaming).toBe(true));
+    hooks.onLine("boot line");
+
+    expect((el as any)._silentReconnects).toBe(0);
+  });
+
   it("a close during the reacquire window cancels the resume", async () => {
     const el = await mount();
     let resolve: (v: unknown) => void;
-    (reacquirePort as any).mockReturnValue(new Promise((r) => (resolve = r)));
+    (openLiveSerialPort as any).mockReturnValue(new Promise((r) => (resolve = r)));
     el.open = true;
-    (el as any)._activePort = { fake: "stale" };
+    (el as any)._activePort = { close: vi.fn(async () => {}) };
 
     (el as any)._onDisconnect();
+    await drainMacrotasks();
     (el as any)._stop();
-    const live = { open: vi.fn(async () => {}), readable: {} };
-    resolve!(live);
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    const late = { readable: {}, close: vi.fn(async () => {}) };
+    resolve!(late);
+    await drainMacrotasks();
 
-    expect(live.open).not.toHaveBeenCalled();
     expect((el as any)._streaming).toBe(false);
+    // The superseded resume reclaims the handle it opened.
+    expect(late.close).toHaveBeenCalled();
     (el as any)._flushPending();
     expect((el as any)._lines).not.toContain("web.logs.reconnected");
   });

--- a/test/web/logs-dialog.test.ts
+++ b/test/web/logs-dialog.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/components/base-dialog.js", () => ({}));
 vi.mock("../../src/components/process-terminal/process-terminal.js", () => ({}));
@@ -44,6 +44,12 @@ afterEach(() => {
   // resetAllMocks (not clearAllMocks): per-test mockResolvedValue
   // implementations must not leak into later tests.
   vi.resetAllMocks();
+});
+
+// resetAllMocks strips module-level spy implementations too; restore the
+// sleep stub so callers awaiting it keep getting a promise.
+beforeEach(() => {
+  sleep.mockImplementation((_ms?: number) => Promise.resolve());
 });
 
 const drainMacrotasks = () => new Promise((r) => setTimeout(r, 0));
@@ -96,7 +102,7 @@ describe("esphome-web-logs-dialog", () => {
     const el = await mount();
     const order: string[] = [];
     const stale = { close: vi.fn(async () => order.push("close")) };
-    const live = { readable: {} };
+    const live = { readable: {}, close: vi.fn(async () => {}) };
     (openLiveSerialPort as any).mockImplementation(async () => {
       order.push("reopen");
       return live;
@@ -118,7 +124,10 @@ describe("esphome-web-logs-dialog", () => {
 
   it("keeps the display paused across an auto-reconnect", async () => {
     const el = await mount();
-    (openLiveSerialPort as any).mockResolvedValue({ readable: {} });
+    (openLiveSerialPort as any).mockResolvedValue({
+      readable: {},
+      close: vi.fn(async () => {}),
+    });
     el.open = true;
     (el as any)._activePort = { close: vi.fn(async () => {}) };
     (el as any)._paused = true;
@@ -145,7 +154,10 @@ describe("esphome-web-logs-dialog", () => {
 
   it("gives up after consecutive reconnects that never produce a line", async () => {
     const el = await mount();
-    (openLiveSerialPort as any).mockResolvedValue({ readable: {} });
+    (openLiveSerialPort as any).mockResolvedValue({
+      readable: {},
+      close: vi.fn(async () => {}),
+    });
     el.open = true;
 
     for (let i = 0; i < 3; i++) {
@@ -154,13 +166,60 @@ describe("esphome-web-logs-dialog", () => {
       await vi.waitFor(() => expect((el as any)._streaming).toBe(true));
     }
     (openLiveSerialPort as any).mockClear();
-    (el as any)._activePort = { close: vi.fn(async () => {}) };
+    const last = { close: vi.fn(async () => {}) };
+    (el as any)._activePort = last;
     (el as any)._onDisconnect();
     await drainMacrotasks();
 
     expect(openLiveSerialPort).not.toHaveBeenCalled();
+    // The stranded handle is released — nothing else holds a cancel for it.
+    expect(last.close).toHaveBeenCalled();
+    expect((el as any)._activePort).toBeUndefined();
     (el as any)._flushPending();
     expect((el as any)._lines).toContain("web.logs.reconnect_failed");
+  });
+
+  it("hands the recovered handle to the parent via port-replaced", async () => {
+    const el = await mount();
+    const live = { readable: {}, close: vi.fn(async () => {}) };
+    (openLiveSerialPort as any).mockResolvedValue(live);
+    el.open = true;
+    (el as any)._activePort = { close: vi.fn(async () => {}) };
+    const replaced = vi.fn();
+    el.addEventListener("port-replaced", (e) => replaced((e as CustomEvent).detail));
+
+    (el as any)._onDisconnect();
+    await vi.waitFor(() => expect(replaced).toHaveBeenCalledWith(live));
+  });
+
+  it("a throw in the resume tail ends as reconnect_failed, not a stuck spinner", async () => {
+    const el = await mount();
+    (openLiveSerialPort as any).mockResolvedValue({
+      readable: {},
+      close: vi.fn(async () => {}),
+    });
+    (streamSerialLines as any).mockImplementation(() => {
+      throw new TypeError("stream already locked");
+    });
+    el.open = true;
+    (el as any)._activePort = { close: vi.fn(async () => {}) };
+
+    (el as any)._onDisconnect();
+    await vi.waitFor(() =>
+      expect((el as any)._lines).toContain("web.logs.reconnect_failed")
+    );
+    expect((el as any)._streaming).toBe(false);
+  });
+
+  it("closing the dialog releases a handle orphaned by a dead stream", async () => {
+    const el = await mount();
+    const orphan = { close: vi.fn(async () => {}) };
+    (el as any)._activePort = orphan;
+    (el as any)._cancel = undefined;
+
+    (el as any)._stop();
+
+    expect(orphan.close).toHaveBeenCalled();
   });
 
   it("a line arriving after a resume resets the give-up counter", async () => {
@@ -170,7 +229,10 @@ describe("esphome-web-logs-dialog", () => {
       hooks = h;
       return vi.fn();
     });
-    (openLiveSerialPort as any).mockResolvedValue({ readable: {} });
+    (openLiveSerialPort as any).mockResolvedValue({
+      readable: {},
+      close: vi.fn(async () => {}),
+    });
     el.open = true;
     (el as any)._activePort = { close: vi.fn(async () => {}) };
 
@@ -204,7 +266,7 @@ describe("esphome-web-logs-dialog", () => {
 
   it("renders a Clear label and toggles Stop ⇄ Start", async () => {
     const el = await mount();
-    el.port = { readable: {} } as unknown as SerialPort;
+    el.port = { readable: {}, close: vi.fn(async () => {}) } as unknown as SerialPort;
     el.open = true;
     // _start() flips _streaming inside updated(), which schedules a second
     // render — await both cycles before asserting on the toolbar.
@@ -231,7 +293,7 @@ describe("esphome-web-logs-dialog", () => {
 
   it("drops incoming lines while paused, keeps them while streaming", async () => {
     const el = await mount();
-    el.port = { readable: {} } as unknown as SerialPort;
+    el.port = { readable: {}, close: vi.fn(async () => {}) } as unknown as SerialPort;
     el.open = true;
     await el.updateComplete;
 

--- a/test/web/logs-dialog.test.ts
+++ b/test/web/logs-dialog.test.ts
@@ -181,7 +181,7 @@ describe("esphome-web-logs-dialog", () => {
     expect(last.close).toHaveBeenCalled();
     expect((el as any)._activePort).toBeUndefined();
     (el as any)._flushPending();
-    expect((el as any)._lines).toContain("web.logs.reconnect_failed");
+    expect((el as any)._lines).toContain("web.logs.reconnect_gave_up");
   });
 
   it("a throw in the resume tail ends as reconnect_failed, not a stuck spinner", async () => {

--- a/test/web/pico-connect-card.test.ts
+++ b/test/web/pico-connect-card.test.ts
@@ -73,6 +73,27 @@ describe("esphome-web-pico-connect-card first-time setup", () => {
 });
 
 describe("esphome-web-pico-connect-card disconnect resilience", () => {
+  it("folds a dialog-recovered handle in via port-replaced (composed hop)", async () => {
+    const adopted = makeDisconnectPort();
+    const live = makeDisconnectPort();
+    const el = await mount();
+    (el as any)._adoptPort(adopted);
+    await (el as any).updateComplete;
+
+    // The logs dialog dispatches from inside the device card's shadow
+    // root; give the stubbed card one so the event genuinely crosses a
+    // shadow boundary — composed: true is what carries it out.
+    const device = el.shadowRoot!.querySelector("esphome-web-pico-device-card")!;
+    const inner = document.createElement("div");
+    device.attachShadow({ mode: "open" }).appendChild(inner);
+    inner.dispatchEvent(
+      new CustomEvent("port-replaced", { detail: live, bubbles: true, composed: true })
+    );
+
+    expect((el as any)._port).toBe(live);
+    expect(live.listenerCount()).toBe(1);
+  });
+
   it("keeps the device card through a re-enum blip, rebinding the live handle", async () => {
     const adopted = makeDisconnectPort();
     const fresh = makeDisconnectPort();

--- a/test/web/port-disconnect-watcher.test.ts
+++ b/test/web/port-disconnect-watcher.test.ts
@@ -162,3 +162,39 @@ describe("PortDisconnectWatcher", () => {
     expect(port.listenerCount()).toBe(1);
   });
 });
+
+describe("PortDisconnectWatcher.adopt", () => {
+  it("reports the adopted handle and moves the watch to it", () => {
+    const old = makeDisconnectPort();
+    const adopted = makeDisconnectPort();
+    const { watcher, onReplace } = makeWatcher();
+
+    watcher.watch(old);
+    watcher.adopt(adopted);
+
+    expect(onReplace).toHaveBeenCalledWith(adopted);
+    expect(old.listenerCount()).toBe(0);
+    expect(adopted.listenerCount()).toBe(1);
+  });
+
+  it("supersedes a reacquire in flight for the same disconnect", async () => {
+    const old = makeDisconnectPort();
+    const adopted = makeDisconnectPort();
+    let resolve: (v: unknown) => void;
+    reacquirePort.mockReturnValue(new Promise((r) => (resolve = r)));
+    const { watcher, onReplace, onGone } = makeWatcher();
+
+    watcher.watch(old);
+    old.fire();
+    watcher.adopt(adopted);
+    const stale = makeDisconnectPort();
+    resolve!(stale);
+    await flush();
+
+    // The adopted handle stands; the stale reacquire result is dropped.
+    expect(onReplace).toHaveBeenCalledTimes(1);
+    expect(onReplace).toHaveBeenCalledWith(adopted);
+    expect(onGone).not.toHaveBeenCalled();
+    expect(stale.listenerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Pressing the physical reset button on a native-USB device while the web logs dialog streams killed the terminal for good: the chip re-enumerates, the reader dies, the dialog printed "Terminal disconnected" and offered no way back. The connect card's watcher recovers the card, but the dialog's stream stayed dead; in Firefox the reacquired handle is even the same object, so no property change ever reaches the dialog.

The dialog now rides the blip out itself: on a stream disconnect it prints the disconnected line, closes the dead handle (the reacquired one is often the same object, and re-reading a dead stream would loop), then reopens through openLiveSerialPort, which retries open() across the re-enumeration window preferring a fresh getPorts() handle (Chrome) and falling back to the cached one (Firefox, UART bridges). openLiveSerialPort is promoted out of post-install-logs so both log surfaces share one retry policy, and it skips open-but-locked candidates. On resume the display honours a Stop pressed before the reset, and the recovered handle is handed back to the connect card via a port-replaced event so the card's other actions use it too.

A device that stays gone prints a final "did not come back" line, capped at three consecutive line-less reconnect cycles; every give-up and supersede path releases whatever handle it holds so the device is never locked away from other tools. Closing the dialog or unmounting cancels a pending reacquire via the same generation-counter shape the watcher uses, and the Reset device button pulses the live handle instead of the stale one.

Builds on the re-enumeration helpers #1420 introduced (now merged). A follow up split of web-serial.ts is tracked in #1429.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
