### PR TITLE
Extract a shared mock preamble for the device-page suites

### DIFF
--- a/test/pages/_mock-device-children.ts
+++ b/test/pages/_mock-device-children.ts
@@ -1,0 +1,29 @@
+import { vi } from "vitest";
+
+// Stubs the heavy children the device page renders (yaml-editor drags
+// in CodeMirror, the dialogs crash under happy-dom) plus sonner's
+// toaster. Import for side effect before the page import:
+//   import "./_mock-device-children.js";
+// The vi.mock calls run when this module is evaluated, so they
+// register before later imports pull in the components; the pinned
+// organize-imports plugin never moves side-effect imports, so the
+// ordering is stable. Paths resolve relative to this file, so it must
+// stay beside the page tests. Suite-specific mocks (e.g.
+// board-reselect-dialog) stay in their suites.
+vi.mock("sonner-js", () => ({
+  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("../../src/components/command-dialog.js", () => ({}));
+vi.mock("../../src/components/device/device-editor.js", () => ({}));
+vi.mock("../../src/components/device/device-navigator.js", () => ({}));
+vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
+vi.mock("../../src/components/install-method-dialog.js", () => ({}));
+vi.mock("../../src/components/logs-dialog.js", () => ({}));
+vi.mock("../../src/components/unsaved-changes-dialog.js", () => ({}));
+vi.mock("../../src/components/yaml-validation-dialog.js", () => ({}));
+vi.mock("../../src/components/device/device-install-controller.js", () => ({
+  DeviceInstallController: class {
+    constructor() {}
+  },
+}));

--- a/test/pages/device-cursor-highlight.test.ts
+++ b/test/pages/device-cursor-highlight.test.ts
@@ -9,23 +9,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("sonner-js", () => ({
-  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
-}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("../../src/components/command-dialog.js", () => ({}));
-vi.mock("../../src/components/device/device-editor.js", () => ({}));
-vi.mock("../../src/components/device/device-navigator.js", () => ({}));
-vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
-vi.mock("../../src/components/install-method-dialog.js", () => ({}));
-vi.mock("../../src/components/logs-dialog.js", () => ({}));
-vi.mock("../../src/components/unsaved-changes-dialog.js", () => ({}));
-vi.mock("../../src/components/yaml-validation-dialog.js", () => ({}));
-vi.mock("../../src/components/device/device-install-controller.js", () => ({
-  DeviceInstallController: class {
-    constructor() {}
-  },
-}));
+import "./_mock-device-children.js";
 
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import { ESPHomePageDevice } from "../../src/pages/device.js";

--- a/test/pages/device-cursor-hold.test.ts
+++ b/test/pages/device-cursor-hold.test.ts
@@ -9,23 +9,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("sonner-js", () => ({
-  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
-}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("../../src/components/command-dialog.js", () => ({}));
-vi.mock("../../src/components/device/device-editor.js", () => ({}));
-vi.mock("../../src/components/device/device-navigator.js", () => ({}));
-vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
-vi.mock("../../src/components/install-method-dialog.js", () => ({}));
-vi.mock("../../src/components/logs-dialog.js", () => ({}));
-vi.mock("../../src/components/unsaved-changes-dialog.js", () => ({}));
-vi.mock("../../src/components/yaml-validation-dialog.js", () => ({}));
-vi.mock("../../src/components/device/device-install-controller.js", () => ({
-  DeviceInstallController: class {
-    constructor() {}
-  },
-}));
+import "./_mock-device-children.js";
 
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import { ESPHomePageDevice } from "../../src/pages/device.js";

--- a/test/pages/device-error-highlight.test.ts
+++ b/test/pages/device-error-highlight.test.ts
@@ -7,23 +7,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("sonner-js", () => ({
-  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
-}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("../../src/components/command-dialog.js", () => ({}));
-vi.mock("../../src/components/device/device-editor.js", () => ({}));
-vi.mock("../../src/components/device/device-navigator.js", () => ({}));
-vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
-vi.mock("../../src/components/install-method-dialog.js", () => ({}));
-vi.mock("../../src/components/logs-dialog.js", () => ({}));
-vi.mock("../../src/components/unsaved-changes-dialog.js", () => ({}));
-vi.mock("../../src/components/yaml-validation-dialog.js", () => ({}));
-vi.mock("../../src/components/device/device-install-controller.js", () => ({
-  DeviceInstallController: class {
-    constructor() {}
-  },
-}));
+import "./_mock-device-children.js";
 
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import { ESPHomePageDevice } from "../../src/pages/device.js";

--- a/test/pages/device-platform-ready.test.ts
+++ b/test/pages/device-platform-ready.test.ts
@@ -14,21 +14,8 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("../../src/components/command-dialog.js", () => ({}));
+import "./_mock-device-children.js";
 vi.mock("../../src/components/device/board-reselect-dialog.js", () => ({}));
-vi.mock("../../src/components/device/device-editor.js", () => ({}));
-vi.mock("../../src/components/device/device-navigator.js", () => ({}));
-vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
-vi.mock("../../src/components/install-method-dialog.js", () => ({}));
-vi.mock("../../src/components/logs-dialog.js", () => ({}));
-vi.mock("../../src/components/unsaved-changes-dialog.js", () => ({}));
-vi.mock("../../src/components/yaml-validation-dialog.js", () => ({}));
-vi.mock("../../src/components/device/device-install-controller.js", () => ({
-  DeviceInstallController: class {
-    constructor() {}
-  },
-}));
 
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import type { BoardCatalogEntry } from "../../src/api/types/boards.js";

--- a/test/pages/device-url-line-focus.test.ts
+++ b/test/pages/device-url-line-focus.test.ts
@@ -8,23 +8,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("sonner-js", () => ({
-  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
-}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("../../src/components/command-dialog.js", () => ({}));
-vi.mock("../../src/components/device/device-editor.js", () => ({}));
-vi.mock("../../src/components/device/device-navigator.js", () => ({}));
-vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
-vi.mock("../../src/components/install-method-dialog.js", () => ({}));
-vi.mock("../../src/components/logs-dialog.js", () => ({}));
-vi.mock("../../src/components/unsaved-changes-dialog.js", () => ({}));
-vi.mock("../../src/components/yaml-validation-dialog.js", () => ({}));
-vi.mock("../../src/components/device/device-install-controller.js", () => ({
-  DeviceInstallController: class {
-    constructor() {}
-  },
-}));
+import "./_mock-device-children.js";
 
 import { ESPHomePageDevice } from "../../src/pages/device.js";
 


### PR DESCRIPTION
# What does this implement/fix?

Extracts the verbatim 11 mock preamble (sonner-js, the webawesome icon, the nine device page children, and the `DeviceInstallController` stub) duplicated across the device page suites into `test/pages/_mock-device-children.ts`, mirroring the existing `_mock-dashboard-children.ts` naming and the #1459 harness pattern. Each suite now carries one side effect import placed before its `src` imports; the module documents the import order constraint (organize-imports never moves side effect imports).

Five suites migrate here: cursor-highlight, cursor-hold, error-highlight, platform-ready, and url-line-focus. Suite specific mocks stay local (platform-ready keeps its `board-reselect-dialog` stub). The sixth suite, `device-section-switch-flush`, is being added by #1468 and migrates in a follow up once that merges, keeping this PR conflict free against it.

No behaviour change; the five suites and the full run pass unmodified.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1471

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] Documentation only — `docs`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
