### PR TITLE
Adopt using-based disposables for paired acquire/release state

### DIFF
--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -9,6 +9,7 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { fireEvent } from "../../../util/fire-event.js";
 import { formatApiError } from "../../../util/format-api-error.js";
 import { notifyError } from "../../../util/notify.js";
+import { acquire } from "../../../util/scoped.js";
 import { writeAutomationDelete } from "../apply-removal.js";
 import type { SectionEditor } from "../section-editor.js";
 import {
@@ -356,8 +357,13 @@ export class AutoApplyController implements ReactiveController {
     let settle!: () => void;
     const settled = new Promise<void>((resolve) => (settle = resolve));
     const phase = { kind: "applying" as const, queued: false, settled, settle };
-    this._apply = phase;
     try {
+      this._apply = phase;
+      // Scope-bound: back to idle on every exit of the try — before
+      // the catch and the finally, matching the old finally-first
+      // reset, so the queued re-run below installs its own phase
+      // unclobbered.
+      using _applying = acquire(() => (this._apply = { kind: "idle" }));
       // Pass the host's YAML so the backend computes the diff against
       // the current draft buffer rather than the on-disk YAML —
       // otherwise repeated auto-applies (the user typing into the
@@ -420,7 +426,6 @@ export class AutoApplyController implements ReactiveController {
       if (this._connected || this._anchor?.isConnected) this._surfaceSaveError(err);
       else console.error("Detached auto-apply round failed:", err);
     } finally {
-      this._apply = { kind: "idle" };
       if (phase.queued) {
         // A value-change landed while we were running. Re-run with
         // the latest value so we don't drop the user's last edit.
@@ -472,10 +477,14 @@ export class AutoApplyController implements ReactiveController {
     const hadPending = this._debounce !== null;
     this._cancelDebounce();
     const mode: DeleteMode = { suppressed: false, suppressedFor: null };
-    this._setDeleteMode(mode);
     this._options.setError("");
     let failed = false;
     try {
+      this._setDeleteMode(mode);
+      // Scope-bound: released at try exit, before ``_settleDelete``
+      // re-arms — ``scheduleAutoApply`` refuses to arm while a
+      // delete owns the section.
+      using _deleting = acquire(() => this._setDeleteMode(null));
       // Settle the in-flight upsert (the timer is already cancelled)
       // before computing the delete diff: its late ``yaml-draft``
       // would otherwise land after our ``yaml-updated`` and resurrect
@@ -526,7 +535,6 @@ export class AutoApplyController implements ReactiveController {
       failed = true;
       this._surfaceSaveError(err);
     } finally {
-      this._setDeleteMode(null);
       this._settleDelete(mode, { failed, hadPending, location });
     }
   }

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -26,6 +26,7 @@ import { fireEvent } from "../../util/fire-event.js";
 import { formatApiError } from "../../util/format-api-error.js";
 import { notifyError } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { acquire } from "../../util/scoped.js";
 import { resolveSectionEntries } from "../../util/section-entry-overrides.js";
 import {
   locationFromSectionKey,
@@ -466,6 +467,8 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
     const location = locationFromSectionKey(key);
     if (!this._api || !location || this._deletingRow) return;
     this._deletingRow = key;
+    // Scope-bound: the lists unlock on every exit path.
+    using _row = acquire(() => (this._deletingRow = ""));
     const announceUpdated = prepareSectionEvent(this, "yaml-updated");
     try {
       // Read the buffer and target exactly once: the backend computes
@@ -490,8 +493,6 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
       notifyError(this._localize("device.automation_save_error"), {
         description: msg,
       });
-    } finally {
-      this._deletingRow = "";
     }
   };
 

--- a/src/components/labels/device-labels-editor.ts
+++ b/src/components/labels/device-labels-editor.ts
@@ -46,6 +46,7 @@ import {
 import { labelChipStyleString } from "../../util/label-style.js";
 import { notifyError } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { acquire } from "../../util/scoped.js";
 import { setsEqual } from "../../util/set-equal.js";
 import "./label-form.js";
 import type { ESPHomeLabelForm } from "./label-form.js";
@@ -251,10 +252,11 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
       // Drop any in-flight create snapshot so a late ``label-created``
       // arriving after the swap is ignored rather than misapplied.
       this._pendingCreateConfig = null;
-      // _pendingSaves is deliberately NOT reset: the orphaned task
-      // still runs its finally. Zeroing it here would drive the
-      // counter negative and permanently disable the same-device
-      // clear below.
+      // _pendingSaves is deliberately NOT reset: the orphaned
+      // ``_persist`` still releases its scope-bound hold when its
+      // task settles. Zeroing it here would drive the counter
+      // negative and permanently disable the same-device clear
+      // below.
     } else if (this._pendingSaves === 0) {
       // A same-device prop update — the ``DEVICE_UPDATED`` push that lands
       // after our own ``set_labels`` — now carries the saved labels, so drop
@@ -396,6 +398,11 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
     const api = this._api;
     const config = this.device.configuration;
     this._pendingSaves++;
+    // Scope-bound: the decrement runs when this call settles, on
+    // every exit path — the pairing the counter's invariant needs
+    // (a miss or a double release permanently disables the
+    // same-device clear in ``willUpdate``).
+    using _pending = acquire(() => this._pendingSaves--);
     const task = this._saveChain.then(async () => {
       let failed = false;
       try {
@@ -405,7 +412,6 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
         console.warn("set_labels failed", err);
         notifyError(this._localize("dashboard.labels_save_failed"));
       } finally {
-        this._pendingSaves--;
         // Failure: the prop is the truth the write never changed —
         // revert. Success: hand authority back only once the prop
         // actually carries the saved labels (covers a no-op save the

--- a/src/util/scoped.ts
+++ b/src/util/scoped.ts
@@ -1,0 +1,12 @@
+/**
+ * Scope-bound release for manually paired acquire/release state:
+ * ``using _x = acquire(release)`` runs *release* on every exit path.
+ */
+// Older engines lack the well-known symbol; TS's downlevel emit uses
+// the same Symbol.for fallback, so runtime and emit agree.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(Symbol as any).dispose ??= Symbol.for("Symbol.dispose");
+
+export function acquire(release: () => void): Disposable {
+  return { [Symbol.dispose]: release };
+}

--- a/test/util/scoped.test.ts
+++ b/test/util/scoped.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { acquire } from "../../src/util/scoped.js";
+
+describe("acquire", () => {
+  it("releases on every exit path, in reverse declaration order", () => {
+    const order: string[] = [];
+    function run(fail: boolean) {
+      using _outer = acquire(() => order.push("outer"));
+      using _inner = acquire(() => order.push("inner"));
+      order.push("body");
+      if (fail) throw new Error("boom");
+    }
+    run(false);
+    expect(() => run(true)).toThrow("boom");
+    expect(order).toEqual(["body", "inner", "outer", "body", "inner", "outer"]);
+  });
+
+  it("releases at try exit, before the finally", () => {
+    const order: string[] = [];
+    try {
+      using _guard = acquire(() => order.push("released"));
+      order.push("body");
+    } finally {
+      order.push("finally");
+    }
+    expect(order).toEqual(["body", "released", "finally"]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2021",
-    "lib": ["ES2021", "DOM", "DOM.Iterable"],
+    "lib": ["ES2021", "ESNext.Disposable", "DOM", "DOM.Iterable"],
     "experimentalDecorators": true,
     "useDefineForClassFields": false,
     "module": "ESNext",


### PR DESCRIPTION
# What does this implement/fix?

Adopts `using` declarations for the manually paired acquire/release state the async work left behind, per the retrospective. A new `util/scoped.ts` exports `acquire(release)`, which returns a `Disposable` so `using _x = acquire(...)` runs the release on every exit path with the pairing enforced by scope instead of a distant `finally`.

Four sites convert. The labels editor's `_pendingSaves` counter (the invariant a test guards by convention) is now a scope bound hold in `_persist`, released when the call settles. The engine's apply phase and delete mode reset inside their `try` blocks, which matches the old order exactly: `using` disposes at try exit before the `finally`, so the queued re run still installs its own phase unclobbered and `_settleDelete` still re arms with the delete mode already released. The section editor's `_deletingRow` lock releases on every exit of `_onDeleteRow`, and its `finally` is gone.

Toolchain was verified up front as the issue asked: the pinned tsc 7.0.2 needs `ESNext.Disposable` added to the tsconfig lib (included here), vitest's transform lowers `using` fine, and the production build compiles. `scoped.ts` seeds the `Symbol.for` fallback that TypeScript's own downlevel emit uses, so runtime and emit agree on engines without the well known symbol. A new suite pins the release on every exit path, reverse declaration order, and the dispose before finally ordering the engine conversions rely on.

Chained on #1506 because the engine sites overlap its diff.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1480

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
