### PR TITLE
Hide the advanced-settings toggle when every advanced field is hidden

### DIFF
--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -24,9 +24,11 @@ export function choicePinned(
 /** True when `entries` contains any advanced entry, recursively. Drives whether
  *  the advanced-settings control shows at all: a nested advanced field reveals
  *  in place (it can't move to the bottom section), so the control must surface
- *  even when no *top-level* unit is advanced, or the field is unreachable. */
+ *  even when no *top-level* unit is advanced, or the field is unreachable.
+ *  Hidden entries never render, so they don't count. */
 export function anyAdvancedEntry(entries: ConfigEntry[]): boolean {
   for (const entry of entries) {
+    if (entry.hidden) continue;
     if (entry.advanced) return true;
     if (
       entry.type === ConfigEntryType.NESTED &&

--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -25,7 +25,8 @@ export function choicePinned(
  *  the advanced-settings control shows at all: a nested advanced field reveals
  *  in place (it can't move to the bottom section), so the control must surface
  *  even when no *top-level* unit is advanced, or the field is unreachable.
- *  Hidden entries never render, so they don't count. */
+ *  Hidden entries don't count: empty ones never render, and value-bearing
+ *  ones paint regardless of the toggle. */
 export function anyAdvancedEntry(entries: ConfigEntry[]): boolean {
   for (const entry of entries) {
     if (entry.hidden) continue;

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -380,6 +380,46 @@ describe("config-entry-form advanced-section", () => {
     expect(text).not.toContain("Hidden Adv");
   });
 
+  it("renders no control when the only advanced field is hidden", () => {
+    // output.gpio shape (issue device-builder#2347): setup_priority is the
+    // sole advanced entry and it's hidden, so the control would reveal
+    // nothing at all.
+    const c = renderForm([
+      BASIC,
+      makeConfigEntry({
+        key: "setup_priority",
+        type: ConfigEntryType.STRING,
+        label: "Hidden Adv",
+        advanced: true,
+        hidden: true,
+      }),
+    ]);
+    expect(control(c)).toBeNull();
+    expect(c.textContent).not.toContain("Hidden Adv");
+  });
+
+  it("renders no control when the only advanced field is hidden inside a nested group", () => {
+    const c = renderForm([
+      BASIC,
+      makeConfigEntry({
+        key: "group",
+        type: ConfigEntryType.NESTED,
+        label: "Group",
+        config_entries: [
+          makeConfigEntry({
+            key: "setup_priority",
+            type: ConfigEntryType.STRING,
+            label: "Nested Hidden Adv",
+            advanced: true,
+            hidden: true,
+          }),
+        ],
+      }),
+    ]);
+    expect(control(c)).toBeNull();
+    expect(c.textContent).not.toContain("Nested Hidden Adv");
+  });
+
   it("counts a constraint cluster as one advanced unit, not per member", () => {
     // Two advanced fields sharing an inclusive group fold into one cluster box
     // painted at the first member's slot; the "(N)" count must be 1, not 2.

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -33,6 +33,13 @@ const ADVANCED = makeConfigEntry({
   label: "Advanced Field",
   advanced: true,
 });
+const HIDDEN_ADV = makeConfigEntry({
+  key: "setup_priority",
+  type: ConfigEntryType.STRING,
+  label: "Hidden Adv",
+  advanced: true,
+  hidden: true,
+});
 
 function renderForm(
   entries: ConfigEntry[],
@@ -384,18 +391,26 @@ describe("config-entry-form advanced-section", () => {
     // output.gpio shape (issue device-builder#2347): setup_priority is the
     // sole advanced entry and it's hidden, so the control would reveal
     // nothing at all.
-    const c = renderForm([
-      BASIC,
-      makeConfigEntry({
-        key: "setup_priority",
-        type: ConfigEntryType.STRING,
-        label: "Hidden Adv",
-        advanced: true,
-        hidden: true,
-      }),
-    ]);
+    const c = renderForm([BASIC, HIDDEN_ADV]);
     expect(control(c)).toBeNull();
     expect(c.textContent).not.toContain("Hidden Adv");
+  });
+
+  it("still paints a hidden advanced field that has a value, with no control", () => {
+    const c = renderForm([BASIC, HIDDEN_ADV], {
+      values: { setup_priority: "-100" },
+    });
+    expect(control(c)).toBeNull();
+    expect(c.textContent).toContain("Hidden Adv");
+  });
+
+  it("still paints a value-bearing hidden advanced field under gate-advanced", () => {
+    const c = renderForm([BASIC, HIDDEN_ADV], {
+      values: { setup_priority: "-100" },
+      gateAdvanced: true,
+    });
+    expect(control(c)).toBeNull();
+    expect(c.textContent).toContain("Hidden Adv");
   });
 
   it("renders no control when the only advanced field is hidden inside a nested group", () => {


### PR DESCRIPTION
# What does this implement/fix?

The "Show advanced settings" toggle is decided by `anyAdvancedEntry`, which counts advanced entries without excluding hidden ones, while the render filter drops hidden entries before the toggle can gate them. For components whose only advanced entry is the hidden `setup_priority` (esphome 2026.7 marks it yaml_only upstream, and the catalog cascade makes hidden imply advanced), the toggle rendered but revealed nothing; `output.gpio` from the report is one of 16 such components. `anyAdvancedEntry` now skips hidden entries, mirroring the existing guard in `pathIsAdvanced`, so the toggle only shows when it has something to reveal. A hidden entry with a value in the YAML already renders ungated, so it never depended on the toggle in any state.

Verified live against a dev backend with the reporter's config: the output section shows no toggle, wifi still shows its working toggle.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#2347

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
