### PR TITLE
Ride the section-unmount announcement on the mount-time parent

### DIFF
--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -117,6 +117,8 @@ export class AutoApplyController implements ReactiveController {
   // Whether the host element is on screen; a failure-path re-arm must not
   // schedule a write for a torn-down section.
   private _connected = false;
+  /** Mount-time parent carrying the detached-host unmount dispatch. */
+  private _mountAnchor: ParentNode | null = null;
 
   constructor(
     private readonly _host: AutoApplyHost,
@@ -130,6 +132,10 @@ export class AutoApplyController implements ReactiveController {
    *  device-section-config's section-mount event. */
   hostConnected(): void {
     this._connected = true;
+    // The unmount announcement must ride the mount-time parent:
+    // disconnectedCallback order means the host has already left the
+    // tree, and a detached dispatch bubbles nowhere (#1483).
+    this._mountAnchor = this._host.parentNode;
     fireSectionEvent(this._host, "section-mount", { node: this._host });
   }
 
@@ -138,7 +144,9 @@ export class AutoApplyController implements ReactiveController {
     // Cancel the pending debounced upsert — a write scheduled by a
     // section that's no longer on screen must not fire.
     this._cancelDebounce();
-    fireSectionEvent(this._host, "section-unmount", { node: this._host });
+    fireSectionEvent(this._mountAnchor ?? this._host, "section-unmount", {
+      node: this._host,
+    });
   }
 
   /** Brief-window dirty flag covering the debounce gap so the global

--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -10,7 +10,7 @@ import { fireEvent, fireFromAnchor } from "../../../util/fire-event.js";
 import { formatApiError } from "../../../util/format-api-error.js";
 import { notifyError } from "../../../util/notify.js";
 import type { SectionEditor } from "../section-editor.js";
-import { fireSectionEvent } from "../section-editor.js";
+import { announceSectionMount, fireSectionEvent } from "../section-editor.js";
 import {
   applyYamlDiff,
   emptyAutomationTree,
@@ -117,8 +117,7 @@ export class AutoApplyController implements ReactiveController {
   // Whether the host element is on screen; a failure-path re-arm must not
   // schedule a write for a torn-down section.
   private _connected = false;
-  /** Mount-time parent carrying the detached-host unmount dispatch. */
-  private _mountAnchor: ParentNode | null = null;
+  private _announceUnmount: (() => void) | null = null;
 
   constructor(
     private readonly _host: AutoApplyHost,
@@ -132,11 +131,7 @@ export class AutoApplyController implements ReactiveController {
    *  device-section-config's section-mount event. */
   hostConnected(): void {
     this._connected = true;
-    // The unmount announcement must ride the mount-time parent:
-    // disconnectedCallback order means the host has already left the
-    // tree, and a detached dispatch bubbles nowhere (#1483).
-    this._mountAnchor = this._host.parentNode;
-    fireSectionEvent(this._host, "section-mount", { node: this._host });
+    this._announceUnmount = announceSectionMount(this._host);
   }
 
   hostDisconnected(): void {
@@ -144,9 +139,7 @@ export class AutoApplyController implements ReactiveController {
     // Cancel the pending debounced upsert — a write scheduled by a
     // section that's no longer on screen must not fire.
     this._cancelDebounce();
-    fireSectionEvent(this._mountAnchor ?? this._host, "section-unmount", {
-      node: this._host,
-    });
+    this._announceUnmount?.();
   }
 
   /** Brief-window dirty flag covering the debounce gap so the global

--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -139,7 +139,9 @@ export class AutoApplyController implements ReactiveController {
     // Cancel the pending debounced upsert — a write scheduled by a
     // section that's no longer on screen must not fire.
     this._cancelDebounce();
+    // One-shot: the closure pairs with exactly one mount.
     this._announceUnmount?.();
+    this._announceUnmount = null;
   }
 
   /** Brief-window dirty flag covering the debounce gap so the global

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -302,7 +302,9 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
       clearTimeout(this._draftTimer);
       this._draftTimer = null;
     }
+    // One-shot: the closure pairs with exactly one mount.
     this._announceUnmount?.();
+    this._announceUnmount = null;
   }
 
   // Flush pending draft sync now. The page calls this before save / section

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -189,6 +189,8 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
 
   _loadId = 0;
   _draftTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Mount-time parent carrying the detached-host unmount dispatch. */
+  private _mountAnchor: ParentNode | null = null;
   /** ``focusFieldPath`` key already flashed — one-shot per target. */
   _apiListFlashKey?: string;
   // Parent loops yaml-draft events back through our yaml prop, which would
@@ -289,6 +291,10 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
 
   connectedCallback() {
     super.connectedCallback();
+    // The unmount announcement below must ride the mount-time parent:
+    // disconnectedCallback runs after the node left the tree, and a
+    // detached dispatch bubbles nowhere (#1483).
+    this._mountAnchor = this.parentNode;
     // Announce so the page-level navigation guard (device.ts) can hold a
     // direct ref. The tree is page → device-editor → device-board-info → us;
     // a property passthrough chain would cost three edits per API change.
@@ -301,7 +307,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
       clearTimeout(this._draftTimer);
       this._draftTimer = null;
     }
-    fireSectionEvent(this, "section-unmount", { node: this });
+    fireSectionEvent(this._mountAnchor ?? this, "section-unmount", { node: this });
   }
 
   // Flush pending draft sync now. The page calls this before save / section

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -44,7 +44,7 @@ import type { ESPHomeAddAutomationDialog } from "./add-automation-dialog.js";
 import type { ConfigEntryValueChange } from "./config-entry-form.js";
 import { deviceSectionConfigStyles } from "./device-section-config.styles.js";
 import type { SectionEditor } from "./section-editor.js";
-import { fireSectionEvent } from "./section-editor.js";
+import { announceSectionMount, fireSectionEvent } from "./section-editor.js";
 import {
   applySectionValues,
   flushDraft,
@@ -189,8 +189,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
 
   _loadId = 0;
   _draftTimer: ReturnType<typeof setTimeout> | null = null;
-  /** Mount-time parent carrying the detached-host unmount dispatch. */
-  private _mountAnchor: ParentNode | null = null;
+  private _announceUnmount: (() => void) | null = null;
   /** ``focusFieldPath`` key already flashed — one-shot per target. */
   _apiListFlashKey?: string;
   // Parent loops yaml-draft events back through our yaml prop, which would
@@ -291,14 +290,10 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
 
   connectedCallback() {
     super.connectedCallback();
-    // The unmount announcement below must ride the mount-time parent:
-    // disconnectedCallback runs after the node left the tree, and a
-    // detached dispatch bubbles nowhere (#1483).
-    this._mountAnchor = this.parentNode;
     // Announce so the page-level navigation guard (device.ts) can hold a
     // direct ref. The tree is page → device-editor → device-board-info → us;
     // a property passthrough chain would cost three edits per API change.
-    fireSectionEvent(this, "section-mount", { node: this });
+    this._announceUnmount = announceSectionMount(this);
   }
 
   disconnectedCallback() {
@@ -307,7 +302,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
       clearTimeout(this._draftTimer);
       this._draftTimer = null;
     }
-    fireSectionEvent(this._mountAnchor ?? this, "section-unmount", { node: this });
+    this._announceUnmount?.();
   }
 
   // Flush pending draft sync now. The page calls this before save / section

--- a/src/components/device/section-editor.ts
+++ b/src/components/device/section-editor.ts
@@ -53,6 +53,21 @@ export function fireSectionEvent<K extends keyof SectionEditorEventMap>(
   fireEvent(target, name, detail);
 }
 
+/**
+ * Announce ``section-mount`` from *host* and return the matching
+ * unmount announcer. The unmount rides the parent captured here:
+ * disconnect callbacks run after the node has left the tree, and a
+ * detached dispatch bubbles nowhere (#1483). A never-mounted host
+ * falls back to itself — a harmless no-op dispatch.
+ */
+export function announceSectionMount(
+  host: SectionEditor & EventTarget & { readonly parentNode: ParentNode | null }
+): () => void {
+  const anchor = host.parentNode;
+  fireSectionEvent(host, "section-mount", { node: host });
+  return () => fireSectionEvent(anchor ?? host, "section-unmount", { node: host });
+}
+
 declare global {
   interface HTMLElementEventMap {
     "section-mount": CustomEvent<SectionEditorEventMap["section-mount"]>;

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -515,6 +515,25 @@ describe("AutoApplyController delete", () => {
     expect(selections).toHaveLength(0);
   });
 
+  it("the unmount announcement rides the mount-time parent past detachment", () => {
+    const { host, controller } = setup();
+    const outer = document.createElement("div");
+    const shadow = outer.attachShadow({ mode: "open" });
+    const unmounts: unknown[] = [];
+    outer.addEventListener("section-unmount", (e) =>
+      unmounts.push((e as CustomEvent<{ node: unknown }>).detail.node)
+    );
+    host.parentNode = shadow;
+    // Re-run the connect with the anchor in place (setup connected
+    // before the parent existed), then tear down like Lit does —
+    // after the host has left the tree.
+    controller.hostConnected();
+    host.parentNode = null;
+    controller.hostDisconnected();
+
+    expect(unmounts).toEqual([host]);
+  });
+
   it("a mid-flush retarget without an edit stays on the sibling with nothing re-armed", async () => {
     const { host, controller, upsertAutomation, deleteAutomation } = setup();
     const selections = captureEvents(host, "section-select");

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -519,21 +519,6 @@ describe("AutoApplyController delete", () => {
     expect(selections).toHaveLength(0);
   });
 
-  it("the unmount announcement rides the mount-time parent past detachment", () => {
-    const outer = document.createElement("div");
-    const shadow = outer.attachShadow({ mode: "open" });
-    const { host, controller } = setup({}, shadow);
-    const unmounts: unknown[] = [];
-    outer.addEventListener("section-unmount", (e) =>
-      unmounts.push((e as CustomEvent<{ node: unknown }>).detail.node)
-    );
-    // Tear down like Lit does — after the host has left the tree.
-    host.parentNode = null;
-    controller.hostDisconnected();
-
-    expect(unmounts).toEqual([host]);
-  });
-
   it("a mid-flush retarget without an edit stays on the sibling with nothing re-armed", async () => {
     const { host, controller, upsertAutomation, deleteAutomation } = setup();
     const selections = captureEvents(host, "section-select");
@@ -685,6 +670,8 @@ describe("AutoApplyController host lifecycle", () => {
     expect(addController).toHaveBeenCalledWith(controller);
   });
 
+  // No parent → exercises the ``anchor ?? host`` fallback dispatch;
+  // the anchored path production uses is pinned by the test below.
   it("announces section-mount / section-unmount with the host node", () => {
     const { host, controller } = setup();
     const mounts = captureEvents(host, "section-mount");
@@ -693,6 +680,21 @@ describe("AutoApplyController host lifecycle", () => {
     controller.hostDisconnected();
     expect(mounts.map((e) => e.detail.node)).toEqual([host]);
     expect(unmounts.map((e) => e.detail.node)).toEqual([host]);
+  });
+
+  it("the unmount announcement rides the mount-time parent past detachment", () => {
+    const outer = document.createElement("div");
+    const shadow = outer.attachShadow({ mode: "open" });
+    const { host, controller } = setup({}, shadow);
+    const unmounts: unknown[] = [];
+    outer.addEventListener("section-unmount", (e) =>
+      unmounts.push((e as CustomEvent<{ node: unknown }>).detail.node)
+    );
+    // Tear down like Lit does — after the host has left the tree.
+    host.parentNode = null;
+    controller.hostDisconnected();
+
+    expect(unmounts).toEqual([host]);
   });
 
   it("cancels the pending debounced upsert on host disconnect", async () => {

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -62,8 +62,12 @@ class Host extends EventTarget implements AutoApplyHost {
 
 const localize: LocalizeFunc = identityLocalize as LocalizeFunc;
 
-function setup(over: Partial<AutoApplyOptions> = {}) {
+function setup(
+  over: Partial<AutoApplyOptions> = {},
+  parentNode: ParentNode | null = null
+) {
   const host = new Host();
+  host.parentNode = parentNode;
   const upsertAutomation = vi.fn().mockResolvedValue({ yaml_diff: DIFF });
   const deleteAutomation = vi.fn().mockResolvedValue({ yaml_diff: DIFF });
   const updateConfig = vi.fn().mockResolvedValue(undefined);
@@ -516,18 +520,14 @@ describe("AutoApplyController delete", () => {
   });
 
   it("the unmount announcement rides the mount-time parent past detachment", () => {
-    const { host, controller } = setup();
     const outer = document.createElement("div");
     const shadow = outer.attachShadow({ mode: "open" });
+    const { host, controller } = setup({}, shadow);
     const unmounts: unknown[] = [];
     outer.addEventListener("section-unmount", (e) =>
       unmounts.push((e as CustomEvent<{ node: unknown }>).detail.node)
     );
-    host.parentNode = shadow;
-    // Re-run the connect with the anchor in place (setup connected
-    // before the parent existed), then tear down like Lit does —
-    // after the host has left the tree.
-    controller.hostConnected();
+    // Tear down like Lit does — after the host has left the tree.
     host.parentNode = null;
     controller.hostDisconnected();
 

--- a/test/components/device/section-config-unmount-announce.test.ts
+++ b/test/components/device/section-config-unmount-announce.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that the component editor's section-unmount announcement
+ * survives detachment: disconnectedCallback runs after the node left
+ * the tree, so the dispatch must ride the mount-time parent or the
+ * page's listener never learns the section is gone (#1483).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+import "../../_mock-webawesome.js";
+
+import { ESPHomeDeviceSectionConfig } from "../../../src/components/device/device-section-config.js";
+
+describe("section-unmount announcement", () => {
+  it("rides the mount-time parent past detachment", async () => {
+    const c = new ESPHomeDeviceSectionConfig();
+    const outer = document.createElement("div");
+    const shadow = outer.attachShadow({ mode: "open" });
+    document.body.appendChild(outer);
+    const unmounts: unknown[] = [];
+    outer.addEventListener("section-unmount", (e) =>
+      unmounts.push((e as CustomEvent<{ node: unknown }>).detail.node)
+    );
+
+    try {
+      shadow.appendChild(c);
+      // Lit removes the node first, then runs disconnectedCallback —
+      // the dispatch below happens from a detached element.
+      c.remove();
+      expect(unmounts).toEqual([c]);
+    } finally {
+      outer.remove();
+    }
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

`disconnectedCallback` runs after the node has left the tree, so the `section-unmount` both section editors announce there dispatched from a detached element and never reached the page's `.layout-grid` listener, the same bubbles nowhere mechanism #1475 fixed for the delete paths' `yaml-updated`. The page's `_onSectionUnmount` clears `_activeSection` and `_sectionDirty`; the miss is mostly masked because the incoming section's `section-mount` re points `_activeSection`, but leaving a section with no replacement strands a stale `_sectionDirty` (arming the unsaved changes guard) and a stale `_activeSection` whose `flushPending` the save and switch paths still consult.

Both emitters (`device-section-config.disconnectedCallback` and `AutoApplyController.hostDisconnected`) now snapshot their mount time parent at connect and dispatch the unmount announcement through it, `fireSectionEvent(anchor ?? host, ...)`. The typed helper form is used rather than `fireFromAnchor` because connectedness is always false in a disconnect hook, so the helper's parameter would be a constant; the never mounted fallback dispatches on the host, a harmless no op.

Two tests pin it, one per emitter, each detaching the element first and asserting the announcement lands on the shadow host with the right node in the detail.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1483

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] Documentation only — `docs`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
