### PR TITLE
Route provably mismatched serial log ports straight to network logs

### DIFF
--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -98,6 +98,10 @@ export interface ConfiguredDevice {
    *  unset (open at the 115200 default); `0` means UART logging is disabled;
    *  a positive value is the baud to open at. */
   logger_baud_rate: number | null;
+  /** Resolved `logger:` output interface (UART0 / USB_CDC / USB_SERIAL_JTAG
+   *  / ...). Compared against a Web Serial port's USB vendor to spot a
+   *  console the port can't carry; `null` means unknowable. */
+  logger_interface: string | null;
   current_version: string;
   loaded_integrations: string[];
   /**

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -241,6 +241,7 @@ export function flipToLogs(
     webSerialPort,
     // Raw baud; the logs handler resolves it (0 ⇒ disabled, skip with a notice).
     loggerBaudRate: device.logger_baud_rate,
+    loggerInterface: device.logger_interface,
     reopenInstall: () => host.reopen(),
   });
   if (handled) host._open = false;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -176,6 +176,7 @@
     "logs_method_network_address_submit": "View logs over network",
     "logs_web_serial_unsupported": "Web Serial is not supported in this browser",
     "logs_serial_disabled_fallback": "Serial logging is disabled for this device (logger baud_rate is 0). Showing network logs instead.",
+    "logs_serial_wrong_port_fallback": "This port can't show the device's logs (the logger outputs on {interface}). Showing network logs instead.",
     "install_method_title": "How do you want to install the firmware?",
     "install_method_network": "On the network",
     "install_method_network_desc": "Compile and upload over the network",

--- a/src/util/logs-launch.ts
+++ b/src/util/logs-launch.ts
@@ -8,7 +8,7 @@ import {
   attachSerialLogStream,
   openNetworkLogsFallback,
   reconnectWebSerialLogs,
-  requestAndOpenSerialPort,
+  requestSerialPort,
 } from "./post-install-logs.js";
 import { serialConsoleMismatchNotice } from "./serial-console-match.js";
 
@@ -89,28 +89,33 @@ export async function launchLogsWithMethod(
     }
     let serialPort: SerialPort | null;
     try {
-      serialPort = await requestAndOpenSerialPort(baudRate);
+      serialPort = await requestSerialPort();
     } catch {
-      // The user picked a port but it couldn't open (claimed by another tab,
-      // driver error); unlike a picker dismissal this needs feedback.
+      // A real requestPort failure; unlike a picker dismissal this needs
+      // feedback.
       notifyError(host.localize("dashboard.logs_web_serial_open_failed"));
       return;
     }
     if (!serialPort) return; // User dismissed the port picker.
     host.logsDialog.configuration = device.configuration;
     host.logsDialog.name = device.friendly_name || device.name;
+    // Decide on the unopened port (getInfo needs no open): a provably-silent
+    // port is never opened, so no DTR/RTS pulse reaches a bridge that wires
+    // them to reset lines.
     const mismatch = serialConsoleMismatchNotice(
       device.logger_interface,
       serialPort,
       host.localize
     );
     if (mismatch) {
-      try {
-        await serialPort.close();
-      } catch {
-        // Releasing the provably-silent port is best-effort.
-      }
       openNetworkLogsFallback(host.logsDialog, host.localize, { message: mismatch });
+      return;
+    }
+    try {
+      await serialPort.open({ baudRate });
+    } catch {
+      // The port couldn't open (claimed by another tab, driver error).
+      notifyError(host.localize("dashboard.logs_web_serial_open_failed"));
       return;
     }
     // Reconnect (the dialog's "click Start to reconnect") re-acquires a fresh

--- a/src/util/logs-launch.ts
+++ b/src/util/logs-launch.ts
@@ -10,7 +10,7 @@ import {
   reconnectWebSerialLogs,
   requestAndOpenSerialPort,
 } from "./post-install-logs.js";
-import { serialPortCannotCarryConsole } from "./serial-console-match.js";
+import { serialConsoleMismatchNotice } from "./serial-console-match.js";
 
 /** The host bits both logs entry points need, decoupled from any page class. */
 export interface LogsLaunchHost {
@@ -99,17 +99,18 @@ export async function launchLogsWithMethod(
     if (!serialPort) return; // User dismissed the port picker.
     host.logsDialog.configuration = device.configuration;
     host.logsDialog.name = device.friendly_name || device.name;
-    if (serialPortCannotCarryConsole(device.logger_interface, serialPort)) {
+    const mismatch = serialConsoleMismatchNotice(
+      device.logger_interface,
+      serialPort,
+      host.localize
+    );
+    if (mismatch) {
       try {
         await serialPort.close();
       } catch {
         // Releasing the provably-silent port is best-effort.
       }
-      openNetworkLogsFallback(host.logsDialog, host.localize, {
-        message: host.localize("dashboard.logs_serial_wrong_port_fallback", {
-          interface: device.logger_interface ?? "",
-        }),
-      });
+      openNetworkLogsFallback(host.logsDialog, host.localize, { message: mismatch });
       return;
     }
     // Reconnect (the dialog's "click Start to reconnect") re-acquires a fresh

--- a/src/util/logs-launch.ts
+++ b/src/util/logs-launch.ts
@@ -10,6 +10,7 @@ import {
   reconnectWebSerialLogs,
   requestAndOpenSerialPort,
 } from "./post-install-logs.js";
+import { serialPortCannotCarryConsole } from "./serial-console-match.js";
 
 /** The host bits both logs entry points need, decoupled from any page class. */
 export interface LogsLaunchHost {
@@ -98,6 +99,19 @@ export async function launchLogsWithMethod(
     if (!serialPort) return; // User dismissed the port picker.
     host.logsDialog.configuration = device.configuration;
     host.logsDialog.name = device.friendly_name || device.name;
+    if (serialPortCannotCarryConsole(device.logger_interface, serialPort)) {
+      try {
+        await serialPort.close();
+      } catch {
+        // Releasing the provably-silent port is best-effort.
+      }
+      openNetworkLogsFallback(host.logsDialog, host.localize, {
+        message: host.localize("dashboard.logs_serial_wrong_port_fallback", {
+          interface: device.logger_interface ?? "",
+        }),
+      });
+      return;
+    }
     // Reconnect (the dialog's "click Start to reconnect") re-acquires a fresh
     // port via the picker — the cached handle can be dead after a device reset.
     host.logsDialog.openPassive({

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -4,7 +4,7 @@ import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";
 import { OTA_PORT } from "../components/logs-session.js";
 import { resolveLogBaudRate } from "./log-baud-rate.js";
 import { notifyError, notifyInfo } from "./notify.js";
-import { serialPortCannotCarryConsole } from "./serial-console-match.js";
+import { serialConsoleMismatchNotice } from "./serial-console-match.js";
 import {
   isPortPickerCancel,
   openLiveSerialPort,
@@ -21,9 +21,8 @@ export function openNetworkLogsFallback(
   localize: LocalizeFunc,
   options: { onBackToInstall?: () => void; message?: string } = {}
 ): void {
-  notifyInfo(options.message ?? localize("dashboard.logs_serial_disabled_fallback"));
-  const openOptions: { onBackToInstall?: () => void } = {};
-  if (options.onBackToInstall) openOptions.onBackToInstall = options.onBackToInstall;
+  const { message, ...openOptions } = options;
+  notifyInfo(message ?? localize("dashboard.logs_serial_disabled_fallback"));
   logsDialog.open(OTA_PORT, openOptions);
 }
 
@@ -242,12 +241,15 @@ export async function handlePostInstallShowLogs(
       openNetworkLogsFallback(logsDialog, localize, { onBackToInstall: reopenInstall });
       return;
     }
-    if (serialPortCannotCarryConsole(loggerInterface, webSerialPort)) {
+    const mismatch = serialConsoleMismatchNotice(
+      loggerInterface,
+      webSerialPort,
+      localize
+    );
+    if (mismatch) {
       openNetworkLogsFallback(logsDialog, localize, {
         onBackToInstall: reopenInstall,
-        message: localize("dashboard.logs_serial_wrong_port_fallback", {
-          interface: loggerInterface ?? "",
-        }),
+        message: mismatch,
       });
       return;
     }

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -41,6 +41,23 @@ export function formatSerialPortLabel(port: SerialPort): string {
 }
 
 /**
+ * Prompt for a Web Serial port without opening it. Returns ``null`` if the
+ * user dismissed the picker; throws on a real requestPort failure. Callers
+ * that only need the USB identity can decide before ever opening (no DTR/RTS
+ * pulse on a port that won't be used).
+ */
+export async function requestSerialPort(): Promise<SerialPort | null> {
+  try {
+    return await navigator.serial.requestPort();
+  } catch (err) {
+    if (isPortPickerCancel(err)) {
+      return null; // User dismissed the port picker.
+    }
+    throw err; // A real requestPort failure — let the caller surface it.
+  }
+}
+
+/**
  * Prompt for a Web Serial port and open it at log baud. Returns the open port,
  * or ``null`` if the user dismissed the picker. Throws if a picked port can't
  * be opened (claimed by another tab, driver error) — the caller surfaces that.
@@ -48,15 +65,8 @@ export function formatSerialPortLabel(port: SerialPort): string {
 export async function requestAndOpenSerialPort(
   baudRate: number
 ): Promise<SerialPort | null> {
-  let port: SerialPort;
-  try {
-    port = await navigator.serial.requestPort();
-  } catch (err) {
-    if (isPortPickerCancel(err)) {
-      return null; // User dismissed the port picker.
-    }
-    throw err; // A real requestPort failure — let the caller surface it.
-  }
+  const port = await requestSerialPort();
+  if (!port) return null;
   await port.open({ baudRate });
   return port;
 }

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -4,6 +4,7 @@ import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";
 import { OTA_PORT } from "../components/logs-session.js";
 import { resolveLogBaudRate } from "./log-baud-rate.js";
 import { notifyError, notifyInfo } from "./notify.js";
+import { serialPortCannotCarryConsole } from "./serial-console-match.js";
 import {
   isPortPickerCancel,
   openLiveSerialPort,
@@ -11,16 +12,19 @@ import {
 } from "./web-serial.js";
 
 /**
- * Route a device whose serial console is provably silent (logger baud_rate 0)
- * to the network log stream, with a notice saying why (#1430).
+ * Route a device whose serial console is provably silent (logger baud_rate 0,
+ * or a port that can't carry the console) to the network log stream, with a
+ * notice saying why (#1430). The default message is the baud-0 one.
  */
 export function openNetworkLogsFallback(
   logsDialog: ESPHomeLogsDialog,
   localize: LocalizeFunc,
-  options: { onBackToInstall?: () => void } = {}
+  options: { onBackToInstall?: () => void; message?: string } = {}
 ): void {
-  notifyInfo(localize("dashboard.logs_serial_disabled_fallback"));
-  logsDialog.open(OTA_PORT, options);
+  notifyInfo(options.message ?? localize("dashboard.logs_serial_disabled_fallback"));
+  const openOptions: { onBackToInstall?: () => void } = {};
+  if (options.onBackToInstall) openOptions.onBackToInstall = options.onBackToInstall;
+  logsDialog.open(OTA_PORT, openOptions);
 }
 
 /**
@@ -111,6 +115,10 @@ export interface PostInstallShowLogsDetail {
   // The handler resolves it: null / absent ⇒ 115200 default, 0 ⇒ serial
   // logging disabled (skip with a notice).
   loggerBaudRate?: number | null;
+  // Resolved logger output interface (Device.logger_interface), only
+  // meaningful on the webSerialPort path: a port that can't carry it
+  // reroutes to network logs.
+  loggerInterface?: string | null;
   reopenInstall: () => void;
 }
 
@@ -217,14 +225,30 @@ export async function handlePostInstallShowLogs(
   localize: LocalizeFunc
 ) {
   e.preventDefault();
-  const { configuration, name, port, webSerialPort, loggerBaudRate, reopenInstall } =
-    e.detail;
+  const {
+    configuration,
+    name,
+    port,
+    webSerialPort,
+    loggerBaudRate,
+    loggerInterface,
+    reopenInstall,
+  } = e.detail;
   logsDialog.configuration = configuration;
   logsDialog.name = name;
   if (webSerialPort) {
     const baudRate = resolveLogBaudRate(loggerBaudRate);
     if (baudRate === null) {
       openNetworkLogsFallback(logsDialog, localize, { onBackToInstall: reopenInstall });
+      return;
+    }
+    if (serialPortCannotCarryConsole(loggerInterface, webSerialPort)) {
+      openNetworkLogsFallback(logsDialog, localize, {
+        onBackToInstall: reopenInstall,
+        message: localize("dashboard.logs_serial_wrong_port_fallback", {
+          interface: loggerInterface ?? "",
+        }),
+      });
       return;
     }
     logsDialog.openPassive({

--- a/src/util/serial-console-match.ts
+++ b/src/util/serial-console-match.ts
@@ -1,21 +1,44 @@
-// Espressif's native USB vendor id — the on-chip USB-Serial-JTAG / CDC
-// device (C3/S2/S3/C6/... dev boards flashed over their native port).
-const ESPRESSIF_USB_VID = 0x303a;
+// Vendors that make dedicated USB-UART bridge chips and nothing that
+// enumerates as a device's native USB console. A port from one of these can
+// only be wired to external UART pins.
+const UART_BRIDGE_VENDOR_IDS = new Set([
+  0x1a86, // WCH (CH340 / CH9102)
+  0x10c4, // Silicon Labs (CP210x)
+  0x0403, // FTDI
+  0x067b, // Prolific (PL2303)
+]);
+
+// The on-chip USB-Serial-JTAG device every native-USB ESP32 variant
+// enumerates as. The product id matters: Espressif's 0x303a also covers the
+// ESP-USB-Bridge (0x1002), which IS a UART bridge.
+const ESPRESSIF_USB_JTAG_VID = 0x303a;
+const ESPRESSIF_USB_JTAG_PID = 0x1001;
 
 const USB_CONSOLE_INTERFACES = new Set(["USB_CDC", "USB_SERIAL_JTAG"]);
 
 /**
  * Whether a granted Web Serial port provably cannot carry the device's log
- * console: the logger outputs on the chip's native USB while the port is an
- * external UART bridge, or the reverse. Unknown interface means false —
- * the quiet-serial watchdog stays the backstop.
+ * console. Deliberately fails open: a mismatch is claimed only when the
+ * port's USB identity makes it certain (a dedicated bridge chip watching a
+ * native-USB console, or the on-chip USB-Serial-JTAG device watching a UART
+ * console); anything uncertain returns false and serial is assumed to work,
+ * with the quiet-serial watchdog as the backstop.
  */
 export function serialPortCannotCarryConsole(
   loggerInterface: string | null | undefined,
   port: SerialPort
 ): boolean {
   if (!loggerInterface) return false;
-  const usbConsole = USB_CONSOLE_INTERFACES.has(loggerInterface);
-  const nativePort = port.getInfo().usbVendorId === ESPRESSIF_USB_VID;
-  return nativePort ? !usbConsole : usbConsole;
+  const { usbVendorId, usbProductId } = port.getInfo();
+  if (USB_CONSOLE_INTERFACES.has(loggerInterface)) {
+    // A dedicated bridge chip can't be the chip's own USB device. An
+    // unknown or absent vendor could be a native CDC console (RP2040's
+    // 0x2e8a, nRF52) — assume it works.
+    return usbVendorId !== undefined && UART_BRIDGE_VENDOR_IDS.has(usbVendorId);
+  }
+  // UART-family console: only the on-chip USB-Serial-JTAG device provably
+  // can't carry it; any other port might be wired to the UART pins.
+  return (
+    usbVendorId === ESPRESSIF_USB_JTAG_VID && usbProductId === ESPRESSIF_USB_JTAG_PID
+  );
 }

--- a/src/util/serial-console-match.ts
+++ b/src/util/serial-console-match.ts
@@ -1,0 +1,21 @@
+// Espressif's native USB vendor id — the on-chip USB-Serial-JTAG / CDC
+// device (C3/S2/S3/C6/... dev boards flashed over their native port).
+const ESPRESSIF_USB_VID = 0x303a;
+
+const USB_CONSOLE_INTERFACES = new Set(["USB_CDC", "USB_SERIAL_JTAG"]);
+
+/**
+ * Whether a granted Web Serial port provably cannot carry the device's log
+ * console: the logger outputs on the chip's native USB while the port is an
+ * external UART bridge, or the reverse. Unknown interface means false —
+ * the quiet-serial watchdog stays the backstop.
+ */
+export function serialPortCannotCarryConsole(
+  loggerInterface: string | null | undefined,
+  port: SerialPort
+): boolean {
+  if (!loggerInterface) return false;
+  const usbConsole = USB_CONSOLE_INTERFACES.has(loggerInterface);
+  const nativePort = port.getInfo().usbVendorId === ESPRESSIF_USB_VID;
+  return nativePort ? !usbConsole : usbConsole;
+}

--- a/src/util/serial-console-match.ts
+++ b/src/util/serial-console-match.ts
@@ -18,6 +18,9 @@ const UART_BRIDGE_VENDOR_IDS = new Set([
 // the ESP-USB-Bridge (0x1002), which IS a UART bridge.
 const ESPRESSIF_USB_JTAG_PID = 0x1001;
 
+// Spellings come from the backend's logger_interface_values vocabulary
+// (platform_capabilities.index.json, snapshotted from esphome's logger) -
+// keep in lockstep.
 const USB_CONSOLE_INTERFACES = new Set(["USB_CDC", "USB_SERIAL_JTAG"]);
 
 /**

--- a/src/util/serial-console-match.ts
+++ b/src/util/serial-console-match.ts
@@ -23,6 +23,10 @@ const ESPRESSIF_USB_JTAG_PID = 0x1001;
 // keep in lockstep.
 const USB_CONSOLE_INTERFACES = new Set(["USB_CDC", "USB_SERIAL_JTAG"]);
 
+// UART0 / UART1 / UART2 / UART0_SWAP. Anything matching neither family is
+// an interface this code doesn't know - fail open.
+const UART_CONSOLE_RE = /^UART\d/;
+
 /**
  * Whether a granted Web Serial port provably cannot carry the device's log
  * console. Deliberately fails open: a mismatch is claimed only when the
@@ -43,6 +47,7 @@ export function serialPortCannotCarryConsole(
     // 0x2e8a, nRF52) - assume it works.
     return usbVendorId !== undefined && UART_BRIDGE_VENDOR_IDS.has(usbVendorId);
   }
+  if (!UART_CONSOLE_RE.test(loggerInterface)) return false;
   // UART-family console: only the on-chip USB-Serial-JTAG device provably
   // can't carry it; any other port might be wired to the UART pins.
   return usbVendorId === ESPRESSIF_USB_VID && usbProductId === ESPRESSIF_USB_JTAG_PID;

--- a/src/util/serial-console-match.ts
+++ b/src/util/serial-console-match.ts
@@ -1,6 +1,11 @@
+import type { LocalizeFunc } from "../common/localize.js";
+import { ESPRESSIF_USB_VID } from "./web-serial.js";
+
 // Vendors that make dedicated USB-UART bridge chips and nothing that
 // enumerates as a device's native USB console. A port from one of these can
-// only be wired to external UART pins.
+// only be wired to external UART pins. Mirrors the backend's picker-hint
+// taxonomy in controllers/config/serial_ports.py (_BRIDGE_VIDS) - keep the
+// two sets in lockstep.
 const UART_BRIDGE_VENDOR_IDS = new Set([
   0x1a86, // WCH (CH340 / CH9102)
   0x10c4, // Silicon Labs (CP210x)
@@ -9,9 +14,8 @@ const UART_BRIDGE_VENDOR_IDS = new Set([
 ]);
 
 // The on-chip USB-Serial-JTAG device every native-USB ESP32 variant
-// enumerates as. The product id matters: Espressif's 0x303a also covers the
-// ESP-USB-Bridge (0x1002), which IS a UART bridge.
-const ESPRESSIF_USB_JTAG_VID = 0x303a;
+// enumerates as. The product id matters: Espressif's vendor id also covers
+// the ESP-USB-Bridge (0x1002), which IS a UART bridge.
 const ESPRESSIF_USB_JTAG_PID = 0x1001;
 
 const USB_CONSOLE_INTERFACES = new Set(["USB_CDC", "USB_SERIAL_JTAG"]);
@@ -33,12 +37,25 @@ export function serialPortCannotCarryConsole(
   if (USB_CONSOLE_INTERFACES.has(loggerInterface)) {
     // A dedicated bridge chip can't be the chip's own USB device. An
     // unknown or absent vendor could be a native CDC console (RP2040's
-    // 0x2e8a, nRF52) — assume it works.
+    // 0x2e8a, nRF52) - assume it works.
     return usbVendorId !== undefined && UART_BRIDGE_VENDOR_IDS.has(usbVendorId);
   }
   // UART-family console: only the on-chip USB-Serial-JTAG device provably
   // can't carry it; any other port might be wired to the UART pins.
-  return (
-    usbVendorId === ESPRESSIF_USB_JTAG_VID && usbProductId === ESPRESSIF_USB_JTAG_PID
-  );
+  return usbVendorId === ESPRESSIF_USB_VID && usbProductId === ESPRESSIF_USB_JTAG_PID;
+}
+
+/**
+ * Localized wrong-port notice when the port provably can't carry the
+ * console, else null. The single home for the mismatch decision + message.
+ */
+export function serialConsoleMismatchNotice(
+  loggerInterface: string | null | undefined,
+  port: SerialPort,
+  localize: LocalizeFunc
+): string | null {
+  if (!serialPortCannotCarryConsole(loggerInterface, port)) return null;
+  return localize("dashboard.logs_serial_wrong_port_fallback", {
+    interface: loggerInterface ?? "",
+  });
 }

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -10,7 +10,7 @@ import { ESPLoader, Transport, UsbJtagSerialReset } from "esptool-js";
 import { markSerialActivity } from "./serial-reacquire.js";
 
 /** Espressif's USB Vendor ID — chips with native USB-Serial/JTAG. */
-const ESPRESSIF_USB_VID = 0x303a;
+export const ESPRESSIF_USB_VID = 0x303a;
 
 export interface DetectedChip {
   chipName: string;

--- a/test/_make-configured-device.ts
+++ b/test/_make-configured-device.ts
@@ -34,6 +34,7 @@ const _BASE = {
   labels: [],
   web_port: null,
   logger_baud_rate: null,
+  logger_interface: null,
   current_version: "",
   loaded_integrations: [],
   runtime_state: {

--- a/test/components/dashboard/actions-ui.test.ts
+++ b/test/components/dashboard/actions-ui.test.ts
@@ -104,6 +104,39 @@ describe("openLogsWithMethod web-serial", () => {
     expect(logsDialog.configuration).toBe("x.yaml");
     expect(requestAndOpenSerialPort).not.toHaveBeenCalled();
   });
+
+  it("closes a mismatched port and reroutes to network logs", async () => {
+    vi.stubGlobal("navigator", { serial: {} });
+    const close = vi.fn(async () => {});
+    requestAndOpenSerialPort.mockResolvedValue({
+      getInfo: () => ({ usbVendorId: 0x1a86 }),
+      close,
+    });
+    const logsDialog = {
+      configuration: "",
+      name: "",
+      open: vi.fn(),
+      openPassive: vi.fn(),
+    };
+    const host = makeDashboardHost({ _logsDialog: logsDialog });
+    const device = {
+      configuration: "x.yaml",
+      name: "x",
+      friendly_name: "X",
+      logger_baud_rate: null,
+      logger_interface: "USB_SERIAL_JTAG",
+    } as ConfiguredDevice;
+
+    await openLogsWithMethod(host, device, "web-serial");
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(toastInfo).toHaveBeenCalledWith(
+      expect.stringContaining("dashboard.logs_serial_wrong_port_fallback"),
+      expect.anything()
+    );
+    expect(logsDialog.open).toHaveBeenCalledWith("OTA", {});
+    expect(logsDialog.openPassive).not.toHaveBeenCalled();
+  });
 });
 
 describe("executeRename", () => {

--- a/test/components/dashboard/actions-ui.test.ts
+++ b/test/components/dashboard/actions-ui.test.ts
@@ -30,14 +30,14 @@ vi.mock("sonner-js", () => ({
   },
 }));
 
-const { requestAndOpenSerialPort } = vi.hoisted(() => ({
-  requestAndOpenSerialPort: vi.fn(),
+const { requestSerialPort } = vi.hoisted(() => ({
+  requestSerialPort: vi.fn(),
 }));
 vi.mock("../../../src/util/post-install-logs.js", async (importOriginal) => ({
   // Keep the real openNetworkLogsFallback so the baud-0 reroute test can
   // assert its toast + dialog-open behavior through the real helper.
   ...(await importOriginal<object>()),
-  requestAndOpenSerialPort,
+  requestSerialPort,
   attachSerialLogStream: vi.fn(),
   reconnectWebSerialLogs: vi.fn(),
 }));
@@ -75,7 +75,8 @@ function renameEvent(newName: string): CustomEvent<string> {
 describe("openLogsWithMethod web-serial", () => {
   beforeEach(() => {
     toastError.mockClear();
-    requestAndOpenSerialPort.mockClear();
+    toastInfo.mockClear();
+    requestSerialPort.mockReset();
   });
   afterEach(() => {
     vi.restoreAllMocks();
@@ -102,15 +103,15 @@ describe("openLogsWithMethod web-serial", () => {
     expect(toastError).not.toHaveBeenCalled();
     expect(logsDialog.open).toHaveBeenCalledWith("OTA", {});
     expect(logsDialog.configuration).toBe("x.yaml");
-    expect(requestAndOpenSerialPort).not.toHaveBeenCalled();
+    expect(requestSerialPort).not.toHaveBeenCalled();
   });
 
-  it("closes a mismatched port and reroutes to network logs", async () => {
+  it("reroutes a mismatched port to network logs without ever opening it", async () => {
     vi.stubGlobal("navigator", { serial: {} });
-    const close = vi.fn(async () => {});
-    requestAndOpenSerialPort.mockResolvedValue({
+    const open = vi.fn(async () => {});
+    requestSerialPort.mockResolvedValue({
       getInfo: () => ({ usbVendorId: 0x1a86 }),
-      close,
+      open,
     });
     const logsDialog = {
       configuration: "",
@@ -129,13 +130,44 @@ describe("openLogsWithMethod web-serial", () => {
 
     await openLogsWithMethod(host, device, "web-serial");
 
-    expect(close).toHaveBeenCalledTimes(1);
+    // Never opened: no DTR/RTS pulse reaches a provably-silent port.
+    expect(open).not.toHaveBeenCalled();
     expect(toastInfo).toHaveBeenCalledWith(
       expect.stringContaining("dashboard.logs_serial_wrong_port_fallback"),
       expect.anything()
     );
     expect(logsDialog.open).toHaveBeenCalledWith("OTA", {});
     expect(logsDialog.openPassive).not.toHaveBeenCalled();
+  });
+
+  it("opens a matching port and starts the serial session", async () => {
+    vi.stubGlobal("navigator", { serial: {} });
+    const open = vi.fn(async () => {});
+    requestSerialPort.mockResolvedValue({
+      getInfo: () => ({ usbVendorId: 0x303a, usbProductId: 0x1001 }),
+      open,
+    });
+    const logsDialog = {
+      configuration: "",
+      name: "",
+      open: vi.fn(),
+      openPassive: vi.fn(),
+    };
+    const host = makeDashboardHost({ _logsDialog: logsDialog });
+    const device = {
+      configuration: "x.yaml",
+      name: "x",
+      friendly_name: "X",
+      logger_baud_rate: null,
+      logger_interface: "USB_SERIAL_JTAG",
+    } as ConfiguredDevice;
+
+    await openLogsWithMethod(host, device, "web-serial");
+
+    expect(open).toHaveBeenCalledWith({ baudRate: 115200 });
+    expect(logsDialog.openPassive).toHaveBeenCalledTimes(1);
+    expect(logsDialog.open).not.toHaveBeenCalled();
+    expect(toastInfo).not.toHaveBeenCalled();
   });
 });
 

--- a/test/components/firmware-install-dialog/flip-to-logs.test.ts
+++ b/test/components/firmware-install-dialog/flip-to-logs.test.ts
@@ -8,7 +8,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { dispatchShowLogsAfterInstall } = vi.hoisted(() => ({
   dispatchShowLogsAfterInstall: vi.fn(
-    (_source: HTMLElement, _detail: { loggerBaudRate?: number | null }) => true
+    (
+      _source: HTMLElement,
+      _detail: { loggerBaudRate?: number | null; loggerInterface?: string | null }
+    ) => true
   ),
 }));
 vi.mock("../../../src/util/post-install-logs.js", () => ({
@@ -19,13 +22,17 @@ import type { ESPHomeFirmwareInstallDialog } from "../../../src/components/firmw
 import { flipToLogs } from "../../../src/components/firmware-install-dialog/install-flow.js";
 import { identityLocalize } from "../../_dom.js";
 
-function makeHost(loggerBaudRate: number | null): ESPHomeFirmwareInstallDialog {
+function makeHost(
+  loggerBaudRate: number | null,
+  loggerInterface: string | null = null
+): ESPHomeFirmwareInstallDialog {
   return {
     _device: {
       configuration: "x.yaml",
       name: "x",
       friendly_name: "X",
       logger_baud_rate: loggerBaudRate,
+      logger_interface: loggerInterface,
     },
     _localize: identityLocalize,
     _open: true,
@@ -42,5 +49,11 @@ describe("flipToLogs", () => {
     flipToLogs(makeHost(baud), port);
     expect(dispatchShowLogsAfterInstall).toHaveBeenCalledTimes(1);
     expect(dispatchShowLogsAfterInstall.mock.calls[0][1].loggerBaudRate).toBe(baud);
+  });
+
+  it.each(["USB_SERIAL_JTAG", null])("forwards the logger interface %s", (iface) => {
+    flipToLogs(makeHost(115200, iface), port);
+    expect(dispatchShowLogsAfterInstall).toHaveBeenCalledTimes(1);
+    expect(dispatchShowLogsAfterInstall.mock.calls[0][1].loggerInterface).toBe(iface);
   });
 });

--- a/test/util/post-install-logs.test.ts
+++ b/test/util/post-install-logs.test.ts
@@ -308,4 +308,36 @@ describe("handlePostInstallShowLogs serial baud", () => {
     expect(dialog.openPassive).not.toHaveBeenCalled();
     expect(dialog.setSerialStream).not.toHaveBeenCalled();
   });
+
+  it("reroutes to network logs when the port can't carry the console", async () => {
+    // A CH340-class bridge on a device whose logger outputs on native USB —
+    // the #1430 heat-pump shape.
+    const dialog = logsDialog();
+    const event = new CustomEvent("request-show-logs-after-install", {
+      cancelable: true,
+      detail: {
+        ...detail(115200),
+        webSerialPort: openPort({ usbVendorId: 0x1a86, usbProductId: 0x7523 }),
+        loggerInterface: "USB_SERIAL_JTAG",
+      },
+    });
+    await handlePostInstallShowLogs(event, dialog as never, defaultLocalize);
+    expect(dialog.open).toHaveBeenCalledWith("OTA", {
+      onBackToInstall: event.detail.reopenInstall,
+    });
+    expect(toastInfo).toHaveBeenCalledTimes(1);
+    expect(dialog.openPassive).not.toHaveBeenCalled();
+  });
+
+  it("keeps the serial session when the port matches the console", async () => {
+    // Native Espressif port + native-USB console: the common healthy path.
+    const dialog = logsDialog();
+    const event = new CustomEvent("request-show-logs-after-install", {
+      cancelable: true,
+      detail: { ...detail(115200), loggerInterface: "USB_SERIAL_JTAG" },
+    });
+    await handlePostInstallShowLogs(event, dialog as never, defaultLocalize);
+    expect(dialog.open).not.toHaveBeenCalled();
+    expect(dialog.openPassive).toHaveBeenCalledTimes(1);
+  });
 });

--- a/test/util/serial-console-match.test.ts
+++ b/test/util/serial-console-match.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { serialPortCannotCarryConsole } from "../../src/util/serial-console-match.js";
+import type { LocalizeFunc } from "../../src/common/localize.js";
+import {
+  serialConsoleMismatchNotice,
+  serialPortCannotCarryConsole,
+} from "../../src/util/serial-console-match.js";
 
 const ESP_JTAG = { usbVendorId: 0x303a, usbProductId: 0x1001 };
 const ESP_USB_BRIDGE = { usbVendorId: 0x303a, usbProductId: 0x1002 };
@@ -65,5 +69,22 @@ describe("serialPortCannotCarryConsole", () => {
     expect(serialPortCannotCarryConsole(null, port(CH340))).toBe(false);
     expect(serialPortCannotCarryConsole(undefined, port(ESP_JTAG))).toBe(false);
     expect(serialPortCannotCarryConsole("", port(CH340))).toBe(false);
+  });
+});
+
+describe("serialConsoleMismatchNotice", () => {
+  const localize = ((key: string, params?: Record<string, string>) =>
+    params ? `${key}:${params.interface}` : key) as unknown as LocalizeFunc;
+
+  it("names the interface in the wrong-port notice", () => {
+    expect(serialConsoleMismatchNotice("USB_SERIAL_JTAG", port(CH340), localize)).toBe(
+      "dashboard.logs_serial_wrong_port_fallback:USB_SERIAL_JTAG"
+    );
+  });
+
+  it("is null when the port can carry the console (or is uncertain)", () => {
+    expect(serialConsoleMismatchNotice("UART0", port(CH340), localize)).toBeNull();
+    expect(serialConsoleMismatchNotice(null, port(CH340), localize)).toBeNull();
+    expect(serialConsoleMismatchNotice("USB_CDC", port(PICO), localize)).toBeNull();
   });
 });

--- a/test/util/serial-console-match.test.ts
+++ b/test/util/serial-console-match.test.ts
@@ -77,6 +77,9 @@ describe("serialPortCannotCarryConsole", () => {
     expect(serialPortCannotCarryConsole(null, port(CH340))).toBe(false);
     expect(serialPortCannotCarryConsole(undefined, port(ESP_JTAG))).toBe(false);
     expect(serialPortCannotCarryConsole("", port(CH340))).toBe(false);
+    // An interface name outside both known families fails open too, even on
+    // the port that would mismatch a UART console.
+    expect(serialPortCannotCarryConsole("SOMETHING_NEW", port(ESP_JTAG))).toBe(false);
   });
 });
 

--- a/test/util/serial-console-match.test.ts
+++ b/test/util/serial-console-match.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { serialPortCannotCarryConsole } from "../../src/util/serial-console-match.js";
+
+const ESPRESSIF = 0x303a;
+const CH340 = 0x1a86;
+
+function port(usbVendorId?: number): SerialPort {
+  return { getInfo: () => ({ usbVendorId }) } as unknown as SerialPort;
+}
+
+describe("serialPortCannotCarryConsole", () => {
+  it.each(["USB_SERIAL_JTAG", "USB_CDC"])(
+    "native Espressif port carries a %s console",
+    (iface) => {
+      expect(serialPortCannotCarryConsole(iface, port(ESPRESSIF))).toBe(false);
+    }
+  );
+
+  it.each(["UART0", "UART1", "UART2", "UART0_SWAP"])(
+    "native Espressif port cannot carry a %s console",
+    (iface) => {
+      expect(serialPortCannotCarryConsole(iface, port(ESPRESSIF))).toBe(true);
+    }
+  );
+
+  it("bridge port cannot carry a native-USB console (the #1430 heat-pump case)", () => {
+    expect(serialPortCannotCarryConsole("USB_SERIAL_JTAG", port(CH340))).toBe(true);
+    expect(serialPortCannotCarryConsole("USB_CDC", port(CH340))).toBe(true);
+  });
+
+  it("bridge port carries a UART console", () => {
+    expect(serialPortCannotCarryConsole("UART0", port(CH340))).toBe(false);
+  });
+
+  it("a port with no USB identity counts as a bridge", () => {
+    expect(serialPortCannotCarryConsole("USB_CDC", port(undefined))).toBe(true);
+    expect(serialPortCannotCarryConsole("UART0", port(undefined))).toBe(false);
+  });
+
+  it("unknown interface never claims a mismatch", () => {
+    expect(serialPortCannotCarryConsole(null, port(CH340))).toBe(false);
+    expect(serialPortCannotCarryConsole(undefined, port(ESPRESSIF))).toBe(false);
+    expect(serialPortCannotCarryConsole("", port(CH340))).toBe(false);
+  });
+});

--- a/test/util/serial-console-match.test.ts
+++ b/test/util/serial-console-match.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @vitest-environment happy-dom
+ */
 import { describe, expect, it } from "vitest";
 import type { LocalizeFunc } from "../../src/common/localize.js";
 import {

--- a/test/util/serial-console-match.test.ts
+++ b/test/util/serial-console-match.test.ts
@@ -1,45 +1,69 @@
 import { describe, expect, it } from "vitest";
 import { serialPortCannotCarryConsole } from "../../src/util/serial-console-match.js";
 
-const ESPRESSIF = 0x303a;
-const CH340 = 0x1a86;
+const ESP_JTAG = { usbVendorId: 0x303a, usbProductId: 0x1001 };
+const ESP_USB_BRIDGE = { usbVendorId: 0x303a, usbProductId: 0x1002 };
+const CH340 = { usbVendorId: 0x1a86, usbProductId: 0x7523 };
+const PICO = { usbVendorId: 0x2e8a, usbProductId: 0x0005 };
 
-function port(usbVendorId?: number): SerialPort {
-  return { getInfo: () => ({ usbVendorId }) } as unknown as SerialPort;
+function port(info: SerialPortInfo): SerialPort {
+  return { getInfo: () => info } as unknown as SerialPort;
 }
 
 describe("serialPortCannotCarryConsole", () => {
   it.each(["USB_SERIAL_JTAG", "USB_CDC"])(
-    "native Espressif port carries a %s console",
+    "the on-chip USB device carries a %s console",
     (iface) => {
-      expect(serialPortCannotCarryConsole(iface, port(ESPRESSIF))).toBe(false);
+      expect(serialPortCannotCarryConsole(iface, port(ESP_JTAG))).toBe(false);
     }
   );
 
-  it.each(["UART0", "UART1", "UART2", "UART0_SWAP"])(
-    "native Espressif port cannot carry a %s console",
-    (iface) => {
-      expect(serialPortCannotCarryConsole(iface, port(ESPRESSIF))).toBe(true);
+  it.each([0x1a86, 0x10c4, 0x0403, 0x067b])(
+    "a dedicated bridge chip (vendor 0x%s) cannot carry a native-USB console",
+    (vendor) => {
+      // The #1430 heat-pump shape: C3 logger on USB_SERIAL_JTAG, user
+      // watching through an external UART bridge.
+      expect(
+        serialPortCannotCarryConsole(
+          "USB_SERIAL_JTAG",
+          port({ usbVendorId: vendor, usbProductId: 0x1 })
+        )
+      ).toBe(true);
     }
   );
 
-  it("bridge port cannot carry a native-USB console (the #1430 heat-pump case)", () => {
-    expect(serialPortCannotCarryConsole("USB_SERIAL_JTAG", port(CH340))).toBe(true);
-    expect(serialPortCannotCarryConsole("USB_CDC", port(CH340))).toBe(true);
-  });
-
-  it("bridge port carries a UART console", () => {
+  it("a bridge chip carries a UART console", () => {
     expect(serialPortCannotCarryConsole("UART0", port(CH340))).toBe(false);
   });
 
-  it("a port with no USB identity counts as a bridge", () => {
-    expect(serialPortCannotCarryConsole("USB_CDC", port(undefined))).toBe(true);
-    expect(serialPortCannotCarryConsole("UART0", port(undefined))).toBe(false);
+  it.each(["UART0", "UART1", "UART2", "UART0_SWAP"])(
+    "the on-chip USB-Serial-JTAG device cannot carry a %s console",
+    (iface) => {
+      expect(serialPortCannotCarryConsole(iface, port(ESP_JTAG))).toBe(true);
+    }
+  );
+
+  it("fails open for a native CDC console on a non-Espressif chip (Pico)", () => {
+    // RP2040 / nRF52 native USB_CDC enumerate under their own vendors; an
+    // unknown vendor must never be mistaken for a bridge.
+    expect(serialPortCannotCarryConsole("USB_CDC", port(PICO))).toBe(false);
+  });
+
+  it("fails open for a port with no USB identity", () => {
+    expect(serialPortCannotCarryConsole("USB_CDC", port({}))).toBe(false);
+    expect(serialPortCannotCarryConsole("UART0", port({}))).toBe(false);
+  });
+
+  it("fails open for the ESP-USB-Bridge (0x303a but not the on-chip device)", () => {
+    expect(serialPortCannotCarryConsole("UART0", port(ESP_USB_BRIDGE))).toBe(false);
+    expect(serialPortCannotCarryConsole("USB_SERIAL_JTAG", port(ESP_USB_BRIDGE))).toBe(
+      false
+    );
   });
 
   it("unknown interface never claims a mismatch", () => {
     expect(serialPortCannotCarryConsole(null, port(CH340))).toBe(false);
-    expect(serialPortCannotCarryConsole(undefined, port(ESPRESSIF))).toBe(false);
+    expect(serialPortCannotCarryConsole(undefined, port(ESP_JTAG))).toBe(false);
     expect(serialPortCannotCarryConsole("", port(CH340))).toBe(false);
   });
 });

--- a/test/util/serial-console-match.test.ts
+++ b/test/util/serial-console-match.test.ts
@@ -22,9 +22,14 @@ describe("serialPortCannotCarryConsole", () => {
     }
   );
 
-  it.each([0x1a86, 0x10c4, 0x0403, 0x067b])(
+  it.each([
+    ["1a86", 0x1a86],
+    ["10c4", 0x10c4],
+    ["0403", 0x0403],
+    ["067b", 0x067b],
+  ])(
     "a dedicated bridge chip (vendor 0x%s) cannot carry a native-USB console",
-    (vendor) => {
+    (_hex, vendor) => {
       // The #1430 heat-pump shape: C3 logger on USB_SERIAL_JTAG, user
       // watching through an external UART bridge.
       expect(


### PR DESCRIPTION
# What does this implement/fix?

Frontend half of esphome/device-builder#2310, building on the #1442 escape hatches: when the backend can resolve which interface the device's `logger:` outputs on (`Device.logger_interface`, from the companion backend PR esphome/device-builder#2312), a Web Serial port that provably cannot carry that console reroutes straight to network logs instead of waiting out the 5s quiet-serial watchdog.

The check (`serialPortCannotCarryConsole` in `src/util/serial-console-match.ts`) compares the resolved interface against the granted port's USB vendor id:

- The on-chip USB-Serial-JTAG device (`0x303a:0x1001`) + a `USB_SERIAL_JTAG` / `USB_CDC` console: match, keep serial (the common healthy post-flash path).
- Dedicated bridge chip (WCH / Silicon Labs / FTDI / Prolific vendor ids) + a native-USB console: provably silent — the #1430 heat-pump shape, where a C3's logger defaults to `USB_SERIAL_JTAG` but the user watches through a UART bridge.
- The on-chip USB-Serial-JTAG device + a `UART0`-family console: provably silent in reverse. Everything uncertain fails open and assumes serial works: unknown vendors (RP2040/nRF52 native CDC), ports with no USB identity, and Espressif's ESP-USB-Bridge (`0x303a:0x1002`, a real bridge) never claim a mismatch.
- Unknown interface (`null`): never claims a mismatch; the #1442 watchdog stays the backstop.

Wired into both entry points, mirroring the baud-0 handling: the post-install hand-off checks the flashing port before opening the serial session, and the manual Logs > "Plug into this computer" path decides on the picked port **before opening it** (`getInfo()` needs no open, so a provably-silent port never gets the DTR/RTS pulse Chrome asserts on open). To support that, `requestSerialPort` (picker only) is split out of `requestAndOpenSerialPort`, which now composes from it — `reconnectWebSerialLogs` is unchanged. Both reroutes go through the shared `openNetworkLogsFallback`, which takes an optional message so the toast names the actual interface.

**Related issue or feature (if applicable):**

- part of esphome/device-builder#2310 (backend: esphome/device-builder#2312 — this PR degrades to current behavior until that field ships)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
