### PR TITLE
Remove board-info's unreachable add dialogs

### DIFF
--- a/src/components/device/add-config-dialog.ts
+++ b/src/components/device/add-config-dialog.ts
@@ -13,9 +13,9 @@ import type { ESPHomeAddComponentDialog } from "./add-component-dialog.js";
  * configuration entries (api, wifi, logger, target platforms,
  * substitutions, …).
  *
- * Kept as its own custom element so the navigator / board-info host
- * can `@query("esphome-add-config-dialog")` and call `.open()`
- * without conflating the two entry points.
+ * Kept as its own custom element so the navigator host can
+ * `@query("esphome-add-config-dialog")` and call `.open()` without
+ * conflating the two entry points.
  */
 @customElement("esphome-add-config-dialog")
 export class ESPHomeAddConfigDialog extends LitElement {

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -33,9 +33,7 @@ import { SECTION_ICON } from "./section-icons.js";
 import "@home-assistant/webawesome/dist/components/badge/badge.js";
 import "@home-assistant/webawesome/dist/components/callout/callout.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
-import "./add-automation-dialog.js";
 import "./add-component-dialog.js";
-import "./add-config-dialog.js";
 import "./automation-editor/api-action-editor.js";
 import "./automation-editor/automation-editor.js";
 import "./automation-editor/script-editor.js";
@@ -331,13 +329,6 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
             `
       }
 
-      <esphome-add-config-dialog
-        .boardName=${board?.name ?? ""}
-        .configuration=${this.configuration}
-        .platform=${board?.esphome.platform ?? ""}
-        .board=${board}
-        .yaml=${this.yaml}
-      ></esphome-add-config-dialog>
       <esphome-add-component-dialog
         .boardName=${board?.name ?? ""}
         .configuration=${this.configuration}
@@ -345,12 +336,6 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
         .board=${board}
         .yaml=${this.yaml}
       ></esphome-add-component-dialog>
-      <esphome-add-automation-dialog
-        .boardName=${board?.name ?? ""}
-        .configuration=${this.configuration}
-        .board=${board}
-        .yaml=${this.yaml}
-      ></esphome-add-automation-dialog>
       <esphome-change-board-dialog
         .currentBoard=${board}
         .boards=${this._alternateBoards}

--- a/test/components/device/device-board-info-welcome-banner.test.ts
+++ b/test/components/device/device-board-info-welcome-banner.test.ts
@@ -10,9 +10,7 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@home-assistant/webawesome/dist/components/badge/badge.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/callout/callout.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("../../../src/components/device/add-automation-dialog.js", () => ({}));
 vi.mock("../../../src/components/device/add-component-dialog.js", () => ({}));
-vi.mock("../../../src/components/device/add-config-dialog.js", () => ({}));
 vi.mock(
   "../../../src/components/device/automation-editor/api-action-editor.js",
   () => ({})


### PR DESCRIPTION
# What does this implement/fix?

Removes the `esphome-add-config-dialog` and `esphome-add-automation-dialog` instances from `device-board-info`'s template, along with their side effect imports. Both dialogs open only via imperative `open()`, and the only handles on these copies were two `@query` refs that nothing called, removed as dead in #1462. The live copies users actually reach are the ones rendered by `device-navigator`, so these instances were unreachable DOM weight and a trap for the next person wiring an open call to the wrong instance.

The `add-component-dialog` and `change-board-dialog` instances stay; both are opened from this component. The welcome banner test's mocks for the two removed imports are dropped too.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1463

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] Documentation only — `docs`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
