### PR TITLE
Hold flushPending until the queued re-run settles

### DIFF
--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -208,20 +208,26 @@ export class AutoApplyController implements ReactiveController {
    * Force a pending debounced auto-apply to flush immediately. The
    * device page calls this (via the host) on the active section
    * before its global save so the YAML buffer is fully caught up.
-   * Resolves only once nothing is applying — including the queued
-   * re-run a debounce cancelled into an in-flight call.
+   * Resolves only once nothing is pending — neither a debounce
+   * (even one armed mid-poll by a late keystroke) nor an in-flight
+   * call, including the queued re-run a cancelled debounce leaves
+   * on one.
    */
   async flushPending(): Promise<void> {
-    if (this._debounce) {
-      this._cancelDebounce();
-      // With a call already in flight this only queues a re-run —
-      // fall through to the poll so the caller isn't released while
-      // the keystroke it came to flush is still unwritten.
-      await this.autoApply();
-    }
-    // Wait for the in-flight call (and any queued re-run) to settle.
-    while (this._apply.kind === "applying") {
-      await new Promise((r) => setTimeout(r, 20));
+    // Terminates: during a delete, ``scheduleAutoApply`` refuses to
+    // arm (the delete mode suppresses instead), so ``delete()``'s
+    // call site can't spin; outside one, each iteration retires the
+    // pending work that gated it.
+    while (this._debounce || this._apply.kind === "applying") {
+      if (this._debounce) {
+        this._cancelDebounce();
+        // With a call already in flight this only queues a re-run —
+        // loop back to the poll so the caller isn't released while
+        // the keystroke it came to flush is still unwritten.
+        await this.autoApply();
+      } else {
+        await new Promise((r) => setTimeout(r, 20));
+      }
     }
   }
 

--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -208,16 +208,20 @@ export class AutoApplyController implements ReactiveController {
    * Force a pending debounced auto-apply to flush immediately. The
    * device page calls this (via the host) on the active section
    * before its global save so the YAML buffer is fully caught up.
+   * Resolves only once nothing is applying — including the queued
+   * re-run a debounce cancelled into an in-flight call.
    */
   async flushPending(): Promise<void> {
     if (this._debounce) {
       this._cancelDebounce();
+      // With a call already in flight this only queues a re-run —
+      // fall through to the poll so the caller isn't released while
+      // the keystroke it came to flush is still unwritten.
       await this.autoApply();
-    } else {
-      // Wait for the in-flight call to settle.
-      while (this._apply.kind === "applying") {
-        await new Promise((r) => setTimeout(r, 20));
-      }
+    }
+    // Wait for the in-flight call (and any queued re-run) to settle.
+    while (this._apply.kind === "applying") {
+      await new Promise((r) => setTimeout(r, 20));
     }
   }
 

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -226,6 +226,37 @@ describe("AutoApplyController auto-apply", () => {
     expect(upsertAutomation).toHaveBeenCalledTimes(1);
   });
 
+  it("flushPending waits out the re-run queued by a debounce cancelled into an in-flight apply", async () => {
+    const { controller, upsertAutomation } = setup();
+    let resolveFirst!: (v: { yaml_diff: YamlDiff }) => void;
+    upsertAutomation.mockImplementationOnce(
+      () =>
+        new Promise((r) => {
+          resolveFirst = r;
+        })
+    );
+    const applying = controller.autoApply();
+    // A keystroke lands inside the debounce window while the round
+    // trip is outstanding.
+    controller.scheduleAutoApply();
+    let flushed = false;
+    const flushing = controller.flushPending().then(() => {
+      flushed = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(60);
+    // Releasing here would let the global save commit the
+    // pre-keystroke YAML while the queued re-run is still unwritten.
+    expect(flushed).toBe(false);
+
+    resolveFirst({ yaml_diff: DIFF });
+    await vi.advanceTimersByTimeAsync(60);
+    await Promise.all([applying, flushing]);
+    expect(flushed).toBe(true);
+    // The queued re-run actually ran before the flush released.
+    expect(upsertAutomation).toHaveBeenCalledTimes(2);
+  });
+
   it("shouldSkipReload skips the echo of its own write, not a foreign edit", async () => {
     const { host, controller } = setup();
     expect(controller.shouldSkipReload()).toBe(false);

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -227,7 +227,7 @@ describe("AutoApplyController auto-apply", () => {
   });
 
   it("flushPending waits out the re-run queued by a debounce cancelled into an in-flight apply", async () => {
-    const { controller, upsertAutomation } = setup();
+    const { host, controller, upsertAutomation } = setup();
     let resolveFirst!: (v: { yaml_diff: YamlDiff }) => void;
     upsertAutomation.mockImplementationOnce(
       () =>
@@ -235,26 +235,50 @@ describe("AutoApplyController auto-apply", () => {
           resolveFirst = r;
         })
     );
+    const order: string[] = [];
+    host.addEventListener("yaml-draft", () => order.push("draft"));
     const applying = controller.autoApply();
     // A keystroke lands inside the debounce window while the round
     // trip is outstanding.
     controller.scheduleAutoApply();
-    let flushed = false;
-    const flushing = controller.flushPending().then(() => {
-      flushed = true;
-    });
+    const flushing = controller.flushPending().then(() => order.push("flushed"));
 
     await vi.advanceTimersByTimeAsync(60);
     // Releasing here would let the global save commit the
     // pre-keystroke YAML while the queued re-run is still unwritten.
-    expect(flushed).toBe(false);
+    expect(order).not.toContain("flushed");
 
     resolveFirst({ yaml_diff: DIFF });
     await vi.advanceTimersByTimeAsync(60);
     await Promise.all([applying, flushing]);
-    expect(flushed).toBe(true);
-    // The queued re-run actually ran before the flush released.
-    expect(upsertAutomation).toHaveBeenCalledTimes(2);
+    // Both drafts reached the page buffer before the caller was
+    // released, not merely before this assertion.
+    expect(order).toEqual(["draft", "draft", "flushed"]);
+  });
+
+  it("flushPending waits out a debounce armed while it was already polling", async () => {
+    const { host, controller, upsertAutomation } = setup();
+    let resolveFirst!: (v: { yaml_diff: YamlDiff }) => void;
+    upsertAutomation.mockImplementationOnce(
+      () =>
+        new Promise((r) => {
+          resolveFirst = r;
+        })
+    );
+    const order: string[] = [];
+    host.addEventListener("yaml-draft", () => order.push("draft"));
+    const applying = controller.autoApply();
+    // No debounce yet — the flush enters the settle poll directly.
+    const flushing = controller.flushPending().then(() => order.push("flushed"));
+    await vi.advanceTimersByTimeAsync(30);
+    // The keystroke lands during the poll, after the debounce check.
+    controller.scheduleAutoApply();
+
+    resolveFirst({ yaml_diff: DIFF });
+    await vi.advanceTimersByTimeAsync(AUTO_APPLY_DEBOUNCE_MS + 60);
+    await Promise.all([applying, flushing]);
+    // The late keystroke's upsert still lands before the release.
+    expect(order).toEqual(["draft", "draft", "flushed"]);
   });
 
   it("shouldSkipReload skips the echo of its own write, not a foreign edit", async () => {


### PR DESCRIPTION
# What does this implement/fix?

When a debounce timer and an in-flight apply overlapped (a keystroke landing inside the 200ms window while a round trip was outstanding), `flushPending()` cancelled the timer and awaited `autoApply()`, which merely queued a re-run on the in-flight call and resolved. The caller was released while the keystroke it came to flush was still unwritten, so the device page's global save could commit the pre keystroke YAML and the queued re-run then re dirtied the buffer the user just saved.

The debounce branch now falls through to the settle poll instead of returning, so `flushPending()` resolves only once nothing is applying, including the queued re-run. The #1469 `ApplyPhase` union is what makes the poll condition cover both.

The new test pins the overlap: the flush must not release while the first round trip is outstanding, and the queued re-run must have run before it does. Verified the test fails on the pre fix code.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1472

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] Documentation only — `docs`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
