### PR TITLE
Show pin panels for a scalar ${var} pin value

### DIFF
--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -916,9 +916,11 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // A ${var} value can't drive a typed widget (number/select/switch): it
     // blanks the literal and the first interaction clobbers it. Edit it as
     // text so the token round-trips and stays editable mid-keystroke;
-    // SECURE_STRING stays masked (#1391).
+    // SECURE_STRING stays masked (#1391). PIN is exempt — renderPinField owns
+    // its own ${var} handling (scalar and long-form) so the Mode/Wiring
+    // panels still render (#2348).
     const raw = ctx.getAt(path);
-    if (isSubstitutionString(raw)) {
+    if (isSubstitutionString(raw) && entry.type !== ConfigEntryType.PIN) {
       const inputType =
         entry.type === ConfigEntryType.SECURE_STRING ? "password" : "text";
       return renderStringField(entry, inputType, path, ctx);

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -916,11 +916,13 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // A ${var} value can't drive a typed widget (number/select/switch): it
     // blanks the literal and the first interaction clobbers it. Edit it as
     // text so the token round-trips and stays editable mid-keystroke;
-    // SECURE_STRING stays masked (#1391). PIN is exempt — renderPinField owns
-    // its own ${var} handling (scalar and long-form) so the Mode/Wiring
-    // panels still render (#2348).
+    // SECURE_STRING stays masked (#1391). A single-value PIN is exempt —
+    // renderPinField owns its own ${var} handling (scalar and long-form) so
+    // the Mode/Wiring panels still render (#2348). A multi_value PIN routes to
+    // renderMultiValueField below, not renderPinField, so it keeps the gate.
     const raw = ctx.getAt(path);
-    if (isSubstitutionString(raw) && entry.type !== ConfigEntryType.PIN) {
+    const isScalarPinField = entry.type === ConfigEntryType.PIN && !entry.multi_value;
+    if (isSubstitutionString(raw) && !isScalarPinField) {
       const inputType =
         entry.type === ConfigEntryType.SECURE_STRING ? "password" : "text";
       return renderStringField(entry, inputType, path, ctx);

--- a/src/components/device/pin/renderer.ts
+++ b/src/components/device/pin/renderer.ts
@@ -299,14 +299,17 @@ export function renderPinField(
   ctx: RenderCtx
 ): TemplateResult {
   const rawValue = ctx.getAt(path);
-  // A long-form pin whose ``number`` is a ``${var}`` reference can't drive
-  // the board-GPIO picker — no option matches, so the select rendered blank
-  // (#2268) — and a pick would clobber the reference with a literal. Edit
-  // ``number`` as text with the resolves-to hint, mirroring the scalar
-  // ${var} gate in ``config-entry-form``. Checked before the boardless
-  // fallback, which would bail an object value to the YAML-only shell.
-  if (isPlainObject(rawValue) && isSubstitutionString(rawValue.number)) {
-    return renderSubstitutionPin(entry, path, ctx, rawValue, rawValue.number);
+  // A ``${var}`` reference can't drive the board-GPIO picker — no option
+  // matches, so the select rendered blank (#2268) — and a pick would clobber
+  // the reference with a literal. Edit it as text with the resolves-to hint,
+  // both for a scalar ``pin: ${var}`` (#2348) and a long-form ``number``.
+  // Checked before the boardless fallback, which would bail an object value
+  // to the YAML-only shell.
+  if (
+    isSubstitutionString(rawValue) ||
+    (isPlainObject(rawValue) && isSubstitutionString(rawValue.number))
+  ) {
+    return renderSubstitutionPin(entry, path, ctx, rawValue);
   }
   if (!ctx.board || ctx.board.pins.length === 0) {
     return renderStringField(entry, "text", path, ctx);
@@ -510,17 +513,19 @@ export function renderPinField(
   `;
 }
 
-/** Long-form pin with a ``${var}`` ``number``: a text input for the
- *  reference (edits route to ``path.number``, so mode / inverted are
- *  preserved) plus the Advanced disclosure the normal path renders. */
+/** Pin whose ``${var}`` reference can't drive the picker: a text input for
+ *  the reference plus the Advanced disclosure the normal path renders.
+ *  Long-form edits route to ``path.number`` (mode / inverted preserved);
+ *  a scalar ``pin: ${var}`` edits ``path`` itself. */
 function renderSubstitutionPin(
   entry: ConfigEntry,
   path: string[],
   ctx: RenderCtx,
-  rawValue: Record<string, unknown>,
-  number: string
+  rawValue: unknown
 ): TemplateResult {
-  const numberPath = [...path, "number"];
+  const isLongForm = isPlainObject(rawValue);
+  const number = (isLongForm ? rawValue.number : rawValue) as string;
+  const numberPath = isLongForm ? [...path, "number"] : path;
   const invalid = ctx.errorAt(numberPath) !== null;
   const fieldDisabled = effectiveDisabled(entry, ctx);
   // The ``${var}`` can still resolve to the board's designation for this
@@ -535,7 +540,7 @@ function renderSubstitutionPin(
   const pins = ctx.board?.pins ?? [];
   const resolvedNumber = resolveSubstitutions(number, ctx.substitutions);
   const resolved =
-    parsePinGpio({ ...rawValue, number: resolvedNumber }) ??
+    parsePinGpio(isLongForm ? { ...rawValue, number: resolvedNumber } : resolvedNumber) ??
     (isExpanderPinValue(rawValue) ? null : gpioFromAlias(resolvedNumber, pins));
   const boardPins = boardPinsForSection(ctx, entry.key);
   const boardPreset =

--- a/src/components/device/pin/renderer.ts
+++ b/src/components/device/pin/renderer.ts
@@ -523,9 +523,9 @@ function renderSubstitutionPin(
   ctx: RenderCtx,
   rawValue: unknown
 ): TemplateResult {
-  const isLongForm = isPlainObject(rawValue);
-  const number = (isLongForm ? rawValue.number : rawValue) as string;
-  const numberPath = isLongForm ? [...path, "number"] : path;
+  const longForm = isPlainObject(rawValue) ? rawValue : null;
+  const number = (longForm ? longForm.number : rawValue) as string;
+  const numberPath = longForm ? [...path, "number"] : path;
   const invalid = ctx.errorAt(numberPath) !== null;
   const fieldDisabled = effectiveDisabled(entry, ctx);
   // The ``${var}`` can still resolve to the board's designation for this
@@ -540,7 +540,7 @@ function renderSubstitutionPin(
   const pins = ctx.board?.pins ?? [];
   const resolvedNumber = resolveSubstitutions(number, ctx.substitutions);
   const resolved =
-    parsePinGpio(isLongForm ? { ...rawValue, number: resolvedNumber } : resolvedNumber) ??
+    parsePinGpio(longForm ? { ...longForm, number: resolvedNumber } : resolvedNumber) ??
     (isExpanderPinValue(rawValue) ? null : gpioFromAlias(resolvedNumber, pins));
   const boardPins = boardPinsForSection(ctx, entry.key);
   const boardPreset =

--- a/test/components/device/pin/renderer.test.ts
+++ b/test/components/device/pin/renderer.test.ts
@@ -938,3 +938,49 @@ describe("renderPinField long-form substitution number", () => {
     expect(findTemplatesByAnchor(result, "<wa-select").length).toBe(1);
   });
 });
+
+describe("renderPinField scalar substitution", () => {
+  // esphome/device-builder#2348: a bare `pin: ${testpin1}` was swallowed by
+  // the config-entry-form ${var} gate and rendered as plain text, hiding the
+  // Mode/Wiring panels. It now reaches renderPinField and behaves like the
+  // long-form ${var} case: a reference input plus the Advanced disclosure.
+  const subEntry = () =>
+    makeEntry(ConfigEntryType.PIN, { key: "pin", required: true, pin_features: [] });
+
+  it("renders a text input for the reference instead of the picker", () => {
+    const ctx = makeRenderCtx({ pin: "${testpin1}" });
+    const result = renderPinField(subEntry(), ["pin"], ctx);
+    expect(findTemplatesByAnchor(result, "<wa-select").length).toBe(0);
+    const input = findElementBindings(result, "input")[0];
+    expect(input[".value"]).toBe("${testpin1}");
+  });
+
+  it("routes edits to the scalar path, not path.number", () => {
+    const ctx = makeRenderCtx({ pin: "${testpin1}" });
+    const result = renderPinField(subEntry(), ["pin"], ctx);
+    const input = findTemplatesByAnchor(result, "<input")[0];
+    const onInput = extractAttributeBindings(input)["@input"] as (e: Event) => void;
+    onInput({ target: { value: "${testpin2}" } } as never);
+    expect(ctx.emitChange).toHaveBeenCalledWith(["pin"], "${testpin2}");
+  });
+
+  it("previews the resolved value from the file's substitutions", () => {
+    const yaml = "substitutions:\n  testpin1: GPIO10\n";
+    const ctx = makeRenderCtx({ pin: "${testpin1}" }, { overrides: { yaml } });
+    const result = renderPinField(subEntry(), ["pin"], ctx);
+    const hint = findTemplatesByAnchor(result, "substitution-note")[0];
+    expect(hint.values).toContain("GPIO10");
+  });
+
+  it("marks an unresolvable reference as external", () => {
+    const ctx = makeRenderCtx({ pin: "${from_package}" });
+    const result = renderPinField(subEntry(), ["pin"], ctx);
+    expect(findTemplatesByAnchor(result, "substitution-note--external").length).toBe(1);
+  });
+
+  it("still renders the board picker for a literal scalar pin", () => {
+    const ctx = makeRenderCtx({ pin: "GPIO5" });
+    const result = renderPinField(subEntry(), ["pin"], ctx);
+    expect(findTemplatesByAnchor(result, "<wa-select").length).toBe(1);
+  });
+});

--- a/test/components/device/render-substitution-typed-fields.test.ts
+++ b/test/components/device/render-substitution-typed-fields.test.ts
@@ -157,4 +157,20 @@ describe("leaf dispatch routes ${var} values to an editable text field (#1391)",
     )._renderEntryLeaf(entry, ["field"], ctx);
     expect(serialize(result)).toContain("pin-advanced");
   });
+
+  it("keeps the gate for a multi_value PIN ${var} (routes to the list, not the pin renderer)", () => {
+    // A whole-value ${var} on a multi_value PIN (octal SPI data_pins) never
+    // reaches renderPinField — the exemption is scoped to single-value PINs so
+    // it still edits as text rather than an empty list the Add button clobbers.
+    const entry = makeEntry(ConfigEntryType.PIN, {
+      key: "field",
+      multi_value: true,
+      pin_features: [],
+    });
+    const result = renderLeaf(entry, "${current_res}");
+    const inputs = findElementBindings(result, "input");
+    expect(inputs[0]["type"]).toBe("text");
+    expect(inputs[0][".value"]).toBe("${current_res}");
+    expect(serialize(result)).not.toContain("pin-advanced");
+  });
 });

--- a/test/components/device/render-substitution-typed-fields.test.ts
+++ b/test/components/device/render-substitution-typed-fields.test.ts
@@ -12,7 +12,7 @@ import {
 import { ESPHomeConfigEntryForm } from "../../../src/components/device/config-entry-form.js";
 import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
-import { findElementBindings, makeRenderCtx } from "./_renderer-fixtures.js";
+import { findElementBindings, makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
 
 const YAML = ["substitutions:", '  current_res: "0.05"', '  voltage_div: "720"', ""].join(
   "\n"
@@ -123,5 +123,38 @@ describe("leaf dispatch routes ${var} values to an editable text field (#1391)",
     const json = serialize(result);
     expect(json).not.toContain("substitution-note");
     expect(json).not.toContain("720");
+  });
+
+  it("exempts a PIN ${var}: reaches renderPinField, keeping the wiring panel (#2348)", () => {
+    // Unlike the typed fields above, a scalar `pin: ${var}` must NOT be
+    // flattened to a bare text input — it reaches renderPinField, which still
+    // renders the Advanced/Mode disclosure (`pin-advanced`) the plain gate can't.
+    const modeChild = makeEntry(ConfigEntryType.NESTED, {
+      key: "mode",
+      config_entries: [
+        makeEntry(ConfigEntryType.BOOLEAN, { key: "output", advanced: true }),
+      ],
+    });
+    const invertedChild = makeEntry(ConfigEntryType.BOOLEAN, {
+      key: "inverted",
+      advanced: true,
+    });
+    const entry = makeEntry(ConfigEntryType.PIN, {
+      key: "field",
+      required: true,
+      pin_features: [],
+      config_entries: [modeChild, invertedChild],
+    });
+    const form = new ESPHomeConfigEntryForm();
+    const ctx: RenderCtx = makeRenderCtx(
+      { field: "${current_res}" },
+      { overrides: { sectionKey: "sensor.gpio", yaml: YAML } }
+    );
+    const result = (
+      form as unknown as {
+        _renderEntryLeaf(e: ConfigEntry, p: string[], c: RenderCtx): unknown;
+      }
+    )._renderEntryLeaf(entry, ["field"], ctx);
+    expect(serialize(result)).toContain("pin-advanced");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

A pin written as a bare substitution such as `pin: ${var}` rendered as a plain text box with no Mode or Wiring panels, unlike a literal pin or the long form `${var}` shape; the scalar value was caught by the config entry form's substitution gate before it reached the pin renderer. This exempts pin fields from that gate and routes a scalar `${var}` through the same renderer that already handles the long form object, so the reference input and the Advanced disclosure both render. Presets stay withheld because the resolved GPIO is unknown, matching the existing long form behavior.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2348

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
