### PR TITLE
Await the section-switch flush before swapping the selection

### DIFF
--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1577,8 +1577,9 @@ export class ESPHomePageDevice extends LitElement {
     }
     this._heldUnknownInstance = null;
     // Cross-section: set the field path only when the switch actually
-    // applies, so a guard veto (unsaved edits) can't point the old
-    // section's form at a path meant for the new one.
+    // applies (after the flush barrier, and not at all if the page
+    // unmounted during it), so it can't point the old section's form
+    // at a path meant for the new one.
     void this._guardSectionSwitch(() => {
       this._selectedSection = sectionKey;
       this._selectedFromLine = match.fromLine;

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1326,7 +1326,7 @@ export class ESPHomePageDevice extends LitElement {
    *  not this one. */
   private _onBack = () => {
     this._heldUnknownInstance = null;
-    this._guardSectionSwitch(() => {
+    void this._guardSectionSwitch(() => {
       const prev = this._sectionHistory.length
         ? this._sectionHistory[this._sectionHistory.length - 1]
         : null;
@@ -1579,7 +1579,7 @@ export class ESPHomePageDevice extends LitElement {
     // Cross-section: set the field path only when the switch actually
     // applies, so a guard veto (unsaved edits) can't point the old
     // section's form at a path meant for the new one.
-    this._guardSectionSwitch(() => {
+    void this._guardSectionSwitch(() => {
       this._selectedSection = sectionKey;
       this._selectedFromLine = match.fromLine;
       this._focusFieldPath = rel;
@@ -1724,7 +1724,7 @@ export class ESPHomePageDevice extends LitElement {
       this._drawerOpen = false;
       return;
     }
-    this._guardSectionSwitch(() => {
+    void this._guardSectionSwitch(() => {
       // Back-stack bookkeeping: A → B pushes A so back returns to it.
       // Going back to no-section clears the trail — a later trip into
       // a section is a fresh navigation, not a continuation of the
@@ -1762,9 +1762,19 @@ export class ESPHomePageDevice extends LitElement {
    *  re-render in the form when they come back to this section.
    *  The leave-page guard (``_confirmLeave``) is the only thing
    *  that prompts about unsaved YAML, since *that's* the only
-   *  state that's actually at risk. */
-  private _guardSectionSwitch(action: () => void): void {
-    this._activeSection?.flushPending();
+   *  state that's actually at risk.
+   *
+   *  The flush is awaited before the switch: the automation
+   *  editors' flush is a backend upsert round trip, and swapping
+   *  the selection first can unmount the editor mid-flight — its
+   *  ``yaml-draft`` then fires from a detached element and never
+   *  reaches the page, silently dropping the last edit. */
+  private async _guardSectionSwitch(action: () => void): Promise<void> {
+    // Only a returned promise defers the switch; the component
+    // editor's sync flush (and no active section) keeps the switch
+    // synchronous, so cursor-driven selection stays re-entrant safe.
+    const pending = this._activeSection?.flushPending();
+    if (pending) await pending;
     action();
   }
 

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1724,6 +1724,10 @@ export class ESPHomePageDevice extends LitElement {
       this._drawerOpen = false;
       return;
     }
+    // Close the drawer before the guard's flush barrier: on mobile it
+    // is the only visual acknowledgement of the tap, and it is pure
+    // chrome — nothing about it depends on the flushed buffer.
+    this._drawerOpen = false;
     void this._guardSectionSwitch(() => {
       // Back-stack bookkeeping: A → B pushes A so back returns to it.
       // Going back to no-section clears the trail — a later trip into
@@ -1748,7 +1752,6 @@ export class ESPHomePageDevice extends LitElement {
       // user never pointed at.
       this._focusFieldPath = undefined;
       this._focusYamlPath = undefined;
-      this._drawerOpen = false;
       this._updateUrl();
     });
   }
@@ -1774,7 +1777,15 @@ export class ESPHomePageDevice extends LitElement {
     // editor's sync flush (and no active section) keeps the switch
     // synchronous, so cursor-driven selection stays re-entrant safe.
     const pending = this._activeSection?.flushPending();
-    if (pending) await pending;
+    if (pending) {
+      // A failed flush already surfaced its own error; still switch —
+      // blocking navigation on it is strictly worse than a stale draft.
+      try {
+        await pending;
+      } catch {
+        // Handled by the editor.
+      }
+    }
     action();
   }
 

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1792,7 +1792,11 @@ export class ESPHomePageDevice extends LitElement {
    *  editors' flush is a backend upsert round trip, and swapping
    *  the selection first can unmount the editor mid-flight — its
    *  ``yaml-draft`` then fires from a detached element and never
-   *  reaches the page, silently dropping the last edit. */
+   *  reaches the page, silently dropping the last edit. The wait is
+   *  bounded by the WS command timeout (~10s worst case) and shows
+   *  no desktop busy affordance — a deliberate trade; repeat clicks
+   *  are harmless under the supersede token (#1478 tracks an
+   *  affordance). */
   private async _guardSectionSwitch(
     action: () => void,
     opts: { compose?: boolean } = {}

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1776,6 +1776,8 @@ export class ESPHomePageDevice extends LitElement {
     // Only a returned promise defers the switch; the component
     // editor's sync flush (and no active section) keeps the switch
     // synchronous, so cursor-driven selection stays re-entrant safe.
+    // The automation editors' flushPending is async, so switching out
+    // of one always defers — idle or not.
     const pending = this._activeSection?.flushPending();
     if (pending) {
       // A failed flush already surfaced its own error; still switch —
@@ -1785,6 +1787,9 @@ export class ESPHomePageDevice extends LitElement {
       } catch {
         // Handled by the editor.
       }
+      // The page can unmount across the flush; a late action would
+      // replaceState on whatever URL the user has since landed on.
+      if (!this.isConnected) return;
     }
     action();
   }

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1737,6 +1737,10 @@ export class ESPHomePageDevice extends LitElement {
     const { sectionKey, fromLine } = e.detail;
     this._heldUnknownInstance = null;
     if (sectionKey === this._selectedSection && fromLine === this._selectedFromLine) {
+      // Also supersede any switch still queued behind the flush
+      // barrier — the displayed section is the pre-switch one for the
+      // whole window, so a click on it is the user's newest intent.
+      this._switchSeq++;
       this._drawerOpen = false;
       return;
     }

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -330,8 +330,9 @@ export class ESPHomePageDevice extends LitElement {
    *  page and the section editor. */
   private _activeSection: SectionEditor | null = null;
 
-  /** Supersede token for the section-switch guard: a switch queued
-   *  behind the flush barrier yields to any later one. */
+  /** Supersede token for the section-switch guard: a queued absolute
+   *  switch yields to any later one; composing actions (Back) always
+   *  land but still bump the token. */
   private _switchSeq = 0;
 
   @state()

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -330,6 +330,10 @@ export class ESPHomePageDevice extends LitElement {
    *  page and the section editor. */
   private _activeSection: SectionEditor | null = null;
 
+  /** Supersede token for the section-switch guard: a switch queued
+   *  behind the flush barrier yields to any later one. */
+  private _switchSeq = 0;
+
   @state()
   private _sectionDirty = false;
 
@@ -1779,6 +1783,7 @@ export class ESPHomePageDevice extends LitElement {
     // synchronous, so cursor-driven selection stays re-entrant safe.
     // The automation editors' flushPending is async, so switching out
     // of one always defers — idle or not.
+    const seq = ++this._switchSeq;
     const pending = this._activeSection?.flushPending();
     if (pending) {
       // A failed flush already surfaced its own error; still switch —
@@ -1788,9 +1793,13 @@ export class ESPHomePageDevice extends LitElement {
       } catch {
         // Handled by the editor.
       }
-      // The page can unmount across the flush; a late action would
-      // replaceState on whatever URL the user has since landed on.
-      if (!this.isConnected) return;
+      // The page can unmount across the flush (a late action would
+      // replaceState on whatever URL the user has since landed on),
+      // and a later switch supersedes this one — the callers' dedupe
+      // reads pre-switch state for the whole window, so without the
+      // token a duplicate click double-pushes the back stack and a
+      // caret returning home still gets yanked away.
+      if (!this.isConnected || seq !== this._switchSeq) return;
     }
     action();
   }

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1330,21 +1330,26 @@ export class ESPHomePageDevice extends LitElement {
    *  not this one. */
   private _onBack = () => {
     this._heldUnknownInstance = null;
-    void this._guardSectionSwitch(() => {
-      const prev = this._sectionHistory.length
-        ? this._sectionHistory[this._sectionHistory.length - 1]
-        : null;
-      if (prev) {
-        this._sectionHistory = this._sectionHistory.slice(0, -1);
-        this._selectedSection = prev.key;
-        this._selectedFromLine = prev.fromLine;
-      } else {
-        this._selectedSection = null;
-        this._selectedFromLine = undefined;
-      }
-      this._setHighlight(null, false);
-      this._updateUrl();
-    });
+    // compose: each press pops one entry, so two presses inside one
+    // flush window must both land rather than the newest winning.
+    void this._guardSectionSwitch(
+      () => {
+        const prev = this._sectionHistory.length
+          ? this._sectionHistory[this._sectionHistory.length - 1]
+          : null;
+        if (prev) {
+          this._sectionHistory = this._sectionHistory.slice(0, -1);
+          this._selectedSection = prev.key;
+          this._selectedFromLine = prev.fromLine;
+        } else {
+          this._selectedSection = null;
+          this._selectedFromLine = undefined;
+        }
+        this._setHighlight(null, false);
+        this._updateUrl();
+      },
+      { compose: true }
+    );
   };
 
   /** Left-edge expand affordance. On mobile it opens the drawer; on
@@ -1559,6 +1564,12 @@ export class ESPHomePageDevice extends LitElement {
     ) {
       // Same section: update the field target directly for intra-section
       // moves (the switch below would early-return and freeze it).
+      // Also supersede any switch still queued behind the flush
+      // barrier — a caret that left and came home must not be yanked
+      // back out when the queued action fires. Safe against spurious
+      // cancellation: yaml-cursor-line only fires on selectionSet,
+      // which the flush's own draft sync never carries.
+      this._switchSeq++;
       this._focusFieldPath = rel;
       this._focusYamlPath = e.detail.indexedPath;
       return;
@@ -1777,7 +1788,10 @@ export class ESPHomePageDevice extends LitElement {
    *  the selection first can unmount the editor mid-flight — its
    *  ``yaml-draft`` then fires from a detached element and never
    *  reaches the page, silently dropping the last edit. */
-  private async _guardSectionSwitch(action: () => void): Promise<void> {
+  private async _guardSectionSwitch(
+    action: () => void,
+    opts: { compose?: boolean } = {}
+  ): Promise<void> {
     // Only a returned promise defers the switch; the component
     // editor's sync flush (and no active section) keeps the switch
     // synchronous, so cursor-driven selection stays re-entrant safe.
@@ -1798,8 +1812,12 @@ export class ESPHomePageDevice extends LitElement {
       // and a later switch supersedes this one — the callers' dedupe
       // reads pre-switch state for the whole window, so without the
       // token a duplicate click double-pushes the back stack and a
-      // caret returning home still gets yanked away.
-      if (!this.isConnected || seq !== this._switchSeq) return;
+      // caret returning home still gets yanked away. Composing
+      // actions (Back's relative history pop) are never dropped —
+      // two Back presses must pop twice — but still take the token,
+      // so a pending absolute switch yields to them.
+      if (!this.isConnected) return;
+      if (!opts.compose && seq !== this._switchSeq) return;
     }
     action();
   }

--- a/test/pages/device-cursor-highlight.test.ts
+++ b/test/pages/device-cursor-highlight.test.ts
@@ -104,15 +104,17 @@ describe("cursor-driven YAML highlight (#1885)", () => {
     expect(internals(page)._highlightRange).toBe(first);
   });
 
-  it("leaves highlight and selection on the old section when the guard vetoes", () => {
+  it("leaves highlight and selection on the old section when the guarded switch never lands", () => {
     const page = makePage();
     clickYamlLine(page, 2); // select i2c
     highlightViaNavigator(page, 1, 3);
     const before = internals(page)._highlightRange;
     expect(before).toEqual({ fromLine: 1, toLine: 3 });
 
+    // A switch whose action never runs (superseded, or the page
+    // unmounted during the flush) must leave the old state intact.
     vi.spyOn(internals(page), "_guardSectionSwitch").mockImplementation(() => {});
-    clickYamlLine(page, 5); // would move to sensor, but vetoed
+    clickYamlLine(page, 5); // would move to sensor; the action never lands
 
     expect(internals(page)._selectedSection).toBe("i2c");
     expect(internals(page)._highlightRange).toBe(before);

--- a/test/pages/device-section-switch-flush.test.ts
+++ b/test/pages/device-section-switch-flush.test.ts
@@ -68,6 +68,18 @@ describe("section-switch flush barrier", () => {
     expect(action).toHaveBeenCalledOnce();
   });
 
+  it("still switches when the flush rejects", async () => {
+    const page = new ESPHomePageDevice();
+    internals(page)._activeSection = {
+      dirty: true,
+      flushPending: () => Promise.reject(new Error("upsert failed")),
+      reload: () => {},
+    } satisfies SectionEditor;
+    const action = vi.fn();
+    await internals(page)._guardSectionSwitch(action);
+    expect(action).toHaveBeenCalledOnce();
+  });
+
   it("runs the action after a sync flush (component editor shape)", async () => {
     const page = new ESPHomePageDevice();
     const flushPending = vi.fn();

--- a/test/pages/device-section-switch-flush.test.ts
+++ b/test/pages/device-section-switch-flush.test.ts
@@ -213,6 +213,36 @@ describe("section-switch flush barrier", () => {
     expect(internals(page)._selectedFromLine).toBe(1);
   });
 
+  it("re-clicking the displayed section cancels the switch queued behind the flush", async () => {
+    const page = new ESPHomePageDevice();
+    setConnected(page, true);
+    let resolveFlush!: () => void;
+    internals(page)._activeSection = {
+      dirty: true,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          resolveFlush = resolve;
+        }),
+      reload: () => {},
+    } satisfies SectionEditor;
+    internals(page)._selectedSection = "i2c";
+    internals(page)._selectedFromLine = 1;
+
+    const select = (sectionKey: string, fromLine: number) =>
+      internals(page)._onSectionSelect(
+        new CustomEvent("section-select", { detail: { sectionKey, fromLine } })
+      );
+    // Click sensor — cross-section, queued behind the flush…
+    select("sensor", 3);
+    // …then click the still-displayed i2c again before it resolves.
+    select("i2c", 1);
+
+    resolveFlush();
+    await new Promise((r) => setTimeout(r));
+    expect(internals(page)._selectedSection).toBe("i2c");
+    expect(internals(page)._selectedFromLine).toBe(1);
+  });
+
   it("skips the action when the page unmounts during the flush", async () => {
     const page = new ESPHomePageDevice();
     let resolveFlush!: () => void;

--- a/test/pages/device-section-switch-flush.test.ts
+++ b/test/pages/device-section-switch-flush.test.ts
@@ -32,9 +32,15 @@ import type { SectionEditor } from "../../src/components/device/section-editor.j
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const internals = (page: ESPHomePageDevice) => page as any;
 
+/** Stub Node.isConnected — attaching the real page element would run
+ *  its full connectedCallback against a mockless backend. */
+const setConnected = (page: ESPHomePageDevice, value: boolean) =>
+  Object.defineProperty(page, "isConnected", { value, configurable: true });
+
 describe("section-switch flush barrier", () => {
   it("defers the switch until an async flushPending resolves", async () => {
     const page = new ESPHomePageDevice();
+    setConnected(page, true);
     let resolveFlush!: () => void;
     const editor: SectionEditor = {
       dirty: true,
@@ -60,16 +66,20 @@ describe("section-switch flush barrier", () => {
     expect(order).toEqual(["returned", "action"]);
   });
 
-  it("runs the action with no active section", async () => {
+  it("runs the action synchronously with no active section", async () => {
     const page = new ESPHomePageDevice();
     internals(page)._activeSection = null;
     const action = vi.fn();
-    await internals(page)._guardSectionSwitch(action);
+    const switching = internals(page)._guardSectionSwitch(action) as Promise<void>;
+    // No microtask hop: an async function runs synchronously up to
+    // its first await, and the no-flush path has none.
     expect(action).toHaveBeenCalledOnce();
+    await switching;
   });
 
   it("still switches when the flush rejects", async () => {
     const page = new ESPHomePageDevice();
+    setConnected(page, true);
     internals(page)._activeSection = {
       dirty: true,
       flushPending: () => Promise.reject(new Error("upsert failed")),
@@ -80,7 +90,7 @@ describe("section-switch flush barrier", () => {
     expect(action).toHaveBeenCalledOnce();
   });
 
-  it("runs the action after a sync flush (component editor shape)", async () => {
+  it("runs the action synchronously after a sync flush (component editor shape)", async () => {
     const page = new ESPHomePageDevice();
     const flushPending = vi.fn();
     internals(page)._activeSection = {
@@ -89,8 +99,35 @@ describe("section-switch flush barrier", () => {
       reload: () => {},
     } satisfies SectionEditor;
     const action = vi.fn();
-    await internals(page)._guardSectionSwitch(action);
+    const switching = internals(page)._guardSectionSwitch(action) as Promise<void>;
     expect(flushPending).toHaveBeenCalledOnce();
+    // No microtask hop: a void-returning flush must not defer the
+    // switch, or the cursor-driven paths become re-entrant.
     expect(action).toHaveBeenCalledOnce();
+    await switching;
+  });
+
+  it("skips the action when the page unmounts during the flush", async () => {
+    const page = new ESPHomePageDevice();
+    let resolveFlush!: () => void;
+    internals(page)._activeSection = {
+      dirty: true,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          resolveFlush = resolve;
+        }),
+      reload: () => {},
+    } satisfies SectionEditor;
+    setConnected(page, true);
+    const action = vi.fn();
+    const switching = internals(page)._guardSectionSwitch(action) as Promise<void>;
+
+    // The user leaves the device page while the flush is in flight; a
+    // late action would replaceState on whatever URL they landed on.
+    setConnected(page, false);
+
+    resolveFlush();
+    await switching;
+    expect(action).not.toHaveBeenCalled();
   });
 });

--- a/test/pages/device-section-switch-flush.test.ts
+++ b/test/pages/device-section-switch-flush.test.ts
@@ -8,23 +8,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("sonner-js", () => ({
-  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
-}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("../../src/components/command-dialog.js", () => ({}));
-vi.mock("../../src/components/device/device-editor.js", () => ({}));
-vi.mock("../../src/components/device/device-navigator.js", () => ({}));
-vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
-vi.mock("../../src/components/install-method-dialog.js", () => ({}));
-vi.mock("../../src/components/logs-dialog.js", () => ({}));
-vi.mock("../../src/components/unsaved-changes-dialog.js", () => ({}));
-vi.mock("../../src/components/yaml-validation-dialog.js", () => ({}));
-vi.mock("../../src/components/device/device-install-controller.js", () => ({
-  DeviceInstallController: class {
-    constructor() {}
-  },
-}));
+import "./_mock-device-children.js";
 
 import { ESPHomePageDevice } from "../../src/pages/device.js";
 import type { SectionEditor } from "../../src/components/device/section-editor.js";
@@ -133,6 +117,100 @@ describe("section-switch flush barrier", () => {
 
     expect(first).not.toHaveBeenCalled();
     expect(second).toHaveBeenCalledOnce();
+  });
+
+  it("composing actions queued behind one flush all land (Back pops twice)", async () => {
+    const page = new ESPHomePageDevice();
+    setConnected(page, true);
+    const resolvers: (() => void)[] = [];
+    internals(page)._activeSection = {
+      dirty: true,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve);
+        }),
+      reload: () => {},
+    } satisfies SectionEditor;
+
+    const pops: number[] = [];
+    const press = (n: number) =>
+      internals(page)._guardSectionSwitch(() => pops.push(n), {
+        compose: true,
+      }) as Promise<void>;
+    const p1 = press(1);
+    const p2 = press(2);
+
+    resolvers.forEach((r) => r());
+    await Promise.all([p1, p2]);
+    expect(pops).toEqual([1, 2]);
+  });
+
+  it("a composing action still supersedes a pending absolute switch", async () => {
+    const page = new ESPHomePageDevice();
+    setConnected(page, true);
+    const resolvers: (() => void)[] = [];
+    internals(page)._activeSection = {
+      dirty: true,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve);
+        }),
+      reload: () => {},
+    } satisfies SectionEditor;
+
+    const absolute = vi.fn();
+    const back = vi.fn();
+    const s1 = internals(page)._guardSectionSwitch(absolute) as Promise<void>;
+    const s2 = internals(page)._guardSectionSwitch(back, {
+      compose: true,
+    }) as Promise<void>;
+
+    resolvers.forEach((r) => r());
+    await Promise.all([s1, s2]);
+    expect(absolute).not.toHaveBeenCalled();
+    expect(back).toHaveBeenCalledOnce();
+  });
+
+  it("a caret returning home cancels the switch queued behind the flush", async () => {
+    const page = new ESPHomePageDevice();
+    setConnected(page, true);
+    let resolveFlush!: () => void;
+    internals(page)._activeSection = {
+      dirty: true,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          resolveFlush = resolve;
+        }),
+      reload: () => {},
+    } satisfies SectionEditor;
+    // Two top-level sections; the selection sits on i2c (line 1).
+    internals(page)._yaml = [
+      "i2c:",
+      "  sda: 1",
+      "sensor:",
+      "  - platform: aht10",
+      "",
+    ].join("\n");
+    internals(page)._savedYaml = internals(page)._yaml;
+    internals(page)._knownTopLevelKeys = new Set(["i2c", "sensor"]);
+    internals(page)._selectedSection = "i2c";
+    internals(page)._selectedFromLine = 1;
+
+    const cursor = (line: number) =>
+      internals(page)._onYamlCursorLine(
+        new CustomEvent("yaml-cursor-line", {
+          detail: { line, path: [], viaEdit: false },
+        })
+      );
+    // Caret moves into sensor — cross-section, queued behind the flush.
+    cursor(4);
+    // …and returns home to the exact block it left before it resolves.
+    cursor(2);
+
+    resolveFlush();
+    await new Promise((r) => setTimeout(r));
+    expect(internals(page)._selectedSection).toBe("i2c");
+    expect(internals(page)._selectedFromLine).toBe(1);
   });
 
   it("skips the action when the page unmounts during the flush", async () => {

--- a/test/pages/device-section-switch-flush.test.ts
+++ b/test/pages/device-section-switch-flush.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the section-switch guard's flush barrier: the switch action
+ * must not run until the active section's flushPending resolves, so
+ * an automation editor's in-flight upsert can dispatch yaml-draft
+ * from an element that is still in the tree.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("../../src/components/command-dialog.js", () => ({}));
+vi.mock("../../src/components/device/device-editor.js", () => ({}));
+vi.mock("../../src/components/device/device-navigator.js", () => ({}));
+vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
+vi.mock("../../src/components/install-method-dialog.js", () => ({}));
+vi.mock("../../src/components/logs-dialog.js", () => ({}));
+vi.mock("../../src/components/unsaved-changes-dialog.js", () => ({}));
+vi.mock("../../src/components/yaml-validation-dialog.js", () => ({}));
+vi.mock("../../src/components/device/device-install-controller.js", () => ({
+  DeviceInstallController: class {
+    constructor() {}
+  },
+}));
+
+import { ESPHomePageDevice } from "../../src/pages/device.js";
+import type { SectionEditor } from "../../src/components/device/section-editor.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const internals = (page: ESPHomePageDevice) => page as any;
+
+describe("section-switch flush barrier", () => {
+  it("defers the switch until an async flushPending resolves", async () => {
+    const page = new ESPHomePageDevice();
+    let resolveFlush!: () => void;
+    const editor: SectionEditor = {
+      dirty: true,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          resolveFlush = resolve;
+        }),
+      reload: () => {},
+    };
+    internals(page)._activeSection = editor;
+
+    const order: string[] = [];
+    const switching = internals(page)._guardSectionSwitch(() => {
+      order.push("action");
+    }) as Promise<void>;
+    order.push("returned");
+
+    await Promise.resolve();
+    expect(order).toEqual(["returned"]);
+
+    resolveFlush();
+    await switching;
+    expect(order).toEqual(["returned", "action"]);
+  });
+
+  it("runs the action with no active section", async () => {
+    const page = new ESPHomePageDevice();
+    internals(page)._activeSection = null;
+    const action = vi.fn();
+    await internals(page)._guardSectionSwitch(action);
+    expect(action).toHaveBeenCalledOnce();
+  });
+
+  it("runs the action after a sync flush (component editor shape)", async () => {
+    const page = new ESPHomePageDevice();
+    const flushPending = vi.fn();
+    internals(page)._activeSection = {
+      dirty: false,
+      flushPending,
+      reload: () => {},
+    } satisfies SectionEditor;
+    const action = vi.fn();
+    await internals(page)._guardSectionSwitch(action);
+    expect(flushPending).toHaveBeenCalledOnce();
+    expect(action).toHaveBeenCalledOnce();
+  });
+});

--- a/test/pages/device-section-switch-flush.test.ts
+++ b/test/pages/device-section-switch-flush.test.ts
@@ -243,6 +243,35 @@ describe("section-switch flush barrier", () => {
     expect(internals(page)._selectedFromLine).toBe(1);
   });
 
+  it("closes the drawer before the flush barrier (mobile tap feedback)", async () => {
+    const page = new ESPHomePageDevice();
+    setConnected(page, true);
+    let resolveFlush!: () => void;
+    internals(page)._activeSection = {
+      dirty: true,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          resolveFlush = resolve;
+        }),
+      reload: () => {},
+    } satisfies SectionEditor;
+    internals(page)._selectedSection = "i2c";
+    internals(page)._selectedFromLine = 1;
+    internals(page)._drawerOpen = true;
+
+    internals(page)._onSectionSelect(
+      new CustomEvent("section-select", {
+        detail: { sectionKey: "sensor.aht10", fromLine: 3 },
+      })
+    );
+    // Chrome, not selection state: the close must not wait on the
+    // barrier, or the mobile tap gets no acknowledgement.
+    expect(internals(page)._drawerOpen).toBe(false);
+
+    resolveFlush();
+    await new Promise((r) => setTimeout(r));
+  });
+
   it("skips the action when the page unmounts during the flush", async () => {
     const page = new ESPHomePageDevice();
     let resolveFlush!: () => void;

--- a/test/pages/device-section-switch-flush.test.ts
+++ b/test/pages/device-section-switch-flush.test.ts
@@ -107,6 +107,34 @@ describe("section-switch flush barrier", () => {
     await switching;
   });
 
+  it("a later switch supersedes one queued behind the flush", async () => {
+    const page = new ESPHomePageDevice();
+    setConnected(page, true);
+    const resolvers: (() => void)[] = [];
+    internals(page)._activeSection = {
+      dirty: true,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve);
+        }),
+      reload: () => {},
+    } satisfies SectionEditor;
+
+    const first = vi.fn();
+    const second = vi.fn();
+    // Both callers pass their dedupe against the same pre-switch
+    // selection (it only advances inside the action), so both reach
+    // the guard; only the newest may run.
+    const switching1 = internals(page)._guardSectionSwitch(first) as Promise<void>;
+    const switching2 = internals(page)._guardSectionSwitch(second) as Promise<void>;
+
+    resolvers.forEach((r) => r());
+    await Promise.all([switching1, switching2]);
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+  });
+
   it("skips the action when the page unmounts during the flush", async () => {
     const page = new ESPHomePageDevice();
     let resolveFlush!: () => void;


### PR DESCRIPTION
# What does this implement/fix?

`_guardSectionSwitch` fired `_activeSection?.flushPending()` and then swapped the selection synchronously. For the automation editors that flush is a backend `automations/upsert` round trip, so the swap could unmount the editor while the upsert was still in flight; the controller's `yaml-draft` then dispatches from a detached element, bubbles nowhere, and the user's last edit before switching silently never reaches the page buffer.

The guard now awaits the flush before running the switch action. The await is conditional on the flush actually returning a promise, so the component editor's synchronous flush (and the no active section case) keeps the switch synchronous and the cursor driven selection paths stay re-entrant safe; a rejecting flush still switches, matching `_saveYaml`'s treatment of the same contract case.

The deferral window this creates is managed explicitly:

- A `_switchSeq` supersede token drops a queued switch when a later one arrives, so a double click cannot double push the back stack. Both same-section dedupe returns (`_onSectionSelect` and `_onYamlCursorLine`) also take the token, so clicking or caret-returning to the still-displayed section cancels a queued switch instead of being yanked away when it fires.
- Back passes `compose: true`: its action pops one history entry, so two presses inside one window must both land rather than the newest winning; composing actions still take the token so pending absolute switches yield to them.
- The mobile drawer closes synchronously before the barrier, keeping tap feedback instant (it is pure chrome and does not depend on the flushed buffer).
- After the await the guard bails if the page unmounted (`isConnected`), so a late action cannot `replaceState` onto whatever URL the user has since landed on.

The leave, beforeunload, and popstate paths are unchanged; they already fail conservative through `_sectionDirty`. Ten tests pin the barrier, both synchronous paths (asserted before awaiting), the rejecting flush, supersede and compose semantics, both dedupe cancellations, and the unmount bail.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1457

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] Documentation only — `docs`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
