### PR TITLE
Revert optimistic label assignments when set_labels fails

### DIFF
--- a/src/components/labels/device-labels-editor.ts
+++ b/src/components/labels/device-labels-editor.ts
@@ -60,6 +60,10 @@ registerMdiIcons({
   "tag-multiple": mdiTagMultiple,
 });
 
+/** Order-insensitive label-id set equality. */
+const sameIds = (a: string[], b: string[]): boolean =>
+  a.length === b.length && b.every((id) => a.includes(id));
+
 @customElement("esphome-device-labels-editor")
 export class ESPHomeDeviceLabelsEditor extends LitElement {
   @consume({ context: localizeContext, subscribe: true })
@@ -250,6 +254,10 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
       // Drop any in-flight create snapshot so a late ``label-created``
       // arriving after the swap is ignored rather than misapplied.
       this._pendingCreateConfig = null;
+      // _pendingSaves is deliberately NOT reset: the orphaned task
+      // still runs its finally. Zeroing it here would drive the
+      // counter negative and permanently disable the same-device
+      // clear below.
     } else if (this._pendingSaves === 0) {
       // A same-device prop update — the ``DEVICE_UPDATED`` push that lands
       // after our own ``set_labels`` — now carries the saved labels, so drop
@@ -392,18 +400,26 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
     const config = this.device.configuration;
     this._pendingSaves++;
     const task = this._saveChain.then(async () => {
+      let failed = false;
       try {
         await api.setDeviceLabels(config, nextIds);
       } catch (err) {
+        failed = true;
         console.warn("set_labels failed", err);
         notifyError(this._localize("dashboard.labels_save_failed"));
       } finally {
         this._pendingSaves--;
-        // Success: the DEVICE_UPDATED push rode the socket ahead of
-        // this reply, so the prop is authoritative. Failure: the prop
-        // is the truth the write never changed. Either way drop the
-        // override, unless a newer click already owns it.
-        if (this._optimisticLabels === nextIds) this._optimisticLabels = null;
+        // Failure: the prop is the truth the write never changed —
+        // revert. Success: hand authority back only once the prop
+        // actually carries the saved labels (covers a no-op save the
+        // backend doesn't push for); otherwise ``willUpdate`` drops
+        // the override when the DEVICE_UPDATED push lands, since
+        // ``_pendingSaves`` is 0 by then. Never clobber a newer
+        // click's override (identity check).
+        const propAgrees = sameIds(this.device.labels ?? [], nextIds);
+        if (this._optimisticLabels === nextIds && (failed || propAgrees)) {
+          this._optimisticLabels = null;
+        }
       }
     });
     this._saveChain = task;

--- a/src/components/labels/device-labels-editor.ts
+++ b/src/components/labels/device-labels-editor.ts
@@ -104,6 +104,11 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
    *  state non-deterministic on overlapping requests. */
   private _saveChain: Promise<unknown> = Promise.resolve();
 
+  /** Saves queued or in flight; while non-zero a same-device prop
+   *  update must not drop the optimistic override (an unrelated
+   *  ``DEVICE_UPDATED`` push would revert the chips mid-save). */
+  private _pendingSaves = 0;
+
   private readonly _dialog = new DialogOpenController(this);
 
   @query("esphome-label-form")
@@ -232,24 +237,27 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
   protected willUpdate(changed: Map<string, unknown>) {
     if (!changed.has("device")) return;
     const prev = changed.get("device") as ConfiguredDevice | undefined;
-    // A same-device prop update — the ``DEVICE_UPDATED`` push that lands
-    // after our own ``set_labels`` — now carries the saved labels, so drop
-    // the optimistic override and trust the prop. Crucially, DON'T close the
-    // dialog: the user is mid-edit and toggling more labels, and each toggle
-    // round-trips through this same push.
-    this._optimisticLabels = null;
     // Only a real swap to a *different* device tears down the transient edit
     // state and closes the dialog; otherwise a half-typed "create" form would
     // persist into the next device's editor and a still-pending save chained
     // against the previous device would keep gating this one through
     // the stale _saveChain.
     if (prev !== undefined && prev.configuration !== this.device.configuration) {
+      this._optimisticLabels = null;
       this._dialog.open = false;
       this._createForm?.collapse();
       this._saveChain = Promise.resolve();
       // Drop any in-flight create snapshot so a late ``label-created``
       // arriving after the swap is ignored rather than misapplied.
       this._pendingCreateConfig = null;
+    } else if (this._pendingSaves === 0) {
+      // A same-device prop update — the ``DEVICE_UPDATED`` push that lands
+      // after our own ``set_labels`` — now carries the saved labels, so drop
+      // the optimistic override and trust the prop. Only with no save
+      // pending: an unrelated push mid-save must not revert the chips.
+      // Crucially, DON'T close the dialog: the user is mid-edit and toggling
+      // more labels, and each toggle round-trips through this same push.
+      this._optimisticLabels = null;
     }
   }
 
@@ -382,12 +390,20 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
     if (!this._api) return;
     const api = this._api;
     const config = this.device.configuration;
+    this._pendingSaves++;
     const task = this._saveChain.then(async () => {
       try {
         await api.setDeviceLabels(config, nextIds);
       } catch (err) {
         console.warn("set_labels failed", err);
         notifyError(this._localize("dashboard.labels_save_failed"));
+      } finally {
+        this._pendingSaves--;
+        // Success: the DEVICE_UPDATED push rode the socket ahead of
+        // this reply, so the prop is authoritative. Failure: the prop
+        // is the truth the write never changed. Either way drop the
+        // override, unless a newer click already owns it.
+        if (this._optimisticLabels === nextIds) this._optimisticLabels = null;
       }
     });
     this._saveChain = task;

--- a/src/components/labels/device-labels-editor.ts
+++ b/src/components/labels/device-labels-editor.ts
@@ -46,6 +46,7 @@ import {
 import { labelChipStyleString } from "../../util/label-style.js";
 import { notifyError } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { setsEqual } from "../../util/set-equal.js";
 import "./label-form.js";
 import type { ESPHomeLabelForm } from "./label-form.js";
 import { labelsListStyles } from "./labels-list-styles.js";
@@ -59,10 +60,6 @@ registerMdiIcons({
   pencil: mdiPencil,
   "tag-multiple": mdiTagMultiple,
 });
-
-/** Order-insensitive label-id set equality. */
-const sameIds = (a: string[], b: string[]): boolean =>
-  a.length === b.length && b.every((id) => a.includes(id));
 
 @customElement("esphome-device-labels-editor")
 export class ESPHomeDeviceLabelsEditor extends LitElement {
@@ -390,10 +387,10 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
   };
 
   /** Re-emit a ``label_ids`` change as a serialized
-   *  ``set_labels`` round trip. We rely on the backend's
-   *  ``DEVICE_UPDATED`` push to refresh the chip row; the
-   *  optimistic-state fallback keeps the UI consistent in the
-   *  meantime. */
+   *  ``set_labels`` round trip. The ``DEVICE_UPDATED`` push
+   *  refreshes the chip row when it arrives; the save's finally
+   *  releases the optimistic override on failure, or on success
+   *  once the prop already agrees. */
   private async _persist(nextIds: string[]) {
     if (!this._api) return;
     const api = this._api;
@@ -416,7 +413,7 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
         // the override when the DEVICE_UPDATED push lands, since
         // ``_pendingSaves`` is 0 by then. Never clobber a newer
         // click's override (identity check).
-        const propAgrees = sameIds(this.device.labels ?? [], nextIds);
+        const propAgrees = setsEqual(new Set(this.device.labels ?? []), new Set(nextIds));
         if (this._optimisticLabels === nextIds && (failed || propAgrees)) {
           this._optimisticLabels = null;
         }

--- a/src/components/labels/device-labels-editor.ts
+++ b/src/components/labels/device-labels-editor.ts
@@ -18,10 +18,10 @@
  * round trips and ``labelsContext`` for the live catalog (so a
  * ``label_*`` event from another client updates the dialog without
  * a re-fetch). Per-device assignments are owned by the caller —
- * we receive ``device`` as a property and rely on the subsequent
- * ``DEVICE_UPDATED`` push (fired from the backend after
- * ``set_labels`` reloads the device) to reset our optimistic
- * override.
+ * we receive ``device`` as a property; the optimistic override is
+ * dropped by whichever comes first, the save settling with the
+ * prop in agreement (or having failed), or the next same-device
+ * ``DEVICE_UPDATED`` push while no save is pending.
  */
 import { consume } from "@lit/context";
 import { mdiCheck, mdiClose, mdiPencil, mdiTagMultiple } from "@mdi/js";
@@ -94,10 +94,10 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
   /** Optimistic label assignment that overrides ``device.labels``
    *  while a save is in flight or queued. Lets the user toggle
    *  multiple chips quickly without each click computing ``next``
-   *  off a stale prop — the editor reads from this state until
-   *  the next ``DEVICE_UPDATED`` push hands the prop a list that
-   *  matches what we already wrote. ``null`` means "no pending
-   *  override; trust the prop". */
+   *  off a stale prop. Dropped by whichever comes first: the save
+   *  settling with the prop in agreement (or having failed), or
+   *  the next same-device push while no save is pending. ``null``
+   *  means "no pending override; trust the prop". */
   @state()
   private _optimisticLabels: string[] | null = null;
 

--- a/test/components/labels/device-labels-editor.test.ts
+++ b/test/components/labels/device-labels-editor.test.ts
@@ -270,5 +270,8 @@ describe("device-labels-editor optimistic override lifecycle", () => {
 
     resolveSave();
     await saving;
+    // Save succeeded but the prop hasn't caught up — the override
+    // must survive until the push lands.
+    expect(chipIds(el)).toEqual(["a"]);
   });
 });

--- a/test/components/labels/device-labels-editor.test.ts
+++ b/test/components/labels/device-labels-editor.test.ts
@@ -157,7 +157,37 @@ describe("device-labels-editor optimistic override lifecycle", () => {
     await second;
   });
 
-  it("drops the override once the save resolves", async () => {
+  it("drops the override in the save's finally when the push landed first", async () => {
+    const el = await mount();
+    let resolveSave!: () => void;
+    withApi(
+      el,
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        })
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const saving = (el as any)._toggleAssignment("a", true) as Promise<void>;
+    // DEVICE_UPDATED for our own write, riding ahead of the command
+    // reply; _pendingSaves > 0 blocks willUpdate from clearing here.
+    el.device = {
+      configuration: "kitchen",
+      labels: ["a"],
+    } as unknown as ConfiguredDevice;
+    await el.updateComplete;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._optimisticLabels).not.toBeNull();
+
+    resolveSave();
+    await saving;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._optimisticLabels).toBeNull();
+    expect(chipIds(el)).toEqual(["a"]);
+  });
+
+  it("a same-device push after the save settles drops the override", async () => {
     const el = await mount();
     withApi(el, () => Promise.resolve());
 

--- a/test/components/labels/device-labels-editor.test.ts
+++ b/test/components/labels/device-labels-editor.test.ts
@@ -10,6 +10,9 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
+vi.mock("sonner-js", () => ({
+  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 // Stub esphome-label-form with the one method the editor calls on its @query
@@ -24,6 +27,8 @@ vi.mock("../../../src/components/labels/label-form.js", () => {
   return {};
 });
 
+import toast from "sonner-js";
+
 import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
 import { ESPHomeDeviceLabelsEditor } from "../../../src/components/labels/device-labels-editor.js";
 
@@ -35,7 +40,7 @@ async function mount(): Promise<ESPHomeDeviceLabelsEditor> {
   return el;
 }
 
-/** Chip labels currently rendered, i.e. the effective assignment. */
+/** Effective label ids (optimistic override or prop). */
 const chipIds = (el: ESPHomeDeviceLabelsEditor): string[] =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (el as any)._currentLabelIds as string[];
@@ -117,6 +122,7 @@ describe("device-labels-editor optimistic override lifecycle", () => {
     await (el as any)._toggleAssignment("a", true);
 
     expect(chipIds(el)).toEqual([]);
+    expect(toast.error).toHaveBeenCalled();
   });
 
   it("keeps a newer click's optimistic state when an older save fails", async () => {

--- a/test/components/labels/device-labels-editor.test.ts
+++ b/test/components/labels/device-labels-editor.test.ts
@@ -204,6 +204,41 @@ describe("device-labels-editor optimistic override lifecycle", () => {
     expect((el as any)._optimisticLabels).toBeNull();
   });
 
+  it("a device swap mid-save leaves the pending counter consistent", async () => {
+    const el = await mount();
+    let resolveSave!: () => void;
+    withApi(
+      el,
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        })
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const saving = (el as any)._toggleAssignment("a", true) as Promise<void>;
+    el.device = {
+      configuration: "bedroom",
+      labels: [],
+    } as unknown as ConfiguredDevice;
+    await el.updateComplete;
+    resolveSave();
+    await saving;
+
+    // Counter drained back to 0, so the same-device exit still works;
+    // resetting _pendingSaves in the swap branch drives it negative
+    // and permanently disables this clear.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._optimisticLabels = ["x"];
+    el.device = {
+      configuration: "bedroom",
+      labels: ["y"],
+    } as unknown as ConfiguredDevice;
+    await el.updateComplete;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._optimisticLabels).toBeNull();
+  });
+
   it("an unrelated same-device push mid-save does not revert the chips", async () => {
     const el = await mount();
     let resolveSave!: () => void;

--- a/test/components/labels/device-labels-editor.test.ts
+++ b/test/components/labels/device-labels-editor.test.ts
@@ -7,8 +7,14 @@
  * close (Escape / X / outside-click) actually dismisses. Saves fire on every
  * label toggle while the dialog stays open, so it deliberately does NOT bind
  * ?busy (that would dim/lock the dialog on each toggle).
+ *
+ * Also pins the optimistic-override lifecycle: the override is dropped
+ * when the save settles (failure, or success once the prop agrees) or
+ * by a same-device push while no save is pending, a newer click's
+ * override survives an older save's failure, and a device swap
+ * mid-save must not reset the pending counter.
  */
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("sonner-js", () => ({
   default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
@@ -114,6 +120,10 @@ describe("device-labels-editor open/close contract", () => {
 });
 
 describe("device-labels-editor optimistic override lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("reverts the optimistic assignment when set_labels fails", async () => {
     const el = await mount();
     withApi(el, () => Promise.reject(new Error("nope")));
@@ -122,7 +132,7 @@ describe("device-labels-editor optimistic override lifecycle", () => {
     await (el as any)._toggleAssignment("a", true);
 
     expect(chipIds(el)).toEqual([]);
-    expect(toast.error).toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledTimes(1);
   });
 
   it("keeps a newer click's optimistic state when an older save fails", async () => {

--- a/test/components/labels/device-labels-editor.test.ts
+++ b/test/components/labels/device-labels-editor.test.ts
@@ -35,6 +35,19 @@ async function mount(): Promise<ESPHomeDeviceLabelsEditor> {
   return el;
 }
 
+/** Chip labels currently rendered, i.e. the effective assignment. */
+const chipIds = (el: ESPHomeDeviceLabelsEditor): string[] =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._currentLabelIds as string[];
+
+const withApi = (
+  el: ESPHomeDeviceLabelsEditor,
+  setDeviceLabels: (config: string, ids: string[]) => Promise<void>
+) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._api = { setDeviceLabels };
+};
+
 const dialog = (el: ESPHomeDeviceLabelsEditor): HTMLElement =>
   el.shadowRoot!.querySelector("esphome-base-dialog")!;
 
@@ -92,5 +105,89 @@ describe("device-labels-editor open/close contract", () => {
     } as unknown as ConfiguredDevice;
     await el.updateComplete;
     expect(isOpen(el)).toBe(true);
+  });
+});
+
+describe("device-labels-editor optimistic override lifecycle", () => {
+  it("reverts the optimistic assignment when set_labels fails", async () => {
+    const el = await mount();
+    withApi(el, () => Promise.reject(new Error("nope")));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any)._toggleAssignment("a", true);
+
+    expect(chipIds(el)).toEqual([]);
+  });
+
+  it("keeps a newer click's optimistic state when an older save fails", async () => {
+    const el = await mount();
+    let rejectFirst!: (e: Error) => void;
+    let resolveSecond!: () => void;
+    let calls = 0;
+    withApi(el, () =>
+      ++calls === 1
+        ? new Promise<void>((_, reject) => {
+            rejectFirst = reject;
+          })
+        : new Promise<void>((resolve) => {
+            resolveSecond = resolve;
+          })
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const first = (el as any)._toggleAssignment("a", true) as Promise<void>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const second = (el as any)._toggleAssignment("b", true) as Promise<void>;
+    // Let the chained task start so the first save is actually in flight.
+    await new Promise((r) => setTimeout(r));
+
+    rejectFirst(new Error("nope"));
+    await first;
+    // The failed save must not clobber the newer click's override.
+    expect(chipIds(el)).toEqual(["a", "b"]);
+    // Let the queued second save reach the API before releasing it.
+    await new Promise((r) => setTimeout(r));
+    resolveSecond();
+    await second;
+  });
+
+  it("drops the override once the save resolves", async () => {
+    const el = await mount();
+    withApi(el, () => Promise.resolve());
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any)._toggleAssignment("a", true);
+    el.device = {
+      configuration: "kitchen",
+      labels: ["a"],
+    } as unknown as ConfiguredDevice;
+    await el.updateComplete;
+
+    expect(chipIds(el)).toEqual(["a"]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._optimisticLabels).toBeNull();
+  });
+
+  it("an unrelated same-device push mid-save does not revert the chips", async () => {
+    const el = await mount();
+    let resolveSave!: () => void;
+    withApi(
+      el,
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        })
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const saving = (el as any)._toggleAssignment("a", true) as Promise<void>;
+    // A DEVICE_UPDATED push for something else (state flip) lands while
+    // the save is still in flight, carrying the pre-save labels.
+    el.device = { configuration: "kitchen", labels: [] } as unknown as ConfiguredDevice;
+    await el.updateComplete;
+    expect(chipIds(el)).toEqual(["a"]);
+
+    resolveSave();
+    await saving;
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

When a `devices/set_labels` round trip failed, the label editor kept showing the optimistic assignment; the toast fired but the chips stayed on state that was never persisted until the drawer reopened or the device broadcast. The save task now drops the optimistic override when it settles, guarded by identity against the snapshot it was chained with so a newer click's override is never clobbered. On failure that reverts the chips to the prop's truth per the repo's revert on failure rule; on success it hands authority back to the prop, which already carries the saved labels because the `DEVICE_UPDATED` push rides the same socket ahead of the command reply.

The same change tightens `willUpdate`: a same device prop update now only clears the override while no save is pending, so an unrelated push landing mid save (a state flip) can no longer briefly revert the chips to pre save labels.

Four new tests pin the failure revert, the newer click guard, the success drop, and the mid save push protection.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1464

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] Documentation only — `docs`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
