### PR TITLE
Upload imported bundles over HTTP instead of the WebSocket

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -806,17 +806,45 @@ export class ESPHomeAPI {
     return this.sendCommand<WizardResponse>("devices/create", args);
   }
 
-  /** Import an `esphome bundle` archive as a device.
+  /** Mint a single-use token authorizing the HTTP upload of one bundle. */
+  async importBundleToken(): Promise<{ token: string }> {
+    return this.sendCommand<{ token: string }>("devices/import_bundle_token");
+  }
+
+  /** Upload an `esphome bundle` archive over HTTP and import it.
    *
-   * `file_content_b64` is the base64 of the raw `.tar.gz`. Omit
-   * `overwrite` on the first call; if the response is 'conflicts', let
-   * the user pick which paths to replace and re-call with those paths in
-   * `overwrite` (paths left out keep the on-disk file). */
-  async importBundle(args: {
-    file_content_b64: string;
-    overwrite?: string[];
-  }): Promise<ImportBundleResponse> {
-    return this.sendCommand<ImportBundleResponse>("devices/import_bundle", args, 60000);
+   * HTTP, not the WS, so a large bundle isn't capped by a proxy's
+   * WebSocket `max_msg_size`. Omit `overwrite` on the first (detect) call;
+   * if the response is 'conflicts', let the user pick which paths to
+   * replace and re-call with those paths in `overwrite` (paths left out
+   * keep the on-disk file). The token is the route's auth. */
+  async importBundleUpload(
+    file: Blob,
+    overwrite?: string[]
+  ): Promise<ImportBundleResponse> {
+    const { token } = await this.importBundleToken();
+    const params = new URLSearchParams({ token });
+    if (overwrite !== undefined) {
+      params.set("mode", "resolve");
+      for (const path of overwrite) params.append("overwrite", path);
+    }
+    const response = await fetch(`${BASE_PATH}api/devices/import_bundle?${params}`, {
+      method: "POST",
+      body: file,
+    });
+    if (!response.ok) {
+      let errorCode = "http_error";
+      let details = `Bundle upload failed: ${response.status}`;
+      try {
+        const body = await response.json();
+        errorCode = body.error_code ?? errorCode;
+        details = body.details ?? details;
+      } catch {
+        // A non-JSON body (e.g. a 413's plain text) keeps the generic message.
+      }
+      throw new APIError(errorCode, details);
+    }
+    return response.json() as Promise<ImportBundleResponse>;
   }
 
   /** Update device metadata. Keyed by `configuration` (the YAML filename),

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -832,11 +832,15 @@ export class ESPHomeAPI {
     });
     if (!response.ok) {
       let errorCode = "http_error";
-      let details = `Bundle upload failed: ${response.status}`;
+      let details =
+        `Bundle upload failed: ${response.status} ${response.statusText}`.trim();
       try {
-        const body = await response.json();
-        errorCode = body.error_code ?? errorCode;
-        details = body.details ?? details;
+        const body: unknown = await response.json();
+        if (body && typeof body === "object") {
+          const { error_code, details: d } = body as Record<string, unknown>;
+          if (typeof error_code === "string") errorCode = error_code;
+          if (typeof d === "string") details = d;
+        }
       } catch {
         // A non-JSON body (e.g. a 413's plain text) keeps the generic message.
       }

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -806,23 +806,21 @@ export class ESPHomeAPI {
     return this.sendCommand<WizardResponse>("devices/create", args);
   }
 
-  /** Mint a single-use token authorizing the HTTP upload of one bundle. */
-  async importBundleToken(): Promise<{ token: string }> {
-    return this.sendCommand<{ token: string }>("devices/import_bundle_token");
-  }
-
   /** Upload an `esphome bundle` archive over HTTP and import it.
    *
    * HTTP, not the WS, so a large bundle isn't capped by a proxy's
    * WebSocket `max_msg_size`. Omit `overwrite` on the first (detect) call;
    * if the response is 'conflicts', let the user pick which paths to
    * replace and re-call with those paths in `overwrite` (paths left out
-   * keep the on-disk file). The token is the route's auth. */
+   * keep the on-disk file). A single-use token minted over the WS is the
+   * route's auth. */
   async importBundleUpload(
     file: Blob,
     overwrite?: string[]
   ): Promise<ImportBundleResponse> {
-    const { token } = await this.importBundleToken();
+    const { token } = await this.sendCommand<{ token: string }>(
+      "devices/import_bundle_token"
+    );
     const params = new URLSearchParams({ token });
     if (overwrite !== undefined) {
       params.set("mode", "resolve");

--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -294,11 +294,11 @@ export interface WizardResponse {
   configuration: string;
 }
 
-/** Response from devices/import_bundle.
+/** Response from `POST /api/devices/import_bundle`.
  *
  * 'conflicts' means nothing was written: `conflicts` lists the bundle
  * files that already exist on disk, so the user picks which to overwrite
- * and re-submits the same bytes with those paths in `overwrite`.
+ * and re-uploads the same file with those paths in `overwrite`.
  * 'imported' means the tree landed; `written`/`kept` report which files
  * were placed vs left untouched (a non-empty `kept` is a partial import).
  * secrets.yaml is always merged. */

--- a/src/components/wizard/import-flow-controller.ts
+++ b/src/components/wizard/import-flow-controller.ts
@@ -67,6 +67,10 @@ export class ImportFlowController implements ReactiveController {
 
   /** Begin importing the picked file (YAML upload or bundle). */
   start(file: File): void {
+    // Don't clobber the file/state of an import already in flight — its
+    // conflict round-trip re-uploads this._file, so overwriting it mid-flight
+    // would resolve against the wrong archive.
+    if (this._host.importBusy) return;
     // Clear any prior pick's cached bytes / conflicts so a re-selection
     // can't re-submit the previous file or its stale state.
     this.reset();

--- a/src/components/wizard/import-flow-controller.ts
+++ b/src/components/wizard/import-flow-controller.ts
@@ -2,7 +2,6 @@ import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { APIError, apiErrorDetails } from "../../api/api-error.js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { LocalizeFunc } from "../../common/localize.js";
-import { arrayBufferToBase64 } from "../../util/base64.js";
 import { safeUploadFilename } from "../../util/safe-upload-filename.js";
 import { isBundleFilename } from "../../util/upload-file-types.js";
 
@@ -40,8 +39,6 @@ export class ImportFlowController implements ReactiveController {
 
   private readonly _host: ImportFlowHost;
   private _file: File | null = null;
-  /** Cached base64 so the conflict round-trip re-submits the same bytes. */
-  private _bundleB64: string | null = null;
   private _pendingUpload: { slug: string; fileContent: string } | null = null;
 
   constructor(host: ImportFlowHost) {
@@ -61,7 +58,6 @@ export class ImportFlowController implements ReactiveController {
   /** Clear all flow state (called when the dialog (re)opens). */
   reset(): void {
     this._file = null;
-    this._bundleB64 = null;
     this.conflicts = [];
     this.hasSecrets = false;
     this.mainConfig = "";
@@ -157,31 +153,19 @@ export class ImportFlowController implements ReactiveController {
     }
   }
 
-  /** Import an esphome bundle. The first call sends the bytes; a 'conflicts'
+  /** Import an esphome bundle. The first call uploads the file; a 'conflicts'
    *  response routes to the resolve step, whose confirm re-enters here with
-   *  the chosen `overwrite` paths (the cached base64 is reused). */
+   *  the chosen `overwrite` paths (the same file is re-uploaded). */
   private async _importBundleFlow(overwrite?: string[]): Promise<void> {
-    // Flip busy synchronously, before the first await (the file read), so a
-    // fast double-click can't fire two parallel import_bundle commands.
+    // Flip busy synchronously, before the first await (the upload), so a
+    // fast double-click can't fire two parallel imports.
     if (this._host.importBusy) return;
     if (!this._file) return;
     this._host.resetErrors();
     this._host.importBusy = true;
 
     try {
-      if (this._bundleB64 === null) {
-        try {
-          this._bundleB64 = arrayBufferToBase64(await this._file.arrayBuffer());
-        } catch {
-          this._host.setImportError(this._host.localize("wizard.import_read_error"));
-          return;
-        }
-      }
-
-      const res = await this._host.api.importBundle({
-        file_content_b64: this._bundleB64,
-        ...(overwrite !== undefined ? { overwrite } : {}),
-      });
+      const res = await this._host.api.importBundleUpload(this._file, overwrite);
       if (res.status === "conflicts") {
         this.conflicts = res.conflicts;
         this.hasSecrets = res.has_secrets;

--- a/src/components/wizard/import-flow-controller.ts
+++ b/src/components/wizard/import-flow-controller.ts
@@ -3,7 +3,7 @@ import { APIError, apiErrorDetails } from "../../api/api-error.js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { safeUploadFilename } from "../../util/safe-upload-filename.js";
-import { isBundleFilename } from "../../util/upload-file-types.js";
+import { isBundleFilename, isYamlFilename } from "../../util/upload-file-types.js";
 
 /** Wizard steps the import flow can route the host dialog to. */
 export type ImportStep = "resolve-conflicts" | "confirm-overwrite" | "import-partial";
@@ -100,6 +100,14 @@ export class ImportFlowController implements ReactiveController {
     }
 
     this._host.resetErrors();
+
+    // The file input accepts a bare `.gz` (a macOS quirk needed to select a
+    // compound `.tar.gz`), so reject anything that isn't a recognised YAML
+    // config rather than reading binary through the text-import path.
+    if (!isYamlFilename(this._file.name)) {
+      this._host.setImportError(this._host.localize("wizard.import_unsupported_type"));
+      return;
+    }
 
     let fileContent: string;
     try {

--- a/src/components/wizard/wizard-step-method.ts
+++ b/src/components/wizard/wizard-step-method.ts
@@ -10,7 +10,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 import { FileDropController } from "../../util/file-drop-controller.js";
 import { fireEvent } from "../../util/fire-event.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
-import { ACCEPTED_UPLOAD_EXTENSIONS } from "../../util/upload-file-types.js";
+import { FILE_INPUT_ACCEPT } from "../../util/upload-file-types.js";
 import { tourAnchor } from "../guided-tour/tour-anchor.js";
 import { renderDisclosure } from "../shared/disclosure.js";
 
@@ -199,7 +199,7 @@ export class ESPHomeWizardStepMethod extends LitElement {
         <input
           id="file-input"
           type="file"
-          accept=${ACCEPTED_UPLOAD_EXTENSIONS.join(",")}
+          accept=${FILE_INPUT_ACCEPT}
           hidden
           @change=${this._onFileSelected}
         />

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -581,7 +581,7 @@
     "add_board": "Select",
     "import_read_error": "Failed to read the file.",
     "import_general_error": "Failed to import the config file. Please try again.",
-    "import_unsupported_type": "Unsupported file type. Import a YAML config (.yaml, .yml) or an ESPHome bundle (.tar.gz).",
+    "import_unsupported_type": "Unsupported file type. Import a YAML config (.yaml, .yml) or an ESPHome bundle (.tar.gz, .tgz, or .esphomebundle).",
     "import_invalid_filename": "The filename \"{name}\" can't be used as-is — it contains only characters that aren't allowed in a configuration filename. Rename the file to something with letters, digits, hyphens, or underscores and try again.",
     "importing_device": "Creating device from imported file…",
     "import_bundle_conflicts_title": "Some files already exist",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -581,6 +581,7 @@
     "add_board": "Select",
     "import_read_error": "Failed to read the file.",
     "import_general_error": "Failed to import the config file. Please try again.",
+    "import_unsupported_type": "Unsupported file type. Import a YAML config (.yaml, .yml) or an ESPHome bundle (.tar.gz).",
     "import_invalid_filename": "The filename \"{name}\" can't be used as-is — it contains only characters that aren't allowed in a configuration filename. Rename the file to something with letters, digits, hyphens, or underscores and try again.",
     "importing_device": "Creating device from imported file…",
     "import_bundle_conflicts_title": "Some files already exist",

--- a/src/util/upload-file-types.ts
+++ b/src/util/upload-file-types.ts
@@ -5,8 +5,17 @@ export const YAML_EXTENSIONS = [".yaml", ".yml"];
 /** Bundle archives (binary): an `esphome bundle` .tar.gz. */
 export const BUNDLE_EXTENSIONS = [".tar.gz", ".tgz", ".esphomebundle"];
 
-/** Value for the file input's `accept` attribute. */
+/** Extensions accepted by drag-drop (matched against the filename directly). */
 export const ACCEPTED_UPLOAD_EXTENSIONS = [...YAML_EXTENSIONS, ...BUNDLE_EXTENSIONS];
+
+/** Value for the file input's `accept` attribute.
+ *
+ * Adds bare `.gz` on top of the real extensions: macOS' native file dialog
+ * filters on the *last* extension only, so a compound `.tar.gz` /
+ * `.esphomebundle.tar.gz` is greyed out without it. Drag-drop matches the
+ * whole filename (see `isBundleFilename`) and doesn't need the widening.
+ */
+export const FILE_INPUT_ACCEPT = [...ACCEPTED_UPLOAD_EXTENSIONS, ".gz"].join(",");
 
 /** True when *filename* is a bundle archive rather than a text YAML config. */
 export function isBundleFilename(filename: string): boolean {

--- a/src/util/upload-file-types.ts
+++ b/src/util/upload-file-types.ts
@@ -22,3 +22,9 @@ export function isBundleFilename(filename: string): boolean {
   const lower = filename.toLowerCase();
   return BUNDLE_EXTENSIONS.some((ext) => lower.endsWith(ext));
 }
+
+/** True when *filename* is a plain YAML config. */
+export function isYamlFilename(filename: string): boolean {
+  const lower = filename.toLowerCase();
+  return YAML_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -2256,6 +2256,22 @@ describe("ESPHomeAPI — import bundle upload (HTTP)", () => {
     );
   });
 
+  it("emits mode=resolve with no overwrite params for an empty resolve (keep all)", async () => {
+    installMockWebSocket();
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const fetchFn = vi.fn(async () => ({ ok: true, json: async () => IMPORTED }));
+    vi.stubGlobal("fetch", fetchFn);
+    const file = new File([new Uint8Array([1])], "device.esphomebundle.tar.gz");
+
+    await upload(api, ws, file, []);
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "/api/devices/import_bundle?token=a+b%2Fc&mode=resolve",
+      { method: "POST", body: file }
+    );
+  });
+
   it("surfaces the server's {error_code, details} on a non-OK JSON response", async () => {
     installMockWebSocket();
     const api = new ESPHomeAPI();

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -2191,6 +2191,113 @@ describe("ESPHomeAPI — firmware download (HTTP)", () => {
   });
 });
 
+describe("ESPHomeAPI — import bundle upload (HTTP)", () => {
+  const IMPORTED = {
+    status: "imported",
+    configuration: "device.yaml",
+    conflicts: [],
+    written: ["device.yaml"],
+    kept: [],
+    has_secrets: false,
+    esphome_version: "2026.6.0",
+  };
+
+  afterEach(() => {
+    uninstallMockWebSocket();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  // Mint the upload token the inlined WS command expects, so the POST proceeds.
+  async function upload(
+    api: ESPHomeAPI,
+    ws: MockWebSocket,
+    file: Blob,
+    overwrite?: string[]
+  ): ReturnType<ESPHomeAPI["importBundleUpload"]> {
+    const pending = api.importBundleUpload(file, overwrite);
+    const sent = ws.sentAs<{ command: string; message_id: string }>(0);
+    expect(sent.command).toBe("devices/import_bundle_token");
+    ws.receive({ message_id: sent.message_id, result: { token: "a b/c" } });
+    return pending;
+  }
+
+  it("mints a token over the WS then POSTs the file (detect pass)", async () => {
+    installMockWebSocket();
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const fetchFn = vi.fn(async () => ({ ok: true, json: async () => IMPORTED }));
+    vi.stubGlobal("fetch", fetchFn);
+    const file = new File([new Uint8Array([1, 2, 3])], "device.esphomebundle.tar.gz");
+
+    const result = await upload(api, ws, file);
+
+    expect(result).toEqual(IMPORTED);
+    // token is URL-encoded and no mode/overwrite params on the detect pass.
+    expect(fetchFn).toHaveBeenCalledWith("/api/devices/import_bundle?token=a+b%2Fc", {
+      method: "POST",
+      body: file,
+    });
+  });
+
+  it("adds mode=resolve and a repeated overwrite param per path", async () => {
+    installMockWebSocket();
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const fetchFn = vi.fn(async () => ({ ok: true, json: async () => IMPORTED }));
+    vi.stubGlobal("fetch", fetchFn);
+    const file = new File([new Uint8Array([1])], "device.esphomebundle.tar.gz");
+
+    await upload(api, ws, file, ["device.yaml", "common/wifi.yaml"]);
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "/api/devices/import_bundle?token=a+b%2Fc&mode=resolve&overwrite=device.yaml&overwrite=common%2Fwifi.yaml",
+      { method: "POST", body: file }
+    );
+  });
+
+  it("surfaces the server's {error_code, details} on a non-OK JSON response", async () => {
+    installMockWebSocket();
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        json: async () => ({
+          error_code: "invalid_args",
+          details: "Not a valid ESPHome bundle",
+        }),
+      }))
+    );
+    const file = new File([new Uint8Array([1])], "device.esphomebundle.tar.gz");
+
+    await expect(upload(api, ws, file)).rejects.toThrow("Not a valid ESPHome bundle");
+  });
+
+  it("falls back to status + statusText when the error body isn't JSON (e.g. a 413)", async () => {
+    installMockWebSocket();
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 413,
+        statusText: "Request Entity Too Large",
+        json: async () => {
+          throw new Error("not json");
+        },
+      }))
+    );
+    const file = new File([new Uint8Array([1])], "device.esphomebundle.tar.gz");
+
+    await expect(upload(api, ws, file)).rejects.toThrow(/413 Request Entity Too Large/);
+  });
+});
+
 describe("ESPHomeAPI — console-debug redaction", () => {
   beforeEach(() => {
     installMockWebSocket();

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -652,16 +652,16 @@ describe("create-config-dialog open/close contract", () => {
   });
 });
 
-// A .tar.gz is binary, so the wizard routes it to importBundle (base64)
-// instead of reading it as text and shoving garbage into createDevice.
+// A .tar.gz is binary, so the wizard routes it to importBundleUpload (HTTP
+// POST) instead of reading it as text and shoving garbage into createDevice.
 describe("create-config-dialog bundle import", () => {
   const step = (el: ESPHomeCreateConfigDialog): string =>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (el as any)._step;
 
-  it("imports a bundle as base64 and never calls createDevice", async () => {
+  it("uploads a bundle over HTTP and never calls createDevice", async () => {
     const createDevice = vi.fn();
-    const importBundle = vi.fn().mockResolvedValue({
+    const importBundleUpload = vi.fn().mockResolvedValue({
       status: "imported",
       configuration: "device.yaml",
       conflicts: [],
@@ -670,20 +670,20 @@ describe("create-config-dialog bundle import", () => {
       has_secrets: false,
       esphome_version: "2026.6.0",
     });
-    const el = await mount({ createDevice, importBundle });
+    const el = await mount({ createDevice, importBundleUpload });
 
     emitImport(el, bundleFile());
     await flush();
 
     expect(createDevice).not.toHaveBeenCalled();
-    expect(importBundle).toHaveBeenCalledTimes(1);
-    const arg = importBundle.mock.calls[0][0];
-    expect(arg.file_content_b64).toBeTruthy();
-    expect(arg.overwrite).toBeUndefined();
+    expect(importBundleUpload).toHaveBeenCalledTimes(1);
+    const [file, overwrite] = importBundleUpload.mock.calls[0];
+    expect(file).toBeInstanceOf(File);
+    expect(overwrite).toBeUndefined();
   });
 
-  it("routes a conflicts response to the resolve step, then re-submits the same bytes with overwrite", async () => {
-    const importBundle = vi
+  it("routes a conflicts response to the resolve step, then re-uploads the same file with overwrite", async () => {
+    const importBundleUpload = vi
       .fn()
       .mockResolvedValueOnce({
         status: "conflicts",
@@ -701,28 +701,28 @@ describe("create-config-dialog bundle import", () => {
         has_secrets: true,
         esphome_version: "2026.6.0",
       });
-    const el = await mount({ importBundle });
+    const el = await mount({ importBundleUpload });
 
     emitImport(el, bundleFile());
     await flush();
     await el.updateComplete;
 
     expect(step(el)).toBe("resolve-conflicts");
-    const firstB64 = importBundle.mock.calls[0][0].file_content_b64;
+    const firstFile = importBundleUpload.mock.calls[0][0];
 
     emitResolve(el, ["device.yaml"]);
     await flush();
 
-    expect(importBundle).toHaveBeenCalledTimes(2);
-    const secondArg = importBundle.mock.calls[1][0];
-    expect(secondArg.overwrite).toEqual(["device.yaml"]);
-    // Same cached bytes re-sent; the file isn't re-read.
-    expect(secondArg.file_content_b64).toBe(firstB64);
+    expect(importBundleUpload).toHaveBeenCalledTimes(2);
+    const [secondFile, overwrite] = importBundleUpload.mock.calls[1];
+    expect(overwrite).toEqual(["device.yaml"]);
+    // The same File is re-uploaded; it isn't re-read or re-wrapped.
+    expect(secondFile).toBe(firstFile);
   });
 
   it("ignores a second Import click while a resolve submit is in flight", async () => {
     const inflight = deferred<{ status: string }>();
-    const importBundle = vi
+    const importBundleUpload = vi
       .fn()
       .mockResolvedValueOnce({
         status: "conflicts",
@@ -732,7 +732,7 @@ describe("create-config-dialog bundle import", () => {
         esphome_version: "2026.6.0",
       })
       .mockReturnValueOnce(inflight.promise);
-    const el = await mount({ importBundle });
+    const el = await mount({ importBundleUpload });
 
     emitImport(el, bundleFile());
     await flush();
@@ -743,24 +743,24 @@ describe("create-config-dialog bundle import", () => {
     await flush();
 
     // Initial conflicts call + one resolve call; the double-click is dropped.
-    expect(importBundle).toHaveBeenCalledTimes(2);
+    expect(importBundleUpload).toHaveBeenCalledTimes(2);
   });
 
-  it("guards a double-click on the first import (across the file-read window)", async () => {
+  it("guards a double-click on the first import (across the upload window)", async () => {
     const inflight = deferred<{ status: string }>();
-    const importBundle = vi.fn().mockReturnValueOnce(inflight.promise);
-    const el = await mount({ importBundle });
+    const importBundleUpload = vi.fn().mockReturnValueOnce(inflight.promise);
+    const el = await mount({ importBundleUpload });
 
-    // Two synchronous picks before the awaited arrayBuffer() resolves.
+    // Two synchronous picks before the awaited upload resolves.
     emitImport(el, bundleFile());
     emitImport(el, bundleFile());
     await flush();
 
-    expect(importBundle).toHaveBeenCalledTimes(1);
+    expect(importBundleUpload).toHaveBeenCalledTimes(1);
   });
 
   it("shows a distinct partial-import result when the backend keeps files", async () => {
-    const importBundle = vi.fn().mockResolvedValue({
+    const importBundleUpload = vi.fn().mockResolvedValue({
       status: "imported",
       configuration: "device.yaml",
       conflicts: [],
@@ -769,7 +769,7 @@ describe("create-config-dialog bundle import", () => {
       has_secrets: false,
       esphome_version: "2026.6.0",
     });
-    const el = await mount({ importBundle });
+    const el = await mount({ importBundleUpload });
 
     emitImport(el, bundleFile());
     await flush();

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -785,6 +785,23 @@ describe("create-config-dialog bundle import", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((partialStep as any).kept).toEqual(["device.yaml", "common/wifi.yaml"]);
   });
+
+  it("rejects a bare .gz that isn't a bundle instead of reading binary as YAML", async () => {
+    // The file input accepts ".gz" so macOS can select a compound ".tar.gz";
+    // a bare ".gz" must be refused, not routed through the YAML text path.
+    const createDevice = vi.fn();
+    const importBundleUpload = vi.fn();
+    const el = await mount({ createDevice, importBundleUpload });
+
+    emitImport(el, new File([new Uint8Array([0x1f, 0x8b])], "log.gz"));
+    await flush();
+    await el.updateComplete;
+
+    expect(importBundleUpload).not.toHaveBeenCalled();
+    expect(createDevice).not.toHaveBeenCalled();
+    expect(step(el)).toBe("method");
+    expect(el.shadowRoot!.querySelector("p.error")).not.toBeNull();
+  });
 });
 
 // A YAML upload that collides routes to a confirm step; confirming

--- a/test/util/upload-file-types.test.ts
+++ b/test/util/upload-file-types.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   ACCEPTED_UPLOAD_EXTENSIONS,
+  FILE_INPUT_ACCEPT,
   isBundleFilename,
 } from "../../src/util/upload-file-types.js";
 
@@ -23,5 +24,14 @@ describe("ACCEPTED_UPLOAD_EXTENSIONS", () => {
   it("covers both YAML and bundle extensions", () => {
     expect(ACCEPTED_UPLOAD_EXTENSIONS).toContain(".yaml");
     expect(ACCEPTED_UPLOAD_EXTENSIONS).toContain(".tar.gz");
+  });
+});
+
+describe("FILE_INPUT_ACCEPT", () => {
+  it("adds bare .gz so macOS' native dialog admits a compound .tar.gz", () => {
+    const tokens = FILE_INPUT_ACCEPT.split(",");
+    expect(tokens).toContain(".tar.gz");
+    expect(tokens).toContain(".gz");
+    expect(tokens).toContain(".yaml");
   });
 });

--- a/test/util/upload-file-types.test.ts
+++ b/test/util/upload-file-types.test.ts
@@ -4,6 +4,7 @@ import {
   ACCEPTED_UPLOAD_EXTENSIONS,
   FILE_INPUT_ACCEPT,
   isBundleFilename,
+  isYamlFilename,
 } from "../../src/util/upload-file-types.js";
 
 describe("isBundleFilename", () => {
@@ -17,6 +18,15 @@ describe("isBundleFilename", () => {
   it("treats plain YAML as not-a-bundle", () => {
     expect(isBundleFilename("device.yaml")).toBe(false);
     expect(isBundleFilename("device.yml")).toBe(false);
+  });
+});
+
+describe("isYamlFilename", () => {
+  it("accepts both YAML extensions, case-insensitively", () => {
+    expect(isYamlFilename("device.yaml")).toBe(true);
+    expect(isYamlFilename("DEVICE.YML")).toBe(true);
+    expect(isYamlFilename("device.tar.gz")).toBe(false);
+    expect(isYamlFilename("log.gz")).toBe(false);
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Move the "import bundle" upload from the `devices/import_bundle` WebSocket command (which base64-encoded the whole `.tar.gz` into one WS message, capped at aiohttp's 4 MiB `/ws` `max_msg_size`) to the new `POST /api/devices/import_bundle` HTTP route, so an image/font-heavy bundle up to the shared 128 MiB limit can be imported through the UI.

`importBundleUpload(file, overwrite?)` mints a single-use token over the WS (`devices/import_bundle_token`) and `POST`s the `File` straight to the route, mirroring how `firmwareDownloadUrl` authorizes the HTTP download route with a token in the query string (no `Authorization` header). It parses the same `ImportBundleResponse` shape the WS command returned, so the two-phase conflict flow, the resolve-conflicts step, and the partial-import step are unchanged. The import-flow controller now re-uploads the retained `File` on resolve instead of caching base64, so the base64 read is gone.

Requires the backend companion (adds the route + token command and removes the old WS command); they land in lock-step.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2327
- backend companion: https://github.com/esphome/device-builder/pull/2340

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
