### PR TITLE
Re-resolve the cursor target's line against the flush-settled buffer

### DIFF
--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1597,8 +1597,15 @@ export class ESPHomePageDevice extends LitElement {
     // unmounted during it), so it can't point the old section's form
     // at a path meant for the new one.
     void this._guardSectionSwitch(() => {
+      // The awaited flush can rewrite the buffer (an upsert's diff
+      // shifts every section below it), making the snapshot's
+      // fromLine a pre-flush coordinate that _focusedSection and the
+      // URL would then mis-resolve (#1470). Re-resolve the intended
+      // section against the settled buffer: same key, instance
+      // nearest the snapshot; keep the snapshot if the key vanished.
       this._selectedSection = sectionKey;
-      this._selectedFromLine = match.fromLine;
+      this._selectedFromLine =
+        this._nearestSectionLine(sectionKey, match.fromLine) ?? match.fromLine;
       this._focusFieldPath = rel;
       this._focusYamlPath = e.detail.indexedPath;
       // The navigator selection follows the caret; a block highlight
@@ -1608,6 +1615,15 @@ export class ESPHomePageDevice extends LitElement {
       this._clearBlockHighlight();
       this._updateUrl();
     });
+  }
+
+  /** Current fromLine of *sectionKey*'s instance nearest *near*. */
+  private _nearestSectionLine(sectionKey: string, near: number): number | undefined {
+    const lines = parseYamlTopLevelSections(this._yaml)
+      .filter((s) => sectionKeyOf(s) === sectionKey)
+      .map((s) => s.fromLine);
+    if (!lines.length) return undefined;
+    return lines.reduce((a, b) => (Math.abs(b - near) < Math.abs(a - near) ? b : a));
   }
 
   /** The YamlSection backing the current selection, resolved by line

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1343,12 +1343,14 @@ export class ESPHomePageDevice extends LitElement {
           this._sectionHistory = this._sectionHistory.slice(0, -1);
           this._selectedSection = prev.key;
           // History entries were recorded against an older buffer;
-          // re-resolve like the click paths (#1470).
-          this._selectedFromLine =
-            prev.fromLine !== undefined
-              ? (resolveCurrentSectionLine(this._yaml, prev.key, prev.fromLine) ??
-                prev.fromLine)
-              : undefined;
+          // re-resolve like the click paths (#1470). A vanished key
+          // leaves the line unset rather than pointing at whatever
+          // now sits on the stale line.
+          this._selectedFromLine = resolveCurrentSectionLine(
+            this._yaml,
+            prev.key,
+            prev.fromLine
+          );
         } else {
           this._selectedSection = null;
           this._selectedFromLine = undefined;
@@ -1609,13 +1611,16 @@ export class ESPHomePageDevice extends LitElement {
       // fromLine a pre-flush coordinate that _focusedSection and the
       // URL would then mis-resolve (#1470). Re-resolve the intended
       // section against the settled buffer — same key (automation or
-      // top-level), instance nearest the snapshot — falling back to
-      // the snapshot when the key has no instance in the settled
-      // buffer.
+      // top-level), instance nearest the snapshot. A key with no
+      // instance left leaves the line unset: downstream resolution
+      // then falls back to the key instead of latching onto whatever
+      // unrelated section now starts at the stale line.
       this._selectedSection = sectionKey;
-      this._selectedFromLine =
-        resolveCurrentSectionLine(this._yaml, sectionKey, match.fromLine) ??
-        match.fromLine;
+      this._selectedFromLine = resolveCurrentSectionLine(
+        this._yaml,
+        sectionKey,
+        match.fromLine
+      );
       this._focusFieldPath = rel;
       this._focusYamlPath = e.detail.indexedPath;
       // The navigator selection follows the caret; a block highlight
@@ -1786,12 +1791,12 @@ export class ESPHomePageDevice extends LitElement {
       this._selectedSection = sectionKey;
       // The navigator captured fromLine against the click-time buffer;
       // the awaited flush can shift every section below its upsert
-      // (#1470). Re-resolve against the settled buffer, same rule as
-      // the cursor path.
+      // (#1470). Re-resolve against the settled buffer, same rule and
+      // same vanished-key handling as the cursor path.
       this._selectedFromLine =
-        sectionKey !== null && fromLine !== undefined
-          ? (resolveCurrentSectionLine(this._yaml, sectionKey, fromLine) ?? fromLine)
-          : fromLine;
+        sectionKey !== null
+          ? resolveCurrentSectionLine(this._yaml, sectionKey, fromLine)
+          : undefined;
       // A navigator click carries no field intent — a stale cursor path
       // would scroll/flash a target in the newly mounted editor that the
       // user never pointed at.

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1792,9 +1792,11 @@ export class ESPHomePageDevice extends LitElement {
       // The navigator captured fromLine against the click-time buffer;
       // the awaited flush can shift every section below its upsert
       // (#1470). Re-resolve against the settled buffer, same rule and
-      // same vanished-key handling as the cursor path.
+      // same vanished-key handling as the cursor path. Emitters that
+      // send no fromLine keep an unset line (key-based resolution),
+      // as before.
       this._selectedFromLine =
-        sectionKey !== null
+        sectionKey !== null && fromLine !== undefined
           ? resolveCurrentSectionLine(this._yaml, sectionKey, fromLine)
           : undefined;
       // A navigator click carries no field intent — a stale cursor path

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1783,7 +1783,14 @@ export class ESPHomePageDevice extends LitElement {
         ];
       }
       this._selectedSection = sectionKey;
-      this._selectedFromLine = fromLine;
+      // The navigator captured fromLine against the click-time buffer;
+      // the awaited flush can shift every section below its upsert
+      // (#1470). Re-resolve against the settled buffer, same rule as
+      // the cursor path.
+      this._selectedFromLine =
+        sectionKey !== null && fromLine !== undefined
+          ? (this._nearestSectionLine(sectionKey, fromLine) ?? fromLine)
+          : fromLine;
       // A navigator click carries no field intent — a stale cursor path
       // would scroll/flash a target in the newly mounted editor that the
       // user never pointed at.

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -68,6 +68,7 @@ import {
 import {
   findFieldLine,
   parseYamlTopLevelSections,
+  resolveCurrentSectionLine,
   sectionForCursor,
   sectionKeyOf,
   type YamlSection,
@@ -1341,7 +1342,13 @@ export class ESPHomePageDevice extends LitElement {
         if (prev) {
           this._sectionHistory = this._sectionHistory.slice(0, -1);
           this._selectedSection = prev.key;
-          this._selectedFromLine = prev.fromLine;
+          // History entries were recorded against an older buffer;
+          // re-resolve like the click paths (#1470).
+          this._selectedFromLine =
+            prev.fromLine !== undefined
+              ? (resolveCurrentSectionLine(this._yaml, prev.key, prev.fromLine) ??
+                prev.fromLine)
+              : undefined;
         } else {
           this._selectedSection = null;
           this._selectedFromLine = undefined;
@@ -1601,11 +1608,14 @@ export class ESPHomePageDevice extends LitElement {
       // shifts every section below it), making the snapshot's
       // fromLine a pre-flush coordinate that _focusedSection and the
       // URL would then mis-resolve (#1470). Re-resolve the intended
-      // section against the settled buffer: same key, instance
-      // nearest the snapshot; keep the snapshot if the key vanished.
+      // section against the settled buffer — same key (automation or
+      // top-level), instance nearest the snapshot — falling back to
+      // the snapshot when the key has no instance in the settled
+      // buffer.
       this._selectedSection = sectionKey;
       this._selectedFromLine =
-        this._nearestSectionLine(sectionKey, match.fromLine) ?? match.fromLine;
+        resolveCurrentSectionLine(this._yaml, sectionKey, match.fromLine) ??
+        match.fromLine;
       this._focusFieldPath = rel;
       this._focusYamlPath = e.detail.indexedPath;
       // The navigator selection follows the caret; a block highlight
@@ -1615,15 +1625,6 @@ export class ESPHomePageDevice extends LitElement {
       this._clearBlockHighlight();
       this._updateUrl();
     });
-  }
-
-  /** Current fromLine of *sectionKey*'s instance nearest *near*. */
-  private _nearestSectionLine(sectionKey: string, near: number): number | undefined {
-    const lines = parseYamlTopLevelSections(this._yaml)
-      .filter((s) => sectionKeyOf(s) === sectionKey)
-      .map((s) => s.fromLine);
-    if (!lines.length) return undefined;
-    return lines.reduce((a, b) => (Math.abs(b - near) < Math.abs(a - near) ? b : a));
   }
 
   /** The YamlSection backing the current selection, resolved by line
@@ -1789,7 +1790,7 @@ export class ESPHomePageDevice extends LitElement {
       // the cursor path.
       this._selectedFromLine =
         sectionKey !== null && fromLine !== undefined
-          ? (this._nearestSectionLine(sectionKey, fromLine) ?? fromLine)
+          ? (resolveCurrentSectionLine(this._yaml, sectionKey, fromLine) ?? fromLine)
           : fromLine;
       // A navigator click carries no field intent — a stale cursor path
       // would scroll/flash a target in the newly mounted editor that the

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -343,6 +343,9 @@ export function sectionKeyOf(section: YamlSection): string {
  * recovery for that case. Equidistant ties prefer the first
  * match (the test pins this; `reduce` with `<` keeps the
  * accumulator on ties).
+ *
+ * Top-level sections only — `automation:*` keys never match here;
+ * use `resolveCurrentSectionLine` for a key that may be either.
  */
 export function resolveCurrentFromLine(
   yaml: string,

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -353,6 +353,35 @@ export function resolveCurrentFromLine(
   const matches = parseYamlTopLevelSections(yaml).filter(
     (s) => sectionKeyOf(s) === sectionKey
   );
+  return _nearestFromLine(matches, staleFromLine);
+}
+
+/**
+ * Like ``resolveCurrentFromLine`` but consulting the same two layers
+ * as ``sectionAtLine``: ``automation:*`` keys resolve against
+ * ``parseYamlAutomations``, everything else against the top-level
+ * sections. Same closest-match heuristic and duplicate-instance
+ * caveats.
+ */
+export function resolveCurrentSectionLine(
+  yaml: string,
+  sectionKey: string,
+  staleFromLine?: number
+): number | undefined {
+  if (!yaml || !sectionKey) return undefined;
+  if (sectionKey.startsWith("automation:")) {
+    const matches = parseYamlAutomations(yaml).filter((s) => s.key === sectionKey);
+    return _nearestFromLine(matches, staleFromLine);
+  }
+  return resolveCurrentFromLine(yaml, sectionKey, staleFromLine);
+}
+
+/** Closest ``fromLine`` to *staleFromLine* among *matches* (first on
+ *  ties; sole/first match when no stale line is given). */
+function _nearestFromLine(
+  matches: { fromLine: number }[],
+  staleFromLine?: number
+): number | undefined {
   if (matches.length === 0) return undefined;
   if (matches.length === 1 || staleFromLine === undefined) {
     return matches[0].fromLine;

--- a/test/pages/device-section-switch-flush.test.ts
+++ b/test/pages/device-section-switch-flush.test.ts
@@ -356,6 +356,147 @@ describe("section-switch flush barrier", () => {
     expect(internals(page)._selectedFromLine).toBe(6);
   });
 
+  it("re-resolves an automation target's line — the section kind whose flush defers", async () => {
+    const page = new ESPHomePageDevice();
+    setConnected(page, true);
+    let resolveFlush!: () => void;
+    internals(page)._activeSection = {
+      dirty: true,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          resolveFlush = resolve;
+        }),
+      reload: () => {},
+    } satisfies SectionEditor;
+    internals(page)._yaml = [
+      "i2c:",
+      "  sda: 1",
+      "binary_sensor:",
+      "  - platform: gpio",
+      "    id: btn",
+      "    on_press:",
+      "      - logger.log: hi",
+    ].join("\n");
+    internals(page)._knownTopLevelKeys = new Set(["i2c", "binary_sensor"]);
+    internals(page)._selectedSection = "i2c";
+    internals(page)._selectedFromLine = 1;
+
+    // Caret clicks into the on_press block (line 7 pre-flush).
+    internals(page)._onYamlCursorLine(
+      new CustomEvent("yaml-cursor-line", {
+        detail: { line: 7, path: [], viaEdit: false },
+      })
+    );
+    // The flush grows the i2c block by two lines.
+    internals(page)._yaml = [
+      "i2c:",
+      "  sda: 1",
+      "  scl: 0",
+      "  frequency: 100khz",
+      "binary_sensor:",
+      "  - platform: gpio",
+      "    id: btn",
+      "    on_press:",
+      "      - logger.log: hi",
+    ].join("\n");
+
+    resolveFlush();
+    await new Promise((r) => setTimeout(r));
+    expect(internals(page)._selectedSection).toBe("automation:component_on:btn:on_press");
+    // on_press sat on line 6 pre-flush; line 8 after the shift.
+    expect(internals(page)._selectedFromLine).toBe(8);
+  });
+
+  it("re-resolves a multi-instance key onto the instance nearest the snapshot", async () => {
+    const page = new ESPHomePageDevice();
+    setConnected(page, true);
+    let resolveFlush!: () => void;
+    internals(page)._activeSection = {
+      dirty: true,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          resolveFlush = resolve;
+        }),
+      reload: () => {},
+    } satisfies SectionEditor;
+    internals(page)._yaml = [
+      "i2c:",
+      "  sda: 1",
+      "sensor:",
+      "  - platform: aht10",
+      "    name: one",
+      "    id: a",
+      "  - platform: aht10",
+      "    name: two",
+      "    id: b",
+    ].join("\n");
+    internals(page)._knownTopLevelKeys = new Set(["i2c", "sensor"]);
+    internals(page)._selectedSection = "i2c";
+    internals(page)._selectedFromLine = 1;
+
+    // Caret clicks inside the second instance (fromLine 7 pre-flush).
+    internals(page)._onYamlCursorLine(
+      new CustomEvent("yaml-cursor-line", {
+        detail: { line: 8, path: [], viaEdit: false },
+      })
+    );
+    // The flush grows the i2c block by one line — smaller than half
+    // the inter-instance gap, so nearest-line stays exact.
+    internals(page)._yaml = [
+      "i2c:",
+      "  sda: 1",
+      "  scl: 0",
+      "sensor:",
+      "  - platform: aht10",
+      "    name: one",
+      "    id: a",
+      "  - platform: aht10",
+      "    name: two",
+      "    id: b",
+    ].join("\n");
+
+    resolveFlush();
+    await new Promise((r) => setTimeout(r));
+    // The second instance (now line 8) wins, not the first (line 5).
+    expect(internals(page)._selectedFromLine).toBe(8);
+  });
+
+  it("Back re-resolves the restored history entry against the settled buffer", async () => {
+    const page = new ESPHomePageDevice();
+    setConnected(page, true);
+    let resolveFlush!: () => void;
+    internals(page)._activeSection = {
+      dirty: true,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          resolveFlush = resolve;
+        }),
+      reload: () => {},
+    } satisfies SectionEditor;
+    internals(page)._yaml = ["i2c:", "  sda: 1", "sensor:", "  - platform: aht10"].join(
+      "\n"
+    );
+    internals(page)._selectedSection = "sensor.aht10";
+    internals(page)._selectedFromLine = 4;
+    // History recorded sensor's old coordinate against an older buffer.
+    internals(page)._sectionHistory = [{ key: "sensor.aht10", fromLine: 4 }];
+
+    internals(page)._onBack();
+    // The flush grows the i2c block before the pop lands.
+    internals(page)._yaml = [
+      "i2c:",
+      "  sda: 1",
+      "  scl: 0",
+      "sensor:",
+      "  - platform: aht10",
+    ].join("\n");
+
+    resolveFlush();
+    await new Promise((r) => setTimeout(r));
+    expect(internals(page)._selectedSection).toBe("sensor.aht10");
+    expect(internals(page)._selectedFromLine).toBe(5);
+  });
+
   it("skips the action when the page unmounts during the flush", async () => {
     const page = new ESPHomePageDevice();
     let resolveFlush!: () => void;

--- a/test/pages/device-section-switch-flush.test.ts
+++ b/test/pages/device-section-switch-flush.test.ts
@@ -21,6 +21,20 @@ const internals = (page: ESPHomePageDevice) => page as any;
 const setConnected = (page: ESPHomePageDevice, value: boolean) =>
   Object.defineProperty(page, "isConnected", { value, configurable: true });
 
+/** Stub the active section with a flush the test resolves on demand. */
+const gateFlush = (page: ESPHomePageDevice) => {
+  let resolve!: () => void;
+  internals(page)._activeSection = {
+    dirty: true,
+    flushPending: () =>
+      new Promise<void>((r) => {
+        resolve = r;
+      }),
+    reload: () => {},
+  } satisfies SectionEditor;
+  return () => resolve();
+};
+
 describe("section-switch flush barrier", () => {
   it("defers the switch until an async flushPending resolves", async () => {
     const page = new ESPHomePageDevice();
@@ -174,15 +188,7 @@ describe("section-switch flush barrier", () => {
   it("a caret returning home cancels the switch queued behind the flush", async () => {
     const page = new ESPHomePageDevice();
     setConnected(page, true);
-    let resolveFlush!: () => void;
-    internals(page)._activeSection = {
-      dirty: true,
-      flushPending: () =>
-        new Promise<void>((resolve) => {
-          resolveFlush = resolve;
-        }),
-      reload: () => {},
-    } satisfies SectionEditor;
+    const resolveFlush = gateFlush(page);
     // Two top-level sections; the selection sits on i2c (line 1).
     internals(page)._yaml = [
       "i2c:",
@@ -216,15 +222,7 @@ describe("section-switch flush barrier", () => {
   it("re-clicking the displayed section cancels the switch queued behind the flush", async () => {
     const page = new ESPHomePageDevice();
     setConnected(page, true);
-    let resolveFlush!: () => void;
-    internals(page)._activeSection = {
-      dirty: true,
-      flushPending: () =>
-        new Promise<void>((resolve) => {
-          resolveFlush = resolve;
-        }),
-      reload: () => {},
-    } satisfies SectionEditor;
+    const resolveFlush = gateFlush(page);
     internals(page)._selectedSection = "i2c";
     internals(page)._selectedFromLine = 1;
 
@@ -246,15 +244,7 @@ describe("section-switch flush barrier", () => {
   it("closes the drawer before the flush barrier (mobile tap feedback)", async () => {
     const page = new ESPHomePageDevice();
     setConnected(page, true);
-    let resolveFlush!: () => void;
-    internals(page)._activeSection = {
-      dirty: true,
-      flushPending: () =>
-        new Promise<void>((resolve) => {
-          resolveFlush = resolve;
-        }),
-      reload: () => {},
-    } satisfies SectionEditor;
+    const resolveFlush = gateFlush(page);
     internals(page)._selectedSection = "i2c";
     internals(page)._selectedFromLine = 1;
     internals(page)._drawerOpen = true;
@@ -275,15 +265,7 @@ describe("section-switch flush barrier", () => {
   it("re-resolves the target section's line against the buffer the flush settled", async () => {
     const page = new ESPHomePageDevice();
     setConnected(page, true);
-    let resolveFlush!: () => void;
-    internals(page)._activeSection = {
-      dirty: true,
-      flushPending: () =>
-        new Promise<void>((resolve) => {
-          resolveFlush = resolve;
-        }),
-      reload: () => {},
-    } satisfies SectionEditor;
+    const resolveFlush = gateFlush(page);
     internals(page)._yaml = ["i2c:", "  sda: 1", "sensor:", "  - platform: aht10"].join(
       "\n"
     );
@@ -319,15 +301,7 @@ describe("section-switch flush barrier", () => {
   it("re-resolves a navigator click's line against the buffer the flush settled", async () => {
     const page = new ESPHomePageDevice();
     setConnected(page, true);
-    let resolveFlush!: () => void;
-    internals(page)._activeSection = {
-      dirty: true,
-      flushPending: () =>
-        new Promise<void>((resolve) => {
-          resolveFlush = resolve;
-        }),
-      reload: () => {},
-    } satisfies SectionEditor;
+    const resolveFlush = gateFlush(page);
     internals(page)._yaml = ["i2c:", "  sda: 1", "sensor:", "  - platform: aht10"].join(
       "\n"
     );
@@ -359,15 +333,7 @@ describe("section-switch flush barrier", () => {
   it("re-resolves an automation target's line — the section kind whose flush defers", async () => {
     const page = new ESPHomePageDevice();
     setConnected(page, true);
-    let resolveFlush!: () => void;
-    internals(page)._activeSection = {
-      dirty: true,
-      flushPending: () =>
-        new Promise<void>((resolve) => {
-          resolveFlush = resolve;
-        }),
-      reload: () => {},
-    } satisfies SectionEditor;
+    const resolveFlush = gateFlush(page);
     internals(page)._yaml = [
       "i2c:",
       "  sda: 1",
@@ -410,15 +376,7 @@ describe("section-switch flush barrier", () => {
   it("re-resolves a multi-instance key onto the instance nearest the snapshot", async () => {
     const page = new ESPHomePageDevice();
     setConnected(page, true);
-    let resolveFlush!: () => void;
-    internals(page)._activeSection = {
-      dirty: true,
-      flushPending: () =>
-        new Promise<void>((resolve) => {
-          resolveFlush = resolve;
-        }),
-      reload: () => {},
-    } satisfies SectionEditor;
+    const resolveFlush = gateFlush(page);
     internals(page)._yaml = [
       "i2c:",
       "  sda: 1",
@@ -464,15 +422,7 @@ describe("section-switch flush barrier", () => {
   it("Back re-resolves the restored history entry against the settled buffer", async () => {
     const page = new ESPHomePageDevice();
     setConnected(page, true);
-    let resolveFlush!: () => void;
-    internals(page)._activeSection = {
-      dirty: true,
-      flushPending: () =>
-        new Promise<void>((resolve) => {
-          resolveFlush = resolve;
-        }),
-      reload: () => {},
-    } satisfies SectionEditor;
+    const resolveFlush = gateFlush(page);
     internals(page)._yaml = ["i2c:", "  sda: 1", "sensor:", "  - platform: aht10"].join(
       "\n"
     );
@@ -500,15 +450,7 @@ describe("section-switch flush barrier", () => {
   it("Back leaves the line unset when the restored key vanished mid-flush", async () => {
     const page = new ESPHomePageDevice();
     setConnected(page, true);
-    let resolveFlush!: () => void;
-    internals(page)._activeSection = {
-      dirty: true,
-      flushPending: () =>
-        new Promise<void>((resolve) => {
-          resolveFlush = resolve;
-        }),
-      reload: () => {},
-    } satisfies SectionEditor;
+    const resolveFlush = gateFlush(page);
     internals(page)._yaml = ["i2c:", "  sda: 1", "logger:", "  level: DEBUG"].join("\n");
     internals(page)._selectedSection = "i2c";
     internals(page)._selectedFromLine = 1;
@@ -528,15 +470,7 @@ describe("section-switch flush barrier", () => {
 
   it("skips the action when the page unmounts during the flush", async () => {
     const page = new ESPHomePageDevice();
-    let resolveFlush!: () => void;
-    internals(page)._activeSection = {
-      dirty: true,
-      flushPending: () =>
-        new Promise<void>((resolve) => {
-          resolveFlush = resolve;
-        }),
-      reload: () => {},
-    } satisfies SectionEditor;
+    const resolveFlush = gateFlush(page);
     setConnected(page, true);
     const action = vi.fn();
     const switching = internals(page)._guardSectionSwitch(action) as Promise<void>;

--- a/test/pages/device-section-switch-flush.test.ts
+++ b/test/pages/device-section-switch-flush.test.ts
@@ -316,6 +316,46 @@ describe("section-switch flush barrier", () => {
     expect(internals(page)._selectedFromLine).toBe(6);
   });
 
+  it("re-resolves a navigator click's line against the buffer the flush settled", async () => {
+    const page = new ESPHomePageDevice();
+    setConnected(page, true);
+    let resolveFlush!: () => void;
+    internals(page)._activeSection = {
+      dirty: true,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          resolveFlush = resolve;
+        }),
+      reload: () => {},
+    } satisfies SectionEditor;
+    internals(page)._yaml = ["i2c:", "  sda: 1", "sensor:", "  - platform: aht10"].join(
+      "\n"
+    );
+    internals(page)._selectedSection = "i2c";
+    internals(page)._selectedFromLine = 1;
+
+    // Navigator click captured fromLine 4 against the click-time buffer.
+    internals(page)._onSectionSelect(
+      new CustomEvent("section-select", {
+        detail: { sectionKey: "sensor.aht10", fromLine: 4 },
+      })
+    );
+    // The flush's upsert grows the i2c block before the action runs.
+    internals(page)._yaml = [
+      "i2c:",
+      "  sda: 1",
+      "  scl: 0",
+      "  frequency: 100khz",
+      "sensor:",
+      "  - platform: aht10",
+    ].join("\n");
+
+    resolveFlush();
+    await new Promise((r) => setTimeout(r));
+    expect(internals(page)._selectedSection).toBe("sensor.aht10");
+    expect(internals(page)._selectedFromLine).toBe(6);
+  });
+
   it("skips the action when the page unmounts during the flush", async () => {
     const page = new ESPHomePageDevice();
     let resolveFlush!: () => void;

--- a/test/pages/device-section-switch-flush.test.ts
+++ b/test/pages/device-section-switch-flush.test.ts
@@ -497,6 +497,35 @@ describe("section-switch flush barrier", () => {
     expect(internals(page)._selectedFromLine).toBe(5);
   });
 
+  it("Back leaves the line unset when the restored key vanished mid-flush", async () => {
+    const page = new ESPHomePageDevice();
+    setConnected(page, true);
+    let resolveFlush!: () => void;
+    internals(page)._activeSection = {
+      dirty: true,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          resolveFlush = resolve;
+        }),
+      reload: () => {},
+    } satisfies SectionEditor;
+    internals(page)._yaml = ["i2c:", "  sda: 1", "logger:", "  level: DEBUG"].join("\n");
+    internals(page)._selectedSection = "i2c";
+    internals(page)._selectedFromLine = 1;
+    // History points at a section the flush is about to remove; its
+    // old line now holds an unrelated section.
+    internals(page)._sectionHistory = [{ key: "sensor.aht10", fromLine: 3 }];
+
+    internals(page)._onBack();
+    resolveFlush();
+    await new Promise((r) => setTimeout(r));
+
+    expect(internals(page)._selectedSection).toBe("sensor.aht10");
+    // Unset, not the stale 3 — downstream resolution must fall back
+    // to the key rather than the logger section sitting on line 3.
+    expect(internals(page)._selectedFromLine).toBeUndefined();
+  });
+
   it("skips the action when the page unmounts during the flush", async () => {
     const page = new ESPHomePageDevice();
     let resolveFlush!: () => void;

--- a/test/pages/device-section-switch-flush.test.ts
+++ b/test/pages/device-section-switch-flush.test.ts
@@ -272,6 +272,50 @@ describe("section-switch flush barrier", () => {
     await new Promise((r) => setTimeout(r));
   });
 
+  it("re-resolves the target section's line against the buffer the flush settled", async () => {
+    const page = new ESPHomePageDevice();
+    setConnected(page, true);
+    let resolveFlush!: () => void;
+    internals(page)._activeSection = {
+      dirty: true,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          resolveFlush = resolve;
+        }),
+      reload: () => {},
+    } satisfies SectionEditor;
+    internals(page)._yaml = ["i2c:", "  sda: 1", "sensor:", "  - platform: aht10"].join(
+      "\n"
+    );
+    internals(page)._savedYaml = internals(page)._yaml;
+    internals(page)._knownTopLevelKeys = new Set(["i2c", "sensor"]);
+    internals(page)._selectedSection = "i2c";
+    internals(page)._selectedFromLine = 1;
+
+    // Caret clicks into sensor (line 3 pre-flush) — queued behind the flush.
+    internals(page)._onYamlCursorLine(
+      new CustomEvent("yaml-cursor-line", {
+        detail: { line: 4, path: [], viaEdit: false },
+      })
+    );
+    // The flush's upsert grows the i2c block, shifting sensor to line 5.
+    internals(page)._yaml = [
+      "i2c:",
+      "  sda: 1",
+      "  scl: 0",
+      "  frequency: 100khz",
+      "sensor:",
+      "  - platform: aht10",
+    ].join("\n");
+
+    resolveFlush();
+    await new Promise((r) => setTimeout(r));
+    expect(internals(page)._selectedSection).toBe("sensor.aht10");
+    // The post-flush coordinate (platform item now on line 6), not
+    // the pre-flush 4.
+    expect(internals(page)._selectedFromLine).toBe(6);
+  });
+
   it("skips the action when the page unmounts during the flush", async () => {
     const page = new ESPHomePageDevice();
     let resolveFlush!: () => void;

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -7,6 +7,7 @@ import {
   parseYamlAutomations,
   parseYamlTopLevelSections,
   resolveCurrentFromLine,
+  resolveCurrentSectionLine,
   sectionAtLine,
   sectionForCursor,
   sectionKeyOf,
@@ -1415,5 +1416,39 @@ describe("resolveCurrentFromLine", () => {
     expect(resolved).toBeUndefined();
     const values = parseYamlSectionValues(yaml, "ota.esphome", resolved);
     expect(values).toEqual({});
+  });
+});
+
+describe("resolveCurrentSectionLine", () => {
+  const yaml = [
+    "i2c:",
+    "  sda: 1",
+    "binary_sensor:",
+    "  - platform: gpio",
+    "    id: btn",
+    "    on_press:",
+    "      - logger.log: hi",
+    "sensor:",
+    "  - platform: aht10",
+    "  - platform: aht10",
+  ].join("\n");
+
+  it("resolves an automation key via the automations layer", () => {
+    expect(
+      resolveCurrentSectionLine(yaml, "automation:component_on:btn:on_press", 4)
+    ).toBe(6);
+  });
+
+  it("delegates non-automation keys to the top-level resolver", () => {
+    expect(resolveCurrentSectionLine(yaml, "i2c", 1)).toBe(1);
+  });
+
+  it("picks the same-key instance nearest the stale line", () => {
+    expect(resolveCurrentSectionLine(yaml, "sensor.aht10", 11)).toBe(10);
+  });
+
+  it("returns undefined when the key has no instance", () => {
+    expect(resolveCurrentSectionLine(yaml, "automation:script:gone", 3)).toBeUndefined();
+    expect(resolveCurrentSectionLine(yaml, "wifi", 3)).toBeUndefined();
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

In `_onYamlCursorLine`, the target section is resolved from `this._yaml` before the section-switch guard runs, but the flush the guard awaits is exactly what mutates the buffer: the upsert's diff shifts every section below it. The guarded action then wrote `match.fromLine`, a line number from the pre flush document, so `_focusedSection()` could resolve the wrong instance of a multi instance key and `_updateUrl()` persisted the stale line.

The guarded action now re resolves the intended section against the settled buffer: same section key, the instance whose fromLine is nearest the snapshot, falling back to the snapshot when the key vanished mid flush. The user's intent (the section they clicked in the document they saw) is preserved by keying on the snapshot's section key rather than re reading whatever now sits under the caret line.

The new test drives the real sequence through `_onYamlCursorLine`: caret clicks into a section queued behind the flush, the flush grows an earlier block, and the selection lands on the post flush coordinate.

Chained on #1468 (base `await-section-switch-flush`) since the barrier is what makes the staleness observable and both touch the same handler; retarget to `main` after it merges.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1470

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] Documentation only — `docs`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
