### PR TITLE
Gate the reconnect picker on the console mismatch and match esptool's JTAG reset check

### DIFF
--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -253,9 +253,10 @@ export class ESPHomeLogsDialog extends LitElement {
   }
 
   /** Swap the current Web Serial session for the network stream in place,
-   *  keeping the log buffer and the back-to-install affordance. */
-  public switchToNetworkLogs() {
-    switchToOtaLogs(this);
+   *  keeping the log buffer and the back-to-install affordance. A *reason*
+   *  is appended to the pane ahead of the switch line. */
+  public switchToNetworkLogs(reason?: string) {
+    switchToOtaLogs(this, reason);
   }
 
   public close() {

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -252,6 +252,12 @@ export class ESPHomeLogsDialog extends LitElement {
     abortSerialReconnect(this);
   }
 
+  /** Swap the current Web Serial session for the network stream in place,
+   *  keeping the log buffer and the back-to-install affordance. */
+  public switchToNetworkLogs() {
+    switchToOtaLogs(this);
+  }
+
   public close() {
     void teardownSession(this);
     this._open = false;

--- a/src/components/logs-dialog/session.ts
+++ b/src/components/logs-dialog/session.ts
@@ -138,12 +138,15 @@ export function teardownSession(host: ESPHomeLogsDialog): Promise<void> {
  * attach from an in-flight reconnect is absorbed by ``setSerialStream``'s
  * passive-session guard.
  */
-export function switchToOtaLogs(host: ESPHomeLogsDialog): void {
+export function switchToOtaLogs(host: ESPHomeLogsDialog, reason?: string): void {
   if (!isPassive(host._session)) return;
   void teardownSession(host);
   host._reconnect = null;
   host._session = { kind: "ota", port: OTA_PORT, streamId: null };
-  host._log.append([host._localize("dashboard.logs_switched_to_network")]);
+  const switched = host._localize("dashboard.logs_switched_to_network");
+  // The reason lands in the pane too, so a user who looked away still sees
+  // why the source changed after the toast expires.
+  host._log.append(reason ? [reason, switched] : [switched]);
   startOtaStream(host);
 }
 

--- a/src/util/logs-launch.ts
+++ b/src/util/logs-launch.ts
@@ -10,7 +10,7 @@ import {
   reconnectWebSerialLogs,
   requestSerialPort,
 } from "./post-install-logs.js";
-import { serialConsoleMismatchNotice } from "./serial-console-match.js";
+import { serialConsoleMismatch } from "./serial-console-match.js";
 
 /** The host bits both logs entry points need, decoupled from any page class. */
 export interface LogsLaunchHost {
@@ -102,13 +102,15 @@ export async function launchLogsWithMethod(
     // Decide on the unopened port (getInfo needs no open): a provably-silent
     // port is never opened, so no DTR/RTS pulse reaches a bridge that wires
     // them to reset lines.
-    const mismatch = serialConsoleMismatchNotice(
+    const mismatch = serialConsoleMismatch(
       device.logger_interface,
       serialPort,
       host.localize
     );
     if (mismatch) {
-      openNetworkLogsFallback(host.logsDialog, host.localize, { message: mismatch });
+      openNetworkLogsFallback(host.logsDialog, host.localize, {
+        message: mismatch.message,
+      });
       return;
     }
     try {
@@ -121,7 +123,13 @@ export async function launchLogsWithMethod(
     // Reconnect (the dialog's "click Start to reconnect") re-acquires a fresh
     // port via the picker — the cached handle can be dead after a device reset.
     host.logsDialog.openPassive({
-      onReconnect: () => reconnectWebSerialLogs(host.logsDialog, host.localize, baudRate),
+      onReconnect: () =>
+        reconnectWebSerialLogs(
+          host.logsDialog,
+          host.localize,
+          baudRate,
+          device.logger_interface
+        ),
     });
     // attach toasts the reopen-retry failure itself; cover any other rejection
     // so it can't escape this fire-and-forget call as an unhandled rejection.

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -93,7 +93,7 @@ export async function reconnectWebSerialLogs(
   const mismatch = serialConsoleMismatch(loggerInterface, port, localize);
   if (mismatch) {
     notifyInfo(mismatch.message);
-    logsDialog.switchToNetworkLogs();
+    logsDialog.switchToNetworkLogs(mismatch.message);
     return;
   }
   try {

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -72,7 +72,7 @@ export async function reconnectWebSerialLogs(
   logsDialog: ESPHomeLogsDialog,
   localize: LocalizeFunc,
   baudRate: number,
-  loggerInterface?: string | null
+  loggerInterface: string | null
 ): Promise<void> {
   let port: SerialPort | null;
   try {
@@ -269,7 +269,7 @@ export async function handlePostInstallShowLogs(
       // fresh port via the picker rather than reopening the cached esptool
       // handle, which a native-USB chip's post-flash re-enumeration leaves dead.
       onReconnect: () =>
-        reconnectWebSerialLogs(logsDialog, localize, baudRate, loggerInterface),
+        reconnectWebSerialLogs(logsDialog, localize, baudRate, loggerInterface ?? null),
     });
     /* Settling delay — some USB-UART bridges (notably the CH9102F on
        M5Stamp boards) don't resync their internal CDC state cleanly

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -58,20 +58,6 @@ export async function requestSerialPort(): Promise<SerialPort | null> {
 }
 
 /**
- * Prompt for a Web Serial port and open it at log baud. Returns the open port,
- * or ``null`` if the user dismissed the picker. Throws if a picked port can't
- * be opened (claimed by another tab, driver error) — the caller surfaces that.
- */
-export async function requestAndOpenSerialPort(
-  baudRate: number
-): Promise<SerialPort | null> {
-  const port = await requestSerialPort();
-  if (!port) return null;
-  await port.open({ baudRate });
-  return port;
-}
-
-/**
  * Reconnect a dead Web Serial logs session by acquiring a FRESH port via the
  * picker, not reopening the cached handle.
  *
@@ -101,11 +87,13 @@ export async function reconnectWebSerialLogs(
     logsDialog.abortSerialReconnect(); // Picker dismissed — back to "Start", quietly.
     return;
   }
-  // Same pre-open gate as the entry points: a re-picked port that provably
-  // can't carry the console reroutes instead of reopening a dead end.
+  // Same pre-open gate as the entry points, but this fires mid-session:
+  // swap the source in place so the buffer and the back-to-install
+  // affordance survive, rather than re-opening a fresh session.
   const mismatch = serialConsoleMismatch(loggerInterface, port, localize);
   if (mismatch) {
-    openNetworkLogsFallback(logsDialog, localize, { message: mismatch.message });
+    notifyInfo(mismatch.message);
+    logsDialog.switchToNetworkLogs();
     return;
   }
   try {

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -4,7 +4,7 @@ import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";
 import { OTA_PORT } from "../components/logs-session.js";
 import { resolveLogBaudRate } from "./log-baud-rate.js";
 import { notifyError, notifyInfo } from "./notify.js";
-import { serialConsoleMismatchNotice } from "./serial-console-match.js";
+import { serialConsoleMismatch } from "./serial-console-match.js";
 import {
   isPortPickerCancel,
   openLiveSerialPort,
@@ -85,11 +85,12 @@ export async function requestAndOpenSerialPort(
 export async function reconnectWebSerialLogs(
   logsDialog: ESPHomeLogsDialog,
   localize: LocalizeFunc,
-  baudRate: number
+  baudRate: number,
+  loggerInterface?: string | null
 ): Promise<void> {
   let port: SerialPort | null;
   try {
-    port = await requestAndOpenSerialPort(baudRate);
+    port = await requestSerialPort();
   } catch {
     const message = localize("dashboard.logs_web_serial_open_failed");
     logsDialog.setSerialOpenFailed(message);
@@ -98,6 +99,21 @@ export async function reconnectWebSerialLogs(
   }
   if (!port) {
     logsDialog.abortSerialReconnect(); // Picker dismissed — back to "Start", quietly.
+    return;
+  }
+  // Same pre-open gate as the entry points: a re-picked port that provably
+  // can't carry the console reroutes instead of reopening a dead end.
+  const mismatch = serialConsoleMismatch(loggerInterface, port, localize);
+  if (mismatch) {
+    openNetworkLogsFallback(logsDialog, localize, { message: mismatch.message });
+    return;
+  }
+  try {
+    await port.open({ baudRate });
+  } catch {
+    const message = localize("dashboard.logs_web_serial_open_failed");
+    logsDialog.setSerialOpenFailed(message);
+    notifyError(message);
     return;
   }
   await attachSerialLogStream(port, logsDialog, localize, baudRate);
@@ -251,15 +267,11 @@ export async function handlePostInstallShowLogs(
       openNetworkLogsFallback(logsDialog, localize, { onBackToInstall: reopenInstall });
       return;
     }
-    const mismatch = serialConsoleMismatchNotice(
-      loggerInterface,
-      webSerialPort,
-      localize
-    );
+    const mismatch = serialConsoleMismatch(loggerInterface, webSerialPort, localize);
     if (mismatch) {
       openNetworkLogsFallback(logsDialog, localize, {
         onBackToInstall: reopenInstall,
-        message: mismatch,
+        message: mismatch.message,
       });
       return;
     }
@@ -268,7 +280,8 @@ export async function handlePostInstallShowLogs(
       // "click Start to reconnect" after a reopen failure (#636). Re-acquire a
       // fresh port via the picker rather than reopening the cached esptool
       // handle, which a native-USB chip's post-flash re-enumeration leaves dead.
-      onReconnect: () => reconnectWebSerialLogs(logsDialog, localize, baudRate),
+      onReconnect: () =>
+        reconnectWebSerialLogs(logsDialog, localize, baudRate, loggerInterface),
     });
     /* Settling delay — some USB-UART bridges (notably the CH9102F on
        M5Stamp boards) don't resync their internal CDC state cleanly

--- a/src/util/serial-console-match.ts
+++ b/src/util/serial-console-match.ts
@@ -1,5 +1,5 @@
 import type { LocalizeFunc } from "../common/localize.js";
-import { ESPRESSIF_USB_VID } from "./web-serial.js";
+import { ESPRESSIF_USB_JTAG_PID, ESPRESSIF_USB_VID } from "./web-serial.js";
 
 // Vendors that make dedicated USB-UART bridge chips and nothing that
 // enumerates as a device's native USB console. A port from one of these can
@@ -12,11 +12,6 @@ const UART_BRIDGE_VENDOR_IDS = new Set([
   0x0403, // FTDI
   0x067b, // Prolific (PL2303)
 ]);
-
-// The on-chip USB-Serial-JTAG device every native-USB ESP32 variant
-// enumerates as. The product id matters: Espressif's vendor id also covers
-// the ESP-USB-Bridge (0x1002), which IS a UART bridge.
-const ESPRESSIF_USB_JTAG_PID = 0x1001;
 
 // Spellings come from the backend's logger_interface_values vocabulary
 // (platform_capabilities.index.json, snapshotted from esphome's logger) -
@@ -54,16 +49,19 @@ export function serialPortCannotCarryConsole(
 }
 
 /**
- * Localized wrong-port notice when the port provably can't carry the
- * console, else null. The single home for the mismatch decision + message.
+ * Mismatch verdict + localized notice when the port provably can't carry
+ * the console, else null. The single home for the decision and its message;
+ * an object so callers gate on the verdict, never on the copy's truthiness.
  */
-export function serialConsoleMismatchNotice(
+export function serialConsoleMismatch(
   loggerInterface: string | null | undefined,
   port: SerialPort,
   localize: LocalizeFunc
-): string | null {
+): { message: string } | null {
   if (!serialPortCannotCarryConsole(loggerInterface, port)) return null;
-  return localize("dashboard.logs_serial_wrong_port_fallback", {
-    interface: loggerInterface ?? "",
-  });
+  return {
+    message: localize("dashboard.logs_serial_wrong_port_fallback", {
+      interface: loggerInterface ?? "",
+    }),
+  };
 }

--- a/src/util/serial-console-match.ts
+++ b/src/util/serial-console-match.ts
@@ -1,5 +1,5 @@
 import type { LocalizeFunc } from "../common/localize.js";
-import { ESPRESSIF_USB_JTAG_PID, ESPRESSIF_USB_VID } from "./web-serial.js";
+import { isEspressifUsbJtagPort } from "./web-serial.js";
 
 // Vendors that make dedicated USB-UART bridge chips and nothing that
 // enumerates as a device's native USB console. A port from one of these can
@@ -35,17 +35,17 @@ export function serialPortCannotCarryConsole(
   port: SerialPort
 ): boolean {
   if (!loggerInterface) return false;
-  const { usbVendorId, usbProductId } = port.getInfo();
   if (USB_CONSOLE_INTERFACES.has(loggerInterface)) {
     // A dedicated bridge chip can't be the chip's own USB device. An
     // unknown or absent vendor could be a native CDC console (RP2040's
     // 0x2e8a, nRF52) - assume it works.
+    const { usbVendorId } = port.getInfo();
     return usbVendorId !== undefined && UART_BRIDGE_VENDOR_IDS.has(usbVendorId);
   }
   if (!UART_CONSOLE_RE.test(loggerInterface)) return false;
   // UART-family console: only the on-chip USB-Serial-JTAG device provably
   // can't carry it; any other port might be wired to the UART pins.
-  return usbVendorId === ESPRESSIF_USB_VID && usbProductId === ESPRESSIF_USB_JTAG_PID;
+  return isEspressifUsbJtagPort(port);
 }
 
 /**

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -16,7 +16,13 @@ export const ESPRESSIF_USB_VID = 0x303a;
  *  discriminator (it gates on this PID alone). The vendor id alone is not
  *  native-USB proof: Espressif also ships real UART bridges under it
  *  (ESP-USB-Bridge, 0x1002); we pair both as the conservative check. */
-export const ESPRESSIF_USB_JTAG_PID = 0x1001;
+const ESPRESSIF_USB_JTAG_PID = 0x1001;
+
+/** Whether *port* is a chip's own USB-Serial-JTAG device (vs any bridge). */
+export function isEspressifUsbJtagPort(port: SerialPort): boolean {
+  const { usbVendorId, usbProductId } = port.getInfo();
+  return usbVendorId === ESPRESSIF_USB_VID && usbProductId === ESPRESSIF_USB_JTAG_PID;
+}
 
 export interface DetectedChip {
   chipName: string;
@@ -478,8 +484,7 @@ async function hardResetChip(
   port: SerialPort
 ): Promise<void> {
   if (await watchdogReset(loader, transport)) return;
-  const { usbVendorId, usbProductId } = port.getInfo();
-  if (usbVendorId === ESPRESSIF_USB_VID && usbProductId === ESPRESSIF_USB_JTAG_PID) {
+  if (isEspressifUsbJtagPort(port)) {
     await new UsbJtagSerialReset(transport).reset();
   } else {
     await classicHardReset(transport);

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -12,6 +12,11 @@ import { markSerialActivity } from "./serial-reacquire.js";
 /** Espressif's USB Vendor ID — chips with native USB-Serial/JTAG. */
 export const ESPRESSIF_USB_VID = 0x303a;
 
+/** The on-chip USB-Serial-JTAG device's product id. The vendor id alone is
+ *  not native-USB proof: Espressif also ships real UART bridges under it
+ *  (ESP-USB-Bridge, 0x1002). */
+export const ESPRESSIF_USB_JTAG_PID = 0x1001;
+
 export interface DetectedChip {
   chipName: string;
   port: SerialPort;
@@ -454,7 +459,9 @@ async function classicHardReset(transport: Transport): Promise<void> {
  *   CP210x, etc.) and the chip's own USB-Serial-JTAG alike, and
  *   doesn't depend on the board's auto-reset circuit having the
  *   "cancellation" behaviour the DTR/RTS sequence implicitly assumes.
- * - Native USB-Serial/JTAG (VID 0x303A) for chips not in the WDT
+ * - Native USB-Serial/JTAG (0x303a:0x1001, matching esptool; other
+ *   0x303a products like the ESP-USB-Bridge are real UART bridges) for
+ *   chips not in the WDT
  *   list (mostly fall-through; safety net): esptool-js's
  *   ``UsbJtagSerialReset``.
  * - Everything else (classic ESP32 / ESP8266 via CP210x / CH340 /
@@ -470,8 +477,8 @@ async function hardResetChip(
   port: SerialPort
 ): Promise<void> {
   if (await watchdogReset(loader, transport)) return;
-  const vendorId = port.getInfo().usbVendorId;
-  if (vendorId === ESPRESSIF_USB_VID) {
+  const { usbVendorId, usbProductId } = port.getInfo();
+  if (usbVendorId === ESPRESSIF_USB_VID && usbProductId === ESPRESSIF_USB_JTAG_PID) {
     await new UsbJtagSerialReset(transport).reset();
   } else {
     await classicHardReset(transport);

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -12,9 +12,10 @@ import { markSerialActivity } from "./serial-reacquire.js";
 /** Espressif's USB Vendor ID — chips with native USB-Serial/JTAG. */
 export const ESPRESSIF_USB_VID = 0x303a;
 
-/** The on-chip USB-Serial-JTAG device's product id. The vendor id alone is
- *  not native-USB proof: Espressif also ships real UART bridges under it
- *  (ESP-USB-Bridge, 0x1002). */
+/** The on-chip USB-Serial-JTAG device's product id — esptool-js's own
+ *  discriminator (it gates on this PID alone). The vendor id alone is not
+ *  native-USB proof: Espressif also ships real UART bridges under it
+ *  (ESP-USB-Bridge, 0x1002); we pair both as the conservative check. */
 export const ESPRESSIF_USB_JTAG_PID = 0x1001;
 
 export interface DetectedChip {
@@ -459,9 +460,9 @@ async function classicHardReset(transport: Transport): Promise<void> {
  *   CP210x, etc.) and the chip's own USB-Serial-JTAG alike, and
  *   doesn't depend on the board's auto-reset circuit having the
  *   "cancellation" behaviour the DTR/RTS sequence implicitly assumes.
- * - Native USB-Serial/JTAG (0x303a:0x1001, matching esptool; other
- *   0x303a products like the ESP-USB-Bridge are real UART bridges) for
- *   chips not in the WDT
+ * - Native USB-Serial/JTAG (0x303a:0x1001 — esptool-js discriminates on
+ *   the PID; other 0x303a products like the ESP-USB-Bridge are real UART
+ *   bridges) for chips not in the WDT
  *   list (mostly fall-through; safety net): esptool-js's
  *   ``UsbJtagSerialReset``.
  * - Everything else (classic ESP32 / ESP8266 via CP210x / CH340 /

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -10,7 +10,7 @@ import { ESPLoader, Transport, UsbJtagSerialReset } from "esptool-js";
 import { markSerialActivity } from "./serial-reacquire.js";
 
 /** Espressif's USB Vendor ID — chips with native USB-Serial/JTAG. */
-export const ESPRESSIF_USB_VID = 0x303a;
+const ESPRESSIF_USB_VID = 0x303a;
 
 /** The on-chip USB-Serial-JTAG device's product id — esptool-js's own
  *  discriminator (it gates on this PID alone). The vendor id alone is not

--- a/test/components/dashboard/render-dialogs.test.ts
+++ b/test/components/dashboard/render-dialogs.test.ts
@@ -10,7 +10,6 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
 vi.mock("../../../src/util/post-install-logs.js", () => ({
-  requestAndOpenSerialPort: vi.fn(),
   attachSerialLogStream: vi.fn(),
   reconnectWebSerialLogs: vi.fn(),
 }));

--- a/test/components/logs-dialog-quiet-serial.test.ts
+++ b/test/components/logs-dialog-quiet-serial.test.ts
@@ -181,6 +181,17 @@ describe("switchToOtaLogs", () => {
     ]);
   });
 
+  it("appends the reason ahead of the switch line when given", () => {
+    const cancel = vi.fn();
+    el.openPassive({ onReconnect: () => Promise.resolve() });
+    el.setSerialStream(port, cancel as unknown as () => void);
+    switchToOtaLogs(el, "wrong port for this console");
+    expect((el as any)._log.lines.slice(0, 2)).toEqual([
+      "wrong port for this console",
+      "dashboard.logs_switched_to_network",
+    ]);
+  });
+
   it("keeps the back-to-install affordance across the switch", () => {
     el.openPassive({
       onReconnect: () => Promise.resolve(),

--- a/test/util/post-install-logs.test.ts
+++ b/test/util/post-install-logs.test.ts
@@ -57,6 +57,7 @@ function deadPort(
 
 function stubDialog() {
   return {
+    open: vi.fn(),
     setSerialStream: vi.fn(),
     setSerialOpenFailed: vi.fn(),
     abortSerialReconnect: vi.fn(),
@@ -147,6 +148,32 @@ describe("reconnectWebSerialLogs", () => {
       expect(dialog.abortSerialReconnect).toHaveBeenCalledTimes(1);
       expect(dialog.setSerialOpenFailed).not.toHaveBeenCalled();
       expect(toastError).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("reroutes a reconnect onto a mismatched port without opening it", async () => {
+    // Re-picked a bridge port for a native-USB console: same pre-open gate
+    // as the entry points, so no DTR/RTS pulse and no dead serial session.
+    const bridge = {
+      readable: null,
+      getInfo: () => ({ usbVendorId: 0x1a86, usbProductId: 0x7523 }),
+      open: vi.fn(),
+    } as unknown as SerialPort;
+    const restore = withRequestPort(async () => bridge);
+    const dialog = stubDialog();
+    try {
+      await reconnectWebSerialLogs(
+        dialog as never,
+        defaultLocalize,
+        115200,
+        "USB_SERIAL_JTAG"
+      );
+      expect(bridge.open).not.toHaveBeenCalled();
+      expect(dialog.open).toHaveBeenCalledWith("OTA", {});
+      expect(toastInfo).toHaveBeenCalledTimes(1);
+      expect(dialog.setSerialStream).not.toHaveBeenCalled();
     } finally {
       restore();
     }

--- a/test/util/post-install-logs.test.ts
+++ b/test/util/post-install-logs.test.ts
@@ -172,8 +172,11 @@ describe("reconnectWebSerialLogs", () => {
         "USB_SERIAL_JTAG"
       );
       expect(bridge.open).not.toHaveBeenCalled();
-      // Mid-session swap, not a fresh open: buffer + back-to-install survive.
-      expect(dialog.switchToNetworkLogs).toHaveBeenCalledTimes(1);
+      // Mid-session swap, not a fresh open: buffer + back-to-install survive;
+      // the reason rides into the pane so it outlives the toast.
+      expect(dialog.switchToNetworkLogs).toHaveBeenCalledWith(
+        expect.stringContaining("logger outputs on USB_SERIAL_JTAG")
+      );
       expect(dialog.open).not.toHaveBeenCalled();
       expect(toastInfo).toHaveBeenCalledTimes(1);
       expect(dialog.setSerialStream).not.toHaveBeenCalled();

--- a/test/util/post-install-logs.test.ts
+++ b/test/util/post-install-logs.test.ts
@@ -116,7 +116,7 @@ describe("reconnectWebSerialLogs", () => {
     const restore = withRequestPort(async () => openPort());
     const dialog = stubDialog();
     try {
-      await reconnectWebSerialLogs(dialog as never, defaultLocalize, 115200);
+      await reconnectWebSerialLogs(dialog as never, defaultLocalize, 115200, null);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((navigator as any).serial.requestPort).toHaveBeenCalledTimes(1);
       expect(dialog.setSerialStream).toHaveBeenCalledTimes(1);
@@ -131,7 +131,7 @@ describe("reconnectWebSerialLogs", () => {
     const restore = withRequestPort(async () => port);
     const dialog = stubDialog();
     try {
-      await reconnectWebSerialLogs(dialog as never, defaultLocalize, 19200);
+      await reconnectWebSerialLogs(dialog as never, defaultLocalize, 19200, null);
       expect(port.open).toHaveBeenCalledWith({ baudRate: 19200 });
     } finally {
       restore();
@@ -145,7 +145,7 @@ describe("reconnectWebSerialLogs", () => {
     });
     const dialog = stubDialog();
     try {
-      await reconnectWebSerialLogs(dialog as never, defaultLocalize, 115200);
+      await reconnectWebSerialLogs(dialog as never, defaultLocalize, 115200, null);
       expect(dialog.abortSerialReconnect).toHaveBeenCalledTimes(1);
       expect(dialog.setSerialOpenFailed).not.toHaveBeenCalled();
       expect(toastError).not.toHaveBeenCalled();
@@ -191,7 +191,7 @@ describe("reconnectWebSerialLogs", () => {
     });
     const dialog = stubDialog();
     try {
-      await reconnectWebSerialLogs(dialog as never, defaultLocalize, 115200);
+      await reconnectWebSerialLogs(dialog as never, defaultLocalize, 115200, null);
       expect(dialog.setSerialOpenFailed).toHaveBeenCalledTimes(1);
       expect(toastError).toHaveBeenCalledTimes(1);
       expect(dialog.abortSerialReconnect).not.toHaveBeenCalled();
@@ -206,7 +206,7 @@ describe("reconnectWebSerialLogs", () => {
     const restore = withRequestPort(async () => port);
     const dialog = stubDialog();
     try {
-      await reconnectWebSerialLogs(dialog as never, defaultLocalize, 115200);
+      await reconnectWebSerialLogs(dialog as never, defaultLocalize, 115200, null);
       expect(dialog.setSerialOpenFailed).toHaveBeenCalledTimes(1);
       expect(toastError).toHaveBeenCalledTimes(1);
       expect(dialog.abortSerialReconnect).not.toHaveBeenCalled();

--- a/test/util/post-install-logs.test.ts
+++ b/test/util/post-install-logs.test.ts
@@ -58,6 +58,7 @@ function deadPort(
 function stubDialog() {
   return {
     open: vi.fn(),
+    switchToNetworkLogs: vi.fn(),
     setSerialStream: vi.fn(),
     setSerialOpenFailed: vi.fn(),
     abortSerialReconnect: vi.fn(),
@@ -171,7 +172,9 @@ describe("reconnectWebSerialLogs", () => {
         "USB_SERIAL_JTAG"
       );
       expect(bridge.open).not.toHaveBeenCalled();
-      expect(dialog.open).toHaveBeenCalledWith("OTA", {});
+      // Mid-session swap, not a fresh open: buffer + back-to-install survive.
+      expect(dialog.switchToNetworkLogs).toHaveBeenCalledTimes(1);
+      expect(dialog.open).not.toHaveBeenCalled();
       expect(toastInfo).toHaveBeenCalledTimes(1);
       expect(dialog.setSerialStream).not.toHaveBeenCalled();
     } finally {

--- a/test/util/serial-console-match.test.ts
+++ b/test/util/serial-console-match.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from "vitest";
 import type { LocalizeFunc } from "../../src/common/localize.js";
 import {
-  serialConsoleMismatchNotice,
+  serialConsoleMismatch,
   serialPortCannotCarryConsole,
 } from "../../src/util/serial-console-match.js";
 
@@ -83,19 +83,24 @@ describe("serialPortCannotCarryConsole", () => {
   });
 });
 
-describe("serialConsoleMismatchNotice", () => {
+describe("serialConsoleMismatch", () => {
   const localize = ((key: string, params?: Record<string, string>) =>
     params ? `${key}:${params.interface}` : key) as unknown as LocalizeFunc;
 
   it("names the interface in the wrong-port notice", () => {
-    expect(serialConsoleMismatchNotice("USB_SERIAL_JTAG", port(CH340), localize)).toBe(
-      "dashboard.logs_serial_wrong_port_fallback:USB_SERIAL_JTAG"
-    );
+    expect(serialConsoleMismatch("USB_SERIAL_JTAG", port(CH340), localize)).toEqual({
+      message: "dashboard.logs_serial_wrong_port_fallback:USB_SERIAL_JTAG",
+    });
+  });
+
+  it("stays truthy even when localization produces an empty string", () => {
+    const empty = (() => "") as unknown as LocalizeFunc;
+    expect(serialConsoleMismatch("USB_SERIAL_JTAG", port(CH340), empty)).toBeTruthy();
   });
 
   it("is null when the port can carry the console (or is uncertain)", () => {
-    expect(serialConsoleMismatchNotice("UART0", port(CH340), localize)).toBeNull();
-    expect(serialConsoleMismatchNotice(null, port(CH340), localize)).toBeNull();
-    expect(serialConsoleMismatchNotice("USB_CDC", port(PICO), localize)).toBeNull();
+    expect(serialConsoleMismatch("UART0", port(CH340), localize)).toBeNull();
+    expect(serialConsoleMismatch(null, port(CH340), localize)).toBeNull();
+    expect(serialConsoleMismatch("USB_CDC", port(PICO), localize)).toBeNull();
   });
 });

--- a/test/util/web-serial-reset.test.ts
+++ b/test/util/web-serial-reset.test.ts
@@ -8,6 +8,15 @@
  */
 import type { ESPLoader, Transport } from "esptool-js";
 import { describe, expect, it, vi } from "vitest";
+
+const { jtagResetSpy } = vi.hoisted(() => ({ jtagResetSpy: vi.fn() }));
+vi.mock("esptool-js", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  UsbJtagSerialReset: class {
+    reset = jtagResetSpy;
+  },
+}));
+
 import { resetAndDisconnect } from "../../src/util/web-serial.js";
 
 function fakeTransport() {
@@ -38,5 +47,33 @@ describe("resetAndDisconnect — classic ESP32 / ESP8266 over a UART bridge", ()
     expect(transport.setDTR).toHaveBeenCalledWith(false);
     expect(transport.setDTR.mock.calls.every((c) => c[0] === false)).toBe(true);
     expect(transport.disconnect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("resetAndDisconnect — Espressif USB identity discriminator", () => {
+  it("uses the JTAG reset only for the on-chip USB-Serial-JTAG device", async () => {
+    jtagResetSpy.mockClear();
+    const transport = fakeTransport();
+    const jtagPort = {
+      getInfo: () => ({ usbVendorId: 0x303a, usbProductId: 0x1001 }),
+    } as unknown as SerialPort;
+    await resetAndDisconnect(esp8266Loader, transport as unknown as Transport, jtagPort);
+    expect(jtagResetSpy).toHaveBeenCalledTimes(1);
+    expect(transport.setRTS.mock.calls.map((c) => c[0])).not.toEqual([true, false]);
+  });
+
+  it("treats the ESP-USB-Bridge as a bridge despite the Espressif vendor id", async () => {
+    jtagResetSpy.mockClear();
+    const transport = fakeTransport();
+    const bridgePort = {
+      getInfo: () => ({ usbVendorId: 0x303a, usbProductId: 0x1002 }),
+    } as unknown as SerialPort;
+    await resetAndDisconnect(
+      esp8266Loader,
+      transport as unknown as Transport,
+      bridgePort
+    );
+    expect(jtagResetSpy).not.toHaveBeenCalled();
+    expect(transport.setRTS.mock.calls.map((c) => c[0])).toEqual([true, false]);
   });
 });

--- a/test/util/web-serial-reset.test.ts
+++ b/test/util/web-serial-reset.test.ts
@@ -59,7 +59,7 @@ describe("resetAndDisconnect — Espressif USB identity discriminator", () => {
     } as unknown as SerialPort;
     await resetAndDisconnect(esp8266Loader, transport as unknown as Transport, jtagPort);
     expect(jtagResetSpy).toHaveBeenCalledTimes(1);
-    expect(transport.setRTS.mock.calls.map((c) => c[0])).not.toEqual([true, false]);
+    expect(transport.setRTS).not.toHaveBeenCalled();
   });
 
   it("treats the ESP-USB-Bridge as a bridge despite the Espressif vendor id", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #1446, taking the non-urgent items from its final review:

- **The reconnect picker is now mismatch-gated.** The "click Start to reconnect" path (`reconnectWebSerialLogs`) runs the same pre-open check as both entry points: pick, decide on the unopened port, and reroute when it provably can't carry the console — via the in-session `switchToNetworkLogs` swap (buffer and back-to-install survive), so a user on a two-port S3 devkit who re-picks the wrong port no longer lands back in the open-silent-wait shape. `requestAndOpenSerialPort` is deleted outright: no production callers remain and it encoded the open-before-deciding shape this arc removed. `loggerInterface` is threaded through from both call sites, which already had it in scope. Pinned by a test asserting the re-picked bridge port is never opened.
- **The mismatch gate no longer rides on string truthiness.** `serialConsoleMismatchNotice` became `serialConsoleMismatch`, returning `{ message } | null`, so callers branch on the verdict object and the copy can never influence the decision (pinned with an empty-localizer test).
- **`hardResetChip` matches esptool's actual check.** It picked `UsbJtagSerialReset` on the Espressif vendor id alone; esptool-js discriminates on product id `0x1001` (the on-chip USB-Serial-JTAG device) — we pair it with the vendor id as the conservative conjunct. An ESP-USB-Bridge (`0x303a:0x1002`, a real UART bridge) now gets the classic EN-pulse reset it needs instead of a JTAG reset frame it ignores. `ESPRESSIF_USB_JTAG_PID` moves to `web-serial.ts` beside the vendor id and `serial-console-match.ts` imports it, so the identity constants have one home.

The merged PR's description was also updated for its final shape (decide-before-open, `requestSerialPort` split), per the same review.

**Related issue or feature (if applicable):**

- Follow-up to #1446 (final review suggestions); part of the esphome/device-builder#2310 arc.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
