### PR TITLE
Re-base a superseded delete onto the live buffer

### DIFF
--- a/src/components/device/apply-removal.ts
+++ b/src/components/device/apply-removal.ts
@@ -1,0 +1,38 @@
+/**
+ * Re-apply a delete's removal to a buffer it was not computed
+ * against (#1490). Lives beside the ``RemovedSectionRef`` contract
+ * but outside it, so the type module stays free of API and YAML
+ * machinery.
+ */
+import type { ESPHomeAPI } from "../../api/esphome-api.js";
+import { removeSectionFromYaml } from "../../util/yaml-section-values.js";
+import { resolveCurrentSectionLine } from "../../util/yaml-sections.js";
+import { applyYamlDiff } from "./automation-editor/serialise.js";
+import type { RemovedSectionRef } from "./section-editor.js";
+
+/**
+ * Re-apply *removed* to *buffer*. Component sections splice
+ * client-side; automations recompute their diff via the
+ * side-effect-free ``deleteAutomation``. Returns the re-based
+ * buffer, or ``null`` when the removal cannot land in it.
+ */
+export async function applyRemoval(
+  removed: RemovedSectionRef,
+  buffer: string,
+  api: Pick<ESPHomeAPI, "deleteAutomation">,
+  configuration: string
+): Promise<string | null> {
+  if (removed.kind === "automation") {
+    const { yaml_diff } = await api.deleteAutomation(
+      configuration,
+      removed.location,
+      buffer
+    );
+    const next = applyYamlDiff(buffer, yaml_diff);
+    return next === buffer ? null : next;
+  }
+  const line = resolveCurrentSectionLine(buffer, removed.sectionKey, removed.fromLine);
+  if (line === undefined) return null;
+  const next = removeSectionFromYaml(buffer, removed.sectionKey, line);
+  return next === buffer ? null : next;
+}

--- a/src/components/device/apply-removal.ts
+++ b/src/components/device/apply-removal.ts
@@ -9,7 +9,7 @@ import type { AutomationLocation } from "../../api/types/automations.js";
 import { removeSectionFromYaml } from "../../util/yaml-section-values.js";
 import { resolveCurrentSectionLine } from "../../util/yaml-sections.js";
 import { applyYamlDiff } from "./automation-editor/serialise.js";
-import type { RemovedSectionRef, YamlUpdatedDetail } from "./section-editor.js";
+import type { YamlUpdatedDetail } from "./section-editor.js";
 
 /**
  * Shared core of the disk-writing automation deletes (editor engine,
@@ -29,6 +29,7 @@ export async function writeAutomationDelete(
   const newYaml = applyYamlDiff(yaml, yaml_diff);
   await api.updateConfig(configuration, newYaml);
   announce(connected(), {
+    configuration,
     yaml: newYaml,
     basedOn: yaml,
     removed: { kind: "automation", location },
@@ -36,28 +37,59 @@ export async function writeAutomationDelete(
 }
 
 /**
- * Re-apply *removed* to *buffer*. Component sections splice
+ * Re-apply *write*'s removal to *buffer*. Component sections splice
  * client-side; automations recompute their diff via the
  * side-effect-free ``deleteAutomation``. Returns the re-based
- * buffer, or ``null`` when the removal cannot land in it.
+ * buffer, or ``null`` when the removal cannot land in it — including
+ * when the re-resolved target removed different lines than the
+ * delete did (positional locations and the nearest-line heuristic
+ * are not authoritative in a diverged buffer).
  */
 export async function applyRemoval(
-  removed: RemovedSectionRef,
+  write: YamlUpdatedDetail,
   buffer: string,
-  api: Pick<ESPHomeAPI, "deleteAutomation">,
-  configuration: string
+  api: Pick<ESPHomeAPI, "deleteAutomation">
 ): Promise<string | null> {
+  const { removed, configuration } = write;
+  let next: string;
   if (removed.kind === "automation") {
     const { yaml_diff } = await api.deleteAutomation(
       configuration,
       removed.location,
       buffer
     );
-    const next = applyYamlDiff(buffer, yaml_diff);
-    return next === buffer ? null : next;
+    next = applyYamlDiff(buffer, yaml_diff);
+  } else {
+    const line = resolveCurrentSectionLine(buffer, removed.sectionKey, removed.fromLine);
+    if (line === undefined) return null;
+    next = removeSectionFromYaml(buffer, removed.sectionKey, line);
   }
-  const line = resolveCurrentSectionLine(buffer, removed.sectionKey, removed.fromLine);
-  if (line === undefined) return null;
-  const next = removeSectionFromYaml(buffer, removed.sectionKey, line);
-  return next === buffer ? null : next;
+  const expected = removedLines(write.basedOn, write.yaml);
+  const actual = removedLines(buffer, next);
+  if (
+    expected === null ||
+    actual === null ||
+    actual.length === 0 ||
+    expected.join("\n") !== actual.join("\n")
+  ) {
+    return null;
+  }
+  return next;
+}
+
+/** Lines removed going from *before* to *after*, or ``null`` when
+ *  the edit is not a pure contiguous removal. */
+function removedLines(before: string, after: string): string[] | null {
+  const b = before.split("\n");
+  const a = after.split("\n");
+  let start = 0;
+  while (start < a.length && b[start] === a[start]) start++;
+  let endB = b.length - 1;
+  let endA = a.length - 1;
+  while (endA >= start && endB >= start && b[endB] === a[endA]) {
+    endB--;
+    endA--;
+  }
+  if (endA >= start) return null;
+  return b.slice(start, endB + 1);
 }

--- a/src/components/device/apply-removal.ts
+++ b/src/components/device/apply-removal.ts
@@ -1,14 +1,39 @@
 /**
- * Re-apply a delete's removal to a buffer it was not computed
- * against (#1490). Lives beside the ``RemovedSectionRef`` contract
- * but outside it, so the type module stays free of API and YAML
- * machinery.
+ * Delete-removal mechanics: the write-through core shared by the
+ * automation delete paths and the superseded re-base (#1490). Lives
+ * beside the ``RemovedSectionRef`` contract but outside it, so the
+ * type module stays free of API and YAML machinery.
  */
 import type { ESPHomeAPI } from "../../api/esphome-api.js";
+import type { AutomationLocation } from "../../api/types/automations.js";
 import { removeSectionFromYaml } from "../../util/yaml-section-values.js";
 import { resolveCurrentSectionLine } from "../../util/yaml-sections.js";
 import { applyYamlDiff } from "./automation-editor/serialise.js";
-import type { RemovedSectionRef } from "./section-editor.js";
+import type { RemovedSectionRef, YamlUpdatedDetail } from "./section-editor.js";
+
+/**
+ * Shared core of the disk-writing automation deletes (editor engine,
+ * manage-list row): recompute the diff against the settled *yaml*,
+ * write through, and announce the write with its basis and removed
+ * ref. *connected* is read at announce time, after the awaits.
+ */
+export async function writeAutomationDelete(
+  api: Pick<ESPHomeAPI, "deleteAutomation" | "updateConfig">,
+  configuration: string,
+  location: AutomationLocation,
+  yaml: string,
+  announce: (connected: boolean, write: YamlUpdatedDetail) => void,
+  connected: () => boolean
+): Promise<void> {
+  const { yaml_diff } = await api.deleteAutomation(configuration, location, yaml);
+  const newYaml = applyYamlDiff(yaml, yaml_diff);
+  await api.updateConfig(configuration, newYaml);
+  announce(connected(), {
+    yaml: newYaml,
+    basedOn: yaml,
+    removed: { kind: "automation", location },
+  });
+}
 
 /**
  * Re-apply *removed* to *buffer*. Component sections splice

--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -9,6 +9,7 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { fireEvent } from "../../../util/fire-event.js";
 import { formatApiError } from "../../../util/format-api-error.js";
 import { notifyError } from "../../../util/notify.js";
+import { writeAutomationDelete } from "../apply-removal.js";
 import type { SectionEditor } from "../section-editor.js";
 import {
   announceSectionMount,
@@ -366,18 +367,18 @@ export class AutoApplyController implements ReactiveController {
       // splicing into a later re-read (a YAML-pane keystroke during
       // the round-trip) would silently mangle the write-through.
       const yaml = this._host.yaml;
-      const { yaml_diff } = await api.deleteAutomation(configuration, location, yaml);
-      const newYaml = applyYamlDiff(yaml, yaml_diff);
-      await api.updateConfig(configuration, newYaml);
-      // ``newYaml`` derives from the pre-round-trip snapshot; the
-      // basis lets the page supersede-check it, so a draft a newly
-      // mounted section made in the interim survives as visible
-      // dirty state instead of being overwritten (#1476).
-      announceUpdated(this._connected, {
-        yaml: newYaml,
-        basedOn: yaml,
-        removed: { kind: "automation", location },
-      });
+      // The written YAML derives from the pre-round-trip snapshot;
+      // the basis lets the page supersede-check it, so a draft a
+      // newly mounted section made in the interim survives as
+      // visible dirty state instead of being overwritten (#1476).
+      await writeAutomationDelete(
+        api,
+        configuration,
+        location,
+        yaml,
+        announceUpdated,
+        () => this._connected
+      );
       // Navigate away only while the editor is still on screen showing
       // the deleted section. After a mid-flush retarget the user is
       // already on a sibling (yanking them to null would also unmount

--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -373,7 +373,11 @@ export class AutoApplyController implements ReactiveController {
       // basis lets the page supersede-check it, so a draft a newly
       // mounted section made in the interim survives as visible
       // dirty state instead of being overwritten (#1476).
-      announceUpdated(this._connected, { yaml: newYaml, basedOn: yaml });
+      announceUpdated(this._connected, {
+        yaml: newYaml,
+        basedOn: yaml,
+        removed: { sectionKey: sectionKeyFromLocation(location), location },
+      });
       // Navigate away only while the editor is still on screen showing
       // the deleted section. After a mid-flush retarget the user is
       // already on a sibling (yanking them to null would also unmount

--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -376,7 +376,7 @@ export class AutoApplyController implements ReactiveController {
       announceUpdated(this._connected, {
         yaml: newYaml,
         basedOn: yaml,
-        removed: { sectionKey: sectionKeyFromLocation(location), location },
+        removed: { kind: "automation", location },
       });
       // Navigate away only while the editor is still on screen showing
       // the deleted section. After a mid-flush retarget the user is

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -470,7 +470,11 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
       );
       const newYaml = applyYamlDiff(yaml, yaml_diff);
       await this._api.updateConfig(configuration, newYaml);
-      announceUpdated(this.isConnected, { yaml: newYaml, basedOn: yaml });
+      announceUpdated(this.isConnected, {
+        yaml: newYaml,
+        basedOn: yaml,
+        removed: { sectionKey: key, location },
+      });
     } catch (err) {
       const msg = formatApiError(err, this._localize, "device.automation_save_error");
       notifyError(this._localize("device.automation_save_error"), {

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -473,7 +473,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
       announceUpdated(this.isConnected, {
         yaml: newYaml,
         basedOn: yaml,
-        removed: { sectionKey: key, location },
+        removed: { kind: "automation", location },
       });
     } catch (err) {
       const msg = formatApiError(err, this._localize, "device.automation_save_error");

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -28,7 +28,6 @@ import { notifyError } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { resolveSectionEntries } from "../../util/section-entry-overrides.js";
 import {
-  applyYamlDiff,
   locationFromSectionKey,
   sectionKeyFromLocation,
 } from "./automation-editor/serialise.js";
@@ -43,6 +42,7 @@ import type { ESPHomeAddApiActionDialog } from "./add-api-action-dialog.js";
 import type { ESPHomeAddAutomationDialog } from "./add-automation-dialog.js";
 import type { ConfigEntryValueChange } from "./config-entry-form.js";
 import { deviceSectionConfigStyles } from "./device-section-config.styles.js";
+import { writeAutomationDelete } from "./apply-removal.js";
 import type { SectionEditor } from "./section-editor.js";
 import {
   announceSectionMount,
@@ -463,18 +463,14 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
       // itself.
       const configuration = this.configuration;
       const yaml = settleOwnDraft(this);
-      const { yaml_diff } = await this._api.deleteAutomation(
+      await writeAutomationDelete(
+        this._api,
         configuration,
         location,
-        yaml
+        yaml,
+        announceUpdated,
+        () => this.isConnected
       );
-      const newYaml = applyYamlDiff(yaml, yaml_diff);
-      await this._api.updateConfig(configuration, newYaml);
-      announceUpdated(this.isConnected, {
-        yaml: newYaml,
-        basedOn: yaml,
-        removed: { kind: "automation", location },
-      });
     } catch (err) {
       const msg = formatApiError(err, this._localize, "device.automation_save_error");
       notifyError(this._localize("device.automation_save_error"), {

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -141,19 +141,22 @@ export async function onDeleteConfirmed(host: ESPHomeDeviceSectionConfig): Promi
   host._error = "";
   const title = host._config.title;
   const announceUpdated = prepareYamlUpdated(host);
-  // The section key is snapshotted: Lit reuses this element across
-  // same-kind switches, so a mid-round-trip retarget keeps it
-  // connected while the deleted section is no longer on screen.
+  // The section key and target are snapshotted: Lit reuses this
+  // element across same-kind switches, so a mid-round-trip retarget
+  // keeps it connected while the deleted section is no longer on
+  // screen.
   const deletedKey = host.sectionKey;
+  const configuration = host.configuration;
   try {
     const newYaml = removeSectionFromYaml(baseYaml, host.sectionKey, fromLine);
     if (newYaml === baseYaml) {
       host._error = host._localize("device.section_delete_error");
       return;
     }
-    await host._api.updateConfig(host.configuration, newYaml);
+    await host._api.updateConfig(configuration, newYaml);
     host._setDirty(false);
     announceUpdated(host.isConnected, {
+      configuration,
       yaml: newYaml,
       basedOn: baseYaml,
       removed: { kind: "component", sectionKey: deletedKey, fromLine },

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -153,7 +153,11 @@ export async function onDeleteConfirmed(host: ESPHomeDeviceSectionConfig): Promi
     }
     await host._api.updateConfig(host.configuration, newYaml);
     host._setDirty(false);
-    announceUpdated(host.isConnected, { yaml: newYaml, basedOn: baseYaml });
+    announceUpdated(host.isConnected, {
+      yaml: newYaml,
+      basedOn: baseYaml,
+      removed: { sectionKey: deletedKey, fromLine },
+    });
     // Navigate away only while the user is still here, on the
     // section that was deleted.
     if (host.isConnected && host.sectionKey === deletedKey) {

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -156,7 +156,7 @@ export async function onDeleteConfirmed(host: ESPHomeDeviceSectionConfig): Promi
     announceUpdated(host.isConnected, {
       yaml: newYaml,
       basedOn: baseYaml,
-      removed: { sectionKey: deletedKey, fromLine },
+      removed: { kind: "component", sectionKey: deletedKey, fromLine },
     });
     // Navigate away only while the user is still here, on the
     // section that was deleted.

--- a/src/components/device/section-editor.ts
+++ b/src/components/device/section-editor.ts
@@ -10,8 +10,12 @@
  * ``HTMLElementEventMap``, so a renamed event or a reshaped detail
  * is a compile error on both ends.
  */
+import type { ESPHomeAPI } from "../../api/esphome-api.js";
 import type { AutomationLocation } from "../../api/types/automations.js";
 import { fireEvent } from "../../util/fire-event.js";
+import { removeSectionFromYaml } from "../../util/yaml-section-values.js";
+import { resolveCurrentSectionLine } from "../../util/yaml-sections.js";
+import { applyYamlDiff } from "./automation-editor/serialise.js";
 export interface SectionEditor {
   /** Brief-window dirty flag so the global save button arms as
    *  soon as the user edits. */
@@ -41,13 +45,36 @@ export interface SectionDirtyChangeDetail {
 }
 
 /** What a delete removed, so a superseded write can be re-based
- *  onto the live buffer (#1490): the section key plus either the
- *  pre-delete line hint (component sections, removed client-side)
- *  or the automation location (recomputed via the backend). */
-export interface RemovedSectionRef {
-  sectionKey: string;
-  fromLine?: number;
-  location?: AutomationLocation;
+ *  onto the live buffer (#1490): component sections carry the key
+ *  plus the pre-delete line hint and splice client-side; automations
+ *  carry their location and recompute via the backend. */
+export type RemovedSectionRef =
+  | { kind: "component"; sectionKey: string; fromLine: number }
+  | { kind: "automation"; location: AutomationLocation };
+
+/**
+ * Re-apply *removed* to a buffer the delete was not computed
+ * against. Returns the re-based buffer, or ``null`` when the
+ * removal cannot land in it.
+ */
+export async function applyRemoval(
+  removed: RemovedSectionRef,
+  buffer: string,
+  api: Pick<ESPHomeAPI, "deleteAutomation">,
+  configuration: string
+): Promise<string | null> {
+  if (removed.kind === "automation") {
+    const { yaml_diff } = await api.deleteAutomation(
+      configuration,
+      removed.location,
+      buffer
+    );
+    return applyYamlDiff(buffer, yaml_diff);
+  }
+  const line = resolveCurrentSectionLine(buffer, removed.sectionKey, removed.fromLine);
+  if (line === undefined) return null;
+  const next = removeSectionFromYaml(buffer, removed.sectionKey, line);
+  return next === buffer ? null : next;
 }
 
 /** A completed disk write, the buffer it was computed against — the

--- a/src/components/device/section-editor.ts
+++ b/src/components/device/section-editor.ts
@@ -10,12 +10,8 @@
  * ``HTMLElementEventMap``, so a renamed event or a reshaped detail
  * is a compile error on both ends.
  */
-import type { ESPHomeAPI } from "../../api/esphome-api.js";
 import type { AutomationLocation } from "../../api/types/automations.js";
 import { fireEvent } from "../../util/fire-event.js";
-import { removeSectionFromYaml } from "../../util/yaml-section-values.js";
-import { resolveCurrentSectionLine } from "../../util/yaml-sections.js";
-import { applyYamlDiff } from "./automation-editor/serialise.js";
 export interface SectionEditor {
   /** Brief-window dirty flag so the global save button arms as
    *  soon as the user edits. */
@@ -51,31 +47,6 @@ export interface SectionDirtyChangeDetail {
 export type RemovedSectionRef =
   | { kind: "component"; sectionKey: string; fromLine: number }
   | { kind: "automation"; location: AutomationLocation };
-
-/**
- * Re-apply *removed* to a buffer the delete was not computed
- * against. Returns the re-based buffer, or ``null`` when the
- * removal cannot land in it.
- */
-export async function applyRemoval(
-  removed: RemovedSectionRef,
-  buffer: string,
-  api: Pick<ESPHomeAPI, "deleteAutomation">,
-  configuration: string
-): Promise<string | null> {
-  if (removed.kind === "automation") {
-    const { yaml_diff } = await api.deleteAutomation(
-      configuration,
-      removed.location,
-      buffer
-    );
-    return applyYamlDiff(buffer, yaml_diff);
-  }
-  const line = resolveCurrentSectionLine(buffer, removed.sectionKey, removed.fromLine);
-  if (line === undefined) return null;
-  const next = removeSectionFromYaml(buffer, removed.sectionKey, line);
-  return next === buffer ? null : next;
-}
 
 /** A completed disk write, the buffer it was computed against — the
  *  page supersede-checks the basis and advances only the saved side

--- a/src/components/device/section-editor.ts
+++ b/src/components/device/section-editor.ts
@@ -10,6 +10,7 @@
  * ``HTMLElementEventMap``, so a renamed event or a reshaped detail
  * is a compile error on both ends.
  */
+import type { AutomationLocation } from "../../api/types/automations.js";
 import { fireEvent } from "../../util/fire-event.js";
 export interface SectionEditor {
   /** Brief-window dirty flag so the global save button arms as
@@ -39,12 +40,24 @@ export interface SectionDirtyChangeDetail {
   node: SectionEditor;
 }
 
-/** A completed disk write and the buffer it was computed against —
- *  the page supersede-checks the basis and advances only the saved
- *  side when the pane has moved past it (#1476). */
+/** What a delete removed, so a superseded write can be re-based
+ *  onto the live buffer (#1490): the section key plus either the
+ *  pre-delete line hint (component sections, removed client-side)
+ *  or the automation location (recomputed via the backend). */
+export interface RemovedSectionRef {
+  sectionKey: string;
+  fromLine?: number;
+  location?: AutomationLocation;
+}
+
+/** A completed disk write, the buffer it was computed against — the
+ *  page supersede-checks the basis and advances only the saved side
+ *  when the pane has moved past it (#1476) — and what it removed,
+ *  for the re-base onto the live buffer (#1490). */
 export interface YamlUpdatedDetail {
   yaml: string;
   basedOn: string;
+  removed: RemovedSectionRef;
 }
 
 /** The events every section editor dispatches for the device page. */

--- a/src/components/device/section-editor.ts
+++ b/src/components/device/section-editor.ts
@@ -42,7 +42,8 @@ export interface SectionDirtyChangeDetail {
 
 /** What a delete removed, so a superseded write can be re-based
  *  onto the live buffer (#1490): component sections carry the key
- *  plus the pre-delete line hint and splice client-side; automations
+ *  plus the 1-indexed pre-delete line hint (matching
+ *  ``YamlSection.fromLine``) and splice client-side; automations
  *  carry their location and recompute via the backend. */
 export type RemovedSectionRef =
   | { kind: "component"; sectionKey: string; fromLine: number }

--- a/src/components/device/section-editor.ts
+++ b/src/components/device/section-editor.ts
@@ -52,8 +52,12 @@ export type RemovedSectionRef =
 /** A completed disk write, the buffer it was computed against — the
  *  page supersede-checks the basis and advances only the saved side
  *  when the pane has moved past it (#1476) — and what it removed,
- *  for the re-base onto the live buffer (#1490). */
+ *  for the re-base onto the live buffer (#1490). ``configuration``
+ *  is the emitter's snapshotted target so a write landing after a
+ *  device switch is dropped instead of spliced into the wrong
+ *  device's buffer. */
 export interface YamlUpdatedDetail {
+  configuration: string;
   yaml: string;
   basedOn: string;
   removed: RemovedSectionRef;

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1758,7 +1758,11 @@ export class ESPHomePageDevice extends LitElement {
      * ``yaml-draft`` event (see ``_onYamlDraft`` below) which
      * advances only ``_yaml`` — those are committed via the right-
      * pane Save button. */
-    const { yaml, basedOn } = e.detail;
+    const { configuration, yaml, basedOn } = e.detail;
+    // A write landing after a device switch belongs to the previous
+    // device — the router reuses this element, so acting on it would
+    // splice the wrong device's buffer (#1489-style identity guard).
+    if (configuration !== this.id) return;
     if (basedOn !== this._yaml) {
       // The write was computed against a buffer this pane has moved
       // past (a delete landing after a newer draft, #1476). Advance
@@ -1781,7 +1785,7 @@ export class ESPHomePageDevice extends LitElement {
     const live = this._yaml;
     let rebased: string | null = null;
     try {
-      rebased = await applyRemoval(detail.removed, live, this._api, this.id);
+      rebased = await applyRemoval(detail, live, this._api);
     } catch (err) {
       console.error("Re-base of superseded delete failed:", err);
       rebased = null;
@@ -1790,6 +1794,15 @@ export class ESPHomePageDevice extends LitElement {
     // was computed — stale coordinates no longer apply.
     if (rebased !== null && live === this._yaml) {
       this._setYaml(rebased);
+      // The removal shifted lines under the selection; re-pin it so
+      // line-keyed lookups don't latch onto a neighbour (#1470).
+      if (this._selectedSection) {
+        this._selectedFromLine = resolveCurrentSectionLine(
+          rebased,
+          this._selectedSection,
+          this._selectedFromLine
+        );
+      }
       return;
     }
     notifyInfo(this._localize("device.delete_superseded"), {

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -17,9 +17,10 @@ import { notifyError, notifyInfo, notifySuccess } from "../util/notify.js";
 // page itself doesn't pass it down anymore now that the step CTAs
 // always render.
 import { DeviceInstallController } from "../components/device/device-install-controller.js";
-import type {
-  SectionEditor,
-  YamlUpdatedDetail,
+import {
+  applyRemoval,
+  type SectionEditor,
+  type YamlUpdatedDetail,
 } from "../components/device/section-editor.js";
 import type { ESPHomeFirmwareInstallDialog } from "../components/firmware-install-dialog.js";
 import { TourLayoutController } from "../components/guided-tour/tour-layout-controller.js";
@@ -68,8 +69,6 @@ import {
   getLastValidatedResult,
   type YamlDiagnosticsDetail,
 } from "../util/yaml-lint-backend.js";
-import { removeSectionFromYaml } from "../util/yaml-section-values.js";
-import { applyYamlDiff } from "../components/device/automation-editor/serialise.js";
 import {
   findFieldLine,
   parseYamlTopLevelSections,
@@ -1777,38 +1776,18 @@ export class ESPHomePageDevice extends LitElement {
     this._savedYaml = yaml;
   }
 
-  /** Apply a superseded delete's removal to the live buffer (#1490).
-   *  Component sections splice client-side; automations recompute
-   *  their diff via the side-effect-free ``deleteAutomation``. */
+  /** Apply a superseded delete's removal to the live buffer (#1490). */
   private async _rebaseSupersededDelete(detail: YamlUpdatedDetail): Promise<void> {
-    const { removed } = detail;
     const live = this._yaml;
     let rebased: string | null = null;
     try {
-      if (removed.location && this._api) {
-        const { yaml_diff } = await this._api.deleteAutomation(
-          this.id,
-          removed.location,
-          live
-        );
-        // The pane moved again while the diff was computed — its
-        // coordinates no longer apply.
-        rebased = live === this._yaml ? applyYamlDiff(live, yaml_diff) : null;
-      } else if (!removed.location) {
-        const line = resolveCurrentSectionLine(
-          live,
-          removed.sectionKey,
-          removed.fromLine
-        );
-        if (line !== undefined) {
-          const next = removeSectionFromYaml(live, removed.sectionKey, line);
-          rebased = next === live ? null : next;
-        }
-      }
+      rebased = await applyRemoval(detail.removed, live, this._api, this.id);
     } catch {
       rebased = null;
     }
-    if (rebased !== null) {
+    // Land the re-base only if the pane didn't move again while it
+    // was computed — stale coordinates no longer apply.
+    if (rebased !== null && live === this._yaml) {
       this._setYaml(rebased);
       return;
     }

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1790,6 +1790,11 @@ export class ESPHomePageDevice extends LitElement {
       console.error("Re-base of superseded delete failed:", err);
       rebased = null;
     }
+    // The device switched mid-recompute: the continuation (and its
+    // toast) belongs to the previous device. ``_loadYaml`` doesn't
+    // clear ``_yaml`` before its fetch, so the buffer guard below
+    // can't catch this window.
+    if (detail.configuration !== this.id) return;
     // Land the re-base only if the pane didn't move again while it
     // was computed — stale coordinates no longer apply.
     if (rebased !== null && live === this._yaml) {

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -17,10 +17,10 @@ import { notifyError, notifyInfo, notifySuccess } from "../util/notify.js";
 // page itself doesn't pass it down anymore now that the step CTAs
 // always render.
 import { DeviceInstallController } from "../components/device/device-install-controller.js";
-import {
-  applyRemoval,
-  type SectionEditor,
-  type YamlUpdatedDetail,
+import { applyRemoval } from "../components/device/apply-removal.js";
+import type {
+  SectionEditor,
+  YamlUpdatedDetail,
 } from "../components/device/section-editor.js";
 import type { ESPHomeFirmwareInstallDialog } from "../components/firmware-install-dialog.js";
 import { TourLayoutController } from "../components/guided-tour/tour-layout-controller.js";
@@ -1782,7 +1782,8 @@ export class ESPHomePageDevice extends LitElement {
     let rebased: string | null = null;
     try {
       rebased = await applyRemoval(detail.removed, live, this._api, this.id);
-    } catch {
+    } catch (err) {
+      console.error("Re-base of superseded delete failed:", err);
       rebased = null;
     }
     // Land the re-base only if the pane didn't move again while it

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -17,7 +17,10 @@ import { notifyError, notifyInfo, notifySuccess } from "../util/notify.js";
 // page itself doesn't pass it down anymore now that the step CTAs
 // always render.
 import { DeviceInstallController } from "../components/device/device-install-controller.js";
-import type { SectionEditor } from "../components/device/section-editor.js";
+import type {
+  SectionEditor,
+  YamlUpdatedDetail,
+} from "../components/device/section-editor.js";
 import type { ESPHomeFirmwareInstallDialog } from "../components/firmware-install-dialog.js";
 import { TourLayoutController } from "../components/guided-tour/tour-layout-controller.js";
 import { tourAnchor } from "../components/guided-tour/tour-anchor.js";
@@ -65,6 +68,8 @@ import {
   getLastValidatedResult,
   type YamlDiagnosticsDetail,
 } from "../util/yaml-lint-backend.js";
+import { removeSectionFromYaml } from "../util/yaml-section-values.js";
+import { applyYamlDiff } from "../components/device/automation-editor/serialise.js";
 import {
   findFieldLine,
   parseYamlTopLevelSections,
@@ -1741,7 +1746,7 @@ export class ESPHomePageDevice extends LitElement {
     this._errorHighlight = isError && range !== null ? "active" : "none";
   }
 
-  private _onYamlUpdated(e: CustomEvent<{ yaml: string; basedOn: string }>) {
+  private _onYamlUpdated(e: CustomEvent<YamlUpdatedDetail>) {
     /* ``yaml-updated`` fires from the three disk-writing delete
      * paths only (the automation editors' engine, the component
      * editor's section delete, and its manage-list row delete), all
@@ -1758,21 +1763,58 @@ export class ESPHomePageDevice extends LitElement {
     if (basedOn !== this._yaml) {
       // The write was computed against a buffer this pane has moved
       // past (a delete landing after a newer draft, #1476). Advance
-      // only the saved side: the pane keeps what the user sees and
-      // the page shows honestly dirty. Note the trade: the retained
-      // buffer predates the on-disk deletion (a section draft was
-      // spliced into the pre-delete buffer; a pane edit advanced it
-      // directly), so a later wholesale Save may undo the deletion —
-      // the toast makes that visible instead of silent (re-basing
-      // the delete onto the live buffer is tracked in #1490).
+      // the saved side and re-base the removal onto the live buffer
+      // (#1490) so the retained draft no longer carries the deleted
+      // section and a later wholesale Save cannot undo the deletion.
+      // When the re-base cannot land (the section is unresolvable in
+      // the moved buffer, or it moved again mid-recompute), fall back
+      // to honestly dirty plus the visibility toast.
       this._savedYaml = yaml;
-      notifyInfo(this._localize("device.delete_superseded"), {
-        description: this._localize("device.delete_superseded_detail"),
-      });
+      void this._rebaseSupersededDelete(e.detail);
       return;
     }
     this._setYaml(yaml);
     this._savedYaml = yaml;
+  }
+
+  /** Apply a superseded delete's removal to the live buffer (#1490).
+   *  Component sections splice client-side; automations recompute
+   *  their diff via the side-effect-free ``deleteAutomation``. */
+  private async _rebaseSupersededDelete(detail: YamlUpdatedDetail): Promise<void> {
+    const { removed } = detail;
+    const live = this._yaml;
+    let rebased: string | null = null;
+    try {
+      if (removed.location && this._api) {
+        const { yaml_diff } = await this._api.deleteAutomation(
+          this.id,
+          removed.location,
+          live
+        );
+        // The pane moved again while the diff was computed — its
+        // coordinates no longer apply.
+        rebased = live === this._yaml ? applyYamlDiff(live, yaml_diff) : null;
+      } else if (!removed.location) {
+        const line = resolveCurrentSectionLine(
+          live,
+          removed.sectionKey,
+          removed.fromLine
+        );
+        if (line !== undefined) {
+          const next = removeSectionFromYaml(live, removed.sectionKey, line);
+          rebased = next === live ? null : next;
+        }
+      }
+    } catch {
+      rebased = null;
+    }
+    if (rebased !== null) {
+      this._setYaml(rebased);
+      return;
+    }
+    notifyInfo(this._localize("device.delete_superseded"), {
+      description: this._localize("device.delete_superseded_detail"),
+    });
   }
 
   private _onYamlDraft(e: CustomEvent<{ yaml: string }>) {

--- a/test/components/device/apply-removal.test.ts
+++ b/test/components/device/apply-removal.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Pins applyRemoval's removed-lines verification: a re-base lands
+ * only when it removed the exact lines the delete did; everything
+ * else reports null for the conservative fallback.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { ESPHomeAPI } from "../../../src/api/index.js";
+import { applyRemoval } from "../../../src/components/device/apply-removal.js";
+import type { YamlUpdatedDetail } from "../../../src/components/device/section-editor.js";
+
+const NO_API = {} as Pick<ESPHomeAPI, "deleteAutomation">;
+
+const componentWrite = (over: Partial<YamlUpdatedDetail> = {}): YamlUpdatedDetail => ({
+  configuration: "device.yaml",
+  yaml: "logger:\n",
+  basedOn: "wifi:\n  ssid: home\nlogger:\n",
+  removed: { kind: "component", sectionKey: "wifi", fromLine: 1 },
+  ...over,
+});
+
+describe("applyRemoval verification", () => {
+  it("lands a component re-base that removed the same lines", async () => {
+    const rebased = await applyRemoval(
+      componentWrite(),
+      "wifi:\n  ssid: home\nlogger:\n  level: DEBUG\n",
+      NO_API
+    );
+
+    expect(rebased).toBe("logger:\n  level: DEBUG\n");
+  });
+
+  it("rejects a component re-base that would remove different content", async () => {
+    // The user re-typed a fresh wifi block during the round trip;
+    // splicing it out would silently delete new content.
+    const rebased = await applyRemoval(
+      componentWrite(),
+      "wifi:\n  ssid: other\nlogger:\n  level: DEBUG\n",
+      NO_API
+    );
+
+    expect(rebased).toBeNull();
+  });
+
+  it("rejects when the announced write was not a pure removal", async () => {
+    // basedOn -> yaml inserted a line, so there is no removed block
+    // to verify against.
+    const rebased = await applyRemoval(
+      componentWrite({ yaml: "wifi:\n  ssid: home\nlogger:\nweb_server:\n" }),
+      "wifi:\n  ssid: home\nlogger:\n  level: DEBUG\n",
+      NO_API
+    );
+
+    expect(rebased).toBeNull();
+  });
+
+  it("rejects a recompute whose diff is not a pure removal", async () => {
+    const api = {
+      deleteAutomation: vi
+        .fn()
+        .mockResolvedValue({ yaml_diff: { fromLine: 1, toLine: 1, replacement: "x" } }),
+    } as unknown as Pick<ESPHomeAPI, "deleteAutomation">;
+
+    const rebased = await applyRemoval(
+      {
+        configuration: "device.yaml",
+        yaml: "logger:\n",
+        basedOn: "logger:\nscript:\n  - id: s1\n",
+        removed: { kind: "automation", location: { kind: "script", id: "s1" } },
+      },
+      "logger:\n  level: DEBUG\nscript:\n  - id: s1\n",
+      api
+    );
+
+    expect(rebased).toBeNull();
+  });
+
+  it("lands an automation re-base whose diff removed the same lines", async () => {
+    const api = {
+      deleteAutomation: vi
+        .fn()
+        .mockResolvedValue({ yaml_diff: { fromLine: 3, toLine: 4, replacement: "" } }),
+    } as unknown as Pick<ESPHomeAPI, "deleteAutomation">;
+
+    const rebased = await applyRemoval(
+      {
+        configuration: "device.yaml",
+        yaml: "logger:\n",
+        basedOn: "logger:\nscript:\n  - id: s1\n",
+        removed: { kind: "automation", location: { kind: "script", id: "s1" } },
+      },
+      "logger:\n  level: DEBUG\nscript:\n  - id: s1\n",
+      api
+    );
+
+    expect(rebased).toBe("logger:\n  level: DEBUG\n");
+  });
+});

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -438,7 +438,7 @@ describe("AutoApplyController delete", () => {
       {
         yaml: "replaced\nline2",
         basedOn: "replaced\nline2",
-        removed: { sectionKey: expect.any(String), location: SCRIPT },
+        removed: { kind: "automation", location: SCRIPT },
       },
     ]);
   });

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -436,6 +436,7 @@ describe("AutoApplyController delete", () => {
     // The basis is the settled pre-delete buffer, not the write.
     expect(updatedDetails).toEqual([
       {
+        configuration: "device.yaml",
         yaml: "replaced\nline2",
         basedOn: "replaced\nline2",
         removed: { kind: "automation", location: SCRIPT },

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -27,6 +27,7 @@ import {
   type AutoApplyHost,
   type AutoApplyOptions,
 } from "../../../../src/components/device/automation-editor/auto-apply-controller.js";
+import type { YamlUpdatedDetail } from "../../../../src/components/device/section-editor.js";
 import { flushTimers, identityLocalize } from "../../../_dom.js";
 
 const SCRIPT: AutomationLocation = {
@@ -410,10 +411,10 @@ describe("AutoApplyController delete", () => {
           host.yaml = yaml;
         });
     });
-    const updatedDetails: { yaml: string; basedOn: string }[] = [];
+    const updatedDetails: YamlUpdatedDetail[] = [];
     host.addEventListener("yaml-updated", (e) => {
       order.push("updated");
-      updatedDetails.push((e as CustomEvent<{ yaml: string; basedOn: string }>).detail);
+      updatedDetails.push((e as CustomEvent<YamlUpdatedDetail>).detail);
     });
 
     const applying = controller.autoApply();
@@ -434,7 +435,11 @@ describe("AutoApplyController delete", () => {
     expect(order).toEqual(["draft", "updated"]);
     // The basis is the settled pre-delete buffer, not the write.
     expect(updatedDetails).toEqual([
-      { yaml: "replaced\nline2", basedOn: "replaced\nline2" },
+      {
+        yaml: "replaced\nline2",
+        basedOn: "replaced\nline2",
+        removed: { sectionKey: expect.any(String), location: SCRIPT },
+      },
     ]);
   });
 

--- a/test/components/device/section-config-delete-unmount.test.ts
+++ b/test/components/device/section-config-delete-unmount.test.ts
@@ -78,6 +78,7 @@ describe("onDeleteConfirmed mid-round-trip navigation", () => {
       // The basis is the pre-delete snapshot, not the write.
       expect(updates).toEqual([
         {
+          configuration: "device.yaml",
           yaml: "logger:\n",
           basedOn: "wifi:\n  ssid: home\nlogger:\n",
           removed: { kind: "component", sectionKey: "wifi", fromLine: 1 },
@@ -134,6 +135,7 @@ describe("onDeleteConfirmed mid-round-trip navigation", () => {
       expect(updates[0].yaml).not.toContain("on_press");
       // The basis is the pre-delete buffer the diff was computed on.
       expect(updates[0].basedOn).toBe(ROW_YAML);
+      expect(updates[0].configuration).toBe("device.yaml");
       expect(updates[0].removed).toEqual({
         kind: "automation",
         location: locationFromSectionKey("automation:component_on:btn:on_press"),

--- a/test/components/device/section-config-delete-unmount.test.ts
+++ b/test/components/device/section-config-delete-unmount.test.ts
@@ -79,7 +79,7 @@ describe("onDeleteConfirmed mid-round-trip navigation", () => {
         {
           yaml: "logger:\n",
           basedOn: "wifi:\n  ssid: home\nlogger:\n",
-          removed: { sectionKey: "wifi", fromLine: 1 },
+          removed: { kind: "component", sectionKey: "wifi", fromLine: 1 },
         },
       ]);
       expect(selections).toHaveLength(0);
@@ -134,7 +134,7 @@ describe("onDeleteConfirmed mid-round-trip navigation", () => {
       // The basis is the pre-delete buffer the diff was computed on.
       expect(updates[0].basedOn).toBe(ROW_YAML);
       expect(updates[0].removed).toEqual({
-        sectionKey: "automation:component_on:btn:on_press",
+        kind: "automation",
         location: expect.anything(),
       });
     } finally {

--- a/test/components/device/section-config-delete-unmount.test.ts
+++ b/test/components/device/section-config-delete-unmount.test.ts
@@ -17,6 +17,7 @@ import "../../_mock-webawesome.js";
 
 import { ESPHomeDeviceSectionConfig } from "../../../src/components/device/device-section-config.js";
 import { onDeleteConfirmed } from "../../../src/components/device/device-section-config/draft-and-delete.js";
+import { locationFromSectionKey } from "../../../src/components/device/automation-editor/serialise.js";
 import type { YamlUpdatedDetail } from "../../../src/components/device/section-editor.js";
 
 const ROW_YAML = [
@@ -135,7 +136,7 @@ describe("onDeleteConfirmed mid-round-trip navigation", () => {
       expect(updates[0].basedOn).toBe(ROW_YAML);
       expect(updates[0].removed).toEqual({
         kind: "automation",
-        location: expect.anything(),
+        location: locationFromSectionKey("automation:component_on:btn:on_press"),
       });
     } finally {
       outer.remove();

--- a/test/components/device/section-config-delete-unmount.test.ts
+++ b/test/components/device/section-config-delete-unmount.test.ts
@@ -17,6 +17,7 @@ import "../../_mock-webawesome.js";
 
 import { ESPHomeDeviceSectionConfig } from "../../../src/components/device/device-section-config.js";
 import { onDeleteConfirmed } from "../../../src/components/device/device-section-config/draft-and-delete.js";
+import type { YamlUpdatedDetail } from "../../../src/components/device/section-editor.js";
 
 const ROW_YAML = [
   "binary_sensor:",
@@ -58,9 +59,9 @@ describe("onDeleteConfirmed mid-round-trip navigation", () => {
     const shadow = outer.attachShadow({ mode: "open" });
     shadow.appendChild(c);
     document.body.appendChild(outer);
-    const updates: { yaml: string; basedOn: string }[] = [];
+    const updates: YamlUpdatedDetail[] = [];
     outer.addEventListener("yaml-updated", (e) =>
-      updates.push((e as CustomEvent<{ yaml: string; basedOn: string }>).detail)
+      updates.push((e as CustomEvent<YamlUpdatedDetail>).detail)
     );
     const selections: unknown[] = [];
     outer.addEventListener("section-select", (e) => selections.push(e));
@@ -75,7 +76,11 @@ describe("onDeleteConfirmed mid-round-trip navigation", () => {
 
       // The basis is the pre-delete snapshot, not the write.
       expect(updates).toEqual([
-        { yaml: "logger:\n", basedOn: "wifi:\n  ssid: home\nlogger:\n" },
+        {
+          yaml: "logger:\n",
+          basedOn: "wifi:\n  ssid: home\nlogger:\n",
+          removed: { sectionKey: "wifi", fromLine: 1 },
+        },
       ]);
       expect(selections).toHaveLength(0);
     } finally {
@@ -106,9 +111,9 @@ describe("onDeleteConfirmed mid-round-trip navigation", () => {
     const shadow = outer.attachShadow({ mode: "open" });
     shadow.appendChild(c);
     document.body.appendChild(outer);
-    const updates: { yaml: string; basedOn: string }[] = [];
+    const updates: YamlUpdatedDetail[] = [];
     outer.addEventListener("yaml-updated", (e) =>
-      updates.push((e as CustomEvent<{ yaml: string; basedOn: string }>).detail)
+      updates.push((e as CustomEvent<YamlUpdatedDetail>).detail)
     );
 
     try {
@@ -128,6 +133,10 @@ describe("onDeleteConfirmed mid-round-trip navigation", () => {
       expect(updates[0].yaml).not.toContain("on_press");
       // The basis is the pre-delete buffer the diff was computed on.
       expect(updates[0].basedOn).toBe(ROW_YAML);
+      expect(updates[0].removed).toEqual({
+        sectionKey: "automation:component_on:btn:on_press",
+        location: expect.anything(),
+      });
     } finally {
       outer.remove();
     }
@@ -180,9 +189,9 @@ describe("onDeleteConfirmed mid-round-trip navigation", () => {
     const container = document.createElement("div");
     container.appendChild(c);
     document.body.appendChild(container);
-    const updates: { yaml: string; basedOn: string }[] = [];
+    const updates: YamlUpdatedDetail[] = [];
     container.addEventListener("yaml-updated", (e) =>
-      updates.push((e as CustomEvent<{ yaml: string; basedOn: string }>).detail)
+      updates.push((e as CustomEvent<YamlUpdatedDetail>).detail)
     );
 
     try {

--- a/test/components/device/section-editor.test.ts
+++ b/test/components/device/section-editor.test.ts
@@ -22,6 +22,7 @@ describe("prepareYamlUpdated", () => {
     // the anchor captured up front and carries the write's basis.
     host.parentNode = null as unknown as ParentNode;
     announce(false, {
+      configuration: "device.yaml",
       yaml: "b:\n",
       basedOn: "a:\n",
       removed: { kind: "component", sectionKey: "wifi", fromLine: 1 },
@@ -29,6 +30,7 @@ describe("prepareYamlUpdated", () => {
 
     expect(seen).toEqual([
       {
+        configuration: "device.yaml",
         yaml: "b:\n",
         basedOn: "a:\n",
         removed: { kind: "component", sectionKey: "wifi", fromLine: 1 },
@@ -46,6 +48,7 @@ describe("prepareYamlUpdated", () => {
     anchor.addEventListener("yaml-updated", () => seen.push("anchor"));
 
     prepareYamlUpdated(host)(true, {
+      configuration: "device.yaml",
       yaml: "b:\n",
       basedOn: "a:\n",
       removed: { kind: "component", sectionKey: "wifi", fromLine: 1 },
@@ -62,6 +65,7 @@ describe("prepareYamlUpdated", () => {
     // Deliberate contract: a host that never mounted has nowhere to
     // deliver — swallow rather than throw.
     prepareYamlUpdated(host)(false, {
+      configuration: "device.yaml",
       yaml: "b:\n",
       basedOn: "a:\n",
       removed: { kind: "component", sectionKey: "wifi", fromLine: 1 },

--- a/test/components/device/section-editor.test.ts
+++ b/test/components/device/section-editor.test.ts
@@ -24,11 +24,15 @@ describe("prepareYamlUpdated", () => {
     announce(false, {
       yaml: "b:\n",
       basedOn: "a:\n",
-      removed: { sectionKey: "wifi" },
+      removed: { kind: "component", sectionKey: "wifi", fromLine: 0 },
     });
 
     expect(seen).toEqual([
-      { yaml: "b:\n", basedOn: "a:\n", removed: { sectionKey: "wifi" } },
+      {
+        yaml: "b:\n",
+        basedOn: "a:\n",
+        removed: { kind: "component", sectionKey: "wifi", fromLine: 0 },
+      },
     ]);
   });
 
@@ -41,7 +45,11 @@ describe("prepareYamlUpdated", () => {
     host.addEventListener("yaml-updated", () => seen.push("host"));
     anchor.addEventListener("yaml-updated", () => seen.push("anchor"));
 
-    prepareYamlUpdated(host)(true, { yaml: "b:\n", basedOn: "a:\n" });
+    prepareYamlUpdated(host)(true, {
+      yaml: "b:\n",
+      basedOn: "a:\n",
+      removed: { kind: "component", sectionKey: "wifi", fromLine: 0 },
+    });
 
     expect(seen).toEqual(["host"]);
   });
@@ -53,7 +61,11 @@ describe("prepareYamlUpdated", () => {
 
     // Deliberate contract: a host that never mounted has nowhere to
     // deliver — swallow rather than throw.
-    prepareYamlUpdated(host)(false, { yaml: "b:\n", basedOn: "a:\n" });
+    prepareYamlUpdated(host)(false, {
+      yaml: "b:\n",
+      basedOn: "a:\n",
+      removed: { kind: "component", sectionKey: "wifi", fromLine: 0 },
+    });
 
     expect(seen).toEqual([]);
   });

--- a/test/components/device/section-editor.test.ts
+++ b/test/components/device/section-editor.test.ts
@@ -21,9 +21,15 @@ describe("prepareYamlUpdated", () => {
     // The host unmounts mid round trip; the announcement still rides
     // the anchor captured up front and carries the write's basis.
     host.parentNode = null as unknown as ParentNode;
-    announce(false, { yaml: "b:\n", basedOn: "a:\n" });
+    announce(false, {
+      yaml: "b:\n",
+      basedOn: "a:\n",
+      removed: { sectionKey: "wifi" },
+    });
 
-    expect(seen).toEqual([{ yaml: "b:\n", basedOn: "a:\n" }]);
+    expect(seen).toEqual([
+      { yaml: "b:\n", basedOn: "a:\n", removed: { sectionKey: "wifi" } },
+    ]);
   });
 
   it("dispatches from the host while it is still connected", () => {

--- a/test/components/device/section-editor.test.ts
+++ b/test/components/device/section-editor.test.ts
@@ -24,14 +24,14 @@ describe("prepareYamlUpdated", () => {
     announce(false, {
       yaml: "b:\n",
       basedOn: "a:\n",
-      removed: { kind: "component", sectionKey: "wifi", fromLine: 0 },
+      removed: { kind: "component", sectionKey: "wifi", fromLine: 1 },
     });
 
     expect(seen).toEqual([
       {
         yaml: "b:\n",
         basedOn: "a:\n",
-        removed: { kind: "component", sectionKey: "wifi", fromLine: 0 },
+        removed: { kind: "component", sectionKey: "wifi", fromLine: 1 },
       },
     ]);
   });
@@ -48,7 +48,7 @@ describe("prepareYamlUpdated", () => {
     prepareYamlUpdated(host)(true, {
       yaml: "b:\n",
       basedOn: "a:\n",
-      removed: { kind: "component", sectionKey: "wifi", fromLine: 0 },
+      removed: { kind: "component", sectionKey: "wifi", fromLine: 1 },
     });
 
     expect(seen).toEqual(["host"]);
@@ -64,7 +64,7 @@ describe("prepareYamlUpdated", () => {
     prepareYamlUpdated(host)(false, {
       yaml: "b:\n",
       basedOn: "a:\n",
-      removed: { kind: "component", sectionKey: "wifi", fromLine: 0 },
+      removed: { kind: "component", sectionKey: "wifi", fromLine: 1 },
     });
 
     expect(seen).toEqual([]);

--- a/test/pages/device-error-highlight.test.ts
+++ b/test/pages/device-error-highlight.test.ts
@@ -82,7 +82,12 @@ describe("error-jump highlight lifecycle (#1404)", () => {
 
     internals(page)._onYamlUpdated(
       new CustomEvent("yaml-updated", {
-        detail: { yaml: YAML + "    pin: GPIO11\n", basedOn: YAML },
+        detail: {
+          configuration: "kitchen.yaml",
+          yaml: YAML + "    pin: GPIO11\n",
+          basedOn: YAML,
+          removed: { kind: "component", sectionKey: "switch", fromLine: 3 },
+        },
       })
     );
     lintCompleted(page);

--- a/test/pages/device-yaml-updated-basis.test.ts
+++ b/test/pages/device-yaml-updated-basis.test.ts
@@ -126,4 +126,84 @@ describe("yaml-updated supersede check", () => {
     expect(page._savedYaml).toBe("logger:\n");
     expect(toast.info).not.toHaveBeenCalled();
   });
+
+  it("bails to the toast when the pane moves again mid-recompute", async () => {
+    const page = makePage(
+      "logger:\n  level: DEBUG\nscript:\n  - id: s1\n",
+      "logger:\nscript:\n  - id: s1\n"
+    );
+    page.id = "device.yaml";
+    const deleteAutomation = vi.fn().mockImplementation(async () => {
+      // The user keeps editing while the diff is recomputed.
+      page._yaml = "moved:\n";
+      return { yaml_diff: { fromLine: 3, toLine: 4, replacement: "" } };
+    });
+    page._api = { deleteAutomation } as unknown as ESPHomeAPI;
+
+    updated(page, {
+      yaml: "logger:\n",
+      basedOn: "logger:\nscript:\n  - id: s1\n",
+      removed: { kind: "automation", location: { kind: "script", id: "s1" } },
+    });
+    await settle();
+
+    // The stale re-base must not land on the moved buffer.
+    expect(page._yaml).toBe("moved:\n");
+    expect(page._savedYaml).toBe("logger:\n");
+    expect(toast.info).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a no-op recompute diff as an unlandable re-base", async () => {
+    const page = makePage(
+      "logger:\n  level: DEBUG\nscript:\n  - id: s1\n",
+      "logger:\nscript:\n  - id: s1\n"
+    );
+    page.id = "device.yaml";
+    page._api = {
+      deleteAutomation: vi
+        .fn()
+        .mockResolvedValue({ yaml_diff: { fromLine: 1, toLine: 0, replacement: "" } }),
+    } as unknown as ESPHomeAPI;
+
+    updated(page, {
+      yaml: "logger:\n",
+      basedOn: "logger:\nscript:\n  - id: s1\n",
+      removed: { kind: "automation", location: { kind: "script", id: "s1" } },
+    });
+    await settle();
+
+    // A diff that removes nothing must not report success and
+    // silence the divergence warning.
+    expect(page._yaml).toBe("logger:\n  level: DEBUG\nscript:\n  - id: s1\n");
+    expect(toast.info).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the toast when the recompute call fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const page = makePage(
+        "logger:\n  level: DEBUG\nscript:\n  - id: s1\n",
+        "logger:\nscript:\n  - id: s1\n"
+      );
+      page.id = "device.yaml";
+      page._api = {
+        deleteAutomation: vi.fn().mockRejectedValue(new Error("backend down")),
+      } as unknown as ESPHomeAPI;
+
+      updated(page, {
+        yaml: "logger:\n",
+        basedOn: "logger:\nscript:\n  - id: s1\n",
+        removed: { kind: "automation", location: { kind: "script", id: "s1" } },
+      });
+      await settle();
+
+      expect(page._yaml).toBe("logger:\n  level: DEBUG\nscript:\n  - id: s1\n");
+      expect(page._savedYaml).toBe("logger:\n");
+      expect(toast.info).toHaveBeenCalledTimes(1);
+      // The cause survives for bug reports instead of vanishing.
+      expect(consoleError).toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
 });

--- a/test/pages/device-yaml-updated-basis.test.ts
+++ b/test/pages/device-yaml-updated-basis.test.ts
@@ -50,7 +50,7 @@ describe("yaml-updated supersede check", () => {
     updated(page, {
       yaml: "b:\n",
       basedOn: "a:\n",
-      removed: { kind: "component", sectionKey: "a", fromLine: 0 },
+      removed: { kind: "component", sectionKey: "a", fromLine: 1 },
     });
 
     expect(page._yaml).toBe("b:\n");

--- a/test/pages/device-yaml-updated-basis.test.ts
+++ b/test/pages/device-yaml-updated-basis.test.ts
@@ -29,6 +29,7 @@ interface BasisView {
 
 const makePage = (yaml: string, saved: string): BasisView => {
   const page = new ESPHomePageDevice() as unknown as BasisView;
+  page.id = "device.yaml";
   page._yaml = yaml;
   page._savedYaml = saved;
   return page;
@@ -48,6 +49,7 @@ describe("yaml-updated supersede check", () => {
     const page = makePage("a:\n", "a:\n");
 
     updated(page, {
+      configuration: "device.yaml",
       yaml: "b:\n",
       basedOn: "a:\n",
       removed: { kind: "component", sectionKey: "a", fromLine: 1 },
@@ -67,6 +69,7 @@ describe("yaml-updated supersede check", () => {
     );
 
     updated(page, {
+      configuration: "device.yaml",
       yaml: "logger:\n",
       basedOn: "wifi:\n  ssid: home\nlogger:\n",
       removed: { kind: "component", sectionKey: "wifi", fromLine: 1 },
@@ -86,6 +89,7 @@ describe("yaml-updated supersede check", () => {
     const page = makePage("logger:\n  level: DEBUG\n", "wifi:\n  ssid: home\nlogger:\n");
 
     updated(page, {
+      configuration: "device.yaml",
       yaml: "logger:\n",
       basedOn: "wifi:\n  ssid: home\nlogger:\n",
       removed: { kind: "component", sectionKey: "wifi", fromLine: 1 },
@@ -102,7 +106,6 @@ describe("yaml-updated supersede check", () => {
       "logger:\n  level: DEBUG\nscript:\n  - id: s1\n",
       "logger:\nscript:\n  - id: s1\n"
     );
-    page.id = "device.yaml";
     const deleteAutomation = vi
       .fn()
       .mockResolvedValue({ yaml_diff: { fromLine: 3, toLine: 4, replacement: "" } });
@@ -110,6 +113,7 @@ describe("yaml-updated supersede check", () => {
     const location: AutomationLocation = { kind: "script", id: "s1" };
 
     updated(page, {
+      configuration: "device.yaml",
       yaml: "logger:\n",
       basedOn: "logger:\nscript:\n  - id: s1\n",
       removed: { kind: "automation", location },
@@ -132,7 +136,6 @@ describe("yaml-updated supersede check", () => {
       "logger:\n  level: DEBUG\nscript:\n  - id: s1\n",
       "logger:\nscript:\n  - id: s1\n"
     );
-    page.id = "device.yaml";
     const deleteAutomation = vi.fn().mockImplementation(async () => {
       // The user keeps editing while the diff is recomputed.
       page._yaml = "moved:\n";
@@ -141,6 +144,7 @@ describe("yaml-updated supersede check", () => {
     page._api = { deleteAutomation } as unknown as ESPHomeAPI;
 
     updated(page, {
+      configuration: "device.yaml",
       yaml: "logger:\n",
       basedOn: "logger:\nscript:\n  - id: s1\n",
       removed: { kind: "automation", location: { kind: "script", id: "s1" } },
@@ -158,7 +162,6 @@ describe("yaml-updated supersede check", () => {
       "logger:\n  level: DEBUG\nscript:\n  - id: s1\n",
       "logger:\nscript:\n  - id: s1\n"
     );
-    page.id = "device.yaml";
     page._api = {
       deleteAutomation: vi
         .fn()
@@ -166,6 +169,7 @@ describe("yaml-updated supersede check", () => {
     } as unknown as ESPHomeAPI;
 
     updated(page, {
+      configuration: "device.yaml",
       yaml: "logger:\n",
       basedOn: "logger:\nscript:\n  - id: s1\n",
       removed: { kind: "automation", location: { kind: "script", id: "s1" } },
@@ -178,6 +182,51 @@ describe("yaml-updated supersede check", () => {
     expect(toast.info).toHaveBeenCalledTimes(1);
   });
 
+  it("drops a write announced for a different device", () => {
+    const page = makePage("draft:\n", "a:\n");
+    const deleteAutomation = vi.fn();
+    page._api = { deleteAutomation } as unknown as ESPHomeAPI;
+
+    updated(page, {
+      configuration: "other.yaml",
+      yaml: "b:\n",
+      basedOn: "a:\n",
+      removed: { kind: "automation", location: { kind: "script", id: "s1" } },
+    });
+
+    // The router reuses the page element across devices; a late
+    // announcement from the previous device must not touch this one.
+    expect(page._yaml).toBe("draft:\n");
+    expect(page._savedYaml).toBe("a:\n");
+    expect(deleteAutomation).not.toHaveBeenCalled();
+    expect(toast.info).not.toHaveBeenCalled();
+  });
+
+  it("rejects a re-base that removed different lines than the delete", async () => {
+    const page = makePage(
+      "logger:\n  level: DEBUG\nscript:\n  - id: s1\n",
+      "logger:\nscript:\n  - id: s1\n"
+    );
+    // The recompute resolves to the wrong sibling: the diff removes
+    // the logger lines instead of the script block the delete took.
+    page._api = {
+      deleteAutomation: vi
+        .fn()
+        .mockResolvedValue({ yaml_diff: { fromLine: 1, toLine: 2, replacement: "" } }),
+    } as unknown as ESPHomeAPI;
+
+    updated(page, {
+      configuration: "device.yaml",
+      yaml: "logger:\n",
+      basedOn: "logger:\nscript:\n  - id: s1\n",
+      removed: { kind: "automation", location: { kind: "script", id: "s1" } },
+    });
+    await settle();
+
+    expect(page._yaml).toBe("logger:\n  level: DEBUG\nscript:\n  - id: s1\n");
+    expect(toast.info).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to the toast when the recompute call fails", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
@@ -185,12 +234,12 @@ describe("yaml-updated supersede check", () => {
         "logger:\n  level: DEBUG\nscript:\n  - id: s1\n",
         "logger:\nscript:\n  - id: s1\n"
       );
-      page.id = "device.yaml";
       page._api = {
         deleteAutomation: vi.fn().mockRejectedValue(new Error("backend down")),
       } as unknown as ESPHomeAPI;
 
       updated(page, {
+        configuration: "device.yaml",
         yaml: "logger:\n",
         basedOn: "logger:\nscript:\n  - id: s1\n",
         removed: { kind: "automation", location: { kind: "script", id: "s1" } },

--- a/test/pages/device-yaml-updated-basis.test.ts
+++ b/test/pages/device-yaml-updated-basis.test.ts
@@ -1,56 +1,123 @@
 /**
  * @vitest-environment happy-dom
  *
- * Pins the yaml-updated supersede check: a disk write computed
- * against a buffer the pane has moved past (a delete landing after a
- * newer draft) advances only the saved side, so the newer draft is
- * neither clobbered nor silently marked clean (#1476).
+ * Pins the yaml-updated supersede check and re-base: a disk write
+ * computed against a buffer the pane has moved past advances only
+ * the saved side, and the removal is re-based onto the live buffer
+ * so a later wholesale Save cannot undo the deletion (#1476, #1490).
+ * Only when the re-base cannot land does the visibility toast fire.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import "./_mock-device-children.js";
 
 import toast from "sonner-js";
 
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import type { YamlUpdatedDetail } from "../../src/components/device/section-editor.js";
 import { ESPHomePageDevice } from "../../src/pages/device.js";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const internals = (page: ESPHomePageDevice) => page as any;
+/** Narrow typed view of the page internals this suite drives. */
+interface BasisView {
+  _yaml: string;
+  _savedYaml: string;
+  _api?: ESPHomeAPI;
+  id: string;
+  _onYamlUpdated(e: CustomEvent<YamlUpdatedDetail>): void;
+}
 
-const updated = (page: ESPHomePageDevice, detail: { yaml: string; basedOn: string }) =>
-  internals(page)._onYamlUpdated(new CustomEvent("yaml-updated", { detail }));
+const view = (page: ESPHomePageDevice) => page as unknown as BasisView;
+
+const updated = (page: BasisView, detail: YamlUpdatedDetail) =>
+  page._onYamlUpdated(new CustomEvent("yaml-updated", { detail }));
+
+const settle = () => new Promise((r) => setTimeout(r));
 
 describe("yaml-updated supersede check", () => {
-  beforeEach(() => {
-    vi.mocked(toast.info).mockClear();
+  it("advances both sides when the write's basis is the live buffer", () => {
+    const page = view(new ESPHomePageDevice());
+    page._yaml = "a:\n";
+    page._savedYaml = "a:\n";
+
+    updated(page, { yaml: "b:\n", basedOn: "a:\n", removed: { sectionKey: "a" } });
+
+    expect(page._yaml).toBe("b:\n");
+    expect(page._savedYaml).toBe("b:\n");
   });
 
-  it("advances both sides when the write's basis is the live buffer", () => {
-    const page = new ESPHomePageDevice();
-    internals(page)._yaml = "a:\n";
-    internals(page)._savedYaml = "a:\n";
+  it("re-bases a superseded component-section delete onto the live buffer", async () => {
+    vi.mocked(toast.info).mockClear();
+    const page = view(new ESPHomePageDevice());
+    // The delete of wifi was computed against the pre-draft buffer;
+    // a draft advanced the pane (logger gained a field) meanwhile.
+    page._yaml = "wifi:\n  ssid: home\nlogger:\n  level: DEBUG\n";
+    page._savedYaml = "wifi:\n  ssid: home\nlogger:\n";
 
-    updated(page, { yaml: "b:\n", basedOn: "a:\n" });
+    updated(page, {
+      yaml: "logger:\n",
+      basedOn: "wifi:\n  ssid: home\nlogger:\n",
+      removed: { sectionKey: "wifi", fromLine: 1 },
+    });
+    await settle();
 
-    expect(internals(page)._yaml).toBe("b:\n");
-    expect(internals(page)._savedYaml).toBe("b:\n");
+    // The live draft keeps its newer edit but loses the deleted
+    // section, so Save cannot resurrect it; no toast needed.
+    expect(page._yaml).toBe("logger:\n  level: DEBUG\n");
+    expect(page._savedYaml).toBe("logger:\n");
     expect(toast.info).not.toHaveBeenCalled();
   });
 
-  it("advances only the saved side when the buffer moved past the basis", () => {
-    const page = new ESPHomePageDevice();
-    // A newer draft landed while the delete round trip was out.
-    internals(page)._yaml = "draft:\n";
-    internals(page)._savedYaml = "a:\n";
+  it("falls back to saved-only plus toast when the section is unresolvable", async () => {
+    vi.mocked(toast.info).mockClear();
+    const page = view(new ESPHomePageDevice());
+    // The pane edit already removed the section itself — nothing to
+    // re-base, and the conservative branch keeps the pane untouched.
+    page._yaml = "logger:\n  level: DEBUG\n";
+    page._savedYaml = "wifi:\n  ssid: home\nlogger:\n";
 
-    updated(page, { yaml: "b:\n", basedOn: "a:\n" });
+    updated(page, {
+      yaml: "logger:\n",
+      basedOn: "wifi:\n  ssid: home\nlogger:\n",
+      removed: { sectionKey: "wifi", fromLine: 1 },
+    });
+    await settle();
 
-    // The pane keeps what the user sees; the page shows honestly
-    // dirty against the disk truth.
-    expect(internals(page)._yaml).toBe("draft:\n");
-    expect(internals(page)._savedYaml).toBe("b:\n");
-    // The toast is the whole user-visible mitigation for the
-    // retained-buffer divergence.
+    expect(page._yaml).toBe("logger:\n  level: DEBUG\n");
+    expect(page._savedYaml).toBe("logger:\n");
     expect(toast.info).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-bases an automation delete through a fresh diff against the live buffer", async () => {
+    vi.mocked(toast.info).mockClear();
+    const page = view(new ESPHomePageDevice());
+    page.id = "device.yaml";
+    const deleteAutomation = vi
+      .fn()
+      .mockResolvedValue({ yaml_diff: { fromLine: 3, toLine: 4, replacement: "" } });
+    page._api = { deleteAutomation } as unknown as ESPHomeAPI;
+    page._yaml = "logger:\n  level: DEBUG\nscript:\n  - id: s1\n";
+    page._savedYaml = "logger:\nscript:\n  - id: s1\n";
+    const location = { kind: "script", id: "s1" };
+
+    updated(page, {
+      yaml: "logger:\n",
+      basedOn: "logger:\nscript:\n  - id: s1\n",
+      removed: {
+        sectionKey: "automation:script:s1",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        location: location as any,
+      },
+    });
+    await settle();
+
+    // The recompute ran against the live buffer, not the basis.
+    expect(deleteAutomation).toHaveBeenCalledWith(
+      "device.yaml",
+      location,
+      "logger:\n  level: DEBUG\nscript:\n  - id: s1\n"
+    );
+    expect(page._yaml).toBe("logger:\n  level: DEBUG\n");
+    expect(page._savedYaml).toBe("logger:\n");
+    expect(toast.info).not.toHaveBeenCalled();
   });
 });

--- a/test/pages/device-yaml-updated-basis.test.ts
+++ b/test/pages/device-yaml-updated-basis.test.ts
@@ -7,13 +7,14 @@
  * so a later wholesale Save cannot undo the deletion (#1476, #1490).
  * Only when the re-base cannot land does the visibility toast fire.
  */
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import "./_mock-device-children.js";
 
 import toast from "sonner-js";
 
 import type { ESPHomeAPI } from "../../src/api/index.js";
+import type { AutomationLocation } from "../../src/api/types/automations.js";
 import type { YamlUpdatedDetail } from "../../src/components/device/section-editor.js";
 import { ESPHomePageDevice } from "../../src/pages/device.js";
 
@@ -26,37 +27,49 @@ interface BasisView {
   _onYamlUpdated(e: CustomEvent<YamlUpdatedDetail>): void;
 }
 
-const view = (page: ESPHomePageDevice) => page as unknown as BasisView;
+const makePage = (yaml: string, saved: string): BasisView => {
+  const page = new ESPHomePageDevice() as unknown as BasisView;
+  page._yaml = yaml;
+  page._savedYaml = saved;
+  return page;
+};
 
 const updated = (page: BasisView, detail: YamlUpdatedDetail) =>
   page._onYamlUpdated(new CustomEvent("yaml-updated", { detail }));
 
 const settle = () => new Promise((r) => setTimeout(r));
 
+beforeEach(() => {
+  vi.mocked(toast.info).mockClear();
+});
+
 describe("yaml-updated supersede check", () => {
   it("advances both sides when the write's basis is the live buffer", () => {
-    const page = view(new ESPHomePageDevice());
-    page._yaml = "a:\n";
-    page._savedYaml = "a:\n";
+    const page = makePage("a:\n", "a:\n");
 
-    updated(page, { yaml: "b:\n", basedOn: "a:\n", removed: { sectionKey: "a" } });
+    updated(page, {
+      yaml: "b:\n",
+      basedOn: "a:\n",
+      removed: { kind: "component", sectionKey: "a", fromLine: 0 },
+    });
 
     expect(page._yaml).toBe("b:\n");
     expect(page._savedYaml).toBe("b:\n");
+    expect(toast.info).not.toHaveBeenCalled();
   });
 
   it("re-bases a superseded component-section delete onto the live buffer", async () => {
-    vi.mocked(toast.info).mockClear();
-    const page = view(new ESPHomePageDevice());
     // The delete of wifi was computed against the pre-draft buffer;
     // a draft advanced the pane (logger gained a field) meanwhile.
-    page._yaml = "wifi:\n  ssid: home\nlogger:\n  level: DEBUG\n";
-    page._savedYaml = "wifi:\n  ssid: home\nlogger:\n";
+    const page = makePage(
+      "wifi:\n  ssid: home\nlogger:\n  level: DEBUG\n",
+      "wifi:\n  ssid: home\nlogger:\n"
+    );
 
     updated(page, {
       yaml: "logger:\n",
       basedOn: "wifi:\n  ssid: home\nlogger:\n",
-      removed: { sectionKey: "wifi", fromLine: 1 },
+      removed: { kind: "component", sectionKey: "wifi", fromLine: 1 },
     });
     await settle();
 
@@ -68,17 +81,14 @@ describe("yaml-updated supersede check", () => {
   });
 
   it("falls back to saved-only plus toast when the section is unresolvable", async () => {
-    vi.mocked(toast.info).mockClear();
-    const page = view(new ESPHomePageDevice());
     // The pane edit already removed the section itself — nothing to
     // re-base, and the conservative branch keeps the pane untouched.
-    page._yaml = "logger:\n  level: DEBUG\n";
-    page._savedYaml = "wifi:\n  ssid: home\nlogger:\n";
+    const page = makePage("logger:\n  level: DEBUG\n", "wifi:\n  ssid: home\nlogger:\n");
 
     updated(page, {
       yaml: "logger:\n",
       basedOn: "wifi:\n  ssid: home\nlogger:\n",
-      removed: { sectionKey: "wifi", fromLine: 1 },
+      removed: { kind: "component", sectionKey: "wifi", fromLine: 1 },
     });
     await settle();
 
@@ -88,25 +98,21 @@ describe("yaml-updated supersede check", () => {
   });
 
   it("re-bases an automation delete through a fresh diff against the live buffer", async () => {
-    vi.mocked(toast.info).mockClear();
-    const page = view(new ESPHomePageDevice());
+    const page = makePage(
+      "logger:\n  level: DEBUG\nscript:\n  - id: s1\n",
+      "logger:\nscript:\n  - id: s1\n"
+    );
     page.id = "device.yaml";
     const deleteAutomation = vi
       .fn()
       .mockResolvedValue({ yaml_diff: { fromLine: 3, toLine: 4, replacement: "" } });
     page._api = { deleteAutomation } as unknown as ESPHomeAPI;
-    page._yaml = "logger:\n  level: DEBUG\nscript:\n  - id: s1\n";
-    page._savedYaml = "logger:\nscript:\n  - id: s1\n";
-    const location = { kind: "script", id: "s1" };
+    const location: AutomationLocation = { kind: "script", id: "s1" };
 
     updated(page, {
       yaml: "logger:\n",
       basedOn: "logger:\nscript:\n  - id: s1\n",
-      removed: {
-        sectionKey: "automation:script:s1",
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        location: location as any,
-      },
+      removed: { kind: "automation", location },
     });
     await settle();
 


### PR DESCRIPTION
# What does this implement/fix?

#1485 made a superseded delete honest (saved side advances, toast) but left the trade that the retained draft predates the on disk deletion, so a later wholesale Save could undo it. This closes that: the delete announcements now also carry what was removed (`RemovedSectionRef`, a tagged union of the component section key plus its 1-indexed pre delete line hint, or the automation location) and the emitter's snapshotted `configuration`, and the page re-bases the removal onto the live buffer when the basis is superseded.

Component sections re-base client side: re-resolve the key in the live buffer (nearest instance to the pre delete hint) and splice it out with `removeSectionFromYaml`. Automations recompute their diff against the live buffer through the side effect free `deleteAutomation` (the write already happened; only the diff is wanted) and apply it locally. Because re-resolved coordinates are not authoritative in a diverged buffer, the re-base only lands when it removed the same lines the delete did; a mismatch, a no-op diff, an unresolvable section, a mid recompute race, or a failed backend call (logged to the console) all fall back to the existing conservative branch: saved only advance plus the visibility toast. A write announced for a different device (the router reuses the page element) is dropped entirely. When the re-base lands, the pane keeps the newer draft minus the deleted section, the page is honestly dirty against disk, the selection line is re-pinned, and no toast fires.

The removal mechanics live in `apply-removal.ts` beside the contract module: `applyRemoval` (the re-base) and `writeAutomationDelete`, the write through core now shared by the two automation delete paths (editor engine and manage list row) instead of being copied at each.

Nine handler cells are pinned (matching basis; component re-base with the draft preserved; unresolvable fall back; automation recompute against the live buffer; mid recompute race bail; no-op diff rejection; wrong lines rejection; cross device drop; backend failure with the logged cause), and the emitter tests assert the removed ref and configuration ride every dispatch.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1490

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] Documentation only — `docs`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
