### PR TITLE
Swap web.esphome.io native title tooltips for wa-tooltip

### DIFF
--- a/src/web/dashboard/esphome-web-esp-device-card.ts
+++ b/src/web/dashboard/esphome-web-esp-device-card.ts
@@ -23,6 +23,7 @@ import { cardActionsRowStyles } from "./card-actions-row.js";
 import "./esphome-web-card.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "@home-assistant/webawesome/dist/components/tooltip/tooltip.js";
 
 registerMdiIcons({
   "rocket-launch": mdiRocketLaunch,
@@ -97,37 +98,47 @@ export class ESPHomeWebEspDeviceCard extends LitElement {
             ${this._localize("web.actions.prepare")}
           </button>
           <button
+            id="btn-install"
             class="action-btn action-btn--ghost action-btn--tile"
-            title=${this._localize("dashboard.install")}
             aria-label=${this._localize("dashboard.install")}
             @click=${this._showInstall}
           >
             <wa-icon library="mdi" name="upload"></wa-icon>
           </button>
+          <wa-tooltip for="btn-install"
+            >${this._localize("dashboard.install")}</wa-tooltip
+          >
           <button
+            id="btn-logs"
             class="action-btn action-btn--ghost action-btn--tile"
-            title=${this._localize("dashboard.logs")}
             aria-label=${this._localize("dashboard.logs")}
             @click=${this._showLogs}
           >
             <wa-icon library="mdi" name="text-box-outline"></wa-icon>
           </button>
+          <wa-tooltip for="btn-logs">${this._localize("dashboard.logs")}</wa-tooltip>
           <button
+            id="btn-wifi"
             class="action-btn action-btn--ghost action-btn--tile"
-            title=${this._localize("web.actions.configure_wifi")}
             aria-label=${this._localize("web.actions.configure_wifi")}
             @click=${this._configureWifi}
           >
             <wa-icon library="mdi" name="wifi-cog"></wa-icon>
           </button>
+          <wa-tooltip for="btn-wifi"
+            >${this._localize("web.actions.configure_wifi")}</wa-tooltip
+          >
           <button
+            id="btn-disconnect"
             class="action-btn action-btn--ghost action-btn--icon-only"
-            title=${this._localize("web.actions.disconnect")}
             aria-label=${this._localize("web.actions.disconnect")}
             @click=${this._disconnect}
           >
             <wa-icon library="mdi" name="link-off"></wa-icon>
           </button>
+          <wa-tooltip for="btn-disconnect"
+            >${this._localize("web.actions.disconnect")}</wa-tooltip
+          >
         </div>
       </esphome-web-card>
       <esphome-web-install-adoptable-dialog

--- a/src/web/dashboard/esphome-web-pico-device-card.ts
+++ b/src/web/dashboard/esphome-web-pico-device-card.ts
@@ -14,6 +14,7 @@ import { cardActionsRowStyles } from "./card-actions-row.js";
 import "./esphome-web-card.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "@home-assistant/webawesome/dist/components/tooltip/tooltip.js";
 
 registerMdiIcons({
   "text-box-outline": mdiTextBoxOutline,
@@ -64,21 +65,25 @@ export class ESPHomeWebPicoDeviceCard extends LitElement {
             ${this._localize("web.actions.configure_wifi")}
           </button>
           <button
+            id="btn-logs"
             class="action-btn action-btn--ghost action-btn--tile"
-            title=${this._localize("dashboard.logs")}
             aria-label=${this._localize("dashboard.logs")}
             @click=${this._showLogs}
           >
             <wa-icon library="mdi" name="text-box-outline"></wa-icon>
           </button>
+          <wa-tooltip for="btn-logs">${this._localize("dashboard.logs")}</wa-tooltip>
           <button
+            id="btn-disconnect"
             class="action-btn action-btn--ghost action-btn--icon-only"
-            title=${this._localize("web.actions.disconnect")}
             aria-label=${this._localize("web.actions.disconnect")}
             @click=${this._disconnect}
           >
             <wa-icon library="mdi" name="link-off"></wa-icon>
           </button>
+          <wa-tooltip for="btn-disconnect"
+            >${this._localize("web.actions.disconnect")}</wa-tooltip
+          >
         </div>
       </esphome-web-card>
       <esphome-web-logs-dialog

--- a/src/web/entrypoint.ts
+++ b/src/web/entrypoint.ts
@@ -25,3 +25,10 @@ if (typeof crypto !== "undefined" && !crypto.randomUUID) {
 
 import "../styles/apply-theme.js";
 import "./esphome-web-app.js";
+
+import { installWaTooltipTouchSuppression } from "../util/wa-tooltip-touch-suppression.js";
+
+// Same guard the dashboard entrypoint installs: without it a tap's emulated
+// mouseover shows a wa-tooltip after the click already opened the dialog or
+// menu, with nothing to ever hide it.
+installWaTooltipTouchSuppression();

--- a/src/web/header/esphome-web-header-actions.ts
+++ b/src/web/header/esphome-web-header-actions.ts
@@ -12,6 +12,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "@home-assistant/webawesome/dist/components/tooltip/tooltip.js";
 
 registerMdiIcons({
   "bug-outline": mdiBugOutline,
@@ -38,14 +39,15 @@ export class ESPHomeWebHeaderActions extends OverflowMenuElement {
     const kebabLabel = this._localize("web.header.more_options");
     return html`
       <button
+        id="btn-kebab"
         type="button"
         class="menu-btn menu-kebab"
         @click=${this._toggle}
-        title=${kebabLabel}
         aria-label=${kebabLabel}
       >
         <wa-icon library="mdi" name="dots-vertical"></wa-icon>
       </button>
+      <wa-tooltip for="btn-kebab">${kebabLabel}</wa-tooltip>
       ${
         this._open
           ? html`

--- a/src/web/header/esphome-web-header.ts
+++ b/src/web/header/esphome-web-header.ts
@@ -64,7 +64,6 @@ export class ESPHomeWebHeader extends LitElement {
                 <button
                   class="switch-btn"
                   @click=${this._onToggle}
-                  title=${targetLabel}
                   aria-label=${targetLabel}
                 >
                   <img class="target-logo" src="/static/logo/${targetLogo}.png" alt="" />

--- a/src/web/header/esphome-web-header.ts
+++ b/src/web/header/esphome-web-header.ts
@@ -11,6 +11,7 @@ import { isWebSerialSupported } from "../../util/web-serial.js";
 import { modeUrl, type WebMode } from "../web-mode.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "@home-assistant/webawesome/dist/components/tooltip/tooltip.js";
 import "./esphome-web-header-actions.js";
 
 registerMdiIcons({ "swap-horizontal": mdiSwapHorizontal });
@@ -62,6 +63,7 @@ export class ESPHomeWebHeader extends LitElement {
           !this.minimal && isWebSerialSupported()
             ? html`
                 <button
+                  id="btn-switch"
                   class="switch-btn"
                   @click=${this._onToggle}
                   aria-label=${targetLabel}
@@ -70,6 +72,10 @@ export class ESPHomeWebHeader extends LitElement {
                   <span class="target-label">${targetLabel}</span>
                   <wa-icon library="mdi" name="swap-horizontal"></wa-icon>
                 </button>
+                <!-- Redundant beside the visible label on wide windows, but the
+                     870px query hides the label by width, not pointer — a
+                     narrow desktop window still hovers. -->
+                <wa-tooltip for="btn-switch">${targetLabel}</wa-tooltip>
               `
             : nothing
         }

--- a/test/web/_tooltip-anchors.ts
+++ b/test/web/_tooltip-anchors.ts
@@ -1,0 +1,16 @@
+import { expect } from "vitest";
+
+/**
+ * Assert every ``wa-tooltip[for]`` in the element's shadow root resolves to
+ * a real id, the same way ``wa-tooltip`` itself anchors
+ * (``getRootNode().getElementById``). With the native ``title`` gone, a
+ * typo'd or renamed anchor id would otherwise degrade silently.
+ */
+export function expectTooltipsAnchored(el: HTMLElement, count: number): void {
+  const tips = [...el.shadowRoot!.querySelectorAll("wa-tooltip[for]")];
+  expect(tips.length).toBe(count);
+  for (const tip of tips) {
+    const id = tip.getAttribute("for")!;
+    expect(el.shadowRoot!.getElementById(id), id).not.toBeNull();
+  }
+}

--- a/test/web/esp-connect-card.test.ts
+++ b/test/web/esp-connect-card.test.ts
@@ -16,6 +16,7 @@ vi.mock("../../src/web/dashboard/esphome-web-esp-device-card.js", () => ({}));
 vi.mock("../../src/util/register-icons.js", () => ({ registerMdiIcons: vi.fn() }));
 vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
 
 import toast from "sonner-js";
 import { flush } from "../_dom.js";

--- a/test/web/esp-device-card-provision.test.ts
+++ b/test/web/esp-device-card-provision.test.ts
@@ -18,6 +18,7 @@ vi.mock("../../src/web/logs/esphome-web-logs-dialog.js", () => ({}));
 vi.mock("../../src/web/dashboard/esphome-web-card.js", () => ({}));
 vi.mock("../../src/util/register-icons.js", () => ({ registerMdiIcons: vi.fn() }));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
 
 import { ESPHomeWebEspDeviceCard } from "../../src/web/dashboard/esphome-web-esp-device-card.js";
 

--- a/test/web/esp-device-card-provision.test.ts
+++ b/test/web/esp-device-card-provision.test.ts
@@ -21,6 +21,7 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
 
 import { ESPHomeWebEspDeviceCard } from "../../src/web/dashboard/esphome-web-esp-device-card.js";
+import { expectTooltipsAnchored } from "./_tooltip-anchors.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -59,5 +60,10 @@ describe("esphome-web-esp-device-card Improv hand-off", () => {
     (el as any)._configureWifi();
 
     expect(openImprovDialog).toHaveBeenCalledOnce();
+  });
+
+  it("anchors every action tooltip to a real button id", async () => {
+    const el = await mount();
+    expectTooltipsAnchored(el, 4);
   });
 });

--- a/test/web/pico-connect-card.test.ts
+++ b/test/web/pico-connect-card.test.ts
@@ -19,6 +19,7 @@ vi.mock("../../src/util/web-serial.js", () => ({
 }));
 vi.mock("../../src/web/util/pico-port-filter.js", () => ({ picoPortFilters: [] }));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
 
 import { flush } from "../_dom.js";
 import { makeDisconnectPort } from "../_web-serial.js";

--- a/test/web/pico-device-card.test.ts
+++ b/test/web/pico-device-card.test.ts
@@ -11,6 +11,7 @@ vi.mock("../../src/web/logs/esphome-web-logs-dialog.js", () => ({
 vi.mock("../../src/web/dashboard/esphome-web-card.js", () => ({}));
 vi.mock("../../src/util/register-icons.js", () => ({ registerMdiIcons: vi.fn() }));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
 
 import { ESPHomeWebPicoDeviceCard } from "../../src/web/dashboard/esphome-web-pico-device-card.js";
 

--- a/test/web/pico-device-card.test.ts
+++ b/test/web/pico-device-card.test.ts
@@ -14,6 +14,7 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
 
 import { ESPHomeWebPicoDeviceCard } from "../../src/web/dashboard/esphome-web-pico-device-card.js";
+import { expectTooltipsAnchored } from "./_tooltip-anchors.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -35,5 +36,14 @@ describe("esphome-web-pico-device-card", () => {
 
     expect(close).toHaveBeenCalledOnce();
     expect(closed).toHaveBeenCalledOnce();
+  });
+
+  it("anchors every action tooltip to a real button id", async () => {
+    const el = new ESPHomeWebPicoDeviceCard();
+    (el as any)._localize = (k: string) => k;
+    el.port = { close: vi.fn(async () => {}) } as unknown as SerialPort;
+    document.body.appendChild(el);
+    await el.updateComplete;
+    expectTooltipsAnchored(el, 2);
   });
 });

--- a/test/web/web-header-actions.test.ts
+++ b/test/web/web-header-actions.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/util/register-icons.js", () => ({ registerMdiIcons: vi.fn() }));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
 
 import { ESPHomeWebHeaderActions } from "../../src/web/header/esphome-web-header-actions.js";
 import { identityLocalize } from "../_dom.js";

--- a/test/web/web-header-actions.test.ts
+++ b/test/web/web-header-actions.test.ts
@@ -12,6 +12,7 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
 
 import { ESPHomeWebHeaderActions } from "../../src/web/header/esphome-web-header-actions.js";
+import { expectTooltipsAnchored } from "./_tooltip-anchors.js";
 import { identityLocalize } from "../_dom.js";
 
 afterEach(() => {
@@ -69,5 +70,10 @@ describe("esphome-web-header-actions", () => {
     await el.updateComplete;
 
     expect(el.shadowRoot!.querySelector(".menu")).toBeNull();
+  });
+
+  it("anchors the kebab tooltip to the button id", async () => {
+    const el = await mount();
+    expectTooltipsAnchored(el, 1);
   });
 });

--- a/test/web/web-header.test.ts
+++ b/test/web/web-header.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/util/register-icons.js", () => ({ registerMdiIcons: vi.fn() }));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
 
 import { ESPHomeWebHeader } from "../../src/web/header/esphome-web-header.js";
 

--- a/test/web/web-header.test.ts
+++ b/test/web/web-header.test.ts
@@ -6,6 +6,7 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
 
 import { ESPHomeWebHeader } from "../../src/web/header/esphome-web-header.js";
+import { expectTooltipsAnchored } from "./_tooltip-anchors.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -68,5 +69,10 @@ describe("esphome-web-header switch target", () => {
     const el = await mount("esp", true);
 
     expect(el.shadowRoot!.querySelector("esphome-web-header-actions")).not.toBeNull();
+  });
+
+  it("anchors the switch tooltip to the button id", async () => {
+    const el = await mount("esp");
+    expectTooltipsAnchored(el, 1);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

web.esphome.io's icon buttons used native `title` attributes, and the browser tooltip can render far from the hovered control (the issue screenshot shows Install pinned to the card's top left corner). The device card actions, the pico card actions, and the header kebab now use the same `wa-tooltip` anchored by `for`/id pattern the builder's device cards use, so the tooltip always sits on its button. The `aria-label`s stay for accessibility.

The header's ESP to Pico switch button gets the same treatment as review pointed out the 870px label hide is a width query, not a pointer query, so a narrow desktop window still hovers; the tooltip is redundant beside the visible label at wide widths but harmless. Since these are the first `wa-tooltip`s in `src/web`, the web entrypoint now installs `installWaTooltipTouchSuppression()` like the dashboard entrypoint, so a tap can't strand a tooltip over an opened dialog or menu.

Verified against the dev web server: all card, kebab and switch tooltips render anchored to their buttons, and no `title` attributes remain in `src/web`. A shared test helper asserts every `wa-tooltip[for]` resolves to a real id in each component's shadow root.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1441

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).

