### PR TITLE
Replace flushPending's 20ms poll with a settled promise on ApplyPhase

### DIFF
--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -67,8 +67,12 @@ export interface AutoApplyOptions {
  *  is now one value. The debounce timer stays a separate handle:
  *  typing during an in-flight round trip legitimately arms it
  *  while applying, and teardown cancels it without touching the
- *  in-flight call. */
-type ApplyPhase = { kind: "idle" } | { kind: "applying"; queued: boolean };
+ *  in-flight call. ``settled`` resolves in the finally, after the
+ *  queued re-run decision (its phase is installed first), so a
+ *  waiter observes each round at its actual boundary. */
+type ApplyPhase =
+  | { kind: "idle" }
+  | { kind: "applying"; queued: boolean; settled: Promise<void>; settle(): void };
 
 /** A delete owning the section. Carrying the suppression record
  *  inside the mode means it cannot exist without a delete and
@@ -233,11 +237,17 @@ export class AutoApplyController implements ReactiveController {
       if (this._debounce) {
         this._cancelDebounce();
         // With a call already in flight this only queues a re-run —
-        // loop back to the poll so the caller isn't released while
-        // the keystroke it came to flush is still unwritten.
+        // loop back so the caller isn't released while the keystroke
+        // it came to flush is still unwritten.
         await this.autoApply();
-      } else {
-        await new Promise((r) => setTimeout(r, 20));
+      } else if (this._apply.kind === "applying") {
+        await this._apply.settled;
+        // Macrotask hop before the re-check: nested Lit update
+        // cycles carry the settling upsert's ``yaml-draft`` back
+        // into ``.yaml`` on microtasks, so resolving straight off
+        // the settle would release the caller against a stale
+        // buffer and reintroduce #1451.
+        await new Promise((r) => setTimeout(r));
       }
     }
   }
@@ -274,7 +284,10 @@ export class AutoApplyController implements ReactiveController {
       this._apply.queued = true;
       return;
     }
-    this._apply = { kind: "applying", queued: false };
+    let settle!: () => void;
+    const settled = new Promise<void>((resolve) => (settle = resolve));
+    const phase = { kind: "applying" as const, queued: false, settled, settle };
+    this._apply = phase;
     try {
       // Pass the host's YAML so the backend computes the diff against
       // the current draft buffer rather than the on-disk YAML —
@@ -303,11 +316,12 @@ export class AutoApplyController implements ReactiveController {
     } catch (err) {
       this._surfaceSaveError(err);
     } finally {
-      const queued = this._apply.queued;
       this._apply = { kind: "idle" };
-      if (queued) {
+      if (phase.queued) {
         // A value-change landed while we were running. Re-run with
         // the latest value so we don't drop the user's last edit.
+        // Synchronously installs the re-run's phase, so a waiter
+        // woken by the settle below re-checks against it.
         void this.autoApply();
       } else if (this._debounce === null) {
         // No further pending change — the page's YAML is now in sync
@@ -319,6 +333,7 @@ export class AutoApplyController implements ReactiveController {
         // re-pointed at, #1486); their own settle clears the flag.
         this._setDirty(false);
       }
+      phase.settle();
     }
   }
 
@@ -356,11 +371,10 @@ export class AutoApplyController implements ReactiveController {
       // would otherwise land after our ``yaml-updated`` and resurrect
       // the deleted section (#1451). The delete mode blocks the
       // queued re-run, so this terminates.
-      // ``flushPending`` must resolve on a MACROTASK: three nested
-      // Lit update cycles carry the settling upsert's ``yaml-draft``
-      // back down into ``.yaml``, and only the poll's setTimeout
-      // drains them all. A promise-await refactor of the poll would
-      // resolve on a microtask and reintroduce #1451.
+      // ``flushPending`` must resolve on a MACROTASK — its settled
+      // wait's setTimeout hop is load bearing here, not decorative:
+      // dropping it would release this call against a stale
+      // ``.yaml`` and reintroduce #1451.
       await this.flushPending();
       // Read the settled buffer exactly once: the backend computes
       // the diff's line coordinates against the string we send, so

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -316,6 +316,32 @@ describe("AutoApplyController auto-apply", () => {
     expect(order).toEqual(["draft", "draft", "flushed"]);
   });
 
+  it("flushPending wakes on the settle boundary, not a poll tick", async () => {
+    const { controller, upsertAutomation } = setup();
+    let resolveFirst!: (v: { yaml_diff: YamlDiff }) => void;
+    upsertAutomation.mockImplementationOnce(
+      () =>
+        new Promise((r) => {
+          resolveFirst = r;
+        })
+    );
+    const applying = controller.autoApply();
+    let flushed = false;
+    const flushing = controller.flushPending().then(() => (flushed = true));
+
+    // Parked on the in-flight round trip: no amount of waiting
+    // releases the caller while the upsert is outstanding.
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(flushed).toBe(false);
+
+    resolveFirst({ yaml_diff: DIFF });
+    // One zero-delay macrotask hop after the settle releases the
+    // caller — a poll would still be asleep in its interval here.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(flushed).toBe(true);
+    await Promise.all([applying, flushing]);
+  });
+
   it("shouldSkipReload skips the echo of its own write, not a foreign edit", async () => {
     const { host, controller } = setup();
     expect(controller.shouldSkipReload()).toBe(false);


### PR DESCRIPTION
# What does this implement/fix?

`flushPending()` settled on a 20ms `setTimeout` poll over the apply phase: a waiter observing an in-flight upsert it did not start could be released up to 20ms after the actual settle, every waiter spun its own timer, and the termination story lived in comments around the poll timing.

The `applying` phase variant now owns its completion signal: a `settled` promise created at entry and resolved in the finally, after the queued re-run decision. Because the queued re-run's phase is installed synchronously before the old promise resolves, a waiter woken by the settle re-checks against the new round and cannot slip through a gap. Waiters observe each round at its actual boundary and idle costs zero timers.

The load bearing macrotask requirement stays, now as one explicit zero delay hop after each settled wait: nested Lit update cycles carry the settling upsert's `yaml-draft` back into `.yaml` on microtasks, so resolving straight off the settle would release the caller against a stale buffer (the #1451 regression the old poll's timing prevented implicitly). The rationale now sits on that one line, and `delete()`'s comment points at it.

Timing is the only behavior change; the engine suite's ordering cells (draft before updated, queued re-run order arrays) gate it unchanged. A new cell pins the boundary itself: a waiter parked on an in-flight upsert stays parked through a full second of timer advance, then releases on a single zero delay hop after the settle, where a poll would still be asleep in its interval.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1481

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] Documentation only — `docs`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
