### PR TITLE
Render an uncatalogued automation action read-only in place

### DIFF
--- a/src/api/types/automations.ts
+++ b/src/api/types/automations.ts
@@ -212,8 +212,11 @@ export interface ParsedAutomation {
    *  form is unrecoverable. */
   raw_yaml: string;
   /** Set when this one automation failed to decompose (unknown
-   *  action / condition id). Siblings still parse; the editor renders
-   *  it read-only so its empty tree can't overwrite the real YAML. */
+   *  condition id, or a misrouted body). An uncatalogued *action* no
+   *  longer fails here — it becomes a read-only passthrough node
+   *  (see ``ActionNode.unknown``). Siblings still parse; the editor
+   *  renders a flagged automation read-only so its empty tree can't
+   *  overwrite the real YAML. */
   error?: string | null;
   /** True when ``error`` is a *known* action with no structured form
    *  (an oversized LVGL ``*.update``) rather than a genuine parse

--- a/src/api/types/automations.ts
+++ b/src/api/types/automations.ts
@@ -155,12 +155,17 @@ export type AutomationLocation =
  *  action's ``accepts_action_list`` entries (e.g.
  *  ``{ then: [...], else: [...] }`` for ``if``). ``conditions`` is
  *  populated only for ``if`` (the boolean gate) — other control-flow
- *  actions have their gate elsewhere. */
+ *  actions have their gate elsewhere. ``unknown`` marks an uncatalogued
+ *  action (from an ``external_components`` source, or a typo): it's
+ *  shown read-only, and ``raw_body`` is round-tripped verbatim so the
+ *  sibling actions stay editable. */
 export interface ActionNode {
   action_id: string;
   params: Record<string, unknown>;
   children?: Record<string, ActionNode[]>;
   conditions?: ConditionNode[];
+  unknown?: boolean;
+  raw_body?: unknown;
 }
 
 /** A single condition inside an ``if`` / ``while`` / ``wait_until``.

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -315,12 +315,20 @@ export class ESPHomeAutomationActionNode extends LitElement {
             ? nothing
             : html`<div class="ae-row-body">
                 ${
-                  def?.description
-                    ? html`<p class="ae-row-desc">${renderMarkdown(def.description)}</p>`
-                    : nothing
+                  this.value.unknown
+                    ? html`<p class="ae-row-unknown">
+                        ${this._localize("device.automation_action_unknown")}
+                      </p>`
+                    : html`${
+                        def?.description
+                          ? html`<p class="ae-row-desc">
+                              ${renderMarkdown(def.description)}
+                            </p>`
+                          : nothing
+                      }
+                      ${this._renderActionParams(def)} ${this._renderScriptParams(def)}
+                      ${this._renderConditionGate(def)} ${this._renderNestedLists(def)}`
                 }
-                ${this._renderActionParams(def)} ${this._renderScriptParams(def)}
-                ${this._renderConditionGate(def)} ${this._renderNestedLists(def)}
               </div>`
         }
       </div>

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -315,20 +315,22 @@ export class ESPHomeAutomationActionNode extends LitElement {
             ? nothing
             : html`<div class="ae-row-body">
                 ${
+                  // An unknown action is by definition absent from the catalog,
+                  // so def is undefined and the four renderers below already
+                  // yield nothing; the hint is the only body it shows.
                   this.value.unknown
-                    ? html`<p class="ae-row-unknown">
+                    ? html`<p class="ae-row-unknown" role="note">
                         ${this._localize("device.automation_action_unknown")}
                       </p>`
-                    : html`${
-                        def?.description
-                          ? html`<p class="ae-row-desc">
-                              ${renderMarkdown(def.description)}
-                            </p>`
-                          : nothing
-                      }
-                      ${this._renderActionParams(def)} ${this._renderScriptParams(def)}
-                      ${this._renderConditionGate(def)} ${this._renderNestedLists(def)}`
+                    : nothing
                 }
+                ${
+                  def?.description
+                    ? html`<p class="ae-row-desc">${renderMarkdown(def.description)}</p>`
+                    : nothing
+                }
+                ${this._renderActionParams(def)} ${this._renderScriptParams(def)}
+                ${this._renderConditionGate(def)} ${this._renderNestedLists(def)}
               </div>`
         }
       </div>

--- a/src/components/device/automation-editor/automation-editor-rows.styles.ts
+++ b/src/components/device/automation-editor/automation-editor-rows.styles.ts
@@ -49,6 +49,16 @@ export const automationEditorRowStyles = css`
     line-height: 1.5;
   }
 
+  .ae-row-unknown {
+    margin: 0;
+    padding: var(--wa-space-s) var(--wa-space-m);
+    border-radius: var(--wa-border-radius-s);
+    background: var(--wa-color-neutral-fill-quiet);
+    font-size: var(--wa-font-size-xs);
+    color: var(--wa-color-text-quiet);
+    line-height: 1.5;
+  }
+
   /* Each action / condition row lives inside its own custom
      element shadow, so .ae-row + .ae-row would never match — the
      rows aren't siblings in any one tree. The selector below

--- a/src/components/device/automation-editor/parse-error-controller.ts
+++ b/src/components/device/automation-editor/parse-error-controller.ts
@@ -13,11 +13,12 @@ import { sectionKeyFromLocation } from "./serialise.js";
  * Shared read-only behaviour for the automation / script / api-action
  * editors.
  *
- * When the backend flags one automation with a parse error (unknown
- * condition id, or a misrouted body — an uncatalogued action instead
- * becomes a read-only passthrough node) its tree comes back empty; the
+ * When the backend flags one automation with a parse error (an unknown
+ * condition id, or a misrouted body), its tree comes back empty; the
  * editor must render read-only and never upsert, or that empty tree
- * would overwrite the real YAML block (#1050). Each host:
+ * would overwrite the real YAML block (#1050). An uncatalogued action
+ * no longer triggers this: it decomposes to a read-only passthrough
+ * node, leaving the rest of the automation editable. Each host:
  *
  *   1. Calls ``resolve(parsed, location[, kind])`` in its hydrate path
  *      and adopts the returned tree (``null`` = leave ``value`` alone).

--- a/src/components/device/automation-editor/parse-error-controller.ts
+++ b/src/components/device/automation-editor/parse-error-controller.ts
@@ -14,9 +14,10 @@ import { sectionKeyFromLocation } from "./serialise.js";
  * editors.
  *
  * When the backend flags one automation with a parse error (unknown
- * action/condition id) its tree comes back empty; the editor must
- * render read-only and never upsert, or that empty tree would
- * overwrite the real YAML block (#1050). Each host:
+ * condition id, or a misrouted body — an uncatalogued action instead
+ * becomes a read-only passthrough node) its tree comes back empty; the
+ * editor must render read-only and never upsert, or that empty tree
+ * would overwrite the real YAML block (#1050). Each host:
  *
  *   1. Calls ``resolve(parsed, location[, kind])`` in its hydrate path
  *      and adopts the returned tree (``null`` = leave ``value`` alone).

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -971,6 +971,7 @@
     "automation_action_collapse": "Collapse",
     "automation_action_expand": "Expand",
     "automation_action_pick": "Change action",
+    "automation_action_unknown": "This action isn't in the catalog (it comes from an external component, or the id is a typo), so it can't be edited here. Edit it in the YAML view; it's kept as-is when you save the rest of the automation.",
     "automation_action_delay_unit_us": "Microseconds",
     "automation_action_delay_unit_ms": "Milliseconds",
     "automation_action_delay_unit_s": "Seconds",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -971,7 +971,7 @@
     "automation_action_collapse": "Collapse",
     "automation_action_expand": "Expand",
     "automation_action_pick": "Change action",
-    "automation_action_unknown": "This action isn't in the catalog (it comes from an external component, or the id is a typo), so it can't be edited here. Edit it in the YAML view; it's kept as-is when you save the rest of the automation.",
+    "automation_action_unknown": "This action isn't in the catalog (it comes from an external component, or the id is a typo), so its settings can't be edited here. Edit them in the YAML view, or use the change-action button to replace it. It's kept as-is when you save the rest of the automation.",
     "automation_action_delay_unit_us": "Microseconds",
     "automation_action_delay_unit_ms": "Milliseconds",
     "automation_action_delay_unit_s": "Seconds",

--- a/test/components/device/automation-editor/automation-action-list-unknown-passthrough.test.ts
+++ b/test/components/device/automation-editor/automation-action-list-unknown-passthrough.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Editing a sibling action keeps an uncatalogued passthrough node's
+ * raw_body intact through the list's immutable splice (#2350).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-action-node.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/catalog-picker-dialog.js",
+  () => ({})
+);
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import type { ActionNode } from "../../../../src/api/types/automations.js";
+import { ESPHomeAutomationActionList } from "../../../../src/components/device/automation-editor/automation-action-list.js";
+
+const unknownNode: ActionNode = {
+  action_id: "storage.file_append",
+  params: {},
+  unknown: true,
+  raw_body: { path: "/data/my.log", format: "hello" },
+};
+
+describe("automation-action-list unknown passthrough round-trip (#2350)", () => {
+  it("preserves an untouched unknown node when a sibling is edited", async () => {
+    const list = new ESPHomeAutomationActionList();
+    list.actions = [unknownNode, { action_id: "logger.log", params: { format: "a" } }];
+    list.catalog = [];
+    document.body.appendChild(list);
+    await list.updateComplete;
+
+    let emitted: ActionNode[] | null = null;
+    list.addEventListener("actions-change", (e) => {
+      emitted = (e as CustomEvent<{ actions: ActionNode[] }>).detail.actions;
+    });
+
+    // The logger row (index 1) emits an edited value, as its params form would.
+    const rows = list.shadowRoot!.querySelectorAll("esphome-automation-action-node");
+    rows[1].dispatchEvent(
+      new CustomEvent("action-change", {
+        detail: { value: { action_id: "logger.log", params: { format: "edited" } } },
+        bubbles: true,
+        composed: true,
+      })
+    );
+
+    expect(emitted).not.toBeNull();
+    // The untouched passthrough node survives verbatim, raw_body and all.
+    expect(emitted![0]).toEqual(unknownNode);
+    expect(emitted![1].params.format).toBe("edited");
+
+    list.remove();
+  });
+});

--- a/test/components/device/automation-editor/automation-action-node-unknown.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-unknown.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * An uncatalogued (external-component) action renders a read-only hint
+ * instead of a params form, and carries its raw_body through unchanged
+ * so a sibling edit round-trips it (esphome/device-builder#2350).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-action-list.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-condition-tree.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/catalog-picker-dialog.js",
+  () => ({})
+);
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+
+import type { ActionNode } from "../../../../src/api/types/automations.js";
+import { ESPHomeAutomationActionNode } from "../../../../src/components/device/automation-editor/automation-action-node.js";
+import { mount } from "../../../_dom.js";
+
+const unknownNode: ActionNode = {
+  action_id: "storage.file_append",
+  params: {},
+  unknown: true,
+  raw_body: { path: "/data/my.log", format: "hello" },
+};
+
+describe("automation-action-node unknown passthrough (#2350)", () => {
+  it("shows the raw action id and the read-only hint, no params form", async () => {
+    const el = await mount(new ESPHomeAutomationActionNode(), {
+      value: unknownNode,
+      catalog: [],
+    });
+    expect(el.shadowRoot!.querySelector(".ae-row-picker-name")!.textContent!.trim()).toBe(
+      "storage.file_append"
+    );
+    expect(el.shadowRoot!.querySelector(".ae-row-unknown")).not.toBeNull();
+    expect(el.shadowRoot!.querySelector("esphome-config-entry-form")).toBeNull();
+  });
+
+  it("keeps unknown + raw_body on the node value for round-trip", async () => {
+    const el = await mount(new ESPHomeAutomationActionNode(), {
+      value: unknownNode,
+      catalog: [],
+    });
+    expect(el.value.unknown).toBe(true);
+    expect(el.value.raw_body).toEqual({ path: "/data/my.log", format: "hello" });
+  });
+});

--- a/test/components/device/automation-editor/automation-action-node-unknown.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-unknown.test.ts
@@ -44,16 +44,9 @@ describe("automation-action-node unknown passthrough (#2350)", () => {
     expect(el.shadowRoot!.querySelector(".ae-row-picker-name")!.textContent!.trim()).toBe(
       "storage.file_append"
     );
-    expect(el.shadowRoot!.querySelector(".ae-row-unknown")).not.toBeNull();
+    const hint = el.shadowRoot!.querySelector(".ae-row-unknown");
+    expect(hint).not.toBeNull();
+    expect(hint!.getAttribute("role")).toBe("note");
     expect(el.shadowRoot!.querySelector("esphome-config-entry-form")).toBeNull();
-  });
-
-  it("keeps unknown + raw_body on the node value for round-trip", async () => {
-    const el = await mount(new ESPHomeAutomationActionNode(), {
-      value: unknownNode,
-      catalog: [],
-    });
-    expect(el.value.unknown).toBe(true);
-    expect(el.value.raw_body).toEqual({ path: "/data/my.log", format: "hello" });
   });
 });

--- a/test/components/device/automation-editor/automation-editor-uneditable.test.ts
+++ b/test/components/device/automation-editor/automation-editor-uneditable.test.ts
@@ -30,8 +30,11 @@ const erroredParse = (): ParsedAutomation[] => [
     automation: { trigger_id: "on_boot", trigger_params: {}, actions: [] },
     from_line: 1,
     to_line: 3,
-    raw_yaml: "on_boot:\n  then:\n    - made_up: 1\n",
-    error: "Unknown action id: 'made_up'",
+    // An unknown condition still fails the whole automation (an uncatalogued
+    // action instead becomes a passthrough node, so it's no longer a trigger).
+    raw_yaml:
+      "on_boot:\n  then:\n    - if:\n        condition:\n          - made_up:\n        then: []\n",
+    error: "Unknown condition id: 'made_up'",
   } as unknown as ParsedAutomation,
 ];
 

--- a/test/components/device/automation-editor/parse-error-controller.test.ts
+++ b/test/components/device/automation-editor/parse-error-controller.test.ts
@@ -49,7 +49,7 @@ describe("ParseErrorController.resolve", () => {
   it("goes read-only and withholds the tree on a parse error", () => {
     const c = new ParseErrorController(fakeHost());
     expect(
-      c.resolve([parsed({ error: "Unknown action id: 'x'" })], SCRIPT, "script")
+      c.resolve([parsed({ error: "Unknown condition id: 'x'" })], SCRIPT, "script")
     ).toBeNull();
     expect(c.active).toBe(true);
   });
@@ -114,7 +114,7 @@ describe("ParseErrorController.resolve", () => {
 
   it("renders the error alert for a genuine parse error", () => {
     const c = new ParseErrorController(fakeHost());
-    c.resolve([parsed({ error: "Unknown action id: 'x'" })], SCRIPT, "script");
+    c.resolve([parsed({ error: "Unknown condition id: 'x'" })], SCRIPT, "script");
     const localize = vi.fn(identityLocalize);
     c.renderPanel(localize as never);
     expect(localize).toHaveBeenCalledWith("device.automation_parse_error");
@@ -132,7 +132,7 @@ describe("ParseErrorController.resolve", () => {
   it("swaps the unsupported hint for the error alert when a later resolve is a plain error", () => {
     const c = new ParseErrorController(fakeHost());
     c.resolve([parsed({ error: "boom", unsupported: true })], SCRIPT, "script");
-    c.resolve([parsed({ error: "Unknown action id: 'x'" })], SCRIPT, "script");
+    c.resolve([parsed({ error: "Unknown condition id: 'x'" })], SCRIPT, "script");
     expect(c.active).toBe(true);
     const localize = vi.fn(identityLocalize);
     c.renderPanel(localize as never);


### PR DESCRIPTION
# What does this implement/fix?

When an automation contained an action from an `external_components` source, the whole automation dropped to a read-only YAML block, so even its known siblings (a plain `logger.log`, say) could not be edited in the structured editor. The backend now decomposes an uncatalogued action into an opaque passthrough node instead of failing the automation; this side renders that node read-only in place, with a short hint that it comes from an external component (or is a typo) and is preserved on save. The action's `raw_body` rides through the immutable tree splice unchanged, so editing a sibling round-trips the external action verbatim.

Companion backend PR: esphome/device-builder#2351

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2350

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
