### PR TITLE
Split the re-enumeration helpers into serial-reacquire.ts

### DIFF
--- a/src/util/serial-reacquire.ts
+++ b/src/util/serial-reacquire.ts
@@ -1,0 +1,197 @@
+/**
+ * Native-USB re-enumeration helpers for Web Serial.
+ *
+ * ESP32-C3 / S3 / C6 (USB-Serial/JTAG) drop off the bus and re-enumerate
+ * after a plug-in, reset, or flash. This module owns riding that window
+ * out: the activity-window suppression the connect-event toast keys off,
+ * device matching, per-round enumeration, and the reacquire / reopen
+ * retry loops. Everything here is re-exported from ``web-serial.ts`` so
+ * existing import paths keep working.
+ */
+import { sleep } from "./sleep.js";
+
+/**
+ * Suppression window for the ``navigator.serial`` connect-event
+ * toast. esptool-js's chip reset (DTR/RTS via ``loader.main``)
+ * briefly drops native-USB devices like ESP32-C6 / S3 / C3, and
+ * the re-enumeration fires a fresh ``connect`` event for the same
+ * port — without this guard the toast in ``app-shell`` would loop
+ * every time the wizard runs a serial op.
+ *
+ * Every entry point in this module stamps ``_lastSerialActivityMs``
+ * at the start (and the toast click handler in ``app-shell`` does
+ * the same to cover the gap between the user's click and the first
+ * internal op). ``isRecentSerialActivity`` answers whether we're
+ * inside the window defined by ``SERIAL_ACTIVITY_WINDOW_MS``.
+ */
+let _lastSerialActivityMs = 0;
+
+// Sized to cover the worst case: a chip reset that drops the USB
+// device, plus macOS / Linux re-enumeration delay (~2-3s on macOS),
+// plus our internal disconnect → port.close → optional hard_reset
+// chain. Bursts of re-enum events extend the window further (see
+// the handler in ``app-shell``), so this is just the floor.
+export const SERIAL_ACTIVITY_WINDOW_MS = 6000;
+
+export function markSerialActivity(): void {
+  _lastSerialActivityMs = Date.now();
+}
+
+export function isRecentSerialActivity(
+  windowMs: number = SERIAL_ACTIVITY_WINDOW_MS
+): boolean {
+  return Date.now() - _lastSerialActivityMs < windowMs;
+}
+
+// Budget for finding a usable handle after a disconnect / post-reset close:
+// covers the native-USB re-enumeration window (SERIAL_ACTIVITY_WINDOW_MS) with
+// margin for a slower first enumeration on a brand-new board.
+export const SERIAL_REOPEN_TIMEOUT_MS = SERIAL_ACTIVITY_WINDOW_MS + 2000;
+
+// Same USB device by vendor/product id. Requires both ids present so two
+// non-USB ports (undefined === undefined) aren't treated as a match.
+// VID:PID isn't a unique device id: two identical boards both match and
+// getPorts() order picks one; Web Serial exposes no per-device serial to
+// disambiguate, and every caller's flow is single-device anyway.
+export const matchesDevice = (a: SerialPortInfo, b: SerialPortInfo): boolean =>
+  a.usbVendorId !== undefined &&
+  a.usbProductId !== undefined &&
+  a.usbVendorId === b.usbVendorId &&
+  a.usbProductId === b.usbProductId;
+
+/**
+ * One enumeration round for a possibly re-enumerating device: the
+ * freshly-granted handles matching cachedPort's USB ids (a re-enum on Chrome
+ * hands out a new handle), plus whether cachedPort itself is still granted.
+ * getPorts() can transiently reject mid-re-enumeration; that round counts as
+ * nothing granted and the caller's next round retries.
+ */
+export async function grantedHandlesFor(
+  cachedPort: SerialPort
+): Promise<{ fresh: SerialPort[]; cachedGranted: boolean }> {
+  const want = cachedPort.getInfo();
+  let granted: SerialPort[] = [];
+  try {
+    granted = await navigator.serial.getPorts();
+  } catch {
+    /* Transient mid-re-enumeration rejection; see the contract above. */
+  }
+  return {
+    fresh: granted.filter((p) => p !== cachedPort && matchesDevice(p.getInfo(), want)),
+    cachedGranted: granted.includes(cachedPort),
+  };
+}
+
+/**
+ * Reacquire a live handle for a just-disconnected authorized port, waiting out
+ * the native-USB re-enumeration window. ESP32-C3 / S3 / C6 (USB-Serial/JTAG)
+ * drop off the bus and come back seconds later, firing a spurious disconnect
+ * on the way; without this the UI holding the port treats the blip as a real
+ * unplug (#1410).
+ *
+ * Prefers a freshly-granted getPorts() handle for the same device, falling
+ * back to the cached handle when it is granted and connected again (Firefox
+ * and UART bridges keep the same handle usable). Returns the handle without
+ * opening it, or null when the device stays gone past timeoutMs (a genuine
+ * unplug) or the caller cancels.
+ */
+export async function reacquirePort(
+  cachedPort: SerialPort,
+  options: { timeoutMs?: number; cancelled?: () => boolean } = {}
+): Promise<SerialPort | null> {
+  const { timeoutMs = SERIAL_REOPEN_TIMEOUT_MS, cancelled = () => false } = options;
+  const deadline = Date.now() + timeoutMs;
+  while (!cancelled()) {
+    const { fresh, cachedGranted } = await grantedHandlesFor(cachedPort);
+    // Presence in getPorts() means the device is granted and physically
+    // present; the connected check filters implementations that also return
+    // granted-but-unplugged ports (undefined tolerates ones without it).
+    const live = [...fresh, ...(cachedGranted ? [cachedPort] : [])].find(
+      (p) => p.connected !== false
+    );
+    if (live) return live;
+    if (Date.now() >= deadline) return null;
+    await sleep(200);
+  }
+  return null;
+}
+
+/**
+ * Open a live handle for a possibly re-enumerating device, retrying through
+ * the re-enumeration window. Returns the OPEN port, or ``null`` past
+ * ``timeoutMs`` / on cancel.
+ *
+ * Presence in ``getPorts()`` isn't enough — a device can be enumerated but
+ * not yet openable (Chrome throws ``NetworkError`` in that window) — so the
+ * ``open()`` attempt is the real liveness test. Each round prefers a
+ * freshly-granted handle (Chrome's re-enumerated port), then the cached
+ * handle (Firefox / UART bridges reopen it in place).
+ */
+export async function openLiveSerialPort(
+  cachedPort: SerialPort,
+  options: {
+    baudRate: number;
+    bufferSize?: number;
+    timeoutMs?: number;
+    cancelled?: () => boolean;
+  }
+): Promise<SerialPort | null> {
+  const {
+    baudRate,
+    bufferSize,
+    timeoutMs = SERIAL_REOPEN_TIMEOUT_MS,
+    cancelled = () => false,
+  } = options;
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown = null;
+  while (!cancelled()) {
+    const { fresh } = await grantedHandlesFor(cachedPort);
+    const candidates = [...fresh, cachedPort];
+    for (const p of candidates) {
+      if (p.readable) {
+        // Open but locked by an existing reader → unusable: the caller's
+        // getReader() would throw "already locked". Skip it and try the
+        // next candidate (mirrors live-log-port's candidate walk).
+        if (p.readable.locked) {
+          lastErr = new Error("port stream already locked");
+          continue;
+        }
+        return p; // already open (a reset race left it usable)
+      }
+      try {
+        await p.open(bufferSize ? { baudRate, bufferSize } : { baudRate });
+        return p;
+      } catch (err) {
+        lastErr = err;
+        const name = err instanceof DOMException ? err.name : "";
+        const message = err instanceof Error ? err.message : "";
+        // Already open (a reset race / another candidate) — usable only
+        // with an actual unlocked stream: a fatal read error leaves a port
+        // open with readable null, and returning that would just throw at
+        // getReader(). Re-read readable: the failed open() invalidates the
+        // null the loop head narrowed to.
+        const readableNow = p.readable as ReadableStream<Uint8Array> | null;
+        if (
+          name === "InvalidStateError" &&
+          /already open/i.test(message) &&
+          readableNow &&
+          !readableNow.locked
+        ) {
+          return p;
+        }
+        // Unusable this round — still re-enumerating (NetworkError), claimed
+        // by another app, or a transient driver / security error. Fall
+        // through to the next candidate and only give up at the deadline.
+      }
+    }
+    if (Date.now() >= deadline) {
+      console.error("[Web Serial] Failed to reopen port:", lastErr);
+      return null;
+    }
+    // Re-check before the inter-round sleep so a teardown that landed
+    // mid-round short-circuits instead of napping on it.
+    if (cancelled()) return null;
+    await sleep(200);
+  }
+  return null;
+}

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -7,7 +7,7 @@
  */
 import { ESPLoader, Transport, UsbJtagSerialReset } from "esptool-js";
 
-import { sleep } from "./sleep.js";
+import { markSerialActivity } from "./serial-reacquire.js";
 
 /** Espressif's USB Vendor ID — chips with native USB-Serial/JTAG. */
 const ESPRESSIF_USB_VID = 0x303a;
@@ -143,191 +143,18 @@ export function secureLoopbackUrl(): string | null {
   return url.toString();
 }
 
-/**
- * Suppression window for the ``navigator.serial`` connect-event
- * toast. esptool-js's chip reset (DTR/RTS via ``loader.main``)
- * briefly drops native-USB devices like ESP32-C6 / S3 / C3, and
- * the re-enumeration fires a fresh ``connect`` event for the same
- * port — without this guard the toast in ``app-shell`` would loop
- * every time the wizard runs a serial op.
- *
- * Every entry point in this module stamps ``_lastSerialActivityMs``
- * at the start (and the toast click handler in ``app-shell`` does
- * the same to cover the gap between the user's click and the first
- * internal op). ``isRecentSerialActivity`` answers whether we're
- * inside the window defined by ``SERIAL_ACTIVITY_WINDOW_MS``.
- */
-let _lastSerialActivityMs = 0;
-
-// Sized to cover the worst case: a chip reset that drops the USB
-// device, plus macOS / Linux re-enumeration delay (~2-3s on macOS),
-// plus our internal disconnect → port.close → optional hard_reset
-// chain. Bursts of re-enum events extend the window further (see
-// the handler in ``app-shell``), so this is just the floor.
-export const SERIAL_ACTIVITY_WINDOW_MS = 6000;
-
-export function markSerialActivity(): void {
-  _lastSerialActivityMs = Date.now();
-}
-
-export function isRecentSerialActivity(
-  windowMs: number = SERIAL_ACTIVITY_WINDOW_MS
-): boolean {
-  return Date.now() - _lastSerialActivityMs < windowMs;
-}
-
-// Budget for finding a usable handle after a disconnect / post-reset close:
-// covers the native-USB re-enumeration window (SERIAL_ACTIVITY_WINDOW_MS) with
-// margin for a slower first enumeration on a brand-new board.
-export const SERIAL_REOPEN_TIMEOUT_MS = SERIAL_ACTIVITY_WINDOW_MS + 2000;
-
-// Same USB device by vendor/product id. Requires both ids present so two
-// non-USB ports (undefined === undefined) aren't treated as a match.
-// VID:PID isn't a unique device id: two identical boards both match and
-// getPorts() order picks one; Web Serial exposes no per-device serial to
-// disambiguate, and every caller's flow is single-device anyway.
-export const matchesDevice = (a: SerialPortInfo, b: SerialPortInfo): boolean =>
-  a.usbVendorId !== undefined &&
-  a.usbProductId !== undefined &&
-  a.usbVendorId === b.usbVendorId &&
-  a.usbProductId === b.usbProductId;
-
-/**
- * One enumeration round for a possibly re-enumerating device: the
- * freshly-granted handles matching cachedPort's USB ids (a re-enum on Chrome
- * hands out a new handle), plus whether cachedPort itself is still granted.
- * getPorts() can transiently reject mid-re-enumeration; that round counts as
- * nothing granted and the caller's next round retries.
- */
-export async function grantedHandlesFor(
-  cachedPort: SerialPort
-): Promise<{ fresh: SerialPort[]; cachedGranted: boolean }> {
-  const want = cachedPort.getInfo();
-  let granted: SerialPort[] = [];
-  try {
-    granted = await navigator.serial.getPorts();
-  } catch {
-    /* Transient mid-re-enumeration rejection; see the contract above. */
-  }
-  return {
-    fresh: granted.filter((p) => p !== cachedPort && matchesDevice(p.getInfo(), want)),
-    cachedGranted: granted.includes(cachedPort),
-  };
-}
-
-/**
- * Reacquire a live handle for a just-disconnected authorized port, waiting out
- * the native-USB re-enumeration window. ESP32-C3 / S3 / C6 (USB-Serial/JTAG)
- * drop off the bus and come back seconds later, firing a spurious disconnect
- * on the way; without this the UI holding the port treats the blip as a real
- * unplug (#1410).
- *
- * Prefers a freshly-granted getPorts() handle for the same device, falling
- * back to the cached handle when it is granted and connected again (Firefox
- * and UART bridges keep the same handle usable). Returns the handle without
- * opening it, or null when the device stays gone past timeoutMs (a genuine
- * unplug) or the caller cancels.
- */
-export async function reacquirePort(
-  cachedPort: SerialPort,
-  options: { timeoutMs?: number; cancelled?: () => boolean } = {}
-): Promise<SerialPort | null> {
-  const { timeoutMs = SERIAL_REOPEN_TIMEOUT_MS, cancelled = () => false } = options;
-  const deadline = Date.now() + timeoutMs;
-  while (!cancelled()) {
-    const { fresh, cachedGranted } = await grantedHandlesFor(cachedPort);
-    // Presence in getPorts() means the device is granted and physically
-    // present; the connected check filters implementations that also return
-    // granted-but-unplugged ports (undefined tolerates ones without it).
-    const live = [...fresh, ...(cachedGranted ? [cachedPort] : [])].find(
-      (p) => p.connected !== false
-    );
-    if (live) return live;
-    if (Date.now() >= deadline) return null;
-    await sleep(200);
-  }
-  return null;
-}
-
-/**
- * Open a live handle for a possibly re-enumerating device, retrying through
- * the re-enumeration window. Returns the OPEN port, or ``null`` past
- * ``timeoutMs`` / on cancel.
- *
- * Presence in ``getPorts()`` isn't enough — a device can be enumerated but
- * not yet openable (Chrome throws ``NetworkError`` in that window) — so the
- * ``open()`` attempt is the real liveness test. Each round prefers a
- * freshly-granted handle (Chrome's re-enumerated port), then the cached
- * handle (Firefox / UART bridges reopen it in place).
- */
-export async function openLiveSerialPort(
-  cachedPort: SerialPort,
-  options: {
-    baudRate: number;
-    bufferSize?: number;
-    timeoutMs?: number;
-    cancelled?: () => boolean;
-  }
-): Promise<SerialPort | null> {
-  const {
-    baudRate,
-    bufferSize,
-    timeoutMs = SERIAL_REOPEN_TIMEOUT_MS,
-    cancelled = () => false,
-  } = options;
-  const deadline = Date.now() + timeoutMs;
-  let lastErr: unknown = null;
-  while (!cancelled()) {
-    const { fresh } = await grantedHandlesFor(cachedPort);
-    const candidates = [...fresh, cachedPort];
-    for (const p of candidates) {
-      if (p.readable) {
-        // Open but locked by an existing reader → unusable: the caller's
-        // getReader() would throw "already locked". Skip it and try the
-        // next candidate (mirrors live-log-port's candidate walk).
-        if (p.readable.locked) {
-          lastErr = new Error("port stream already locked");
-          continue;
-        }
-        return p; // already open (a reset race left it usable)
-      }
-      try {
-        await p.open(bufferSize ? { baudRate, bufferSize } : { baudRate });
-        return p;
-      } catch (err) {
-        lastErr = err;
-        const name = err instanceof DOMException ? err.name : "";
-        const message = err instanceof Error ? err.message : "";
-        // Already open (a reset race / another candidate) — usable only
-        // with an actual unlocked stream: a fatal read error leaves a port
-        // open with readable null, and returning that would just throw at
-        // getReader(). Re-read readable: the failed open() invalidates the
-        // null the loop head narrowed to.
-        const readableNow = p.readable as ReadableStream<Uint8Array> | null;
-        if (
-          name === "InvalidStateError" &&
-          /already open/i.test(message) &&
-          readableNow &&
-          !readableNow.locked
-        ) {
-          return p;
-        }
-        // Unusable this round — still re-enumerating (NetworkError), claimed
-        // by another app, or a transient driver / security error. Fall
-        // through to the next candidate and only give up at the deadline.
-      }
-    }
-    if (Date.now() >= deadline) {
-      console.error("[Web Serial] Failed to reopen port:", lastErr);
-      return null;
-    }
-    // Re-check before the inter-round sleep so a teardown that landed
-    // mid-round short-circuits instead of napping on it.
-    if (cancelled()) return null;
-    await sleep(200);
-  }
-  return null;
-}
+// The re-enumeration helpers live in ``serial-reacquire.ts``; re-exported
+// here so long-standing import paths (and their tests) keep working.
+export {
+  grantedHandlesFor,
+  isRecentSerialActivity,
+  markSerialActivity,
+  matchesDevice,
+  openLiveSerialPort,
+  reacquirePort,
+  SERIAL_ACTIVITY_WINDOW_MS,
+  SERIAL_REOPEN_TIMEOUT_MS,
+} from "./serial-reacquire.js";
 
 /**
  * Open an already-authorized serial port and detect the connected chip.


### PR DESCRIPTION
# What does this implement/fix?

web-serial.ts passed the repo's 500 to 600 line cap when #1426 promoted openLiveSerialPort into it. The re-enumeration slice — the activity window trio (SERIAL_ACTIVITY_WINDOW_MS, markSerialActivity, isRecentSerialActivity), matchesDevice, grantedHandlesFor, reacquirePort, openLiveSerialPort, and SERIAL_REOPEN_TIMEOUT_MS — moves to src/util/serial-reacquire.ts, with everything re-exported from web-serial.ts so existing import paths and tests keep working untouched.

The activity window trio rides along beyond the issue's list because SERIAL_REOPEN_TIMEOUT_MS derives from SERIAL_ACTIVITY_WINDOW_MS; leaving it behind would create an import cycle between the two modules, and it is the same re-enumeration domain anyway. Behavior free: no code changes beyond the move, one import bridge for web-serial's own markSerialActivity stamps, and web-serial lands at 503 lines.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1429

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
