### PR TITLE
Carry the emitter's configuration on yaml-draft and identity-guard it

### DIFF
--- a/src/components/device/add-api-action-dialog.ts
+++ b/src/components/device/add-api-action-dialog.ts
@@ -31,6 +31,7 @@ import { renderMarkdown } from "../../util/markdown.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { parseYamlAutomations } from "../../util/yaml-sections.js";
 import { applyYamlDiff, sectionKeyFromLocation } from "./automation-editor/serialise.js";
+import { fireSectionEvent } from "./section-editor.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "../base-dialog.js";
@@ -220,20 +221,18 @@ export class ESPHomeAddApiActionDialog extends LitElement {
         trigger_params: {},
         actions: [],
       };
+      // Snapshot the target and buffer together: the diff's line
+      // coordinates are relative to the string we send.
+      const configuration = this.configuration;
+      const yaml = this.yaml;
       const { yaml_diff } = await this._api.upsertAutomation(
-        this.configuration,
+        configuration,
         tree,
         location,
-        this.yaml
+        yaml
       );
-      const newYaml = applyYamlDiff(this.yaml, yaml_diff);
-      this.dispatchEvent(
-        new CustomEvent<{ yaml: string }>("yaml-draft", {
-          detail: { yaml: newYaml },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      const newYaml = applyYamlDiff(yaml, yaml_diff);
+      fireSectionEvent(this, "yaml-draft", { configuration, yaml: newYaml });
       this.dispatchEvent(
         new CustomEvent<{ sectionKey: string }>("automation-added", {
           detail: { sectionKey: sectionKeyFromLocation(location) },

--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -486,16 +486,21 @@ export class ESPHomeAddAutomationDialog extends LitElement {
             : {},
         actions: [],
       };
-      // Hand the backend our current draft yaml so the splice
-      // lands relative to any pending edits the user hasn't saved
-      // yet — matches the auto-apply path in the editor.
+      // Snapshot the target and buffer together, before the await:
+      // the diff's line coordinates are relative to the string we
+      // send, and a router-level device swap reassigns both props
+      // from above mid round trip. The buffer is the current draft
+      // so the splice lands relative to any pending edits the user
+      // hasn't saved yet — matches the auto-apply path in the editor.
+      const configuration = this.configuration;
+      const yaml = this.yaml;
       const { yaml_diff } = await this._api.upsertAutomation(
-        this.configuration,
+        configuration,
         tree,
         location,
-        this.yaml
+        yaml
       );
-      dispatchAutomationAdded(this, this.configuration, this.yaml, location, yaml_diff);
+      dispatchAutomationAdded(this, configuration, yaml, location, yaml_diff);
       this._dialog.open = false;
     } catch (err) {
       const msg = formatApiError(err, this._localize, "device.automation_save_error");

--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -495,7 +495,7 @@ export class ESPHomeAddAutomationDialog extends LitElement {
         location,
         this.yaml
       );
-      dispatchAutomationAdded(this, this.yaml, location, yaml_diff);
+      dispatchAutomationAdded(this, this.configuration, this.yaml, location, yaml_diff);
       this._dialog.open = false;
     } catch (err) {
       const msg = formatApiError(err, this._localize, "device.automation_save_error");

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -15,6 +15,7 @@ import { collectExistingIds } from "../../util/default-component-id.js";
 import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import { buildFeaturedId, isFeaturedId } from "../../util/featured-id.js";
 import { fireEvent } from "../../util/fire-event.js";
+import { fireSectionEvent } from "./section-editor.js";
 import { formatApiError } from "../../util/format-api-error.js";
 import { notifyError, notifySuccess } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -670,7 +671,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
 
   /** Surface the merged YAML as an unsaved editor draft (host saves explicitly). */
   private _dispatchDraft(yaml: string) {
-    fireEvent(this, "yaml-draft", { yaml });
+    fireSectionEvent(this, "yaml-draft", { configuration: this.configuration, yaml });
   }
 
   /**

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -543,6 +543,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
     if (this._submitting) return;
     const { bundle, boardId } = e.detail;
     if (!boardId || bundle.component_ids.length === 0 || !this.configuration) return;
+    // Snapshot the target before the awaits: a router-level device
+    // swap reassigns the prop from above, and a live re-read would
+    // slip the merged draft past the page's identity guard.
+    const configuration = this.configuration;
     const fullIds = bundle.component_ids.map((localId) =>
       buildFeaturedId(boardId, localId)
     );
@@ -560,7 +564,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // interactive queue, carrying the just-added dependency's id into the opened
     // form's matching reference field (the chaining bundles rely on).
     const handOff = async (idx: number) => {
-      if (addedAny) this._dispatchDraft(this.yaml);
+      if (addedAny) this._dispatchDraft(configuration, this.yaml);
       // Keep `_submitting` set across the hydrate so the dialog can't be
       // dismissed or a new selection started mid-hand-off (which would make the
       // hydrate stale); release it once the form is up.
@@ -598,14 +602,14 @@ export class ESPHomeAddComponentDialog extends LitElement {
           // A newer selection superseded this batch; publish what merged so far
           // for symmetry with the throw/hand-off paths (the superseding flow
           // also threads `this.yaml`, but don't rely on it cancelling).
-          if (addedAny) this._dispatchDraft(this.yaml);
+          if (addedAny) this._dispatchDraft(configuration, this.yaml);
           return;
         }
         if (result.kind === "error") {
           // A body fetch failed; routing through hand-off would only re-fetch
           // the same member and drop this message. Surface it directly and keep
           // what merged so far.
-          if (addedAny) this._dispatchDraft(this.yaml);
+          if (addedAny) this._dispatchDraft(configuration, this.yaml);
           this._submitError = result.message;
           return;
         }
@@ -631,7 +635,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
           continue;
         }
         const { yaml } = await this._api.addComponent(
-          this.configuration,
+          configuration,
           { component_id: fullIds[i], fields },
           draft
         );
@@ -644,7 +648,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
         this.yaml = yaml;
         lastAdded = this._chainReference(entry, fields);
       }
-      if (addedAny) this._dispatchDraft(this.yaml);
+      if (addedAny) this._dispatchDraft(configuration, this.yaml);
       this._dialog.open = false;
       this._selected = null;
       this._resetDetourState();
@@ -657,7 +661,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
       // A member failed mid-batch: publish what merged so far so the host keeps
       // the already-added members (the draft is otherwise only published on the
       // success or hand-off paths, not on a throw).
-      if (addedAny) this._dispatchDraft(this.yaml);
+      if (addedAny) this._dispatchDraft(configuration, this.yaml);
       this._submitError = formatApiError(
         err,
         this._localize,
@@ -670,8 +674,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
   }
 
   /** Surface the merged YAML as an unsaved editor draft (host saves explicitly). */
-  private _dispatchDraft(yaml: string) {
-    fireSectionEvent(this, "yaml-draft", { configuration: this.configuration, yaml });
+  private _dispatchDraft(configuration: string, yaml: string) {
+    fireSectionEvent(this, "yaml-draft", { configuration, yaml });
   }
 
   /**
@@ -740,6 +744,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
    */
   private async _submitComponent(fields: Record<string, unknown>, notify = false) {
     if (!this._selected || !this.configuration || this._submitting) return;
+    // Same pre-await target snapshot as the bundle flow.
+    const configuration = this.configuration;
     this._submitting = true;
     this._submitError = "";
     // Invalidate any in-flight dep-nav lookup — a late resolve must
@@ -753,7 +759,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
       // merging into "" would drop the on-disk config, so an empty draft
       // omits the arg and the backend falls back to the on-disk YAML.
       const { yaml } = await this._api.addComponent(
-        this.configuration,
+        configuration,
         {
           component_id: this._selected.id,
           fields,
@@ -767,7 +773,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
       // (so the dependency we just added shows up in the original
       // component's dropdown). `yaml-draft` advances only the working
       // buffer, leaving the dirty flag on so the user saves explicitly.
-      this._dispatchDraft(yaml);
+      this._dispatchDraft(configuration, yaml);
 
       if (this._returnTo) {
         // Just finished adding a dependency — restore the original

--- a/src/components/device/add-script-dialog.ts
+++ b/src/components/device/add-script-dialog.ts
@@ -235,16 +235,21 @@ export class ESPHomeAddScriptDialog extends LitElement {
         trigger_params: { mode: "single" },
         actions: [],
       };
-      // Hand the backend our current draft yaml so the splice
-      // lands relative to any pending edits the user hasn't saved
-      // yet — matches the auto-apply path in the editor.
+      // Snapshot the target and buffer together, before the await:
+      // the diff's line coordinates are relative to the string we
+      // send, and a router-level device swap reassigns both props
+      // from above mid round trip. The buffer is the current draft
+      // so the splice lands relative to any pending edits the user
+      // hasn't saved yet — matches the auto-apply path in the editor.
+      const configuration = this.configuration;
+      const yaml = this.yaml;
       const { yaml_diff } = await this._api.upsertAutomation(
-        this.configuration,
+        configuration,
         tree,
         location,
-        this.yaml
+        yaml
       );
-      dispatchAutomationAdded(this, this.configuration, this.yaml, location, yaml_diff);
+      dispatchAutomationAdded(this, configuration, yaml, location, yaml_diff);
       this._dialog.open = false;
     } catch (err) {
       const msg = formatApiError(err, this._localize, "device.automation_save_error");

--- a/src/components/device/add-script-dialog.ts
+++ b/src/components/device/add-script-dialog.ts
@@ -244,7 +244,7 @@ export class ESPHomeAddScriptDialog extends LitElement {
         location,
         this.yaml
       );
-      dispatchAutomationAdded(this, this.yaml, location, yaml_diff);
+      dispatchAutomationAdded(this, this.configuration, this.yaml, location, yaml_diff);
       this._dialog.open = false;
     } catch (err) {
       const msg = formatApiError(err, this._localize, "device.automation_save_error");

--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -296,8 +296,9 @@ export class AutoApplyController implements ReactiveController {
       // otherwise repeated auto-applies (the user typing into the
       // same field) would each re-insert the automation on top of
       // the previous draft's insertion.
+      const configuration = this._host.configuration;
       const { yaml_diff } = await api.upsertAutomation(
-        this._host.configuration,
+        configuration,
         value,
         location,
         this._host.yaml
@@ -308,13 +309,7 @@ export class AutoApplyController implements ReactiveController {
       // synchronous and may already trigger ``updated()`` on the way
       // back, which is where the skip check runs.
       this._lastSelfWrittenYaml = newYaml;
-      this._host.dispatchEvent(
-        new CustomEvent<{ yaml: string }>("yaml-draft", {
-          detail: { yaml: newYaml },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      fireSectionEvent(this._host, "yaml-draft", { configuration, yaml: newYaml });
     } catch (err) {
       this._surfaceSaveError(err);
     } finally {

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -14,7 +14,7 @@ import {
 import { resolveCurrentFromLine } from "../../../util/yaml-sections.js";
 import type { ConfigEntryValueChange } from "../config-entry-form.js";
 import type { ESPHomeDeviceSectionConfig } from "../device-section-config.js";
-import { prepareYamlUpdated } from "../section-editor.js";
+import { fireSectionEvent, prepareYamlUpdated } from "../section-editor.js";
 
 // Validates against the *render* schema (resolveSectionEntries), not the raw
 // catalog. MAP_SECTIONS (substitutions / packages) carry an irrelevant flat
@@ -59,7 +59,10 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): string | null {
   if (newYaml === host.yaml) return null;
 
   host._lastSelfWrittenYaml = newYaml;
-  fireEvent(host, "yaml-draft", { yaml: newYaml });
+  fireSectionEvent(host, "yaml-draft", {
+    configuration: host.configuration,
+    yaml: newYaml,
+  });
   return newYaml;
 }
 

--- a/src/components/device/dispatch-automation-added.ts
+++ b/src/components/device/dispatch-automation-added.ts
@@ -10,12 +10,13 @@
  */
 import type { AutomationLocation, YamlDiff } from "../../api/types/automations.js";
 import { applyYamlDiff, sectionKeyFromLocation } from "./automation-editor/serialise.js";
+import { fireSectionEvent } from "./section-editor.js";
 
 /**
  * Apply ``yamlDiff`` to ``yaml`` and dispatch the two bubbling,
  * composed events the device page listens for:
  *
- * - ``yaml-draft`` (``detail: { yaml }``) — the spliced YAML, so
+ * - ``yaml-draft`` (``detail: { configuration, yaml }``) — the spliced YAML, so
  *   the new automation lands in the page's YAML state (and thus
  *   the YAML pane + the global save button see the change). The
  *   page advances ``_yaml`` without touching ``_savedYaml`` —
@@ -25,18 +26,13 @@ import { applyYamlDiff, sectionKeyFromLocation } from "./automation-editor/seria
  */
 export function dispatchAutomationAdded(
   host: HTMLElement,
+  configuration: string,
   yaml: string,
   location: AutomationLocation,
   yamlDiff: YamlDiff
 ): void {
   const newYaml = applyYamlDiff(yaml, yamlDiff);
-  host.dispatchEvent(
-    new CustomEvent<{ yaml: string }>("yaml-draft", {
-      detail: { yaml: newYaml },
-      bubbles: true,
-      composed: true,
-    })
-  );
+  fireSectionEvent(host, "yaml-draft", { configuration, yaml: newYaml });
   host.dispatchEvent(
     new CustomEvent<{ sectionKey: string }>("automation-added", {
       detail: { sectionKey: sectionKeyFromLocation(location) },

--- a/src/components/device/section-editor.ts
+++ b/src/components/device/section-editor.ts
@@ -49,6 +49,15 @@ export type RemovedSectionRef =
   | { kind: "component"; sectionKey: string; fromLine: number }
   | { kind: "automation"; location: AutomationLocation };
 
+/** A draft advance of the page's YAML buffer (unsaved; the global
+ *  Save writes it). ``configuration`` is the emitter's snapshotted
+ *  target so a draft landing after a device switch is dropped
+ *  instead of spliced into the wrong device's buffer (#1479). */
+export interface YamlDraftDetail {
+  configuration: string;
+  yaml: string;
+}
+
 /** A completed disk write, the buffer it was computed against — the
  *  page supersede-checks the basis and advances only the saved side
  *  when the pane has moved past it (#1476) — and what it removed,
@@ -68,6 +77,7 @@ export interface SectionEditorEventMap {
   "section-mount": SectionLifecycleDetail;
   "section-unmount": SectionLifecycleDetail;
   "dirty-change": SectionDirtyChangeDetail;
+  "yaml-draft": YamlDraftDetail;
   "yaml-updated": YamlUpdatedDetail;
 }
 
@@ -120,6 +130,7 @@ declare global {
     "section-mount": CustomEvent<SectionEditorEventMap["section-mount"]>;
     "section-unmount": CustomEvent<SectionEditorEventMap["section-unmount"]>;
     "dirty-change": CustomEvent<SectionEditorEventMap["dirty-change"]>;
+    "yaml-draft": CustomEvent<SectionEditorEventMap["yaml-draft"]>;
     "yaml-updated": CustomEvent<SectionEditorEventMap["yaml-updated"]>;
   }
 }

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -20,6 +20,7 @@ import { DeviceInstallController } from "../components/device/device-install-con
 import { applyRemoval } from "../components/device/apply-removal.js";
 import type {
   SectionEditor,
+  YamlDraftDetail,
   YamlUpdatedDetail,
 } from "../components/device/section-editor.js";
 import type { ESPHomeFirmwareInstallDialog } from "../components/firmware-install-dialog.js";
@@ -1815,12 +1816,17 @@ export class ESPHomePageDevice extends LitElement {
     });
   }
 
-  private _onYamlDraft(e: CustomEvent<{ yaml: string }>) {
+  private _onYamlDraft(e: CustomEvent<YamlDraftDetail>) {
     /* Form auto-sync: the section editor spliced its current
      * ``_values`` into the YAML and is asking us to surface that
      * in the YAML pane. Only ``_yaml`` advances; ``_savedYaml``
      * stays put so the right-pane Save button activates and the
      * user sees the buffer is dirty. */
+    // A draft landing after a device switch belongs to the previous
+    // device — the router reuses this element, so splicing it here
+    // would put the old device's section into the new device's
+    // buffer (the yaml-updated identity guard's sibling, #1479).
+    if (e.detail.configuration !== this.id) return;
     this._setYaml(e.detail.yaml);
     this._retryPendingFieldLine();
   }

--- a/test/components/device/add-dialog-target-snapshot.test.ts
+++ b/test/components/device/add-dialog-target-snapshot.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the add dialogs' pre-await target/buffer snapshot (#1479): a
+ * device switch during the round trip must not retarget the draft,
+ * or the page's identity guard compares new-vs-new and passes.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import "../../_mock-webawesome.js";
+
+vi.mock("../../../src/components/device/add-component-form.js", () => ({}));
+vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+vi.mock("sonner-js", () => ({
+  default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+import type { YamlDiff } from "../../../src/api/types/automations.js";
+import { ESPHomeAddAutomationDialog } from "../../../src/components/device/add-automation-dialog.js";
+import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
+import { ESPHomeAddScriptDialog } from "../../../src/components/device/add-script-dialog.js";
+import type { YamlDraftDetail } from "../../../src/components/device/section-editor.js";
+import { identityLocalize } from "../../_dom.js";
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+/** Prepends "added:" to line 1 without deleting anything. */
+const DIFF: YamlDiff = { fromLine: 1, toLine: 0, replacement: "added:\n" };
+
+const capture = (el: EventTarget) => {
+  const seen: YamlDraftDetail[] = [];
+  el.addEventListener("yaml-draft", (e) =>
+    seen.push((e as CustomEvent<YamlDraftDetail>).detail)
+  );
+  return seen;
+};
+
+describe("add dialogs snapshot their target before the await", () => {
+  it("add-automation keeps the pre-switch target and basis", async () => {
+    const dialog = new ESPHomeAddAutomationDialog();
+    const upsert = deferred<{ yaml_diff: YamlDiff }>();
+    Object.assign(dialog as unknown as Record<string, unknown>, {
+      _api: { upsertAutomation: vi.fn(() => upsert.promise) },
+      _localize: identityLocalize,
+      _kind: "interval",
+      _intervalValue: "5",
+    });
+    dialog.configuration = "device.yaml";
+    dialog.yaml = "esphome:\n";
+    const seen = capture(dialog);
+
+    const continuing = (
+      dialog as unknown as { _onContinue: () => Promise<void> }
+    )._onContinue();
+    // The router swaps the device mid round trip.
+    dialog.configuration = "other.yaml";
+    dialog.yaml = "other:\n";
+    upsert.resolve({ yaml_diff: DIFF });
+    await continuing;
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].configuration).toBe("device.yaml");
+    // The diff landed on the pre-switch buffer, not the new device's.
+    expect(seen[0].yaml).toBe("added:\nesphome:\n");
+  });
+
+  it("add-script keeps the pre-switch target and basis", async () => {
+    const dialog = new ESPHomeAddScriptDialog();
+    const upsert = deferred<{ yaml_diff: YamlDiff }>();
+    Object.assign(dialog as unknown as Record<string, unknown>, {
+      _api: { upsertAutomation: vi.fn(() => upsert.promise) },
+      _localize: identityLocalize,
+      _id: "my_script",
+    });
+    dialog.configuration = "device.yaml";
+    dialog.yaml = "esphome:\n";
+    const seen = capture(dialog);
+
+    const continuing = (
+      dialog as unknown as { _onContinue: () => Promise<void> }
+    )._onContinue();
+    dialog.configuration = "other.yaml";
+    dialog.yaml = "other:\n";
+    upsert.resolve({ yaml_diff: DIFF });
+    await continuing;
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].configuration).toBe("device.yaml");
+    expect(seen[0].yaml).toBe("added:\nesphome:\n");
+  });
+
+  it("add-component keeps the pre-switch target", async () => {
+    const dialog = new ESPHomeAddComponentDialog();
+    const add = deferred<{ yaml: string }>();
+    // `_returnTo` truthy drives the restore branch, which doesn't
+    // touch the wa-dialog query — pure logic, no render.
+    Object.assign(dialog as unknown as Record<string, unknown>, {
+      _api: { addComponent: vi.fn(() => add.promise) },
+      _selected: { id: "i2c" },
+      _returnTo: { id: "orig" },
+      _depDomain: null,
+    });
+    dialog.configuration = "device.yaml";
+    dialog.yaml = "esphome:\n";
+    const seen = capture(dialog);
+
+    const submitting = (
+      dialog as unknown as { _onFormSubmit: (e: CustomEvent) => Promise<void> }
+    )._onFormSubmit(new CustomEvent("form-submit", { detail: { fields: {} } }));
+    dialog.configuration = "other.yaml";
+    add.resolve({ yaml: "MERGED" });
+    await submitting;
+
+    expect(seen).toEqual([{ configuration: "device.yaml", yaml: "MERGED" }]);
+  });
+});

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -124,8 +124,10 @@ describe("AutoApplyController auto-apply", () => {
       SCRIPT,
       "line1\nline2"
     );
-    // The returned diff is applied locally and pushed up as a draft.
+    // The returned diff is applied locally and pushed up as a draft
+    // carrying its snapshotted target for the page's identity guard.
     expect(drafts.map((e) => e.detail.yaml)).toEqual(["replaced\nline2"]);
+    expect(drafts[0].detail.configuration).toBe("device.yaml");
   });
 
   it("withValue patches the host value, announces automation-change, and schedules", async () => {

--- a/test/components/device/dispatch-automation-added.test.ts
+++ b/test/components/device/dispatch-automation-added.test.ts
@@ -49,13 +49,22 @@ describe("dispatchAutomationAdded", () => {
       });
     }
 
-    dispatchAutomationAdded(host, YAML, { kind: "script", id: "my_script" }, DIFF);
+    dispatchAutomationAdded(
+      host,
+      "device.yaml",
+      YAML,
+      { kind: "script", id: "my_script" },
+      DIFF
+    );
 
     expect(seen.map((s) => s.type)).toEqual(["yaml-draft", "automation-added"]);
     // The dispatch contract is "the diff-applied YAML", not a
     // particular splice formatting, so compare against
     // applyYamlDiff (which has its own unit tests) ...
-    expect(seen[0].detail).toEqual({ yaml: applyYamlDiff(YAML, DIFF) });
+    expect(seen[0].detail).toEqual({
+      configuration: "device.yaml",
+      yaml: applyYamlDiff(YAML, DIFF),
+    });
     // ... and pin that the new block actually made it into the
     // draft, so a wrong-yaml dispatch still fails loudly here.
     expect((seen[0].detail as { yaml: string }).yaml).toContain(
@@ -75,6 +84,7 @@ describe("dispatchAutomationAdded", () => {
 
     dispatchAutomationAdded(
       host,
+      "device.yaml",
       YAML,
       { kind: "component_on", component_id: "my_switch", trigger: "on_turn_on" },
       DIFF

--- a/test/pages/device-error-highlight.test.ts
+++ b/test/pages/device-error-highlight.test.ts
@@ -70,7 +70,9 @@ describe("error-jump highlight lifecycle (#1404)", () => {
     goToError(page);
 
     internals(page)._onYamlDraft(
-      new CustomEvent("yaml-draft", { detail: { yaml: YAML + "    pin: GPIO11\n" } })
+      new CustomEvent("yaml-draft", {
+        detail: { configuration: "kitchen.yaml", yaml: YAML + "    pin: GPIO11\n" },
+      })
     );
     lintCompleted(page);
     expect(internals(page)._highlightRange).toBeNull();

--- a/test/pages/device-yaml-draft-identity.test.ts
+++ b/test/pages/device-yaml-draft-identity.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the yaml-draft identity guard (#1479): a draft announced for
+ * a different device is dropped instead of spliced into the reused
+ * page element's buffer.
+ */
+import { describe, expect, it } from "vitest";
+
+import "./_mock-device-children.js";
+
+import type { YamlDraftDetail } from "../../src/components/device/section-editor.js";
+import { ESPHomePageDevice } from "../../src/pages/device.js";
+
+interface DraftView {
+  _yaml: string;
+  id: string;
+  _onYamlDraft(e: CustomEvent<YamlDraftDetail>): void;
+}
+
+const makePage = (yaml: string): DraftView => {
+  const page = new ESPHomePageDevice() as unknown as DraftView;
+  page.id = "device.yaml";
+  page._yaml = yaml;
+  return page;
+};
+
+const draft = (page: DraftView, detail: YamlDraftDetail) =>
+  page._onYamlDraft(new CustomEvent("yaml-draft", { detail }));
+
+describe("yaml-draft identity guard", () => {
+  it("applies a draft announced for this device", () => {
+    const page = makePage("a:\n");
+
+    draft(page, { configuration: "device.yaml", yaml: "a:\n  x: 1\n" });
+
+    expect(page._yaml).toBe("a:\n  x: 1\n");
+  });
+
+  it("drops a draft announced for a different device", () => {
+    const page = makePage("b-config:\n");
+
+    // The router reuses the page element across devices; a late
+    // upsert echo from the previous device must not splice here.
+    draft(page, { configuration: "other.yaml", yaml: "a:\n  x: 1\n" });
+
+    expect(page._yaml).toBe("b-config:\n");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

First step of the #1479 arc, and a standing hazard fix on its own: `yaml-draft` had no device identity, so a draft resolving after a device switch spliced the previous device's section into the new device's buffer. The router reuses one page element across device routes, which is the same cross device window #1491 closed for `yaml-updated`; the draft path was still open.

`yaml-draft` now has a typed detail in the section editor contract, `YamlDraftDetail { configuration, yaml }`, wired through `SectionEditorEventMap` and the global `HTMLElementEventMap` so every firer type checks. All five emitters (the auto apply engine, the component editor's debounced splice, the add component dialog, the api action dialog, and the shared add automation and add script dispatch helper) carry their snapshotted target, and the page's `_onYamlDraft` drops a mismatched announcement before touching the buffer.

The `basedOn` basis extension the sync switch needs is deliberately not in this PR; it lands with the consumer that gives it semantics.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder-frontend/issues/1479

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] Documentation only — `docs`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
