### PR TITLE
Show a busy affordance while a section switch waits on the flush

### DIFF
--- a/src/components/device/device-navigator.styles.ts
+++ b/src/components/device/device-navigator.styles.ts
@@ -118,7 +118,7 @@ export const deviceNavigatorStyles = css`
     align-items: center;
     justify-content: space-between;
     padding: 0 var(--wa-space-m);
-    cursor: pointer;
+    cursor: var(--navigator-busy-cursor, pointer);
     user-select: none;
     flex-shrink: 0;
   }
@@ -161,7 +161,7 @@ export const deviceNavigatorStyles = css`
        as the rows do; the header-to-rows gap lives on .nav-items--grouped. */
     padding: 0 var(--wa-space-m);
     margin-top: var(--wa-space-2xs);
-    cursor: pointer;
+    cursor: var(--navigator-busy-cursor, pointer);
     user-select: none;
     flex-shrink: 0;
   }
@@ -255,7 +255,7 @@ export const deviceNavigatorStyles = css`
     display: flex;
     align-items: center;
     gap: var(--wa-space-xs);
-    cursor: pointer;
+    cursor: var(--navigator-busy-cursor, pointer);
     user-select: none;
     transition:
       background 0.1s,
@@ -346,7 +346,7 @@ export const deviceNavigatorStyles = css`
     background: var(--esphome-primary);
     color: var(--esphome-on-primary);
     justify-content: space-between;
-    cursor: pointer;
+    cursor: var(--navigator-busy-cursor, pointer);
     user-select: none;
     transition:
       background 0.1s,

--- a/src/components/device/device-navigator.styles.ts
+++ b/src/components/device/device-navigator.styles.ts
@@ -22,6 +22,10 @@ export const deviceNavigatorStyles = css`
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    /* Busy dim fed from the host page (the host itself is
+       display: contents, so opacity must land on this box). */
+    opacity: var(--navigator-busy-opacity, 1);
+    transition: opacity 120ms ease var(--navigator-busy-delay, 0ms);
   }
 
   .card-header {

--- a/src/pages/device-styles.ts
+++ b/src/pages/device-styles.ts
@@ -30,6 +30,24 @@ export const devicePageStyles = css`
     grid-template-columns: minmax(0, 5fr);
   }
 
+  /* Busy affordance while a section switch is parked behind the
+     active editor's flush (up to the WS command timeout). The dim
+     engages only after a delay so the common fast flush never
+     flickers; the base state carries no delay, so clearing un-dims
+     immediately. */
+  .layout-grid .desktop-nav {
+    transition: opacity 120ms ease;
+  }
+
+  .layout-grid.switch-pending {
+    cursor: progress;
+  }
+
+  .layout-grid.switch-pending .desktop-nav {
+    opacity: 0.6;
+    transition-delay: 200ms;
+  }
+
   .layout-grid.nav-collapsed .desktop-nav {
     display: none;
   }

--- a/src/pages/device-styles.ts
+++ b/src/pages/device-styles.ts
@@ -31,21 +31,21 @@ export const devicePageStyles = css`
   }
 
   /* Busy affordance while a section switch is parked behind the
-     active editor's flush (up to the WS command timeout). The dim
-     engages only after a delay so the common fast flush never
-     flickers; the base state carries no delay, so clearing un-dims
-     immediately. */
-  .layout-grid .desktop-nav {
-    transition: opacity 120ms ease;
-  }
-
+     active editor's flush (up to the WS command timeout). The dim is
+     fed through custom properties because the navigator host is
+     display: contents (opacity on the host is a no-op); it engages
+     only after a delay so the common fast flush never flickers, and
+     clears immediately (the shadow side's base delay is 0). Rows keep
+     their pointer cursor on purpose — clicking during the barrier
+     stays meaningful (last switch wins), so the progress cursor shows
+     on the non-interactive surface only. */
   .layout-grid.switch-pending {
     cursor: progress;
   }
 
   .layout-grid.switch-pending .desktop-nav {
-    opacity: 0.6;
-    transition-delay: 200ms;
+    --navigator-busy-opacity: 0.6;
+    --navigator-busy-delay: 200ms;
   }
 
   .layout-grid.nav-collapsed .desktop-nav {

--- a/src/pages/device-styles.ts
+++ b/src/pages/device-styles.ts
@@ -31,14 +31,13 @@ export const devicePageStyles = css`
   }
 
   /* Busy affordance while a section switch is parked behind the
-     active editor's flush (up to the WS command timeout). The dim is
-     fed through custom properties because the navigator host is
-     display: contents (opacity on the host is a no-op); it engages
-     only after a delay so the common fast flush never flickers, and
-     clears immediately (the shadow side's base delay is 0). Rows keep
-     their pointer cursor on purpose — clicking during the barrier
-     stays meaningful (last switch wins), so the progress cursor shows
-     on the non-interactive surface only. */
+     active editor's flush (up to the WS command timeout). The dim and
+     cursor are fed through custom properties because the navigator
+     host is display: contents (box properties on the host are a
+     no-op) and its rows sit behind the shadow boundary; the dim
+     engages only after a delay so the common fast flush never
+     flickers, and clears immediately (the shadow side's base delay
+     is 0). */
   .layout-grid.switch-pending {
     cursor: progress;
   }
@@ -46,9 +45,8 @@ export const devicePageStyles = css`
   .layout-grid.switch-pending .desktop-nav {
     --navigator-busy-opacity: 0.6;
     --navigator-busy-delay: 200ms;
-    /* Rows stay clickable (last switch wins under the supersede
-       token); the cursor still signals the wait where the pointer
-       actually sits. */
+    /* Rows show the wait where the pointer actually sits but stay
+       clickable (last switch wins under the supersede token). */
     --navigator-busy-cursor: progress;
   }
 

--- a/src/pages/device-styles.ts
+++ b/src/pages/device-styles.ts
@@ -46,6 +46,10 @@ export const devicePageStyles = css`
   .layout-grid.switch-pending .desktop-nav {
     --navigator-busy-opacity: 0.6;
     --navigator-busy-delay: 200ms;
+    /* Rows stay clickable (last switch wins under the supersede
+       token); the cursor still signals the wait where the pointer
+       actually sits. */
+    --navigator-busy-cursor: progress;
   }
 
   .layout-grid.nav-collapsed .desktop-nav {

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -336,6 +336,15 @@ export class ESPHomePageDevice extends LitElement {
    *  land but still bump the token. */
   private _switchSeq = 0;
 
+  /** True while at least one section switch is parked behind the
+   *  flush barrier — drives the desktop busy affordance (#1478). */
+  @state()
+  private _switchPending = false;
+
+  /** Guard calls currently awaiting their flush; the affordance
+   *  clears only when the last one settles. */
+  private _switchWaiters = 0;
+
   @state()
   private _sectionDirty = false;
 
@@ -1191,7 +1200,9 @@ export class ESPHomePageDevice extends LitElement {
 
       <div class="page">
         <div
-          class="layout-grid ${this._navCollapsed ? "nav-collapsed" : ""}"
+          class="layout-grid ${this._navCollapsed ? "nav-collapsed" : ""} ${
+            this._switchPending ? "switch-pending" : ""
+          }"
           @section-toggle=${this._onSectionToggle}
           @section-reveal=${this._onSectionReveal}
           @layout-change=${this._onLayoutChange}
@@ -1840,12 +1851,16 @@ export class ESPHomePageDevice extends LitElement {
     const seq = ++this._switchSeq;
     const pending = this._activeSection?.flushPending();
     if (pending) {
+      this._switchWaiters++;
+      this._switchPending = true;
       // A failed flush already surfaced its own error; still switch —
       // blocking navigation on it is strictly worse than a stale draft.
       try {
         await pending;
       } catch {
         // Handled by the editor.
+      } finally {
+        if (--this._switchWaiters === 0) this._switchPending = false;
       }
       // The page can unmount across the flush (a late action would
       // replaceState on whatever URL the user has since landed on),

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1835,10 +1835,10 @@ export class ESPHomePageDevice extends LitElement {
    *  the selection first can unmount the editor mid-flight — its
    *  ``yaml-draft`` then fires from a detached element and never
    *  reaches the page, silently dropping the last edit. The wait is
-   *  bounded by the WS command timeout (~10s worst case) and shows
-   *  no desktop busy affordance — a deliberate trade; repeat clicks
-   *  are harmless under the supersede token (#1478 tracks an
-   *  affordance). */
+   *  bounded by the WS command timeout (~10s worst case);
+   *  ``_switchPending`` surfaces it as the desktop busy affordance
+   *  (progress cursor + delayed navigator dim), and repeat clicks
+   *  are harmless under the supersede token. */
   private async _guardSectionSwitch(
     action: () => void,
     opts: { compose?: boolean } = {}

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1203,6 +1203,7 @@ export class ESPHomePageDevice extends LitElement {
           class="layout-grid ${this._navCollapsed ? "nav-collapsed" : ""} ${
             this._switchPending ? "switch-pending" : ""
           }"
+          aria-busy=${this._switchPending}
           @section-toggle=${this._onSectionToggle}
           @section-reveal=${this._onSectionReveal}
           @layout-change=${this._onLayoutChange}

--- a/test/pages/device-section-switch-flush.test.ts
+++ b/test/pages/device-section-switch-flush.test.ts
@@ -468,6 +468,69 @@ describe("section-switch flush barrier", () => {
     expect(internals(page)._selectedFromLine).toBeUndefined();
   });
 
+  it("flags the busy affordance while parked behind the flush, never on the sync path", async () => {
+    const page = new ESPHomePageDevice();
+    setConnected(page, true);
+    const resolveFlush = gateFlush(page);
+
+    const switching = internals(page)._guardSectionSwitch(vi.fn()) as Promise<void>;
+    expect(internals(page)._switchPending).toBe(true);
+
+    resolveFlush();
+    await switching;
+    expect(internals(page)._switchPending).toBe(false);
+
+    // Sync path (component editor shape): no flicker, flag never set.
+    internals(page)._activeSection = {
+      dirty: false,
+      flushPending: vi.fn(),
+      reload: () => {},
+    } satisfies SectionEditor;
+    const sync = internals(page)._guardSectionSwitch(vi.fn()) as Promise<void>;
+    expect(internals(page)._switchPending).toBe(false);
+    await sync;
+  });
+
+  it("the affordance clears only when the last parked switch settles", async () => {
+    const page = new ESPHomePageDevice();
+    setConnected(page, true);
+    const resolvers: (() => void)[] = [];
+    internals(page)._activeSection = {
+      dirty: true,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve);
+        }),
+      reload: () => {},
+    } satisfies SectionEditor;
+
+    const s1 = internals(page)._guardSectionSwitch(vi.fn()) as Promise<void>;
+    const s2 = internals(page)._guardSectionSwitch(vi.fn()) as Promise<void>;
+    expect(internals(page)._switchPending).toBe(true);
+
+    resolvers[0]();
+    await s1;
+    // The second switch is still parked.
+    expect(internals(page)._switchPending).toBe(true);
+
+    resolvers[1]();
+    await s2;
+    expect(internals(page)._switchPending).toBe(false);
+  });
+
+  it("a rejecting flush still clears the affordance", async () => {
+    const page = new ESPHomePageDevice();
+    setConnected(page, true);
+    internals(page)._activeSection = {
+      dirty: true,
+      flushPending: () => Promise.reject(new Error("upsert failed")),
+      reload: () => {},
+    } satisfies SectionEditor;
+
+    await internals(page)._guardSectionSwitch(vi.fn());
+    expect(internals(page)._switchPending).toBe(false);
+  });
+
   it("skips the action when the page unmounts during the flush", async () => {
     const page = new ESPHomePageDevice();
     const resolveFlush = gateFlush(page);

--- a/test/pages/device-section-switch-flush.test.ts
+++ b/test/pages/device-section-switch-flush.test.ts
@@ -9,6 +9,10 @@
 import { describe, expect, it, vi } from "vitest";
 
 import "./_mock-device-children.js";
+// The render-level case attaches the real page; the reselect dialog
+// is not in the shared preamble and its WebAwesome button crashes
+// happy-dom (same local mock as the platform-ready suite).
+vi.mock("../../src/components/device/board-reselect-dialog.js", () => ({}));
 
 import { ESPHomePageDevice } from "../../src/pages/device.js";
 import type { SectionEditor } from "../../src/components/device/section-editor.js";
@@ -516,6 +520,29 @@ describe("section-switch flush barrier", () => {
     resolvers[1]();
     await s2;
     expect(internals(page)._switchPending).toBe(false);
+  });
+
+  it("the pending flag reaches the DOM: switch-pending class and aria-busy", async () => {
+    const page = new ESPHomePageDevice();
+    page.id = "kitchen.yaml";
+    document.body.appendChild(page);
+    try {
+      await page.updateComplete;
+      const resolveFlush = gateFlush(page);
+      const switching = internals(page)._guardSectionSwitch(vi.fn()) as Promise<void>;
+      await page.updateComplete;
+      const grid = page.shadowRoot!.querySelector(".layout-grid")!;
+      expect(grid.classList.contains("switch-pending")).toBe(true);
+      expect(grid.getAttribute("aria-busy")).toBe("true");
+
+      resolveFlush();
+      await switching;
+      await page.updateComplete;
+      expect(grid.classList.contains("switch-pending")).toBe(false);
+      expect(grid.getAttribute("aria-busy")).toBe("false");
+    } finally {
+      page.remove();
+    }
   });
 
   it("a rejecting flush still clears the affordance", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Since #1468 a section switch out of an automation editor waits on that editor's upsert flush, bounded by the WS command timeout (about 10s worst case). Mobile gets the drawer close as tap feedback; desktop got nothing, so on a slow backend a click produced no visible reaction until the flush settled.

The guard now tracks a `_switchPending` state around its awaited barrier, counted per waiter so the affordance clears only when the last parked switch settles, including on a rejecting flush. While set, the layout grid shows a `progress` cursor and dims the desktop navigator. The dim engages only after a 200ms delay so the common fast flush never flickers, and the base state carries no delay so clearing un-dims immediately. The synchronous paths (component editor flush, no active section) never set the flag.

Pure CSS on existing structure, no new components or tokens. Three tests pin the flag around the deferred, multi waiter, rejecting, and synchronous paths.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1478

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] Documentation only — `docs`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
