### PR TITLE
Extract a shared harness for the automation-editor suites

### DIFF
--- a/test/components/device/automation-editor/_editor-harness.ts
+++ b/test/components/device/automation-editor/_editor-harness.ts
@@ -1,8 +1,13 @@
 /**
  * Shared scaffolding for the automation-editor suites. Import this
- * module BEFORE any editor import — the ``vi.mock`` registrations
- * are import-order dependent (same pattern as
- * ``test/pages/_mock-dashboard-children.ts``). Carries the union of
+ * module with a bare side-effect import BEFORE any editor import —
+ * the ``vi.mock`` registrations are import-order dependent (same
+ * pattern as ``test/pages/_mock-dashboard-children.ts``), and the
+ * pinned organize-imports plugin alphabetizes *named* imports below
+ * the ``../../../../src`` editor specifiers while leaving
+ * side-effect imports in place. The suites' separate named import
+ * for the helpers is therefore deliberate, not redundant.
+ * Carries the union of
  * the heavy-children no-op mocks every mount suite needs, the slim
  * catalog factory, a parameterizable API mock, and the mount
  * helper. Suite-specific fixtures stay in their suites.
@@ -58,14 +63,13 @@ export const seedTree = (): AutomationTree => ({
   actions: [],
 });
 
-export const slimAvailable = (): AvailableAutomations =>
-  ({
-    triggers: [],
-    actions: [],
-    conditions: [],
-    scripts: [],
-    devices: [],
-  }) as unknown as AvailableAutomations;
+export const slimAvailable = (): AvailableAutomations => ({
+  triggers: [],
+  actions: [],
+  conditions: [],
+  scripts: [],
+  devices: [],
+});
 
 const editorApiDefaults = (available: AvailableAutomations) => ({
   getAvailableAutomations: vi.fn().mockResolvedValue(available),

--- a/test/components/device/automation-editor/_editor-harness.ts
+++ b/test/components/device/automation-editor/_editor-harness.ts
@@ -1,0 +1,120 @@
+/**
+ * Shared scaffolding for the automation-editor suites. Import this
+ * module BEFORE any editor import — the ``vi.mock`` registrations
+ * are import-order dependent (same pattern as
+ * ``test/pages/_mock-dashboard-children.ts``). Carries the union of
+ * the heavy-children no-op mocks every mount suite needs, the slim
+ * catalog factory, a parameterizable API mock, and the mount
+ * helper. Suite-specific fixtures stay in their suites.
+ */
+import { vi } from "vitest";
+
+vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-action-list.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-target-picker.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-trigger-picker.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/callable-params-editor.js",
+  () => ({})
+);
+vi.mock("../../../../src/components/confirm-dialog.js", () => {
+  /** Stub with an observable ``open()`` so delete-gate suites can
+   *  assert the dialog was asked to show. */
+  class StubConfirmDialog extends HTMLElement {
+    open = vi.fn();
+  }
+  customElements.define("esphome-confirm-dialog", StubConfirmDialog);
+  return {};
+});
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+
+import type { ESPHomeAPI } from "../../../../src/api/index.js";
+import type {
+  AutomationLocation,
+  AutomationTree,
+  AvailableAutomations,
+} from "../../../../src/api/types/automations.js";
+import type { BaseAutomationEditor } from "../../../../src/components/device/automation-editor/base-editor.js";
+import { flushMicrotasks } from "../../../_dom.js";
+
+export const slimAvailable = (): AvailableAutomations =>
+  ({
+    triggers: [],
+    actions: [],
+    conditions: [],
+    scripts: [],
+    devices: [],
+  }) as unknown as AvailableAutomations;
+
+/** API mock covering every verb the editors call at mount or on
+ *  write; override per suite for behaviour under test. */
+export const makeEditorApi = (overrides: Record<string, unknown> = {}) => ({
+  getAvailableAutomations: vi.fn().mockResolvedValue(slimAvailable()),
+  getAutomationBodies: vi.fn().mockResolvedValue({}),
+  parseDeviceAutomations: vi.fn().mockResolvedValue([]),
+  upsertAutomation: vi.fn().mockResolvedValue({
+    yaml_diff: { fromLine: 0, toLine: 0, replacement: "" },
+  }),
+  deleteAutomation: vi.fn().mockResolvedValue({
+    yaml_diff: { fromLine: 0, toLine: 0, replacement: "" },
+  }),
+  updateConfig: vi.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+export type EditorApiMock = ReturnType<typeof makeEditorApi>;
+
+/** Slim catalog carrying one hydratable action — shared by the
+ *  script / api-action hydration suites (#1286). */
+export const slimWithLoggerAction = (): AvailableAutomations =>
+  ({
+    triggers: [],
+    actions: [{ id: "logger.log", config_entries: [] }],
+    conditions: [],
+    scripts: [],
+    devices: [],
+  }) as unknown as AvailableAutomations;
+
+export const loggerBodies = () => ({
+  "actions/logger.log": {
+    id: "logger.log",
+    config_entries: [{ key: "format", type: "string", label: "Format", required: true }],
+  },
+});
+
+/** Plant the api, seed the optional identity, mount, and settle. */
+export async function mountEditor<E extends BaseAutomationEditor<AutomationLocation>>(
+  editor: E,
+  api: EditorApiMock | ESPHomeAPI,
+  opts: {
+    configuration?: string;
+    location?: AutomationLocation;
+    value?: AutomationTree;
+    /** Microtask flushes after mount; hydration suites need more. */
+    settle?: number;
+  } = {}
+): Promise<E> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (editor as any)._api = api as unknown as ESPHomeAPI;
+  if (opts.configuration !== undefined) editor.configuration = opts.configuration;
+  if (opts.location !== undefined) editor.location = opts.location;
+  if (opts.value !== undefined) editor.value = opts.value;
+  document.body.appendChild(editor);
+  await editor.updateComplete;
+  await flushMicrotasks(opts.settle ?? 5);
+  return editor;
+}

--- a/test/components/device/automation-editor/_editor-harness.ts
+++ b/test/components/device/automation-editor/_editor-harness.ts
@@ -1,16 +1,17 @@
 /**
- * Shared scaffolding for the automation-editor suites. Import this
- * module with a bare side-effect import BEFORE any editor import —
- * the ``vi.mock`` registrations are import-order dependent (same
- * pattern as ``test/pages/_mock-dashboard-children.ts``), and the
- * pinned organize-imports plugin alphabetizes *named* imports below
- * the ``../../../../src`` editor specifiers while leaving
+ * Shared scaffolding for the automation-editor suites: the union of
+ * the heavy-children no-op ``vi.mock``s every mount suite needs, the
+ * slim catalog and seed-tree factories, a parameterizable API mock,
+ * and the mount-and-settle helper. Suite-specific fixtures stay in
+ * their suites.
+ *
+ * Import this module with a bare side-effect import BEFORE any
+ * editor import — the mock registrations are import-order dependent
+ * (same pattern as ``test/pages/_mock-dashboard-children.ts``), and
+ * the pinned organize-imports plugin alphabetizes *named* imports
+ * below the ``../../../../src`` editor specifiers while leaving
  * side-effect imports in place. The suites' separate named import
  * for the helpers is therefore deliberate, not redundant.
- * Carries the union of
- * the heavy-children no-op mocks every mount suite needs, the slim
- * catalog factory, a parameterizable API mock, and the mount
- * helper. Suite-specific fixtures stay in their suites.
  */
 import { vi } from "vitest";
 

--- a/test/components/device/automation-editor/_editor-harness.ts
+++ b/test/components/device/automation-editor/_editor-harness.ts
@@ -51,6 +51,13 @@ import type {
 import type { BaseAutomationEditor } from "../../../../src/components/device/automation-editor/base-editor.js";
 import { flushMicrotasks } from "../../../_dom.js";
 
+/** Minimal editable tree for seeding an editor in edit mode. */
+export const seedTree = (): AutomationTree => ({
+  trigger_id: null,
+  trigger_params: {},
+  actions: [],
+});
+
 export const slimAvailable = (): AvailableAutomations =>
   ({
     triggers: [],

--- a/test/components/device/automation-editor/_editor-harness.ts
+++ b/test/components/device/automation-editor/_editor-harness.ts
@@ -67,10 +67,8 @@ export const slimAvailable = (): AvailableAutomations =>
     devices: [],
   }) as unknown as AvailableAutomations;
 
-/** API mock covering every verb the editors call at mount or on
- *  write; override per suite for behaviour under test. */
-export const makeEditorApi = (overrides: Record<string, unknown> = {}) => ({
-  getAvailableAutomations: vi.fn().mockResolvedValue(slimAvailable()),
+const editorApiDefaults = (available: AvailableAutomations) => ({
+  getAvailableAutomations: vi.fn().mockResolvedValue(available),
   getAutomationBodies: vi.fn().mockResolvedValue({}),
   parseDeviceAutomations: vi.fn().mockResolvedValue([]),
   upsertAutomation: vi.fn().mockResolvedValue({
@@ -80,10 +78,21 @@ export const makeEditorApi = (overrides: Record<string, unknown> = {}) => ({
     yaml_diff: { fromLine: 0, toLine: 0, replacement: "" },
   }),
   updateConfig: vi.fn().mockResolvedValue(undefined),
-  ...overrides,
 });
 
-export type EditorApiMock = ReturnType<typeof makeEditorApi>;
+export type EditorApiMock = ReturnType<typeof editorApiDefaults>;
+
+/** API mock covering every verb the editors call at mount or on
+ *  write. ``overrides`` is keyed to the real verbs so a typo is a
+ *  compile error instead of a vacuous pass; ``available`` is the
+ *  catalog the default load resolves. */
+export const makeEditorApi = (
+  overrides: Partial<EditorApiMock> = {},
+  available: AvailableAutomations = slimAvailable()
+): EditorApiMock => ({
+  ...editorApiDefaults(available),
+  ...overrides,
+});
 
 /** Slim catalog carrying one hydratable action — shared by the
  *  script / api-action hydration suites (#1286). */

--- a/test/components/device/automation-editor/api-action-editor-mount.test.ts
+++ b/test/components/device/automation-editor/api-action-editor-mount.test.ts
@@ -8,57 +8,31 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
-vi.mock(
-  "../../../../src/components/device/automation-editor/automation-action-list.js",
-  () => ({})
-);
-vi.mock(
-  "../../../../src/components/device/automation-editor/callable-params-editor.js",
-  () => ({})
-);
-vi.mock("../../../../src/components/confirm-dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
-vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+import "./_editor-harness.js";
 
 import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type { AvailableAutomations } from "../../../../src/api/types/automations.js";
 import { ESPHomeApiActionEditor } from "../../../../src/components/device/automation-editor/api-action-editor.js";
 import { _clearAutomationBodyCache } from "../../../../src/util/automation-body-cache.js";
-import { flushMicrotasks } from "../../../_dom.js";
 
-const slimWithLoggerAction = (): AvailableAutomations =>
-  ({
-    triggers: [],
-    actions: [{ id: "logger.log", config_entries: [] }],
-    conditions: [],
-    scripts: [],
-    devices: [],
-  }) as unknown as AvailableAutomations;
-
-const loggerBodies = () => ({
-  "actions/logger.log": {
-    id: "logger.log",
-    config_entries: [{ key: "format", type: "string", label: "Format", required: true }],
-  },
-});
+import {
+  loggerBodies,
+  mountEditor as mountHarness,
+  slimWithLoggerAction,
+} from "./_editor-harness.js";
 
 async function mountEditor(
   api: ESPHomeAPI,
   configuration?: string,
   props: object = {}
 ): Promise<ESPHomeApiActionEditor> {
-  const editor = new ESPHomeApiActionEditor();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (editor as any)._api = api;
-  if (configuration !== undefined) editor.configuration = configuration;
-  Object.assign(editor, props);
-  document.body.appendChild(editor);
-  await editor.updateComplete;
-  await flushMicrotasks(30);
-  return editor;
+  const editor = Object.assign(new ESPHomeApiActionEditor(), props);
+  return mountHarness(
+    editor,
+    api,
+    configuration !== undefined ? { configuration, settle: 30 } : { settle: 30 }
+  );
 }
 
 describe("api-action-editor action-catalog hydration (#1286)", () => {

--- a/test/components/device/automation-editor/automation-editor-mount.test.ts
+++ b/test/components/device/automation-editor/automation-editor-mount.test.ts
@@ -4,83 +4,38 @@
  * Behavioral mount tests for ``automation-editor.ts``. The editor's
  * deps drag CodeMirror in through ``config-entry-form`` →
  * ``lambda-editor``, plus the action-list / target-picker /
- * trigger-picker children. ``vi.mock`` no-ops them so the editor
- * itself can construct in a happy-dom window.
+ * trigger-picker children. The shared harness no-ops them so the
+ * editor itself can construct in a happy-dom window.
  */
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
-vi.mock(
-  "../../../../src/components/device/automation-editor/automation-action-list.js",
-  () => ({})
-);
-vi.mock(
-  "../../../../src/components/device/automation-editor/automation-target-picker.js",
-  () => ({})
-);
-vi.mock(
-  "../../../../src/components/device/automation-editor/automation-trigger-picker.js",
-  () => ({})
-);
-vi.mock("../../../../src/components/confirm-dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}));
-vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+import "./_editor-harness.js";
 
-import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type { AvailableAutomations } from "../../../../src/api/types/automations.js";
 import { ESPHomeAutomationEditor } from "../../../../src/components/device/automation-editor/automation-editor.js";
 import { flushMicrotasks } from "../../../_dom.js";
-
-const slimAvailable = (): AvailableAutomations =>
-  ({
-    triggers: [],
-    actions: [],
-    conditions: [],
-    scripts: [],
-    devices: [],
-  }) as unknown as AvailableAutomations;
-
-/** Construct an editor, plant the api on its consumer-private
- *  ``_api`` slot (no Lit context provider in the test tree),
- *  optionally set ``configuration``, then mount and settle the
- *  lifecycle. */
-async function mountEditor(
-  api: ESPHomeAPI,
-  configuration?: string
-): Promise<ESPHomeAutomationEditor> {
-  const editor = new ESPHomeAutomationEditor();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (editor as any)._api = api;
-  if (configuration !== undefined) editor.configuration = configuration;
-  document.body.appendChild(editor);
-  await editor.updateComplete;
-  await flushMicrotasks(5);
-  return editor;
-}
+import { makeEditorApi, mountEditor } from "./_editor-harness.js";
 
 describe("automation-editor mount-time load (behavioral)", () => {
   it("editor mounted with configuration preset issues exactly one getAvailableAutomations call", async () => {
-    const getAvailableAutomations = vi.fn().mockResolvedValue(slimAvailable());
-    const getAutomationBodies = vi.fn().mockResolvedValue({});
-    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
+    const api = makeEditorApi();
 
-    await mountEditor(api, "device.yaml");
+    await mountEditor(new ESPHomeAutomationEditor(), api, {
+      configuration: "device.yaml",
+    });
 
-    expect(getAvailableAutomations).toHaveBeenCalledTimes(1);
+    expect(api.getAvailableAutomations).toHaveBeenCalledTimes(1);
     // Second arg is the editor's draft yaml (empty here), forwarded so a
     // wizard-added component's triggers scope off the draft (#1348).
-    expect(getAvailableAutomations).toHaveBeenCalledWith("device.yaml", "");
+    expect(api.getAvailableAutomations).toHaveBeenCalledWith("device.yaml", "");
   });
 
   it("editor mounted without configuration does not call getAvailableAutomations", async () => {
-    const getAvailableAutomations = vi.fn().mockResolvedValue(slimAvailable());
-    const api = { getAvailableAutomations } as unknown as ESPHomeAPI;
+    const api = makeEditorApi();
 
-    await mountEditor(api);
+    await mountEditor(new ESPHomeAutomationEditor(), api);
 
-    expect(getAvailableAutomations).not.toHaveBeenCalled();
+    expect(api.getAvailableAutomations).not.toHaveBeenCalled();
   });
 
   it("drops the loading spinner once the slim list lands (paint before hydration)", async () => {
@@ -96,19 +51,22 @@ describe("automation-editor mount-time load (behavioral)", () => {
       devices: [],
     } as unknown as AvailableAutomations;
     let resolveBodies!: (v: Record<string, unknown>) => void;
-    const getAvailableAutomations = vi.fn().mockResolvedValue(slim);
-    const getAutomationBodies = vi.fn(
-      () =>
-        new Promise<Record<string, unknown>>((r) => {
-          resolveBodies = r;
-        })
-    );
-    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
+    const api = makeEditorApi({
+      getAvailableAutomations: vi.fn().mockResolvedValue(slim),
+      getAutomationBodies: vi.fn(
+        () =>
+          new Promise<Record<string, unknown>>((r) => {
+            resolveBodies = r;
+          })
+      ),
+    });
 
-    const editor = await mountEditor(api, "device.yaml");
+    const editor = await mountEditor(new ESPHomeAutomationEditor(), api, {
+      configuration: "device.yaml",
+    });
 
-    expect(getAvailableAutomations).toHaveBeenCalledTimes(1);
-    expect(getAutomationBodies).toHaveBeenCalled();
+    expect(api.getAvailableAutomations).toHaveBeenCalledTimes(1);
+    expect(api.getAutomationBodies).toHaveBeenCalled();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((editor as any)._loading).toBe(false);
 
@@ -117,44 +75,36 @@ describe("automation-editor mount-time load (behavioral)", () => {
   });
 
   it("setting configuration after mount triggers the load", async () => {
-    const getAvailableAutomations = vi.fn().mockResolvedValue(slimAvailable());
-    const getAutomationBodies = vi.fn().mockResolvedValue({});
-    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
+    const api = makeEditorApi();
 
-    const editor = await mountEditor(api);
-    expect(getAvailableAutomations).not.toHaveBeenCalled();
+    const editor = await mountEditor(new ESPHomeAutomationEditor(), api);
+    expect(api.getAvailableAutomations).not.toHaveBeenCalled();
 
     editor.configuration = "device.yaml";
     await editor.updateComplete;
     await flushMicrotasks(5);
 
-    expect(getAvailableAutomations).toHaveBeenCalledTimes(1);
+    expect(api.getAvailableAutomations).toHaveBeenCalledTimes(1);
   });
 
   it("renders a component_action location titled by the field label", async () => {
-    const getAvailableAutomations = vi.fn().mockResolvedValue(slimAvailable());
-    const getAutomationBodies = vi.fn().mockResolvedValue({});
-    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
-
+    const api = makeEditorApi();
     const editor = new ESPHomeAutomationEditor();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (editor as any)._api = api;
     // Interpolating localize stub (no context provider in the test tree)
     // so the ``{name} action`` header template resolves.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (editor as any)._localize = (key: string, values?: Record<string, string>) =>
       key === "device.action_field_label" ? `${values?.name} action` : key;
-    editor.configuration = "device.yaml";
-    editor.location = {
-      kind: "component_action",
-      component_id: "my_gate",
-      field: "open_action",
-    };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (editor as any).value = { trigger_id: null, trigger_params: {}, actions: [] };
-    document.body.appendChild(editor);
-    await editor.updateComplete;
-    await flushMicrotasks(5);
+
+    await mountEditor(editor, api, {
+      configuration: "device.yaml",
+      location: {
+        kind: "component_action",
+        component_id: "my_gate",
+        field: "open_action",
+      },
+      value: { trigger_id: null, trigger_params: {}, actions: [] } as never,
+    });
 
     // Header derives from the field (no trigger to name); edit-mode means
     // the add-only trigger picker is never instantiated.

--- a/test/components/device/automation-editor/automation-editor-mount.test.ts
+++ b/test/components/device/automation-editor/automation-editor-mount.test.ts
@@ -14,7 +14,7 @@ import "./_editor-harness.js";
 import type { AvailableAutomations } from "../../../../src/api/types/automations.js";
 import { ESPHomeAutomationEditor } from "../../../../src/components/device/automation-editor/automation-editor.js";
 import { flushMicrotasks } from "../../../_dom.js";
-import { makeEditorApi, mountEditor } from "./_editor-harness.js";
+import { makeEditorApi, mountEditor, seedTree } from "./_editor-harness.js";
 
 describe("automation-editor mount-time load (behavioral)", () => {
   it("editor mounted with configuration preset issues exactly one getAvailableAutomations call", async () => {
@@ -103,7 +103,7 @@ describe("automation-editor mount-time load (behavioral)", () => {
         component_id: "my_gate",
         field: "open_action",
       },
-      value: { trigger_id: null, trigger_params: {}, actions: [] } as never,
+      value: seedTree(),
     });
 
     // Header derives from the field (no trigger to name); edit-mode means

--- a/test/components/device/automation-editor/automation-editor-uneditable.test.ts
+++ b/test/components/device/automation-editor/automation-editor-uneditable.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import "./_editor-harness.js";
-import { slimAvailable } from "./_editor-harness.js";
+import { mountEditor, slimAvailable } from "./_editor-harness.js";
 
 import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type {
@@ -56,14 +56,11 @@ describe("automation-editor uneditable (errored parse)", () => {
       upsertAutomation,
     } as unknown as ESPHomeAPI;
 
-    const editor = new ESPHomeAutomationEditor();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (editor as any)._api = api;
-    editor.configuration = "device.yaml";
-    editor.location = ON_BOOT;
-    document.body.appendChild(editor);
-    await editor.updateComplete;
-    await flushMicrotasks(8);
+    const editor = await mountEditor(new ESPHomeAutomationEditor(), api, {
+      configuration: "device.yaml",
+      location: ON_BOOT,
+      settle: 8,
+    });
 
     // The errored automation is flagged read-only; its empty tree was
     // not adopted, and the error surfaces in the rendered panel.
@@ -83,6 +80,8 @@ describe("automation-editor uneditable (errored parse)", () => {
       upsertAutomation,
     } as unknown as ESPHomeAPI;
 
+    // Inline mount: unlike the harness helper this seeds a non-null
+    // value and stops at updateComplete with no microtask flush.
     const editor = new ESPHomeAutomationEditor();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (editor as any)._api = api;

--- a/test/components/device/automation-editor/automation-editor-uneditable.test.ts
+++ b/test/components/device/automation-editor/automation-editor-uneditable.test.ts
@@ -7,24 +7,8 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
-vi.mock(
-  "../../../../src/components/device/automation-editor/automation-action-list.js",
-  () => ({})
-);
-vi.mock(
-  "../../../../src/components/device/automation-editor/automation-target-picker.js",
-  () => ({})
-);
-vi.mock(
-  "../../../../src/components/device/automation-editor/automation-trigger-picker.js",
-  () => ({})
-);
-vi.mock("../../../../src/components/confirm-dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}));
-vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+import "./_editor-harness.js";
+import { slimAvailable } from "./_editor-harness.js";
 
 import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type {
@@ -62,15 +46,6 @@ const validParse = (): ParsedAutomation[] => [
     raw_yaml: "on_boot:\n  then: []\n",
   } as unknown as ParsedAutomation,
 ];
-
-const slimAvailable = (): AvailableAutomations =>
-  ({
-    triggers: [],
-    actions: [],
-    conditions: [],
-    scripts: [],
-    devices: [],
-  }) as unknown as AvailableAutomations;
 
 describe("automation-editor uneditable (errored parse)", () => {
   it("renders read-only and never upserts when the parsed automation has an error", async () => {

--- a/test/components/device/automation-editor/automation-editor-uneditable.test.ts
+++ b/test/components/device/automation-editor/automation-editor-uneditable.test.ts
@@ -13,7 +13,6 @@ import { slimAvailable } from "./_editor-harness.js";
 import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type {
   AutomationLocation,
-  AvailableAutomations,
   ParsedAutomation,
 } from "../../../../src/api/types/automations.js";
 import { ESPHomeAutomationEditor } from "../../../../src/components/device/automation-editor/automation-editor.js";

--- a/test/components/device/automation-editor/can-apply-wiring.test.ts
+++ b/test/components/device/automation-editor/can-apply-wiring.test.ts
@@ -16,7 +16,12 @@ import { flushMicrotasks } from "../../../_dom.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { type EditorApiMock, makeEditorApi, mountEditor } from "./_editor-harness.js";
+import {
+  type EditorApiMock,
+  makeEditorApi,
+  mountEditor,
+  seedTree,
+} from "./_editor-harness.js";
 
 async function mountAndFlush(
   editor: ESPHomeScriptEditor | ESPHomeApiActionEditor,
@@ -26,7 +31,7 @@ async function mountAndFlush(
   await mountEditor(editor, api, {
     configuration: "device.yaml",
     location,
-    value: { trigger_id: null, trigger_params: {}, actions: [] } as never,
+    value: seedTree(),
   });
   (editor as any)._engine.withValue({ actions: [] });
   await editor.flushPending();

--- a/test/components/device/automation-editor/can-apply-wiring.test.ts
+++ b/test/components/device/automation-editor/can-apply-wiring.test.ts
@@ -7,64 +7,27 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
-vi.mock(
-  "../../../../src/components/device/automation-editor/automation-action-list.js",
-  () => ({})
-);
-vi.mock(
-  "../../../../src/components/device/automation-editor/callable-params-editor.js",
-  () => ({})
-);
-vi.mock("../../../../src/components/confirm-dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
-vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+import "./_editor-harness.js";
 
-import type { ESPHomeAPI } from "../../../../src/api/index.js";
-import type {
-  AutomationLocation,
-  AvailableAutomations,
-} from "../../../../src/api/types/automations.js";
+import type { AutomationLocation } from "../../../../src/api/types/automations.js";
 import { ESPHomeApiActionEditor } from "../../../../src/components/device/automation-editor/api-action-editor.js";
 import { ESPHomeScriptEditor } from "../../../../src/components/device/automation-editor/script-editor.js";
 import { flushMicrotasks } from "../../../_dom.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-const slimAvailable = (): AvailableAutomations =>
-  ({
-    triggers: [],
-    actions: [],
-    conditions: [],
-    scripts: [],
-    devices: [],
-  }) as unknown as AvailableAutomations;
-
-const makeApi = () => ({
-  getAvailableAutomations: vi.fn().mockResolvedValue(slimAvailable()),
-  getAutomationBodies: vi.fn().mockResolvedValue({}),
-  parseDeviceAutomations: vi.fn().mockResolvedValue([]),
-  upsertAutomation: vi.fn().mockResolvedValue({
-    yaml_diff: { fromLine: 0, toLine: 0, replacement: "" },
-  }),
-  updateConfig: vi.fn().mockResolvedValue(undefined),
-});
+import { type EditorApiMock, makeEditorApi, mountEditor } from "./_editor-harness.js";
 
 async function mountAndFlush(
   editor: ESPHomeScriptEditor | ESPHomeApiActionEditor,
-  api: ReturnType<typeof makeApi>,
+  api: EditorApiMock,
   location: AutomationLocation
 ) {
-  (editor as any)._api = api as unknown as ESPHomeAPI;
-  editor.configuration = "device.yaml";
-  (editor as any).location = location;
-  (editor as any).value = { trigger_id: null, trigger_params: {}, actions: [] };
-  document.body.appendChild(editor);
-  await editor.updateComplete;
-  await flushMicrotasks(5);
+  await mountEditor(editor, api, {
+    configuration: "device.yaml",
+    location,
+    value: { trigger_id: null, trigger_params: {}, actions: [] } as never,
+  });
   (editor as any)._engine.withValue({ actions: [] });
   await editor.flushPending();
   await flushMicrotasks(5);
@@ -95,21 +58,21 @@ const CASES: Array<{
 
 describe.each(CASES)("$name _canApply wiring", ({ make, blocked, allowed, sibling }) => {
   it("blocks the upsert while the identity is empty", async () => {
-    const api = makeApi();
+    const api = makeEditorApi();
     await mountAndFlush(make(), api, blocked);
 
     expect(api.upsertAutomation).not.toHaveBeenCalled();
   });
 
   it("upserts once the identity is set", async () => {
-    const api = makeApi();
+    const api = makeEditorApi();
     await mountAndFlush(make(), api, allowed);
 
     expect(api.upsertAutomation).toHaveBeenCalled();
   });
 
   it("a navigator swap to a sibling invalidates the stale value and re-hydrates", async () => {
-    const api = makeApi();
+    const api = makeEditorApi();
     const editor = make();
     await mountAndFlush(editor, api, allowed);
     expect(api.parseDeviceAutomations).not.toHaveBeenCalled();

--- a/test/components/device/automation-editor/can-apply-wiring.test.ts
+++ b/test/components/device/automation-editor/can-apply-wiring.test.ts
@@ -5,7 +5,7 @@
  * identity-less script / api action never writes, and dropping an
  * override would silently fall back to the base's permissive default.
  */
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import "./_editor-harness.js";
 

--- a/test/components/device/automation-editor/delete-confirm.test.ts
+++ b/test/components/device/automation-editor/delete-confirm.test.ts
@@ -76,9 +76,7 @@ describe.each(CASES)(
   "$name delete confirm gate",
   ({ make, location, available, expectedName }) => {
     it("clicking Delete opens the confirm dialog without deleting", async () => {
-      const api = makeEditorApi(
-        available ? { getAvailableAutomations: vi.fn().mockResolvedValue(available) } : {}
-      );
+      const api = makeEditorApi({}, available);
       const editor = make();
       await mountAndSettle(editor, api, location);
 
@@ -106,9 +104,7 @@ describe.each(CASES)(
     });
 
     it("names the delete target in the confirm message", async () => {
-      const api = makeEditorApi(
-        available ? { getAvailableAutomations: vi.fn().mockResolvedValue(available) } : {}
-      );
+      const api = makeEditorApi({}, available);
       const editor = make();
       (editor as any)._localize = (key: string, params?: Record<string, string>) =>
         params?.name ? `${key}:${params.name}` : key;

--- a/test/components/device/automation-editor/delete-confirm.test.ts
+++ b/test/components/device/automation-editor/delete-confirm.test.ts
@@ -8,38 +8,8 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
-vi.mock(
-  "../../../../src/components/device/automation-editor/automation-action-list.js",
-  () => ({})
-);
-vi.mock(
-  "../../../../src/components/device/automation-editor/automation-target-picker.js",
-  () => ({})
-);
-vi.mock(
-  "../../../../src/components/device/automation-editor/automation-trigger-picker.js",
-  () => ({})
-);
-vi.mock(
-  "../../../../src/components/device/automation-editor/callable-params-editor.js",
-  () => ({})
-);
-vi.mock("../../../../src/components/confirm-dialog.js", () => {
-  class StubConfirmDialog extends HTMLElement {
-    open = vi.fn();
-  }
-  customElements.define("esphome-confirm-dialog", StubConfirmDialog);
-  return {};
-});
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}));
-vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+import "./_editor-harness.js";
 
-import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type {
   AutomationLocation,
   AvailableAutomations,
@@ -51,36 +21,18 @@ import { flushMicrotasks } from "../../../_dom.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-const slimAvailable = (): AvailableAutomations =>
-  ({
-    triggers: [],
-    actions: [],
-    conditions: [],
-    scripts: [],
-    devices: [],
-  }) as unknown as AvailableAutomations;
+import { makeEditorApi, mountEditor, slimAvailable } from "./_editor-harness.js";
 
-const makeApi = (available: AvailableAutomations = slimAvailable()) => ({
-  getAvailableAutomations: vi.fn().mockResolvedValue(available),
-  getAutomationBodies: vi.fn().mockResolvedValue({}),
-  deleteAutomation: vi.fn().mockResolvedValue({
-    yaml_diff: { fromLine: 0, toLine: 0, replacement: "" },
-  }),
-  updateConfig: vi.fn().mockResolvedValue(undefined),
-});
-
-async function mountEditor(
+async function mountAndSettle(
   editor: ESPHomeAutomationEditor | ESPHomeScriptEditor | ESPHomeApiActionEditor,
-  api: ReturnType<typeof makeApi>,
+  api: ReturnType<typeof makeEditorApi>,
   location: AutomationLocation
 ) {
-  (editor as any)._api = api as unknown as ESPHomeAPI;
-  editor.configuration = "device.yaml";
-  (editor as any).location = location;
-  (editor as any).value = { trigger_id: null, trigger_params: {}, actions: [] };
-  document.body.appendChild(editor);
-  await editor.updateComplete;
-  await flushMicrotasks(5);
+  await mountEditor(editor, api, {
+    configuration: "device.yaml",
+    location,
+    value: { trigger_id: null, trigger_params: {}, actions: [] } as never,
+  });
   await editor.updateComplete;
 }
 
@@ -119,9 +71,11 @@ describe.each(CASES)(
   "$name delete confirm gate",
   ({ make, location, available, expectedName }) => {
     it("clicking Delete opens the confirm dialog without deleting", async () => {
-      const api = makeApi(available);
+      const api = makeEditorApi(
+        available ? { getAvailableAutomations: vi.fn().mockResolvedValue(available) } : {}
+      );
       const editor = make();
-      await mountEditor(editor, api, location);
+      await mountAndSettle(editor, api, location);
 
       const button = editor.shadowRoot!.querySelector<HTMLButtonElement>(".ae-danger")!;
       expect(button).not.toBeNull();
@@ -134,9 +88,9 @@ describe.each(CASES)(
     });
 
     it("the dialog's confirm event runs the delete", async () => {
-      const api = makeApi();
+      const api = makeEditorApi();
       const editor = make();
-      await mountEditor(editor, api, location);
+      await mountAndSettle(editor, api, location);
 
       const dialog = editor.shadowRoot!.querySelector("esphome-confirm-dialog")!;
       dialog.dispatchEvent(new CustomEvent("confirm", { bubbles: true }));
@@ -147,11 +101,13 @@ describe.each(CASES)(
     });
 
     it("names the delete target in the confirm message", async () => {
-      const api = makeApi(available);
+      const api = makeEditorApi(
+        available ? { getAvailableAutomations: vi.fn().mockResolvedValue(available) } : {}
+      );
       const editor = make();
       (editor as any)._localize = (key: string, params?: Record<string, string>) =>
         params?.name ? `${key}:${params.name}` : key;
-      await mountEditor(editor, api, location);
+      await mountAndSettle(editor, api, location);
 
       const dialog = editor.shadowRoot!.querySelector("esphome-confirm-dialog")!;
       expect(dialog.getAttribute("message")!.endsWith(`:${expectedName}`)).toBe(true);
@@ -161,11 +117,11 @@ describe.each(CASES)(
 
 describe("automation editor delete confirm before the catalog resolves", () => {
   it("falls back to the raw trigger key, not the generic title", async () => {
-    const api = makeApi();
+    const api = makeEditorApi();
     const editor = new ESPHomeAutomationEditor();
     (editor as any)._localize = (key: string, params?: Record<string, string>) =>
       params?.name ? `${key}:${params.name}` : key;
-    await mountEditor(editor, api, { kind: "device_on", trigger: "on_boot" });
+    await mountAndSettle(editor, api, { kind: "device_on", trigger: "on_boot" });
 
     const dialog = editor.shadowRoot!.querySelector("esphome-confirm-dialog")!;
     expect(dialog.getAttribute("message")!.endsWith(":on_boot")).toBe(true);

--- a/test/components/device/automation-editor/delete-confirm.test.ts
+++ b/test/components/device/automation-editor/delete-confirm.test.ts
@@ -6,7 +6,7 @@
  * children are no-op mocked; the confirm dialog is stubbed with an
  * observable ``open()``.
  */
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import "./_editor-harness.js";
 

--- a/test/components/device/automation-editor/delete-confirm.test.ts
+++ b/test/components/device/automation-editor/delete-confirm.test.ts
@@ -21,7 +21,12 @@ import { flushMicrotasks } from "../../../_dom.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { makeEditorApi, mountEditor, slimAvailable } from "./_editor-harness.js";
+import {
+  makeEditorApi,
+  mountEditor,
+  seedTree,
+  slimAvailable,
+} from "./_editor-harness.js";
 
 async function mountAndSettle(
   editor: ESPHomeAutomationEditor | ESPHomeScriptEditor | ESPHomeApiActionEditor,
@@ -31,7 +36,7 @@ async function mountAndSettle(
   await mountEditor(editor, api, {
     configuration: "device.yaml",
     location,
-    value: { trigger_id: null, trigger_params: {}, actions: [] } as never,
+    value: seedTree(),
   });
   await editor.updateComplete;
 }

--- a/test/components/device/automation-editor/script-editor-mount.test.ts
+++ b/test/components/device/automation-editor/script-editor-mount.test.ts
@@ -9,59 +9,31 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
-vi.mock(
-  "../../../../src/components/device/automation-editor/automation-action-list.js",
-  () => ({})
-);
-vi.mock(
-  "../../../../src/components/device/automation-editor/callable-params-editor.js",
-  () => ({})
-);
-vi.mock("../../../../src/components/confirm-dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
-vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+import "./_editor-harness.js";
 
 import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type { AvailableAutomations } from "../../../../src/api/types/automations.js";
 import { ESPHomeScriptEditor } from "../../../../src/components/device/automation-editor/script-editor.js";
 import { _clearAutomationBodyCache } from "../../../../src/util/automation-body-cache.js";
-import { flushMicrotasks } from "../../../_dom.js";
 
-const slimWithLoggerAction = (): AvailableAutomations =>
-  ({
-    triggers: [],
-    actions: [{ id: "logger.log", config_entries: [] }],
-    conditions: [],
-    scripts: [],
-    devices: [],
-  }) as unknown as AvailableAutomations;
-
-const loggerBodies = () => ({
-  "actions/logger.log": {
-    id: "logger.log",
-    config_entries: [{ key: "format", type: "string", label: "Format", required: true }],
-  },
-});
+import {
+  loggerBodies,
+  mountEditor as mountHarness,
+  slimWithLoggerAction,
+} from "./_editor-harness.js";
 
 async function mountEditor(
   api: ESPHomeAPI,
   configuration?: string,
   props: object = {}
 ): Promise<ESPHomeScriptEditor> {
-  const editor = new ESPHomeScriptEditor();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (editor as any)._api = api;
-  if (configuration !== undefined) editor.configuration = configuration;
-  Object.assign(editor, props);
-  document.body.appendChild(editor);
-  await editor.updateComplete;
-  await flushMicrotasks(30);
-  return editor;
+  const editor = Object.assign(new ESPHomeScriptEditor(), props);
+  return mountHarness(
+    editor,
+    api,
+    configuration !== undefined ? { configuration, settle: 30 } : { settle: 30 }
+  );
 }
 
 describe("script-editor action-catalog hydration (#1286)", () => {


### PR DESCRIPTION
# What does this implement/fix?

Extracts the shared scaffolding the automation editor suites had been copy pasting into `test/components/device/automation-editor/_editor-harness.ts`, following the `test/pages/_mock-dashboard-children.ts` pattern: a side effect module carrying the union of the heavy children `vi.mock` no-ops (imported first, registration is import order dependent), plus `slimAvailable`, a parameterizable `makeEditorApi` covering every verb the editors call, the mount and settle helper with a `settle` knob for the hydration suites, and the hoisted `slimWithLoggerAction` / `loggerBodies` fixtures that were byte identical between the script and api action hydration suites.

Six suites migrate onto it: the three mount suites, `automation-editor-uneditable`, `delete-confirm`, and `can-apply-wiring`. Two files from the issue's inventory stay put deliberately: `automation-focus-plumbing` needs the real action list (the harness no-ops it), and `hydrate-available-bodies`' catalog factory is a different fixture (populated triggers) rather than a true duplicate. Suite specific fixtures remain in their suites.

Behavior free for the suite: same 254 tests in the directory, full run green.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1452

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
