### PR TITLE
Unify the action-list add buttons on the dashed quiet style

### DIFF
--- a/src/components/device/automation-editor/automation-editor-actions.styles.ts
+++ b/src/components/device/automation-editor/automation-editor-actions.styles.ts
@@ -16,7 +16,7 @@ export const automationEditorActionStyles = css`
     width: 100%;
     appearance: none;
     border: 1px dashed var(--wa-color-neutral-border-quiet, #d1d5db);
-    background: transparent;
+    background: var(--esphome-primary-light);
     color: var(--wa-color-text-quiet);
     padding: var(--wa-space-xs) var(--wa-space-m);
     border-radius: var(--wa-border-radius-m);

--- a/src/components/device/automation-editor/automation-editor-actions.styles.ts
+++ b/src/components/device/automation-editor/automation-editor-actions.styles.ts
@@ -31,8 +31,8 @@ export const automationEditorActionStyles = css`
   }
 
   .ae-add:hover:not(:disabled) {
-    border-color: var(--wa-color-brand-fill-loud, #0b5cad);
-    color: var(--wa-color-brand-fill-loud, #0b5cad);
+    border-color: var(--wa-color-brand-fill-loud, var(--esphome-primary));
+    color: var(--wa-color-brand-fill-loud, var(--esphome-primary));
     background: transparent;
   }
 

--- a/src/components/device/automation-editor/automation-editor-actions.styles.ts
+++ b/src/components/device/automation-editor/automation-editor-actions.styles.ts
@@ -33,7 +33,6 @@ export const automationEditorActionStyles = css`
   .ae-add:hover:not(:disabled) {
     border-color: var(--wa-color-brand-fill-loud, var(--esphome-primary));
     color: var(--wa-color-brand-fill-loud, var(--esphome-primary));
-    background: transparent;
   }
 
   .ae-add:disabled {

--- a/src/components/device/automation-editor/automation-editor-actions.styles.ts
+++ b/src/components/device/automation-editor/automation-editor-actions.styles.ts
@@ -2,12 +2,12 @@ import { css } from "lit";
 
 /** Add affordances, empty/error states, and the bottom save/delete action bar. */
 export const automationEditorActionStyles = css`
-  /* Add button — used at the bottom of every list. The default is
-     a modest dashed affordance for nested lists (then/else inside
-     an "if"). The top-level list (wrapped in .ae-section) gets
-     the prominent overlay below — that's the primary "Add action"
-     / "Add condition" the user reaches for from a fresh
-     automation, so it should pop. */
+  /* Add button — one dashed quiet affordance at the bottom of every
+     list, top-level and nested alike (#1450); brand color on hover
+     for affordance. Nested lists (via :host-context() reaching the
+     parent action-node's .ae-nested wrapper, the only way a sibling
+     custom-element with its own shadow can scope the rule) only
+     tighten the density. */
   .ae-add {
     display: flex;
     justify-content: center;
@@ -15,13 +15,13 @@ export const automationEditorActionStyles = css`
     gap: var(--wa-space-2xs);
     width: 100%;
     appearance: none;
-    border: 1px solid var(--wa-color-brand-fill-loud, var(--esphome-primary));
-    background: var(--esphome-primary-light);
-    color: var(--wa-color-brand-fill-loud, var(--esphome-primary));
-    padding: var(--wa-space-s) var(--wa-space-m);
+    border: 1px dashed var(--wa-color-neutral-border-quiet, #d1d5db);
+    background: transparent;
+    color: var(--wa-color-text-quiet);
+    padding: var(--wa-space-xs) var(--wa-space-m);
     border-radius: var(--wa-border-radius-m);
     cursor: pointer;
-    font-size: var(--wa-font-size-s);
+    font-size: var(--wa-font-size-xs);
     font-weight: var(--wa-font-weight-semibold);
     margin-top: var(--wa-space-s);
     transition:
@@ -31,11 +31,9 @@ export const automationEditorActionStyles = css`
   }
 
   .ae-add:hover:not(:disabled) {
-    background: color-mix(
-      in srgb,
-      var(--wa-color-brand-fill-loud, var(--esphome-primary)) 18%,
-      transparent
-    );
+    border-color: var(--wa-color-brand-fill-loud, #0b5cad);
+    color: var(--wa-color-brand-fill-loud, #0b5cad);
+    background: transparent;
   }
 
   .ae-add:disabled {
@@ -43,25 +41,10 @@ export const automationEditorActionStyles = css`
     cursor: not-allowed;
   }
 
-  /* Nested add buttons (inside then / else / while / repeat) —
-     dashed, quiet so the eye reads the prominent outer button as
-     the primary CTA. :host-context() reaches across the
-     action-list's shadow boundary into the parent action-node's
-     .ae-nested wrapper, which is the only way a sibling
-     custom-element with its own shadow can scope the rule. They
-     still pick up the brand color on hover for affordance. */
   :host-context(.ae-nested) .ae-add {
-    border: 1px dashed var(--wa-color-neutral-border-quiet, #d1d5db);
-    color: var(--wa-color-text-quiet);
     padding: var(--wa-space-2xs) var(--wa-space-s);
     font-size: var(--wa-font-size-2xs);
     margin-top: var(--wa-space-2xs);
-  }
-
-  :host-context(.ae-nested) .ae-add:hover:not(:disabled) {
-    border-color: var(--wa-color-brand-fill-loud, #0b5cad);
-    color: var(--wa-color-brand-fill-loud, #0b5cad);
-    background: transparent;
   }
 
   .ae-error {

--- a/src/components/device/automation-editor/automation-editor-actions.styles.ts
+++ b/src/components/device/automation-editor/automation-editor-actions.styles.ts
@@ -25,7 +25,6 @@ export const automationEditorActionStyles = css`
     font-weight: var(--wa-font-weight-semibold);
     margin-top: var(--wa-space-s);
     transition:
-      background 0.12s,
       border-color 0.12s,
       color 0.12s;
   }


### PR DESCRIPTION
# What does this implement/fix?

Unifies the action list "Add action" buttons on one visual style. #1447 placed the top level button at the bottom of the list using the loud brand variant, directly above the quiet dashed buttons the nested then, otherwise, and while lists use, and stacked together the two variants read as inconsistent rather than as a hierarchy.

The `.ae-add` rule now carries a single style (neutral dashed border, quiet text, the subtle brand tinted fill the nested buttons have always had, and brand border and text on hover) for every list level; the `:host-context(.ae-nested)` override shrinks to density only (tighter padding and font size for nested lists). The top level button drops from the loud brand fill to the same language as its nested siblings and steps down one density notch as part of quieting (padding and font size from s to xs), landing between its old size and the nested compact one.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1450

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
