### PR TITLE
Adopt ESLint with type-aware promise rules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    name: Lint
+  style:
+    name: Prettier + ESLint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -40,11 +40,29 @@ jobs:
       - name: Prettier format check
         run: pnpm run format:check
 
-      - name: Lint (TypeScript type check)
-        run: pnpm run lint
-
       - name: ESLint
         run: pnpm run lint:eslint
+
+  typecheck:
+    name: Type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint (TypeScript type check)
+        run: pnpm run lint
 
   test:
     name: Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Lint (TypeScript type check)
         run: pnpm run lint
 
+      - name: ESLint
+        run: pnpm run lint:eslint
+
       - name: Tests
         run: pnpm test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-and-lint:
-    name: Test and Lint
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -46,8 +46,44 @@ jobs:
       - name: ESLint
         run: pnpm run lint:eslint
 
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Tests
         run: pnpm test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,3 +108,22 @@ jobs:
 
       - name: Build ESPHome Web
         run: pnpm run build:web
+
+  # Single stable context for branch protection: the required check
+  # keeps the historical "Test and Lint" name no matter how the jobs
+  # above are split or renamed. `if: always()` so a failed dependency
+  # reports failure here instead of leaving the check forever
+  # "expected" as skipped.
+  summary:
+    name: Test and Lint
+    runs-on: ubuntu-latest
+    needs: [style, typecheck, test, build]
+    if: always()
+    steps:
+      - name: Check job results
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job failed or was cancelled."
+            exit 1
+          fi
+          echo "All jobs passed."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
     steps:
       - name: Check job results
         run: |
-          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" = "true" ]; then
             echo "A required job failed or was cancelled."
             exit 1
           fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
 pnpm run format:check
 pnpm run lint
+pnpm run lint:eslint
 pnpm test

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,7 +1,16 @@
 // typescript-eslint drives the TS 6 JS API; the repo's own `typescript`
-// is the TS 7 native port whose API it cannot load (their issue #10940).
+// is the TS 7 native port whose API it cannot load:
+// https://github.com/typescript-eslint/typescript-eslint/issues/10940
 // Give the typescript-eslint packages a private TS 6 dependency so the
 // fast TS 7 `tsc --noEmit` gate and the type-aware lint coexist.
+//
+// Consequences to keep in mind:
+// - Lint evaluates the codebase under TS ~6.0.3 while the build and
+//   the `lint` gate use the package.json `typescript` pin; a TS 7-only
+//   construct can surface as an ESLint-only parse/type error.
+// - The pin below is disconnected from package.json and nothing warns
+//   on drift (the peer dependency is deleted on purpose).
+// DELETE THIS WHOLE FILE once typescript-eslint supports the TS 7 API.
 function readPackage(pkg) {
   if (pkg.name === "typescript-eslint" || pkg.name?.startsWith("@typescript-eslint/")) {
     if (pkg.peerDependencies?.typescript) delete pkg.peerDependencies.typescript;

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,0 +1,12 @@
+// typescript-eslint drives the TS 6 JS API; the repo's own `typescript`
+// is the TS 7 native port whose API it cannot load (their issue #10940).
+// Give the typescript-eslint packages a private TS 6 dependency so the
+// fast TS 7 `tsc --noEmit` gate and the type-aware lint coexist.
+function readPackage(pkg) {
+  if (pkg.name === "typescript-eslint" || pkg.name?.startsWith("@typescript-eslint/")) {
+    if (pkg.peerDependencies?.typescript) delete pkg.peerDependencies.typescript;
+    pkg.dependencies = { ...pkg.dependencies, typescript: "~6.0.3" };
+  }
+  return pkg;
+}
+module.exports = { hooks: { readPackage } };

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -11,6 +11,9 @@
 // - The pin below is disconnected from package.json and nothing warns
 //   on drift (the peer dependency is deleted on purpose).
 // DELETE THIS WHOLE FILE once typescript-eslint supports the TS 7 API.
+// NOTE: any edit to this file (comments included) changes the
+// pnpmfileChecksum pnpm stamps into the lockfile; run `pnpm install`
+// afterwards or --frozen-lockfile installs fail.
 function readPackage(pkg) {
   if (pkg.name === "typescript-eslint" || pkg.name?.startsWith("@typescript-eslint/")) {
     if (pkg.peerDependencies?.typescript) delete pkg.peerDependencies.typescript;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,40 @@
+// Gate rationale in the repo issue tracker (#1501): tsc strict owns
+// type errors; this config adds the promise-safety rules tsc cannot
+// express plus the recommended baseline the codebase's existing
+// eslint-disable comments were already written against.
+import tseslint from "typescript-eslint";
+
+export default tseslint.config({
+  files: ["src/**/*.ts", "test/**/*.ts"],
+  extends: [...tseslint.configs.recommended],
+  languageOptions: {
+    parserOptions: {
+      projectService: true,
+      tsconfigRootDir: import.meta.dirname,
+    },
+  },
+  rules: {
+    "@typescript-eslint/no-floating-promises": "error",
+    // inheritedMethods off: Lit's async lifecycle overrides
+    // (connectedCallback et al.) are idiomatic; the base class never
+    // consumes the return value.
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+      { checksVoidReturn: { inheritedMethods: false } },
+    ],
+    // Mirrors home-assistant/frontend: underscore names opt out, the
+    // same convention the tsc gate's noUnusedLocals already follows.
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        args: "all",
+        argsIgnorePattern: "^_",
+        caughtErrors: "all",
+        caughtErrorsIgnorePattern: "^_",
+        destructuredArrayIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+        ignoreRestSiblings: true,
+      },
+    ],
+  },
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,10 @@
 // eslint-disable comments were already written against.
 import tseslint from "typescript-eslint";
 
+// No --cache in the script: type-aware rules depend on other files'
+// types, which ESLint's per-file cache cannot invalidate. Scope is
+// deliberately src + test only — the config files and build-scripts
+// live outside tsconfig's include, so projectService cannot type them.
 export default tseslint.config({
   files: ["src/**/*.ts", "test/**/*.ts"],
   extends: [...tseslint.configs.recommended],
@@ -14,6 +18,10 @@ export default tseslint.config({
     },
   },
   rules: {
+    // A variable read by a closure before its single assignment
+    // cannot be a const; the option covers the pattern instead of
+    // per-site disables.
+    "prefer-const": ["error", { ignoreReadBeforeAssign: true }],
     "@typescript-eslint/no-floating-promises": "error",
     // inheritedMethods off: Lit's async lifecycle overrides
     // (connectedCallback et al.) are idiomatic; the base class never

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:web": "node build-scripts/build-web.cjs",
     "gen:languages": "node build-scripts/gen-language-manifest.cjs",
     "lint": "node build-scripts/gen-language-manifest.cjs && tsc --noEmit",
-    "lint:eslint": "eslint src test --max-warnings=0 --cache --cache-location node_modules/.cache/eslint/",
+    "lint:eslint": "eslint src test --max-warnings=0",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:web": "node build-scripts/build-web.cjs",
     "gen:languages": "node build-scripts/gen-language-manifest.cjs",
     "lint": "node build-scripts/gen-language-manifest.cjs && tsc --noEmit",
+    "lint:eslint": "eslint src test --max-warnings=0 --cache --cache-location node_modules/.cache/eslint/",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "vitest run",
@@ -61,12 +62,14 @@
     "@swc/helpers": "0.5.23",
     "@types/node": "26.1.1",
     "@types/w3c-web-serial": "^1.0.8",
+    "eslint": "^10.8.0",
     "fflate": "^0.8.3",
     "happy-dom": "^20.11.1",
     "husky": "^9.1.7",
     "prettier": "3.9.6",
     "prettier-plugin-organize-imports": "^4.3.0",
     "typescript": "7.0.2",
+    "typescript-eslint": "^8.65.0",
     "vitest": "^4.1.10"
   },
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:web": "node build-scripts/build-web.cjs",
     "gen:languages": "node build-scripts/gen-language-manifest.cjs",
     "lint": "node build-scripts/gen-language-manifest.cjs && tsc --noEmit",
-    "lint:eslint": "eslint src test --max-warnings=0",
+    "lint:eslint": "node build-scripts/gen-language-manifest.cjs && eslint src test --max-warnings=0",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "vitest run",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-vnyFT5HVe9nRiVjQ58MnDenxYl1FUkOK6SdEPz4fCL4=
+pnpmfileChecksum: sha256-Z1nKaYraEDs6+AWL+UsFrh442DRwCougvqXRBNXNLSM=
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,8 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+pnpmfileChecksum: sha256-vnyFT5HVe9nRiVjQ58MnDenxYl1FUkOK6SdEPz4fCL4=
+
 importers:
 
   .:
@@ -105,6 +107,9 @@ importers:
       '@types/w3c-web-serial':
         specifier: ^1.0.8
         version: 1.0.8
+      eslint:
+        specifier: ^10.8.0
+        version: 10.8.0
       fflate:
         specifier: ^0.8.3
         version: 0.8.3
@@ -123,6 +128,9 @@ importers:
       typescript:
         specifier: 7.0.2
         version: 7.0.2
+      typescript-eslint:
+        specifier: ^8.65.0
+        version: 8.65.0(eslint@10.8.0)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@26.1.1)(happy-dom@20.11.1)(vite@8.1.4(@types/node@26.1.1))
@@ -175,6 +183,36 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
+  '@eslint-community/eslint-utils@4.10.1':
+    resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.2':
+    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
@@ -196,6 +234,26 @@ packages:
   '@home-assistant/webawesome@3.7.0':
     resolution: {integrity: sha512-7j8N8DDQqhO+d+WEzPYUXwE2s/OxtwTX/LGvg68eeKWtL8j4DOEtydM2rB6KPnMTLrZpBR5DHA7stxxfGPS48Q==}
     engines: {node: '>=14.17.0'}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -485,8 +543,14 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
@@ -505,6 +569,55 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@typescript-eslint/eslint-plugin@8.65.0':
+    resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.65.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+
+  '@typescript-eslint/parser@8.65.0':
+    resolution: {integrity: sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+
+  '@typescript-eslint/project-service@8.65.0':
+    resolution: {integrity: sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.65.0':
+    resolution: {integrity: sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.65.0':
+    resolution: {integrity: sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/type-utils@8.65.0':
+    resolution: {integrity: sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+
+  '@typescript-eslint/types@8.65.0':
+    resolution: {integrity: sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.65.0':
+    resolution: {integrity: sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/utils@8.65.0':
+    resolution: {integrity: sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+
+  '@typescript-eslint/visitor-keys@8.65.0':
+    resolution: {integrity: sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -655,12 +768,33 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
   atob-lite@2.0.0:
     resolution: {integrity: sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   buffer-image-size@0.6.4:
     resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
@@ -684,8 +818,24 @@ packages:
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -698,15 +848,70 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.8.0:
+    resolution: {integrity: sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   esptool-js@0.6.0:
     resolution: {integrity: sha512-ZyuSBXvmS+4DRKM6GrDHfCscnq3YSNlRfM+Zw0DoS7uC3SdkyC262s/ji4MjDYVmMH8SE2BiYx3/dZ1J23Xiew==}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -720,10 +925,29 @@ packages:
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.3:
+    resolution: {integrity: sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
 
   happy-dom@20.11.1:
     resolution: {integrity: sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==}
@@ -734,11 +958,50 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
+    engines: {node: '>= 4'}
+
   improv-wifi-serial-sdk@2.8.1:
     resolution: {integrity: sha512-KU2D7bNbdUDUX0JK2nQGTGTuxJNH+loXyMR6DXBIzAh4/2dwiR2cxK0igvl+dLWjf4wRv43iUn/eQuUClw5V3g==}
 
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
   intl-messageformat@11.2.12:
     resolution: {integrity: sha512-KW70Xxfcvy7vV3qODfvShWkFDPMqKDAa4N+hSyVBWGNtVhTUFYaqlD/l88DaYPKiVcPP4rPQ3qnH7i5K82Mg7g==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
@@ -823,6 +1086,10 @@ packages:
   lit@3.3.3:
     resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
 
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -834,6 +1101,13 @@ packages:
   memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -844,11 +1118,34 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
   pako@2.1.0:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -863,6 +1160,10 @@ packages:
   postcss@8.5.22:
     resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
 
   prettier-plugin-organize-imports@4.3.0:
     resolution: {integrity: sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==}
@@ -879,6 +1180,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   qr-creator@1.0.0:
     resolution: {integrity: sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ==}
 
@@ -886,6 +1191,19 @@ packages:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -921,8 +1239,29 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript-eslint@8.65.0:
+    resolution: {integrity: sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
@@ -931,6 +1270,9 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   urlpattern-polyfill@10.1.0:
     resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
@@ -1026,10 +1368,19 @@ packages:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
 
   ws@8.21.1:
     resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
@@ -1042,6 +1393,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
 snapshots:
 
@@ -1135,6 +1490,36 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.0)':
+    dependencies:
+      eslint: 10.8.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.7.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.2':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
@@ -1169,6 +1554,22 @@ snapshots:
     transitivePeerDependencies:
       - '@floating-ui/utils'
       - '@types/react'
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -1394,7 +1795,11 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/node@26.1.1':
     dependencies:
@@ -1413,6 +1818,101 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 26.1.1
+
+  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0))(eslint@10.8.0)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/type-utils': 8.65.0(eslint@10.8.0)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)
+      '@typescript-eslint/visitor-keys': 8.65.0
+      eslint: 10.8.0
+      ignore: 7.0.6
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.65.0(eslint@10.8.0)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0
+      '@typescript-eslint/visitor-keys': 8.65.0
+      debug: 4.4.3
+      eslint: 10.8.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.65.0':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.65.0':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/visitor-keys': 8.65.0
+      typescript: 6.0.3
+
+  '@typescript-eslint/tsconfig-utils@8.65.0':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/type-utils@8.65.0(eslint@10.8.0)':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0
+      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)
+      debug: 4.4.3
+      eslint: 10.8.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.65.0':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/typescript-estree@8.65.0':
+    dependencies:
+      '@typescript-eslint/project-service': 8.65.0
+      '@typescript-eslint/tsconfig-utils': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/visitor-keys': 8.65.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.65.0(eslint@10.8.0)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0
+      eslint: 10.8.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.65.0':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      eslint-visitor-keys: 5.0.1
+      typescript: 6.0.3
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -1515,9 +2015,28 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
   assertion-error@2.0.1: {}
 
   atob-lite@2.0.0: {}
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@5.0.8:
+    dependencies:
+      balanced-match: 4.0.4
 
   buffer-image-size@0.6.4:
     dependencies:
@@ -1543,7 +2062,19 @@ snapshots:
 
   crelt@1.0.6: {}
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
 
   detect-libc@2.1.2: {}
 
@@ -1551,17 +2082,89 @@ snapshots:
 
   es-module-lexer@2.1.0: {}
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.8.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.7.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 5.0.1
+
   esptool-js@0.6.0:
     dependencies:
       atob-lite: 2.0.0
       pako: 2.1.0
       tslib: 2.8.1
 
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
 
+  esutils@2.0.3: {}
+
   expect-type@1.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -1569,8 +2172,28 @@ snapshots:
 
   fflate@0.8.3: {}
 
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.3
+      keyv: 4.5.4
+
+  flatted@3.4.3: {}
+
   fsevents@2.3.3:
     optional: true
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
 
   happy-dom@20.11.1:
     dependencies:
@@ -1587,15 +2210,44 @@ snapshots:
 
   husky@9.1.7: {}
 
+  ignore@5.3.2: {}
+
+  ignore@7.0.6: {}
+
   improv-wifi-serial-sdk@2.8.1:
     dependencies:
       '@material/web': 2.5.0
       tslib: 2.8.1
 
+  imurmurhash@0.1.4: {}
+
   intl-messageformat@11.2.12:
     dependencies:
       '@formatjs/fast-memoize': 3.1.7
       '@formatjs/icu-messageformat-parser': 3.5.15
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  isexe@2.0.0: {}
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lightningcss-android-arm64@1.33.0:
     optional: true
@@ -1662,6 +2314,10 @@ snapshots:
       lit-element: 4.2.2
       lit-html: 3.3.3
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1670,13 +2326,42 @@ snapshots:
 
   memoize-one@6.0.0: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.8
+
+  ms@2.1.3: {}
+
   nanoid@3.3.16: {}
 
   nanoid@5.1.6: {}
 
+  natural-compare@1.4.0: {}
+
   obug@2.1.1: {}
 
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
   pako@2.1.0: {}
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
 
   pathe@2.0.3: {}
 
@@ -1690,12 +2375,16 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prelude-ls@1.2.1: {}
+
   prettier-plugin-organize-imports@4.3.0(prettier@3.9.6)(typescript@7.0.2):
     dependencies:
       prettier: 3.9.6
       typescript: 7.0.2
 
   prettier@3.9.6: {}
+
+  punycode@2.3.1: {}
 
   qr-creator@1.0.0: {}
 
@@ -1720,6 +2409,14 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
 
+  semver@7.8.5: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
 
   sonner-js@1.1.3: {}
@@ -1743,7 +2440,28 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  ts-api-utils@2.5.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
   tslib@2.8.1: {}
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript-eslint@8.65.0(eslint@10.8.0):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0))(eslint@10.8.0)
+      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)
+      '@typescript-eslint/typescript-estree': 8.65.0
+      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)
+      eslint: 10.8.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript@6.0.3: {}
 
   typescript@7.0.2:
     optionalDependencies:
@@ -1769,6 +2487,10 @@ snapshots:
       '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@8.3.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   urlpattern-polyfill@10.1.0: {}
 
@@ -1815,9 +2537,17 @@ snapshots:
 
   whatwg-mimetype@3.0.0: {}
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  word-wrap@1.2.5: {}
+
   ws@8.21.1: {}
+
+  yocto-queue@0.1.0: {}

--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -211,7 +211,7 @@ export class ESPHomeAdoptDialog extends LitElement {
   private readonly _dialog = new DialogOpenController(this);
 
   // Enter submits; _submit self-guards on name validity and re-entry.
-  private _enter = new EnterController(this, () => this._submit());
+  private _enter = new EnterController(this, () => void this._submit());
 
   protected willUpdate(): void {
     // Re-sync every update (set() no-ops on same value) — the open flag
@@ -241,7 +241,7 @@ export class ESPHomeAdoptDialog extends LitElement {
     // validate (esphome/device-builder#1742). Probe the shared secrets so
     // the Wi-Fi step can prompt + store them before importing.
     if (this._needsWifi && this._api) {
-      fetchSecretKeys(this._api).then((keys) => {
+      void fetchSecretKeys(this._api).then((keys) => {
         this._hasWifiSecrets = hasSharedWifiSecret(keys);
       });
     }

--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -241,7 +241,8 @@ export class ESPHomeAdoptDialog extends LitElement {
     // validate (esphome/device-builder#1742). Probe the shared secrets so
     // the Wi-Fi step can prompt + store them before importing.
     if (this._needsWifi && this._api) {
-      void fetchSecretKeys(this._api).then((keys) => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+      fetchSecretKeys(this._api).then((keys) => {
         this._hasWifiSecrets = hasSharedWifiSecret(keys);
       });
     }

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -472,7 +472,8 @@ export class ESPHomeApp extends LitElement {
   private async _afterAuthenticated() {
     this._authState = "authed";
     this._authError = null;
-    void this._subscribeToEvents();
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+    this._subscribeToEvents();
     subscribeToFollowJobs(this);
     void loadIntegrationDocs(this);
     void loadLabels(this);

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -472,7 +472,7 @@ export class ESPHomeApp extends LitElement {
   private async _afterAuthenticated() {
     this._authState = "authed";
     this._authError = null;
-    this._subscribeToEvents();
+    void this._subscribeToEvents();
     subscribeToFollowJobs(this);
     void loadIntegrationDocs(this);
     void loadLabels(this);

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -318,7 +318,7 @@ export class ESPHomeCommandDialog extends LitElement {
   _resetAnsiLogScroll() {
     // The ansi-log instance is reused across opens; scrollToBottom clears
     // its _isUserScrolled latch so streaming-to-bottom re-engages.
-    this.updateComplete.then(() => this._terminal?.scrollToBottom());
+    void this.updateComplete.then(() => this._terminal?.scrollToBottom());
   }
 
   // Attach to a firmware job's stream. Handles any state — terminal jobs

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -318,7 +318,8 @@ export class ESPHomeCommandDialog extends LitElement {
   _resetAnsiLogScroll() {
     // The ansi-log instance is reused across opens; scrollToBottom clears
     // its _isUserScrolled latch so streaming-to-bottom re-engages.
-    void this.updateComplete.then(() => this._terminal?.scrollToBottom());
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+    this.updateComplete.then(() => this._terminal?.scrollToBottom());
   }
 
   // Attach to a firmware job's stream. Handles any state — terminal jobs

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -385,7 +385,7 @@ function renderActions(host: ESPHomeCommandDialog): TemplateResult | typeof noth
             icon: "refresh",
             label: host._localize("command.retry"),
             variant: "start",
-            onClick: host._start,
+            onClick: () => void host._start(),
           })}
           ${close}`;
     case "success":

--- a/src/components/command-palette-actions.ts
+++ b/src/components/command-palette-actions.ts
@@ -49,7 +49,7 @@ export function buildCommands(ctx: CommandActionContext): CommandAction[] {
       label: t("command_palette.go_dashboard"),
       icon: "home",
       keywords: ["dashboard", "devices"],
-      run: () => navigate("/"),
+      run: () => void navigate("/"),
     },
     {
       id: "nav.secrets",
@@ -57,7 +57,7 @@ export function buildCommands(ctx: CommandActionContext): CommandAction[] {
       label: t("layout.secrets"),
       icon: "key-variant",
       keywords: ["password", "wifi"],
-      run: () => navigate("/secrets"),
+      run: () => void navigate("/secrets"),
     },
   ];
 

--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -399,7 +399,14 @@ export async function fetchApiKey(
  * next session — a Copilot find on PR #68). The cancel stops the loop AND
  * closes the port; a Stop pause never calls it.
  */
-export function streamSerialToDialog(port: any, dialog: any): () => void {
+export function streamSerialToDialog(
+  port: SerialPort,
+  dialog: {
+    _serialPaused?: boolean;
+    _noteSerialActivity(): void;
+    _enqueueLine(line: string): void;
+  }
+): () => void {
   return streamSerialLines(port, {
     onLine: (line) => {
       // Keep draining while paused (Stop) but don't display (#526).

--- a/src/components/dashboard/device-table-grid.ts
+++ b/src/components/dashboard/device-table-grid.ts
@@ -1,4 +1,6 @@
 import { flexRender } from "@tanstack/lit-table";
+import type { Cell, Header, HeaderGroup, Row, Table } from "@tanstack/lit-table";
+import type { DeviceRow } from "./table-columns.js";
 import { html, nothing, type TemplateResult } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { repeat } from "lit/directives/repeat.js";
@@ -8,15 +10,15 @@ import { tourAnchor } from "../guided-tour/tour-anchor.js";
 import { getActiveTourConfiguration } from "../guided-tour/tour-session.js";
 
 export interface DeviceTableHeadProps {
-  table: any;
+  table: Table<DeviceRow>;
   selectMode: boolean;
   allSelected: boolean;
   onToggleAll: () => void;
 }
 
 export interface DeviceTableBodyProps {
-  table: any;
-  rows: any[];
+  table: Table<DeviceRow>;
+  rows: Row<DeviceRow>[];
   selectMode: boolean;
   selectedDevices: Set<string>;
   highlightConfiguration: string | null;
@@ -38,7 +40,7 @@ export function renderDeviceTableHead(p: DeviceTableHeadProps): TemplateResult {
   return html`
     <thead>
       ${p.table.getHeaderGroups().map(
-        (hg: any) => html`
+        (hg: HeaderGroup<DeviceRow>) => html`
           <tr role="row">
             ${
               p.selectMode
@@ -52,7 +54,7 @@ export function renderDeviceTableHead(p: DeviceTableHeadProps): TemplateResult {
                   </th>`
                 : nothing
             }
-            ${hg.headers.map((header: any) => {
+            ${hg.headers.map((header: Header<DeviceRow, unknown>) => {
               const sorted = header.column.getIsSorted();
               const canSort = header.column.getCanSort();
               return html`
@@ -159,7 +161,7 @@ export function renderDeviceTableBody(p: DeviceTableBodyProps): TemplateResult {
                         </td>`
                       : nothing
                   }
-                  ${row.getVisibleCells().map((cell: any) => {
+                  ${row.getVisibleCells().map((cell: Cell<DeviceRow, unknown>) => {
                     // The stacked mobile layout (table-styles.ts) shows each
                     // cell's column header as a field label. It's a real
                     // span (not a CSS ::before) so screen readers announce

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -58,6 +58,7 @@ import {
 import { tableCellStyles } from "./table-cell-styles.js";
 import type { ToggleableColumn } from "./table-column-toggle.js";
 import { createDeviceColumns, type DeviceRow } from "./table-columns.js";
+import type { Row, Table } from "@tanstack/lit-table";
 import { tableLayoutStyles } from "./table-styles.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -217,7 +218,7 @@ export class ESPHomeDeviceTable extends LitElement {
   };
 
   private _globalFilterFn = (
-    row: any,
+    row: Row<DeviceRow>,
     _columnId: string,
     filterValue: unknown
   ): boolean => {
@@ -323,9 +324,9 @@ export class ESPHomeDeviceTable extends LitElement {
         globalFilter: this.search,
         pagination: { pageSize: effectivePageSize, pageIndex: effectivePageIndex },
       },
-      onSortingChange: this._handleSortingChange as any,
-      onColumnVisibilityChange: this._handleVisibilityChange as any,
-      onPaginationChange: this._handlePaginationChange as any,
+      onSortingChange: this._handleSortingChange,
+      onColumnVisibilityChange: this._handleVisibilityChange,
+      onPaginationChange: this._handlePaginationChange,
       getCoreRowModel: coreRowModel,
       getSortedRowModel: sortedRowModel,
       getFilteredRowModel: filteredRowModel,
@@ -475,7 +476,7 @@ export class ESPHomeDeviceTable extends LitElement {
     `;
   }
 
-  private _renderControls(table: any, toggleCols: ToggleableColumn[]) {
+  private _renderControls(table: Table<DeviceRow>, toggleCols: ToggleableColumn[]) {
     return html`
       <div class="controls">
         <slot name="toolbar"></slot>
@@ -530,9 +531,8 @@ export class ESPHomeDeviceTable extends LitElement {
        behind it. */
     if ((e.target as Element)?.closest("button, a")) return;
     e.preventDefault();
-    this.selectMode
-      ? this._onToggleSelect(device.configuration)
-      : this._onRowClick(device);
+    if (this.selectMode) this._onToggleSelect(device.configuration);
+    else this._onRowClick(device);
   }
 
   private _openActionsMenu(e: MouseEvent, device: ConfiguredDevice) {

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -280,7 +280,7 @@ export function renderDrawer(host: ESPHomePageDashboard): TemplateResult {
       }}
       @open-logs=${(e: CustomEvent) => {
         host._drawerOpen = false;
-        host._openLogs(e.detail);
+        void host._openLogs(e.detail);
       }}
       @clean-build=${(e: CustomEvent<ConfiguredDevice>) => {
         host._drawerOpen = false;

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -280,7 +280,8 @@ export function renderDrawer(host: ESPHomePageDashboard): TemplateResult {
       }}
       @open-logs=${(e: CustomEvent) => {
         host._drawerOpen = false;
-        void host._openLogs(e.detail);
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+        host._openLogs(e.detail);
       }}
       @clean-build=${(e: CustomEvent<ConfiguredDevice>) => {
         host._drawerOpen = false;

--- a/src/components/dashboard/render-dialogs.ts
+++ b/src/components/dashboard/render-dialogs.ts
@@ -149,14 +149,16 @@ export function executeConfirm(
       const selected = [...host._selectedDevices];
       host._selectMode = false;
       host._selectedDevices = new Set();
-      void deleteBulkDevices(selected, host._devices, host._api, host._localize);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+      deleteBulkDevices(selected, host._devices, host._api, host._localize);
       return;
     }
     case "archive-bulk": {
       const selected = [...host._selectedDevices];
       host._selectMode = false;
       host._selectedDevices = new Set();
-      void archiveBulkDevices(selected, host._devices, host._api, host._localize);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+      archiveBulkDevices(selected, host._devices, host._api, host._localize);
       return;
     }
     case "delete-single":

--- a/src/components/dashboard/render-dialogs.ts
+++ b/src/components/dashboard/render-dialogs.ts
@@ -149,14 +149,14 @@ export function executeConfirm(
       const selected = [...host._selectedDevices];
       host._selectMode = false;
       host._selectedDevices = new Set();
-      deleteBulkDevices(selected, host._devices, host._api, host._localize);
+      void deleteBulkDevices(selected, host._devices, host._api, host._localize);
       return;
     }
     case "archive-bulk": {
       const selected = [...host._selectedDevices];
       host._selectMode = false;
       host._selectedDevices = new Set();
-      archiveBulkDevices(selected, host._devices, host._api, host._localize);
+      void archiveBulkDevices(selected, host._devices, host._api, host._localize);
       return;
     }
     case "delete-single":

--- a/src/components/dashboard/render-yaml.ts
+++ b/src/components/dashboard/render-yaml.ts
@@ -55,7 +55,7 @@ function renderSnippetBlock(
       @click=${(e: MouseEvent) => {
         if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
         e.preventDefault();
-        navigate(href);
+        void navigate(href);
       }}
     >
       ${block.lines.map((text, i) => {
@@ -91,7 +91,7 @@ function renderYamlDeviceTitle(
           @click=${(e: MouseEvent) => {
             if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
             e.preventDefault();
-            navigate(deviceHref);
+            void navigate(deviceHref);
           }}
           >${label}</a
         >

--- a/src/components/dashboard/render-yaml.ts
+++ b/src/components/dashboard/render-yaml.ts
@@ -55,7 +55,8 @@ function renderSnippetBlock(
       @click=${(e: MouseEvent) => {
         if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
         e.preventDefault();
-        void navigate(href);
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+        navigate(href);
       }}
     >
       ${block.lines.map((text, i) => {
@@ -91,7 +92,8 @@ function renderYamlDeviceTitle(
           @click=${(e: MouseEvent) => {
             if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
             e.preventDefault();
-            void navigate(deviceHref);
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+            navigate(deviceHref);
           }}
           >${label}</a
         >

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -301,7 +301,7 @@ export class ESPHomeTableRowMenu extends LitElement {
     const vh = window.innerHeight;
     const pad = 8;
 
-    let x = this.position.x;
+    const x = this.position.x;
     let y = this.position.y;
     let useRight = this.anchorRight;
 

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -199,7 +199,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._submitError = "";
     this._submitting = false;
     this._dialog.open = true;
-    this.updateComplete.then(() => this._catalog?.load());
+    void this.updateComplete.then(() => this._catalog?.load());
   }
 
   /**
@@ -215,7 +215,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._submitError = "";
     this._submitting = false;
     this._dialog.open = true;
-    this.updateComplete.then(() => this._catalog?.filterByDomain(domain));
+    void this.updateComplete.then(() => this._catalog?.filterByDomain(domain));
   }
 
   /** See ``navigateToDep`` for the seq-counter contract. */

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -199,7 +199,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._submitError = "";
     this._submitting = false;
     this._dialog.open = true;
-    void this.updateComplete.then(() => this._catalog?.load());
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+    this.updateComplete.then(() => this._catalog?.load());
   }
 
   /**
@@ -215,7 +216,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._submitError = "";
     this._submitting = false;
     this._dialog.open = true;
-    void this.updateComplete.then(() => this._catalog?.filterByDomain(domain));
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+    this.updateComplete.then(() => this._catalog?.filterByDomain(domain));
   }
 
   /** See ``navigateToDep`` for the seq-counter contract. */

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -256,7 +256,7 @@ export class ESPHomeComponentCatalog extends LitElement {
     // A late web-font swap changes wrap heights without a resize or a
     // render, stranding stale expand buttons; re-measure once fonts
     // settle. Optional-chained: happy-dom has no document.fonts.
-    document.fonts?.ready.then(() => this._measureDescriptionOverflow());
+    void document.fonts?.ready.then(() => this._measureDescriptionOverflow());
   }
 
   protected updated() {

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -256,7 +256,8 @@ export class ESPHomeComponentCatalog extends LitElement {
     // A late web-font swap changes wrap heights without a resize or a
     // render, stranding stale expand buttons; re-measure once fonts
     // settle. Optional-chained: happy-dom has no document.fonts.
-    void document.fonts?.ready.then(() => this._measureDescriptionOverflow());
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+    document.fonts?.ready.then(() => this._measureDescriptionOverflow());
   }
 
   protected updated() {

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -874,7 +874,6 @@ export class ESPHomeConfigEntryForm extends LitElement {
       // shape is wrong) leaves the user staring at empty space —
       // the visible form looks correct, the data appears gone,
       // and the only signal is in the dev console.
-
       console.error(
         "esphome-config-entry-form: render failed for entry",
         { key: entry.key, type: entry.type, path },

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -478,7 +478,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // material value, the same rule ``filterRenderable`` uses to keep pre-filled
     // advanced leaves visible. Every other host keeps the whole advanced group
     // gated (inline: none), so the split runs only under gateAdvanced.
-    let inlineAdvanced: (ConfigEntry | ConfigEntry[])[] = [];
+    const inlineAdvanced: (ConfigEntry | ConfigEntry[])[] = [];
     let gatedAdvanced = advanced;
     if (this.gateAdvanced) {
       const unitPrefilled = (item: ConfigEntry | ConfigEntry[]): boolean => {
@@ -874,7 +874,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
       // shape is wrong) leaves the user staring at empty space —
       // the visible form looks correct, the data appears gone,
       // and the only signal is in the dev console.
-      // eslint-disable-next-line no-console
+
       console.error(
         "esphome-config-entry-form: render failed for entry",
         { key: entry.key, type: entry.type, path },

--- a/src/components/device/constraint-cluster-controller.ts
+++ b/src/components/device/constraint-cluster-controller.ts
@@ -68,6 +68,6 @@ export class ConstraintClusterController implements ReactiveController {
     // ones that are and let the next render recover, rather than aborting the
     // whole pass (don't "fix" this into a throw).
     await Promise.all(groups.map((group) => group.updateComplete?.catch(() => {})));
-    for (const group of groups) group.syncRadioElements?.();
+    for (const group of groups) void group.syncRadioElements?.();
   }
 }

--- a/src/components/device/constraint-cluster-controller.ts
+++ b/src/components/device/constraint-cluster-controller.ts
@@ -68,6 +68,7 @@ export class ConstraintClusterController implements ReactiveController {
     // ones that are and let the next render recover, rather than aborting the
     // whole pass (don't "fix" this into a throw).
     await Promise.all(groups.map((group) => group.updateComplete?.catch(() => {})));
-    for (const group of groups) void group.syncRadioElements?.();
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+    for (const group of groups) group.syncRadioElements?.();
   }
 }

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -141,7 +141,7 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
     // await; doing that in willUpdate folds it into the in-progress render
     // instead of scheduling a second one.
     if (changedProperties.has("board")) {
-      this._refreshAlternateBoards();
+      void this._refreshAlternateBoards();
     }
   }
 

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -141,7 +141,8 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
     // await; doing that in willUpdate folds it into the in-progress render
     // instead of scheduling a second one.
     if (changedProperties.has("board")) {
-      void this._refreshAlternateBoards();
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+      this._refreshAlternateBoards();
     }
   }
 

--- a/src/components/device/secret-value.ts
+++ b/src/components/device/secret-value.ts
@@ -309,7 +309,8 @@ export class ESPHomeSecretValue extends LitElement {
       @keydown=${(e: KeyboardEvent) => {
         if (e.key === "Enter") {
           e.preventDefault();
-          this.present ? this._save() : this._create();
+          if (this.present) this._save();
+          else this._create();
         }
       }}
     ></esphome-password-input>`;

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -387,7 +387,7 @@ export class ESPHomeHeaderActions extends OverflowMenuElement {
 
   private _openSecrets() {
     this._close();
-    navigate("/secrets");
+    void navigate("/secrets");
   }
 
   /** Opens the Wi-Fi credentials dialog on demand. The kebab item

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -387,7 +387,8 @@ export class ESPHomeHeaderActions extends OverflowMenuElement {
 
   private _openSecrets() {
     this._close();
-    void navigate("/secrets");
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+    navigate("/secrets");
   }
 
   /** Opens the Wi-Fi credentials dialog on demand. The kebab item

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -596,12 +596,14 @@ export function compileAndWait(
   host: ESPHomeFirmwareInstallDialog,
   configuration: string
 ): Promise<void> {
-  return new Promise(async (resolve, reject) => {
+  return new Promise((resolve, reject) => {
     // Capture reject on the dialog so a mid-flight detach (header-X / Escape /
     // reopen) can settle this promise. followJob callbacks clear the hook to
     // null on fire so a normal completion doesn't double-reject on teardown.
     host._compileReject = reject;
-    try {
+    // Not an async executor: a throw before the first await would be
+    // swallowed by the Promise constructor instead of rejecting.
+    const start = async () => {
       const job = await host._api.firmwareCompile(configuration);
       host._jobId = job.job_id;
       // Capture so a compile failure can pick the right hint variant:
@@ -645,9 +647,10 @@ export function compileAndWait(
           reject(new Error(error));
         },
       });
-    } catch (err) {
+    };
+    start().catch((err: unknown) => {
       host._compileReject = null;
-      reject(err);
-    }
+      reject(err instanceof Error ? err : new Error(String(err)));
+    });
   });
 }

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -601,8 +601,8 @@ export function compileAndWait(
     // reopen) can settle this promise. followJob callbacks clear the hook to
     // null on fire so a normal completion doesn't double-reject on teardown.
     host._compileReject = reject;
-    // Not an async executor: a throw before the first await would be
-    // swallowed by the Promise constructor instead of rejecting.
+    // Not an async executor (no-misused-promises): an async function
+    // where the constructor expects a void-returning one.
     const start = async () => {
       const job = await host._api.firmwareCompile(configuration);
       host._jobId = job.job_id;
@@ -650,7 +650,8 @@ export function compileAndWait(
     };
     start().catch((err: unknown) => {
       host._compileReject = null;
-      reject(err instanceof Error ? err : new Error(String(err)));
+      // Raw rejection: compileFailureDetail normalizes downstream.
+      reject(err);
     });
   });
 }

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -272,7 +272,8 @@ export class ESPHomeLogsDialog extends LitElement {
        back to the bottom themselves. ``scrollToBottom()`` clears the
        flag and forces a scroll. updateComplete makes sure the @query
        has resolved on first open. */
-    void this.updateComplete.then(() => this._terminal?.scrollToBottom());
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+    this.updateComplete.then(() => this._terminal?.scrollToBottom());
   }
 
   protected render() {

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -272,7 +272,7 @@ export class ESPHomeLogsDialog extends LitElement {
        back to the bottom themselves. ``scrollToBottom()`` clears the
        flag and forces a scroll. updateComplete makes sure the @query
        has resolved on first open. */
-    this.updateComplete.then(() => this._terminal?.scrollToBottom());
+    void this.updateComplete.then(() => this._terminal?.scrollToBottom());
   }
 
   protected render() {
@@ -320,7 +320,7 @@ export class ESPHomeLogsDialog extends LitElement {
                     icon: "arrow-left",
                     label: this._localize("dashboard.logs_back_to_install"),
                     title: this._localize("dashboard.logs_back_to_install_tooltip"),
-                    onClick: this._onBackToInstall,
+                    onClick: () => void this._onBackToInstall(),
                   })}
                 </div>`
               : ""
@@ -359,14 +359,14 @@ export class ESPHomeLogsDialog extends LitElement {
                     icon: "restart",
                     label: this._localize("dashboard.logs_reset_device"),
                     disabled: !hasSerialPort(s),
-                    onClick: this._onResetDevice,
+                    onClick: () => void this._onResetDevice(),
                   })
                 : isOtaNetwork(s)
                   ? // States arrive only over the network/API connection, so the
                     // toggle is hidden for a server serial source (#539).
                     renderTermToggle({
                       active: this._showStates,
-                      onClick: this._toggleShowStates,
+                      onClick: () => void this._toggleShowStates(),
                       icon: "pulse",
                       label: this._localize("dashboard.logs_states"),
                       title: toggleLabel,

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -53,7 +53,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
   }
 
   // Enter submits; _save() self-guards on a blank SSID / too-short password.
-  private _enter = new EnterController(this, () => this._save());
+  private _enter = new EnterController(this, () => void this._save());
 
   open() {
     this._ssid = "";

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -268,8 +268,8 @@ export class ESPHomePairBuildServerDialog extends LitElement {
   // Enter submits the current step; the read-only "sent" step has no action.
   // Each handler self-guards on its own validity (empty hostname, labels).
   private _enterAction(): (() => void) | undefined {
-    if (this._step === "input") return this._onPreviewSubmit;
-    if (this._step === "confirm") return this._onConfirmSubmit;
+    if (this._step === "input") return () => void this._onPreviewSubmit();
+    if (this._step === "confirm") return () => void this._onConfirmSubmit();
     return undefined;
   }
 }

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -1036,7 +1036,8 @@ export class ESPHomePageDashboard extends LitElement {
     () => this._localize
   );
   _onRequestOpenEditor = (e: CustomEvent<{ configuration: string }>) => {
-    void navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+    navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
   };
 
   /** Chip-mismatch recovery hand-off from the install dialog. */

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -390,7 +390,7 @@ export class ESPHomePageDashboard extends LitElement {
     if (!this._showIgnored) this._showDiscovered = true;
     this._toggleShowIgnored();
   };
-  private _onShowArchivedDialog = () => this._archivedDialog?.open();
+  private _onShowArchivedDialog = () => void this._archivedDialog?.open();
 
   _onEnterSelectMode = (configuration?: string) => {
     this._selectMode = true;
@@ -1036,7 +1036,7 @@ export class ESPHomePageDashboard extends LitElement {
     () => this._localize
   );
   _onRequestOpenEditor = (e: CustomEvent<{ configuration: string }>) => {
-    navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
+    void navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
   };
 
   /** Chip-mismatch recovery hand-off from the install dialog. */

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -388,6 +388,8 @@ export class ESPHomePageDevice extends LitElement {
   private _installCtrl = this._createInstallController();
 
   private _createInstallController(): DeviceInstallController {
+    // The object literal's getter below rebinds `this`.
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const page = this;
     return new DeviceInstallController({
       addController: (c) => page.addController(c),
@@ -531,7 +533,7 @@ export class ESPHomePageDevice extends LitElement {
     if (!this._isDirty) return;
     e.stopImmediatePropagation();
     window.history.pushState({}, "", withBase(`/device/${this.id}`));
-    this._confirmLeave().then((canLeave) => {
+    void this._confirmLeave().then((canLeave) => {
       if (canLeave) {
         this._allowingLeave = true;
         window.history.back();
@@ -541,7 +543,7 @@ export class ESPHomePageDevice extends LitElement {
 
   async connectedCallback() {
     super.connectedCallback();
-    this._loadPreferences();
+    void this._loadPreferences();
     setLeaveGuard(this._confirmLeave);
     window.addEventListener("beforeunload", this._onBeforeUnload);
     window.addEventListener("popstate", this._onPopState, { capture: true });
@@ -607,7 +609,7 @@ export class ESPHomePageDevice extends LitElement {
       if (this._backendErrors.length) this._backendErrors = [];
       this._heldUnknownInstance = null;
       this._kickKnownKeys();
-      this._loadYaml();
+      void this._loadYaml();
     }
     // Devices context arrives async after connect; kick off the board
     // fetch as soon as we have a `board_id` (and re-fetch only when it
@@ -620,7 +622,7 @@ export class ESPHomePageDevice extends LitElement {
       // ``board_id``. Restored on success, left null on failure.
       this._board = null;
       this._platformReady = false;
-      this._loadBoard(boardId);
+      void this._loadBoard(boardId);
     } else if (!boardId) {
       // No manifest to fetch (device has no ``board_id`` or our
       // id isn't in the loaded context — deleted / stale link).
@@ -1153,7 +1155,7 @@ export class ESPHomePageDevice extends LitElement {
   private _onRequestOpenEditor = (e: CustomEvent<{ configuration: string }>) => {
     e.stopPropagation();
     if (e.detail.configuration === this._device?.configuration) return;
-    navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
+    void navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
   };
 
   static styles = [espHomeStyles, devicePageStyles];

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -533,7 +533,8 @@ export class ESPHomePageDevice extends LitElement {
     if (!this._isDirty) return;
     e.stopImmediatePropagation();
     window.history.pushState({}, "", withBase(`/device/${this.id}`));
-    void this._confirmLeave().then((canLeave) => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+    this._confirmLeave().then((canLeave) => {
       if (canLeave) {
         this._allowingLeave = true;
         window.history.back();
@@ -543,7 +544,8 @@ export class ESPHomePageDevice extends LitElement {
 
   async connectedCallback() {
     super.connectedCallback();
-    void this._loadPreferences();
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+    this._loadPreferences();
     setLeaveGuard(this._confirmLeave);
     window.addEventListener("beforeunload", this._onBeforeUnload);
     window.addEventListener("popstate", this._onPopState, { capture: true });
@@ -609,7 +611,8 @@ export class ESPHomePageDevice extends LitElement {
       if (this._backendErrors.length) this._backendErrors = [];
       this._heldUnknownInstance = null;
       this._kickKnownKeys();
-      void this._loadYaml();
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+      this._loadYaml();
     }
     // Devices context arrives async after connect; kick off the board
     // fetch as soon as we have a `board_id` (and re-fetch only when it
@@ -622,7 +625,8 @@ export class ESPHomePageDevice extends LitElement {
       // ``board_id``. Restored on success, left null on failure.
       this._board = null;
       this._platformReady = false;
-      void this._loadBoard(boardId);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+      this._loadBoard(boardId);
     } else if (!boardId) {
       // No manifest to fetch (device has no ``board_id`` or our
       // id isn't in the loaded context — deleted / stale link).
@@ -1155,7 +1159,8 @@ export class ESPHomePageDevice extends LitElement {
   private _onRequestOpenEditor = (e: CustomEvent<{ configuration: string }>) => {
     e.stopPropagation();
     if (e.detail.configuration === this._device?.configuration) return;
-    void navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
+    navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
   };
 
   static styles = [espHomeStyles, devicePageStyles];

--- a/src/util/batched-cache.ts
+++ b/src/util/batched-cache.ts
@@ -67,7 +67,7 @@ export class BatchedCache<V, Ctx> {
       if (bucket === undefined) {
         bucket = { api, ctx, pending: new Map() };
         this._batches.set(bk, bucket);
-        queueMicrotask(() => this._flush(bk));
+        queueMicrotask(() => void this._flush(bk));
       }
       bucket.pending.set(key, { resolve, reject });
     }).finally(() => {

--- a/src/util/safe-upload-filename.ts
+++ b/src/util/safe-upload-filename.ts
@@ -72,7 +72,6 @@ const WINDOWS_RESERVED_NAMES = new Set([
 export function safeUploadFilename(stem: string): string {
   const cleaned = stem
     .replace(/[/\\]/g, "")
-
     .replace(/[<>:"|?*#\x00-\x1f]/g, "")
     .replace(/^[\s.]+|[\s.]+$/g, "");
   // Windows reserves the device name regardless of any trailing

--- a/src/util/safe-upload-filename.ts
+++ b/src/util/safe-upload-filename.ts
@@ -72,7 +72,7 @@ const WINDOWS_RESERVED_NAMES = new Set([
 export function safeUploadFilename(stem: string): string {
   const cleaned = stem
     .replace(/[/\\]/g, "")
-    // eslint-disable-next-line no-control-regex
+
     .replace(/[<>:"|?*#\x00-\x1f]/g, "")
     .replace(/^[\s.]+|[\s.]+$/g, "");
   // Windows reserves the device name regardless of any trailing

--- a/src/util/stacktrace-decoder.ts
+++ b/src/util/stacktrace-decoder.ts
@@ -62,10 +62,9 @@ class HostedDecoder {
     if (!target) return null;
     const id = `d${++this._seq}`;
     return new Promise((resolve) => {
-      let timer: ReturnType<typeof setTimeout> | undefined;
       const done = (frames: DecodedFrame[] | null) => {
         window.removeEventListener("message", onMessage);
-        if (timer !== undefined) clearTimeout(timer);
+        clearTimeout(timer);
         resolve(frames);
       };
       const onMessage = (ev: MessageEvent) => {
@@ -76,7 +75,7 @@ class HostedDecoder {
         else if (data.type === MSG_ERROR) done(null);
       };
       window.addEventListener("message", onMessage);
-      timer = setTimeout(() => done(null), DECODE_TIMEOUT_MS);
+      const timer = setTimeout(() => done(null), DECODE_TIMEOUT_MS);
       try {
         // Cloned, not transferred. The decoder is a foreign origin, so the
         // bytes cross a process boundary and get copied either way; transferring
@@ -117,10 +116,9 @@ class HostedDecoder {
       frame.src = `${DECODER_URL}#nonce=${encodeURIComponent(nonce)}&origin=${encodeURIComponent(
         location.origin
       )}`;
-      let timer: ReturnType<typeof setTimeout> | undefined;
       const settle = (ok: boolean) => {
         window.removeEventListener("message", onReady);
-        if (timer !== undefined) clearTimeout(timer);
+        clearTimeout(timer);
         if (!ok) frame.remove();
         resolve(ok);
       };
@@ -154,7 +152,7 @@ class HostedDecoder {
       window.addEventListener("message", onReady);
       // The page is unreachable when offline or when Pages is down, and an
       // iframe that never loads fires no error we can rely on, so time out.
-      timer = setTimeout(() => settle(false), READY_TIMEOUT_MS);
+      const timer = setTimeout(() => settle(false), READY_TIMEOUT_MS);
       document.body.appendChild(frame);
     });
   }

--- a/src/util/trailing-edge-dispatcher.ts
+++ b/src/util/trailing-edge-dispatcher.ts
@@ -87,7 +87,6 @@ export class TrailingEdgeDispatcher<T> {
       try {
         await this._runner(input);
       } catch (err) {
-        // eslint-disable-next-line no-console
         console.debug("TrailingEdgeDispatcher: runner threw", err);
       }
     } finally {

--- a/src/util/usb-flasher.ts
+++ b/src/util/usb-flasher.ts
@@ -55,9 +55,7 @@ export function openFlasher(
 
   let bytes: ArrayBuffer | null = firmware;
   const controller = new AbortController();
-  let readyTimer: ReturnType<typeof setTimeout> | undefined;
   let watchdog: ReturnType<typeof setTimeout> | undefined;
-  let closePoll: ReturnType<typeof setInterval> | undefined;
   let finished = false;
   let handedOff = false;
   // True while the user is sitting on a delivered error (the tab stays open for
@@ -169,13 +167,13 @@ export function openFlasher(
   };
 
   window.addEventListener("message", onMessage, { signal: controller.signal });
-  closePoll = setInterval(() => {
+  const closePoll = setInterval(() => {
     if (!win.closed) return;
     // The dialog already shows the real error; a quiet finish keeps it instead
     // of overwriting with "lost contact".
     if (errored) finish();
     else lost();
   }, 1000);
-  readyTimer = setTimeout(lost, READY_TIMEOUT_MS);
+  const readyTimer = setTimeout(lost, READY_TIMEOUT_MS);
   return finish;
 }

--- a/src/util/usb-flasher.ts
+++ b/src/util/usb-flasher.ts
@@ -71,9 +71,9 @@ export function openFlasher(
     if (finished) return;
     finished = true;
     controller.abort();
-    if (readyTimer !== undefined) clearTimeout(readyTimer);
+    clearTimeout(readyTimer);
     if (watchdog !== undefined) clearTimeout(watchdog);
-    if (closePoll !== undefined) clearInterval(closePoll);
+    clearInterval(closePoll);
   };
   const lost = () => {
     if (finished) return;
@@ -92,7 +92,7 @@ export function openFlasher(
     };
     if (!data?.type) return;
     if (data.type === MSG_READY) {
-      if (readyTimer !== undefined) clearTimeout(readyTimer);
+      clearTimeout(readyTimer);
       if (handedOff || !bytes) return;
       // Forward-compat: a flasher advertising a newer protocol still gets our
       // v1 frame (additive fields are ignored); just note the mismatch. When a

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -140,7 +140,7 @@ describe("ESPHomeAPI — sendCommand", () => {
   it("omits args when none are given", async () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
-    api.sendCommand("ping");
+    void api.sendCommand("ping");
     const sent = ws.sentAs<{ args?: unknown }>(0);
     expect(sent.args).toBeUndefined();
   });
@@ -191,8 +191,8 @@ describe("ESPHomeAPI — sendCommand", () => {
   it("assigns sequential message_ids", async () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
-    api.sendCommand("a");
-    api.sendCommand("b");
+    void api.sendCommand("a");
+    void api.sendCommand("b");
     const id0 = ws.sentAs<{ message_id: string }>(0).message_id;
     const id1 = ws.sentAs<{ message_id: string }>(1).message_id;
     expect(Number(id1)).toBe(Number(id0) + 1);
@@ -289,7 +289,7 @@ describe("ESPHomeAPI — cloneDevice", () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
 
-    api.cloneDevice("kitchen.yaml", "bedroom-bulb");
+    void api.cloneDevice("kitchen.yaml", "bedroom-bulb");
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
 
     expect(sent.args).toEqual({
@@ -309,7 +309,7 @@ describe("ESPHomeAPI — cloneDevice", () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
 
-    api.cloneDevice("kitchen.yaml", "bedroom-bulb", "");
+    void api.cloneDevice("kitchen.yaml", "bedroom-bulb", "");
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
 
     expect(sent.args).toEqual({
@@ -621,7 +621,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     ws.receive({ message_id: streamId, event: "output", data: "before-stop" });
     expect(onOutput).toHaveBeenCalledWith("before-stop");
 
-    api.stopStream(streamId);
+    void api.stopStream(streamId);
 
     // Anything that arrives after stop — whether genuinely racing or a
     // misbehaving backend that keeps sending — must not reach the caller.
@@ -775,7 +775,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   it("firmwareInstall defaults port to OTA, force_local and bootloader to false", async () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
-    api.firmwareInstall("foo.yaml");
+    void api.firmwareInstall("foo.yaml");
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
     expect(sent.args).toEqual({
       configuration: "foo.yaml",
@@ -788,7 +788,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   it("firmwareInstall threads force_local through to the backend", async () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
-    api.firmwareInstall("foo.yaml", "OTA", true);
+    void api.firmwareInstall("foo.yaml", "OTA", true);
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
     expect(sent.args).toEqual({
       configuration: "foo.yaml",
@@ -801,7 +801,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   it("firmwareInstall threads bootloader through to the backend", async () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
-    api.firmwareInstall("foo.yaml", "OTA", false, true);
+    void api.firmwareInstall("foo.yaml", "OTA", false, true);
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
     expect(sent.args).toEqual({
       configuration: "foo.yaml",
@@ -854,7 +854,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   it("updatePreferences passes the partial prefs as args", async () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
-    api.updatePreferences({ theme: "dark" as never });
+    void api.updatePreferences({ theme: "dark" as never });
     const sent = ws.sentAs<{ command: string; args: Record<string, unknown> }>(0);
     expect(sent.command).toBe("config/set_preferences");
     expect(sent.args).toEqual({ theme: "dark" });
@@ -1682,7 +1682,7 @@ describe("ESPHomeAPI — automations catalog", () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
 
-    api.getAutomationTriggers("esp32", "esp32-s3-devkitc-1");
+    void api.getAutomationTriggers("esp32", "esp32-s3-devkitc-1");
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
     expect(sent.args).toEqual({
       platform: "esp32",
@@ -1796,7 +1796,7 @@ describe("ESPHomeAPI — getComponentBodies", () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
 
-    api.getComponentBodies(["wifi"], "esp32", "esp32-s3-devkitc-1");
+    void api.getComponentBodies(["wifi"], "esp32", "esp32-s3-devkitc-1");
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
     expect(sent.args).toEqual({
       component_ids: ["wifi"],
@@ -1809,7 +1809,7 @@ describe("ESPHomeAPI — getComponentBodies", () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
 
-    api.getComponentBodies(["wifi"]);
+    void api.getComponentBodies(["wifi"]);
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
     expect(sent.args).toEqual({ component_ids: ["wifi"] });
     expect("platform" in sent.args).toBe(false);

--- a/test/components/dashboard/stream-serial-to-dialog.test.ts
+++ b/test/components/dashboard/stream-serial-to-dialog.test.ts
@@ -65,6 +65,11 @@ function createMockPort(chunks: Uint8Array[]) {
     },
     close: vi.fn(async () => {}),
     _reader: reader,
+    // Structural stand-in for the real port; the stream only touches
+    // readable/close.
+  } as unknown as SerialPort & {
+    _reader: typeof reader;
+    close: ReturnType<typeof vi.fn>;
   };
 }
 

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -422,7 +422,6 @@ describe("add-automation-dialog sub-entity targets (#1263)", () => {
       "aht20_temperature",
     ]);
     // Entity triggers are now offered.
-
     expect(
       (dialog as unknown as { _filteredTriggers(): { id: string }[] })
         ._filteredTriggers()

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -422,9 +422,11 @@ describe("add-automation-dialog sub-entity targets (#1263)", () => {
       "aht20_temperature",
     ]);
     // Entity triggers are now offered.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     expect(
-      (dialog as any)._filteredTriggers().map((t: { id: string }) => t.id)
+      (dialog as unknown as { _filteredTriggers(): { id: string }[] })
+        ._filteredTriggers()
+        .map((t) => t.id)
     ).toContain("sensor.on_value_range");
   });
 

--- a/test/components/device/automation-editor/catalog-picker-dialog.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog.test.ts
@@ -15,11 +15,11 @@
 import { describe, expect, it } from "vitest";
 
 async function readSource(): Promise<string> {
-  // @ts-ignore — node-only modules
+  // @ts-expect-error node-only module; tsconfig types are restricted
   const fs = await import("node:fs");
-  // @ts-ignore
+  // @ts-expect-error node-only module; tsconfig types are restricted
   const path = await import("node:path");
-  // @ts-ignore
+  // @ts-expect-error node-only module; tsconfig types are restricted
   const url = await import("node:url");
   const here = path.dirname(url.fileURLToPath(import.meta.url));
   return fs.readFileSync(

--- a/test/components/device/config-entry-form-map-sync.test.ts
+++ b/test/components/device/config-entry-form-map-sync.test.ts
@@ -47,8 +47,7 @@ const logsEntry = () =>
  *  routed through the real select renderer, and return every
  *  ``data-field-key`` decoded back to a path. */
 function renderedFieldPaths(values: Record<string, unknown>): string[][] {
-  let ctx: RenderCtx;
-  ctx = makeRenderCtx(values, {
+  const ctx: RenderCtx = makeRenderCtx(values, {
     overrides: { renderEntry: (entry, path) => renderSelectField(entry, path, ctx) },
   });
   const result = renderMapField(logsEntry(), ["logs"], ctx);

--- a/test/components/logs-dialog-decode.test.ts
+++ b/test/components/logs-dialog-decode.test.ts
@@ -24,11 +24,19 @@ const CRASH = [
 
 describe("logs-dialog inline backtrace decode", () => {
   let el: ESPHomeLogsDialog;
-  let decodeBacktrace: ReturnType<typeof vi.fn>;
+  type DecodeMock = (
+    configuration: string,
+    lines: string[]
+  ) => Promise<{
+    decoded: { index: number; text: string }[];
+    stale_build: boolean;
+    unavailable_reason: string;
+  }>;
+  let decodeBacktrace: ReturnType<typeof vi.fn<DecodeMock>>;
 
   beforeEach(() => {
     el = new ESPHomeLogsDialog();
-    decodeBacktrace = vi.fn(async () => ({
+    decodeBacktrace = vi.fn<DecodeMock>(async () => ({
       decoded: [{ index: 2, text: "Decoded 0x400d1a2c: loop() at main.cpp:42" }],
       stale_build: false,
       unavailable_reason: "",

--- a/test/components/update-all-dialog.test.ts
+++ b/test/components/update-all-dialog.test.ts
@@ -52,7 +52,7 @@ async function mount(
   internals._localize = (key, args) =>
     args?.count !== undefined ? `${key}:${args.count}` : key;
   document.body.appendChild(el);
-  el.open();
+  void el.open();
   await el.updateComplete;
   return el;
 }

--- a/test/util/environment.test.ts
+++ b/test/util/environment.test.ts
@@ -5,7 +5,6 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import { detectEnvironment } from "../../src/util/environment.js";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 const origLocation = Object.getOwnPropertyDescriptor(window, "location");
 const setHost = (hostname: string) =>
   Object.defineProperty(window, "location", { configurable: true, value: { hostname } });
@@ -14,7 +13,6 @@ const api = (haAddon = false) => ({ serverInfo: { ha_addon: haAddon } }) as ESPH
 afterEach(() => {
   if (origLocation) Object.defineProperty(window, "location", origLocation);
 });
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 describe("detectEnvironment", () => {
   it("ha_addon wins regardless of host", () => {

--- a/test/util/esphome-schema.test.ts
+++ b/test/util/esphome-schema.test.ts
@@ -63,11 +63,11 @@ const SENSOR_BUNDLE = {
   },
 };
 
-let fetchSpy: ReturnType<typeof vi.fn>;
+let fetchSpy: ReturnType<typeof vi.fn<(url: string) => Promise<Response>>>;
 
 beforeEach(() => {
   _resetSchemaCacheForTests();
-  fetchSpy = vi.fn();
+  fetchSpy = vi.fn<(url: string) => Promise<Response>>();
   // ``vi.stubGlobal`` is the repo's convention for swapping
   // built-ins; matching ``vi.unstubAllGlobals`` in afterEach
   // restores the original ``fetch`` so a later test that doesn't

--- a/test/util/pairing-window-controller.test.ts
+++ b/test/util/pairing-window-controller.test.ts
@@ -79,6 +79,7 @@ describe("PairingWindowController", () => {
   });
 
   it("auto-open parks quietly until the api context lands, then opens", () => {
+    // eslint-disable-next-line prefer-const -- assigned later to simulate the api context landing
     let api: ReturnType<typeof makeApi> | undefined;
     const onOpenFailed = vi.fn();
     const host = new FakeHost();

--- a/test/util/pairing-window-controller.test.ts
+++ b/test/util/pairing-window-controller.test.ts
@@ -79,7 +79,6 @@ describe("PairingWindowController", () => {
   });
 
   it("auto-open parks quietly until the api context lands, then opens", () => {
-    // eslint-disable-next-line prefer-const -- assigned later to simulate the api context landing
     let api: ReturnType<typeof makeApi> | undefined;
     const onOpenFailed = vi.fn();
     const host = new FakeHost();

--- a/test/util/remote-build-identity-controller.test.ts
+++ b/test/util/remote-build-identity-controller.test.ts
@@ -45,7 +45,6 @@ describe("RemoteBuildIdentityController", () => {
 
   it("retries on a later host update once the api context lands", async () => {
     const host = new FakeHost();
-    // eslint-disable-next-line prefer-const -- assigned later to simulate the api context landing
     let api: ESPHomeAPI | undefined;
     const ctrl = new RemoteBuildIdentityController(host, () => api);
     ctrl.hostConnected();

--- a/test/util/remote-build-identity-controller.test.ts
+++ b/test/util/remote-build-identity-controller.test.ts
@@ -45,6 +45,7 @@ describe("RemoteBuildIdentityController", () => {
 
   it("retries on a later host update once the api context lands", async () => {
     const host = new FakeHost();
+    // eslint-disable-next-line prefer-const -- assigned later to simulate the api context landing
     let api: ESPHomeAPI | undefined;
     const ctrl = new RemoteBuildIdentityController(host, () => api);
     ctrl.hostConnected();

--- a/test/util/section-entry-overrides.test.ts
+++ b/test/util/section-entry-overrides.test.ts
@@ -169,11 +169,11 @@ describe("device-section-config wiring", () => {
   it("forwards renderEntries / resolveSectionEntries to the form's .entries prop", async () => {
     // tsconfig restricts `types` to @types/w3c-web-serial, so node
     // module specifiers don't type-check; vitest resolves them fine.
-    // @ts-ignore — node-only module
+    // @ts-expect-error node-only module; tsconfig types are restricted
     const fs = await import("node:fs");
-    // @ts-ignore — node-only module
+    // @ts-expect-error node-only module; tsconfig types are restricted
     const path = await import("node:path");
-    // @ts-ignore — node-only module
+    // @ts-expect-error node-only module; tsconfig types are restricted
     const url = await import("node:url");
     const here = path.dirname(url.fileURLToPath(import.meta.url));
     const sourcePath = path.resolve(
@@ -219,11 +219,11 @@ describe("device-section-config wiring", () => {
     // continuously, and the explicit Validate button runs the
     // full ESPHome compile against the saved file. The "x y is
     // invalid" feedback now flows through those two surfaces.
-    // @ts-ignore — node-only module
+    // @ts-expect-error node-only module; tsconfig types are restricted
     const fs = await import("node:fs");
-    // @ts-ignore — node-only module
+    // @ts-expect-error node-only module; tsconfig types are restricted
     const path = await import("node:path");
-    // @ts-ignore — node-only module
+    // @ts-expect-error node-only module; tsconfig types are restricted
     const url = await import("node:url");
     const here = path.dirname(url.fileURLToPath(import.meta.url));
     const sourcePath = path.resolve(

--- a/test/util/session-blob-cache-controller.test.ts
+++ b/test/util/session-blob-cache-controller.test.ts
@@ -52,7 +52,6 @@ describe("SessionBlobCacheController", () => {
 
   it("does not fetch while the api is absent, then fetches once it arrives", async () => {
     const { binding, fetcher } = bindingFor(["x"]);
-    // eslint-disable-next-line prefer-const -- assigned later to simulate the api context landing
     let api: ESPHomeAPI | undefined;
     const c = new SessionBlobCacheController(fakeHost(), binding, () => api);
     c.hostUpdated();

--- a/test/util/session-blob-cache-controller.test.ts
+++ b/test/util/session-blob-cache-controller.test.ts
@@ -52,6 +52,7 @@ describe("SessionBlobCacheController", () => {
 
   it("does not fetch while the api is absent, then fetches once it arrives", async () => {
     const { binding, fetcher } = bindingFor(["x"]);
+    // eslint-disable-next-line prefer-const -- assigned later to simulate the api context landing
     let api: ESPHomeAPI | undefined;
     const c = new SessionBlobCacheController(fakeHost(), binding, () => api);
     c.hostUpdated();

--- a/test/util/yaml-completion-top-level.test.ts
+++ b/test/util/yaml-completion-top-level.test.ts
@@ -210,7 +210,11 @@ describe("resolveAvailableEntries (platform-merged)", () => {
             .map((id) => [id, platformEntry])
         ),
     } as never;
-    const out = await (resolveAvailableEntries as unknown as Function)(
+    const out = await (
+      resolveAvailableEntries as unknown as (
+        ...args: unknown[]
+      ) => Promise<{ key: string }[]>
+    )(
       fakeApi,
       c,
       "platform", // parentKey from indent walker
@@ -237,13 +241,11 @@ describe("resolveAvailableEntries (platform-merged)", () => {
       getComponentBodies: async (ids: string[]) =>
         Object.fromEntries(ids.filter((id) => id === "wifi").map((id) => [id, body])),
     } as never;
-    const out = await (resolveAvailableEntries as unknown as Function)(
-      fakeApi,
-      c,
-      "wifi",
-      null,
-      null
-    );
+    const out = await (
+      resolveAvailableEntries as unknown as (
+        ...args: unknown[]
+      ) => Promise<{ key: string }[]>
+    )(fakeApi, c, "wifi", null, null);
     expect(out.map((e: { key: string }) => e.key)).toContain("ssid");
   });
 });

--- a/test/web/install-adoptable-dialog.test.ts
+++ b/test/web/install-adoptable-dialog.test.ts
@@ -4,10 +4,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 // runFlash drives the flow straight to "done" so the dialog shows its Continue
 // (Wi-Fi hand-off) button without touching real serial/firmware code.
 vi.mock("../../src/web/install/run-flash.js", () => ({
-  runFlash: vi.fn(async (_port: unknown, _plan: unknown, hooks: any) => {
-    hooks.onStep("done");
-    return true;
-  }),
+  runFlash: vi.fn(
+    async (_port: unknown, _plan: unknown, hooks: { onStep(step: string): void }) => {
+      hooks.onStep("done");
+      return true;
+    }
+  ),
 }));
 vi.mock("../../src/components/base-dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/button/button.js", () => ({}));


### PR DESCRIPTION
# What does this implement/fix?

Adopts ESLint as a fourth gate (script, pre-commit hook, CI step), closing the state where 303 `eslint-disable` comments existed with no ESLint anywhere. The config is typescript-eslint's recommended baseline plus the two type-aware promise rules that motivated the issue, `no-floating-promises` and `no-misused-promises` (with Lit's async lifecycle overrides exempted via `checksVoidReturn.inheritedMethods`), and the home-assistant/frontend `no-unused-vars` underscore conventions.

The repo pins TypeScript 7 (the native port) whose API typescript-eslint cannot load yet, so a `.pnpmfile.cjs` hook gives the typescript-eslint packages a private TS 6 dependency; the fast TS 7 `tsc --noEmit` gate is untouched and the two coexist.

The backlog the first run surfaced (179 findings) is fixed for real where a fix was safe and marked honestly where it was not: async handlers passed where void returns are expected are wrapped or properly typed (two untyped `vi.fn()` mocks accounted for 37 findings), the install flow's async promise executor is unwrapped per no-misused-promises, the dashboard table's 13 `any`s got real tanstack generics over the existing `DeviceRow`, `@ts-ignore` became described `@ts-expect-error`, and the rest are hoisted-timer `const` conversions and structural mock types. Per review discussion the ~25 unaudited fire and forget sites in `src/` are NOT blessed with `void` (which would claim each drop was reviewed); they carry `eslint-disable-next-line ... FIXME(#1505)` and #1505 tracks the per-site audit whose outcomes are the reviewed `void`, `await`, or `.catch`. Test-file voids stay: a request deliberately never settled so a test can assert on the wire is documented intent.

CI is restructured alongside: the single job is split into four parallel jobs (Prettier + ESLint, Type check, Tests, Build) plus a `summary` job that keeps the historical `Test and Lint` check context, so branch protection survives the split and future job reshuffles. One operational trap is documented in `.pnpmfile.cjs` itself: any edit to that file changes the `pnpmfileChecksum` pnpm stamps into the lockfile, so `pnpm install` must be re-run or frozen installs fail.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1501

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Maintenance / chore — `maintenance`
- [ ] Documentation only — `docs`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

