### PR TITLE
Correction of the spelling/capitalization of keyboard shortcuts

### DIFF
--- a/src/components/command-palette.ts
+++ b/src/components/command-palette.ts
@@ -366,7 +366,7 @@ export class ESPHomeCommandPalette extends LitElement {
           )}</span
         >
         <span><kbd>↵</kbd> ${this._localize("command_palette.select_hint")}</span>
-        <span><kbd>esc</kbd> ${this._localize("command_palette.close_hint")}</span>
+        <span><kbd>Esc</kbd> ${this._localize("command_palette.close_hint")}</span>
         ${
           this._expertMode
             ? html`<span class="yaml-hint">

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1218,7 +1218,7 @@
     "theme_system": "System",
     "settings": "Settings",
     "search": "Search commands",
-    "search_shortcut": "Ctrl K",
+    "search_shortcut": "Ctrl+K",
     "guided_tour": "Take a tour",
     "archived_devices": "Archived devices",
     "show_ignored_discoveries": "Show ignored discoveries ({count})",


### PR DESCRIPTION
# What does this implement/fix?

In two places, keyboard shortcuts were written in an unusual way.

Ctrl K → Ctrl+K
esc → Esc

The spelling/capitalization has been corrected. No code has been changed.

**Related issue or feature (if applicable):**

- fixes n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pnpm run lint` passes.
- [ ] `pnpm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
