### PR TITLE
Collect LIST_SECTIONS item ids as reference candidates

### DIFF
--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -19,6 +19,7 @@
 import type { ComponentCatalogEntry } from "../api/types/components.js";
 import { isValidEspHomeId } from "./esphome-id.js";
 import { isPinFieldKey, parsePinGpio, scanPinGpios } from "./pin/gpio.js";
+import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import { hasSubstitutionReference } from "./substitutions.js";
 import { indentOf } from "./yaml-line-walker.js";
 import {
@@ -412,8 +413,16 @@ export function findComponentsByProviders(
     // not add the section's own id on top: for a multi-entity platform it is
     // the hub (the wrong type for the reference), and a hybrid's root entity
     // already arrived through its ["id"] path.
-    if (ownIdMatched && !hasIdPathProvider && section.id) {
-      add(section.id, section.name ?? "");
+    if (ownIdMatched && !hasIdPathProvider) {
+      if (section.id) {
+        add(section.id, section.name ?? "");
+      } else if (LIST_SECTIONS.has(section.key)) {
+        // A LIST_SECTIONS block stays un-expanded (no per-item sections
+        // carrying an id), so enumerate its item ids directly.
+        lines ??= yaml.split("\n");
+        for (const inst of collectIdsAtPath(lines, section, ["id"]))
+          add(inst.id, inst.name);
+      }
     }
   }
   providerMemo.set(probe, result);

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -457,6 +457,29 @@ describe("findReferenceCandidates (LIST_SECTIONS domain)", () => {
     expect(isCertainlyDanglingId("id_global", candidates, yaml)).toBe(false);
     expect(isCertainlyDanglingId("id_typo", candidates, yaml)).toBe(true);
   });
+
+  it("handles the zero-indented sequence form", () => {
+    const zeroIndent = [
+      "globals:",
+      "- id: id_global",
+      "  type: int",
+      "- id: id_other",
+      "  type: bool",
+      "",
+    ].join("\n");
+    expect(findReferenceCandidates(zeroIndent, "globals", [])).toEqual([
+      { id: "id_global", name: "" },
+      { id: "id_other", name: "" },
+    ]);
+  });
+
+  it("does not leak an adjacent top-level section's ids", () => {
+    const config = [yaml, "sensor:", "  - platform: adc", "    id: adc_a", ""].join("\n");
+    expect(findReferenceCandidates(config, "globals", [])).toEqual([
+      { id: "id_global", name: "" },
+      { id: "id_other", name: "" },
+    ]);
+  });
 });
 
 describe("findComponentsByProviders", () => {

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -431,6 +431,34 @@ describe("findReferenceCandidates (same-domain base case)", () => {
   });
 });
 
+describe("findReferenceCandidates (LIST_SECTIONS domain)", () => {
+  // The globals: block stays one un-expanded section (LIST_SECTIONS), so
+  // candidates come from the per-item id scan, not the section's own id.
+  const yaml = [
+    "globals:",
+    "  - id: id_global",
+    "    type: int",
+    '    initial_value: "0"',
+    "    restore_value: true",
+    "  - id: id_other",
+    "    type: bool",
+    "",
+  ].join("\n");
+
+  it("returns every item id in a globals block", () => {
+    expect(findReferenceCandidates(yaml, "globals", [])).toEqual([
+      { id: "id_global", name: "" },
+      { id: "id_other", name: "" },
+    ]);
+  });
+
+  it("does not report a defined global as dangling", () => {
+    const candidates = findReferenceCandidates(yaml, "globals", []);
+    expect(isCertainlyDanglingId("id_global", candidates, yaml)).toBe(false);
+    expect(isCertainlyDanglingId("id_typo", candidates, yaml)).toBe(true);
+  });
+});
+
 describe("findComponentsByProviders", () => {
   const yaml = [
     "sensor:",


### PR DESCRIPTION
# What does this implement/fix?

The visual editor flagged a defined global as undefined in the globals.set ID picker; the id only appeared in the dropdown as the unresolved fallback option. The reference scan never collected ids from a globals block, because globals is a LIST_SECTIONS member whose section carries no id, and the scan only read section.id. Enumerate the block's item ids with the existing collectIdsAtPath helper instead; this also fixes YAML autocomplete and sole candidate resolution for globals references. Verified in the live editor with the issue's config, before and after.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2349

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
