### PR TITLE
Type the section-editor event contract

### DIFF
--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -7,10 +7,10 @@ import type {
 } from "../../../api/types/automations.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { fireEvent } from "../../../util/fire-event.js";
-import type { SectionEditor } from "../section-editor.js";
-import { fireSectionEvent } from "../section-editor.js";
 import { formatApiError } from "../../../util/format-api-error.js";
 import { notifyError } from "../../../util/notify.js";
+import type { SectionEditor } from "../section-editor.js";
+import { fireSectionEvent } from "../section-editor.js";
 import { applyYamlDiff, emptyAutomationTree } from "./serialise.js";
 
 /** Debounce window between a value change and the auto-apply upsert.

--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -7,6 +7,8 @@ import type {
 } from "../../../api/types/automations.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { fireEvent } from "../../../util/fire-event.js";
+import type { SectionEditor } from "../section-editor.js";
+import { fireSectionEvent } from "../section-editor.js";
 import { formatApiError } from "../../../util/format-api-error.js";
 import { notifyError } from "../../../util/notify.js";
 import { applyYamlDiff, emptyAutomationTree } from "./serialise.js";
@@ -19,7 +21,8 @@ export const AUTO_APPLY_DEBOUNCE_MS = 200;
 /** The slice of an automation-section editor the engine reads (and,
  *  for ``value``, writes). All three hosts (automation / script /
  *  api-action editor) expose exactly these reactive properties. */
-export interface AutoApplyHost extends ReactiveControllerHost, EventTarget {
+export interface AutoApplyHost
+  extends ReactiveControllerHost, EventTarget, SectionEditor {
   configuration: string;
   yaml: string;
   addMode: boolean;
@@ -93,14 +96,14 @@ export class AutoApplyController implements ReactiveController {
    *  ``flushPending()`` before its global save. Mirrors
    *  device-section-config's section-mount event. */
   hostConnected(): void {
-    fireEvent(this._host, "section-mount", { node: this._host });
+    fireSectionEvent(this._host, "section-mount", { node: this._host });
   }
 
   hostDisconnected(): void {
     // Cancel the pending debounced upsert — a write scheduled by a
     // section that's no longer on screen must not fire.
     this._clearTimer();
-    fireEvent(this._host, "section-unmount", { node: this._host });
+    fireSectionEvent(this._host, "section-unmount", { node: this._host });
   }
 
   /** Brief-window dirty flag covering the debounce gap so the global
@@ -315,7 +318,7 @@ export class AutoApplyController implements ReactiveController {
     if (this._dirty === value) return;
     this._dirty = value;
     this._host.requestUpdate();
-    fireEvent(this._host, "dirty-change", { dirty: value });
+    fireSectionEvent(this._host, "dirty-change", { dirty: value });
   }
 
   private _setDeleting(value: boolean): void {

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -44,6 +44,7 @@ import type { ESPHomeAddAutomationDialog } from "./add-automation-dialog.js";
 import type { ConfigEntryValueChange } from "./config-entry-form.js";
 import { deviceSectionConfigStyles } from "./device-section-config.styles.js";
 import type { SectionEditor } from "./section-editor.js";
+import { fireSectionEvent } from "./section-editor.js";
 import {
   applySectionValues,
   flushDraft,
@@ -291,7 +292,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
     // Announce so the page-level navigation guard (device.ts) can hold a
     // direct ref. The tree is page → device-editor → device-board-info → us;
     // a property passthrough chain would cost three edits per API change.
-    fireEvent(this, "section-mount", { node: this });
+    fireSectionEvent(this, "section-mount", { node: this });
   }
 
   disconnectedCallback() {
@@ -300,7 +301,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
       clearTimeout(this._draftTimer);
       this._draftTimer = null;
     }
-    fireEvent(this, "section-unmount", { node: this });
+    fireSectionEvent(this, "section-unmount", { node: this });
   }
 
   // Flush pending draft sync now. The page calls this before save / section
@@ -334,7 +335,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
   _setDirty(value: boolean): void {
     if (this._dirty === value) return;
     this._dirty = value;
-    fireEvent(this, "dirty-change", { dirty: value });
+    fireSectionEvent(this, "dirty-change", { dirty: value });
   }
 
   _scheduleDraftFlush() {

--- a/src/components/device/section-editor.ts
+++ b/src/components/device/section-editor.ts
@@ -28,7 +28,7 @@ export interface SectionEditor {
   reload(): void;
 }
 
-export interface SectionMountDetail {
+export interface SectionLifecycleDetail {
   node: SectionEditor;
 }
 
@@ -38,8 +38,8 @@ export interface SectionDirtyChangeDetail {
 
 /** The events every section editor dispatches for the device page. */
 export interface SectionEditorEventMap {
-  "section-mount": SectionMountDetail;
-  "section-unmount": SectionMountDetail;
+  "section-mount": SectionLifecycleDetail;
+  "section-unmount": SectionLifecycleDetail;
   "dirty-change": SectionDirtyChangeDetail;
 }
 
@@ -55,8 +55,8 @@ export function fireSectionEvent<K extends keyof SectionEditorEventMap>(
 
 declare global {
   interface HTMLElementEventMap {
-    "section-mount": CustomEvent<SectionMountDetail>;
-    "section-unmount": CustomEvent<SectionMountDetail>;
-    "dirty-change": CustomEvent<SectionDirtyChangeDetail>;
+    "section-mount": CustomEvent<SectionEditorEventMap["section-mount"]>;
+    "section-unmount": CustomEvent<SectionEditorEventMap["section-unmount"]>;
+    "dirty-change": CustomEvent<SectionEditorEventMap["dirty-change"]>;
   }
 }

--- a/src/components/device/section-editor.ts
+++ b/src/components/device/section-editor.ts
@@ -5,9 +5,12 @@
  * drift is a compile error instead of a save-guard edge case; the
  * page's ``section-mount`` / ``section-unmount`` handlers and the
  * YAML-driven reload path type against it. The event trio the same
- * editors dispatch (``section-mount`` / ``section-unmount`` /
- * ``dirty-change``) is deliberately not covered here.
+ * editors dispatch is covered too: firers go through
+ * ``fireSectionEvent`` and consumers read the augmented
+ * ``HTMLElementEventMap``, so a renamed event or a reshaped detail
+ * is a compile error on both ends.
  */
+import { fireEvent } from "../../util/fire-event.js";
 export interface SectionEditor {
   /** Brief-window dirty flag so the global save button arms as
    *  soon as the user edits. */
@@ -23,4 +26,37 @@ export interface SectionEditor {
   /** Re-hydrate from the live YAML after the pane changes the
    *  document out from under the editor. */
   reload(): void;
+}
+
+export interface SectionMountDetail {
+  node: SectionEditor;
+}
+
+export interface SectionDirtyChangeDetail {
+  dirty: boolean;
+}
+
+/** The events every section editor dispatches for the device page. */
+export interface SectionEditorEventMap {
+  "section-mount": SectionMountDetail;
+  "section-unmount": SectionMountDetail;
+  "dirty-change": SectionDirtyChangeDetail;
+}
+
+/** ``fireEvent`` narrowed to the section-editor trio so both the
+ *  name and the detail shape are checked at the firer. */
+export function fireSectionEvent<K extends keyof SectionEditorEventMap>(
+  target: EventTarget,
+  name: K,
+  detail: SectionEditorEventMap[K]
+): void {
+  fireEvent(target, name, detail);
+}
+
+declare global {
+  interface HTMLElementEventMap {
+    "section-mount": CustomEvent<SectionMountDetail>;
+    "section-unmount": CustomEvent<SectionMountDetail>;
+    "dirty-change": CustomEvent<SectionDirtyChangeDetail>;
+  }
 }

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1781,23 +1781,20 @@ export class ESPHomePageDevice extends LitElement {
     });
   }
 
-  private _onSectionMount = (e: Event) => {
-    const ev = e as CustomEvent<{ node: SectionEditor }>;
-    this._activeSection = ev.detail.node;
-    this._sectionDirty = ev.detail.node.dirty;
+  private _onSectionMount = (e: HTMLElementEventMap["section-mount"]) => {
+    this._activeSection = e.detail.node;
+    this._sectionDirty = e.detail.node.dirty;
   };
 
-  private _onSectionUnmount = (e: Event) => {
-    const ev = e as CustomEvent<{ node: SectionEditor }>;
-    if (this._activeSection === ev.detail.node) {
+  private _onSectionUnmount = (e: HTMLElementEventMap["section-unmount"]) => {
+    if (this._activeSection === e.detail.node) {
       this._activeSection = null;
       this._sectionDirty = false;
     }
   };
 
-  private _onSectionDirtyChange = (e: Event) => {
-    const ev = e as CustomEvent<{ dirty: boolean }>;
-    this._sectionDirty = ev.detail.dirty;
+  private _onSectionDirtyChange = (e: HTMLElementEventMap["dirty-change"]) => {
+    this._sectionDirty = e.detail.dirty;
   };
 
   // ─── URL State Persistence ─────────────────────────────────

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -46,6 +46,10 @@ class Host extends EventTarget implements AutoApplyHost {
   addMode = false;
   value: AutomationTree | null = tree();
   location: AutomationLocation | null = SCRIPT;
+  // SectionEditor surface the real hosts delegate to the engine.
+  dirty = false;
+  flushPending(): void {}
+  reload(): void {}
   updates = 0;
   addController(_c: ReactiveController): void {}
   removeController(): void {}


### PR DESCRIPTION
# What does this implement/fix?

Types the event half of the section editor contract, finishing what #1456 did for the member half. The trio the page depends on (`section-mount` / `section-unmount` with `{ node }`, `dirty-change` with `{ dirty }`) was still duck typed between its two firers and `device.ts`.

`section-editor.ts` now declares the detail interfaces and a `SectionEditorEventMap`, both firers dispatch through a `fireSectionEvent` wrapper that checks the name and the detail shape at compile time, and a global `HTMLElementEventMap` augmentation types the consumer side, letting `device.ts` drop its three event casts. The generic `fireEvent` stays untyped on purpose: call sites across the repo already use names that collide with built in DOM map keys (`change`, `cancel`, `close`), so a repo wide typed overload would break them; the wrapper scopes enforcement to the trio that has two independent firers.

`AutoApplyHost` now extends `SectionEditor`, which is truthful (every real host exposes those members by delegating to the engine) and is what lets the controller's `{ node: this._host }` dispatch type check. The engine test's host stub gains the three members. Enforcement is `tsc`; no behavior change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1458

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
