### PR TITLE
Retire the poll vocabulary and note the settled-branch-only hop

### DIFF
--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -224,7 +224,7 @@ export class AutoApplyController implements ReactiveController {
    * device page calls this (via the host) on the active section
    * before its global save so the YAML buffer is fully caught up.
    * Resolves only once nothing is pending — neither a debounce
-   * (even one armed mid-poll by a late keystroke) nor an in-flight
+   * (even one armed mid-wait by a late keystroke) nor an in-flight
    * call, including the queued re-run a cancelled debounce leaves
    * on one.
    */
@@ -246,7 +246,9 @@ export class AutoApplyController implements ReactiveController {
         // cycles carry the settling upsert's ``yaml-draft`` back
         // into ``.yaml`` on microtasks, so resolving straight off
         // the settle would release the caller against a stale
-        // buffer and reintroduce #1451.
+        // buffer and reintroduce #1451. Only this settled branch
+        // hops — ``delete()`` relies on entering with
+        // ``_debounce === null`` so its wait lands here.
         await new Promise((r) => setTimeout(r));
       }
     }

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -291,7 +291,7 @@ describe("AutoApplyController auto-apply", () => {
     expect(order).toEqual(["draft", "draft", "flushed"]);
   });
 
-  it("flushPending waits out a debounce armed while it was already polling", async () => {
+  it("flushPending waits out a debounce armed while it was already settle-waiting", async () => {
     const { host, controller, upsertAutomation } = setup();
     let resolveFirst!: (v: { yaml_diff: YamlDiff }) => void;
     upsertAutomation.mockImplementationOnce(
@@ -303,10 +303,10 @@ describe("AutoApplyController auto-apply", () => {
     const order: string[] = [];
     host.addEventListener("yaml-draft", () => order.push("draft"));
     const applying = controller.autoApply();
-    // No debounce yet — the flush enters the settle poll directly.
+    // No debounce yet — the flush parks on the settled promise.
     const flushing = controller.flushPending().then(() => order.push("flushed"));
     await vi.advanceTimersByTimeAsync(30);
-    // The keystroke lands during the poll, after the debounce check.
+    // The keystroke lands mid-wait, after the debounce check.
     controller.scheduleAutoApply();
 
     resolveFirst({ yaml_diff: DIFF });
@@ -427,8 +427,8 @@ describe("AutoApplyController delete", () => {
       order.push("draft");
       // Mirror the page faithfully: three nested Lit update cycles
       // carry the draft back down, each on its own microtask — only
-      // the flush poll's macrotask boundary drains them all before
-      // the delete reads the buffer.
+      // the flush's macrotask hop drains them all before the delete
+      // reads the buffer.
       const yaml = (e as CustomEvent<{ yaml: string }>).detail.yaml;
       void Promise.resolve()
         .then(() => Promise.resolve())


### PR DESCRIPTION
# What does this implement/fix?

The Kōan follow-up on #1494 raced its merge: the review's two comment nits were committed and pushed just as the PR merged, so the merge carried only the main commit. This lands that follow-up commit unchanged.

Comment and test wording only, no behavior: the live descriptions drop the deleted poll vocabulary (the `flushPending` doc says "armed mid-wait", the settle-wait test is renamed "already settle-waiting", the delete-ordering mock's comment says "the flush's macrotask hop"), and the hop comment now states the invariant's scope, only the settled branch hops and `delete()` relies on entering with `_debounce === null`.

**Related issue or feature (if applicable):**

- follow-up to https://github.com/esphome/device-builder-frontend/pull/1494

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] Documentation only — `docs`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
