### PR TITLE
Name the activity window's write side and mirror the test file

### DIFF
--- a/src/util/serial-reacquire.ts
+++ b/src/util/serial-reacquire.ts
@@ -18,11 +18,14 @@ import { sleep } from "./sleep.js";
  * port — without this guard the toast in ``app-shell`` would loop
  * every time the wizard runs a serial op.
  *
- * Every entry point in this module stamps ``_lastSerialActivityMs``
- * at the start (and the toast click handler in ``app-shell`` does
- * the same to cover the gap between the user's click and the first
- * internal op). ``isRecentSerialActivity`` answers whether we're
- * inside the window defined by ``SERIAL_ACTIVITY_WINDOW_MS``.
+ * The serial entry points in ``web-serial.ts`` (connectToPort,
+ * detectChip, flashFirmware, disconnect, resetAndDisconnect, ...) stamp
+ * ``_lastSerialActivityMs`` at the start via ``markSerialActivity``, and
+ * the toast click handler in ``app-shell`` does the same to cover the
+ * gap between the user's click and the first internal op. The
+ * reacquire/reopen loops below do NOT stamp. ``isRecentSerialActivity``
+ * answers whether we're inside the window defined by
+ * ``SERIAL_ACTIVITY_WINDOW_MS``.
  */
 let _lastSerialActivityMs = 0;
 

--- a/test/util/serial-reacquire.test.ts
+++ b/test/util/serial-reacquire.test.ts
@@ -8,7 +8,11 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { openLiveSerialPort, reacquirePort } from "../../src/util/web-serial.js";
+import {
+  openLiveSerialPort as openLiveViaBarrel,
+  reacquirePort as reacquireViaBarrel,
+} from "../../src/util/web-serial.js";
+import { openLiveSerialPort, reacquirePort } from "../../src/util/serial-reacquire.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -185,5 +189,14 @@ describe("openLiveSerialPort", () => {
     });
     expect(got).toBe(null);
     expect(rounds).toBeLessThanOrEqual(3);
+  });
+});
+
+// The web-serial barrel re-exports must stay pointed at these exact
+// functions — long-standing import paths depend on the bridge (#1432).
+describe("web-serial re-export bridge", () => {
+  it("resolves to the same functions as serial-reacquire", () => {
+    expect(reacquireViaBarrel).toBe(reacquirePort);
+    expect(openLiveViaBarrel).toBe(openLiveSerialPort);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The two items deferred from the #1432 split to keep it a verbatim move.

The activity window docblock in serial-reacquire.ts still claimed "every entry point in this module" stamps the timestamp, wording written when the block lived in web-serial.ts. It now names the actual write side: web-serial.ts's serial entry points (connectToPort, detectChip, flashFirmware, disconnect, resetAndDisconnect) plus app-shell's toast click handler, and notes the reacquire/reopen loops themselves never stamp.

The test file renames to serial-reacquire.test.ts per the test/util mirroring convention, importing the helpers from their real module, with one bridge canary asserting the web-serial re-exports still resolve to the same functions — the permanence of that bridge is the #1432 decision.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1434

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
