### PR TITLE
Await the section flush before the leave dialog

### DIFF
--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -220,8 +220,11 @@ export class AutoApplyController implements ReactiveController {
   /** Whether the most recent settled round failed — its edit never
    *  landed in the page's buffer and a settled round cannot be
    *  re-run, so leaving would discard it. Cleared by the next
-   *  round that lands, and dropped on a retarget (a reused element
-   *  re-pointed at a sibling holds no failed form state to protect). */
+   *  round that lands, and dropped on a retarget, hydrate, or
+   *  remount (replaced form state holds nothing to protect).
+   *  Tracks settle failures only: a round that lands but whose
+   *  draft the page rejects as superseded counts as landed — that
+   *  path already toasts its own discard. */
   get lastRoundFailed(): boolean {
     return this._lastRoundFailed;
   }

--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -137,6 +137,9 @@ export class AutoApplyController implements ReactiveController {
   private _detachedBasis: string | null = null;
   private _dirty = false;
   private _lastRoundFailed = false;
+  /** Section key the host was last seen bound to, so a retarget can
+   *  drop a latched failure (see ``hostUpdated``). */
+  private _boundSectionKey: string | null = null;
   // Whether the host element is on screen; a failure-path re-arm must not
   // schedule a write for a torn-down section.
   private _connected = false;
@@ -187,6 +190,17 @@ export class AutoApplyController implements ReactiveController {
     this._announceUnmount = null;
   }
 
+  hostUpdated(): void {
+    // Lit reuses the element across same-kind switches; a failure
+    // latched for the previous section must not block leaving the
+    // clean sibling the host now points at (its form state is gone
+    // with the retarget, so the latch protects nothing).
+    const key = this._host.location ? sectionKeyFromLocation(this._host.location) : null;
+    if (key === this._boundSectionKey) return;
+    this._boundSectionKey = key;
+    this._lastRoundFailed = false;
+  }
+
   /** Brief-window dirty flag covering the debounce gap so the global
    *  save button activates as soon as the user types. */
   get dirty(): boolean {
@@ -196,7 +210,8 @@ export class AutoApplyController implements ReactiveController {
   /** Whether the most recent settled round failed — its edit never
    *  landed in the page's buffer and a settled round cannot be
    *  re-run, so leaving would discard it. Cleared by the next
-   *  round that lands. */
+   *  round that lands, and dropped on a retarget (a reused element
+   *  re-pointed at a sibling holds no failed form state to protect). */
   get lastRoundFailed(): boolean {
     return this._lastRoundFailed;
   }
@@ -377,7 +392,16 @@ export class AutoApplyController implements ReactiveController {
       });
       this._lastRoundFailed = false;
     } catch (err) {
-      this._lastRoundFailed = true;
+      // A failure latched onto a re-pointed host would block leaving
+      // a clean sibling; the failed section's form state is gone with
+      // the retarget, so there is nothing left for the latch to
+      // protect. Same guard as the announce above.
+      if (
+        this._host.location !== null &&
+        sectionKeyFromLocation(this._host.location) === sectionKeyFromLocation(location)
+      ) {
+        this._lastRoundFailed = true;
+      }
       // A switch-path round resolves after the editor unmounted, so
       // ``_connected`` alone would silence the dominant path. The
       // page still being alive (live anchor) means the user must

--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -163,6 +163,9 @@ export class AutoApplyController implements ReactiveController {
     this._connected = true;
     this._detachedBasis = null;
     this._anchor = this._host.parentNode;
+    // A remount rebuilds the form from live YAML; the failed edit a
+    // latch protected is gone with the old form state.
+    this._lastRoundFailed = false;
     this._announceUnmount = announceSectionMount(this._host);
   }
 
@@ -198,6 +201,13 @@ export class AutoApplyController implements ReactiveController {
     const key = this._host.location ? sectionKeyFromLocation(this._host.location) : null;
     if (key === this._boundSectionKey) return;
     this._boundSectionKey = key;
+    this._lastRoundFailed = false;
+  }
+
+  /** The host replaced its form state with a fresh hydrate; the
+   *  failed edit the latch protected no longer exists, so keeping
+   *  it would refuse a leave over nothing. */
+  notifyHydrated(): void {
     this._lastRoundFailed = false;
   }
 

--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -136,6 +136,7 @@ export class AutoApplyController implements ReactiveController {
    *  re-pointed host loses the exemption via ``RETARGETED_EMITTER``. */
   private _detachedBasis: string | null = null;
   private _dirty = false;
+  private _lastRoundFailed = false;
   // Whether the host element is on screen; a failure-path re-arm must not
   // schedule a write for a torn-down section.
   private _connected = false;
@@ -190,6 +191,14 @@ export class AutoApplyController implements ReactiveController {
    *  save button activates as soon as the user types. */
   get dirty(): boolean {
     return this._dirty;
+  }
+
+  /** Whether the most recent settled round failed — its edit never
+   *  landed in the page's buffer and a settled round cannot be
+   *  re-run, so leaving would discard it. Cleared by the next
+   *  round that lands. */
+  get lastRoundFailed(): boolean {
+    return this._lastRoundFailed;
   }
 
   /** Disables the host's form chrome while a delete is running. */
@@ -366,7 +375,9 @@ export class AutoApplyController implements ReactiveController {
         basedOn: yaml,
         node: retargeted ? RETARGETED_EMITTER : this._host,
       });
+      this._lastRoundFailed = false;
     } catch (err) {
+      this._lastRoundFailed = true;
       // A switch-path round resolves after the editor unmounted, so
       // ``_connected`` alone would silence the dominant path. The
       // page still being alive (live anchor) means the user must

--- a/src/components/device/automation-editor/base-editor.ts
+++ b/src/components/device/automation-editor/base-editor.ts
@@ -130,6 +130,10 @@ export abstract class BaseAutomationEditor<L extends AutomationLocation>
     return this._engine.flushPending();
   }
 
+  public get lastFlushFailed(): boolean {
+    return this._engine.lastRoundFailed;
+  }
+
   static styles: CSSResultGroup = [espHomeStyles, inputStyles, automationEditorStyles];
 
   /** Loading spinner / parse-error panel that preempts the body

--- a/src/components/device/automation-editor/base-editor.ts
+++ b/src/components/device/automation-editor/base-editor.ts
@@ -198,6 +198,10 @@ export abstract class BaseAutomationEditor<L extends AutomationLocation>
       if (m) {
         this.location = m.location;
         this.value = m.tree;
+        // The re-read tree replaced the form state, failed edit
+        // included — a still-latched flush failure would refuse a
+        // leave over an edit that no longer exists.
+        this._engine.notifyHydrated();
       }
     } catch (err) {
       this._error = formatApiError(err, this._localize, "device.automation_parse_error");

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -323,6 +323,9 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
     settleOwnDraft(this);
   }
 
+  // The flush is a local splice — it cannot fail.
+  public readonly lastFlushFailed = false;
+
   // Reload config from live YAML. Two skip cases: (a) yaml exactly matches
   // what we wrote in _flushDraft (reload would re-parse our own write and
   // lose field focus), (b) a debounced flush is pending (form is mid-edit,

--- a/src/components/device/section-editor.ts
+++ b/src/components/device/section-editor.ts
@@ -24,6 +24,13 @@ export interface SectionEditor {
    *  settled buffer. */
   flushPending(): void | Promise<void>;
 
+  /** Whether the editor's most recent settled write round failed —
+   *  the edit never reached the page's buffer, ``dirty`` was
+   *  cleared on settle, and a settled round cannot be re-run, so a
+   *  leave would silently discard it. Always ``false`` for the
+   *  component editor (its flush is a local splice). */
+  readonly lastFlushFailed: boolean;
+
   /** Re-hydrate from the live YAML after the pane changes the
    *  document out from under the editor. */
   reload(): void;

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -503,9 +503,9 @@ export class ESPHomePageDevice extends LitElement {
     try {
       await this._activeSection?.flushPending();
     } catch (err) {
-      // The editors self-catch their upsert failures, so this only
-      // sees a synchronous throw — a backstop, not the live error
-      // path (that path is the failed-round case handled above).
+      // The editors self-catch their upsert failures, so a throw or
+      // rejection here is a backstop, not the live error path (that
+      // path is the failed-round case handled above).
       console.error("Section flush before leave failed:", err);
     }
     const ok = await this._unsavedGuard.run({

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -517,13 +517,25 @@ export class ESPHomePageDevice extends LitElement {
         // it resolves ``false`` and we propagate that up — the
         // user isn't done editing, so the page-leave guard
         // shouldn't proceed with navigation.
-        // Gated on the same conservative decision the guard used:
-        // on the failed-round path the buffer looks clean, and
-        // ``_saveYaml``'s own awaited flush is the retry that can
-        // land the draft (it early-outs itself when nothing did).
+        // Gated on the same conservative decision the guard used.
+        // ``_saveYaml`` flushes still-pending work and early-outs
+        // when nothing landed — it cannot re-run a settled failed
+        // round, so "Save" must not pretend it did: if the buffer
+        // is untouched and nothing was written while the pre-flush
+        // decision said dirty, the pending edit never reached the
+        // buffer. Stay put — the editor still holds the form state
+        // and has already surfaced the failure.
         if (dirtyBefore || this._isYamlDirty) {
+          const savedYamlBefore = this._savedYaml;
           const saved = await this._saveYaml();
           if (!saved) return false;
+          if (
+            dirtyBefore &&
+            this._savedYaml === savedYamlBefore &&
+            this._yaml === savedYamlBefore
+          ) {
+            return false;
+          }
         }
         this._allowingLeave = true;
         return true;

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -499,12 +499,15 @@ export class ESPHomePageDevice extends LitElement {
     // editor reports it through ``lastFlushFailed`` — the real
     // signal, so a flush that settles as a no-op (the user typed
     // and undid a keystroke) still leaves silently.
-    let flushFailed = false;
+    let flushThrew = false;
     // The awaited flush is the same slow phase ``_saveYaml`` covers
     // with the Save spinner; borrow the flag so Back doesn't read as
     // dead for the length of the upsert. Own it only if free — a
-    // save already in flight keeps its own lifecycle.
-    const ownBusy = !this._saving;
+    // save already in flight keeps its own lifecycle, and while the
+    // validation prompt waits (``_saving`` false, resolver armed) a
+    // "Save anyway" started mid-flush must not have its lock and
+    // spinner cleared by our finally.
+    const ownBusy = !this._saving && this._pendingValidationResolve === null;
     if (ownBusy) this._saving = true;
     try {
       await this._activeSection?.flushPending();
@@ -513,13 +516,19 @@ export class ESPHomePageDevice extends LitElement {
       // rejection here is a backstop, not the live error path (that
       // path is ``lastFlushFailed`` below).
       console.error("Section flush before leave failed:", err);
-      flushFailed = true;
+      flushThrew = true;
     } finally {
       if (ownBusy) this._saving = false;
     }
-    flushFailed ||= this._activeSection?.lastFlushFailed ?? false;
+    // The throw backstop is sticky; the latch reads live at each
+    // decision, because the dialog can stay open across a reload
+    // timer's hydrate that clears the latch along with the failed
+    // edit it protected — a stale snapshot would refuse a leave
+    // over an edit that no longer exists.
+    const flushFailed = () =>
+      flushThrew || (this._activeSection?.lastFlushFailed ?? false);
     const ok = await this._unsavedGuard.run({
-      dirty: flushFailed || this._isDirty,
+      dirty: flushFailed() || this._isDirty,
       open: () => this._unsavedDialog?.open(),
       save: async () => {
         // ``_saveYaml`` may open the validation prompt and await
@@ -529,7 +538,7 @@ export class ESPHomePageDevice extends LitElement {
         // shouldn't proceed with navigation.
         const saved = await this._saveYaml();
         if (!saved) return false;
-        if (flushFailed) {
+        if (flushFailed()) {
           // The failed round's edit never reached the buffer and a
           // settled round cannot be re-run, so "Save" must not
           // pretend it saved it. Stay put — the editor still holds

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -495,9 +495,11 @@ export class ESPHomePageDevice extends LitElement {
     // conservative either way (#1503).
     try {
       await this._activeSection?.flushPending();
-    } catch {
+    } catch (err) {
       // The editor already surfaced its own failure; run the guard
-      // with the freshest state available.
+      // with the freshest state available, but keep the cause
+      // diagnosable like the kick does.
+      console.error("Section flush before leave failed:", err);
     }
     const ok = await this._unsavedGuard.run({
       dirty: this._isDirty,

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -486,11 +486,19 @@ export class ESPHomePageDevice extends LitElement {
   private _confirmLeave = async (): Promise<boolean> => {
     // Promote any pending form keystrokes into ``_yaml`` before the
     // dialog so the user is shown the canonical "do you want to
-    // save?" question. Without this flush, a user who typed in the
-    // form and immediately hit back would see the dialog reflect
-    // ``_sectionDirty`` (transient) rather than the YAML diff that
-    // ``Save`` is going to commit.
-    this._kickSectionFlush();
+    // save?" question. Awaited (mirroring ``_saveYaml``) so the
+    // automation editors' backend upsert settles too — a kicked
+    // flush would show the dialog against ``_sectionDirty``
+    // (transient) rather than the YAML diff ``Save`` will commit.
+    // The dirty *decision* was never at risk: ``_sectionDirty``
+    // stays set until the upsert lands, so the guard fails
+    // conservative either way (#1503).
+    try {
+      await this._activeSection?.flushPending();
+    } catch {
+      // The editor already surfaced its own failure; run the guard
+      // with the freshest state available.
+    }
     const ok = await this._unsavedGuard.run({
       dirty: this._isDirty,
       open: () => this._unsavedDialog?.open(),
@@ -513,10 +521,10 @@ export class ESPHomePageDevice extends LitElement {
   };
 
   private _onBeforeUnload = (e: BeforeUnloadEvent) => {
-    // Flush the form's pending debounce so a user who typed in the
-    // form and immediately closed the tab gets warned (the form's
-    // own keystroke would otherwise sit in the debounce window with
-    // no representation in ``_yaml``).
+    // Synchronous by contract — the browser reads the decision on
+    // return, so the async flush cannot be awaited here. Safe
+    // regardless: ``_sectionDirty`` arms ``_isDirty`` from the
+    // first keystroke, so the warning fails conservative (#1503).
     this._kickSectionFlush();
     if (this._isDirty) {
       e.preventDefault();
@@ -529,6 +537,9 @@ export class ESPHomePageDevice extends LitElement {
       this._allowingLeave = false;
       return;
     }
+    // Synchronous by contract (the popped entry must be re-pushed
+    // in the same task); the dirty pre-check fails conservative via
+    // ``_sectionDirty``, same as beforeunload (#1503).
     this._kickSectionFlush();
     if (!this._isDirty) return;
     e.stopImmediatePropagation();

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -500,6 +500,12 @@ export class ESPHomePageDevice extends LitElement {
     // signal, so a flush that settles as a no-op (the user typed
     // and undid a keystroke) still leaves silently.
     let flushFailed = false;
+    // The awaited flush is the same slow phase ``_saveYaml`` covers
+    // with the Save spinner; borrow the flag so Back doesn't read as
+    // dead for the length of the upsert. Own it only if free — a
+    // save already in flight keeps its own lifecycle.
+    const ownBusy = !this._saving;
+    if (ownBusy) this._saving = true;
     try {
       await this._activeSection?.flushPending();
     } catch (err) {
@@ -508,6 +514,8 @@ export class ESPHomePageDevice extends LitElement {
       // path is ``lastFlushFailed`` below).
       console.error("Section flush before leave failed:", err);
       flushFailed = true;
+    } finally {
+      if (ownBusy) this._saving = false;
     }
     flushFailed ||= this._activeSection?.lastFlushFailed ?? false;
     const ok = await this._unsavedGuard.run({

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -449,9 +449,12 @@ export class ESPHomePageDevice extends LitElement {
    *  ``_activeSection?.flushPending()`` before they read this
    *  getter. The component editor's flush promotes pending form
    *  edits into ``_yaml`` synchronously; the automation editors'
-   *  flush is a backend round-trip that only the save path awaits,
-   *  so the other paths lean on ``_sectionDirty`` staying set until
-   *  the upsert lands (they fail conservative). */
+   *  flush is a backend round-trip that the save and leave paths
+   *  await; the synchronous paths (beforeunload, popstate) lean on
+   *  ``_sectionDirty`` staying set until the upsert *settles*. A
+   *  settled-as-failed round clears the flag without landing a
+   *  draft, which is why the leave path ORs in a pre-flush
+   *  snapshot rather than trusting the post-flush read. */
   private get _isDirty(): boolean {
     return this._isYamlDirty || this._sectionDirty;
   }
@@ -514,7 +517,11 @@ export class ESPHomePageDevice extends LitElement {
         // it resolves ``false`` and we propagate that up — the
         // user isn't done editing, so the page-leave guard
         // shouldn't proceed with navigation.
-        if (this._isYamlDirty) {
+        // Gated on the same conservative decision the guard used:
+        // on the failed-round path the buffer looks clean, and
+        // ``_saveYaml``'s own awaited flush is the retry that can
+        // land the draft (it early-outs itself when nothing did).
+        if (dirtyBefore || this._isYamlDirty) {
           const saved = await this._saveYaml();
           if (!saved) return false;
         }

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -450,11 +450,12 @@ export class ESPHomePageDevice extends LitElement {
    *  getter. The component editor's flush promotes pending form
    *  edits into ``_yaml`` synchronously; the automation editors'
    *  flush is a backend round-trip that the save and leave paths
-   *  await; the synchronous paths (beforeunload, popstate) lean on
-   *  ``_sectionDirty`` staying set until the upsert *settles*. A
-   *  settled-as-failed round clears the flag without landing a
-   *  draft, which is why the leave path ORs in a pre-flush
-   *  snapshot rather than trusting the post-flush read. */
+   *  await. A settled-as-failed round clears ``_sectionDirty``
+   *  without landing a draft, so every leave path additionally
+   *  reads the editor's ``lastFlushFailed`` — including the
+   *  synchronous ones (beforeunload, popstate), where
+   *  ``_sectionDirty`` covers a round still pending and
+   *  ``lastFlushFailed`` covers one already settled as failed. */
   private get _isDirty(): boolean {
     return this._isYamlDirty || this._sectionDirty;
   }
@@ -493,23 +494,24 @@ export class ESPHomePageDevice extends LitElement {
     // automation editors' backend upsert settles too — a kicked
     // flush would show the dialog against ``_sectionDirty``
     // (transient) rather than the YAML diff ``Save`` will commit.
-    // ``_sectionDirty`` stays set only until the upsert *settles*:
-    // a failed round clears it without landing a draft, so the
-    // post-flush read alone would fail open. Snapshot the pre-flush
-    // decision and OR it in — the decision only gets more
-    // conservative, while the dialog content still reflects the
-    // settled buffer.
-    const dirtyBefore = this._isDirty;
+    // A failed round clears ``_sectionDirty`` without landing a
+    // draft, so the post-flush read alone would fail open; the
+    // editor reports it through ``lastFlushFailed`` — the real
+    // signal, so a flush that settles as a no-op (the user typed
+    // and undid a keystroke) still leaves silently.
+    let flushFailed = false;
     try {
       await this._activeSection?.flushPending();
     } catch (err) {
       // The editors self-catch their upsert failures, so a throw or
       // rejection here is a backstop, not the live error path (that
-      // path is the failed-round case handled above).
+      // path is ``lastFlushFailed`` below).
       console.error("Section flush before leave failed:", err);
+      flushFailed = true;
     }
+    flushFailed ||= this._activeSection?.lastFlushFailed ?? false;
     const ok = await this._unsavedGuard.run({
-      dirty: dirtyBefore || this._isDirty,
+      dirty: flushFailed || this._isDirty,
       open: () => this._unsavedDialog?.open(),
       save: async () => {
         // ``_saveYaml`` may open the validation prompt and await
@@ -517,25 +519,15 @@ export class ESPHomePageDevice extends LitElement {
         // it resolves ``false`` and we propagate that up — the
         // user isn't done editing, so the page-leave guard
         // shouldn't proceed with navigation.
-        // Gated on the same conservative decision the guard used.
-        // ``_saveYaml`` flushes still-pending work and early-outs
-        // when nothing landed — it cannot re-run a settled failed
-        // round, so "Save" must not pretend it did: if the buffer
-        // is untouched and nothing was written while the pre-flush
-        // decision said dirty, the pending edit never reached the
-        // buffer. Stay put — the editor still holds the form state
-        // and has already surfaced the failure.
-        if (dirtyBefore || this._isYamlDirty) {
-          const savedYamlBefore = this._savedYaml;
-          const saved = await this._saveYaml();
-          if (!saved) return false;
-          if (
-            dirtyBefore &&
-            this._savedYaml === savedYamlBefore &&
-            this._yaml === savedYamlBefore
-          ) {
-            return false;
-          }
+        const saved = await this._saveYaml();
+        if (!saved) return false;
+        if (flushFailed) {
+          // The failed round's edit never reached the buffer and a
+          // settled round cannot be re-run, so "Save" must not
+          // pretend it saved it. Stay put — the editor still holds
+          // the form state — and say why the leave didn't happen.
+          notifyError(this._localize("device.leave_last_change_unsaved"));
+          return false;
         }
         this._allowingLeave = true;
         return true;
@@ -549,9 +541,11 @@ export class ESPHomePageDevice extends LitElement {
     // Synchronous by contract — the browser reads the decision on
     // return, so the async flush cannot be awaited here. Safe
     // regardless: ``_sectionDirty`` arms ``_isDirty`` from the
-    // first keystroke, so the warning fails conservative (#1503).
+    // first keystroke, and ``lastFlushFailed`` covers a round
+    // already settled as failed, so the warning fails
+    // conservative (#1503).
     this._kickSectionFlush();
-    if (this._isDirty) {
+    if (this._isDirty || this._activeSection?.lastFlushFailed) {
       e.preventDefault();
       e.returnValue = "";
     }
@@ -564,9 +558,10 @@ export class ESPHomePageDevice extends LitElement {
     }
     // Synchronous by contract (the popped entry must be re-pushed
     // in the same task); the dirty pre-check fails conservative via
-    // ``_sectionDirty``, same as beforeunload (#1503).
+    // ``_sectionDirty`` (round pending) plus ``lastFlushFailed``
+    // (round settled as failed), same as beforeunload (#1503).
     this._kickSectionFlush();
-    if (!this._isDirty) return;
+    if (!this._isDirty && !this._activeSection?.lastFlushFailed) return;
     e.stopImmediatePropagation();
     window.history.pushState({}, "", withBase(`/device/${this.id}`));
     // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
@@ -835,8 +830,10 @@ export class ESPHomePageDevice extends LitElement {
    *
    * Also resolves ``true`` for the no-op "save when not dirty"
    * case (the guard treats that as "nothing to save, fine to
-   * leave"); the page's user-facing Save button doesn't read
-   * the return value.
+   * leave" — unless the editor's ``lastFlushFailed`` says the
+   * buffer is clean only because a failed round never landed,
+   * which the leave guard checks separately); the page's
+   * user-facing Save button doesn't read the return value.
    */
   private _saveYaml = async (): Promise<boolean> => {
     // Refuse to start a second save while one is already in progress.

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -520,15 +520,19 @@ export class ESPHomePageDevice extends LitElement {
     } finally {
       if (ownBusy) this._saving = false;
     }
-    // The throw backstop is sticky; the latch reads live at each
-    // decision, because the dialog can stay open across a reload
-    // timer's hydrate that clears the latch along with the failed
-    // edit it protected — a stale snapshot would refuse a leave
-    // over an edit that no longer exists.
-    const flushFailed = () =>
-      flushThrew || (this._activeSection?.lastFlushFailed ?? false);
+    // Two distinct failure signals. The throw backstop only arms
+    // the prompt (fail conservative on an unknown state); the latch
+    // additionally gates Save, read live at each decision because
+    // the dialog can stay open across a reload timer's hydrate that
+    // clears it along with the failed edit it protected — a stale
+    // snapshot would refuse a leave over an edit that no longer
+    // exists. A one-off throw does NOT gate Save: ``_saveYaml``
+    // re-runs the flush for real, so either its retry lands the
+    // edit (leaving is correct) or it fails again and ``saved``
+    // already blocks the leave.
+    const latched = () => this._activeSection?.lastFlushFailed ?? false;
     const ok = await this._unsavedGuard.run({
-      dirty: flushFailed() || this._isDirty,
+      dirty: flushThrew || latched() || this._isDirty,
       open: () => this._unsavedDialog?.open(),
       save: async () => {
         // ``_saveYaml`` may open the validation prompt and await
@@ -538,7 +542,7 @@ export class ESPHomePageDevice extends LitElement {
         // shouldn't proceed with navigation.
         const saved = await this._saveYaml();
         if (!saved) return false;
-        if (flushFailed()) {
+        if (latched()) {
           // The failed round's edit never reached the buffer and a
           // settled round cannot be re-run, so "Save" must not
           // pretend it saved it. Stay put — the editor still holds

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -490,19 +490,23 @@ export class ESPHomePageDevice extends LitElement {
     // automation editors' backend upsert settles too — a kicked
     // flush would show the dialog against ``_sectionDirty``
     // (transient) rather than the YAML diff ``Save`` will commit.
-    // The dirty *decision* was never at risk: ``_sectionDirty``
-    // stays set until the upsert lands, so the guard fails
-    // conservative either way (#1503).
+    // ``_sectionDirty`` stays set only until the upsert *settles*:
+    // a failed round clears it without landing a draft, so the
+    // post-flush read alone would fail open. Snapshot the pre-flush
+    // decision and OR it in — the decision only gets more
+    // conservative, while the dialog content still reflects the
+    // settled buffer.
+    const dirtyBefore = this._isDirty;
     try {
       await this._activeSection?.flushPending();
     } catch (err) {
-      // The editor already surfaced its own failure; run the guard
-      // with the freshest state available, but keep the cause
-      // diagnosable like the kick does.
+      // The editors self-catch their upsert failures, so this only
+      // sees a synchronous throw — a backstop, not the live error
+      // path (that path is the failed-round case handled above).
       console.error("Section flush before leave failed:", err);
     }
     const ok = await this._unsavedGuard.run({
-      dirty: this._isDirty,
+      dirty: dirtyBefore || this._isDirty,
       open: () => this._unsavedDialog?.open(),
       save: async () => {
         // ``_saveYaml`` may open the validation prompt and await

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -686,6 +686,7 @@
     "draft_superseded": "Change not applied",
     "draft_superseded_detail": "It finished after the buffer changed and no longer applies. Redo it if needed.",
     "section_delete_error": "Failed to delete section",
+    "leave_last_change_unsaved": "Your last change failed to save. Fix or discard it before leaving.",
     "yaml_saved": "YAML saved",
     "yaml_save_error": "Failed to save YAML",
     "yaml_invalid_title": "Configuration has errors",

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -259,11 +259,19 @@ describe("AutoApplyController auto-apply", () => {
 
   it("lastRoundFailed reports a failed round and clears on the next landing", async () => {
     const { controller, upsertAutomation } = setup();
+    controller.hostUpdated(); // bind the section key
     expect(controller.lastRoundFailed).toBe(false);
 
     upsertAutomation.mockRejectedValueOnce(new Error("boom"));
     controller.scheduleAutoApply();
     await vi.advanceTimersByTimeAsync(AUTO_APPLY_DEBOUNCE_MS);
+    expect(controller.lastRoundFailed).toBe(true);
+
+    // The failed round's own _setDirty(false) re-renders the host,
+    // so a same-section hostUpdated fires immediately after every
+    // failure — it must not drop the latch, or the whole signal
+    // silently no-ops.
+    controller.hostUpdated();
     expect(controller.lastRoundFailed).toBe(true);
 
     controller.scheduleAutoApply();
@@ -273,6 +281,7 @@ describe("AutoApplyController auto-apply", () => {
 
   it("a retarget drops a latched failure — the sibling holds no failed form state", async () => {
     const { host, controller, upsertAutomation } = setup();
+    controller.hostUpdated(); // bind the section key, so the drop below proves the change
     upsertAutomation.mockRejectedValueOnce(new Error("boom"));
     controller.scheduleAutoApply();
     await vi.advanceTimersByTimeAsync(AUTO_APPLY_DEBOUNCE_MS);
@@ -282,6 +291,18 @@ describe("AutoApplyController auto-apply", () => {
     // after the re-point runs hostUpdated.
     host.location = { kind: "script", id: "other" } as unknown as AutomationLocation;
     controller.hostUpdated();
+    expect(controller.lastRoundFailed).toBe(false);
+  });
+
+  it("a fresh hydrate drops a latched failure — the failed edit left with the form state", async () => {
+    const { controller, upsertAutomation } = setup();
+    controller.hostUpdated();
+    upsertAutomation.mockRejectedValueOnce(new Error("boom"));
+    controller.scheduleAutoApply();
+    await vi.advanceTimersByTimeAsync(AUTO_APPLY_DEBOUNCE_MS);
+    expect(controller.lastRoundFailed).toBe(true);
+
+    controller.notifyHydrated();
     expect(controller.lastRoundFailed).toBe(false);
   });
 

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -294,6 +294,19 @@ describe("AutoApplyController auto-apply", () => {
     expect(controller.lastRoundFailed).toBe(false);
   });
 
+  it("a remount drops a latched failure — the form rebuilt from live YAML", async () => {
+    const { controller, upsertAutomation } = setup();
+    controller.hostUpdated();
+    upsertAutomation.mockRejectedValueOnce(new Error("boom"));
+    controller.scheduleAutoApply();
+    await vi.advanceTimersByTimeAsync(AUTO_APPLY_DEBOUNCE_MS);
+    expect(controller.lastRoundFailed).toBe(true);
+
+    controller.hostDisconnected();
+    controller.hostConnected();
+    expect(controller.lastRoundFailed).toBe(false);
+  });
+
   it("a fresh hydrate drops a latched failure — the failed edit left with the form state", async () => {
     const { controller, upsertAutomation } = setup();
     controller.hostUpdated();

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -271,6 +271,38 @@ describe("AutoApplyController auto-apply", () => {
     expect(controller.lastRoundFailed).toBe(false);
   });
 
+  it("a retarget drops a latched failure — the sibling holds no failed form state", async () => {
+    const { host, controller, upsertAutomation } = setup();
+    upsertAutomation.mockRejectedValueOnce(new Error("boom"));
+    controller.scheduleAutoApply();
+    await vi.advanceTimersByTimeAsync(AUTO_APPLY_DEBOUNCE_MS);
+    expect(controller.lastRoundFailed).toBe(true);
+
+    // Lit reuses the element across same-kind switches; the render
+    // after the re-point runs hostUpdated.
+    host.location = { kind: "script", id: "other" } as unknown as AutomationLocation;
+    controller.hostUpdated();
+    expect(controller.lastRoundFailed).toBe(false);
+  });
+
+  it("a failure settling after a mid-flight retarget never latches", async () => {
+    const { host, controller, upsertAutomation } = setup();
+    let rejectFirst!: (e: Error) => void;
+    upsertAutomation.mockImplementationOnce(
+      () =>
+        new Promise((_r, reject) => {
+          rejectFirst = reject;
+        })
+    );
+
+    const applying = controller.autoApply();
+    host.location = { kind: "script", id: "other" } as unknown as AutomationLocation;
+    rejectFirst(new Error("boom"));
+    await applying;
+
+    expect(controller.lastRoundFailed).toBe(false);
+  });
+
   it("flushPending flushes the pending debounce immediately and cancels the timer", async () => {
     const { controller, upsertAutomation } = setup();
     controller.scheduleAutoApply();

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -50,6 +50,7 @@ class Host extends EventTarget implements AutoApplyHost {
   parentNode: ParentNode | null = null;
   // SectionEditor surface the real hosts delegate to the engine.
   dirty = false;
+  lastFlushFailed = false;
   flushPending(): void {}
   reload(): void {}
   updates = 0;
@@ -254,6 +255,20 @@ describe("AutoApplyController auto-apply", () => {
       description: "boom",
       richColors: true,
     });
+  });
+
+  it("lastRoundFailed reports a failed round and clears on the next landing", async () => {
+    const { controller, upsertAutomation } = setup();
+    expect(controller.lastRoundFailed).toBe(false);
+
+    upsertAutomation.mockRejectedValueOnce(new Error("boom"));
+    controller.scheduleAutoApply();
+    await vi.advanceTimersByTimeAsync(AUTO_APPLY_DEBOUNCE_MS);
+    expect(controller.lastRoundFailed).toBe(true);
+
+    controller.scheduleAutoApply();
+    await vi.advanceTimersByTimeAsync(AUTO_APPLY_DEBOUNCE_MS);
+    expect(controller.lastRoundFailed).toBe(false);
   });
 
   it("flushPending flushes the pending debounce immediately and cancels the timer", async () => {

--- a/test/components/device/automation-editor/automation-editor-mount.test.ts
+++ b/test/components/device/automation-editor/automation-editor-mount.test.ts
@@ -111,3 +111,39 @@ describe("automation-editor mount-time load (behavioral)", () => {
     expect(editor.shadowRoot?.textContent ?? "").toContain("Open action");
   });
 });
+
+describe("reload clears a latched flush failure (behavioral)", () => {
+  it("a hydrate through reload() drops lastFlushFailed with the replaced form state", async () => {
+    const ON_BOOT = { kind: "device_on", trigger: "on_boot" } as never;
+    const parsed = [
+      {
+        location: ON_BOOT,
+        label: "On Boot",
+        automation: { trigger_id: "on_boot", trigger_params: {}, actions: [] },
+        from_line: 1,
+        to_line: 2,
+        raw_yaml: "on_boot:\n  then: []\n",
+      },
+    ];
+    const api = makeEditorApi({
+      parseDeviceAutomations: vi.fn().mockResolvedValue(parsed) as never,
+      upsertAutomation: vi.fn().mockRejectedValue(new Error("boom")) as never,
+    });
+    const editor = await mountEditor(new ESPHomeAutomationEditor(), api, {
+      configuration: "device.yaml",
+      location: ON_BOOT,
+      settle: 8,
+    });
+
+    // Drive a real failed round so the engine latches.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (editor as any)._engine.autoApply();
+    expect(editor.lastFlushFailed).toBe(true);
+
+    // The parent's YAML-driven reload replaces the form state; the
+    // latch must not survive to refuse a leave over a vanished edit.
+    editor.reload();
+    await flushMicrotasks(8);
+    expect(editor.lastFlushFailed).toBe(false);
+  });
+});

--- a/test/pages/device-escape-leave.test.ts
+++ b/test/pages/device-escape-leave.test.ts
@@ -141,3 +141,39 @@ describe("esphome-page-device Escape leave guard", () => {
     expect(backSpy).not.toHaveBeenCalled();
   });
 });
+
+describe("leave guard flush ordering (#1503)", () => {
+  test("the dialog runs only after the automation editor's flush settles", async () => {
+    const { page, dialogOpen } = makePage();
+    const order: string[] = [];
+    let settle!: () => void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (page as any)._activeSection = {
+      dirty: true,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          settle = () => {
+            order.push("flushed");
+            resolve();
+          };
+        }),
+      reload: () => {},
+    };
+    dialogOpen.mockImplementation(() => order.push("dialog"));
+
+    const leaving = page._confirmLeave();
+    // The dialog must not open against a pre-flush buffer.
+    await Promise.resolve();
+    expect(order).toEqual([]);
+
+    settle();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order[0]).toBe("flushed");
+    expect(order).toContain("dialog");
+
+    // Settle the guard so the promise resolves.
+    page._onUnsavedDiscard();
+    await leaving;
+  });
+});

--- a/test/pages/device-escape-leave.test.ts
+++ b/test/pages/device-escape-leave.test.ts
@@ -1,6 +1,12 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+vi.mock("sonner-js", () => ({
+  default: { error: vi.fn(), info: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+
+import toast from "sonner-js";
+
 import { ESPHomePageDevice } from "../../src/pages/device.js";
 import { setLeaveGuard } from "../../src/util/navigation.js";
 
@@ -22,10 +28,12 @@ interface EscapeView {
   _drawerOpen: boolean;
   _activeSection: {
     dirty: boolean;
+    lastFlushFailed: boolean;
     flushPending: () => void | Promise<void>;
     reload: () => void;
   } | null;
   _onKeydown(e: KeyboardEvent): void;
+  _onBeforeUnload(e: BeforeUnloadEvent): void;
   _onUnsavedDiscard(): void;
   _onUnsavedCancel(): void;
   _confirmLeave(): Promise<boolean>;
@@ -153,7 +161,23 @@ describe("esphome-page-device Escape leave guard", () => {
 describe("leave guard flush ordering (#1503)", () => {
   afterEach(() => {
     setLeaveGuard(null);
+    vi.mocked(toast.error).mockClear();
   });
+
+  /** A section whose flush settles a round: clears the transient
+   *  dirty flag and reports whether the round landed. */
+  function settlingSection(page: EscapeView, opts: { failed: boolean }) {
+    const section = {
+      dirty: true,
+      lastFlushFailed: false,
+      flushPending: async () => {
+        page._sectionDirty = false;
+        section.lastFlushFailed = opts.failed;
+      },
+      reload: () => {},
+    };
+    return section;
+  }
 
   test("the dialog runs only after the automation editor's flush settles", async () => {
     const { page, dialogOpen } = makePage();
@@ -161,6 +185,7 @@ describe("leave guard flush ordering (#1503)", () => {
     let settle!: () => void;
     page._activeSection = {
       dirty: true,
+      lastFlushFailed: false,
       flushPending: () =>
         new Promise<void>((resolve) => {
           settle = () => {
@@ -194,16 +219,11 @@ describe("leave guard flush ordering (#1503)", () => {
     // inside the debounce window, represented by _sectionDirty.
     page._savedYaml = page._yaml;
     page._sectionDirty = true;
-    page._activeSection = {
-      dirty: true,
-      // The engine settles a FAILED round by clearing the dirty
-      // flag without landing a draft (its own catch already
-      // toasted); the leave decision must not fail open on that.
-      flushPending: async () => {
-        page._sectionDirty = false;
-      },
-      reload: () => {},
-    };
+    // The engine settles a FAILED round by clearing the dirty flag
+    // without landing a draft (its own catch already toasted); it
+    // reports that through lastFlushFailed, which the leave
+    // decision reads instead of failing open.
+    page._activeSection = settlingSection(page, { failed: true });
 
     const leaving = page._confirmLeave();
     await Promise.resolve();
@@ -214,17 +234,24 @@ describe("leave guard flush ordering (#1503)", () => {
     await leaving;
   });
 
-  test("Save on the failed-round path stays put when nothing landed", async () => {
+  test("a no-op flush leaves silently, exactly as before (#1503)", async () => {
+    const { page, dialogOpen } = makePage();
+    // The user typed and undid a keystroke inside the debounce
+    // window: the round settles clean with nothing to land. That
+    // must not prompt — there is genuinely nothing unsaved.
+    page._savedYaml = page._yaml;
+    page._sectionDirty = true;
+    page._activeSection = settlingSection(page, { failed: false });
+
+    expect(await page._confirmLeave()).toBe(true);
+    expect(dialogOpen).not.toHaveBeenCalled();
+  });
+
+  test("Save on the failed-round path stays put and says why", async () => {
     const { page, dialogOpen } = makePage();
     page._savedYaml = page._yaml;
     page._sectionDirty = true;
-    page._activeSection = {
-      dirty: true,
-      flushPending: async () => {
-        page._sectionDirty = false;
-      },
-      reload: () => {},
-    };
+    page._activeSection = settlingSection(page, { failed: true });
     const saveYaml = vi.fn(async () => true);
     page._saveYaml = saveYaml;
 
@@ -233,25 +260,20 @@ describe("leave guard flush ordering (#1503)", () => {
     await Promise.resolve();
     expect(dialogOpen).toHaveBeenCalledTimes(1);
 
-    // The user picked "keep my work". _saveYaml flushes pending
-    // work but cannot re-run the settled failed round; with the
-    // buffer untouched and nothing written, "Save and leave" must
-    // stay put rather than discard the edit it claimed to keep.
+    // The user picked "keep my work". _saveYaml cannot re-run the
+    // settled failed round, so "Save and leave" must stay put
+    // rather than discard the edit it claimed to keep — and toast,
+    // or the refusal reads as a dead button.
     page._onUnsavedSave();
     expect(await leaving).toBe(false);
     expect(saveYaml).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledTimes(1);
   });
 
   test("Save leaves normally when the save actually writes", async () => {
     const { page, dialogOpen } = makePage();
     page._sectionDirty = true;
-    page._activeSection = {
-      dirty: true,
-      flushPending: async () => {
-        page._sectionDirty = false;
-      },
-      reload: () => {},
-    };
+    page._activeSection = settlingSection(page, { failed: false });
     page._saveYaml = vi.fn(async () => {
       page._savedYaml = page._yaml;
       return true;
@@ -272,6 +294,7 @@ describe("leave guard flush ordering (#1503)", () => {
       const { page, dialogOpen } = makePage();
       page._activeSection = {
         dirty: true,
+        lastFlushFailed: false,
         flushPending: () => Promise.reject(new Error("upsert failed")),
         reload: () => {},
       };
@@ -290,5 +313,20 @@ describe("leave guard flush ordering (#1503)", () => {
     } finally {
       consoleError.mockRestore();
     }
+  });
+
+  test("a settled-as-failed round arms the beforeunload warning", () => {
+    const { page } = makePage();
+    // Buffer clean, transient flag already cleared by the settle —
+    // only lastFlushFailed knows the edit never landed.
+    page._savedYaml = page._yaml;
+    page._sectionDirty = false;
+    const section = settlingSection(page, { failed: true });
+    section.lastFlushFailed = true;
+    page._activeSection = section;
+
+    const preventDefault = vi.fn();
+    page._onBeforeUnload({ preventDefault } as unknown as BeforeUnloadEvent);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/pages/device-escape-leave.test.ts
+++ b/test/pages/device-escape-leave.test.ts
@@ -16,7 +16,13 @@ interface EscapeView {
   id: string;
   _yaml: string;
   _savedYaml: string;
+  _sectionDirty: boolean;
   _drawerOpen: boolean;
+  _activeSection: {
+    dirty: boolean;
+    flushPending: () => void | Promise<void>;
+    reload: () => void;
+  } | null;
   _onKeydown(e: KeyboardEvent): void;
   _onUnsavedDiscard(): void;
   _onUnsavedCancel(): void;
@@ -151,8 +157,7 @@ describe("leave guard flush ordering (#1503)", () => {
     const { page, dialogOpen } = makePage();
     const order: string[] = [];
     let settle!: () => void;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (page as any)._activeSection = {
+    page._activeSection = {
       dirty: true,
       flushPending: () =>
         new Promise<void>((resolve) => {
@@ -181,12 +186,37 @@ describe("leave guard flush ordering (#1503)", () => {
     await leaving;
   });
 
+  test("a failed round that clears the transient flag still prompts", async () => {
+    const { page, dialogOpen } = makePage();
+    // Otherwise-clean buffer: the only pending change is the edit
+    // inside the debounce window, represented by _sectionDirty.
+    page._savedYaml = page._yaml;
+    page._sectionDirty = true;
+    page._activeSection = {
+      dirty: true,
+      // The engine settles a FAILED round by clearing the dirty
+      // flag without landing a draft (its own catch already
+      // toasted); the leave decision must not fail open on that.
+      flushPending: async () => {
+        page._sectionDirty = false;
+      },
+      reload: () => {},
+    };
+
+    const leaving = page._confirmLeave();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(dialogOpen).toHaveBeenCalledTimes(1);
+    page._onUnsavedDiscard();
+    await leaving;
+  });
+
   test("a rejecting flush still runs the guard, with the cause logged", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
       const { page, dialogOpen } = makePage();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (page as any)._activeSection = {
+      page._activeSection = {
         dirty: true,
         flushPending: () => Promise.reject(new Error("upsert failed")),
         reload: () => {},

--- a/test/pages/device-escape-leave.test.ts
+++ b/test/pages/device-escape-leave.test.ts
@@ -226,20 +226,44 @@ describe("leave guard flush ordering (#1503)", () => {
       reload: () => {},
     };
     const saveYaml = vi.fn(async () => true);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (page as any)._saveYaml = saveYaml;
+    page._saveYaml = saveYaml;
 
     const leaving = page._confirmLeave();
     await Promise.resolve();
     await Promise.resolve();
     expect(dialogOpen).toHaveBeenCalledTimes(1);
 
-    // The user picked "keep my work": the save lambda must retry
-    // through _saveYaml (whose own awaited flush re-runs the
-    // upsert) instead of no-opping on the clean-looking buffer.
+    // The user picked "keep my work". _saveYaml flushes pending
+    // work but cannot re-run the settled failed round; with the
+    // buffer untouched and nothing written, "Save and leave" must
+    // stay put rather than discard the edit it claimed to keep.
+    page._onUnsavedSave();
+    expect(await leaving).toBe(false);
+    expect(saveYaml).toHaveBeenCalledTimes(1);
+  });
+
+  test("Save leaves normally when the save actually writes", async () => {
+    const { page, dialogOpen } = makePage();
+    page._sectionDirty = true;
+    page._activeSection = {
+      dirty: true,
+      flushPending: async () => {
+        page._sectionDirty = false;
+      },
+      reload: () => {},
+    };
+    page._saveYaml = vi.fn(async () => {
+      page._savedYaml = page._yaml;
+      return true;
+    });
+
+    const leaving = page._confirmLeave();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(dialogOpen).toHaveBeenCalledTimes(1);
+
     page._onUnsavedSave();
     expect(await leaving).toBe(true);
-    expect(saveYaml).toHaveBeenCalledTimes(1);
   });
 
   test("a rejecting flush still runs the guard, with the cause logged", async () => {

--- a/test/pages/device-escape-leave.test.ts
+++ b/test/pages/device-escape-leave.test.ts
@@ -1,9 +1,7 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-vi.mock("sonner-js", () => ({
-  default: { error: vi.fn(), info: vi.fn(), success: vi.fn(), warning: vi.fn() },
-}));
+import "./_mock-device-children.js";
 
 import toast from "sonner-js";
 
@@ -34,6 +32,7 @@ interface EscapeView {
   } | null;
   _onKeydown(e: KeyboardEvent): void;
   _onBeforeUnload(e: BeforeUnloadEvent): void;
+  _onPopState(e: PopStateEvent): void;
   _onUnsavedDiscard(): void;
   _onUnsavedCancel(): void;
   _confirmLeave(): Promise<boolean>;
@@ -328,5 +327,51 @@ describe("leave guard flush ordering (#1503)", () => {
     const preventDefault = vi.fn();
     page._onBeforeUnload({ preventDefault } as unknown as BeforeUnloadEvent);
     expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  test("a settled-as-failed round intercepts popstate and prompts", async () => {
+    const { page, dialogOpen } = makePage();
+    page._savedYaml = page._yaml;
+    page._sectionDirty = false;
+    const section = settlingSection(page, { failed: true });
+    section.lastFlushFailed = true;
+    page._activeSection = section;
+
+    const stopImmediatePropagation = vi.fn();
+    page._onPopState({
+      stopImmediatePropagation,
+    } as unknown as PopStateEvent);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The popped entry is held (re-pushed) and the guard runs
+    // instead of the router unmounting the page over a lost edit.
+    expect(stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    expect(dialogOpen).toHaveBeenCalledTimes(1);
+    // Cancel settles the guard without a history pop.
+    page._onUnsavedCancel();
+  });
+
+  test("Save leaves once a hydrate clears the latch under the open dialog", async () => {
+    const { page, dialogOpen } = makePage();
+    page._savedYaml = page._yaml;
+    page._sectionDirty = true;
+    const section = settlingSection(page, { failed: true });
+    page._activeSection = section;
+    page._saveYaml = vi.fn(async () => true);
+
+    const leaving = page._confirmLeave();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(dialogOpen).toHaveBeenCalledTimes(1);
+
+    // A reload timer's hydrate replaced the form state and cleared
+    // the latch while the dialog sat open; the refusal must read
+    // the live signal, not the pre-dialog snapshot, or "Save and
+    // leave" refuses over an edit that no longer exists.
+    section.lastFlushFailed = false;
+    page._onUnsavedSave();
+    expect(await leaving).toBe(true);
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/test/pages/device-escape-leave.test.ts
+++ b/test/pages/device-escape-leave.test.ts
@@ -24,6 +24,8 @@ interface EscapeView {
   _saveYaml(): Promise<boolean>;
   _onUnsavedSave(): void;
   _drawerOpen: boolean;
+  _saving: boolean;
+  _pendingValidationResolve: ((saved: boolean) => void) | null;
   _activeSection: {
     dirty: boolean;
     lastFlushFailed: boolean;
@@ -202,8 +204,7 @@ describe("leave guard flush ordering (#1503)", () => {
     expect(order).toEqual([]);
 
     settle();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flush();
     expect(order[0]).toBe("flushed");
     expect(order).toContain("dialog");
 
@@ -225,8 +226,7 @@ describe("leave guard flush ordering (#1503)", () => {
     page._activeSection = settlingSection(page, { failed: true });
 
     const leaving = page._confirmLeave();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flush();
 
     expect(dialogOpen).toHaveBeenCalledTimes(1);
     page._onUnsavedDiscard();
@@ -255,8 +255,7 @@ describe("leave guard flush ordering (#1503)", () => {
     page._saveYaml = saveYaml;
 
     const leaving = page._confirmLeave();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flush();
     expect(dialogOpen).toHaveBeenCalledTimes(1);
 
     // The user picked "keep my work". _saveYaml cannot re-run the
@@ -279,8 +278,7 @@ describe("leave guard flush ordering (#1503)", () => {
     });
 
     const leaving = page._confirmLeave();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flush();
     expect(dialogOpen).toHaveBeenCalledTimes(1);
 
     page._onUnsavedSave();
@@ -299,8 +297,7 @@ describe("leave guard flush ordering (#1503)", () => {
       };
 
       const leaving = page._confirmLeave();
-      await Promise.resolve();
-      await Promise.resolve();
+      await flush();
 
       // The editor already surfaced its own failure; the guard still
       // runs with the freshest available state.
@@ -332,8 +329,7 @@ describe("leave guard flush ordering (#1503)", () => {
       page._saveYaml = vi.fn(async () => true);
 
       const leaving = page._confirmLeave();
-      await Promise.resolve();
-      await Promise.resolve();
+      await flush();
       expect(dialogOpen).toHaveBeenCalledTimes(1);
 
       page._onUnsavedSave();
@@ -342,6 +338,35 @@ describe("leave guard flush ordering (#1503)", () => {
     } finally {
       consoleError.mockRestore();
     }
+  });
+
+  test("an armed validation prompt keeps the busy borrow off", async () => {
+    const { page } = makePage();
+    // The validation dialog is open: _saving is false but the
+    // resolver is armed. The leave flush must not borrow the flag —
+    // its finally would clear a "Save anyway" write's re-entrancy
+    // lock out from under it.
+    page._pendingValidationResolve = () => {};
+    let settle!: () => void;
+    page._activeSection = {
+      dirty: true,
+      lastFlushFailed: false,
+      flushPending: () =>
+        new Promise<void>((resolve) => {
+          settle = resolve;
+        }),
+      reload: () => {},
+    };
+
+    const leaving = page._confirmLeave();
+    await Promise.resolve();
+    expect(page._saving).toBe(false);
+
+    settle();
+    await flush();
+    page._onUnsavedCancel();
+    await leaving;
+    expect(page._saving).toBe(false);
   });
 
   test("a settled-as-failed round arms the beforeunload warning", () => {
@@ -371,8 +396,7 @@ describe("leave guard flush ordering (#1503)", () => {
     page._onPopState({
       stopImmediatePropagation,
     } as unknown as PopStateEvent);
-    await Promise.resolve();
-    await Promise.resolve();
+    await flush();
 
     // The popped entry is held (re-pushed) and the guard runs
     // instead of the router unmounting the page over a lost edit.
@@ -391,8 +415,7 @@ describe("leave guard flush ordering (#1503)", () => {
     page._saveYaml = vi.fn(async () => true);
 
     const leaving = page._confirmLeave();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flush();
     expect(dialogOpen).toHaveBeenCalledTimes(1);
 
     // A reload timer's hydrate replaced the form state and cleared

--- a/test/pages/device-escape-leave.test.ts
+++ b/test/pages/device-escape-leave.test.ts
@@ -143,6 +143,10 @@ describe("esphome-page-device Escape leave guard", () => {
 });
 
 describe("leave guard flush ordering (#1503)", () => {
+  afterEach(() => {
+    setLeaveGuard(null);
+  });
+
   test("the dialog runs only after the automation editor's flush settles", async () => {
     const { page, dialogOpen } = makePage();
     const order: string[] = [];

--- a/test/pages/device-escape-leave.test.ts
+++ b/test/pages/device-escape-leave.test.ts
@@ -180,4 +180,31 @@ describe("leave guard flush ordering (#1503)", () => {
     page._onUnsavedDiscard();
     await leaving;
   });
+
+  test("a rejecting flush still runs the guard, with the cause logged", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { page, dialogOpen } = makePage();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (page as any)._activeSection = {
+        dirty: true,
+        flushPending: () => Promise.reject(new Error("upsert failed")),
+        reload: () => {},
+      };
+
+      const leaving = page._confirmLeave();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // The editor already surfaced its own failure; the guard still
+      // runs with the freshest available state.
+      expect(dialogOpen).toHaveBeenCalledTimes(1);
+      expect(consoleError).toHaveBeenCalled();
+
+      page._onUnsavedDiscard();
+      await leaving;
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
 });

--- a/test/pages/device-escape-leave.test.ts
+++ b/test/pages/device-escape-leave.test.ts
@@ -214,7 +214,7 @@ describe("leave guard flush ordering (#1503)", () => {
     await leaving;
   });
 
-  test("Save on the failed-round path retries through _saveYaml", async () => {
+  test("Save on the failed-round path stays put when nothing landed", async () => {
     const { page, dialogOpen } = makePage();
     page._savedYaml = page._yaml;
     page._sectionDirty = true;

--- a/test/pages/device-escape-leave.test.ts
+++ b/test/pages/device-escape-leave.test.ts
@@ -314,6 +314,36 @@ describe("leave guard flush ordering (#1503)", () => {
     }
   });
 
+  test("Save leaves after a one-off flush throw when the retry lands", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { page, dialogOpen } = makePage();
+      // Buffer clean; only the throw backstop arms the prompt.
+      page._savedYaml = page._yaml;
+      page._activeSection = {
+        dirty: true,
+        lastFlushFailed: false,
+        flushPending: () => Promise.reject(new Error("transient")),
+        reload: () => {},
+      };
+      // ``_saveYaml`` re-runs the flush for real; a one-off throw
+      // that its retry survives leaves nothing stranded, so Save
+      // must leave rather than dead-end on the sticky backstop.
+      page._saveYaml = vi.fn(async () => true);
+
+      const leaving = page._confirmLeave();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(dialogOpen).toHaveBeenCalledTimes(1);
+
+      page._onUnsavedSave();
+      expect(await leaving).toBe(true);
+      expect(toast.error).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   test("a settled-as-failed round arms the beforeunload warning", () => {
     const { page } = makePage();
     // Buffer clean, transient flag already cleared by the settle —

--- a/test/pages/device-escape-leave.test.ts
+++ b/test/pages/device-escape-leave.test.ts
@@ -17,6 +17,8 @@ interface EscapeView {
   _yaml: string;
   _savedYaml: string;
   _sectionDirty: boolean;
+  _saveYaml(): Promise<boolean>;
+  _onUnsavedSave(): void;
   _drawerOpen: boolean;
   _activeSection: {
     dirty: boolean;
@@ -210,6 +212,34 @@ describe("leave guard flush ordering (#1503)", () => {
     expect(dialogOpen).toHaveBeenCalledTimes(1);
     page._onUnsavedDiscard();
     await leaving;
+  });
+
+  test("Save on the failed-round path retries through _saveYaml", async () => {
+    const { page, dialogOpen } = makePage();
+    page._savedYaml = page._yaml;
+    page._sectionDirty = true;
+    page._activeSection = {
+      dirty: true,
+      flushPending: async () => {
+        page._sectionDirty = false;
+      },
+      reload: () => {},
+    };
+    const saveYaml = vi.fn(async () => true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (page as any)._saveYaml = saveYaml;
+
+    const leaving = page._confirmLeave();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(dialogOpen).toHaveBeenCalledTimes(1);
+
+    // The user picked "keep my work": the save lambda must retry
+    // through _saveYaml (whose own awaited flush re-runs the
+    // upsert) instead of no-opping on the clean-looking buffer.
+    page._onUnsavedSave();
+    expect(await leaving).toBe(true);
+    expect(saveYaml).toHaveBeenCalledTimes(1);
   });
 
   test("a rejecting flush still runs the guard, with the cause logged", async () => {

--- a/test/pages/device-section-dirty-guard.test.ts
+++ b/test/pages/device-section-dirty-guard.test.ts
@@ -26,6 +26,7 @@ const view = (page: ESPHomePageDevice) => page as unknown as DirtyGuardView;
 
 const editor = (dirty = false): SectionEditor => ({
   dirty,
+  lastFlushFailed: false,
   flushPending: () => {},
   reload: () => {},
 });

--- a/test/pages/device-section-switch-sync.test.ts
+++ b/test/pages/device-section-switch-sync.test.ts
@@ -27,6 +27,7 @@ const gateFlush = (page: ESPHomePageDevice) => {
   );
   internals(page)._activeSection = {
     dirty: true,
+    lastFlushFailed: false,
     flushPending,
     reload: () => {},
   } satisfies SectionEditor;
@@ -62,6 +63,7 @@ describe("synchronous section switch", () => {
     const page = new ESPHomePageDevice();
     internals(page)._activeSection = {
       dirty: true,
+      lastFlushFailed: false,
       flushPending: () => Promise.reject(new Error("upsert failed")),
       reload: () => {},
     } satisfies SectionEditor;
@@ -115,6 +117,7 @@ describe("synchronous section switch", () => {
     // time it is still the active section (Lit hasn't committed).
     const editor = {
       dirty: true,
+      lastFlushFailed: false,
       flushPending: () => {
         internals(page)._onYamlDraft(
           new CustomEvent("yaml-draft", {


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by the new no-floating-promises gate: `_confirmLeave` kicked the active section's flush fire and forget and built the unsaved-changes dialog on the next line, so for the automation editors (whose flush is a backend upsert settling on a macrotask) the dialog could reflect the transient `_sectionDirty` flag rather than the settled YAML diff Save will commit. The flush is now awaited, mirroring `_saveYaml`'s established shape, with the old barrier's tolerance for an already-surfaced flush failure.

Investigating narrowed the issue's premise: the leave *decision* was never at risk, because `_sectionDirty` arms `_isDirty` from the first keystroke and stays set until the upsert lands, so every path fails conservative. That is now stated at all three sites: `_onBeforeUnload` and `_onPopState` are synchronous by contract (the browser reads the decision on return; the popped entry must be re-pushed in the same task), so they keep the kick, and their comments say why that is safe.

A new cell pins the ordering: the dialog opens only after the automation editor's flush settles.

Review turned up one exception to that premise, and fixing it changes user visible behaviour. The engine clears `_sectionDirty` when a round *settles*, including a settled as failed round whose edit never landed; on main, leaving right after such a round silently discarded the edit. The editors now report that state through a new `lastFlushFailed` on the `SectionEditor` contract (the component editor pins it `false`; the automation engine sets it in its catch and clears it on the next landing). Every leave path reads it: the leave dialog now opens after a failed round even though the buffer looks clean, "Save and leave" refuses to leave in that state (the settled round cannot be re run, so leaving would discard the edit Save claimed to keep) and toasts why, and the synchronous beforeunload and popstate pre checks treat it like dirty. A flush that settles as a harmless no-op (the user typed and undid a keystroke) still leaves silently, exactly as before. The latch is scoped to the form state it protects: a retarget, a fresh hydrate (YAML pane reload, configuration swap), or a remount clears it, so it can never refuse a leave over an edit that no longer exists. The page's Save button and the install path deliberately keep their existing behaviour; the engine already toasts and sets the inline error at failure time, and widening the refusal beyond the leave paths is left for a follow up if wanted. The leave flush also borrows the Save busy flag so Back shows a spinner instead of reading dead for the length of the upsert.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1503

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Maintenance / chore — `maintenance`
- [ ] Documentation only — `docs`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

