### PR TITLE
Deliver the post-delete yaml-updated through the mount-time parent

### DIFF
--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -32,6 +32,10 @@ export interface AutoApplyHost
   addMode: boolean;
   value: AutomationTree | null;
   readonly location: AutomationLocation | null;
+  /** DOM surface the delete path needs to keep its events reachable
+   *  when the element is unmounted mid round trip (#1465). */
+  readonly isConnected: boolean;
+  readonly parentNode: ParentNode | null;
 }
 
 export interface AutoApplyOptions {
@@ -326,6 +330,12 @@ export class AutoApplyController implements ReactiveController {
     // the delete.
     const location = this._host.location;
     const configuration = this._host.configuration;
+    // The parent stays mounted across section switches, so it can
+    // carry the ``yaml-updated`` when a different-kind switch swaps
+    // the element out mid round trip — a detached dispatch bubbles
+    // nowhere and the page's saved buffer would go stale against the
+    // disk write, resurrecting the section on the next global save.
+    const dispatchAnchor = this._host.parentNode;
     // Cancel any pending auto-apply — we're about to delete.
     const hadPending = this._debounce !== null;
     this._cancelDebounce();
@@ -353,20 +363,24 @@ export class AutoApplyController implements ReactiveController {
       const { yaml_diff } = await api.deleteAutomation(configuration, location, yaml);
       const newYaml = applyYamlDiff(yaml, yaml_diff);
       await api.updateConfig(configuration, newYaml);
-      this._host.dispatchEvent(
+      const target = this._host.isConnected ? this._host : dispatchAnchor;
+      target?.dispatchEvent(
         new CustomEvent<{ yaml: string }>("yaml-updated", {
           detail: { yaml: newYaml },
           bubbles: true,
           composed: true,
         })
       );
-      // Navigate away only while the editor still shows the deleted
-      // section. After a mid-flush retarget the user is already on a
-      // sibling; yanking them to null would also unmount the editor
-      // and cancel the sibling's re-armed edit below.
+      // Navigate away only while the editor is still on screen showing
+      // the deleted section. After a mid-flush retarget the user is
+      // already on a sibling (yanking them to null would also unmount
+      // the editor and cancel the sibling's re-armed edit below); after
+      // an unmount they already navigated somewhere else entirely.
       if (
-        !this._host.location ||
-        sectionKeyFromLocation(this._host.location) === sectionKeyFromLocation(location)
+        this._host.isConnected &&
+        (!this._host.location ||
+          sectionKeyFromLocation(this._host.location) ===
+            sectionKeyFromLocation(location))
       ) {
         this._host.dispatchEvent(
           new CustomEvent<{ sectionKey: string | null }>("section-select", {

--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -6,7 +6,7 @@ import type {
   AutomationTree,
 } from "../../../api/types/automations.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
-import { fireEvent } from "../../../util/fire-event.js";
+import { fireEvent, fireFromAnchor } from "../../../util/fire-event.js";
 import { formatApiError } from "../../../util/format-api-error.js";
 import { notifyError } from "../../../util/notify.js";
 import type { SectionEditor } from "../section-editor.js";
@@ -366,14 +366,9 @@ export class AutoApplyController implements ReactiveController {
       // unmount case a draft the newly mounted section made in the
       // interim is overwritten by this dispatch. Narrow window, and
       // still net-positive versus resurrecting the deleted section.
-      const target = this._connected ? this._host : dispatchAnchor;
-      target?.dispatchEvent(
-        new CustomEvent<{ yaml: string }>("yaml-updated", {
-          detail: { yaml: newYaml },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      fireFromAnchor(this._host, this._connected, dispatchAnchor, "yaml-updated", {
+        yaml: newYaml,
+      });
       // Navigate away only while the editor is still on screen showing
       // the deleted section. After a mid-flush retarget the user is
       // already on a sibling (yanking them to null would also unmount

--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -32,9 +32,8 @@ export interface AutoApplyHost
   addMode: boolean;
   value: AutomationTree | null;
   readonly location: AutomationLocation | null;
-  /** DOM surface the delete path needs to keep its events reachable
-   *  when the element is unmounted mid round trip (#1465). */
-  readonly isConnected: boolean;
+  /** Mount-time anchor the delete path needs to keep its events
+   *  reachable when the element is unmounted mid round trip (#1465). */
   readonly parentNode: ParentNode | null;
 }
 
@@ -363,7 +362,11 @@ export class AutoApplyController implements ReactiveController {
       const { yaml_diff } = await api.deleteAutomation(configuration, location, yaml);
       const newYaml = applyYamlDiff(yaml, yaml_diff);
       await api.updateConfig(configuration, newYaml);
-      const target = this._host.isConnected ? this._host : dispatchAnchor;
+      // ``newYaml`` derives from the pre-round-trip snapshot; in the
+      // unmount case a draft the newly mounted section made in the
+      // interim is overwritten by this dispatch. Narrow window, and
+      // still net-positive versus resurrecting the deleted section.
+      const target = this._connected ? this._host : dispatchAnchor;
       target?.dispatchEvent(
         new CustomEvent<{ yaml: string }>("yaml-updated", {
           detail: { yaml: newYaml },
@@ -377,7 +380,7 @@ export class AutoApplyController implements ReactiveController {
       // the editor and cancel the sibling's re-armed edit below); after
       // an unmount they already navigated somewhere else entirely.
       if (
-        this._host.isConnected &&
+        this._connected &&
         (!this._host.location ||
           sectionKeyFromLocation(this._host.location) ===
             sectionKeyFromLocation(location))

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -448,18 +448,20 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
     // unmounts this element mid round trip (#1465).
     const dispatchAnchor = this.parentNode;
     try {
-      // Read the buffer exactly once: the backend computes the diff's
-      // line coordinates against the string we send, so splicing into
-      // a later re-read (the prop reassigned mid round trip) would
-      // silently mangle the write-through.
+      // Read the buffer and target exactly once: the backend computes
+      // the diff's line coordinates against the string we send, and a
+      // router-level device swap reassigns ``configuration`` from
+      // above — splicing into a later re-read would silently mangle
+      // the write-through (or write it to the wrong file).
+      const configuration = this.configuration;
       const yaml = this.yaml;
       const { yaml_diff } = await this._api.deleteAutomation(
-        this.configuration,
+        configuration,
         location,
         yaml
       );
       const newYaml = applyYamlDiff(yaml, yaml_diff);
-      await this._api.updateConfig(this.configuration, newYaml);
+      await this._api.updateConfig(configuration, newYaml);
       fireFromAnchor(this, this.isConnected, dispatchAnchor, "yaml-updated", {
         yaml: newYaml,
       });

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -448,12 +448,17 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
     // unmounts this element mid round trip (#1465).
     const dispatchAnchor = this.parentNode;
     try {
+      // Read the buffer exactly once: the backend computes the diff's
+      // line coordinates against the string we send, so splicing into
+      // a later re-read (the prop reassigned mid round trip) would
+      // silently mangle the write-through.
+      const yaml = this.yaml;
       const { yaml_diff } = await this._api.deleteAutomation(
         this.configuration,
         location,
-        this.yaml
+        yaml
       );
-      const newYaml = applyYamlDiff(this.yaml, yaml_diff);
+      const newYaml = applyYamlDiff(yaml, yaml_diff);
       await this._api.updateConfig(this.configuration, newYaml);
       fireFromAnchor(this, this.isConnected, dispatchAnchor, "yaml-updated", {
         yaml: newYaml,

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -22,7 +22,7 @@ import {
   type InstanceBackendErrors,
 } from "../../util/backend-field-errors.js";
 import type { ValidationError } from "../../util/config-validation.js";
-import { fireEvent } from "../../util/fire-event.js";
+import { fireEvent, fireFromAnchor } from "../../util/fire-event.js";
 import { formatApiError } from "../../util/format-api-error.js";
 import { notifyError } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -444,6 +444,9 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
     const location = locationFromSectionKey(key);
     if (!this._api || !location || this._deletingRow) return;
     this._deletingRow = key;
+    // Mount-time parent carries the dispatch if a section switch
+    // unmounts this element mid round trip (#1465).
+    const dispatchAnchor = this.parentNode;
     try {
       const { yaml_diff } = await this._api.deleteAutomation(
         this.configuration,
@@ -452,7 +455,9 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
       );
       const newYaml = applyYamlDiff(this.yaml, yaml_diff);
       await this._api.updateConfig(this.configuration, newYaml);
-      fireEvent(this, "yaml-updated", { yaml: newYaml });
+      fireFromAnchor(this, this.isConnected, dispatchAnchor, "yaml-updated", {
+        yaml: newYaml,
+      });
     } catch (err) {
       const msg = formatApiError(err, this._localize, "device.automation_save_error");
       notifyError(this._localize("device.automation_save_error"), {

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -116,6 +116,11 @@ export async function onDeleteConfirmed(host: ESPHomeDeviceSectionConfig): Promi
   host._deleting = true;
   host._error = "";
   const title = host._config.title;
+  // The parent stays mounted across section switches, so it can carry
+  // the ``yaml-updated`` when a switch unmounts the editor mid round
+  // trip — a detached dispatch bubbles nowhere and the page's saved
+  // buffer would go stale against the disk write (#1465).
+  const dispatchAnchor = host.parentNode;
   try {
     const newYaml = removeSectionFromYaml(host.yaml, host.sectionKey, fromLine);
     if (newYaml === host.yaml) {
@@ -124,8 +129,11 @@ export async function onDeleteConfirmed(host: ESPHomeDeviceSectionConfig): Promi
     }
     await host._api.updateConfig(host.configuration, newYaml);
     host._setDirty(false);
-    fireEvent(host, "yaml-updated", { yaml: newYaml });
-    fireEvent(host, "section-select", { sectionKey: null });
+    fireEvent(host.isConnected ? host : (dispatchAnchor ?? host), "yaml-updated", {
+      yaml: newYaml,
+    });
+    // Navigating away only applies while the user is still here.
+    if (host.isConnected) fireEvent(host, "section-select", { sectionKey: null });
     notifySuccess(host._localize("device.section_deleted", { name: title }));
   } catch (e) {
     host._error = formatApiError(e, host._localize, "device.section_delete_error");

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -1,8 +1,8 @@
 import { clearPathErrors, validateEntries } from "../../../util/config-validation.js";
-import { fireEvent } from "../../../util/fire-event.js";
+import { fireEvent, fireFromAnchor } from "../../../util/fire-event.js";
 import { formatApiError } from "../../../util/format-api-error.js";
 import { setIn } from "../../../util/nested-values.js";
-import { notifySuccess } from "../../../util/notify.js";
+import { notifyError, notifySuccess } from "../../../util/notify.js";
 import {
   KEEP_EMPTY_STRING_SECTIONS,
   resolveSectionEntries,
@@ -133,8 +133,9 @@ export async function onDeleteConfirmed(host: ESPHomeDeviceSectionConfig): Promi
     }
     await host._api.updateConfig(host.configuration, newYaml);
     host._setDirty(false);
-    const target = host.isConnected ? host : dispatchAnchor;
-    if (target) fireEvent(target, "yaml-updated", { yaml: newYaml });
+    fireFromAnchor(host, host.isConnected, dispatchAnchor, "yaml-updated", {
+      yaml: newYaml,
+    });
     // Navigate away only while the user is still here, on the
     // section that was deleted.
     if (host.isConnected && host.sectionKey === deletedKey) {
@@ -142,7 +143,11 @@ export async function onDeleteConfirmed(host: ESPHomeDeviceSectionConfig): Promi
     }
     notifySuccess(host._localize("device.section_deleted", { name: title }));
   } catch (e) {
-    host._error = formatApiError(e, host._localize, "device.section_delete_error");
+    const msg = formatApiError(e, host._localize, "device.section_delete_error");
+    host._error = msg;
+    // The inline error renders nowhere on an unmounted host; the
+    // toast is page-level and survives the teardown.
+    notifyError(host._localize("device.section_delete_error"), { description: msg });
   } finally {
     host._deleting = false;
   }

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -119,8 +119,12 @@ export async function onDeleteConfirmed(host: ESPHomeDeviceSectionConfig): Promi
   // The parent stays mounted across section switches, so it can carry
   // the ``yaml-updated`` when a switch unmounts the editor mid round
   // trip — a detached dispatch bubbles nowhere and the page's saved
-  // buffer would go stale against the disk write (#1465).
+  // buffer would go stale against the disk write (#1465). The section
+  // key is snapshotted too: Lit reuses this element across same-kind
+  // switches, so a mid-round-trip retarget keeps it connected while
+  // the deleted section is no longer the one on screen.
   const dispatchAnchor = host.parentNode;
+  const deletedKey = host.sectionKey;
   try {
     const newYaml = removeSectionFromYaml(host.yaml, host.sectionKey, fromLine);
     if (newYaml === host.yaml) {
@@ -129,11 +133,13 @@ export async function onDeleteConfirmed(host: ESPHomeDeviceSectionConfig): Promi
     }
     await host._api.updateConfig(host.configuration, newYaml);
     host._setDirty(false);
-    fireEvent(host.isConnected ? host : (dispatchAnchor ?? host), "yaml-updated", {
-      yaml: newYaml,
-    });
-    // Navigating away only applies while the user is still here.
-    if (host.isConnected) fireEvent(host, "section-select", { sectionKey: null });
+    const target = host.isConnected ? host : dispatchAnchor;
+    if (target) fireEvent(target, "yaml-updated", { yaml: newYaml });
+    // Navigate away only while the user is still here, on the
+    // section that was deleted.
+    if (host.isConnected && host.sectionKey === deletedKey) {
+      fireEvent(host, "section-select", { sectionKey: null });
+    }
     notifySuccess(host._localize("device.section_deleted", { name: title }));
   } catch (e) {
     host._error = formatApiError(e, host._localize, "device.section_delete_error");

--- a/src/util/fire-event.ts
+++ b/src/util/fire-event.ts
@@ -12,3 +12,21 @@
 export function fireEvent(target: EventTarget, name: string, detail?: unknown): void {
   target.dispatchEvent(new CustomEvent(name, { detail, bubbles: true, composed: true }));
 }
+
+/**
+ * Dispatch from *host* while it is connected, else from *anchor* — a
+ * detached dispatch bubbles nowhere. The anchor is the host's
+ * mount-time parent, which outlives it across section switches; the
+ * disk-writing delete paths rely on this to reach the page after a
+ * mid-round-trip unmount (#1465).
+ */
+export function fireFromAnchor(
+  host: EventTarget,
+  connected: boolean,
+  anchor: EventTarget | null,
+  name: string,
+  detail?: unknown
+): void {
+  const target = connected ? host : anchor;
+  if (target) fireEvent(target, name, detail);
+}

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -46,7 +46,6 @@ class Host extends EventTarget implements AutoApplyHost {
   addMode = false;
   value: AutomationTree | null = tree();
   location: AutomationLocation | null = SCRIPT;
-  isConnected = true;
   parentNode: ParentNode | null = null;
   // SectionEditor surface the real hosts delegate to the engine.
   dirty = false;
@@ -479,9 +478,13 @@ describe("AutoApplyController delete", () => {
 
   it("a mid-delete unmount still lands yaml-updated through the mount-time parent", async () => {
     const { host, controller, deleteAutomation } = setup();
+    // Listener on the grandparent so the assertion also pins that the
+    // fallback dispatch bubbles, not merely that the target swapped.
+    const grandparent = document.createElement("div");
     const parent = document.createElement("div");
+    grandparent.appendChild(parent);
     const updates: string[] = [];
-    parent.addEventListener("yaml-updated", (e) =>
+    grandparent.addEventListener("yaml-updated", (e) =>
       updates.push((e as CustomEvent<{ yaml: string }>).detail.yaml)
     );
     host.parentNode = parent;
@@ -496,8 +499,9 @@ describe("AutoApplyController delete", () => {
     const deleting = controller.delete();
     await vi.advanceTimersByTimeAsync(1);
     // A different-kind section switch swaps the element out of the
-    // tree while the delete round trip is outstanding.
-    host.isConnected = false;
+    // tree while the delete round trip is outstanding — Lit tears it
+    // down through disconnectedCallback.
+    controller.hostDisconnected();
 
     resolveDelete({ yaml_diff: DIFF });
     await deleting;

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -501,8 +501,10 @@ describe("AutoApplyController delete", () => {
     await vi.advanceTimersByTimeAsync(1);
     // A different-kind section switch swaps the element out of the
     // tree while the delete round trip is outstanding — Lit tears it
-    // down through disconnectedCallback.
+    // down through disconnectedCallback. parentNode nulls too, so a
+    // regression that snapshots the anchor after the awaits fails.
     controller.hostDisconnected();
+    host.parentNode = null;
 
     resolveDelete({ yaml_diff: DIFF });
     await deleting;

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -478,16 +478,17 @@ describe("AutoApplyController delete", () => {
 
   it("a mid-delete unmount still lands yaml-updated through the mount-time parent", async () => {
     const { host, controller, deleteAutomation } = setup();
-    // Listener on the grandparent so the assertion also pins that the
-    // fallback dispatch bubbles, not merely that the target swapped.
-    const grandparent = document.createElement("div");
-    const parent = document.createElement("div");
-    grandparent.appendChild(parent);
+    // Production's anchor is board-info's ShadowRoot, so the listener
+    // sits on the shadow host outside the boundary — the assertion
+    // then pins the composed flag the whole fix rides on, not merely
+    // that the dispatch target swapped.
+    const outer = document.createElement("div");
+    const shadow = outer.attachShadow({ mode: "open" });
     const updates: string[] = [];
-    grandparent.addEventListener("yaml-updated", (e) =>
+    outer.addEventListener("yaml-updated", (e) =>
       updates.push((e as CustomEvent<{ yaml: string }>).detail.yaml)
     );
-    host.parentNode = parent;
+    host.parentNode = shadow;
     const selections = captureEvents(host, "section-select");
     let resolveDelete!: (v: { yaml_diff: YamlDiff }) => void;
     deleteAutomation.mockImplementationOnce(

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -46,6 +46,8 @@ class Host extends EventTarget implements AutoApplyHost {
   addMode = false;
   value: AutomationTree | null = tree();
   location: AutomationLocation | null = SCRIPT;
+  isConnected = true;
+  parentNode: ParentNode | null = null;
   // SectionEditor surface the real hosts delegate to the engine.
   dirty = false;
   flushPending(): void {}
@@ -472,6 +474,37 @@ describe("AutoApplyController delete", () => {
     );
     // The user is on the sibling; the delete must not navigate away
     // (that unmount would cancel the re-armed edit).
+    expect(selections).toHaveLength(0);
+  });
+
+  it("a mid-delete unmount still lands yaml-updated through the mount-time parent", async () => {
+    const { host, controller, deleteAutomation } = setup();
+    const parent = document.createElement("div");
+    const updates: string[] = [];
+    parent.addEventListener("yaml-updated", (e) =>
+      updates.push((e as CustomEvent<{ yaml: string }>).detail.yaml)
+    );
+    host.parentNode = parent;
+    const selections = captureEvents(host, "section-select");
+    let resolveDelete!: (v: { yaml_diff: YamlDiff }) => void;
+    deleteAutomation.mockImplementationOnce(
+      () =>
+        new Promise((r) => {
+          resolveDelete = r;
+        })
+    );
+    const deleting = controller.delete();
+    await vi.advanceTimersByTimeAsync(1);
+    // A different-kind section switch swaps the element out of the
+    // tree while the delete round trip is outstanding.
+    host.isConnected = false;
+
+    resolveDelete({ yaml_diff: DIFF });
+    await deleting;
+
+    // The disk write still reaches the page's buffer via the parent…
+    expect(updates).toEqual(["replaced\nline2"]);
+    // …and no navigation fires at a user who already left.
     expect(selections).toHaveLength(0);
   });
 

--- a/test/components/device/section-config-delete-unmount.test.ts
+++ b/test/components/device/section-config-delete-unmount.test.ts
@@ -41,7 +41,7 @@ function makeHost() {
 }
 
 describe("onDeleteConfirmed mid-round-trip navigation", () => {
-  it("unmounted: lands yaml-updated through the ShadowRoot anchor, no section-select", async () => {
+  it("unmounted mid-flight: lands yaml-updated through the ShadowRoot anchor, no section-select", async () => {
     const { c, release } = makeHost();
     // Production's anchor is board-info's ShadowRoot; the listener on
     // the shadow host pins that the fallback dispatch crosses the
@@ -49,6 +49,7 @@ describe("onDeleteConfirmed mid-round-trip navigation", () => {
     const outer = document.createElement("div");
     const shadow = outer.attachShadow({ mode: "open" });
     shadow.appendChild(c);
+    document.body.appendChild(outer);
     const updates: string[] = [];
     outer.addEventListener("yaml-updated", (e) =>
       updates.push((e as CustomEvent<{ yaml: string }>).detail.yaml)
@@ -56,23 +57,32 @@ describe("onDeleteConfirmed mid-round-trip navigation", () => {
     const selections: unknown[] = [];
     outer.addEventListener("section-select", (e) => selections.push(e));
 
-    const deleting = onDeleteConfirmed(c);
-    release();
-    await deleting;
+    try {
+      // The element is connected when the delete starts — the anchor
+      // snapshot must be taken here, before the unmount.
+      const deleting = onDeleteConfirmed(c);
+      c.remove();
+      release();
+      await deleting;
 
-    expect(updates).toEqual(["logger:\n"]);
-    expect(selections).toHaveLength(0);
+      expect(updates).toEqual(["logger:\n"]);
+      expect(selections).toHaveLength(0);
+    } finally {
+      outer.remove();
+    }
   });
 
   it("same-kind reuse: a retargeted but still-connected element does not navigate away", async () => {
     const { c, inner, release } = makeHost();
-    document.body.appendChild(c);
+    const container = document.createElement("div");
+    container.appendChild(c);
+    document.body.appendChild(container);
     const updates: string[] = [];
-    document.body.addEventListener("yaml-updated", (e) =>
+    container.addEventListener("yaml-updated", (e) =>
       updates.push((e as CustomEvent<{ yaml: string }>).detail.yaml)
     );
     const selections: unknown[] = [];
-    document.body.addEventListener("section-select", (e) => selections.push(e));
+    container.addEventListener("section-select", (e) => selections.push(e));
 
     try {
       const deleting = onDeleteConfirmed(c);
@@ -87,7 +97,7 @@ describe("onDeleteConfirmed mid-round-trip navigation", () => {
       // stops the navigation.
       expect(selections).toHaveLength(0);
     } finally {
-      c.remove();
+      container.remove();
     }
   });
 });

--- a/test/components/device/section-config-delete-unmount.test.ts
+++ b/test/components/device/section-config-delete-unmount.test.ts
@@ -1,10 +1,11 @@
 /**
  * @vitest-environment happy-dom
  *
- * Pins the component editor's delete path when the element is
- * unmounted mid round trip: the disk write's yaml-updated must still
- * reach the page through the mount-time parent, and no
- * section-select navigation fires at a user who already left.
+ * Pins the component editor's delete path against mid-round-trip
+ * navigation: an unmounted element's yaml-updated still reaches the
+ * page through the mount-time ShadowRoot anchor (composed included),
+ * and section-select never fires at a user who left the deleted
+ * section — by unmount or by same-kind element reuse.
  */
 import { describe, expect, it, vi } from "vitest";
 
@@ -19,44 +20,74 @@ import { onDeleteConfirmed } from "../../../src/components/device/device-section
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-describe("onDeleteConfirmed unmounted mid round trip", () => {
-  it("lands yaml-updated through the mount-time parent and skips section-select", async () => {
-    const c = new ESPHomeDeviceSectionConfig();
-    const inner = c as any;
-    inner.yaml = "wifi:\n  ssid: home\nlogger:\n";
-    inner.sectionKey = "wifi";
-    inner.fromLine = 1;
-    inner.configuration = "device.yaml";
-    inner._config = { title: "WiFi", entries: [] };
-    let resolveWrite!: () => void;
-    inner._api = {
-      updateConfig: vi.fn(
-        () =>
-          new Promise<void>((resolve) => {
-            resolveWrite = resolve;
-          })
-      ),
-    };
+function makeHost() {
+  const c = new ESPHomeDeviceSectionConfig();
+  const inner = c as any;
+  inner.yaml = "wifi:\n  ssid: home\nlogger:\n";
+  inner.sectionKey = "wifi";
+  inner.fromLine = 1;
+  inner.configuration = "device.yaml";
+  inner._config = { title: "WiFi", entries: [] };
+  let resolveWrite!: () => void;
+  inner._api = {
+    updateConfig: vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWrite = resolve;
+        })
+    ),
+  };
+  return { c, inner, release: () => resolveWrite() };
+}
 
-    // Detached grandparent chain: isConnected stays false (the
-    // unmounted state under test), the parent carries the dispatch,
-    // and the grandparent listener pins that it bubbles.
-    const grandparent = document.createElement("div");
-    const parent = document.createElement("div");
-    grandparent.appendChild(parent);
-    parent.appendChild(c);
+describe("onDeleteConfirmed mid-round-trip navigation", () => {
+  it("unmounted: lands yaml-updated through the ShadowRoot anchor, no section-select", async () => {
+    const { c, release } = makeHost();
+    // Production's anchor is board-info's ShadowRoot; the listener on
+    // the shadow host pins that the fallback dispatch crosses the
+    // boundary (composed), not merely that the target swapped.
+    const outer = document.createElement("div");
+    const shadow = outer.attachShadow({ mode: "open" });
+    shadow.appendChild(c);
     const updates: string[] = [];
-    grandparent.addEventListener("yaml-updated", (e) =>
+    outer.addEventListener("yaml-updated", (e) =>
       updates.push((e as CustomEvent<{ yaml: string }>).detail.yaml)
     );
     const selections: unknown[] = [];
-    grandparent.addEventListener("section-select", (e) => selections.push(e));
+    outer.addEventListener("section-select", (e) => selections.push(e));
 
     const deleting = onDeleteConfirmed(c);
-    resolveWrite();
+    release();
     await deleting;
 
     expect(updates).toEqual(["logger:\n"]);
     expect(selections).toHaveLength(0);
+  });
+
+  it("same-kind reuse: a retargeted but still-connected element does not navigate away", async () => {
+    const { c, inner, release } = makeHost();
+    document.body.appendChild(c);
+    const updates: string[] = [];
+    document.body.addEventListener("yaml-updated", (e) =>
+      updates.push((e as CustomEvent<{ yaml: string }>).detail.yaml)
+    );
+    const selections: unknown[] = [];
+    document.body.addEventListener("section-select", (e) => selections.push(e));
+
+    try {
+      const deleting = onDeleteConfirmed(c);
+      // Lit reuses this element across same-kind switches: the user
+      // opens logger while wifi's delete is still in flight.
+      inner.sectionKey = "logger";
+      release();
+      await deleting;
+
+      expect(updates).toEqual(["logger:\n"]);
+      // isConnected is true here — only the deletedKey snapshot
+      // stops the navigation.
+      expect(selections).toHaveLength(0);
+    } finally {
+      c.remove();
+    }
   });
 });

--- a/test/components/device/section-config-delete-unmount.test.ts
+++ b/test/components/device/section-config-delete-unmount.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the component editor's delete path when the element is
+ * unmounted mid round trip: the disk write's yaml-updated must still
+ * reach the page through the mount-time parent, and no
+ * section-select navigation fires at a user who already left.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+import { ESPHomeDeviceSectionConfig } from "../../../src/components/device/device-section-config.js";
+import { onDeleteConfirmed } from "../../../src/components/device/device-section-config/draft-and-delete.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe("onDeleteConfirmed unmounted mid round trip", () => {
+  it("lands yaml-updated through the mount-time parent and skips section-select", async () => {
+    const c = new ESPHomeDeviceSectionConfig();
+    const inner = c as any;
+    inner.yaml = "wifi:\n  ssid: home\nlogger:\n";
+    inner.sectionKey = "wifi";
+    inner.fromLine = 1;
+    inner.configuration = "device.yaml";
+    inner._config = { title: "WiFi", entries: [] };
+    let resolveWrite!: () => void;
+    inner._api = {
+      updateConfig: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveWrite = resolve;
+          })
+      ),
+    };
+
+    // Detached grandparent chain: isConnected stays false (the
+    // unmounted state under test), the parent carries the dispatch,
+    // and the grandparent listener pins that it bubbles.
+    const grandparent = document.createElement("div");
+    const parent = document.createElement("div");
+    grandparent.appendChild(parent);
+    parent.appendChild(c);
+    const updates: string[] = [];
+    grandparent.addEventListener("yaml-updated", (e) =>
+      updates.push((e as CustomEvent<{ yaml: string }>).detail.yaml)
+    );
+    const selections: unknown[] = [];
+    grandparent.addEventListener("section-select", (e) => selections.push(e));
+
+    const deleting = onDeleteConfirmed(c);
+    resolveWrite();
+    await deleting;
+
+    expect(updates).toEqual(["logger:\n"]);
+    expect(selections).toHaveLength(0);
+  });
+});

--- a/test/components/device/section-config-delete-unmount.test.ts
+++ b/test/components/device/section-config-delete-unmount.test.ts
@@ -128,6 +128,41 @@ describe("onDeleteConfirmed mid-round-trip navigation", () => {
     }
   });
 
+  it("row delete splices the diff into the buffer it was computed against", async () => {
+    const c = new ESPHomeDeviceSectionConfig();
+    const inner = c as any;
+    inner.yaml = ROW_YAML;
+    inner.sectionKey = "binary_sensor.gpio";
+    inner.fromLine = 2;
+    inner.configuration = "device.yaml";
+    let resolveDelete!: (v: unknown) => void;
+    inner._api = {
+      deleteAutomation: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveDelete = resolve;
+          })
+      ),
+      updateConfig: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const deleting = inner._onDeleteRow(
+      new CustomEvent("delete-row", {
+        detail: { key: "automation:component_on:btn:on_press" },
+      })
+    );
+    // The prop is reassigned mid round trip (a sibling's yaml-updated
+    // pushed a shifted buffer down); the write-through must still
+    // splice into the snapshot the diff's coordinates refer to.
+    inner.yaml = "shifted:\n" + ROW_YAML;
+    resolveDelete({ yaml_diff: { fromLine: 4, toLine: 5, replacement: "" } });
+    await deleting;
+
+    const written = inner._api.updateConfig.mock.calls[0][1] as string;
+    expect(written).not.toContain("shifted:");
+    expect(written).not.toContain("on_press");
+  });
+
   it("same-kind reuse: a retargeted but still-connected element does not navigate away", async () => {
     const { c, inner, release } = makeHost();
     const container = document.createElement("div");

--- a/test/components/device/section-config-delete-unmount.test.ts
+++ b/test/components/device/section-config-delete-unmount.test.ts
@@ -12,6 +12,8 @@ vi.mock("sonner-js", () => ({
   default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
 }));
 
+import "../../_mock-webawesome.js";
+
 import { ESPHomeDeviceSectionConfig } from "../../../src/components/device/device-section-config.js";
 import { onDeleteConfirmed } from "../../../src/components/device/device-section-config/draft-and-delete.js";
 

--- a/test/components/device/section-config-delete-unmount.test.ts
+++ b/test/components/device/section-config-delete-unmount.test.ts
@@ -18,6 +18,14 @@ import "../../_mock-webawesome.js";
 import { ESPHomeDeviceSectionConfig } from "../../../src/components/device/device-section-config.js";
 import { onDeleteConfirmed } from "../../../src/components/device/device-section-config/draft-and-delete.js";
 
+const ROW_YAML = [
+  "binary_sensor:",
+  "  - platform: gpio",
+  "    id: btn",
+  "    on_press:",
+  "      - logger.log: hi",
+].join("\n");
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 function makeHost() {
@@ -67,6 +75,54 @@ describe("onDeleteConfirmed mid-round-trip navigation", () => {
 
       expect(updates).toEqual(["logger:\n"]);
       expect(selections).toHaveLength(0);
+    } finally {
+      outer.remove();
+    }
+  });
+
+  it("row delete unmounted mid-flight still lands yaml-updated through the anchor", async () => {
+    const c = new ESPHomeDeviceSectionConfig();
+    const inner = c as any;
+    inner.yaml = ROW_YAML;
+    inner.sectionKey = "binary_sensor.gpio";
+    inner.fromLine = 2;
+    inner.configuration = "device.yaml";
+    let resolveWrite!: () => void;
+    inner._api = {
+      deleteAutomation: vi
+        .fn()
+        .mockResolvedValue({ yaml_diff: { fromLine: 4, toLine: 5, replacement: "" } }),
+      updateConfig: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveWrite = resolve;
+          })
+      ),
+    };
+    const outer = document.createElement("div");
+    const shadow = outer.attachShadow({ mode: "open" });
+    shadow.appendChild(c);
+    document.body.appendChild(outer);
+    const updates: string[] = [];
+    outer.addEventListener("yaml-updated", (e) =>
+      updates.push((e as CustomEvent<{ yaml: string }>).detail.yaml)
+    );
+
+    try {
+      const deleting = inner._onDeleteRow(
+        new CustomEvent("delete-row", {
+          detail: { key: "automation:component_on:btn:on_press" },
+        })
+      );
+      // The user switches to a different-kind section mid round trip.
+      c.remove();
+      // Let the delete reach the deferred updateConfig before releasing.
+      await new Promise((r) => setTimeout(r));
+      resolveWrite();
+      await deleting;
+
+      expect(updates).toHaveLength(1);
+      expect(updates[0]).not.toContain("on_press");
     } finally {
       outer.remove();
     }

--- a/test/util/fire-event.test.ts
+++ b/test/util/fire-event.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { fireEvent } from "../../src/util/fire-event.js";
+import { fireEvent, fireFromAnchor } from "../../src/util/fire-event.js";
 
 describe("fireEvent", () => {
   it("dispatches a bubbling composed CustomEvent with the detail", () => {
@@ -27,5 +27,43 @@ describe("fireEvent", () => {
     fireEvent(target, "plain");
 
     expect(seen!.detail).toBeNull();
+  });
+});
+
+describe("fireFromAnchor", () => {
+  it("dispatches from the host while connected", () => {
+    const host = new EventTarget();
+    const anchor = new EventTarget();
+    const seen: string[] = [];
+    host.addEventListener("yaml-updated", () => seen.push("host"));
+    anchor.addEventListener("yaml-updated", () => seen.push("anchor"));
+
+    fireFromAnchor(host, true, anchor, "yaml-updated", { yaml: "x" });
+
+    expect(seen).toEqual(["host"]);
+  });
+
+  it("dispatches from the anchor once the host is disconnected", () => {
+    const host = new EventTarget();
+    const anchor = new EventTarget();
+    const seen: string[] = [];
+    host.addEventListener("yaml-updated", () => seen.push("host"));
+    anchor.addEventListener("yaml-updated", () => seen.push("anchor"));
+
+    fireFromAnchor(host, false, anchor, "yaml-updated", { yaml: "x" });
+
+    expect(seen).toEqual(["anchor"]);
+  });
+
+  it("silently no-ops when disconnected with no anchor", () => {
+    const host = new EventTarget();
+    const seen: string[] = [];
+    host.addEventListener("yaml-updated", () => seen.push("host"));
+
+    // Deliberate contract: a host that never mounted has nowhere to
+    // deliver — swallow rather than throw.
+    fireFromAnchor(host, false, null, "yaml-updated", { yaml: "x" });
+
+    expect(seen).toEqual([]);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

A section delete writes the new YAML to disk and then tells the page about it with a `yaml-updated` dispatched from the editor element. If the user navigated to a different kind of section mid round trip, Lit swaps the element out of the tree, the dispatch bubbles nowhere, and the page keeps showing the pre delete YAML as saved; a later global Save writes that stale buffer back, re creating the section the user just deleted.

All three disk writing delete paths (`AutoApplyController.delete`, the component editor's `onDeleteConfirmed`, and `device-section-config._onDeleteRow` for api action, trigger, and component action rows) now route their `yaml-updated` through a shared `fireFromAnchor` helper in `util/fire-event.ts`: it dispatches from the host while connected and from the host's mount time parent (board-info's ShadowRoot, which outlives every same page section switch) once it is not. The helper takes connectedness as a parameter so the controller keeps `_connected` as its single source of truth, and its doc carries the structural assumption that the anchor outlives the host.

Post delete navigation is gated twice: on the host still being connected, and in the component editor also on a `deletedKey` snapshot, since Lit reuses the element across same kind switches where `isConnected` alone cannot see the retarget. `onDeleteConfirmed`'s failure path now also toasts alongside the inline error, matching the controller, so a delete failing after an unmount still reaches the user. `_onDeleteRow` additionally snapshots its buffer once, mirroring the controller's read-the-settled-buffer-exactly-once rule, so a prop reassignment mid round trip cannot splice the diff into a shifted buffer.

Tests: the controller's unmount case dispatches through a real ShadowRoot with the listener on the shadow host (pinning the composed flag) and nulls the parent on unmount so a late anchor snapshot fails; the component editor suite covers the unmount, same kind reuse, and row delete unmount cases; `fireFromAnchor`'s three behaviours, including the deliberate null anchor no op, are pinned at the unit level.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1465

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] Documentation only — `docs`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
