### PR TITLE
Keep the collision check frozen through the create dialog's close

### DIFF
--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -567,10 +567,13 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
         await this._applyFullSetup(configuration, options.board);
       }
       this.navigateToCreated(configuration);
+      // _submitting stays true: dropping it here restores the live
+      // takenHostnames set — which now contains the just-created slug — while
+      // the close animation is still playing, flashing the collision error
+      // (#1438). The next open resets it via _resetTransientState.
     } catch (err) {
       console.error("Failed to create device:", err);
       this._createError = this._extractCreateErrorMessage(err, options.board ?? null);
-    } finally {
       this._submitting = false;
     }
   }

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -46,6 +46,8 @@ type WizardStep =
   | "confirm-overwrite"
   | "import-partial";
 type CreationMethod = "basic" | "empty" | "import";
+
+const EMPTY_TAKEN: ReadonlySet<string> = new Set();
 type WizardStepDetail =
   | WizardStep
   | {
@@ -105,6 +107,12 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
 
   @state()
   private _submitting = false;
+
+  // One-way latch set on a successful create. Distinct from ``_submitting``,
+  // which must drop in ``finally`` — it drives the base dialog's busy gate,
+  // and a busy dialog vetoes its own close (wa-hide preventDefault).
+  @state()
+  private _created = false;
 
   @state()
   private _importError = "";
@@ -198,9 +206,20 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     this._advancedOpen = false;
     this._import.reset();
     this._submitting = false;
+    this._created = false;
     this._pickedBoardId = null;
     this._resetCreateErrors();
     this._dialog.open = true;
+  }
+
+  /**
+   * Collision set handed to the name-input steps. Frozen to empty from
+   * submit through the close: the devices push lands with the just-created
+   * slug while the dialog is still on screen, and the live set would flag
+   * the name as a self-collision (#1416, #1438).
+   */
+  private get _stepTakenHostnames(): ReadonlySet<string> {
+    return this._submitting || this._created ? EMPTY_TAKEN : this.takenHostnames;
   }
 
   /** Clear both error slots so a stale message from a prior
@@ -327,13 +346,13 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
       case "setup":
         return html`<esphome-wizard-step-setup
           .board=${this._selectedBoard}
-          .takenHostnames=${this.takenHostnames}
+          .takenHostnames=${this._stepTakenHostnames}
           ?active=${this._dialog.open}
           ?submitting=${this._submitting}
         ></esphome-wizard-step-setup>`;
       case "empty-config":
         return html`<esphome-wizard-step-empty-config
-          .takenHostnames=${this.takenHostnames}
+          .takenHostnames=${this._stepTakenHostnames}
           ?active=${this._dialog.open}
         ></esphome-wizard-step-empty-config>`;
       case "resolve-conflicts":
@@ -566,14 +585,12 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
       if (options.fullSetup && options.board) {
         await this._applyFullSetup(configuration, options.board);
       }
+      this._created = true; // keep the collision check frozen through the close
       this.navigateToCreated(configuration);
-      // _submitting stays true: dropping it here restores the live
-      // takenHostnames set — which now contains the just-created slug — while
-      // the close animation is still playing, flashing the collision error
-      // (#1438). The next open resets it via _resetTransientState.
     } catch (err) {
       console.error("Failed to create device:", err);
       this._createError = this._extractCreateErrorMessage(err, options.board ?? null);
+    } finally {
       this._submitting = false;
     }
   }

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -229,6 +229,23 @@ describe("create-config-dialog create de-dupe + retry", () => {
     expect((el as any)._createError).toBeTruthy();
   });
 
+  it("keeps submitting set through a successful create until the next open", async () => {
+    // Dropping the flag on success restores the live takenHostnames set —
+    // which now contains the just-created slug — while the close animation
+    // still plays, flashing the collision error (#1438).
+    const createDevice = vi.fn().mockResolvedValueOnce({ configuration: "kitchen.yaml" });
+    const el = await mount({ createDevice });
+
+    emitFinish(el, "kitchen");
+    await flush();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._submitting).toBe(true);
+    el.open();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._submitting).toBe(false);
+  });
+
   it("forwards the hostname and friendly name from the empty-config flow", async () => {
     const createDevice = vi
       .fn()

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -229,21 +229,53 @@ describe("create-config-dialog create de-dupe + retry", () => {
     expect((el as any)._createError).toBeTruthy();
   });
 
-  it("keeps submitting set through a successful create until the next open", async () => {
-    // Dropping the flag on success restores the live takenHostnames set —
-    // which now contains the just-created slug — while the close animation
-    // still plays, flashing the collision error (#1438).
+  it("keeps the setup step's collision set frozen through a successful create", async () => {
+    // The devices push lands with the just-created slug while the close
+    // animation still plays; the live set reaching the step would flash the
+    // collision error (#1438).
     const createDevice = vi.fn().mockResolvedValueOnce({ configuration: "kitchen.yaml" });
     const el = await mount({ createDevice });
+    el.takenHostnames = new Set(["kitchen"]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._step = "setup";
+    await el.updateComplete;
 
     emitFinish(el, "kitchen");
     await flush();
+    await el.updateComplete;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((el as any)._submitting).toBe(true);
-    el.open();
+    // Busy must release on success or the busy gate vetoes the dialog's close.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((el as any)._submitting).toBe(false);
+    const step = el.shadowRoot!.querySelector("esphome-wizard-step-setup")!;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((step as any).takenHostnames.size).toBe(0);
+
+    // The next open unfreezes back to the live set.
+    el.open();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._step = "setup";
+    await el.updateComplete;
+    const reopened = el.shadowRoot!.querySelector("esphome-wizard-step-setup")!;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((reopened as any).takenHostnames.size).toBe(1);
+  });
+
+  it("freezes the empty-config step's collision set too", async () => {
+    const createDevice = vi.fn().mockResolvedValueOnce({ configuration: "kitchen.yaml" });
+    const el = await mount({ createDevice });
+    el.takenHostnames = new Set(["kitchen"]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._step = "empty-config";
+    await el.updateComplete;
+
+    emitCreate(el, "kitchen");
+    await flush();
+    await el.updateComplete;
+
+    const step = el.shadowRoot!.querySelector("esphome-wizard-step-empty-config")!;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((step as any).takenHostnames.size).toBe(0);
   });
 
   it("forwards the hostname and friendly name from the empty-config flow", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Third pass at the create wizard's hostname collision flash. #1416 froze the collision check while the create was in flight, but `_runCreate` reset `_submitting` in its `finally` block, which runs right after `navigateToCreated` on the success path. The moment the flag dropped, the setup step swapped the live `takenHostnames` set back in, and by then the devices push had landed so it contained the just created slug. The dialog was still playing its close animation, so the error flashed during it, shorter than before but still visible.

The freeze is now a one way `_created` latch set on success, separate from `_submitting`, which keeps dropping in `finally`; holding `_submitting` would keep the base dialog's busy gate up and veto the dialog's own close (review finding). A `_stepTakenHostnames` getter on the dialog feeds both name input steps a frozen empty set while `_submitting || _created`, which also closes the previously unguarded empty config path. Every open entry point clears the latch through `_resetTransientState`, so a reopen starts on the live set.

Verified live against the dev backend: create completes, the dialog closes and navigates cleanly, and reopening the wizard shows the live collision set again. The tests pin the behaviour through the step elements' committed `takenHostnames` property for both the setup and empty config steps, plus `_submitting` releasing on success.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1438

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

