### PR TITLE
Unify the three automation-section editors on a shared base class

### DIFF
--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -21,23 +21,15 @@
  * ``inFlightWrite`` signals to the parent's reconnect handler to
  * skip clobbering an in-flight write.
  */
-import { consume } from "@lit/context";
 import { mdiOpenInNew, mdiWebhook } from "@mdi/js";
-import { html, LitElement, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
 
-import type { ESPHomeAPI } from "../../../api/index.js";
 import type {
   AutomationLocation,
   AutomationTree,
-  AvailableAutomations,
 } from "../../../api/types/automations.js";
-import type { BoardCatalogEntry } from "../../../api/types/boards.js";
 import { ESPHOME_DOCS_BASE } from "../../../common/docs.js";
-import type { LocalizeFunc } from "../../../common/localize.js";
-import { apiContext, localizeContext } from "../../../context/index.js";
-import { inputStyles } from "../../../styles/inputs.js";
-import { espHomeStyles } from "../../../styles/shared.js";
 import { getErrorMessage } from "../../../util/error-message.js";
 import { normalizeEspHomeId } from "../../../util/esphome-id.js";
 import { formatApiError } from "../../../util/format-api-error.js";
@@ -45,21 +37,15 @@ import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import { scrollFlashRow } from "../field-highlight.js";
 import { fieldHighlightStyles } from "../field-highlight.styles.js";
-import { AutoApplyController } from "./auto-apply-controller.js";
 import "./automation-action-list.js";
-import { automationEditorStyles } from "./automation-editor.styles.js";
 import {
   actionsFocus,
-  createFocusResolver,
   entryFieldFocus,
   focusKey,
   paramFocus,
-  type YamlPathSegment,
 } from "./automation-focus.js";
+import { BaseAutomationEditor } from "./base-editor.js";
 import "./callable-params-editor.js";
-import { CatalogLoadController } from "./catalog-load-controller.js";
-import { ParseErrorController } from "./parse-error-controller.js";
-import { renderDeleteRow } from "./render-delete-row.js";
 import { emptyAutomationTree } from "./serialise.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -81,84 +67,12 @@ const API_DOCS_URL = `${ESPHOME_DOCS_BASE}/components/api.html`;
 type ApiActionLocation = Extract<AutomationLocation, { kind: "api_action" }>;
 
 @customElement("esphome-api-action-editor")
-export class ESPHomeApiActionEditor extends LitElement {
-  @consume({ context: localizeContext, subscribe: true })
-  @state()
-  private _localize: LocalizeFunc = (key) => key;
+export class ESPHomeApiActionEditor extends BaseAutomationEditor<ApiActionLocation> {
+  // Can't upsert an api action with no name.
+  protected _canApply = (location: AutomationLocation) =>
+    location.kind === "api_action" && !!location.action_name;
 
-  @consume({ context: apiContext })
-  private _api!: ESPHomeAPI;
-
-  @property() configuration = "";
-
-  @property({ attribute: false })
-  board: BoardCatalogEntry | null = null;
-
-  @property() platform = "";
-
-  @property({ attribute: false })
-  value: AutomationTree | null = null;
-
-  @property({ attribute: false })
-  location: ApiActionLocation | null = null;
-
-  /** True when mounted from the "+ Add API action" dialog. Add-mode
-   *  lets the user type the action name; edit-mode locks it. */
-  @property({ type: Boolean, attribute: "add-mode" })
-  addMode = false;
-
-  @property() yaml = "";
-
-  /** Indexed key path at the YAML cursor; resolved against the
-   *  hydrated tree to scroll/highlight the matching action node. */
-  @property({ attribute: false })
-  focusYamlPath?: YamlPathSegment[];
-
-  private _resolveFocus = createFocusResolver();
-
-  /** Scoped catalog response — drives the action / condition / script
-   *  / device pickers inside the action list. */
-  @state() private _available: AvailableAutomations | null = null;
-
-  @state() private _loading = true;
-  @state() private _error = "";
-  /** Renders read-only + blocks auto-apply for a parse-errored
-   *  action so its empty tree can't overwrite the real YAML. */
-  private readonly _parseError = new ParseErrorController(this);
-
-  /** Shared auto-apply / delete / dirty-tracking engine — same
-   *  instance shape as the automation and script editors so the
-   *  page-level save guard can treat all three uniformly. */
-  private readonly _engine = new AutoApplyController(this, {
-    getApi: () => this._api,
-    getLocalize: () => this._localize,
-    isReadOnly: () => this._parseError.active,
-    // Can't upsert an api action with no name.
-    canApply: (location) => location.kind === "api_action" && !!location.action_name,
-    setError: (message) => {
-      this._error = message;
-    },
-  });
-
-  /** Catalog loader; owns the concurrency guard so overlapping loads
-   *  (connectedCallback + updated both reaching ``_loadAvailable``)
-   *  can't clobber ``_available`` or double-fire the toast. */
-  private readonly _catalogLoad = new CatalogLoadController(this);
-
-  public get dirty(): boolean {
-    return this._engine.dirty;
-  }
-
-  public get inFlightWrite(): boolean {
-    return this._engine.inFlightWrite;
-  }
-
-  static styles = [
-    espHomeStyles,
-    inputStyles,
-    automationEditorStyles,
-    fieldHighlightStyles,
-  ];
+  static styles = [...BaseAutomationEditor.styles, fieldHighlightStyles];
 
   connectedCallback(): void {
     super.connectedCallback();
@@ -193,15 +107,6 @@ export class ESPHomeApiActionEditor extends LitElement {
     ) {
       void this._hydrateFromBackend();
     }
-  }
-
-  /**
-   * Force a pending debounced auto-apply to flush immediately.
-   * The device page calls this on the active section before its
-   * global save so the YAML buffer is fully caught up.
-   */
-  public flushPending(): Promise<void> {
-    return this._engine.flushPending();
   }
 
   protected render() {
@@ -252,19 +157,12 @@ export class ESPHomeApiActionEditor extends LitElement {
           @actions-change=${this._onActionsChange}
         ></esphome-automation-action-list>
       </div>
-      ${this._error ? html`<p class="ae-error" role="alert">${this._error}</p>` : nothing}
-      ${
-        this.location && this.value && !this.addMode
-          ? renderDeleteRow({
-              label: this._localize("device.delete_api_action"),
-              message: this._localize("device.confirm_delete_api_action", {
-                name: this.location.action_name,
-              }),
-              disabled,
-              onConfirm: this._onDelete,
-            })
-          : nothing
-      }
+      ${this.renderFooter({
+        label: this._localize("device.delete_api_action"),
+        message: this._localize("device.confirm_delete_api_action", {
+          name: this.location?.action_name ?? "",
+        }),
+      })}
     `;
   }
 
@@ -418,10 +316,6 @@ export class ESPHomeApiActionEditor extends LitElement {
   private _onActionsChange = (e: CustomEvent<{ actions: AutomationTree["actions"] }>) => {
     e.stopPropagation();
     this._engine.withValue({ actions: e.detail.actions });
-  };
-
-  private _onDelete = () => {
-    void this._engine.delete();
   };
 }
 

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -67,8 +67,6 @@ export class ESPHomeApiActionEditor extends CallableAutomationEditor<ApiActionLo
     return location.kind === "api_action" && !!location.action_name;
   }
 
-  protected readonly _sectionKind = "api_action" as const;
-
   static styles = [CallableAutomationEditor.styles, fieldHighlightStyles];
 
   /** ``focusKey`` already name-flashed — one-shot per target. */

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -22,8 +22,8 @@
  * skip clobbering an in-flight write.
  */
 import { mdiOpenInNew, mdiWebhook } from "@mdi/js";
-import { html, nothing } from "lit";
-import { customElement, state } from "lit/decorators.js";
+import { html } from "lit";
+import { customElement } from "lit/decorators.js";
 
 import type {
   AutomationLocation,
@@ -69,8 +69,9 @@ type ApiActionLocation = Extract<AutomationLocation, { kind: "api_action" }>;
 @customElement("esphome-api-action-editor")
 export class ESPHomeApiActionEditor extends BaseAutomationEditor<ApiActionLocation> {
   // Can't upsert an api action with no name.
-  protected _canApply = (location: AutomationLocation) =>
-    location.kind === "api_action" && !!location.action_name;
+  protected override _canApply(location: AutomationLocation): boolean {
+    return location.kind === "api_action" && !!location.action_name;
+  }
 
   static styles = [...BaseAutomationEditor.styles, fieldHighlightStyles];
 
@@ -159,9 +160,10 @@ export class ESPHomeApiActionEditor extends BaseAutomationEditor<ApiActionLocati
       </div>
       ${this.renderFooter({
         label: this._localize("device.delete_api_action"),
-        message: this._localize("device.confirm_delete_api_action", {
-          name: this.location?.action_name ?? "",
-        }),
+        message: (location) =>
+          this._localize("device.confirm_delete_api_action", {
+            name: location.action_name,
+          }),
       })}
     `;
   }

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -35,7 +35,6 @@ import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import { scrollFlashRow } from "../field-highlight.js";
 import { fieldHighlightStyles } from "../field-highlight.styles.js";
-import "./automation-action-list.js";
 import {
   actionsFocus,
   entryFieldFocus,
@@ -43,11 +42,11 @@ import {
   paramFocus,
 } from "./automation-focus.js";
 import { CallableAutomationEditor } from "./callable-editor.js";
+import { renderActionsSection } from "./render-actions-section.js";
 import "./callable-params-editor.js";
 import { emptyAutomationTree } from "./serialise.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
-import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 
 registerMdiIcons({
   "open-in-new": mdiOpenInNew,
@@ -88,15 +87,8 @@ export class ESPHomeApiActionEditor extends CallableAutomationEditor<ApiActionLo
   }
 
   protected render() {
-    if (this._loading) {
-      return html`<div class="ae-empty">
-        <wa-spinner></wa-spinner>
-        ${this._localize("device.loading_automation_catalog")}
-      </div>`;
-    }
-    if (this._parseError.active) {
-      return this._parseError.renderPanel(this._localize);
-    }
+    const gate = this.renderStateGate();
+    if (gate) return gate;
     const automation = this.value ?? emptyAutomationTree();
     const devices = this._available?.devices ?? [];
     const scripts = this._available?.scripts ?? [];
@@ -116,25 +108,20 @@ export class ESPHomeApiActionEditor extends CallableAutomationEditor<ApiActionLo
         .namePlaceholder=${this._localize("device.api_action_variable_name_placeholder")}
         @value-change=${this._onVariablesChange}
       ></esphome-callable-params-editor>
-      <div class="field">
-        <label class="field-label"> ${this._localize("device.automation_action")} </label>
-        <p class="field-description">
-          ${renderMarkdown(this._localize("device.api_action_actions_description"))}
-        </p>
-        <esphome-automation-action-list
-          no-header
-          .focusTarget=${actionsFocus(focus)}
-          .actions=${automation.actions}
-          .catalog=${actions}
-          .conditionCatalog=${conditions}
-          .scripts=${scripts}
-          .devices=${devices}
-          .board=${this.board}
-          .yaml=${this.yaml}
-          ?disabled=${disabled}
-          @actions-change=${this._onActionsChange}
-        ></esphome-automation-action-list>
-      </div>
+      ${renderActionsSection({
+        automation,
+        catalog: actions,
+        conditionCatalog: conditions,
+        scripts,
+        devices,
+        board: this.board,
+        yaml: this.yaml,
+        disabled,
+        localize: this._localize,
+        focusTarget: actionsFocus(focus),
+        descriptionKey: "device.api_action_actions_description",
+        onActionsChange: this._onActionsChange,
+      })}
       ${this.renderFooter({
         label: this._localize("device.delete_api_action"),
         message: (location) =>
@@ -230,11 +217,6 @@ export class ESPHomeApiActionEditor extends CallableAutomationEditor<ApiActionLo
         variables: e.detail.value,
       },
     });
-  };
-
-  private _onActionsChange = (e: CustomEvent<{ actions: AutomationTree["actions"] }>) => {
-    e.stopPropagation();
-    this._engine.withValue({ actions: e.detail.actions });
   };
 }
 

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -73,7 +73,7 @@ export class ESPHomeApiActionEditor extends BaseAutomationEditor<ApiActionLocati
     return location.kind === "api_action" && !!location.action_name;
   }
 
-  static styles = [...BaseAutomationEditor.styles, fieldHighlightStyles];
+  static styles = [BaseAutomationEditor.styles, fieldHighlightStyles];
 
   connectedCallback(): void {
     super.connectedCallback();

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -30,9 +30,7 @@ import type {
   AutomationTree,
 } from "../../../api/types/automations.js";
 import { ESPHOME_DOCS_BASE } from "../../../common/docs.js";
-import { getErrorMessage } from "../../../util/error-message.js";
 import { normalizeEspHomeId } from "../../../util/esphome-id.js";
-import { formatApiError } from "../../../util/format-api-error.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import { scrollFlashRow } from "../field-highlight.js";
@@ -44,7 +42,7 @@ import {
   focusKey,
   paramFocus,
 } from "./automation-focus.js";
-import { BaseAutomationEditor } from "./base-editor.js";
+import { CallableAutomationEditor } from "./callable-editor.js";
 import "./callable-params-editor.js";
 import { emptyAutomationTree } from "./serialise.js";
 
@@ -67,47 +65,26 @@ const API_DOCS_URL = `${ESPHOME_DOCS_BASE}/components/api.html`;
 type ApiActionLocation = Extract<AutomationLocation, { kind: "api_action" }>;
 
 @customElement("esphome-api-action-editor")
-export class ESPHomeApiActionEditor extends BaseAutomationEditor<ApiActionLocation> {
+export class ESPHomeApiActionEditor extends CallableAutomationEditor<ApiActionLocation> {
   // Can't upsert an api action with no name.
   protected override _canApply(location: AutomationLocation): boolean {
     return location.kind === "api_action" && !!location.action_name;
   }
 
-  static styles = [BaseAutomationEditor.styles, fieldHighlightStyles];
+  protected readonly _sectionKind = "api_action" as const;
 
-  connectedCallback(): void {
-    super.connectedCallback();
-    void this._load();
+  protected _identityOf(location: ApiActionLocation): string {
+    return location.action_name;
   }
+
+  static styles = [CallableAutomationEditor.styles, fieldHighlightStyles];
 
   /** ``focusKey`` already name-flashed — one-shot per target. */
   private _nameFlashKey?: string;
 
-  protected updated(changed: Map<string, unknown>) {
+  protected override updated(changed: Map<string, unknown>) {
     this._maybeFlashName();
-    if (changed.has("configuration")) {
-      void this._loadAvailable();
-    }
-    // Navigator-driven location swap (user clicked a different
-    // api_action in the navigator) — invalidate the stale value so
-    // the hydrate path below re-fetches.
-    if (changed.has("location") && !this.addMode) {
-      const prev = changed.get("location") as ApiActionLocation | null | undefined;
-      if (prev && this.location && prev.action_name !== this.location.action_name) {
-        this.value = null;
-      }
-    }
-    if (
-      !this.addMode &&
-      (changed.has("location") ||
-        changed.has("configuration") ||
-        changed.has("_loading")) &&
-      this.location &&
-      this.value === null &&
-      !this._loading
-    ) {
-      void this._hydrateFromBackend();
-    }
+    super.updated(changed);
   }
 
   protected render() {
@@ -232,66 +209,6 @@ export class ESPHomeApiActionEditor extends BaseAutomationEditor<ApiActionLocati
     if (!field) return;
     this._nameFlashKey = key;
     scrollFlashRow(field);
-  }
-
-  private async _load() {
-    if (!this._api) return;
-    this._loading = true;
-    this._error = "";
-    try {
-      if (this.configuration) await this._loadAvailable();
-    } catch (err) {
-      this._error = getErrorMessage(err);
-    } finally {
-      this._loading = false;
-    }
-  }
-
-  private async _loadAvailable() {
-    // Hydrates config_entries (the slim catalog omits them); without
-    // it every action renders fieldless since the node bails on an
-    // empty config_entries list.
-    this._error = "";
-    const { available, error } = await this._catalogLoad.load(
-      this._api,
-      this.configuration,
-      this._localize
-    );
-    if (error !== undefined) this._error = error;
-    if (available) this._available = available;
-  }
-
-  private async _hydrateFromBackend() {
-    if (!this._api || !this.configuration || !this.location) return;
-    try {
-      // Pass ``this.yaml`` so the parser sees the current draft
-      // buffer — without it the post-add hydrate would read on-disk
-      // and miss the just-inserted entry.
-      const parsed = await this._api.parseDeviceAutomations(
-        this.configuration,
-        this.yaml
-      );
-      const m = this._parseError.resolve(parsed, this.location, "api_action");
-      if (m) {
-        this.location = m.location;
-        this.value = m.tree;
-      }
-    } catch (err) {
-      this._error = formatApiError(err, this._localize, "device.automation_parse_error");
-    }
-  }
-
-  /**
-   * Re-hydrate from the live YAML. Called by the parent
-   * (``device-board-info``) when the YAML pane changes the document
-   * out from under us — mirrors device-section-config.reload() and
-   * automation/script reload() so editing YAML in the pane updates
-   * the visual editor.
-   */
-  public reload(): void {
-    if (this.addMode || !this.location) return;
-    if (this._engine.shouldSkipReload()) return;
-    void this._hydrateFromBackend();
   }
 
   private _onActionNameChange(name: string) {

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -25,10 +25,7 @@ import { mdiOpenInNew, mdiWebhook } from "@mdi/js";
 import { html } from "lit";
 import { customElement } from "lit/decorators.js";
 
-import type {
-  AutomationLocation,
-  AutomationTree,
-} from "../../../api/types/automations.js";
+import type { AutomationLocation } from "../../../api/types/automations.js";
 import { ESPHOME_DOCS_BASE } from "../../../common/docs.js";
 import { normalizeEspHomeId } from "../../../util/esphome-id.js";
 import { renderMarkdown } from "../../../util/markdown.js";

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -69,10 +69,6 @@ export class ESPHomeApiActionEditor extends CallableAutomationEditor<ApiActionLo
 
   protected readonly _sectionKind = "api_action" as const;
 
-  protected _identityOf(location: ApiActionLocation): string {
-    return location.action_name;
-  }
-
   static styles = [CallableAutomationEditor.styles, fieldHighlightStyles];
 
   /** ``focusKey`` already name-flashed — one-shot per target. */

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -26,7 +26,7 @@
  * the post-reconnect re-parse path can short-circuit while a write
  * is outstanding.
  */
-import { html, nothing } from "lit";
+import { html } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 
@@ -343,9 +343,10 @@ export class ESPHomeAutomationEditor extends BaseAutomationEditor<AutomationLoca
       })}
       ${this.renderFooter({
         label: this._localize("device.delete_automation"),
-        message: this._localize("device.confirm_delete_automation", {
-          name: this._deleteTargetName(activeTrigger),
-        }),
+        message: () =>
+          this._localize("device.confirm_delete_automation", {
+            name: this._deleteTargetName(activeTrigger),
+          }),
       })}
     `;
   }

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -45,8 +45,8 @@ import { actionsFocus, entryFieldFocus } from "./automation-focus.js";
 import { BaseAutomationEditor } from "./base-editor.js";
 import { loadIntervalComponent } from "./load-interval-component.js";
 import { renderAutomationHeader } from "./render-automation-header.js";
+import { renderActionsSection } from "./render-actions-section.js";
 import {
-  renderActionsSection,
   renderAddModePickers,
   renderIdentityFields,
   renderTriggerParamsForm,
@@ -57,8 +57,6 @@ import {
   sectionKeyFromLocation,
 } from "./serialise.js";
 import { bareTriggerKey, effectiveTriggerIdFor } from "./trigger-identity.js";
-
-import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 
 @customElement("esphome-automation-editor")
 export class ESPHomeAutomationEditor extends BaseAutomationEditor<AutomationLocation> {
@@ -259,15 +257,8 @@ export class ESPHomeAutomationEditor extends BaseAutomationEditor<AutomationLoca
   }
 
   protected render() {
-    if (this._loading) {
-      return html`<div class="ae-empty">
-        <wa-spinner></wa-spinner>
-        ${this._localize("device.loading_automation_catalog")}
-      </div>`;
-    }
-    if (this._parseError.active) {
-      return this._parseError.renderPanel(this._localize);
-    }
+    const gate = this.renderStateGate();
+    if (gate) return gate;
     const automation = this.value ?? emptyAutomationTree();
     const target = this.location;
     const devices = this._available?.devices ?? [];
@@ -405,11 +396,6 @@ export class ESPHomeAutomationEditor extends BaseAutomationEditor<AutomationLoca
   ) => {
     e.stopPropagation();
     this._engine.withValue({ trigger_params: e.detail.params });
-  };
-
-  private _onActionsChange = (e: CustomEvent<{ actions: AutomationTree["actions"] }>) => {
-    e.stopPropagation();
-    this._engine.withValue({ actions: e.detail.actions });
   };
 
   // ─── Delete ──────────────────────────────────────────────────

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -50,11 +50,7 @@ import {
   renderIdentityFields,
   renderTriggerParamsForm,
 } from "./render-automation-sections.js";
-import {
-  applyParamChange,
-  emptyAutomationTree,
-  sectionKeyFromLocation,
-} from "./serialise.js";
+import { applyParamChange, emptyAutomationTree } from "./serialise.js";
 import { bareTriggerKey, effectiveTriggerIdFor } from "./trigger-identity.js";
 
 @customElement("esphome-automation-editor")
@@ -98,46 +94,8 @@ export class ESPHomeAutomationEditor extends BaseAutomationEditor<AutomationLoca
     // shared engine's hostConnected.
   }
 
-  protected updated(changed: Map<string, unknown>) {
-    if (changed.has("configuration")) {
-      void this._loadAvailable();
-    }
-    // Navigator-driven location swap: when the parent passes in a
-    // different ``location`` (user clicked a sibling automation),
-    // the editor element is reused — its previous ``value`` is
-    // stale. Invalidate it so the hydrate path below re-fetches
-    // the matching ParsedAutomation. Without this guard the
-    // trigger / actions panels keep showing the old automation's
-    // content while the location-derived metadata fields update.
-    if (changed.has("location") && !this.addMode) {
-      const prev = changed.get("location") as AutomationLocation | null | undefined;
-      if (
-        prev &&
-        this.location &&
-        sectionKeyFromLocation(prev) !== sectionKeyFromLocation(this.location)
-      ) {
-        this.value = null;
-      }
-    }
-    // Hydrate from the backend in edit-mode: when the editor was
-    // mounted with a known location but no value, we look up the
-    // matching ParsedAutomation and populate value/location from
-    // it. Triggering on ``_loading`` covers the common case where
-    // the editor was mounted with the location already set — the
-    // first ``location`` change fires while ``_loading=true``, so
-    // we re-check after catalogs finish loading rather than waiting
-    // for another location mutation that may never come.
-    if (
-      !this.addMode &&
-      (changed.has("location") ||
-        changed.has("configuration") ||
-        changed.has("_loading")) &&
-      this.location &&
-      this.value === null &&
-      !this._loading
-    ) {
-      void this._hydrateFromBackend();
-    }
+  protected override updated(changed: Map<string, unknown>) {
+    super.updated(changed);
     // Interval automations need the ``interval`` component schema
     // so the header can show its description + docs link + image
     // and the form can render its config_entries (the actual
@@ -170,7 +128,7 @@ export class ESPHomeAutomationEditor extends BaseAutomationEditor<AutomationLoca
    * keeps the editor self-contained — the parent only needs to
    * pass the section key's location.
    */
-  private async _hydrateFromBackend() {
+  protected async _hydrateFromBackend() {
     if (!this._api || !this.configuration || !this.location) return;
     try {
       // Pass ``this.yaml`` so the parser sees the user's current
@@ -198,26 +156,7 @@ export class ESPHomeAutomationEditor extends BaseAutomationEditor<AutomationLoca
     }
   }
 
-  /**
-   * Re-hydrate from the live YAML. Called by the parent
-   * (``device-board-info``) when the YAML pane changes the document
-   * out from under us — mirrors the device-section-config reload
-   * pattern so editing YAML in the pane updates the visual editor.
-   *
-   * Skip cases:
-   *  - Our own write echoing back via the prop (avoid clobbering the
-   *    user's just-applied edit).
-   *  - An auto-apply currently in flight (we're already writing /
-   *    about to overwrite; let it finish).
-   *  - Add mode (no location to hydrate from yet).
-   */
-  public reload(): void {
-    if (this.addMode || !this.location) return;
-    if (this._engine.shouldSkipReload()) return;
-    void this._hydrateFromBackend();
-  }
-
-  private async _loadAvailable() {
+  protected async _loadAvailable() {
     if (!this._api || !this.configuration) return;
     this._loading = true;
     this._error = "";

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -32,7 +32,6 @@ import memoizeOne from "memoize-one";
 
 import type {
   AutomationLocation,
-  AutomationTree,
   AutomationTrigger,
   AvailableComponentInstance,
   AvailableScript,
@@ -330,6 +329,7 @@ export class ESPHomeAutomationEditor extends BaseAutomationEditor<AutomationLoca
         disabled,
         localize: this._localize,
         focusTarget: actionsFocus(focus),
+        descriptionKey: "device.automation_actions_description",
         onActionsChange: this._onActionsChange,
       })}
       ${this.renderFooter({

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -38,7 +38,6 @@ import type {
 } from "../../../api/types/automations.js";
 import type { ComponentCatalogEntry } from "../../../api/types/components.js";
 import { automationHeaderTitle } from "../../../util/automation-header-title.js";
-import { formatApiError } from "../../../util/format-api-error.js";
 import { parseSubstitutions } from "../../../util/substitutions.js";
 import { actionsFocus, entryFieldFocus } from "./automation-focus.js";
 import { BaseAutomationEditor } from "./base-editor.js";
@@ -68,23 +67,12 @@ export class ESPHomeAutomationEditor extends BaseAutomationEditor<AutomationLoca
    *  resets to collapsed, matching the component-editor UX. */
   @state() private _showAdvanced = false;
 
-  /**
-   * Derived: edit-mode = not add-mode. Snapshot taken in
-   * ``connectedCallback`` so hydrate doesn't flip it back.
-   */
-  @state() private _editMode = false;
-
   /** Parse ``substitutions:`` from the current YAML once per edit so the
    *  read-only Target field can preview ${...} like the text fields do. */
   private _parseSubstitutions = memoizeOne(parseSubstitutions);
 
   connectedCallback(): void {
     super.connectedCallback();
-    // Snapshot the add-vs-edit context once at mount so subsequent
-    // property changes (the hydrate-from-backend cycle fills value
-    // and re-pins location) don't accidentally unlock the picker
-    // after it should stay locked.
-    this._editMode = !this.addMode;
     // ``_loadAvailable`` fires from ``updated()`` on the first
     // render once ``configuration`` lands — no separate kickoff
     // here, otherwise we'd send two ``automations/get_available``
@@ -119,41 +107,6 @@ export class ESPHomeAutomationEditor extends BaseAutomationEditor<AutomationLoca
       this.board?.id
     );
     if (entry) this._intervalComponent = entry;
-  }
-
-  /**
-   * When the editor is mounted in edit mode (a navigator click
-   * landed us here with a ``location`` but no ``value``), pull the
-   * parsed automation list and match by stable section key. This
-   * keeps the editor self-contained — the parent only needs to
-   * pass the section key's location.
-   */
-  protected async _hydrateFromBackend() {
-    if (!this._api || !this.configuration || !this.location) return;
-    try {
-      // Pass ``this.yaml`` so the parser sees the user's current
-      // draft buffer — without it the post-add hydrate would read
-      // the on-disk YAML, miss the just-inserted automation, and
-      // leave the form empty even though the YAML pane shows the
-      // user's input.
-      const parsed = await this._api.parseDeviceAutomations(
-        this.configuration,
-        this.yaml
-      );
-      // A successful parse clears any prior parse error, so the banner
-      // doesn't stick after the user fixes invalid YAML in the pane.
-      this._error = "";
-      // Re-pin location to the parser's canonical form (script id
-      // matched, light_effect index resolved against the actual YAML);
-      // the controller withholds a read-only automation's empty tree.
-      const m = this._parseError.resolve(parsed, this.location);
-      if (m) {
-        this.location = m.location;
-        this.value = m.tree;
-      }
-    } catch (err) {
-      this._error = formatApiError(err, this._localize, "device.automation_parse_error");
-    }
   }
 
   protected async _loadAvailable() {

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -26,40 +26,24 @@
  * the post-reconnect re-parse path can short-circuit while a write
  * is outstanding.
  */
-import { consume } from "@lit/context";
-import { html, LitElement, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 
-import type { ESPHomeAPI } from "../../../api/index.js";
 import type {
   AutomationLocation,
   AutomationTree,
   AutomationTrigger,
-  AvailableAutomations,
   AvailableComponentInstance,
   AvailableScript,
 } from "../../../api/types/automations.js";
-import type { BoardCatalogEntry } from "../../../api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../../api/types/components.js";
-import type { LocalizeFunc } from "../../../common/localize.js";
-import { apiContext, localizeContext } from "../../../context/index.js";
-import { inputStyles } from "../../../styles/inputs.js";
-import { espHomeStyles } from "../../../styles/shared.js";
 import { automationHeaderTitle } from "../../../util/automation-header-title.js";
 import { formatApiError } from "../../../util/format-api-error.js";
 import { parseSubstitutions } from "../../../util/substitutions.js";
-import { AutoApplyController } from "./auto-apply-controller.js";
-import { automationEditorStyles } from "./automation-editor.styles.js";
-import {
-  actionsFocus,
-  createFocusResolver,
-  entryFieldFocus,
-  type YamlPathSegment,
-} from "./automation-focus.js";
-import { CatalogLoadController } from "./catalog-load-controller.js";
+import { actionsFocus, entryFieldFocus } from "./automation-focus.js";
+import { BaseAutomationEditor } from "./base-editor.js";
 import { loadIntervalComponent } from "./load-interval-component.js";
-import { ParseErrorController } from "./parse-error-controller.js";
 import { renderAutomationHeader } from "./render-automation-header.js";
 import {
   renderActionsSection,
@@ -67,7 +51,6 @@ import {
   renderIdentityFields,
   renderTriggerParamsForm,
 } from "./render-automation-sections.js";
-import { renderDeleteRow } from "./render-delete-row.js";
 import {
   applyParamChange,
   emptyAutomationTree,
@@ -78,54 +61,7 @@ import { bareTriggerKey, effectiveTriggerIdFor } from "./trigger-identity.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 
 @customElement("esphome-automation-editor")
-export class ESPHomeAutomationEditor extends LitElement {
-  @consume({ context: localizeContext, subscribe: true })
-  @state()
-  private _localize: LocalizeFunc = (key) => key;
-
-  @consume({ context: apiContext })
-  private _api!: ESPHomeAPI;
-
-  @property() configuration = "";
-
-  @property({ attribute: false })
-  board: BoardCatalogEntry | null = null;
-
-  @property() platform = "";
-
-  @property({ attribute: false })
-  value: AutomationTree | null = null;
-
-  @property({ attribute: false })
-  location: AutomationLocation | null = null;
-
-  /**
-   * True when the editor is mounted from the "+ Add automation" /
-   * "+ Add script" entry point. Add-mode lets the user pick / edit
-   * the target (kind + component / script id); edit-mode locks the
-   * target picker (changing it would move the YAML splice to a
-   * different range, which we don't support inline).
-   *
-   * The add-dialog passes a seed ``location`` (so the editor knows
-   * which target kind to render) AND sets ``addMode``, which is
-   * what we'd otherwise have to infer racily.
-   */
-  @property({ type: Boolean, attribute: "add-mode" })
-  addMode = false;
-
-  @property() yaml = "";
-
-  /** Document-absolute indexed key path at the YAML cursor; resolved
-   *  against the hydrated tree to scroll/highlight the matching node
-   *  or field. Ignored when it doesn't land inside this automation. */
-  @property({ attribute: false })
-  focusYamlPath?: YamlPathSegment[];
-
-  /** Scoped catalog response. Trigger / action / condition lists
-   *  come from here (the backend filters to what's actually in the
-   *  device's YAML) so the dropdowns only show what's usable. */
-  @state() private _available: AvailableAutomations | null = null;
-
+export class ESPHomeAutomationEditor extends BaseAutomationEditor<AutomationLocation> {
   /** Component catalog entry for the ``interval`` component, lazily
    *  fetched the first time we render an interval automation. Drives
    *  the header (name / description / docs / image) and the inline
@@ -133,40 +69,11 @@ export class ESPHomeAutomationEditor extends LitElement {
    *  live in a dead "Target #N" readonly box). */
   @state() private _intervalComponent: ComponentCatalogEntry | null = null;
 
-  @state() private _loading = true;
-  @state() private _error = "";
-  /** Renders read-only + blocks auto-apply for a parse-errored
-   *  automation so its empty tree can't overwrite the real YAML. */
-  private readonly _parseError = new ParseErrorController(this);
-
-  /** Owns the catalog-load concurrency guard (sequence token +
-   *  host-disconnect invalidation) so an overlapping load can't
-   *  clobber ``_available``, paint a stale slim catalog, or
-   *  double-fire the partial-hydration toast. Shared with the
-   *  trigger-less editors (script, api-action). */
-  private readonly _catalogLoad = new CatalogLoadController(this);
-
   /** "Show advanced settings" toggle state for the params form.
    *  Mirrors ``device-section-config``'s same-named state but
    *  scoped to this editor instance — switching away and back
    *  resets to collapsed, matching the component-editor UX. */
   @state() private _showAdvanced = false;
-
-  /** Shared auto-apply / delete / dirty-tracking engine — same
-   *  instance shape as the script and api-action editors so the
-   *  page-level save guard can treat all three uniformly. */
-  private readonly _engine = new AutoApplyController(this, {
-    getApi: () => this._api,
-    getLocalize: () => this._localize,
-    isReadOnly: () => this._parseError.active,
-    setError: (message) => {
-      this._error = message;
-    },
-  });
-
-  public get dirty(): boolean {
-    return this._engine.dirty;
-  }
 
   /**
    * Derived: edit-mode = not add-mode. Snapshot taken in
@@ -174,19 +81,9 @@ export class ESPHomeAutomationEditor extends LitElement {
    */
   @state() private _editMode = false;
 
-  /** In-flight write guard — parents that re-fetch on reconnect
-   *  should consult this to skip clobbering an optimistic update. */
-  public get inFlightWrite(): boolean {
-    return this._engine.inFlightWrite;
-  }
-
   /** Parse ``substitutions:`` from the current YAML once per edit so the
    *  read-only Target field can preview ${...} like the text fields do. */
   private _parseSubstitutions = memoizeOne(parseSubstitutions);
-
-  private _resolveFocus = createFocusResolver();
-
-  static styles = [espHomeStyles, inputStyles, automationEditorStyles];
 
   connectedCallback(): void {
     super.connectedCallback();
@@ -444,19 +341,12 @@ export class ESPHomeAutomationEditor extends LitElement {
         focusTarget: actionsFocus(focus),
         onActionsChange: this._onActionsChange,
       })}
-      ${this._error ? html`<p class="ae-error" role="alert">${this._error}</p>` : nothing}
-      ${
-        this.location && this.value && !this.addMode
-          ? renderDeleteRow({
-              label: this._localize("device.delete_automation"),
-              message: this._localize("device.confirm_delete_automation", {
-                name: this._deleteTargetName(activeTrigger),
-              }),
-              disabled,
-              onConfirm: this._onDelete,
-            })
-          : nothing
-      }
+      ${this.renderFooter({
+        label: this._localize("device.delete_automation"),
+        message: this._localize("device.confirm_delete_automation", {
+          name: this._deleteTargetName(activeTrigger),
+        }),
+      })}
     `;
   }
 
@@ -477,16 +367,6 @@ export class ESPHomeAutomationEditor extends LitElement {
   };
 
   // ─── State mutations ─────────────────────────────────────────
-
-  /**
-   * Force a pending debounced auto-apply to flush immediately.
-   * The device page calls this on the active section before its
-   * global save so the YAML buffer is fully caught up with the
-   * editor state.
-   */
-  public flushPending(): Promise<void> {
-    return this._engine.flushPending();
-  }
 
   private _onTargetChange = (e: CustomEvent<{ target: AutomationLocation | null }>) => {
     e.stopPropagation();
@@ -546,10 +426,6 @@ export class ESPHomeAutomationEditor extends LitElement {
     }
     return automationHeaderTitle(location, activeTrigger, this._localize);
   }
-
-  private _onDelete = () => {
-    void this._engine.delete();
-  };
 
   /** Filter declaration for the action buttons (referenced from
    *  the inline styles to keep the editor.styles file generic). */

--- a/src/components/device/automation-editor/base-editor.ts
+++ b/src/components/device/automation-editor/base-editor.ts
@@ -6,7 +6,7 @@
  * render and lifecycle (hydrate, catalog lists, headers).
  */
 import { consume } from "@lit/context";
-import { html, LitElement, nothing } from "lit";
+import { type CSSResultGroup, html, LitElement, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 
 import type { ESPHomeAPI } from "../../../api/index.js";
@@ -124,7 +124,7 @@ export abstract class BaseAutomationEditor<
     return this._engine.flushPending();
   }
 
-  static styles = [espHomeStyles, inputStyles, automationEditorStyles];
+  static styles: CSSResultGroup = [espHomeStyles, inputStyles, automationEditorStyles];
 
   /** Inline error line + the confirm-gated delete footer. The
    *  message factory receives the non-null ``location`` so callers

--- a/src/components/device/automation-editor/base-editor.ts
+++ b/src/components/device/automation-editor/base-editor.ts
@@ -1,0 +1,138 @@
+/**
+ * Shared base for the three automation-section editors (automation,
+ * script, api-action): the common public props, context consumers,
+ * the parse-error / catalog-load / auto-apply controllers, and the
+ * error + confirm-gated delete footer. Subclasses own their body
+ * render and lifecycle (hydrate, catalog lists, headers).
+ */
+import { consume } from "@lit/context";
+import { html, LitElement, nothing } from "lit";
+import { property, state } from "lit/decorators.js";
+
+import type { ESPHomeAPI } from "../../../api/index.js";
+import type {
+  AutomationLocation,
+  AutomationTree,
+  AvailableAutomations,
+} from "../../../api/types/automations.js";
+import type { BoardCatalogEntry } from "../../../api/types/boards.js";
+import type { LocalizeFunc } from "../../../common/localize.js";
+import { apiContext, localizeContext } from "../../../context/index.js";
+import { inputStyles } from "../../../styles/inputs.js";
+import { espHomeStyles } from "../../../styles/shared.js";
+import { AutoApplyController } from "./auto-apply-controller.js";
+import { automationEditorStyles } from "./automation-editor.styles.js";
+import { createFocusResolver, type YamlPathSegment } from "./automation-focus.js";
+import { CatalogLoadController } from "./catalog-load-controller.js";
+import { ParseErrorController } from "./parse-error-controller.js";
+import { renderDeleteRow } from "./render-delete-row.js";
+
+export abstract class BaseAutomationEditor<
+  L extends AutomationLocation,
+> extends LitElement {
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  protected _localize: LocalizeFunc = (key) => key;
+
+  @consume({ context: apiContext })
+  protected _api!: ESPHomeAPI;
+
+  @property() configuration = "";
+
+  @property({ attribute: false })
+  board: BoardCatalogEntry | null = null;
+
+  @property() platform = "";
+
+  @property({ attribute: false })
+  value: AutomationTree | null = null;
+
+  @property({ attribute: false })
+  location: L | null = null;
+
+  /** True when mounted from an add entry point; edit-mode locks the
+   *  identity the wizard collected. */
+  @property({ type: Boolean, attribute: "add-mode" })
+  addMode = false;
+
+  @property() yaml = "";
+
+  /** Indexed key path at the YAML cursor; resolved against the
+   *  hydrated tree to scroll/highlight the matching node or field. */
+  @property({ attribute: false })
+  focusYamlPath?: YamlPathSegment[];
+
+  /** Scoped catalog response — the backend filters to what the
+   *  device's YAML can actually use. */
+  @state() protected _available: AvailableAutomations | null = null;
+
+  @state() protected _loading = true;
+  @state() protected _error = "";
+
+  protected _resolveFocus = createFocusResolver();
+
+  /** Renders read-only + blocks auto-apply for a parse-errored
+   *  section so its empty tree can't overwrite the real YAML. */
+  protected readonly _parseError = new ParseErrorController(this);
+
+  /** Owns the catalog-load concurrency guard so overlapping loads
+   *  can't clobber ``_available`` or double-fire the toast. */
+  protected readonly _catalogLoad = new CatalogLoadController(this);
+
+  /** Per-editor upsert guard (a script can't upsert with an empty
+   *  ``id``, an api action with an empty ``action_name``). */
+  protected _canApply?: (location: AutomationLocation) => boolean;
+
+  /** Shared auto-apply / delete / dirty-tracking engine — one
+   *  instance shape so the page-level save guard treats all three
+   *  editors uniformly. */
+  protected readonly _engine = new AutoApplyController(this, {
+    getApi: () => this._api,
+    getLocalize: () => this._localize,
+    isReadOnly: () => this._parseError.active,
+    canApply: (location) => this._canApply?.(location) ?? true,
+    setError: (message) => {
+      this._error = message;
+    },
+  });
+
+  public get dirty(): boolean {
+    return this._engine.dirty;
+  }
+
+  /** In-flight write guard — parents that re-fetch on reconnect
+   *  consult this to skip clobbering an optimistic update. */
+  public get inFlightWrite(): boolean {
+    return this._engine.inFlightWrite;
+  }
+
+  /**
+   * Force a pending debounced auto-apply to flush immediately.
+   * The device page calls this on the active section before its
+   * global save so the YAML buffer is fully caught up.
+   */
+  public flushPending(): Promise<void> {
+    return this._engine.flushPending();
+  }
+
+  static styles = [espHomeStyles, inputStyles, automationEditorStyles];
+
+  /** Inline error line + the confirm-gated delete footer. */
+  protected renderFooter(deleteOpts: { label: string; message: string }) {
+    return html`${
+      this._error ? html`<p class="ae-error" role="alert">${this._error}</p>` : nothing
+    }${
+      this.location && this.value && !this.addMode
+        ? renderDeleteRow({
+            ...deleteOpts,
+            disabled: this._engine.deleting,
+            onConfirm: this._onDelete,
+          })
+        : nothing
+    }`;
+  }
+
+  protected _onDelete = () => {
+    void this._engine.delete();
+  };
+}

--- a/src/components/device/automation-editor/base-editor.ts
+++ b/src/components/device/automation-editor/base-editor.ts
@@ -17,6 +17,7 @@ import type {
 } from "../../../api/types/automations.js";
 import type { BoardCatalogEntry } from "../../../api/types/boards.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
+import { formatApiError } from "../../../util/format-api-error.js";
 import { apiContext, localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
@@ -165,16 +166,42 @@ export abstract class BaseAutomationEditor<
     }`;
   }
 
-  /** Identity compared on navigator swaps — a different one means
-   *  the reused element's ``value`` is stale. The section key
-   *  already discriminates every location kind. */
-  protected _identityOf(location: L): string {
-    return sectionKeyFromLocation(location);
-  }
+  /** Section kind forwarded to the parse-error resolve; editors
+   *  spanning multiple kinds (the automation editor) leave it
+   *  unset. */
+  protected _sectionKind?: L["kind"];
 
+  /** Implementers own the ``_loading = false`` transition (directly
+   *  or via ``CallableAutomationEditor._load``), or the editor
+   *  sticks on the spinner forever. */
   protected abstract _loadAvailable(): Promise<void>;
 
-  protected abstract _hydrateFromBackend(): Promise<void>;
+  protected async _hydrateFromBackend() {
+    if (!this._api || !this.configuration || !this.location) return;
+    try {
+      // Pass ``this.yaml`` so the parser sees the user's current
+      // draft buffer — without it the post-add hydrate would read
+      // the on-disk YAML, miss the just-inserted section, and
+      // leave the form empty even though the YAML pane shows the
+      // user's input.
+      const parsed = await this._api.parseDeviceAutomations(
+        this.configuration,
+        this.yaml
+      );
+      // A successful parse clears any prior parse error, so the banner
+      // doesn't stick after the user fixes invalid YAML in the pane.
+      this._error = "";
+      // Re-pin location to the parser's canonical form; the
+      // controller withholds a read-only section's empty tree.
+      const m = this._parseError.resolve(parsed, this.location, this._sectionKind);
+      if (m) {
+        this.location = m.location;
+        this.value = m.tree;
+      }
+    } catch (err) {
+      this._error = formatApiError(err, this._localize, "device.automation_parse_error");
+    }
+  }
 
   protected updated(changed: Map<string, unknown>) {
     if (changed.has("configuration")) {
@@ -189,7 +216,7 @@ export abstract class BaseAutomationEditor<
       if (
         prev &&
         this.location &&
-        this._identityOf(prev) !== this._identityOf(this.location)
+        sectionKeyFromLocation(prev) !== sectionKeyFromLocation(this.location)
       ) {
         this.value = null;
       }

--- a/src/components/device/automation-editor/base-editor.ts
+++ b/src/components/device/automation-editor/base-editor.ts
@@ -50,15 +50,22 @@ export abstract class BaseAutomationEditor<
   @property({ attribute: false })
   location: L | null = null;
 
-  /** True when mounted from an add entry point; edit-mode locks the
-   *  identity the wizard collected. */
+  /**
+   * True when mounted from an add entry point (the add-automation /
+   * add-script / add-api-action dialogs). Edit-mode locks the
+   * section's identity — changing it would move the YAML splice to
+   * a different range, which isn't supported inline. The add dialog
+   * passes a seed ``location`` alongside this flag, which we'd
+   * otherwise have to infer racily.
+   */
   @property({ type: Boolean, attribute: "add-mode" })
   addMode = false;
 
   @property() yaml = "";
 
-  /** Indexed key path at the YAML cursor; resolved against the
-   *  hydrated tree to scroll/highlight the matching node or field. */
+  /** Document-absolute indexed key path at the YAML cursor; resolved
+   *  against the hydrated tree to scroll/highlight the matching node
+   *  or field. Ignored when it doesn't land inside this section. */
   @property({ attribute: false })
   focusYamlPath?: YamlPathSegment[];
 
@@ -81,7 +88,9 @@ export abstract class BaseAutomationEditor<
 
   /** Per-editor upsert guard (a script can't upsert with an empty
    *  ``id``, an api action with an empty ``action_name``). */
-  protected _canApply?: (location: AutomationLocation) => boolean;
+  protected _canApply(_location: AutomationLocation): boolean {
+    return true;
+  }
 
   /** Shared auto-apply / delete / dirty-tracking engine — one
    *  instance shape so the page-level save guard treats all three
@@ -90,7 +99,7 @@ export abstract class BaseAutomationEditor<
     getApi: () => this._api,
     getLocalize: () => this._localize,
     isReadOnly: () => this._parseError.active,
-    canApply: (location) => this._canApply?.(location) ?? true,
+    canApply: (location) => this._canApply(location),
     setError: (message) => {
       this._error = message;
     },
@@ -117,14 +126,20 @@ export abstract class BaseAutomationEditor<
 
   static styles = [espHomeStyles, inputStyles, automationEditorStyles];
 
-  /** Inline error line + the confirm-gated delete footer. */
-  protected renderFooter(deleteOpts: { label: string; message: string }) {
+  /** Inline error line + the confirm-gated delete footer. The
+   *  message factory receives the non-null ``location`` so callers
+   *  build it inside the narrowing. */
+  protected renderFooter(deleteOpts: {
+    label: string;
+    message: (location: L) => string;
+  }) {
     return html`${
       this._error ? html`<p class="ae-error" role="alert">${this._error}</p>` : nothing
     }${
       this.location && this.value && !this.addMode
         ? renderDeleteRow({
-            ...deleteOpts,
+            label: deleteOpts.label,
+            message: deleteOpts.message(this.location),
             disabled: this._engine.deleting,
             onConfirm: this._onDelete,
           })

--- a/src/components/device/automation-editor/base-editor.ts
+++ b/src/components/device/automation-editor/base-editor.ts
@@ -166,11 +166,6 @@ export abstract class BaseAutomationEditor<
     }`;
   }
 
-  /** Section kind forwarded to the parse-error resolve; editors
-   *  spanning multiple kinds (the automation editor) leave it
-   *  unset. */
-  protected _sectionKind?: L["kind"];
-
   /** Implementers own the ``_loading = false`` transition (directly
    *  or via ``CallableAutomationEditor._load``), or the editor
    *  sticks on the spinner forever. */
@@ -193,7 +188,7 @@ export abstract class BaseAutomationEditor<
       this._error = "";
       // Re-pin location to the parser's canonical form; the
       // controller withholds a read-only section's empty tree.
-      const m = this._parseError.resolve(parsed, this.location, this._sectionKind);
+      const m = this._parseError.resolve(parsed, this.location);
       if (m) {
         this.location = m.location;
         this.value = m.tree;

--- a/src/components/device/automation-editor/base-editor.ts
+++ b/src/components/device/automation-editor/base-editor.ts
@@ -27,6 +27,8 @@ import { CatalogLoadController } from "./catalog-load-controller.js";
 import { ParseErrorController } from "./parse-error-controller.js";
 import { renderDeleteRow } from "./render-delete-row.js";
 
+import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
+
 export abstract class BaseAutomationEditor<
   L extends AutomationLocation,
 > extends LitElement {
@@ -126,6 +128,21 @@ export abstract class BaseAutomationEditor<
 
   static styles: CSSResultGroup = [espHomeStyles, inputStyles, automationEditorStyles];
 
+  /** Loading spinner / parse-error panel that preempts the body
+   *  render, or ``null`` once the editor is ready to paint. */
+  protected renderStateGate() {
+    if (this._loading) {
+      return html`<div class="ae-empty">
+        <wa-spinner></wa-spinner>
+        ${this._localize("device.loading_automation_catalog")}
+      </div>`;
+    }
+    if (this._parseError.active) {
+      return this._parseError.renderPanel(this._localize);
+    }
+    return null;
+  }
+
   /** Inline error line + the confirm-gated delete footer. The
    *  message factory receives the non-null ``location`` so callers
    *  build it inside the narrowing. */
@@ -149,5 +166,12 @@ export abstract class BaseAutomationEditor<
 
   protected _onDelete = () => {
     void this._engine.delete();
+  };
+
+  protected _onActionsChange = (
+    e: CustomEvent<{ actions: AutomationTree["actions"] }>
+  ) => {
+    e.stopPropagation();
+    this._engine.withValue({ actions: e.detail.actions });
   };
 }

--- a/src/components/device/automation-editor/base-editor.ts
+++ b/src/components/device/automation-editor/base-editor.ts
@@ -26,6 +26,7 @@ import { createFocusResolver, type YamlPathSegment } from "./automation-focus.js
 import { CatalogLoadController } from "./catalog-load-controller.js";
 import { ParseErrorController } from "./parse-error-controller.js";
 import { renderDeleteRow } from "./render-delete-row.js";
+import { sectionKeyFromLocation } from "./serialise.js";
 
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 
@@ -162,6 +163,66 @@ export abstract class BaseAutomationEditor<
           })
         : nothing
     }`;
+  }
+
+  /** Identity compared on navigator swaps — a different one means
+   *  the reused element's ``value`` is stale. The section key
+   *  already discriminates every location kind. */
+  protected _identityOf(location: L): string {
+    return sectionKeyFromLocation(location);
+  }
+
+  protected abstract _loadAvailable(): Promise<void>;
+
+  protected abstract _hydrateFromBackend(): Promise<void>;
+
+  protected updated(changed: Map<string, unknown>) {
+    if (changed.has("configuration")) {
+      void this._loadAvailable();
+    }
+    // Navigator-driven location swap: when the parent passes in a
+    // different ``location`` (user clicked a sibling section), the
+    // editor element is reused — its previous ``value`` is stale.
+    // Invalidate it so the hydrate path below re-fetches.
+    if (changed.has("location") && !this.addMode) {
+      const prev = changed.get("location") as L | null | undefined;
+      if (
+        prev &&
+        this.location &&
+        this._identityOf(prev) !== this._identityOf(this.location)
+      ) {
+        this.value = null;
+      }
+    }
+    // Hydrate from the backend in edit-mode: mounted with a known
+    // location but no value. Triggering on ``_loading`` covers the
+    // common case where the location was already set at mount — the
+    // first change fires while ``_loading=true``, so re-check after
+    // catalogs finish loading rather than waiting for another
+    // location mutation that may never come.
+    if (
+      !this.addMode &&
+      (changed.has("location") ||
+        changed.has("configuration") ||
+        changed.has("_loading")) &&
+      this.location &&
+      this.value === null &&
+      !this._loading
+    ) {
+      void this._hydrateFromBackend();
+    }
+  }
+
+  /**
+   * Re-hydrate from the live YAML. Called by the parent
+   * (``device-board-info``) when the YAML pane changes the document
+   * out from under us — mirrors the device-section-config reload
+   * pattern so editing YAML in the pane updates the visual editor.
+   */
+  public reload(): void {
+    if (this.addMode || !this.location) return;
+    if (this._engine.shouldSkipReload()) return;
+    void this._hydrateFromBackend();
   }
 
   protected _onDelete = () => {

--- a/src/components/device/automation-editor/callable-editor.ts
+++ b/src/components/device/automation-editor/callable-editor.ts
@@ -1,0 +1,118 @@
+/**
+ * Intermediate base for the two trigger-less (callable) editors —
+ * script and api-action. Owns the shared lifecycle the automation
+ * editor diverges from: the mount-time catalog load, the
+ * navigator-swap invalidation, the backend hydrate, and reload.
+ */
+import type { AutomationLocation } from "../../../api/types/automations.js";
+import { getErrorMessage } from "../../../util/error-message.js";
+import { formatApiError } from "../../../util/format-api-error.js";
+import { BaseAutomationEditor } from "./base-editor.js";
+
+export abstract class CallableAutomationEditor<
+  L extends AutomationLocation,
+> extends BaseAutomationEditor<L> {
+  /** Section kind forwarded to the parse-error resolve. */
+  protected abstract readonly _sectionKind: L["kind"];
+
+  /** Identity compared on navigator swaps — a different one means
+   *  the reused element's ``value`` is stale. */
+  protected abstract _identityOf(location: L): string;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    void this._load();
+  }
+
+  protected updated(changed: Map<string, unknown>) {
+    if (changed.has("configuration")) {
+      void this._loadAvailable();
+    }
+    // Navigator-driven location swap (user clicked a different
+    // section in the navigator) — invalidate the stale value so
+    // the hydrate path below re-fetches.
+    if (changed.has("location") && !this.addMode) {
+      const prev = changed.get("location") as L | null | undefined;
+      if (
+        prev &&
+        this.location &&
+        this._identityOf(prev) !== this._identityOf(this.location)
+      ) {
+        this.value = null;
+      }
+    }
+    if (
+      !this.addMode &&
+      (changed.has("location") ||
+        changed.has("configuration") ||
+        changed.has("_loading")) &&
+      this.location &&
+      this.value === null &&
+      !this._loading
+    ) {
+      void this._hydrateFromBackend();
+    }
+  }
+
+  /**
+   * Re-hydrate from the live YAML. Called by the parent
+   * (``device-board-info``) when the YAML pane changes the document
+   * out from under us — mirrors device-section-config.reload() and
+   * automation-editor.reload() so editing YAML in the pane updates
+   * the visual editor.
+   */
+  public reload(): void {
+    if (this.addMode || !this.location) return;
+    if (this._engine.shouldSkipReload()) return;
+    void this._hydrateFromBackend();
+  }
+
+  protected async _load() {
+    if (!this._api) return;
+    this._loading = true;
+    this._error = "";
+    try {
+      if (this.configuration) await this._loadAvailable();
+    } catch (err) {
+      this._error = getErrorMessage(err);
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  protected async _loadAvailable() {
+    // Hydrates config_entries (the slim catalog omits them); without
+    // it every action renders fieldless since the node bails on an
+    // empty config_entries list.
+    this._error = "";
+    const { available, error } = await this._catalogLoad.load(
+      this._api,
+      this.configuration,
+      this._localize
+    );
+    if (error !== undefined) this._error = error;
+    if (available) this._available = available;
+  }
+
+  protected async _hydrateFromBackend() {
+    if (!this._api || !this.configuration || !this.location) return;
+    try {
+      // ``this.yaml`` override mirrors the automation-editor's
+      // hydrate path: post-add the user's draft buffer holds the
+      // new section, but the on-disk YAML doesn't yet. Without the
+      // override the parse returns the stale on-disk state and the
+      // form lands empty.
+      const parsed = await this._api.parseDeviceAutomations(
+        this.configuration,
+        this.yaml
+      );
+      const m = this._parseError.resolve(parsed, this.location, this._sectionKind);
+      if (m) {
+        this.location = m.location;
+        this.value = m.tree;
+      }
+    } catch (err) {
+      this._error = formatApiError(err, this._localize, "device.automation_parse_error");
+    }
+  }
+}

--- a/src/components/device/automation-editor/callable-editor.ts
+++ b/src/components/device/automation-editor/callable-editor.ts
@@ -1,19 +1,15 @@
 /**
  * Intermediate base for the two trigger-less (callable) editors —
- * script and api-action. Owns the mount-time catalog load and the
- * shared hydrate the automation editor diverges from.
+ * script and api-action. Owns the mount-time catalog load the
+ * automation editor diverges from.
  */
 import type { AutomationLocation } from "../../../api/types/automations.js";
 import { getErrorMessage } from "../../../util/error-message.js";
-import { formatApiError } from "../../../util/format-api-error.js";
 import { BaseAutomationEditor } from "./base-editor.js";
 
 export abstract class CallableAutomationEditor<
   L extends AutomationLocation,
 > extends BaseAutomationEditor<L> {
-  /** Section kind forwarded to the parse-error resolve. */
-  protected abstract readonly _sectionKind: L["kind"];
-
   connectedCallback(): void {
     super.connectedCallback();
     void this._load();
@@ -44,27 +40,5 @@ export abstract class CallableAutomationEditor<
     );
     if (error !== undefined) this._error = error;
     if (available) this._available = available;
-  }
-
-  protected async _hydrateFromBackend() {
-    if (!this._api || !this.configuration || !this.location) return;
-    try {
-      // ``this.yaml`` override mirrors the automation-editor's
-      // hydrate path: post-add the user's draft buffer holds the
-      // new section, but the on-disk YAML doesn't yet. Without the
-      // override the parse returns the stale on-disk state and the
-      // form lands empty.
-      const parsed = await this._api.parseDeviceAutomations(
-        this.configuration,
-        this.yaml
-      );
-      const m = this._parseError.resolve(parsed, this.location, this._sectionKind);
-      if (m) {
-        this.location = m.location;
-        this.value = m.tree;
-      }
-    } catch (err) {
-      this._error = formatApiError(err, this._localize, "device.automation_parse_error");
-    }
   }
 }

--- a/src/components/device/automation-editor/callable-editor.ts
+++ b/src/components/device/automation-editor/callable-editor.ts
@@ -1,8 +1,7 @@
 /**
  * Intermediate base for the two trigger-less (callable) editors —
- * script and api-action. Owns the shared lifecycle the automation
- * editor diverges from: the mount-time catalog load, the
- * navigator-swap invalidation, the backend hydrate, and reload.
+ * script and api-action. Owns the mount-time catalog load and the
+ * shared hydrate the automation editor diverges from.
  */
 import type { AutomationLocation } from "../../../api/types/automations.js";
 import { getErrorMessage } from "../../../util/error-message.js";
@@ -15,56 +14,9 @@ export abstract class CallableAutomationEditor<
   /** Section kind forwarded to the parse-error resolve. */
   protected abstract readonly _sectionKind: L["kind"];
 
-  /** Identity compared on navigator swaps — a different one means
-   *  the reused element's ``value`` is stale. */
-  protected abstract _identityOf(location: L): string;
-
   connectedCallback(): void {
     super.connectedCallback();
     void this._load();
-  }
-
-  protected updated(changed: Map<string, unknown>) {
-    if (changed.has("configuration")) {
-      void this._loadAvailable();
-    }
-    // Navigator-driven location swap (user clicked a different
-    // section in the navigator) — invalidate the stale value so
-    // the hydrate path below re-fetches.
-    if (changed.has("location") && !this.addMode) {
-      const prev = changed.get("location") as L | null | undefined;
-      if (
-        prev &&
-        this.location &&
-        this._identityOf(prev) !== this._identityOf(this.location)
-      ) {
-        this.value = null;
-      }
-    }
-    if (
-      !this.addMode &&
-      (changed.has("location") ||
-        changed.has("configuration") ||
-        changed.has("_loading")) &&
-      this.location &&
-      this.value === null &&
-      !this._loading
-    ) {
-      void this._hydrateFromBackend();
-    }
-  }
-
-  /**
-   * Re-hydrate from the live YAML. Called by the parent
-   * (``device-board-info``) when the YAML pane changes the document
-   * out from under us — mirrors device-section-config.reload() and
-   * automation-editor.reload() so editing YAML in the pane updates
-   * the visual editor.
-   */
-  public reload(): void {
-    if (this.addMode || !this.location) return;
-    if (this._engine.shouldSkipReload()) return;
-    void this._hydrateFromBackend();
   }
 
   protected async _load() {

--- a/src/components/device/automation-editor/render-actions-section.ts
+++ b/src/components/device/automation-editor/render-actions-section.ts
@@ -1,0 +1,58 @@
+/**
+ * The Actions section shared by all three editors: label,
+ * description, and the recursive action list (whose bottom Add
+ * button opens the picker).
+ */
+import { html } from "lit";
+
+import type {
+  AutomationAction,
+  AutomationCondition,
+  AutomationTree,
+  AvailableComponentInstance,
+  AvailableScript,
+} from "../../../api/types/automations.js";
+import type { BoardCatalogEntry } from "../../../api/types/boards.js";
+import type { LocalizeFunc } from "../../../common/localize.js";
+import { renderMarkdown } from "../../../util/markdown.js";
+import "./automation-action-list.js";
+import type { AutomationFocus } from "./automation-focus.js";
+
+export function renderActionsSection(opts: {
+  automation: AutomationTree;
+  catalog: AutomationAction[];
+  conditionCatalog: AutomationCondition[];
+  scripts: AvailableScript[];
+  devices: AvailableComponentInstance[];
+  board: BoardCatalogEntry | null;
+  yaml: string;
+  disabled: boolean;
+  localize: LocalizeFunc;
+  focusTarget?: AutomationFocus | null;
+  descriptionKey?: string;
+  onActionsChange: (e: CustomEvent<{ actions: AutomationTree["actions"] }>) => void;
+}) {
+  return html`
+    <div class="field">
+      <label class="field-label"> ${opts.localize("device.automation_action")} </label>
+      <p class="field-description">
+        ${renderMarkdown(
+          opts.localize(opts.descriptionKey ?? "device.automation_actions_description")
+        )}
+      </p>
+      <esphome-automation-action-list
+        no-header
+        .focusTarget=${opts.focusTarget ?? null}
+        .actions=${opts.automation.actions}
+        .catalog=${opts.catalog}
+        .conditionCatalog=${opts.conditionCatalog}
+        .scripts=${opts.scripts}
+        .devices=${opts.devices}
+        .board=${opts.board}
+        .yaml=${opts.yaml}
+        ?disabled=${opts.disabled}
+        @actions-change=${opts.onActionsChange}
+      ></esphome-automation-action-list>
+    </div>
+  `;
+}

--- a/src/components/device/automation-editor/render-actions-section.ts
+++ b/src/components/device/automation-editor/render-actions-section.ts
@@ -29,16 +29,16 @@ export function renderActionsSection(opts: {
   disabled: boolean;
   localize: LocalizeFunc;
   focusTarget?: AutomationFocus | null;
-  descriptionKey?: string;
+  /** Required so each editor names its own copy — a fallback would
+   *  silently render the automation flavour under a script. */
+  descriptionKey: string;
   onActionsChange: (e: CustomEvent<{ actions: AutomationTree["actions"] }>) => void;
 }) {
   return html`
     <div class="field">
       <label class="field-label"> ${opts.localize("device.automation_action")} </label>
       <p class="field-description">
-        ${renderMarkdown(
-          opts.localize(opts.descriptionKey ?? "device.automation_actions_description")
-        )}
+        ${renderMarkdown(opts.localize(opts.descriptionKey))}
       </p>
       <esphome-automation-action-list
         no-header

--- a/src/components/device/automation-editor/render-automation-sections.ts
+++ b/src/components/device/automation-editor/render-automation-sections.ts
@@ -1,16 +1,14 @@
 /**
  * The automation editor's body sections, as pure render functions
  * (matching ``render-target-field.ts``): the legacy add-mode
- * pickers, the edit-mode trigger-params form, and the actions
- * list section. State stays in ``<esphome-automation-editor>``;
+ * pickers, the edit-mode trigger-params form, and the read-only
+ * identity field. State stays in ``<esphome-automation-editor>``;
  * each section receives values plus the host's stable handler
  * references.
  */
 import { html, nothing } from "lit";
 
 import type {
-  AutomationAction,
-  AutomationCondition,
   AutomationLocation,
   AutomationTree,
   AutomationTrigger,
@@ -20,11 +18,8 @@ import type {
 import type { BoardCatalogEntry } from "../../../api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../../api/types/components.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
-import { renderMarkdown } from "../../../util/markdown.js";
 import { triggerParamFormEntries } from "../../../util/trigger-param-form-entries.js";
 import "../config-entry-form.js";
-import "./automation-action-list.js";
-import type { AutomationFocus } from "./automation-focus.js";
 import "./automation-target-picker.js";
 import "./automation-trigger-picker.js";
 import { renderTargetField } from "./render-target-field.js";
@@ -129,44 +124,6 @@ export function renderTriggerParamsForm(opts: {
       @value-change=${opts.onValueChange}
       @advanced-toggle=${opts.onAdvancedToggle}
     ></esphome-config-entry-form>
-  `;
-}
-
-/** The Actions section: label, description, and the recursive
- *  action list (whose bottom Add button opens the picker). */
-export function renderActionsSection(opts: {
-  automation: AutomationTree;
-  catalog: AutomationAction[];
-  conditionCatalog: AutomationCondition[];
-  scripts: AvailableScript[];
-  devices: AvailableComponentInstance[];
-  board: BoardCatalogEntry | null;
-  yaml: string;
-  disabled: boolean;
-  localize: LocalizeFunc;
-  focusTarget?: AutomationFocus | null;
-  onActionsChange: (e: CustomEvent<{ actions: AutomationTree["actions"] }>) => void;
-}) {
-  return html`
-    <div class="field">
-      <label class="field-label"> ${opts.localize("device.automation_action")} </label>
-      <p class="field-description">
-        ${renderMarkdown(opts.localize("device.automation_actions_description"))}
-      </p>
-      <esphome-automation-action-list
-        no-header
-        .focusTarget=${opts.focusTarget ?? null}
-        .actions=${opts.automation.actions}
-        .catalog=${opts.catalog}
-        .conditionCatalog=${opts.conditionCatalog}
-        .scripts=${opts.scripts}
-        .devices=${opts.devices}
-        .board=${opts.board}
-        .yaml=${opts.yaml}
-        ?disabled=${opts.disabled}
-        @actions-change=${opts.onActionsChange}
-      ></esphome-automation-action-list>
-    </div>
   `;
 }
 

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -34,9 +34,7 @@ import {
   fetchComponent,
   getCachedComponent,
 } from "../../../util/component-name-cache.js";
-import { getErrorMessage } from "../../../util/error-message.js";
 import { normalizeEspHomeId } from "../../../util/esphome-id.js";
-import { formatApiError } from "../../../util/format-api-error.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import "../config-entry-form.js";
@@ -48,7 +46,7 @@ import {
   focusKey,
   paramFocus,
 } from "./automation-focus.js";
-import { BaseAutomationEditor } from "./base-editor.js";
+import { CallableAutomationEditor } from "./callable-editor.js";
 import "./callable-params-editor.js";
 import { applyParamChange, emptyAutomationTree } from "./serialise.js";
 
@@ -68,7 +66,7 @@ registerMdiIcons({
 });
 
 @customElement("esphome-script-editor")
-export class ESPHomeScriptEditor extends BaseAutomationEditor<ScriptLocation> {
+export class ESPHomeScriptEditor extends CallableAutomationEditor<ScriptLocation> {
   /** ``focusKey`` already advanced-revealed — one-shot per target so a
    *  later deliberate collapse sticks. */
   private _paramsRevealKey?: string;
@@ -101,63 +99,16 @@ export class ESPHomeScriptEditor extends BaseAutomationEditor<ScriptLocation> {
     return location.kind === "script" && !!location.id;
   }
 
-  connectedCallback(): void {
-    super.connectedCallback();
-    void this._load();
+  protected readonly _sectionKind = "script" as const;
+
+  protected _identityOf(location: ScriptLocation): string {
+    return location.id;
   }
 
-  protected updated(changed: Map<string, unknown>) {
-    if (changed.has("configuration")) {
-      void this._loadAvailable();
-    }
-    // Navigator-driven location swap (user clicked a different
-    // script in the navigator) — invalidate the stale value so
-    // the hydrate path below re-fetches.
-    if (changed.has("location") && !this.addMode) {
-      const prev = changed.get("location") as ScriptLocation | null | undefined;
-      if (prev && this.location && prev.id !== this.location.id) {
-        this.value = null;
-      }
-    }
-    if (
-      !this.addMode &&
-      (changed.has("location") ||
-        changed.has("configuration") ||
-        changed.has("_loading")) &&
-      this.location &&
-      this.value === null &&
-      !this._loading
-    ) {
-      void this._hydrateFromBackend();
-    }
-  }
-
-  private async _load() {
-    if (!this._api) return;
-    this._loading = true;
-    this._error = "";
-    try {
-      if (this.configuration) await this._loadAvailable();
-      void this._loadScriptComponent();
-    } catch (err) {
-      this._error = getErrorMessage(err);
-    } finally {
-      this._loading = false;
-    }
-  }
-
-  private async _loadAvailable() {
-    // Hydrates config_entries (the slim catalog omits them); without
-    // it every action renders fieldless since the node bails on an
-    // empty config_entries list.
-    this._error = "";
-    const { available, error } = await this._catalogLoad.load(
-      this._api,
-      this.configuration,
-      this._localize
-    );
-    if (error !== undefined) this._error = error;
-    if (available) this._available = available;
+  /** The script-component fetch rides along with the shared load. */
+  protected override async _load() {
+    await super._load();
+    void this._loadScriptComponent();
   }
 
   /** Lazy fetch of the ``script`` component catalog entry. Reuses
@@ -179,41 +130,6 @@ export class ESPHomeScriptEditor extends BaseAutomationEditor<ScriptLocation> {
       /* swallow — the editor falls back to the static label if
          the catalog entry isn't available. */
     }
-  }
-
-  private async _hydrateFromBackend() {
-    if (!this._api || !this.configuration || !this.location) return;
-    try {
-      // ``this.yaml`` override mirrors the automation-editor's
-      // hydrate path: post-add the user's draft buffer holds the
-      // new script, but the on-disk YAML doesn't yet. Without the
-      // override the parse returns the stale on-disk state and the
-      // form lands empty.
-      const parsed = await this._api.parseDeviceAutomations(
-        this.configuration,
-        this.yaml
-      );
-      const m = this._parseError.resolve(parsed, this.location, "script");
-      if (m) {
-        this.location = m.location;
-        this.value = m.tree;
-      }
-    } catch (err) {
-      this._error = formatApiError(err, this._localize, "device.automation_parse_error");
-    }
-  }
-
-  /**
-   * Re-hydrate from the live YAML. Called by the parent
-   * (``device-board-info``) when the YAML pane changes the document
-   * out from under us — mirrors device-section-config.reload() and
-   * automation-editor.reload() so editing YAML in the pane updates
-   * the visual editor.
-   */
-  public reload(): void {
-    if (this.addMode || !this.location) return;
-    if (this._engine.shouldSkipReload()) return;
-    void this._hydrateFromBackend();
   }
 
   protected render() {

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -100,10 +100,6 @@ export class ESPHomeScriptEditor extends CallableAutomationEditor<ScriptLocation
 
   protected readonly _sectionKind = "script" as const;
 
-  protected _identityOf(location: ScriptLocation): string {
-    return location.id;
-  }
-
   /** The script-component fetch rides along with the shared load. */
   protected override async _load() {
     await super._load();

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -97,8 +97,9 @@ export class ESPHomeScriptEditor extends BaseAutomationEditor<ScriptLocation> {
   @state() private _showAdvanced = false;
 
   // Can't upsert a script with no id.
-  protected _canApply = (location: AutomationLocation) =>
-    location.kind === "script" && !!location.id;
+  protected override _canApply(location: AutomationLocation): boolean {
+    return location.kind === "script" && !!location.id;
+  }
 
   connectedCallback(): void {
     super.connectedCallback();
@@ -260,9 +261,8 @@ export class ESPHomeScriptEditor extends BaseAutomationEditor<ScriptLocation> {
       </div>
       ${this.renderFooter({
         label: this._localize("device.delete_script"),
-        message: this._localize("device.confirm_delete_script", {
-          name: this.location?.id ?? "",
-        }),
+        message: (location) =>
+          this._localize("device.confirm_delete_script", { name: location.id }),
       })}
     `;
   }

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -98,8 +98,6 @@ export class ESPHomeScriptEditor extends CallableAutomationEditor<ScriptLocation
     return location.kind === "script" && !!location.id;
   }
 
-  protected readonly _sectionKind = "script" as const;
-
   /** The script-component fetch rides along with the shared load. */
   protected override async _load() {
     await super._load();

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -38,7 +38,6 @@ import { normalizeEspHomeId } from "../../../util/esphome-id.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import "../config-entry-form.js";
-import "./automation-action-list.js";
 import {
   actionsFocus,
   type AutomationFocus,
@@ -47,6 +46,7 @@ import {
   paramFocus,
 } from "./automation-focus.js";
 import { CallableAutomationEditor } from "./callable-editor.js";
+import { renderActionsSection } from "./render-actions-section.js";
 import "./callable-params-editor.js";
 import { applyParamChange, emptyAutomationTree } from "./serialise.js";
 
@@ -58,7 +58,6 @@ type ScriptLocation = Extract<AutomationLocation, { kind: "script" }>;
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/option/option.js";
 import "@home-assistant/webawesome/dist/components/select/select.js";
-import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 
 registerMdiIcons({
   "open-in-new": mdiOpenInNew,
@@ -133,15 +132,8 @@ export class ESPHomeScriptEditor extends CallableAutomationEditor<ScriptLocation
   }
 
   protected render() {
-    if (this._loading) {
-      return html`<div class="ae-empty">
-        <wa-spinner></wa-spinner>
-        ${this._localize("device.loading_automation_catalog")}
-      </div>`;
-    }
-    if (this._parseError.active) {
-      return this._parseError.renderPanel(this._localize);
-    }
+    const gate = this.renderStateGate();
+    if (gate) return gate;
     const automation = this.value ?? emptyAutomationTree();
     const devices = this._available?.devices ?? [];
     const scripts = this._available?.scripts ?? [];
@@ -156,25 +148,20 @@ export class ESPHomeScriptEditor extends CallableAutomationEditor<ScriptLocation
           ? this._renderParametersField(automation, disabled, focus)
           : nothing
       }
-      <div class="field">
-        <label class="field-label"> ${this._localize("device.automation_action")} </label>
-        <p class="field-description">
-          ${renderMarkdown(this._localize("device.script_actions_description"))}
-        </p>
-        <esphome-automation-action-list
-          no-header
-          .focusTarget=${actionsFocus(focus)}
-          .actions=${automation.actions}
-          .catalog=${actions}
-          .conditionCatalog=${conditions}
-          .scripts=${scripts}
-          .devices=${devices}
-          .board=${this.board}
-          .yaml=${this.yaml}
-          ?disabled=${disabled}
-          @actions-change=${this._onActionsChange}
-        ></esphome-automation-action-list>
-      </div>
+      ${renderActionsSection({
+        automation,
+        catalog: actions,
+        conditionCatalog: conditions,
+        scripts,
+        devices,
+        board: this.board,
+        yaml: this.yaml,
+        disabled,
+        localize: this._localize,
+        focusTarget: actionsFocus(focus),
+        descriptionKey: "device.script_actions_description",
+        onActionsChange: this._onActionsChange,
+      })}
       ${this.renderFooter({
         label: this._localize("device.delete_script"),
         message: (location) =>
@@ -344,11 +331,6 @@ export class ESPHomeScriptEditor extends CallableAutomationEditor<ScriptLocation
         parameters: e.detail.value,
       },
     });
-  };
-
-  private _onActionsChange = (e: CustomEvent<{ actions: AutomationTree["actions"] }>) => {
-    e.stopPropagation();
-    this._engine.withValue({ actions: e.detail.actions });
   };
 }
 

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -20,24 +20,16 @@
  *   parent's reconnect handler to skip clobbering an in-flight
  *   write.
  */
-import { consume } from "@lit/context";
 import { mdiOpenInNew, mdiScriptTextOutline } from "@mdi/js";
-import { html, LitElement, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
 
-import type { ESPHomeAPI } from "../../../api/index.js";
 import type {
   AutomationLocation,
   AutomationTree,
-  AvailableAutomations,
 } from "../../../api/types/automations.js";
-import type { BoardCatalogEntry } from "../../../api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../../api/types/components.js";
 import { ESPHOME_DOCS_BASE } from "../../../common/docs.js";
-import type { LocalizeFunc } from "../../../common/localize.js";
-import { apiContext, localizeContext } from "../../../context/index.js";
-import { inputStyles } from "../../../styles/inputs.js";
-import { espHomeStyles } from "../../../styles/shared.js";
 import {
   fetchComponent,
   getCachedComponent,
@@ -48,22 +40,16 @@ import { formatApiError } from "../../../util/format-api-error.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import "../config-entry-form.js";
-import { AutoApplyController } from "./auto-apply-controller.js";
 import "./automation-action-list.js";
-import { automationEditorStyles } from "./automation-editor.styles.js";
 import {
   actionsFocus,
   type AutomationFocus,
-  createFocusResolver,
   entryFieldFocus,
   focusKey,
   paramFocus,
-  type YamlPathSegment,
 } from "./automation-focus.js";
+import { BaseAutomationEditor } from "./base-editor.js";
 import "./callable-params-editor.js";
-import { CatalogLoadController } from "./catalog-load-controller.js";
-import { ParseErrorController } from "./parse-error-controller.js";
-import { renderDeleteRow } from "./render-delete-row.js";
 import { applyParamChange, emptyAutomationTree } from "./serialise.js";
 
 /** ``AutomationLocation`` variant for top-level ``script:`` blocks
@@ -82,41 +68,7 @@ registerMdiIcons({
 });
 
 @customElement("esphome-script-editor")
-export class ESPHomeScriptEditor extends LitElement {
-  @consume({ context: localizeContext, subscribe: true })
-  @state()
-  private _localize: LocalizeFunc = (key) => key;
-
-  @consume({ context: apiContext })
-  private _api!: ESPHomeAPI;
-
-  @property() configuration = "";
-
-  @property({ attribute: false })
-  board: BoardCatalogEntry | null = null;
-
-  @property() platform = "";
-
-  @property({ attribute: false })
-  value: AutomationTree | null = null;
-
-  @property({ attribute: false })
-  location: ScriptLocation | null = null;
-
-  /** True when mounted from the "+ Add script" wizard. Add-mode
-   *  lets the user type the id; edit-mode locks it. */
-  @property({ type: Boolean, attribute: "add-mode" })
-  addMode = false;
-
-  @property() yaml = "";
-
-  /** Indexed key path at the YAML cursor; resolved against the
-   *  hydrated tree to scroll/highlight the matching node or field. */
-  @property({ attribute: false })
-  focusYamlPath?: YamlPathSegment[];
-
-  private _resolveFocus = createFocusResolver();
-
+export class ESPHomeScriptEditor extends BaseAutomationEditor<ScriptLocation> {
   /** ``focusKey`` already advanced-revealed — one-shot per target so a
    *  later deliberate collapse sticks. */
   private _paramsRevealKey?: string;
@@ -131,13 +83,6 @@ export class ESPHomeScriptEditor extends LitElement {
     if (paramFocus(focus, "parameters") !== null) this._showAdvanced = true;
   }
 
-  @state() private _available: AvailableAutomations | null = null;
-  @state() private _loading = true;
-  @state() private _error = "";
-  /** Renders read-only + blocks auto-apply for a parse-errored
-   *  script so its empty tree can't overwrite the real YAML. */
-  private readonly _parseError = new ParseErrorController(this);
-
   /** Component catalog entry for the ``script`` component, lazily
    *  fetched on mount. Drives the header (name / description /
    *  docs / image) and the inline config-entry form (``id``,
@@ -151,34 +96,9 @@ export class ESPHomeScriptEditor extends LitElement {
    *  isn't drowned out by the rarely-used options. */
   @state() private _showAdvanced = false;
 
-  /** Shared auto-apply / delete / dirty-tracking engine — same
-   *  instance shape as the automation and api-action editors so the
-   *  page-level save guard can treat all three uniformly. */
-  private readonly _engine = new AutoApplyController(this, {
-    getApi: () => this._api,
-    getLocalize: () => this._localize,
-    isReadOnly: () => this._parseError.active,
-    // Can't upsert a script with no id.
-    canApply: (location) => location.kind === "script" && !!location.id,
-    setError: (message) => {
-      this._error = message;
-    },
-  });
-
-  /** Catalog loader; owns the concurrency guard so overlapping loads
-   *  (connectedCallback + updated both reaching ``_loadAvailable``)
-   *  can't clobber ``_available`` or double-fire the toast. */
-  private readonly _catalogLoad = new CatalogLoadController(this);
-
-  public get dirty(): boolean {
-    return this._engine.dirty;
-  }
-
-  public get inFlightWrite(): boolean {
-    return this._engine.inFlightWrite;
-  }
-
-  static styles = [espHomeStyles, inputStyles, automationEditorStyles];
+  // Can't upsert a script with no id.
+  protected _canApply = (location: AutomationLocation) =>
+    location.kind === "script" && !!location.id;
 
   connectedCallback(): void {
     super.connectedCallback();
@@ -338,19 +258,12 @@ export class ESPHomeScriptEditor extends LitElement {
           @actions-change=${this._onActionsChange}
         ></esphome-automation-action-list>
       </div>
-      ${this._error ? html`<p class="ae-error" role="alert">${this._error}</p>` : nothing}
-      ${
-        this.location && this.value && !this.addMode
-          ? renderDeleteRow({
-              label: this._localize("device.delete_script"),
-              message: this._localize("device.confirm_delete_script", {
-                name: this.location.id,
-              }),
-              disabled,
-              onConfirm: this._onDelete,
-            })
-          : nothing
-      }
+      ${this.renderFooter({
+        label: this._localize("device.delete_script"),
+        message: this._localize("device.confirm_delete_script", {
+          name: this.location?.id ?? "",
+        }),
+      })}
     `;
   }
 
@@ -520,14 +433,6 @@ export class ESPHomeScriptEditor extends LitElement {
   private _onActionsChange = (e: CustomEvent<{ actions: AutomationTree["actions"] }>) => {
     e.stopPropagation();
     this._engine.withValue({ actions: e.detail.actions });
-  };
-
-  public flushPending(): Promise<void> {
-    return this._engine.flushPending();
-  }
-
-  private _onDelete = () => {
-    void this._engine.delete();
   };
 }
 

--- a/test/components/device/automation-editor/can-apply-wiring.test.ts
+++ b/test/components/device/automation-editor/can-apply-wiring.test.ts
@@ -46,6 +46,7 @@ const slimAvailable = (): AvailableAutomations =>
 const makeApi = () => ({
   getAvailableAutomations: vi.fn().mockResolvedValue(slimAvailable()),
   getAutomationBodies: vi.fn().mockResolvedValue({}),
+  parseDeviceAutomations: vi.fn().mockResolvedValue([]),
   upsertAutomation: vi.fn().mockResolvedValue({
     yaml_diff: { fromLine: 0, toLine: 0, replacement: "" },
   }),
@@ -74,22 +75,25 @@ const CASES: Array<{
   make: () => ESPHomeScriptEditor | ESPHomeApiActionEditor;
   blocked: AutomationLocation;
   allowed: AutomationLocation;
+  sibling: AutomationLocation;
 }> = [
   {
     name: "script editor",
     make: () => new ESPHomeScriptEditor(),
     blocked: { kind: "script", id: "" },
     allowed: { kind: "script", id: "my_script" },
+    sibling: { kind: "script", id: "other_script" },
   },
   {
     name: "api-action editor",
     make: () => new ESPHomeApiActionEditor(),
     blocked: { kind: "api_action", action_name: "" },
     allowed: { kind: "api_action", action_name: "my_action" },
+    sibling: { kind: "api_action", action_name: "other_action" },
   },
 ];
 
-describe.each(CASES)("$name _canApply wiring", ({ make, blocked, allowed }) => {
+describe.each(CASES)("$name _canApply wiring", ({ make, blocked, allowed, sibling }) => {
   it("blocks the upsert while the identity is empty", async () => {
     const api = makeApi();
     await mountAndFlush(make(), api, blocked);
@@ -102,5 +106,19 @@ describe.each(CASES)("$name _canApply wiring", ({ make, blocked, allowed }) => {
     await mountAndFlush(make(), api, allowed);
 
     expect(api.upsertAutomation).toHaveBeenCalled();
+  });
+
+  it("a navigator swap to a sibling invalidates the stale value and re-hydrates", async () => {
+    const api = makeApi();
+    const editor = make();
+    await mountAndFlush(editor, api, allowed);
+    expect(api.parseDeviceAutomations).not.toHaveBeenCalled();
+
+    (editor as any).location = sibling;
+    await editor.updateComplete;
+    await flushMicrotasks(5);
+
+    expect((editor as any).value).toBeNull();
+    expect(api.parseDeviceAutomations).toHaveBeenCalled();
   });
 });

--- a/test/components/device/automation-editor/can-apply-wiring.test.ts
+++ b/test/components/device/automation-editor/can-apply-wiring.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The editors' ``_canApply`` overrides gate the engine's upsert: an
+ * identity-less script / api action never writes, and dropping an
+ * override would silently fall back to the base's permissive default.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-action-list.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/callable-params-editor.js",
+  () => ({})
+);
+vi.mock("../../../../src/components/confirm-dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+
+import type { ESPHomeAPI } from "../../../../src/api/index.js";
+import type {
+  AutomationLocation,
+  AvailableAutomations,
+} from "../../../../src/api/types/automations.js";
+import { ESPHomeApiActionEditor } from "../../../../src/components/device/automation-editor/api-action-editor.js";
+import { ESPHomeScriptEditor } from "../../../../src/components/device/automation-editor/script-editor.js";
+import { flushMicrotasks } from "../../../_dom.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const slimAvailable = (): AvailableAutomations =>
+  ({
+    triggers: [],
+    actions: [],
+    conditions: [],
+    scripts: [],
+    devices: [],
+  }) as unknown as AvailableAutomations;
+
+const makeApi = () => ({
+  getAvailableAutomations: vi.fn().mockResolvedValue(slimAvailable()),
+  getAutomationBodies: vi.fn().mockResolvedValue({}),
+  upsertAutomation: vi.fn().mockResolvedValue({
+    yaml_diff: { fromLine: 0, toLine: 0, replacement: "" },
+  }),
+  updateConfig: vi.fn().mockResolvedValue(undefined),
+});
+
+async function mountAndFlush(
+  editor: ESPHomeScriptEditor | ESPHomeApiActionEditor,
+  api: ReturnType<typeof makeApi>,
+  location: AutomationLocation
+) {
+  (editor as any)._api = api as unknown as ESPHomeAPI;
+  editor.configuration = "device.yaml";
+  (editor as any).location = location;
+  (editor as any).value = { trigger_id: null, trigger_params: {}, actions: [] };
+  document.body.appendChild(editor);
+  await editor.updateComplete;
+  await flushMicrotasks(5);
+  (editor as any)._engine.withValue({ actions: [] });
+  await editor.flushPending();
+  await flushMicrotasks(5);
+}
+
+const CASES: Array<{
+  name: string;
+  make: () => ESPHomeScriptEditor | ESPHomeApiActionEditor;
+  blocked: AutomationLocation;
+  allowed: AutomationLocation;
+}> = [
+  {
+    name: "script editor",
+    make: () => new ESPHomeScriptEditor(),
+    blocked: { kind: "script", id: "" },
+    allowed: { kind: "script", id: "my_script" },
+  },
+  {
+    name: "api-action editor",
+    make: () => new ESPHomeApiActionEditor(),
+    blocked: { kind: "api_action", action_name: "" },
+    allowed: { kind: "api_action", action_name: "my_action" },
+  },
+];
+
+describe.each(CASES)("$name _canApply wiring", ({ make, blocked, allowed }) => {
+  it("blocks the upsert while the identity is empty", async () => {
+    const api = makeApi();
+    await mountAndFlush(make(), api, blocked);
+
+    expect(api.upsertAutomation).not.toHaveBeenCalled();
+  });
+
+  it("upserts once the identity is set", async () => {
+    const api = makeApi();
+    await mountAndFlush(make(), api, allowed);
+
+    expect(api.upsertAutomation).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Behavior free refactor following up the review discussion on #1447: the three automation section editors (automation, script, api action) now share two base classes instead of each carrying its own copy of the same surface. `BaseAutomationEditor` owns the common public props (`configuration`, `board`, `platform`, `value`, `location`, `addMode`, `yaml`, `focusYamlPath`), the localize and api context consumers, the parse error, catalog load, and auto apply controllers, the `dirty` and `inFlightWrite` getters, `flushPending`, the delete and actions-change handlers, the shared styles, the loading and parse error state gate, and the error plus confirm gated delete footer. `CallableAutomationEditor` layers the lifecycle the two trigger-less editors (script, api action) share on top: the mount time catalog load, the navigator swap invalidation, the backend hydrate, and reload, with `_sectionKind` and `_identityOf` hooks for the two genuine variances.

The upsert guard becomes an overridable `_canApply` method (script requires an `id`, api action an `action_name`), `location` stays precisely typed per editor through a generic parameter, and the Actions section render is shared through `renderActionsSection` with a per editor description key. Each editor keeps only its own body render and editor specific lifecycle.

`BaseAutomationEditor` also owns the navigator swap and hydrate lifecycle (`updated`, `reload`, and an `_identityOf` comparator defaulting to the section key), so the automation editor's override only adds its interval component fetch on top.

Net effect is 793 lines removed against 565 added; every file sits well under the size cap (base 265, callable 44, automation 333, script 337, api action 220). No existing test changed; one new test file, can-apply-wiring.test.ts, pins the `_canApply` overrides at the editor level so a dropped override fails the suite instead of silently upserting an identity-less script or api action. One deliberate unification rides along: the shared hydrate now clears a stale parse error banner on every successful re-parse, which the automation editor already did and the other two had drifted from.

**Related issue or feature (if applicable):**

- follow up to https://github.com/esphome/device-builder-frontend/pull/1447#issuecomment-5077030038

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
