### PR TITLE
Type the frozen collision set's constructor

### DIFF
--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -47,7 +47,7 @@ type WizardStep =
   | "import-partial";
 type CreationMethod = "basic" | "empty" | "import";
 
-const EMPTY_TAKEN: ReadonlySet<string> = new Set();
+const EMPTY_TAKEN: ReadonlySet<string> = new Set<string>();
 type WizardStepDetail =
   | WizardStep
   | {


### PR DESCRIPTION
# What does this implement/fix?

Follow up to a Copilot nit on #1439 that landed after the merge: `EMPTY_TAKEN` is used as a `ReadonlySet<string>` but was constructed as a bare `new Set()`, so the constructor's generic was left to inference. Constructing it as `new Set<string>()` keeps the value's type aligned with its annotation.

**Related issue or feature (if applicable):**

- fixes N/A (review follow up to #1439)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
