### PR TITLE
Replace source-text assertions with behavioral coverage

### DIFF
--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -20,6 +20,10 @@ import { fireSectionEvent, prepareSectionEvent } from "../section-editor.js";
 // catalog. MAP_SECTIONS (substitutions / packages) carry an irrelevant flat
 // catalog schema that doesn't match what the user actually edits in the form —
 // using it would surface phantom "missing required" errors per keystroke.
+// Pre-save backend lint (validateYaml) is deliberately not wired in here: the
+// YAML pane's squiggles (yaml-lint-backend.ts) provide the same lint
+// continuously, and the explicit Validate button runs the full ESPHome
+// compile against the saved file.
 export function flushDraft(host: ESPHomeDeviceSectionConfig): string | null {
   host._draftTimer = null;
   if (!host._config) return null;

--- a/src/util/section-entry-overrides.ts
+++ b/src/util/section-entry-overrides.ts
@@ -68,8 +68,8 @@ export const KEEP_EMPTY_STRING_SECTIONS: ReadonlySet<string> = new Set(["substit
  *  as a red squiggle, so the form's save path delegates to that
  *  same backend lint. Duplicating ESPHome's validators in the
  *  frontend would silently drift the moment upstream's accepted
- *  shape changes. The save path's roundtrip lives in
- *  ``device-section-config``'s ``_onSave``. */
+ *  shape changes. The section path's validation call site is
+ *  ``draft-and-delete.ts``'s ``flushDraft``. */
 const MAP_SECTION_ENTRIES: ConfigEntry[] = [
   makeConfigEntry({
     type: ConfigEntryType.MAP,

--- a/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
@@ -5,9 +5,9 @@
  * migration onto ``esphome-base-dialog``. The wrapper never mutates
  * its own ``open`` on a user-driven close, so the host owns the
  * reactive ``_open`` flag: ``open()`` sets it, ``@request-close``
- * clears it, and picking an item clears it. (The sibling source-scan
- * test in this folder stays node-env; this file opts into happy-dom
- * per-file so the element can mount.)
+ * clears it, and picking an item clears it. The sibling
+ * ``catalog-picker-dialog.test.ts`` covers the filter / grouping
+ * contract; this file owns the open/close lifecycle.
  */
 import { describe, expect, it, vi } from "vitest";
 

--- a/test/components/device/automation-editor/catalog-picker-dialog.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog.test.ts
@@ -65,9 +65,12 @@ async function mountDialog(opts: {
       dialog.kind === "action"
         ? ["by-target", "by-type", "building-blocks"]
         : ["by-type", "building-blocks"];
-    dialog
-      .shadowRoot!.querySelectorAll<HTMLElement>(".picker-tab")
-      [tabs.indexOf(opts.tab)].click();
+    const tab =
+      dialog.shadowRoot!.querySelectorAll<HTMLElement>(".picker-tab")[
+        tabs.indexOf(opts.tab)
+      ];
+    if (!tab) throw new Error(`Tab ${opts.tab} not rendered for kind ${dialog.kind}`);
+    tab.click();
     await dialog.updateComplete;
   }
   return dialog;

--- a/test/components/device/automation-editor/catalog-picker-dialog.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog.test.ts
@@ -1,112 +1,226 @@
 /**
- * Source-scan tests for ``<esphome-catalog-picker-dialog>``.
+ * @vitest-environment happy-dom
  *
- * We can't mount the Lit element under vitest (no DOM), but the
- * filter / grouping logic is the load-bearing surface and can be
- * pinned via the source-level shape. The behavioural contract is:
+ * Behavioral tests for ``<esphome-catalog-picker-dialog>``'s filter /
+ * grouping contract (#1504):
  *
- * - "By type" groups by the bare domain (``switch.template`` and
- *   ``switch.gpio`` both land under ``switch``).
- * - "Building blocks" filters to ``domain === "core"`` items.
- * - "By target" pre-fills the picked action's id-shaped
- *   ConfigEntry with the picked device's id.
  * - Search applies case-insensitively across id, name, description.
+ * - "By type" groups by the bare domain (``switch.template`` and
+ *   ``switch.gpio`` both land under ``switch``) and skips core items.
+ * - "Building blocks" filters to ``domain === "core"`` items.
+ * - "By target" pre-fills the picked action's id-shaped ConfigEntry
+ *   with the picked device's declared id.
+ * - The tab strip drops "By target" for conditions.
+ *
+ * ``open()``'s default-tab contract lives in the sibling
+ * ``catalog-picker-dialog-open-contract.test.ts``.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-async function readSource(): Promise<string> {
-  // @ts-expect-error node-only module; tsconfig types are restricted
-  const fs = await import("node:fs");
-  // @ts-expect-error node-only module; tsconfig types are restricted
-  const path = await import("node:path");
-  // @ts-expect-error node-only module; tsconfig types are restricted
-  const url = await import("node:url");
-  const here = path.dirname(url.fileURLToPath(import.meta.url));
-  return fs.readFileSync(
-    path.resolve(
-      here,
-      "../../../../src/components/device/automation-editor/catalog-picker-dialog.ts"
-    ),
-    "utf-8"
-  );
+vi.mock("../../../../src/components/base-dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import type {
+  AutomationAction,
+  AvailableComponentInstance,
+} from "../../../../src/api/types/automations.js";
+import type { CatalogPickedDetail } from "../../../../src/components/device/automation-editor/catalog-picker-dialog.js";
+import { ESPHomeCatalogPickerDialog } from "../../../../src/components/device/automation-editor/catalog-picker-dialog.js";
+import { makeConfigEntry } from "../../../../src/util/config-entry-defaults.js";
+import { identityLocalize } from "../../../_dom.js";
+
+function action(
+  over: Pick<AutomationAction, "id" | "name" | "domain"> & Partial<AutomationAction>
+): AutomationAction {
+  return {
+    description: "",
+    docs_url: "",
+    config_entries: [],
+    is_control_flow: false,
+    has_else_branch: false,
+    accepts_action_list: [],
+    ...over,
+  };
 }
 
-describe("catalog-picker-dialog filtering contract", () => {
-  /**
-   * Extract the body of a private method definition. Anchors on
-   * ``private <name>`` (including arrow-form ``= (`` and regular
-   * ``(``) and slurps until the next ``private`` / ``}`` boundary.
-   */
-  function methodBody(src: string, name: string): string {
-    const re = new RegExp(
-      `private\\s+${name}[\\s\\S]*?(?=\\n {2}(private|static|public|protected|@|\\}))`
+async function mountDialog(opts: {
+  kind?: "action" | "condition";
+  items?: AutomationAction[];
+  devices?: AvailableComponentInstance[];
+  tab?: "by-target" | "by-type" | "building-blocks";
+}): Promise<ESPHomeCatalogPickerDialog> {
+  const dialog = new ESPHomeCatalogPickerDialog();
+  dialog.kind = opts.kind ?? "action";
+  dialog.items = opts.items ?? [];
+  dialog.devices = opts.devices ?? [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (dialog as any)._localize = identityLocalize; // no context provider in the test tree
+  document.body.appendChild(dialog);
+  dialog.open();
+  if (opts.tab) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (dialog as any)._activeTab = opts.tab;
+  }
+  await dialog.updateComplete;
+  return dialog;
+}
+
+const rowTitles = (dialog: ESPHomeCatalogPickerDialog): string[] =>
+  Array.from(dialog.shadowRoot!.querySelectorAll(".picker-row-title")).map(
+    (n) => n.textContent?.trim() ?? ""
+  );
+
+const groupLabels = (dialog: ESPHomeCatalogPickerDialog): string[] =>
+  Array.from(dialog.shadowRoot!.querySelectorAll(".picker-group-label")).map(
+    (n) => n.textContent?.trim() ?? ""
+  );
+
+async function search(dialog: ESPHomeCatalogPickerDialog, query: string): Promise<void> {
+  const input = dialog.shadowRoot!.querySelector("input")!;
+  input.value = query;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  await dialog.updateComplete;
+}
+
+describe("catalog-picker-dialog search", () => {
+  const items = [
+    action({ id: "fan.turn_on", name: "Spin", domain: "fan" }),
+    action({ id: "light.turn_on", name: "Flicker Glow", domain: "light" }),
+    action({
+      id: "switch.toggle",
+      name: "Toggle",
+      domain: "switch",
+      description: "Makes things glow nicely",
+    }),
+  ];
+
+  it("matches case-insensitively across name and description", async () => {
+    const dialog = await mountDialog({ items, tab: "by-type" });
+    await search(dialog, "GLOW");
+    // "Flicker Glow" by name, "Toggle" by description; "Spin" filtered out.
+    expect(rowTitles(dialog).sort()).toEqual(["Flicker Glow", "Toggle"]);
+  });
+
+  it("matches against the catalog id", async () => {
+    const dialog = await mountDialog({ items, tab: "by-type" });
+    await search(dialog, "fan.turn");
+    expect(rowTitles(dialog)).toEqual(["Spin"]);
+  });
+
+  it("shows the empty state when nothing matches", async () => {
+    const dialog = await mountDialog({ items, tab: "by-type" });
+    await search(dialog, "zzz-no-match");
+    expect(rowTitles(dialog)).toEqual([]);
+    expect(dialog.shadowRoot!.querySelector(".picker-empty")).not.toBeNull();
+  });
+});
+
+describe("catalog-picker-dialog grouping", () => {
+  it("By type groups platform items under their bare domain and skips core", async () => {
+    const dialog = await mountDialog({
+      items: [
+        action({
+          id: "switch.template.toggle",
+          name: "Toggle T",
+          domain: "switch.template",
+        }),
+        action({ id: "switch.gpio.toggle", name: "Toggle G", domain: "switch.gpio" }),
+        action({ id: "light.turn_on", name: "Turn On", domain: "light" }),
+        action({ id: "delay", name: "Delay", domain: "core" }),
+      ],
+      tab: "by-type",
+    });
+    // Domains sorted; switch.template + switch.gpio share one "switch"
+    // group; the core item lives under Building blocks instead.
+    expect(groupLabels(dialog)).toEqual(["light", "switch"]);
+    expect(rowTitles(dialog)).toEqual(["Turn On", "Toggle T", "Toggle G"]);
+  });
+
+  it("Building blocks lists only domain === 'core' items", async () => {
+    const dialog = await mountDialog({
+      items: [
+        action({ id: "delay", name: "Delay", domain: "core" }),
+        action({ id: "switch.toggle", name: "Toggle", domain: "switch" }),
+      ],
+      tab: "building-blocks",
+    });
+    expect(rowTitles(dialog)).toEqual(["Delay"]);
+  });
+});
+
+describe("catalog-picker-dialog by-target pre-fill", () => {
+  const turnOn = action({
+    id: "switch.turn_on",
+    name: "Turn On",
+    domain: "switch",
+    config_entries: [makeConfigEntry({ key: "id", references_component: "switch" })],
+  });
+
+  async function pickFirstRow(
+    dialog: ESPHomeCatalogPickerDialog
+  ): Promise<CatalogPickedDetail> {
+    const picked = vi.fn();
+    dialog.addEventListener("catalog-picked", (e) =>
+      picked((e as CustomEvent<CatalogPickedDetail>).detail)
     );
-    const m = src.match(re);
-    if (!m) throw new Error(`Method ${name} not found`);
-    return m[0];
+    const row = dialog.shadowRoot!.querySelector<HTMLElement>(".picker-row")!;
+    row.click();
+    expect(picked).toHaveBeenCalledTimes(1);
+    return picked.mock.calls[0][0] as CatalogPickedDetail;
   }
 
-  it("applies the search query against id, name, and description", async () => {
-    const src = await readSource();
-    // Pin the _applyQuery body — must consult all three fields,
-    // case-insensitive. A future refactor that drops the
-    // description match (the most surprising hit) should fail this
-    // test.
-    const body = methodBody(src, "_applyQuery");
-    expect(body).toMatch(/\.id\.toLowerCase\(\)\.includes\(q\)/);
-    expect(body).toMatch(/\.name\.toLowerCase\(\)\.includes\(q\)/);
-    expect(body).toMatch(/description.*toLowerCase\(\)\.includes\(q\)/);
+  it("picking under a declared-id device pre-fills the id-shaped param", async () => {
+    const dialog = await mountDialog({
+      items: [turnOn],
+      devices: [
+        {
+          component_id: "switch.gpio",
+          id: "relay1",
+          name: "Warmtepomp",
+          has_explicit_id: true,
+        },
+      ],
+      tab: "by-target",
+    });
+    expect(await pickFirstRow(dialog)).toEqual({
+      id: "switch.turn_on",
+      preFilledParams: { id: "relay1" },
+    });
   });
 
-  it("filters Building blocks to domain === 'core' items", async () => {
-    const src = await readSource();
-    const body = methodBody(src, "_renderBuildingBlocks");
-    expect(body).toMatch(/domain === "core"/);
-  });
-
-  it("By-type skips core items and normalises to bare domain", async () => {
-    const src = await readSource();
-    const body = methodBody(src, "_renderByType");
-    // Must skip core (those go under Building blocks) and split
-    // <domain>.<platform> down to its bare <domain> so
-    // switch.template + switch.gpio land under the same "switch"
-    // header.
-    expect(body).toMatch(/domain === "core"/);
-    expect(body).toMatch(/componentDomain\(item\.domain\)/);
-  });
-
-  it("By-target routes each pick through the shared pre-fill helper", async () => {
-    // The pre-fill behavior itself (declared-id-only, #2208) is pinned by
-    // the pure-function tests in component-targets.test.ts.
-    const src = await readSource();
-    const body = methodBody(src, "_renderByTarget");
-    expect(body).toMatch(/preFillIdParam\(item, device\)/);
+  it("picking under a synthesized-id device leaves the param empty (#2208)", async () => {
+    const dialog = await mountDialog({
+      items: [turnOn],
+      devices: [{ component_id: "switch.gpio", id: "switch_0", name: "Warmtepomp" }],
+      tab: "by-target",
+    });
+    expect(await pickFirstRow(dialog)).toEqual({
+      id: "switch.turn_on",
+      preFilledParams: undefined,
+    });
   });
 });
 
 describe("catalog-picker-dialog tab strip", () => {
-  it("hides 'by-target' for conditions (they have no target)", async () => {
-    const src = await readSource();
-    const m = src.match(/this\.kind === "action"\s*\?\s*\[([^\]]+)\]\s*:\s*\[([^\]]+)\]/);
-    expect(m).not.toBeNull();
-    const actionTabs = m![1];
-    const conditionTabs = m![2];
-    expect(actionTabs).toMatch(/by-target/);
-    expect(conditionTabs).not.toMatch(/by-target/);
-    expect(conditionTabs).toMatch(/by-type/);
-    expect(conditionTabs).toMatch(/building-blocks/);
+  const tabLabels = (dialog: ESPHomeCatalogPickerDialog): string[] =>
+    Array.from(dialog.shadowRoot!.querySelectorAll(".picker-tab")).map(
+      (n) => n.textContent?.trim() ?? ""
+    );
+
+  it("actions get all three tabs, by-target first", async () => {
+    const dialog = await mountDialog({ kind: "action" });
+    expect(tabLabels(dialog)).toEqual([
+      "device.automation_pick_tab_by_target",
+      "device.automation_pick_tab_by_type",
+      "device.automation_pick_tab_building_blocks",
+    ]);
   });
 
-  it("defaults the active tab to by-target for actions, by-type for conditions", async () => {
-    const src = await readSource();
-    // open() pins the initial tab — actions land on "by-target"
-    // because the user usually knows what they want to control,
-    // and conditions skip straight to "by-type" since they don't
-    // have a target axis.
-    const m = src.match(/public open[\s\S]*?_activeTab = ([\s\S]*?);/);
-    expect(m).not.toBeNull();
-    expect(m![1]).toMatch(/"action"/);
-    expect(m![1]).toMatch(/"by-target"/);
-    expect(m![1]).toMatch(/"by-type"/);
+  it("conditions drop by-target (they have no target)", async () => {
+    const dialog = await mountDialog({ kind: "condition" });
+    expect(tabLabels(dialog)).toEqual([
+      "device.automation_pick_tab_by_type",
+      "device.automation_pick_tab_building_blocks",
+    ]);
   });
 });

--- a/test/components/device/automation-editor/catalog-picker-dialog.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog.test.ts
@@ -57,11 +57,19 @@ async function mountDialog(opts: {
   (dialog as any)._localize = identityLocalize; // no context provider in the test tree
   document.body.appendChild(dialog);
   dialog.open();
-  if (opts.tab) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (dialog as any)._activeTab = opts.tab;
-  }
   await dialog.updateComplete;
+  if (opts.tab) {
+    // Switch tabs the way the user does — through the rendered tab
+    // strip — so the @click wiring is covered too.
+    const tabs: string[] =
+      dialog.kind === "action"
+        ? ["by-target", "by-type", "building-blocks"]
+        : ["by-type", "building-blocks"];
+    dialog
+      .shadowRoot!.querySelectorAll<HTMLElement>(".picker-tab")
+      [tabs.indexOf(opts.tab)].click();
+    await dialog.updateComplete;
+  }
   return dialog;
 }
 
@@ -156,17 +164,15 @@ describe("catalog-picker-dialog by-target pre-fill", () => {
     config_entries: [makeConfigEntry({ key: "id", references_component: "switch" })],
   });
 
-  async function pickFirstRow(
-    dialog: ESPHomeCatalogPickerDialog
-  ): Promise<CatalogPickedDetail> {
+  /** Click the first row; the cell asserts the emitted detail (an
+   *  undefined return means the pick never fired). */
+  function pickFirstRow(dialog: ESPHomeCatalogPickerDialog): CatalogPickedDetail {
     const picked = vi.fn();
     dialog.addEventListener("catalog-picked", (e) =>
       picked((e as CustomEvent<CatalogPickedDetail>).detail)
     );
-    const row = dialog.shadowRoot!.querySelector<HTMLElement>(".picker-row")!;
-    row.click();
-    expect(picked).toHaveBeenCalledTimes(1);
-    return picked.mock.calls[0][0] as CatalogPickedDetail;
+    dialog.shadowRoot!.querySelector<HTMLElement>(".picker-row")!.click();
+    return picked.mock.calls[0]?.[0] as CatalogPickedDetail;
   }
 
   it("picking under a declared-id device pre-fills the id-shaped param", async () => {
@@ -182,7 +188,7 @@ describe("catalog-picker-dialog by-target pre-fill", () => {
       ],
       tab: "by-target",
     });
-    expect(await pickFirstRow(dialog)).toEqual({
+    expect(pickFirstRow(dialog)).toEqual({
       id: "switch.turn_on",
       preFilledParams: { id: "relay1" },
     });
@@ -194,7 +200,7 @@ describe("catalog-picker-dialog by-target pre-fill", () => {
       devices: [{ component_id: "switch.gpio", id: "switch_0", name: "Warmtepomp" }],
       tab: "by-target",
     });
-    expect(await pickFirstRow(dialog)).toEqual({
+    expect(pickFirstRow(dialog)).toEqual({
       id: "switch.turn_on",
       preFilledParams: undefined,
     });

--- a/test/components/device/section-config-entries-wiring.test.ts
+++ b/test/components/device/section-config-entries-wiring.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Behavioral pins for the #160 regression class: the structured form
+ * and form-driven validation must both consume
+ * ``resolveSectionEntries``' output, not the raw catalog. A previous
+ * iteration had the override defined but bound the form's
+ * ``.entries`` to the catalog, leaving substitutions silently empty;
+ * the sibling bug validated the resolver-rendered MAP shape against
+ * the catalog's flat schema, so saves bailed on phantom required
+ * fields (#1504 replaced the source-text scans that guarded this).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+vi.mock("../../../src/components/device/config-entry-form.js", () => ({}));
+
+import "../../_mock-webawesome.js";
+
+import {
+  type ConfigEntry,
+  ConfigEntryType,
+} from "../../../src/api/types/config-entries.js";
+import { ESPHomeDeviceSectionConfig } from "../../../src/components/device/device-section-config.js";
+import { flushDraft } from "../../../src/components/device/device-section-config/draft-and-delete.js";
+import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+import { resolveSectionEntries } from "../../../src/util/section-entry-overrides.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// ``configuration`` stays unset so mounting doesn't kick loadConfig
+// (which would need an _api and overwrite the preset _config).
+function makeHost(sectionKey: string, entries: ConfigEntry[]) {
+  const c = new ESPHomeDeviceSectionConfig();
+  const inner = c as any;
+  inner.sectionKey = sectionKey;
+  inner._localize = (key: string) => key;
+  inner._config = { title: sectionKey, entries };
+  inner._presentComponents = new Set<string>();
+  return { c, inner };
+}
+
+// The catalog ships substitutions with a flat schema the user-keyed
+// MAP shape doesn't match (a required field the user rows never
+// carry) — the shape that made raw-catalog consumers misrender (#160)
+// and mis-validate.
+const bogusCatalog = () => [
+  makeConfigEntry({
+    key: "url",
+    type: ConfigEntryType.STRING,
+    label: "String",
+    required: true,
+    advanced: true,
+  }),
+];
+
+describe("structured form entries wiring", () => {
+  it("binds the form's .entries to the resolver's output, not the raw catalog", async () => {
+    const catalog = bogusCatalog();
+    const { c } = makeHost("substitutions", catalog);
+    document.body.appendChild(c);
+    await c.updateComplete;
+
+    const form = c.shadowRoot!.querySelector("esphome-config-entry-form") as any;
+    expect(form).not.toBeNull();
+    expect(form.entries).toBe(resolveSectionEntries("substitutions", catalog));
+    expect(form.entries).not.toBe(catalog);
+    expect(form.entries[0].type).toBe(ConfigEntryType.MAP);
+  });
+
+  it("hands a non-overridden section's catalog to the form unchanged", async () => {
+    const catalog = [makeConfigEntry({ key: "ssid", required: true })];
+    const { c } = makeHost("wifi", catalog);
+    document.body.appendChild(c);
+    await c.updateComplete;
+
+    const form = c.shadowRoot!.querySelector("esphome-config-entry-form") as any;
+    expect(form.entries).toBe(catalog);
+  });
+});
+
+describe("flushDraft validation routing", () => {
+  it("validates user-keyed MAP values against the resolver's schema, then drafts", () => {
+    const { c, inner } = makeHost("substitutions", bogusCatalog());
+    inner.configuration = "device.yaml";
+    inner.yaml = "substitutions:\n  old: gone\n";
+    inner.fromLine = 1;
+    inner._values = { ApolloAutomation: "github://example/repo" };
+    const drafts: string[] = [];
+    c.addEventListener("yaml-draft", (e) =>
+      drafts.push((e as CustomEvent).detail.yaml as string)
+    );
+
+    flushDraft(c);
+
+    // Validated against the raw catalog, the missing required "url"
+    // would populate _fieldErrors and phantom-error every keystroke.
+    expect(inner._fieldErrors.size).toBe(0);
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0]).toContain('ApolloAutomation: "github://example/repo"');
+  });
+
+  it("still enforces catalog requirements for pass-through sections", () => {
+    const { c, inner } = makeHost("wifi", [
+      makeConfigEntry({ key: "ssid", type: ConfigEntryType.STRING, required: true }),
+    ]);
+    inner.yaml = "wifi:\n  password: hunter2\n";
+    inner.fromLine = 1;
+    inner._values = { password: "hunter2" };
+
+    flushDraft(c);
+
+    expect(inner._fieldErrors.has("ssid")).toBe(true);
+  });
+});

--- a/test/util/section-entry-overrides.test.ts
+++ b/test/util/section-entry-overrides.test.ts
@@ -160,7 +160,7 @@ describe("resolveSectionEntries", () => {
 // ``test/components/device/section-config-entries-wiring.test.ts``.
 
 describe("save validation contract", () => {
-  // ``_onSave`` must validate against the *render* schema. Pin
+  // ``flushDraft`` must validate against the *render* schema. Pin
   // the contract directly: a packages-shaped catalog (some
   // required fields the user-keyed rows don't carry) produces
   // errors when validated raw, but no errors once routed through

--- a/test/util/section-entry-overrides.test.ts
+++ b/test/util/section-entry-overrides.test.ts
@@ -154,98 +154,10 @@ describe("resolveSectionEntries", () => {
   });
 });
 
-describe("device-section-config wiring", () => {
-  // The section component imports Lit decorators that need DOM
-  // globals (vitest runs in ``node``), so we can't render it
-  // here. Instead, scan the source for the wiring contract:
-  // the form's ``.entries`` prop must bind to the resolver's
-  // output, not the catalog's raw ``this._config.entries``.
-  //
-  // Regression pin: a previous iteration of #160 had
-  // ``MAP_SECTIONS`` and the synthesised MAP entries defined in
-  // the section component but bound the form's ``.entries``
-  // prop directly to the catalog source — leaving the
-  // substitutions section silently empty in the UI.
-  it("forwards renderEntries / resolveSectionEntries to the form's .entries prop", async () => {
-    // tsconfig restricts `types` to @types/w3c-web-serial, so node
-    // module specifiers don't type-check; vitest resolves them fine.
-    // @ts-expect-error node-only module; tsconfig types are restricted
-    const fs = await import("node:fs");
-    // @ts-expect-error node-only module; tsconfig types are restricted
-    const path = await import("node:path");
-    // @ts-expect-error node-only module; tsconfig types are restricted
-    const url = await import("node:url");
-    const here = path.dirname(url.fileURLToPath(import.meta.url));
-    const sourcePath = path.resolve(
-      here,
-      "../../src/components/device/device-section-config/render-branches.ts"
-    );
-    const src = fs.readFileSync(sourcePath, "utf-8");
-
-    // The form binding must reference the resolver-derived
-    // entries — accept either the local ``renderEntries`` const
-    // or a direct ``resolveSectionEntries(...)`` call.
-    const entriesBinding = /\.entries\s*=\s*\$\{([^}]+)\}/;
-    const match = src.match(entriesBinding);
-    expect(match, "form's .entries prop binding is missing").not.toBeNull();
-    const expr = match![1].trim();
-    expect(
-      expr.includes("renderEntries") || expr.includes("resolveSectionEntries"),
-      `form's .entries binds to '${expr}', not to the resolver's output`
-    ).toBe(true);
-
-    // Pin the inverse too: the catalog source ``this._config.entries``
-    // must NOT be the value bound to the form's ``.entries`` prop.
-    expect(
-      expr.includes("this._config.entries"),
-      "form's .entries binds to the raw catalog entries — substitutions override is bypassed"
-    ).toBe(false);
-  });
-
-  it("routes form-driven validation through the resolver, not the catalog", async () => {
-    // Regression pin for the "Save click does nothing" bug on
-    // ``packages:`` (and the latent equivalent on
-    // ``substitutions:``). The form rendered the resolver's
-    // user-keyed MAP shape, but the form's validation ran against
-    // the catalog's flat schema — whose required fields (``url``
-    // etc. for packages) were absent from the user-named rows, so
-    // ``_fieldErrors`` filled up and the save bailed silently.
-    // ``validateEntries`` must see the same entries the form
-    // rendered.
-    //
-    // Architecture note: pre-save backend lint (``validateYaml``)
-    // is no longer wired into the form. The YAML pane's red
-    // squiggles (``yaml-lint-backend.ts``) provide the same lint
-    // continuously, and the explicit Validate button runs the
-    // full ESPHome compile against the saved file. The "x y is
-    // invalid" feedback now flows through those two surfaces.
-    // @ts-expect-error node-only module; tsconfig types are restricted
-    const fs = await import("node:fs");
-    // @ts-expect-error node-only module; tsconfig types are restricted
-    const path = await import("node:path");
-    // @ts-expect-error node-only module; tsconfig types are restricted
-    const url = await import("node:url");
-    const here = path.dirname(url.fileURLToPath(import.meta.url));
-    const sourcePath = path.resolve(
-      here,
-      "../../src/components/device/device-section-config/draft-and-delete.ts"
-    );
-    const src = fs.readFileSync(sourcePath, "utf-8");
-
-    const validateCall = /validateEntries\s*\(\s*([^,)]+)\s*,/;
-    const match = src.match(validateCall);
-    expect(match, "validateEntries call not found").not.toBeNull();
-    const firstArg = match![1].trim();
-    expect(
-      firstArg.includes("renderEntries") || firstArg.includes("resolveSectionEntries"),
-      `validateEntries' first arg is '${firstArg}', not the resolver's output`
-    ).toBe(true);
-    expect(
-      firstArg === "this._config.entries",
-      "validateEntries reads the raw catalog — MAP-section saves silently bail on the catalog's required fields"
-    ).toBe(false);
-  });
-});
+// The component-side wiring (the form's ``.entries`` binding and
+// ``flushDraft``'s validation both consuming the resolver) is pinned
+// behaviorally in
+// ``test/components/device/section-config-entries-wiring.test.ts``.
 
 describe("save validation contract", () => {
   // ``_onSave`` must validate against the *render* schema. Pin


### PR DESCRIPTION
# What does this implement/fix?

Two suites asserted on component source text read from disk with `fs.readFileSync`, which passes on string presence and fails on innocuous renames while never exercising the wiring. Both are now behavioral.

`catalog-picker-dialog.test.ts` mounts the real dialog under happy-dom and drives it through its rendered surface: search typed into the actual input filters across id, name, and description case insensitively; "By type" groups `switch.template` and `switch.gpio` under one `switch` header and skips core items; "Building blocks" lists only core items; clicking a row on "By target" emits `catalog-picked` with the id param pre filled for a declared id device and left empty for a synthesized one (#2208); the tab strip drops "By target" for conditions. The `open()` default tab contract already lives in the sibling open contract suite.

The two source scans in `section-entry-overrides.test.ts` moved to a new `section-config-entries-wiring.test.ts` that mounts `device-section-config` and pins the #160 regression class directly: the form's `.entries` prop is the resolver's output (a MAP entry for substitutions), not the raw catalog, and `flushDraft` validates the user keyed values against that same resolver schema, so a bogus flat catalog produces no phantom required errors while pass through sections still enforce theirs.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1504

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
