### PR TITLE
Type the section-editor contract the device page relies on

### DIFF
--- a/src/components/device/automation-editor/base-editor.ts
+++ b/src/components/device/automation-editor/base-editor.ts
@@ -26,14 +26,16 @@ import { automationEditorStyles } from "./automation-editor.styles.js";
 import { createFocusResolver, type YamlPathSegment } from "./automation-focus.js";
 import { CatalogLoadController } from "./catalog-load-controller.js";
 import { ParseErrorController } from "./parse-error-controller.js";
+import type { SectionEditor } from "../section-editor.js";
 import { renderDeleteRow } from "./render-delete-row.js";
 import { sectionKeyFromLocation } from "./serialise.js";
 
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 
-export abstract class BaseAutomationEditor<
-  L extends AutomationLocation,
-> extends LitElement {
+export abstract class BaseAutomationEditor<L extends AutomationLocation>
+  extends LitElement
+  implements SectionEditor
+{
   @consume({ context: localizeContext, subscribe: true })
   @state()
   protected _localize: LocalizeFunc = (key) => key;

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -26,13 +26,10 @@ import { registerMdiIcons } from "../../util/register-icons.js";
 import type { ESPHomeAddAutomationDialog } from "./add-automation-dialog.js";
 import type { ESPHomeAddComponentDialog } from "./add-component-dialog.js";
 import type { ESPHomeAddConfigDialog } from "./add-config-dialog.js";
-import type { ESPHomeApiActionEditor } from "./automation-editor/api-action-editor.js";
-import type { ESPHomeAutomationEditor } from "./automation-editor/automation-editor.js";
-import type { ESPHomeScriptEditor } from "./automation-editor/script-editor.js";
 import type { ESPHomeChangeBoardDialog } from "./change-board-dialog.js";
 import { isEmptyToPopulatedYamlChange } from "./device-board-info-helpers.js";
 import { deviceBoardInfoStyles } from "./device-board-info.styles.js";
-import type { ESPHomeDeviceSectionConfig } from "./device-section-config.js";
+import type { SectionEditor } from "./section-editor.js";
 import { SECTION_ICON } from "./section-icons.js";
 
 import "@home-assistant/webawesome/dist/components/badge/badge.js";
@@ -119,7 +116,7 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
   backendErrors: InstanceBackendErrors = NO_INSTANCE_ERRORS;
 
   @query("esphome-device-section-config")
-  private _sectionConfig!: ESPHomeDeviceSectionConfig;
+  private _sectionConfig!: SectionEditor;
 
   /** Refs to the three automation-family editors — one of these is
    *  mounted in the right pane when the navigator's selection lives
@@ -127,13 +124,13 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
    *  component-on / interval). YAML-driven reloads target whichever
    *  one is live. */
   @query("esphome-automation-editor")
-  private _automationEditor!: ESPHomeAutomationEditor;
+  private _automationEditor!: SectionEditor;
 
   @query("esphome-script-editor")
-  private _scriptEditor!: ESPHomeScriptEditor;
+  private _scriptEditor!: SectionEditor;
 
   @query("esphome-api-action-editor")
-  private _apiActionEditor!: ESPHomeApiActionEditor;
+  private _apiActionEditor!: SectionEditor;
 
   @query("esphome-add-component-dialog")
   private _addComponentDialog!: ESPHomeAddComponentDialog;

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -43,6 +43,7 @@ import type { ESPHomeAddApiActionDialog } from "./add-api-action-dialog.js";
 import type { ESPHomeAddAutomationDialog } from "./add-automation-dialog.js";
 import type { ConfigEntryValueChange } from "./config-entry-form.js";
 import { deviceSectionConfigStyles } from "./device-section-config.styles.js";
+import type { SectionEditor } from "./section-editor.js";
 import {
   applySectionValues,
   flushDraft,
@@ -90,7 +91,7 @@ registerMdiIcons({
 const UNDELETABLE_SECTIONS = new Set(["esphome"]);
 
 @customElement("esphome-device-section-config")
-export class ESPHomeDeviceSectionConfig extends LitElement {
+export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEditor {
   @consume({ context: localizeContext, subscribe: true })
   @state()
   _localize: LocalizeFunc = (key) => key;

--- a/src/components/device/section-editor.ts
+++ b/src/components/device/section-editor.ts
@@ -4,7 +4,9 @@
  * automation-family editors. Both sides implement it explicitly so
  * drift is a compile error instead of a save-guard edge case; the
  * page's ``section-mount`` / ``section-unmount`` handlers and the
- * YAML-driven reload path type against it.
+ * YAML-driven reload path type against it. The event trio the same
+ * editors dispatch (``section-mount`` / ``section-unmount`` /
+ * ``dirty-change``) is deliberately not covered here.
  */
 export interface SectionEditor {
   /** Brief-window dirty flag so the global save button arms as

--- a/src/components/device/section-editor.ts
+++ b/src/components/device/section-editor.ts
@@ -1,0 +1,24 @@
+/**
+ * The contract the device page relies on from whichever section
+ * editor is mounted — the component editor or one of the
+ * automation-family editors. Both sides implement it explicitly so
+ * drift is a compile error instead of a save-guard edge case; the
+ * page's ``section-mount`` / ``section-unmount`` handlers and the
+ * YAML-driven reload path type against it.
+ */
+export interface SectionEditor {
+  /** Brief-window dirty flag so the global save button arms as
+   *  soon as the user edits. */
+  readonly dirty: boolean;
+
+  /** Flush a pending debounced draft so callers reading the page's
+   *  YAML next see the user's last keystroke. The component
+   *  editor's local splice is synchronous; the automation editors'
+   *  backend upsert is not — await when the caller needs the
+   *  settled buffer. */
+  flushPending(): void | Promise<void>;
+
+  /** Re-hydrate from the live YAML after the pane changes the
+   *  document out from under the editor. */
+  reload(): void;
+}

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -17,7 +17,7 @@ import { notifyError, notifySuccess } from "../util/notify.js";
 // page itself doesn't pass it down anymore now that the step CTAs
 // always render.
 import { DeviceInstallController } from "../components/device/device-install-controller.js";
-import type { ESPHomeDeviceSectionConfig } from "../components/device/device-section-config.js";
+import type { SectionEditor } from "../components/device/section-editor.js";
 import type { ESPHomeFirmwareInstallDialog } from "../components/firmware-install-dialog.js";
 import { TourLayoutController } from "../components/guided-tour/tour-layout-controller.js";
 import { tourAnchor } from "../components/guided-tour/tour-anchor.js";
@@ -327,7 +327,7 @@ export class ESPHomePageDevice extends LitElement {
    *  three shadow roots between this page and the section
    *  editor, so the registration pattern keeps the call site
    *  for ``activeSection.save()`` cheap and direct. */
-  private _activeSection: ESPHomeDeviceSectionConfig | null = null;
+  private _activeSection: SectionEditor | null = null;
 
   @state()
   private _sectionDirty = false;
@@ -1780,13 +1780,13 @@ export class ESPHomePageDevice extends LitElement {
   }
 
   private _onSectionMount = (e: Event) => {
-    const ev = e as CustomEvent<{ node: ESPHomeDeviceSectionConfig }>;
+    const ev = e as CustomEvent<{ node: SectionEditor }>;
     this._activeSection = ev.detail.node;
     this._sectionDirty = ev.detail.node.dirty;
   };
 
   private _onSectionUnmount = (e: Event) => {
-    const ev = e as CustomEvent<{ node: ESPHomeDeviceSectionConfig }>;
+    const ev = e as CustomEvent<{ node: SectionEditor }>;
     if (this._activeSection === ev.detail.node) {
       this._activeSection = null;
       this._sectionDirty = false;

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -320,13 +320,13 @@ export class ESPHomePageDevice extends LitElement {
   @query("esphome-unsaved-changes-dialog")
   private _unsavedDialog!: ESPHomeUnsavedChangesDialog;
 
-  /** Live ref to the mounted section-config component, when one
-   *  is rendered. Captured via ``section-mount`` /
-   *  ``section-unmount`` events that the component fires on its
-   *  own lifecycle hooks; ``@query`` doesn't reach across the
-   *  three shadow roots between this page and the section
-   *  editor, so the registration pattern keeps the call site
-   *  for ``activeSection.save()`` cheap and direct. */
+  /** Live ref to the mounted section editor (component editor or
+   *  one of the automation family), typed as the ``SectionEditor``
+   *  contract the page consumes (``dirty`` / ``flushPending``).
+   *  Captured via ``section-mount`` / ``section-unmount`` events
+   *  the editors fire on their own lifecycle hooks; ``@query``
+   *  doesn't reach across the three shadow roots between this
+   *  page and the section editor. */
   private _activeSection: SectionEditor | null = null;
 
   @state()

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -437,10 +437,12 @@ export class ESPHomePageDevice extends LitElement {
    *  even though the user explicitly typed it.
    *
    *  The leave-page / save / popstate paths call
-   *  ``_activeSection?.flushPending()`` synchronously before they
-   *  read this getter, so by the time ``_isDirty`` is consulted
-   *  any pending form edits have been promoted into ``_yaml`` and
-   *  the YAML branch is authoritative. */
+   *  ``_activeSection?.flushPending()`` before they read this
+   *  getter. The component editor's flush promotes pending form
+   *  edits into ``_yaml`` synchronously; the automation editors'
+   *  flush is a backend round-trip that only the save path awaits,
+   *  so the other paths lean on ``_sectionDirty`` staying set until
+   *  the upsert lands (they fail conservative). */
   private get _isDirty(): boolean {
     return this._isYamlDirty || this._sectionDirty;
   }


### PR DESCRIPTION
# What does this implement/fix?

Types the section editor contract the device page relies on instead of duck typing it. The page's save guard and reload path consume the same three member surface from two independent implementations, `ESPHomeDeviceSectionConfig` (draft timer engine) and the automation family's `BaseAutomationEditor` (`AutoApplyController` engine), and until now that alignment was held together by parallel prose comments; a drift between them would surface as a save guard edge case at runtime.

A new `SectionEditor` interface (`dirty`, `flushPending`, `reload`) in `src/components/device/section-editor.ts` is now implemented explicitly by both classes, and `device.ts` types `_activeSection` and the `section-mount` / `section-unmount` handlers against it rather than pretending every mounted section is an `ESPHomeDeviceSectionConfig`. `flushPending` is typed `void | Promise<void>` since the component editor's splice is synchronous while the automation editors' upsert is not, which the page's one awaiting call site already handles.

`inFlightWrite` is deliberately not part of the contract: nothing outside the automation subtree consumes it, and the component editor has no equivalent, so including it would force a fake implementation, the inverse of the drift this guards against. Enforcement is the `implements` clause under `tsc`, so no runtime tests are added; the diff is type only with no behavior change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1453

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
