### PR TITLE
Add the ESPHome Web development guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ pnpm run build:web  # static site → esphome_web/ (gitignored)
 
 Unlike the wheel build (`pnpm run build` → `esphome_device_builder_frontend/`), ESPHome Web has no WebSocket, no auth, and no server: everything runs in the browser. Its output (`esphome_web/`) is **never** part of the wheel; `.github/workflows/deploy-web.yml` publishes it to GitHub Pages at web.esphome.io. New copy goes in `en.json` under the `web.*` namespace like the rest of the app.
 
+Development guide (dev server, hardware testing, layout): [src/web/README.md](src/web/README.md).
+
 ## Translations
 
 ### Contributing translations

--- a/src/web/README.md
+++ b/src/web/README.md
@@ -1,0 +1,64 @@
+# ESPHome Web development
+
+The standalone, backend-free Web Serial tool published to
+[web.esphome.io](https://web.esphome.io). Everything runs in the
+browser: connect an ESP or Raspberry Pi Pico W over USB to install
+firmware, stream logs, and provision Wi-Fi via Improv. It shares the
+repo's `src/` tree (design system, the esptool-js flash engine in
+`src/util/web-serial.ts`, localization) and adds only this app.
+
+## Dev server
+
+```bash
+corepack pnpm install
+corepack pnpm run dev:web
+```
+
+HMR dev server on `http://localhost:5174` — no backend needed. Pass
+`PORT=<n>` to run on a different port when 5174 is taken
+(`build-scripts/dev-web-server.cjs` honors it).
+
+Web Serial needs a secure context and a supporting browser: any
+Chromium-based browser, or Firefox 151+. `localhost` counts as secure,
+so the dev server works as-is; testing from another machine needs
+https. Safari has no Web Serial and renders the unsupported card.
+
+## Testing with hardware
+
+Plug a device in and use the site like a user would. The interesting
+hardware classes behave differently:
+
+- **Native-USB chips** (ESP32-C3 / S3 / C6, USB-Serial/JTAG): drop off
+  the bus and re-enumerate after plug-in, reset, or flash. The connect
+  cards and the logs terminal ride these blips out via
+  `reacquirePort`; Chrome hands back a fresh handle, Firefox keeps the
+  same one — test both.
+- **UART bridges** (CP210x, CH34x): no re-enumeration; DTR/RTS reset
+  pulses work.
+- **Pico W**: native-USB CDC; no DTR/RTS reset, and flashing goes
+  through UF2 (its own connect card and install dialog).
+
+## Where things live
+
+| Path | What |
+|---|---|
+| `entrypoint.ts` / `esphome-web-app.ts` | App shell |
+| `dashboard/` | Connect cards (ESP + Pico) and per-device action cards |
+| `install/` | Flash dialogs and the install flow controller |
+| `logs/` | Serial log viewer dialog |
+| `improv/` | Wi-Fi provisioning dialog |
+| `flash-receiver/` | Receives images from a Device Builder over the local network |
+| `util/` | Web-only helpers (port disconnect watcher, firmware fetch, Pico filter) |
+
+New copy goes in `src/translations/en.json` under the `web.*`
+namespace. Tests live in `test/web/` and run with the main suite
+(`corepack pnpm test`); lint with `corepack pnpm run lint`.
+
+## Build and deploy
+
+```bash
+corepack pnpm run build:web   # static site → esphome_web/ (gitignored)
+```
+
+The output is never part of the wheel;
+`.github/workflows/deploy-web.yml` publishes it to GitHub Pages.


### PR DESCRIPTION
# What does this implement/fix?

Adds a development guide for ESPHome Web at src/web/README.md: dev server setup (dev:web, port 5174, PORT override), Web Serial browser and secure context requirements, how the hardware classes differ when testing (native USB re-enumeration vs UART bridges vs Pico), a map of the app's directories, and the build and deploy flow. The main README's ESPHome Web section now links to it.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
