### PR TITLE
Re-bind the logs/install method picker to the live device object

### DIFF
--- a/src/components/dashboard/live-rebind.ts
+++ b/src/components/dashboard/live-rebind.ts
@@ -1,0 +1,14 @@
+import type { ConfiguredDevice } from "../../api/types/devices.js";
+
+/**
+ * The live ``_devices`` object matching *current*'s configuration, or ``null``
+ * when the device left the list. Device state events replace list objects
+ * wholesale, so any snapshot held across renders must re-link through this on
+ * every ``_devices`` change or it silently stops seeing updates.
+ */
+export function relinkLive(
+  devices: ConfiguredDevice[],
+  current: ConfiguredDevice
+): ConfiguredDevice | null {
+  return devices.find((d) => d.configuration === current.configuration) ?? null;
+}

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -601,6 +601,20 @@ export class ESPHomePageDashboard extends LitElement {
         this._drawerOpen = false;
       }
     }
+    // Same re-bind for the install/logs method picker: its OTA row gates on
+    // the device being online, and a device rebooting after an OTA must
+    // un-gray the row while the picker sits open (#1431).
+    if (changed.has("_devices") && this._installMethodDevice) {
+      const live = this._devices.find(
+        (d) => d.configuration === this._installMethodDevice!.configuration
+      );
+      if (live && live !== this._installMethodDevice) {
+        this._installMethodDevice = live;
+      } else if (!live) {
+        this._installMethodDevice = null;
+        this._installMethodOpen = false;
+      }
+    }
   }
 
   protected updated(changed: PropertyValues): void {

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -45,6 +45,7 @@ import {
   openLogs,
   showJobProgress,
 } from "../components/dashboard/install.js";
+import { relinkLive } from "../components/dashboard/live-rebind.js";
 import { loadPreferences, saveTablePreference } from "../components/dashboard/prefs.js";
 import {
   renderCardGrid,
@@ -591,12 +592,10 @@ export class ESPHomePageDashboard extends LitElement {
     // Re-bind drawer to live device so renames / state flaps / DHCP renews
     // don't leave the drawer showing stale fields.
     if (changed.has("_devices") && this._drawerDevice) {
-      const live = this._devices.find(
-        (d) => d.configuration === this._drawerDevice!.configuration
-      );
-      if (live && live !== this._drawerDevice) {
+      const live = relinkLive(this._devices, this._drawerDevice);
+      if (live) {
         this._drawerDevice = live;
-      } else if (!live) {
+      } else {
         this._drawerDevice = null;
         this._drawerOpen = false;
       }
@@ -605,12 +604,10 @@ export class ESPHomePageDashboard extends LitElement {
     // the device being online, and a device rebooting after an OTA must
     // un-gray the row while the picker sits open (#1431).
     if (changed.has("_devices") && this._installMethodDevice) {
-      const live = this._devices.find(
-        (d) => d.configuration === this._installMethodDevice!.configuration
-      );
-      if (live && live !== this._installMethodDevice) {
+      const live = relinkLive(this._devices, this._installMethodDevice);
+      if (live) {
         this._installMethodDevice = live;
-      } else if (!live) {
+      } else {
         this._installMethodDevice = null;
         this._installMethodOpen = false;
       }

--- a/test/components/dashboard/live-rebind.test.ts
+++ b/test/components/dashboard/live-rebind.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { relinkLive } from "../../../src/components/dashboard/live-rebind.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+
+describe("relinkLive", () => {
+  const stale = makeConfiguredDevice({ configuration: "kitchen.yaml" });
+
+  it("returns the live object sharing the snapshot's configuration", () => {
+    const live = makeConfiguredDevice({ configuration: "kitchen.yaml" });
+    expect(relinkLive([live], stale)).toBe(live);
+  });
+
+  it("returns null when the device left the list", () => {
+    const other = makeConfiguredDevice({ configuration: "garage.yaml" });
+    expect(relinkLive([other], stale)).toBeNull();
+  });
+
+  it("returns null on an empty list", () => {
+    expect(relinkLive([], stale)).toBeNull();
+  });
+});

--- a/test/pages/_mock-dashboard-children.ts
+++ b/test/pages/_mock-dashboard-children.ts
@@ -1,0 +1,31 @@
+import { vi } from "vitest";
+
+// Stubs every child component the dashboard page renders (real ones crash
+// under happy-dom). Import for side effect before the page import:
+//   import "./_mock-dashboard-children.js";
+// The vi.mock calls run when this module is evaluated, so they register
+// before later imports pull in the components. Paths resolve relative to
+// this file, so it must stay beside the page tests.
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("../../src/components/accept-peer-dialog.js", () => ({}));
+vi.mock("../../src/components/adopt-dialog.js", () => ({}));
+vi.mock("../../src/components/api-key-dialog.js", () => ({}));
+vi.mock("../../src/components/archived-devices-dialog.js", () => ({}));
+vi.mock("../../src/components/clone-device-dialog.js", () => ({}));
+vi.mock("../../src/components/command-dialog.js", () => ({}));
+vi.mock("../../src/components/confirm-dialog.js", () => ({}));
+vi.mock("../../src/components/dashboard/device-drawer.js", () => ({}));
+vi.mock("../../src/components/dashboard/device-table.js", () => ({}));
+vi.mock("../../src/components/dashboard/table-row-menu.js", () => ({}));
+vi.mock("../../src/components/device-card.js", () => ({}));
+vi.mock("../../src/components/device/board-reselect-dialog.js", () => ({}));
+vi.mock("../../src/components/discovered-device-card.js", () => ({}));
+vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
+vi.mock("../../src/components/friendly-name-dialog.js", () => ({}));
+vi.mock("../../src/components/install-method-dialog.js", () => ({}));
+vi.mock("../../src/components/labels/bulk-labels-dialog.js", () => ({}));
+vi.mock("../../src/components/labels/label-dialog.js", () => ({}));
+vi.mock("../../src/components/logs-dialog.js", () => ({}));
+vi.mock("../../src/components/rename-device-dialog.js", () => ({}));
+vi.mock("../../src/components/select-bar.js", () => ({}));
+vi.mock("../../src/components/wizard/create-config-dialog.js", () => ({}));

--- a/test/pages/dashboard-board-guard.test.ts
+++ b/test/pages/dashboard-board-guard.test.ts
@@ -6,29 +6,8 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("../../src/components/accept-peer-dialog.js", () => ({}));
-vi.mock("../../src/components/adopt-dialog.js", () => ({}));
-vi.mock("../../src/components/api-key-dialog.js", () => ({}));
-vi.mock("../../src/components/archived-devices-dialog.js", () => ({}));
-vi.mock("../../src/components/clone-device-dialog.js", () => ({}));
-vi.mock("../../src/components/command-dialog.js", () => ({}));
-vi.mock("../../src/components/confirm-dialog.js", () => ({}));
-vi.mock("../../src/components/dashboard/device-drawer.js", () => ({}));
-vi.mock("../../src/components/dashboard/device-table.js", () => ({}));
-vi.mock("../../src/components/dashboard/table-row-menu.js", () => ({}));
-vi.mock("../../src/components/device-card.js", () => ({}));
-vi.mock("../../src/components/device/board-reselect-dialog.js", () => ({}));
-vi.mock("../../src/components/discovered-device-card.js", () => ({}));
-vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
-vi.mock("../../src/components/friendly-name-dialog.js", () => ({}));
-vi.mock("../../src/components/install-method-dialog.js", () => ({}));
-vi.mock("../../src/components/labels/bulk-labels-dialog.js", () => ({}));
-vi.mock("../../src/components/labels/label-dialog.js", () => ({}));
-vi.mock("../../src/components/logs-dialog.js", () => ({}));
-vi.mock("../../src/components/rename-device-dialog.js", () => ({}));
-vi.mock("../../src/components/select-bar.js", () => ({}));
-vi.mock("../../src/components/wizard/create-config-dialog.js", () => ({}));
+import "./_mock-dashboard-children.js";
+
 vi.mock("../../src/util/board-change.js", () => ({
   findBoardDisagreement: vi.fn(),
   applyBoardChange: vi.fn(),

--- a/test/pages/dashboard-install-method-rebind.test.ts
+++ b/test/pages/dashboard-install-method-rebind.test.ts
@@ -22,6 +22,10 @@ async function mountWithPickerOpen(): Promise<ESPHomePageDashboard> {
   const page = new ESPHomePageDashboard();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (page as any)._devices = [OFFLINE];
+  // Loaded, so render() produces the real dialog tree (not the skeleton) and
+  // the .deviceState binding under test actually evaluates.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._devicesLoaded = true;
   page._installMethodDevice = OFFLINE;
   page._installMethodMode = "logs";
   page._installMethodOpen = true;
@@ -29,6 +33,12 @@ async function mountWithPickerOpen(): Promise<ESPHomePageDashboard> {
   await page.updateComplete;
   await flushMicrotasks(8);
   return page;
+}
+
+function pickerDeviceState(page: ESPHomePageDashboard): DeviceState | undefined {
+  const dialog = page.shadowRoot!.querySelector("esphome-install-method-dialog");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (dialog as any)?.deviceState;
 }
 
 describe("dashboard install-method picker device re-bind", () => {
@@ -43,6 +53,8 @@ describe("dashboard install-method picker device re-bind", () => {
 
   it("swaps the snapshot for the live object when the device comes back online", async () => {
     const page = await mountWithPickerOpen();
+    expect(pickerDeviceState(page)).toBe(DeviceState.OFFLINE);
+
     const online = makeConfiguredDevice({
       runtime_state: { state: DeviceState.ONLINE },
     });
@@ -51,6 +63,8 @@ describe("dashboard install-method picker device re-bind", () => {
     await page.updateComplete;
     expect(page._installMethodDevice).toBe(online);
     expect(page._installMethodOpen).toBe(true);
+    // The user-visible link: the dialog prop that gates the OTA row.
+    expect(pickerDeviceState(page)).toBe(DeviceState.ONLINE);
   });
 
   it("closes the picker when the device leaves the list", async () => {

--- a/test/pages/dashboard-install-method-rebind.test.ts
+++ b/test/pages/dashboard-install-method-rebind.test.ts
@@ -5,31 +5,9 @@
  * snapshot to the live object on every ``_devices`` change, so the picker's
  * online-gated OTA row tracks the device coming back after an OTA (#1431).
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("../../src/components/accept-peer-dialog.js", () => ({}));
-vi.mock("../../src/components/adopt-dialog.js", () => ({}));
-vi.mock("../../src/components/api-key-dialog.js", () => ({}));
-vi.mock("../../src/components/archived-devices-dialog.js", () => ({}));
-vi.mock("../../src/components/clone-device-dialog.js", () => ({}));
-vi.mock("../../src/components/command-dialog.js", () => ({}));
-vi.mock("../../src/components/confirm-dialog.js", () => ({}));
-vi.mock("../../src/components/dashboard/device-drawer.js", () => ({}));
-vi.mock("../../src/components/dashboard/device-table.js", () => ({}));
-vi.mock("../../src/components/dashboard/table-row-menu.js", () => ({}));
-vi.mock("../../src/components/device-card.js", () => ({}));
-vi.mock("../../src/components/device/board-reselect-dialog.js", () => ({}));
-vi.mock("../../src/components/discovered-device-card.js", () => ({}));
-vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
-vi.mock("../../src/components/friendly-name-dialog.js", () => ({}));
-vi.mock("../../src/components/install-method-dialog.js", () => ({}));
-vi.mock("../../src/components/labels/bulk-labels-dialog.js", () => ({}));
-vi.mock("../../src/components/labels/label-dialog.js", () => ({}));
-vi.mock("../../src/components/logs-dialog.js", () => ({}));
-vi.mock("../../src/components/rename-device-dialog.js", () => ({}));
-vi.mock("../../src/components/select-bar.js", () => ({}));
-vi.mock("../../src/components/wizard/create-config-dialog.js", () => ({}));
+import "./_mock-dashboard-children.js";
 
 import { DeviceState } from "../../src/api/types/devices.js";
 import { ESPHomePageDashboard } from "../../src/pages/dashboard.js";

--- a/test/pages/dashboard-install-method-rebind.test.ts
+++ b/test/pages/dashboard-install-method-rebind.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that the dashboard re-binds the install/logs method picker's device
+ * snapshot to the live object on every ``_devices`` change, so the picker's
+ * online-gated OTA row tracks the device coming back after an OTA (#1431).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("../../src/components/accept-peer-dialog.js", () => ({}));
+vi.mock("../../src/components/adopt-dialog.js", () => ({}));
+vi.mock("../../src/components/api-key-dialog.js", () => ({}));
+vi.mock("../../src/components/archived-devices-dialog.js", () => ({}));
+vi.mock("../../src/components/clone-device-dialog.js", () => ({}));
+vi.mock("../../src/components/command-dialog.js", () => ({}));
+vi.mock("../../src/components/confirm-dialog.js", () => ({}));
+vi.mock("../../src/components/dashboard/device-drawer.js", () => ({}));
+vi.mock("../../src/components/dashboard/device-table.js", () => ({}));
+vi.mock("../../src/components/dashboard/table-row-menu.js", () => ({}));
+vi.mock("../../src/components/device-card.js", () => ({}));
+vi.mock("../../src/components/device/board-reselect-dialog.js", () => ({}));
+vi.mock("../../src/components/discovered-device-card.js", () => ({}));
+vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
+vi.mock("../../src/components/friendly-name-dialog.js", () => ({}));
+vi.mock("../../src/components/install-method-dialog.js", () => ({}));
+vi.mock("../../src/components/labels/bulk-labels-dialog.js", () => ({}));
+vi.mock("../../src/components/labels/label-dialog.js", () => ({}));
+vi.mock("../../src/components/logs-dialog.js", () => ({}));
+vi.mock("../../src/components/rename-device-dialog.js", () => ({}));
+vi.mock("../../src/components/select-bar.js", () => ({}));
+vi.mock("../../src/components/wizard/create-config-dialog.js", () => ({}));
+
+import { DeviceState } from "../../src/api/types/devices.js";
+import { ESPHomePageDashboard } from "../../src/pages/dashboard.js";
+import { flushMicrotasks } from "../_dom.js";
+import { makeConfiguredDevice } from "../_make-configured-device.js";
+
+const OFFLINE = makeConfiguredDevice({
+  runtime_state: { state: DeviceState.OFFLINE },
+});
+
+async function mountWithPickerOpen(): Promise<ESPHomePageDashboard> {
+  const page = new ESPHomePageDashboard();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._devices = [OFFLINE];
+  page._installMethodDevice = OFFLINE;
+  page._installMethodMode = "logs";
+  page._installMethodOpen = true;
+  document.body.appendChild(page);
+  await page.updateComplete;
+  await flushMicrotasks(8);
+  return page;
+}
+
+describe("dashboard install-method picker device re-bind", () => {
+  beforeEach(() => {
+    window.history.replaceState({}, "", "/");
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, "", "/");
+    document.body.innerHTML = "";
+  });
+
+  it("swaps the snapshot for the live object when the device comes back online", async () => {
+    const page = await mountWithPickerOpen();
+    const online = makeConfiguredDevice({
+      runtime_state: { state: DeviceState.ONLINE },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (page as any)._devices = [online];
+    await page.updateComplete;
+    expect(page._installMethodDevice).toBe(online);
+    expect(page._installMethodOpen).toBe(true);
+  });
+
+  it("closes the picker when the device leaves the list", async () => {
+    const page = await mountWithPickerOpen();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (page as any)._devices = [];
+    await page.updateComplete;
+    expect(page._installMethodDevice).toBeNull();
+    expect(page._installMethodOpen).toBe(false);
+  });
+});

--- a/test/pages/dashboard-remote-panel.test.ts
+++ b/test/pages/dashboard-remote-panel.test.ts
@@ -8,33 +8,11 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 // Rendering the loaded dashboard mounts every dialog child, and each
 // wa-dialog's internal form-associated elements (WaButton, WaCheckbox)
 // crash under happy-dom. The layout assertions here don't touch them,
-// so no-op the heavy children (device-platform-ready idiom).
-vi.mock("../../src/components/accept-peer-dialog.js", () => ({}));
-vi.mock("../../src/components/adopt-dialog.js", () => ({}));
-vi.mock("../../src/components/api-key-dialog.js", () => ({}));
-vi.mock("../../src/components/archived-devices-dialog.js", () => ({}));
-vi.mock("../../src/components/clone-device-dialog.js", () => ({}));
-vi.mock("../../src/components/command-dialog.js", () => ({}));
-vi.mock("../../src/components/confirm-dialog.js", () => ({}));
-vi.mock("../../src/components/dashboard/device-drawer.js", () => ({}));
-vi.mock("../../src/components/dashboard/device-table.js", () => ({}));
-vi.mock("../../src/components/dashboard/table-row-menu.js", () => ({}));
-vi.mock("../../src/components/device-card.js", () => ({}));
-vi.mock("../../src/components/device/board-reselect-dialog.js", () => ({}));
-vi.mock("../../src/components/discovered-device-card.js", () => ({}));
-vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
-vi.mock("../../src/components/friendly-name-dialog.js", () => ({}));
-vi.mock("../../src/components/install-method-dialog.js", () => ({}));
-vi.mock("../../src/components/labels/bulk-labels-dialog.js", () => ({}));
-vi.mock("../../src/components/labels/label-dialog.js", () => ({}));
-vi.mock("../../src/components/logs-dialog.js", () => ({}));
-vi.mock("../../src/components/rename-device-dialog.js", () => ({}));
-vi.mock("../../src/components/select-bar.js", () => ({}));
-vi.mock("../../src/components/wizard/create-config-dialog.js", () => ({}));
+// so no-op the heavy children.
+import "./_mock-dashboard-children.js";
 
 import type { ConfiguredDevice } from "../../src/api/types/devices.js";
 import { JobStatus } from "../../src/api/types/firmware-jobs.js";


### PR DESCRIPTION
# What does this implement/fix?

On the dashboard page the install/logs method picker snapshots the device object into `_installMethodDevice` when it opens, but device state events replace the object in the reactive list, so the snapshot never sees the OFFLINE to ONLINE transition. In logs mode the "Connect wirelessly" row gates on the device being online, so after an OTA reboot the row stayed grayed out until the dialog was closed and reopened.

The fix mirrors the drawer's existing live re-bind in `willUpdate`: on every `_devices` change the snapshot is swapped for the live object (the OTA row, address seed, bootloader and never-flashed bindings all refresh), and a device that leaves the list closes the picker, same as the drawer. As a side effect the method selected from the picker now acts on the live device object instead of the stale snapshot.

The device detail page was not affected; its controller reads state through a getter into the context-subscribed device list. The other dashboard snapshots (`_cardContextDevice`, `_actionDevice`) back transient menus and confirm dialogs with no online gating, so they are left alone.

Both re-bind blocks now share a `relinkLive` lookup in `live-rebind.ts`. Test side, the new regression test also asserts the dialog's `deviceState` prop through the DOM, and the dashboard page tests' duplicated child mock block is hoisted into `test/pages/_mock-dashboard-children.ts` (used by the two existing page tests too).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1431

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

