### PR TITLE
Swap the dashboard kebab's native title for wa-tooltip

### DIFF
--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -40,6 +40,7 @@ import { headerActionsStyles } from "./esphome-header-actions.styles.js";
 import { OverflowMenuElement } from "./overflow-menu-element.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "@home-assistant/webawesome/dist/components/tooltip/tooltip.js";
 
 registerMdiIcons({
   "archive-outline": mdiArchiveOutline,
@@ -174,10 +175,10 @@ export class ESPHomeHeaderActions extends OverflowMenuElement {
       : this._localize("layout.search_shortcut");
     return html`
       <button
+        id="btn-kebab"
         type="button"
         class="menu-btn menu-kebab"
         @click=${this._toggle}
-        title=${kebabLabel}
         aria-label=${kebabLabel}
       >
         <wa-icon library="mdi" name="dots-vertical"></wa-icon>
@@ -187,6 +188,7 @@ export class ESPHomeHeaderActions extends OverflowMenuElement {
             : nothing
         }
       </button>
+      <wa-tooltip for="btn-kebab">${kebabLabel}</wa-tooltip>
       ${
         this._open
           ? html`

--- a/test/components/_esphome-header-actions-helpers.ts
+++ b/test/components/_esphome-header-actions-helpers.ts
@@ -6,6 +6,10 @@
  * gating prop they set first, so that boilerplate lives here rather than
  * getting copy-pasted per suite.
  */
+// Before the component import: it now pulls in real wa-tooltip, and the
+// webawesome components crash under happy-dom.
+import "../_mock-webawesome.js";
+
 import type { LocalizeFunc } from "../../src/common/localize.js";
 import { ESPHomeHeaderActions } from "../../src/components/esphome-header-actions.js";
 

--- a/test/components/esphome-header-actions-tooltip.test.ts
+++ b/test/components/esphome-header-actions-tooltip.test.ts
@@ -11,13 +11,12 @@ import { renderOpenHeaderMenu } from "./_esphome-header-actions-helpers.js";
 describe("header-actions kebab tooltip", () => {
   it("anchors the wa-tooltip to the kebab button id, title gone", async () => {
     const el = await renderOpenHeaderMenu();
-    const tips = [...el.shadowRoot!.querySelectorAll("wa-tooltip[for]")];
-    expect(tips.length).toBe(1);
-    for (const tip of tips) {
-      const id = tip.getAttribute("for")!;
-      expect(el.shadowRoot!.getElementById(id), id).not.toBeNull();
-    }
-    const kebab = el.shadowRoot!.querySelector(".menu-kebab")!;
-    expect(kebab.hasAttribute("title")).toBe(false);
+    const tip = el.shadowRoot!.querySelector("wa-tooltip[for]");
+    expect(tip).not.toBeNull();
+    const id = tip!.getAttribute("for")!;
+    const kebab = el.shadowRoot!.getElementById(id);
+    expect(kebab).not.toBeNull();
+    expect(kebab!.classList.contains("menu-kebab")).toBe(true);
+    expect(kebab!.hasAttribute("title")).toBe(false);
   });
 });

--- a/test/components/esphome-header-actions-tooltip.test.ts
+++ b/test/components/esphome-header-actions-tooltip.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the kebab's wa-tooltip anchoring: with the native title gone, a
+ * typo'd or renamed anchor id would degrade to no tooltip silently.
+ */
+import { describe, expect, it } from "vitest";
+
+import { renderOpenHeaderMenu } from "./_esphome-header-actions-helpers.js";
+
+describe("header-actions kebab tooltip", () => {
+  it("anchors the wa-tooltip to the kebab button id, title gone", async () => {
+    const el = await renderOpenHeaderMenu();
+    const tips = [...el.shadowRoot!.querySelectorAll("wa-tooltip[for]")];
+    expect(tips.length).toBe(1);
+    for (const tip of tips) {
+      const id = tip.getAttribute("for")!;
+      expect(el.shadowRoot!.getElementById(id), id).not.toBeNull();
+    }
+    const kebab = el.shadowRoot!.querySelector(".menu-kebab")!;
+    expect(kebab.hasAttribute("title")).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Parity follow up to #1444, from a Kōan note there: the builder dashboard's own header kebab still used a native `title` tooltip while every other icon button in the dashboard uses the styled `wa-tooltip` pattern. The kebab now gets the same `id` plus sibling `wa-tooltip for` treatment, keeping its `aria-label`. The dashboard entrypoint already installs the tooltip touch suppression, so no wiring is needed.

A small test pins the tooltip anchoring to a real button id and the `title` attribute staying gone, since a broken anchor would otherwise degrade silently.

**Related issue or feature (if applicable):**

- follow up to #1444 (review note)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
