### PR TITLE
Resolve the FIXME'd floating-promise sites with reviewed handling

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -241,8 +241,9 @@ export class ESPHomeAdoptDialog extends LitElement {
     // validate (esphome/device-builder#1742). Probe the shared secrets so
     // the Wi-Fi step can prompt + store them before importing.
     if (this._needsWifi && this._api) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-      fetchSecretKeys(this._api).then((keys) => {
+      // The cache resolves its fallback ([]) on a failed fetch, so this
+      // never rejects; the Wi-Fi step then prompts, the safe default.
+      void fetchSecretKeys(this._api).then((keys) => {
         this._hasWifiSecrets = hasSharedWifiSecret(keys);
       });
     }

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -472,8 +472,7 @@ export class ESPHomeApp extends LitElement {
   private async _afterAuthenticated() {
     this._authState = "authed";
     this._authError = null;
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-    this._subscribeToEvents();
+    void this._subscribeToEvents();
     subscribeToFollowJobs(this);
     void loadIntegrationDocs(this);
     void loadLabels(this);

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -318,8 +318,7 @@ export class ESPHomeCommandDialog extends LitElement {
   _resetAnsiLogScroll() {
     // The ansi-log instance is reused across opens; scrollToBottom clears
     // its _isUserScrolled latch so streaming-to-bottom re-engages.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-    this.updateComplete.then(() => this._terminal?.scrollToBottom());
+    void this.updateComplete.then(() => this._terminal?.scrollToBottom());
   }
 
   // Attach to a firmware job's stream. Handles any state — terminal jobs

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -280,8 +280,7 @@ export function renderDrawer(host: ESPHomePageDashboard): TemplateResult {
       }}
       @open-logs=${(e: CustomEvent) => {
         host._drawerOpen = false;
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-        host._openLogs(e.detail);
+        void host._openLogs(e.detail);
       }}
       @clean-build=${(e: CustomEvent<ConfiguredDevice>) => {
         host._drawerOpen = false;

--- a/src/components/dashboard/render-dialogs.ts
+++ b/src/components/dashboard/render-dialogs.ts
@@ -149,16 +149,14 @@ export function executeConfirm(
       const selected = [...host._selectedDevices];
       host._selectMode = false;
       host._selectedDevices = new Set();
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-      deleteBulkDevices(selected, host._devices, host._api, host._localize);
+      void deleteBulkDevices(selected, host._devices, host._api, host._localize);
       return;
     }
     case "archive-bulk": {
       const selected = [...host._selectedDevices];
       host._selectMode = false;
       host._selectedDevices = new Set();
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-      archiveBulkDevices(selected, host._devices, host._api, host._localize);
+      void archiveBulkDevices(selected, host._devices, host._api, host._localize);
       return;
     }
     case "delete-single":

--- a/src/components/dashboard/render-yaml.ts
+++ b/src/components/dashboard/render-yaml.ts
@@ -55,8 +55,7 @@ function renderSnippetBlock(
       @click=${(e: MouseEvent) => {
         if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
         e.preventDefault();
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-        navigate(href);
+        void navigate(href);
       }}
     >
       ${block.lines.map((text, i) => {
@@ -92,8 +91,7 @@ function renderYamlDeviceTitle(
           @click=${(e: MouseEvent) => {
             if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
             e.preventDefault();
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-            navigate(deviceHref);
+            void navigate(deviceHref);
           }}
           >${label}</a
         >

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -199,8 +199,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._submitError = "";
     this._submitting = false;
     this._dialog.open = true;
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-    this.updateComplete.then(() => this._catalog?.load());
+    void this.updateComplete.then(() => this._catalog?.load());
   }
 
   /**
@@ -216,8 +215,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._submitError = "";
     this._submitting = false;
     this._dialog.open = true;
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-    this.updateComplete.then(() => this._catalog?.filterByDomain(domain));
+    void this.updateComplete.then(() => this._catalog?.filterByDomain(domain));
   }
 
   /** See ``navigateToDep`` for the seq-counter contract. */

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -256,8 +256,7 @@ export class ESPHomeComponentCatalog extends LitElement {
     // A late web-font swap changes wrap heights without a resize or a
     // render, stranding stale expand buttons; re-measure once fonts
     // settle. Optional-chained: happy-dom has no document.fonts.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-    document.fonts?.ready.then(() => this._measureDescriptionOverflow());
+    void document.fonts?.ready.then(() => this._measureDescriptionOverflow());
   }
 
   protected updated() {

--- a/src/components/device/constraint-cluster-controller.ts
+++ b/src/components/device/constraint-cluster-controller.ts
@@ -21,6 +21,9 @@ export class ConstraintClusterController implements ReactiveController {
 
   private _stash = new Map<string, unknown>();
 
+  /** Groups whose sync failure was already traced (one warn each). */
+  private _warnedGroups = new WeakSet<RadioGroupElement>();
+
   constructor(private _host: Host) {
     _host.addController(this);
   }
@@ -72,15 +75,22 @@ export class ConstraintClusterController implements ReactiveController {
     // just isn't ready; the next render recovers. The try covers a
     // void-returning implementation that throws synchronously, the
     // catch a rejecting one, and the warn leaves a trace if a
-    // cluster sticks desynced.
+    // cluster sticks desynced — once per group, or a deterministic
+    // failure would log every render of an actively edited form.
     for (const group of groups) {
       try {
         Promise.resolve(group.syncRadioElements?.()).catch((err) =>
-          console.warn("Radio group sync failed:", err)
+          this._warnSyncFailed(group, err)
         );
       } catch (err) {
-        console.warn("Radio group sync failed:", err);
+        this._warnSyncFailed(group, err);
       }
     }
+  }
+
+  private _warnSyncFailed(group: RadioGroupElement, err: unknown): void {
+    if (this._warnedGroups.has(group)) return;
+    this._warnedGroups.add(group);
+    console.warn("Radio group sync failed:", err);
   }
 }

--- a/src/components/device/constraint-cluster-controller.ts
+++ b/src/components/device/constraint-cluster-controller.ts
@@ -68,13 +68,19 @@ export class ConstraintClusterController implements ReactiveController {
     // ones that are and let the next render recover, rather than aborting the
     // whole pass (don't "fix" this into a throw).
     await Promise.all(groups.map((group) => group.updateComplete?.catch(() => {})));
-    // Same tolerance as the settle above: a group whose sync rejects
-    // just isn't ready; the next render recovers. Promise.resolve
-    // normalises the void-returning implementations, and the warn
-    // leaves a trace if a cluster sticks desynced.
-    for (const group of groups)
-      Promise.resolve(group.syncRadioElements?.()).catch((err) =>
-        console.warn("Radio group sync failed:", err)
-      );
+    // Same tolerance as the settle above: a group whose sync fails
+    // just isn't ready; the next render recovers. The try covers a
+    // void-returning implementation that throws synchronously, the
+    // catch a rejecting one, and the warn leaves a trace if a
+    // cluster sticks desynced.
+    for (const group of groups) {
+      try {
+        Promise.resolve(group.syncRadioElements?.()).catch((err) =>
+          console.warn("Radio group sync failed:", err)
+        );
+      } catch (err) {
+        console.warn("Radio group sync failed:", err);
+      }
+    }
   }
 }

--- a/src/components/device/constraint-cluster-controller.ts
+++ b/src/components/device/constraint-cluster-controller.ts
@@ -68,7 +68,10 @@ export class ConstraintClusterController implements ReactiveController {
     // ones that are and let the next render recover, rather than aborting the
     // whole pass (don't "fix" this into a throw).
     await Promise.all(groups.map((group) => group.updateComplete?.catch(() => {})));
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-    for (const group of groups) group.syncRadioElements?.();
+    // Same tolerance as the settle above: a group whose sync rejects
+    // just isn't ready; the next render recovers. Promise.resolve
+    // normalises the void-returning implementations.
+    for (const group of groups)
+      void Promise.resolve(group.syncRadioElements?.()).catch(() => {});
   }
 }

--- a/src/components/device/constraint-cluster-controller.ts
+++ b/src/components/device/constraint-cluster-controller.ts
@@ -70,8 +70,11 @@ export class ConstraintClusterController implements ReactiveController {
     await Promise.all(groups.map((group) => group.updateComplete?.catch(() => {})));
     // Same tolerance as the settle above: a group whose sync rejects
     // just isn't ready; the next render recovers. Promise.resolve
-    // normalises the void-returning implementations.
+    // normalises the void-returning implementations, and the warn
+    // leaves a trace if a cluster sticks desynced.
     for (const group of groups)
-      void Promise.resolve(group.syncRadioElements?.()).catch(() => {});
+      Promise.resolve(group.syncRadioElements?.()).catch((err) =>
+        console.warn("Radio group sync failed:", err)
+      );
   }
 }

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -141,8 +141,7 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
     // await; doing that in willUpdate folds it into the in-progress render
     // instead of scheduling a second one.
     if (changedProperties.has("board")) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-      this._refreshAlternateBoards();
+      void this._refreshAlternateBoards();
     }
   }
 

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -387,8 +387,7 @@ export class ESPHomeHeaderActions extends OverflowMenuElement {
 
   private _openSecrets() {
     this._close();
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-    navigate("/secrets");
+    void navigate("/secrets");
   }
 
   /** Opens the Wi-Fi credentials dialog on demand. The kebab item

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -272,8 +272,7 @@ export class ESPHomeLogsDialog extends LitElement {
        back to the bottom themselves. ``scrollToBottom()`` clears the
        flag and forces a scroll. updateComplete makes sure the @query
        has resolved on first open. */
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-    this.updateComplete.then(() => this._terminal?.scrollToBottom());
+    void this.updateComplete.then(() => this._terminal?.scrollToBottom());
   }
 
   protected render() {

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -1036,8 +1036,7 @@ export class ESPHomePageDashboard extends LitElement {
     () => this._localize
   );
   _onRequestOpenEditor = (e: CustomEvent<{ configuration: string }>) => {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-    navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
+    void navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
   };
 
   /** Chip-mismatch recovery hand-off from the install dialog. */

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -585,19 +585,21 @@ export class ESPHomePageDevice extends LitElement {
     if (!this._isDirty && !this._activeSection?.lastFlushFailed) return;
     e.stopImmediatePropagation();
     window.history.pushState({}, "", withBase(`/device/${this.id}`));
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-    this._confirmLeave().then((canLeave) => {
-      if (canLeave) {
-        this._allowingLeave = true;
-        window.history.back();
-      }
-    });
+    this._confirmLeave()
+      .then((canLeave) => {
+        if (canLeave) {
+          this._allowingLeave = true;
+          window.history.back();
+        }
+      })
+      // The entry was already re-pushed, so staying put is the
+      // fail-safe on an unexpected guard failure.
+      .catch((err) => console.error("Leave confirmation failed:", err));
   };
 
   async connectedCallback() {
     super.connectedCallback();
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-    this._loadPreferences();
+    void this._loadPreferences();
     setLeaveGuard(this._confirmLeave);
     window.addEventListener("beforeunload", this._onBeforeUnload);
     window.addEventListener("popstate", this._onPopState, { capture: true });
@@ -663,8 +665,7 @@ export class ESPHomePageDevice extends LitElement {
       if (this._backendErrors.length) this._backendErrors = [];
       this._heldUnknownInstance = null;
       this._kickKnownKeys();
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-      this._loadYaml();
+      void this._loadYaml();
     }
     // Devices context arrives async after connect; kick off the board
     // fetch as soon as we have a `board_id` (and re-fetch only when it
@@ -677,8 +678,7 @@ export class ESPHomePageDevice extends LitElement {
       // ``board_id``. Restored on success, left null on failure.
       this._board = null;
       this._platformReady = false;
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-      this._loadBoard(boardId);
+      void this._loadBoard(boardId);
     } else if (!boardId) {
       // No manifest to fetch (device has no ``board_id`` or our
       // id isn't in the loaded context — deleted / stale link).
@@ -1213,8 +1213,7 @@ export class ESPHomePageDevice extends LitElement {
   private _onRequestOpenEditor = (e: CustomEvent<{ configuration: string }>) => {
     e.stopPropagation();
     if (e.detail.configuration === this._device?.configuration) return;
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME(#1505): unaudited dropped promise
-    navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
+    void navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
   };
 
   static styles = [espHomeStyles, devicePageStyles];

--- a/src/util/navigation.ts
+++ b/src/util/navigation.ts
@@ -19,10 +19,18 @@ export async function navigate(url: string): Promise<void> {
  * (no guard, or the guard resolved "proceed"). Used by ``navigate`` and by
  * back-navigations that bypass it but still must honour the guard — the header
  * back arrow's ``history.back()``, whose raw popstate the router commits before
- * the device editor's own popstate guard can veto it.
+ * the device editor's own popstate guard can veto it. A guard that throws
+ * resolves ``false``: navigating through unsaved state on a broken guard
+ * would lose it silently, so staying put is the fail-safe.
  */
 export async function runLeaveGuard(): Promise<boolean> {
-  return activeGuard ? activeGuard() : true;
+  if (!activeGuard) return true;
+  try {
+    return await activeGuard();
+  } catch (err) {
+    console.error("Leave guard failed; staying on the page:", err);
+    return false;
+  }
 }
 
 /**

--- a/test/components/device/constraint-cluster-radio-sync.test.ts
+++ b/test/components/device/constraint-cluster-radio-sync.test.ts
@@ -35,12 +35,21 @@ function radioGroup(sync: () => void | Promise<void>): HTMLElement {
 const settle = () => new Promise((r) => setTimeout(r, 0));
 
 describe("constraint-cluster radio sync tolerance", () => {
-  it("a rejecting group's sync neither blocks its siblings nor escapes unhandled", async () => {
+  it("a failing group's sync neither blocks its siblings nor escapes unhandled", async () => {
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
-      const failing = vi.fn(() => Promise.reject(new Error("not ready")));
+      const rejecting = vi.fn(() => Promise.reject(new Error("not ready")));
+      // The declared type is void | Promise<void>, so a synchronous
+      // throw is the other failure shape the loop must tolerate.
+      const throwing = vi.fn(() => {
+        throw new Error("sync throw");
+      });
       const healthy = vi.fn(() => {});
-      const host = makeHost([radioGroup(failing), radioGroup(healthy)]);
+      const host = makeHost([
+        radioGroup(rejecting),
+        radioGroup(throwing),
+        radioGroup(healthy),
+      ]);
       const controller = new ConstraintClusterController(
         host as unknown as ConstructorParameters<typeof ConstraintClusterController>[0]
       );
@@ -48,8 +57,10 @@ describe("constraint-cluster radio sync tolerance", () => {
       controller.hostUpdated();
       await settle();
 
-      expect(failing).toHaveBeenCalledTimes(1);
+      expect(rejecting).toHaveBeenCalledTimes(1);
+      expect(throwing).toHaveBeenCalledTimes(1);
       expect(healthy).toHaveBeenCalledTimes(1);
+      expect(consoleWarn).toHaveBeenCalledTimes(2);
       expect(consoleWarn).toHaveBeenCalledWith(
         "Radio group sync failed:",
         expect.any(Error)

--- a/test/components/device/constraint-cluster-radio-sync.test.ts
+++ b/test/components/device/constraint-cluster-radio-sync.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the radio-sync pass's rejection tolerance (#1505): one
+ * group's failing ``syncRadioElements`` must not abort the pass or
+ * escape as an unhandled rejection — the other groups still sync
+ * and the failure leaves a console trace.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { ConstraintClusterController } from "../../../src/components/device/constraint-cluster-controller.js";
+
+function makeHost(groups: HTMLElement[]) {
+  const outer = document.createElement("div");
+  const shadowRoot = outer.attachShadow({ mode: "open" });
+  for (const g of groups) shadowRoot.appendChild(g);
+  return {
+    shadowRoot,
+    addController: () => {},
+    removeController: () => {},
+    requestUpdate: () => {},
+    updateComplete: Promise.resolve(true),
+  };
+}
+
+function radioGroup(sync: () => void | Promise<void>): HTMLElement {
+  const el = document.createElement("wa-radio-group");
+  Object.assign(el, {
+    syncRadioElements: sync,
+    updateComplete: Promise.resolve(true),
+  });
+  return el;
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+describe("constraint-cluster radio sync tolerance", () => {
+  it("a rejecting group's sync neither blocks its siblings nor escapes unhandled", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const failing = vi.fn(() => Promise.reject(new Error("not ready")));
+      const healthy = vi.fn(() => {});
+      const host = makeHost([radioGroup(failing), radioGroup(healthy)]);
+      const controller = new ConstraintClusterController(
+        host as unknown as ConstructorParameters<typeof ConstraintClusterController>[0]
+      );
+
+      controller.hostUpdated();
+      await settle();
+
+      expect(failing).toHaveBeenCalledTimes(1);
+      expect(healthy).toHaveBeenCalledTimes(1);
+      expect(consoleWarn).toHaveBeenCalledWith(
+        "Radio group sync failed:",
+        expect.any(Error)
+      );
+    } finally {
+      consoleWarn.mockRestore();
+    }
+  });
+});

--- a/test/components/device/constraint-cluster-radio-sync.test.ts
+++ b/test/components/device/constraint-cluster-radio-sync.test.ts
@@ -65,6 +65,12 @@ describe("constraint-cluster radio sync tolerance", () => {
         "Radio group sync failed:",
         expect.any(Error)
       );
+
+      // A persistently failing group warns once, not once per render.
+      controller.hostUpdated();
+      await settle();
+      expect(rejecting).toHaveBeenCalledTimes(2);
+      expect(consoleWarn).toHaveBeenCalledTimes(2);
     } finally {
       consoleWarn.mockRestore();
     }

--- a/test/util/navigation.test.ts
+++ b/test/util/navigation.test.ts
@@ -248,6 +248,23 @@ describe("runLeaveGuard", () => {
     await expect(runLeaveGuard()).resolves.toBe(true);
     expect(stale).not.toHaveBeenCalled();
   });
+
+  it("a throwing guard blocks the leave instead of rejecting (#1505)", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      setLeaveGuard(() => Promise.reject(new Error("guard broke")));
+      // Fail-safe: navigating through unsaved state on a broken
+      // guard would lose it silently, and every ``void navigate()``
+      // caller would surface it as an unhandled rejection.
+      await expect(runLeaveGuard()).resolves.toBe(false);
+      expect(consoleError).toHaveBeenCalledWith(
+        "Leave guard failed; staying on the page:",
+        expect.any(Error)
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
 });
 
 /**


### PR DESCRIPTION
# What does this implement/fix?

Visits every `FIXME(#1505)` floating promise disable from the ESLint adoption (#1502) and replaces it with the reviewed outcome.

Nineteen sites become a deliberate `void`: the device page loaders, `_subscribeToEvents`, `_refreshAlternateBoards`, `launchLogs`, and the bulk delete and archive helpers all self catch and surface their own errors; the adopt dialog's secret key fetch resolves a cached fallback instead of rejecting; the `document.fonts.ready` chains never reject, and the `updateComplete` chains reject only when the render itself already threw and Lit already surfaced it (matching five pre existing `void this.updateComplete.then(...)` sites); and the `navigate()` call sites follow the existing reviewed `void navigate(...)` norm, since navigate only rejects through a throwing leave guard.

Two sites needed real handling, and review hardened both further. The constraint cluster sync now tolerates a rejecting `syncRadioElements` with the same `.catch(() => {})` its settling neighbour deliberately uses, normalised through `Promise.resolve` because implementations may return void. The device page's popstate confirm leave chain gains a logging `.catch`: the history entry was already re pushed, so staying put is the fail safe when the guard fails unexpectedly. Review follow ups: the radio sync's catch now logs a warn so a stuck cluster is diagnosable, `runLeaveGuard` itself resolves false on a throwing guard (covering every `void navigate()` caller at once instead of letting a broken guard surface as an unhandled rejection on a click that does nothing), and both behaviours are pinned by new cells in the navigation and constraint cluster suites.

No `FIXME(#1505)` markers remain in `src/`.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1505

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
