### PR TITLE
Surface connection waits on navigation, YAML load, and reconnects

### DIFF
--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -208,8 +208,11 @@ const createRspackConfig = ({ isProdBuild = false } = {}) => ({
     filename: isProdBuild ? "[name].[contenthash].js" : "[name].js",
     chunkFilename: isProdBuild ? "[name].[contenthash].js" : "[name].js",
     // The default is 120s, which a route's retry loop would multiply into
-    // minutes of dead progress bar on a stalled request.
-    chunkLoadTimeout: 15000,
+    // minutes of dead progress bar on a stalled request. Global: it also
+    // bounds imports with no retry path (@mdi/js, locale chunks), and it
+    // is a wall clock on slow-but-working downloads — hence 30s rather
+    // than something tighter.
+    chunkLoadTimeout: 30000,
     path: OUTPUT_DIR,
     // ``auto`` makes the runtime derive the public path from
     // ``document.currentScript.src`` and HtmlRspackPlugin emit the

--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -207,6 +207,9 @@ const createRspackConfig = ({ isProdBuild = false } = {}) => ({
   output: {
     filename: isProdBuild ? "[name].[contenthash].js" : "[name].js",
     chunkFilename: isProdBuild ? "[name].[contenthash].js" : "[name].js",
+    // The default is 120s, which a route's retry loop would multiply into
+    // minutes of dead progress bar on a stalled request.
+    chunkLoadTimeout: 15000,
     path: OUTPUT_DIR,
     // ``auto`` makes the runtime derive the public path from
     // ``document.currentScript.src`` and HtmlRspackPlugin emit the

--- a/src/api/api-error.ts
+++ b/src/api/api-error.ts
@@ -27,6 +27,11 @@ export function apiErrorDetails(err: unknown): string {
   return err instanceof APIError && err.details.trim() ? err.details.trim() : "";
 }
 
+/** True when *err* is an ``APIError`` carrying exactly *code*. */
+export function isApiErrorCode(err: unknown, code: string): err is APIError {
+  return err instanceof APIError && err.errorCode === code;
+}
+
 /**
  * A command that never got a reply within its timeout. Distinct from
  * ``APIError`` (the server answered) and from a bare transport ``Error``,

--- a/src/api/api-error.ts
+++ b/src/api/api-error.ts
@@ -26,3 +26,20 @@ export class APIError extends Error {
 export function apiErrorDetails(err: unknown): string {
   return err instanceof APIError && err.details.trim() ? err.details.trim() : "";
 }
+
+/**
+ * A command that never got a reply within its timeout. Distinct from
+ * ``APIError`` (the server answered) and from a bare transport ``Error``,
+ * so callers can tell "we gave up waiting" from "there is nothing there".
+ */
+export class CommandTimeoutError extends Error {
+  command: string;
+  timeoutMs: number;
+
+  constructor(command: string, timeoutMs: number) {
+    super(`Command "${command}" timed out after ${timeoutMs}ms`);
+    this.name = "CommandTimeoutError";
+    this.command = command;
+    this.timeoutMs = timeoutMs;
+  }
+}

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1792,8 +1792,8 @@ export class ESPHomeAPI {
   }
 
   /** List available serial ports. */
-  async getSerialPorts(): Promise<SerialPort[]> {
-    return this.sendCommand<SerialPort[]>("config/serial_ports");
+  async getSerialPorts(timeout?: number): Promise<SerialPort[]> {
+    return this.sendCommand<SerialPort[]>("config/serial_ports", undefined, timeout);
   }
 
   /**

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1022,8 +1022,8 @@ export class ESPHomeAPI {
   }
 
   /** Get device YAML config. */
-  async getConfig(configuration: string): Promise<string> {
-    return this.sendCommand<string>("devices/get_config", { configuration });
+  async getConfig(configuration: string, timeout?: number): Promise<string> {
+    return this.sendCommand<string>("devices/get_config", { configuration }, timeout);
   }
 
   /** Save device YAML config. `allowWipe` confirms clearing secrets.yaml. */

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -9,7 +9,7 @@
 import { clearStoredToken, getStoredToken, setStoredToken } from "../util/auth-token.js";
 import { BASE_PATH } from "../util/base-path.js";
 import { hydrateBoard, hydratePagedBoardsResponse } from "../util/board-hydrate.js";
-import { APIError } from "./api-error.js";
+import { APIError, CommandTimeoutError } from "./api-error.js";
 import type {
   AutomationAction,
   AutomationCatalogBody,
@@ -498,7 +498,7 @@ export class ESPHomeAPI {
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(() => {
         this._pendingRequests.delete(messageId);
-        reject(new Error(`Command "${command}" timed out after ${timeout}ms`));
+        reject(new CommandTimeoutError(command, timeout));
       }, timeout);
 
       this._pendingRequests.set(messageId, {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,2 +1,2 @@
-export { APIError } from "./api-error.js";
+export { APIError, CommandTimeoutError } from "./api-error.js";
 export { ESPHomeAPI } from "./esphome-api.js";

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,2 +1,2 @@
-export { APIError, CommandTimeoutError } from "./api-error.js";
+export { APIError, CommandTimeoutError, isApiErrorCode } from "./api-error.js";
 export { ESPHomeAPI } from "./esphome-api.js";

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -88,7 +88,7 @@ import {
   renderReconnectPill,
   renderRouteLoadingBar,
 } from "./app-shell/connection-overlays.js";
-import { createRouter } from "./app-shell/router.js";
+import { consumePreAuthExhaustion, createRouter } from "./app-shell/router.js";
 import { dispatchOrStashSerialSetup } from "./app-shell/serial-setup.js";
 import {
   onPairRequestSent,
@@ -495,18 +495,15 @@ export class ESPHomeApp extends LitElement {
     }
   }
 
-  // One-shot: re-resolve the URL the router gave up on pre-auth (a deep
-  // link whose chunk failed behind the login screen) now that a retry can
-  // be seen. Fires before any routed page mounts, so no popstate guard
-  // intercepts the synthetic event.
-  private _routerRekicked = false;
-
   // Idempotent across reconnects.
   private async _afterAuthenticated() {
     this._authState = "authed";
     this._authError = null;
-    if (!this._routerRekicked) {
-      this._routerRekicked = true;
+    // Re-resolve a URL the router gave up on pre-auth (a deep link whose
+    // chunk failed behind the login screen) now that a retry can be seen.
+    // A pre-auth exhaustion means no routed page ever mounted, so no
+    // popstate guard sees the synthetic event.
+    if (consumePreAuthExhaustion()) {
       window.dispatchEvent(new PopStateEvent("popstate"));
     }
     void this._subscribeToEvents();

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -81,6 +81,11 @@ import {
   onFirmwareHistoryCleared,
   subscribeToFollowJobs,
 } from "./app-shell/jobs.js";
+import {
+  connectionOverlayStyles,
+  renderReconnectPill,
+  renderRouteLoadingBar,
+} from "./app-shell/connection-overlays.js";
 import { createRouter, prefetchLazyRoutes } from "./app-shell/router.js";
 import { dispatchOrStashSerialSetup } from "./app-shell/serial-setup.js";
 import {
@@ -120,6 +125,10 @@ import "./update-all-dialog.js";
 import type { ESPHomeUpdateAllDialog } from "./update-all-dialog.js";
 
 export type AuthState = "connecting" | "needs-login" | "authing" | "authed";
+
+// A healthy reconnect lands well inside this, so the pill (and its
+// screen-reader announcement) never fires for a momentary blip.
+const RECONNECT_PILL_DELAY_MS = 800;
 
 @customElement("esphome-app")
 export class ESPHomeApp extends LitElement {
@@ -228,6 +237,10 @@ export class ESPHomeApp extends LitElement {
   // on disconnect, that would unmount routed pages and lose unsaved YAML buffers.
   @state() _apiConnected = false;
   @state() private _routeLoading = false;
+  // Timer-gated so sub-second reconnect blips neither flash the pill nor
+  // fire its role="status" announcement (a CSS delay would still announce).
+  @state() private _showReconnectPill = false;
+  private _reconnectPillTimer: ReturnType<typeof setTimeout> | null = null;
 
   _recentJobTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
   _remoteBuildSetInFlight = false;
@@ -305,65 +318,8 @@ export class ESPHomeApp extends LitElement {
           transform: rotate(360deg);
         }
       }
-
-      .route-loading-bar {
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 3px;
-        z-index: 10000;
-        overflow: hidden;
-        /* White-on-translucent so it stays visible over the branded
-           (primary-colored) header the bar always overlays. */
-        background: rgba(255, 255, 255, 0.25);
-      }
-
-      .route-loading-bar::after {
-        content: "";
-        position: absolute;
-        inset: 0;
-        width: 40%;
-        background: #fff;
-        box-shadow: 0 0 6px rgba(255, 255, 255, 0.7);
-        animation: route-loading-slide 1.1s ease-in-out infinite;
-      }
-
-      @keyframes route-loading-slide {
-        from {
-          transform: translateX(-100%);
-        }
-        to {
-          transform: translateX(250%);
-        }
-      }
-
-      .reconnect-pill {
-        position: fixed;
-        bottom: var(--wa-space-l);
-        left: 50%;
-        transform: translateX(-50%);
-        z-index: 10000;
-        padding: var(--wa-space-2xs) var(--wa-space-m);
-        border-radius: 999px;
-        background: var(--wa-color-warning-fill-loud, #b45309);
-        color: var(--wa-color-warning-on-loud, #fff);
-        font-size: var(--wa-font-size-s);
-        box-shadow: var(--wa-shadow-m);
-        /* Delay past the sub-second blips a healthy reconnect produces. */
-        animation: reconnect-fade-in 0.2s ease 0.8s both;
-        pointer-events: none;
-      }
-
-      @keyframes reconnect-fade-in {
-        from {
-          opacity: 0;
-        }
-        to {
-          opacity: 1;
-        }
-      }
     `,
+    connectionOverlayStyles,
   ];
 
   private _portToastMs = new Map<SerialPort, number>();
@@ -464,6 +420,10 @@ export class ESPHomeApp extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this._api.disconnect();
+    if (this._reconnectPillTimer) {
+      clearTimeout(this._reconnectPillTimer);
+      this._reconnectPillTimer = null;
+    }
     clearRecentJobs(this);
     if ("serial" in navigator) {
       navigator.serial.removeEventListener("connect", this._onSerialConnect);
@@ -514,6 +474,11 @@ export class ESPHomeApp extends LitElement {
       this._isHaIngress = info.ha_ingress;
       this._isHaAddon = info.ha_addon;
       this._apiConnected = true;
+      if (this._reconnectPillTimer) {
+        clearTimeout(this._reconnectPillTimer);
+        this._reconnectPillTimer = null;
+      }
+      this._showReconnectPill = false;
       void this._api.ready.then(() => this._afterAuthenticated());
     };
     this._api.onAuthRequired = () => {
@@ -524,6 +489,10 @@ export class ESPHomeApp extends LitElement {
     this._api.onDisconnected = () => {
       console.warn("WebSocket disconnected, will auto-reconnect...");
       this._apiConnected = false;
+      this._reconnectPillTimer ??= setTimeout(() => {
+        this._reconnectPillTimer = null;
+        if (!this._apiConnected) this._showReconnectPill = true;
+      }, RECONNECT_PILL_DELAY_MS);
     };
 
     try {
@@ -595,18 +564,8 @@ export class ESPHomeApp extends LitElement {
     }
 
     return html`
-      ${
-        this._routeLoading
-          ? html`<div class="route-loading-bar" role="progressbar"></div>`
-          : nothing
-      }
-      ${
-        this._apiConnected
-          ? nothing
-          : html`<div class="reconnect-pill" role="status">
-              ${this._localize("layout.reconnecting")}
-            </div>`
-      }
+      ${this._routeLoading ? renderRouteLoadingBar() : nothing}
+      ${this._showReconnectPill ? renderReconnectPill(this._localize) : nothing}
       <esphome-layout
         @set-theme=${(e: CustomEvent<string>) => onSetTheme(this, e)}
         @set-expert-mode=${(e: CustomEvent<boolean>) => onSetExpertMode(this, e)}

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -263,6 +263,7 @@ export class ESPHomeApp extends LitElement {
       this._routeLoading = pending;
     },
     localize: () => this._localize,
+    isAuthed: () => this._authState === "authed",
   });
 
   @query("esphome-settings-dialog") private _settingsDialog!: ESPHomeSettingsDialog;
@@ -494,10 +495,20 @@ export class ESPHomeApp extends LitElement {
     }
   }
 
+  // One-shot: re-resolve the URL the router gave up on pre-auth (a deep
+  // link whose chunk failed behind the login screen) now that a retry can
+  // be seen. Fires before any routed page mounts, so no popstate guard
+  // intercepts the synthetic event.
+  private _routerRekicked = false;
+
   // Idempotent across reconnects.
   private async _afterAuthenticated() {
     this._authState = "authed";
     this._authError = null;
+    if (!this._routerRekicked) {
+      this._routerRekicked = true;
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    }
     void this._subscribeToEvents();
     subscribeToFollowJobs(this);
     void loadIntegrationDocs(this);

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -83,6 +83,7 @@ import {
 } from "./app-shell/jobs.js";
 import {
   connectionOverlayStyles,
+  RECONNECTED_EVENT,
   renderReconnectPill,
   renderRouteLoadingBar,
 } from "./app-shell/connection-overlays.js";
@@ -240,6 +241,7 @@ export class ESPHomeApp extends LitElement {
   // Timer-gated so sub-second reconnect blips neither flash the pill nor
   // fire its role="status" announcement (a CSS delay would still announce).
   @state() private _showReconnectPill = false;
+  private _everConnected = false;
   private _reconnectPillTimer: ReturnType<typeof setTimeout> | null = null;
 
   _recentJobTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
@@ -473,7 +475,12 @@ export class ESPHomeApp extends LitElement {
       this._desktopUpdateCapable = info.desktop_update_capable ?? false;
       this._isHaIngress = info.ha_ingress;
       this._isHaAddon = info.ha_addon;
+      // Tell parked pages the socket is usable again before flipping the
+      // flag, so a listener that re-reads state sees the fresh value.
+      const reconnected = this._everConnected;
+      this._everConnected = true;
       this._apiConnected = true;
+      if (reconnected) window.dispatchEvent(new Event(RECONNECTED_EVENT));
       if (this._reconnectPillTimer) {
         clearTimeout(this._reconnectPillTimer);
         this._reconnectPillTimer = null;

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -1,5 +1,5 @@
 import { provide } from "@lit/context";
-import { css, html, LitElement, type PropertyValues } from "lit";
+import { css, html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import toast from "sonner-js";
 import { ESPHomeAPI } from "../api/index.js";
@@ -81,7 +81,7 @@ import {
   onFirmwareHistoryCleared,
   subscribeToFollowJobs,
 } from "./app-shell/jobs.js";
-import { createRouter } from "./app-shell/router.js";
+import { createRouter, prefetchLazyRoutes } from "./app-shell/router.js";
 import { dispatchOrStashSerialSetup } from "./app-shell/serial-setup.js";
 import {
   onPairRequestSent,
@@ -227,6 +227,7 @@ export class ESPHomeApp extends LitElement {
   // Tracks the WS connection independently from auth — we don't flip _authState
   // on disconnect, that would unmount routed pages and lose unsaved YAML buffers.
   @state() _apiConnected = false;
+  @state() private _routeLoading = false;
 
   _recentJobTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
   _remoteBuildSetInFlight = false;
@@ -241,7 +242,12 @@ export class ESPHomeApp extends LitElement {
   // mid-write can't revert the optimistic value. Counter for overlapping flips.
   _offloaderWritesInFlight = 0;
 
-  private _router = createRouter(this);
+  private _router = createRouter(this, {
+    onPending: (pending) => {
+      this._routeLoading = pending;
+    },
+    localize: () => this._localize,
+  });
 
   @query("esphome-settings-dialog") private _settingsDialog!: ESPHomeSettingsDialog;
   @query("esphome-firmware-jobs-dialog")
@@ -297,6 +303,64 @@ export class ESPHomeApp extends LitElement {
       @keyframes auth-spin {
         to {
           transform: rotate(360deg);
+        }
+      }
+
+      .route-loading-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 3px;
+        z-index: 10000;
+        overflow: hidden;
+        /* White-on-translucent so it stays visible over the branded
+           (primary-colored) header the bar always overlays. */
+        background: rgba(255, 255, 255, 0.25);
+      }
+
+      .route-loading-bar::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        width: 40%;
+        background: #fff;
+        box-shadow: 0 0 6px rgba(255, 255, 255, 0.7);
+        animation: route-loading-slide 1.1s ease-in-out infinite;
+      }
+
+      @keyframes route-loading-slide {
+        from {
+          transform: translateX(-100%);
+        }
+        to {
+          transform: translateX(250%);
+        }
+      }
+
+      .reconnect-pill {
+        position: fixed;
+        bottom: var(--wa-space-l);
+        left: 50%;
+        transform: translateX(-50%);
+        z-index: 10000;
+        padding: var(--wa-space-2xs) var(--wa-space-m);
+        border-radius: 999px;
+        background: var(--wa-color-warning-fill-loud, #b45309);
+        color: var(--wa-color-warning-on-loud, #fff);
+        font-size: var(--wa-font-size-s);
+        box-shadow: var(--wa-shadow-m);
+        /* Delay past the sub-second blips a healthy reconnect produces. */
+        animation: reconnect-fade-in 0.2s ease 0.8s both;
+        pointer-events: none;
+      }
+
+      @keyframes reconnect-fade-in {
+        from {
+          opacity: 0;
+        }
+        to {
+          opacity: 1;
         }
       }
     `,
@@ -390,6 +454,7 @@ export class ESPHomeApp extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     void this._init();
+    prefetchLazyRoutes();
     if ("serial" in navigator) {
       navigator.serial.addEventListener("connect", this._onSerialConnect);
     }
@@ -530,6 +595,18 @@ export class ESPHomeApp extends LitElement {
     }
 
     return html`
+      ${
+        this._routeLoading
+          ? html`<div class="route-loading-bar" role="progressbar"></div>`
+          : nothing
+      }
+      ${
+        this._apiConnected
+          ? nothing
+          : html`<div class="reconnect-pill" role="status">
+              ${this._localize("layout.reconnecting")}
+            </div>`
+      }
       <esphome-layout
         @set-theme=${(e: CustomEvent<string>) => onSetTheme(this, e)}
         @set-expert-mode=${(e: CustomEvent<boolean>) => onSetExpertMode(this, e)}

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -493,7 +493,7 @@ export class ESPHomeApp extends LitElement {
       this._apiConnected = false;
       this._reconnectPillTimer ??= setTimeout(() => {
         this._reconnectPillTimer = null;
-        if (!this._apiConnected) this._showReconnectPill = true;
+        this._showReconnectPill = true;
       }, RECONNECT_PILL_DELAY_MS);
     };
 

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -21,6 +21,7 @@ import { defaultLocalize, loadLocalize, type LocalizeFunc } from "../common/loca
 import type { RemoteBuildJobState } from "../context/index.js";
 import {
   activeJobsContext,
+  apiConnectedContext,
   apiContext,
   buildOffloadAlertsContext,
   buildOffloadDiscoveredHostsContext,
@@ -83,11 +84,10 @@ import {
 } from "./app-shell/jobs.js";
 import {
   connectionOverlayStyles,
-  RECONNECTED_EVENT,
   renderReconnectPill,
   renderRouteLoadingBar,
 } from "./app-shell/connection-overlays.js";
-import { createRouter, prefetchLazyRoutes } from "./app-shell/router.js";
+import { createRouter } from "./app-shell/router.js";
 import { dispatchOrStashSerialSetup } from "./app-shell/serial-setup.js";
 import {
   onPairRequestSent,
@@ -236,12 +236,12 @@ export class ESPHomeApp extends LitElement {
   @state() _rateLimitedUntil = 0;
   // Tracks the WS connection independently from auth — we don't flip _authState
   // on disconnect, that would unmount routed pages and lose unsaved YAML buffers.
-  @state() _apiConnected = false;
+  // Provided so a routed page can redo work that failed while it was down.
+  @provide({ context: apiConnectedContext }) @state() _apiConnected = false;
   @state() private _routeLoading = false;
   // Timer-gated so sub-second reconnect blips neither flash the pill nor
   // fire its role="status" announcement (a CSS delay would still announce).
   @state() private _showReconnectPill = false;
-  private _everConnected = false;
   private _reconnectPillTimer: ReturnType<typeof setTimeout> | null = null;
 
   _recentJobTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
@@ -405,6 +405,14 @@ export class ESPHomeApp extends LitElement {
     });
   };
 
+  private _clearReconnectPill() {
+    if (this._reconnectPillTimer) {
+      clearTimeout(this._reconnectPillTimer);
+      this._reconnectPillTimer = null;
+    }
+    this._showReconnectPill = false;
+  }
+
   private _onSecretsSaved = () => {
     void loadOnboardingState(this);
   };
@@ -412,7 +420,6 @@ export class ESPHomeApp extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     void this._init();
-    prefetchLazyRoutes();
     if ("serial" in navigator) {
       navigator.serial.addEventListener("connect", this._onSerialConnect);
     }
@@ -422,10 +429,7 @@ export class ESPHomeApp extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this._api.disconnect();
-    if (this._reconnectPillTimer) {
-      clearTimeout(this._reconnectPillTimer);
-      this._reconnectPillTimer = null;
-    }
+    this._clearReconnectPill();
     clearRecentJobs(this);
     if ("serial" in navigator) {
       navigator.serial.removeEventListener("connect", this._onSerialConnect);
@@ -475,17 +479,8 @@ export class ESPHomeApp extends LitElement {
       this._desktopUpdateCapable = info.desktop_update_capable ?? false;
       this._isHaIngress = info.ha_ingress;
       this._isHaAddon = info.ha_addon;
-      // Tell parked pages the socket is usable again before flipping the
-      // flag, so a listener that re-reads state sees the fresh value.
-      const reconnected = this._everConnected;
-      this._everConnected = true;
       this._apiConnected = true;
-      if (reconnected) window.dispatchEvent(new Event(RECONNECTED_EVENT));
-      if (this._reconnectPillTimer) {
-        clearTimeout(this._reconnectPillTimer);
-        this._reconnectPillTimer = null;
-      }
-      this._showReconnectPill = false;
+      this._clearReconnectPill();
       void this._api.ready.then(() => this._afterAuthenticated());
     };
     this._api.onAuthRequired = () => {

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -84,6 +84,7 @@ import {
 } from "./app-shell/jobs.js";
 import {
   connectionOverlayStyles,
+  ReconnectPillGate,
   renderReconnectPill,
   renderRouteLoadingBar,
 } from "./app-shell/connection-overlays.js";
@@ -239,10 +240,10 @@ export class ESPHomeApp extends LitElement {
   // Provided so a routed page can redo work that failed while it was down.
   @provide({ context: apiConnectedContext }) @state() _apiConnected = false;
   @state() private _routeLoading = false;
-  // Timer-gated so sub-second reconnect blips neither flash the pill nor
-  // fire its role="status" announcement (a CSS delay would still announce).
   @state() private _showReconnectPill = false;
-  private _reconnectPillTimer: ReturnType<typeof setTimeout> | null = null;
+  private _pillGate = new ReconnectPillGate(RECONNECT_PILL_DELAY_MS, (visible) => {
+    this._showReconnectPill = visible;
+  });
 
   _recentJobTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
   _remoteBuildSetInFlight = false;
@@ -405,14 +406,6 @@ export class ESPHomeApp extends LitElement {
     });
   };
 
-  private _clearReconnectPill() {
-    if (this._reconnectPillTimer) {
-      clearTimeout(this._reconnectPillTimer);
-      this._reconnectPillTimer = null;
-    }
-    this._showReconnectPill = false;
-  }
-
   private _onSecretsSaved = () => {
     void loadOnboardingState(this);
   };
@@ -429,7 +422,7 @@ export class ESPHomeApp extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this._api.disconnect();
-    this._clearReconnectPill();
+    this._pillGate.connected();
     clearRecentJobs(this);
     if ("serial" in navigator) {
       navigator.serial.removeEventListener("connect", this._onSerialConnect);
@@ -480,7 +473,7 @@ export class ESPHomeApp extends LitElement {
       this._isHaIngress = info.ha_ingress;
       this._isHaAddon = info.ha_addon;
       this._apiConnected = true;
-      this._clearReconnectPill();
+      this._pillGate.connected();
       void this._api.ready.then(() => this._afterAuthenticated());
     };
     this._api.onAuthRequired = () => {
@@ -491,10 +484,7 @@ export class ESPHomeApp extends LitElement {
     this._api.onDisconnected = () => {
       console.warn("WebSocket disconnected, will auto-reconnect...");
       this._apiConnected = false;
-      this._reconnectPillTimer ??= setTimeout(() => {
-        this._reconnectPillTimer = null;
-        this._showReconnectPill = true;
-      }, RECONNECT_PILL_DELAY_MS);
+      this._pillGate.disconnected();
     };
 
     try {

--- a/src/components/app-shell/connection-overlays.ts
+++ b/src/components/app-shell/connection-overlays.ts
@@ -15,6 +15,7 @@ export const connectionOverlayStyles = css`
     height: 3px;
     z-index: 10000;
     overflow: hidden;
+    pointer-events: none;
     /* White-on-translucent so it stays visible over the branded
        (primary-colored) header the bar always overlays. */
     background: rgba(255, 255, 255, 0.25);

--- a/src/components/app-shell/connection-overlays.ts
+++ b/src/components/app-shell/connection-overlays.ts
@@ -1,10 +1,6 @@
 import { css, html, type TemplateResult } from "lit";
 import type { LocalizeFunc } from "../../common/localize.js";
 
-/** Fired on the window when the socket comes back after a drop, so pages
- *  parked on a failed load can retry without the user clicking. */
-export const RECONNECTED_EVENT = "esphome-reconnected";
-
 /**
  * Fixed-position connection feedback the app shell overlays on the authed
  * layout: the indeterminate route-chunk loading bar and the reconnecting

--- a/src/components/app-shell/connection-overlays.ts
+++ b/src/components/app-shell/connection-overlays.ts
@@ -1,0 +1,77 @@
+import { css, html, type TemplateResult } from "lit";
+import type { LocalizeFunc } from "../../common/localize.js";
+
+/**
+ * Fixed-position connection feedback the app shell overlays on the authed
+ * layout: the indeterminate route-chunk loading bar and the reconnecting
+ * pill. Kept beside ``router.ts`` so the shell's own file stays flat.
+ */
+export const connectionOverlayStyles = css`
+  .route-loading-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    z-index: 10000;
+    overflow: hidden;
+    /* White-on-translucent so it stays visible over the branded
+       (primary-colored) header the bar always overlays. */
+    background: rgba(255, 255, 255, 0.25);
+  }
+
+  .route-loading-bar::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    width: 40%;
+    background: #fff;
+    box-shadow: 0 0 6px rgba(255, 255, 255, 0.7);
+    animation: route-loading-slide 1.1s ease-in-out infinite;
+  }
+
+  @keyframes route-loading-slide {
+    from {
+      transform: translateX(-100%);
+    }
+    to {
+      transform: translateX(250%);
+    }
+  }
+
+  .reconnect-pill {
+    position: fixed;
+    bottom: var(--wa-space-l);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10000;
+    padding: var(--wa-space-2xs) var(--wa-space-m);
+    border-radius: 999px;
+    background: var(--wa-color-warning-fill-loud, #b45309);
+    color: var(--wa-color-warning-on-loud, #fff);
+    font-size: var(--wa-font-size-s);
+    box-shadow: var(--wa-shadow-m);
+    animation: reconnect-fade-in 0.2s ease both;
+    pointer-events: none;
+  }
+
+  @keyframes reconnect-fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+/** Decorative feedback only — failures surface through the toast. */
+export function renderRouteLoadingBar(): TemplateResult {
+  return html`<div class="route-loading-bar" aria-hidden="true"></div>`;
+}
+
+export function renderReconnectPill(localize: LocalizeFunc): TemplateResult {
+  return html`<div class="reconnect-pill" role="status">
+    ${localize("layout.reconnecting")}
+  </div>`;
+}

--- a/src/components/app-shell/connection-overlays.ts
+++ b/src/components/app-shell/connection-overlays.ts
@@ -1,6 +1,10 @@
 import { css, html, type TemplateResult } from "lit";
 import type { LocalizeFunc } from "../../common/localize.js";
 
+/** Fired on the window when the socket comes back after a drop, so pages
+ *  parked on a failed load can retry without the user clicking. */
+export const RECONNECTED_EVENT = "esphome-reconnected";
+
 /**
  * Fixed-position connection feedback the app shell overlays on the authed
  * layout: the indeterminate route-chunk loading bar and the reconnecting

--- a/src/components/app-shell/connection-overlays.ts
+++ b/src/components/app-shell/connection-overlays.ts
@@ -76,3 +76,33 @@ export function renderReconnectPill(localize: LocalizeFunc): TemplateResult {
     ${localize("layout.reconnecting")}
   </div>`;
 }
+
+/**
+ * Timer gate for the reconnect pill: a blip shorter than the delay never
+ * shows it (nor fires its ``role="status"`` announcement — a CSS delay
+ * would still announce). Repeat disconnects while armed keep the first
+ * outage's clock.
+ */
+export class ReconnectPillGate {
+  private _timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private readonly _delayMs: number,
+    private readonly _onChange: (visible: boolean) => void
+  ) {}
+
+  disconnected(): void {
+    this._timer ??= setTimeout(() => {
+      this._timer = null;
+      this._onChange(true);
+    }, this._delayMs);
+  }
+
+  connected(): void {
+    if (this._timer !== null) {
+      clearTimeout(this._timer);
+      this._timer = null;
+    }
+    this._onChange(false);
+  }
+}

--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -49,6 +49,9 @@ export async function lazyEnter(
   const target = window.location.pathname;
   let counted = false;
   const pendingTimer = setTimeout(() => {
+    // An import can't be cancelled, so this fires even for a navigation the
+    // user has already walked away from; don't advertise progress for it.
+    if (window.location.pathname !== target) return;
     counted = true;
     if (++pendingLoads === 1) hooks.onPending(true);
   }, PENDING_FEEDBACK_DELAY_MS);
@@ -63,6 +66,13 @@ export async function lazyEnter(
         if (delay === undefined) {
           console.error("Failed to load route chunk:", err);
           notifyError(hooks.localize()("layout.page_load_failed"));
+          // navigate() pushed this URL before the router ran enter, and a
+          // false return leaves the old page rendered; undo the push so the
+          // address bar doesn't describe a page that never mounted. A null
+          // state means a fresh load (deep link) with nothing to pop.
+          if (window.history.state !== null && typeof window.history.state === "object") {
+            window.history.back();
+          }
           return false;
         }
         await sleep(delay);

--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -5,7 +5,6 @@ import { withBase } from "../../util/base-path.js";
 import {
   isFreshNavigatePush,
   isSameDocumentPush,
-  navigate,
   popPushedEntrySilently,
 } from "../../util/navigation.js";
 import { notifyError } from "../../util/notify.js";
@@ -91,10 +90,14 @@ export async function lazyEnter(
           // already answered. A same-document Back/Forward entry is left
           // alone (popping would move the user a second step back). Any
           // other entry — cold deep link, reload — has nothing rendered
-          // behind it, so it falls back to the dashboard rather than an
-          // empty outlet.
+          // behind it, so it becomes the dashboard rather than an empty
+          // outlet. Replaced, not pushed: a push would leave the broken
+          // URL underneath as a Back-button fail loop.
           if (isFreshNavigatePush()) popPushedEntrySilently();
-          else if (!isSameDocumentPush()) void navigate("/");
+          else if (!isSameDocumentPush()) {
+            window.history.replaceState(null, "", withBase("/"));
+            window.dispatchEvent(new PopStateEvent("popstate"));
+          }
           return false;
         }
         await sleep(RETRY_DELAY_MS);

--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -2,7 +2,7 @@ import { Router } from "@lit-labs/router";
 import { html, type ReactiveControllerHost } from "lit";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { withBase } from "../../util/base-path.js";
-import { hasPushedHistoryEntry } from "../../util/navigation.js";
+import { hasPushedHistoryEntry, popPushedEntrySilently } from "../../util/navigation.js";
 import { notifyError } from "../../util/notify.js";
 import { sleep } from "../../util/sleep.js";
 
@@ -70,8 +70,10 @@ export async function lazyEnter(
           notifyError(hooks.localize()("layout.page_load_failed"));
           // navigate() pushed this URL before the router ran enter, and a
           // false return leaves the old page rendered; undo the push so the
-          // address bar doesn't describe a page that never mounted.
-          if (hasPushedHistoryEntry()) window.history.back();
+          // address bar doesn't describe a page that never mounted. Silent,
+          // or the still-mounted page's popstate guard re-prompts over a
+          // leave the user already answered at navigate() time.
+          if (hasPushedHistoryEntry()) popPushedEntrySilently();
           return false;
         }
         await sleep(delay);

--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -2,6 +2,7 @@ import { Router } from "@lit-labs/router";
 import { html, type ReactiveControllerHost } from "lit";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { withBase } from "../../util/base-path.js";
+import { hasPushedHistoryEntry } from "../../util/navigation.js";
 import { notifyError } from "../../util/notify.js";
 import { sleep } from "../../util/sleep.js";
 
@@ -26,7 +27,8 @@ export interface RouterHooks {
 }
 
 const PENDING_FEEDBACK_DELAY_MS = 200;
-const RETRY_DELAYS_MS = [500, 1500];
+// One retry, since output.chunkLoadTimeout already bounds each attempt.
+const RETRY_DELAYS_MS = [500];
 
 // Slow loads in flight at once; the pending hook fires on the 0↔1 edges so
 // overlapping navigations can't hide each other's progress bar.
@@ -68,11 +70,8 @@ export async function lazyEnter(
           notifyError(hooks.localize()("layout.page_load_failed"));
           // navigate() pushed this URL before the router ran enter, and a
           // false return leaves the old page rendered; undo the push so the
-          // address bar doesn't describe a page that never mounted. A null
-          // state means a fresh load (deep link) with nothing to pop.
-          if (window.history.state !== null && typeof window.history.state === "object") {
-            window.history.back();
-          }
+          // address bar doesn't describe a page that never mounted.
+          if (hasPushedHistoryEntry()) window.history.back();
           return false;
         }
         await sleep(delay);
@@ -81,23 +80,6 @@ export async function lazyEnter(
   } finally {
     clearTimeout(pendingTimer);
     if (counted && --pendingLoads === 0) hooks.onPending(false);
-  }
-}
-
-/**
- * Warm the lazy route chunks once the browser is idle so a later Edit
- * click doesn't pay the chunk download on a degraded connection.
- * Failures are swallowed — the click path retries on its own.
- */
-export function prefetchLazyRoutes(): void {
-  const warm = () => {
-    import("../../pages/device.js").catch(() => {});
-    import("../../pages/secrets.js").catch(() => {});
-  };
-  if ("requestIdleCallback" in window) {
-    requestIdleCallback(warm, { timeout: 5000 });
-  } else {
-    setTimeout(warm, 2000);
   }
 }
 
@@ -112,12 +94,20 @@ export function createRouter(
     },
     {
       path: withBase("/secrets"),
-      enter: () => lazyEnter(() => import("../../pages/secrets.js"), hooks),
+      enter: () =>
+        lazyEnter(
+          () => import(/* webpackPrefetch: true */ "../../pages/secrets.js"),
+          hooks
+        ),
       render: () => html`<esphome-page-secrets></esphome-page-secrets>`,
     },
     {
       path: withBase("/device/:id"),
-      enter: () => lazyEnter(() => import("../../pages/device.js"), hooks),
+      enter: () =>
+        lazyEnter(
+          () => import(/* webpackPrefetch: true */ "../../pages/device.js"),
+          hooks
+        ),
       render: ({ id }) =>
         html`<esphome-page-device .id=${decodeIdParam(id)}></esphome-page-device>`,
     },

--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -56,12 +56,24 @@ export async function lazyEnter(
 ): Promise<boolean> {
   const target = window.location.pathname;
   let counted = false;
+  const release = () => {
+    if (!counted) return;
+    counted = false;
+    if (--pendingLoads === 0) hooks.onPending(false);
+  };
+  // An import can't be cancelled, so a navigation away mid-load would
+  // otherwise keep the bar up on the new page until the stale chunk
+  // settles (up to chunkLoadTimeout).
+  const onNavigatedAway = () => {
+    if (window.location.pathname !== target) release();
+  };
   const pendingTimer = setTimeout(() => {
-    // An import can't be cancelled, so this fires even for a navigation the
-    // user has already walked away from; don't advertise progress for it.
+    // This fires even for a navigation the user has already walked away
+    // from; don't advertise progress for it.
     if (window.location.pathname !== target) return;
     counted = true;
     if (++pendingLoads === 1) hooks.onPending(true);
+    window.addEventListener("popstate", onNavigatedAway);
   }, PENDING_FEEDBACK_DELAY_MS);
   try {
     for (let attempt = 1; ; attempt++) {
@@ -89,7 +101,8 @@ export async function lazyEnter(
     }
   } finally {
     clearTimeout(pendingTimer);
-    if (counted && --pendingLoads === 0) hooks.onPending(false);
+    window.removeEventListener("popstate", onNavigatedAway);
+    release();
   }
 }
 

--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -2,7 +2,12 @@ import { Router } from "@lit-labs/router";
 import { html, type ReactiveControllerHost } from "lit";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { withBase } from "../../util/base-path.js";
-import { hasPushedHistoryEntry, popPushedEntrySilently } from "../../util/navigation.js";
+import {
+  hasPushedHistoryEntry,
+  isFreshNavigatePush,
+  navigate,
+  popPushedEntrySilently,
+} from "../../util/navigation.js";
 import { notifyError } from "../../util/notify.js";
 import { sleep } from "../../util/sleep.js";
 
@@ -68,12 +73,15 @@ export async function lazyEnter(
         if (attempt >= CHUNK_LOAD_ATTEMPTS) {
           console.error("Failed to load route chunk:", err);
           notifyError(hooks.localize()("layout.page_load_failed"));
-          // navigate() pushed this URL before the router ran enter, and a
-          // false return leaves the old page rendered; undo the push so the
-          // address bar doesn't describe a page that never mounted. Silent,
-          // or the still-mounted page's popstate guard re-prompts over a
-          // leave the user already answered at navigate() time.
-          if (hasPushedHistoryEntry()) popPushedEntrySilently();
+          // A fresh navigate() push is undone so the address bar doesn't
+          // describe a page that never mounted — silently, or the still-
+          // mounted page's popstate guard re-prompts over a leave the user
+          // already answered. A Back/Forward entry is left alone (popping
+          // would move the user a second step back), and a cold deep link
+          // has nothing to undo, so it falls back to the dashboard rather
+          // than an empty outlet.
+          if (isFreshNavigatePush()) popPushedEntrySilently();
+          else if (!hasPushedHistoryEntry()) void navigate("/");
           return false;
         }
         await sleep(RETRY_DELAY_MS);

--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -123,6 +123,9 @@ export async function lazyEnter(
           return false;
         }
         await sleep(RETRY_DELAY_MS);
+        // Re-check after the backoff: a navigation during the sleep must
+        // not spend the retry import on an abandoned route.
+        if (window.location.pathname !== target) return false;
       }
     }
   } finally {

--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -1,6 +1,8 @@
 import { Router } from "@lit-labs/router";
 import { html, type ReactiveControllerHost } from "lit";
+import type { LocalizeFunc } from "../../common/localize.js";
 import { withBase } from "../../util/base-path.js";
+import { notifyError } from "../../util/notify.js";
 
 // Decode the :id path param, falling back to the raw value on URIError so a
 // malformed % sequence doesn't crash the whole router — the device page's
@@ -14,7 +16,79 @@ function decodeIdParam(id: string | undefined): string {
   }
 }
 
-export function createRouter(host: ReactiveControllerHost & HTMLElement): Router {
+export interface RouterHooks {
+  /** Flips true when a lazy route chunk has been in flight long enough to
+   *  deserve visible feedback, false when the load settles either way. */
+  onPending(pending: boolean): void;
+  /** Read at failure time — the shell's localize loads async after mount. */
+  localize(): LocalizeFunc;
+}
+
+const PENDING_FEEDBACK_DELAY_MS = 200;
+const RETRY_DELAYS_MS = [500, 1500];
+
+/**
+ * Await a lazy route chunk with pending feedback and retries.
+ *
+ * On exhaustion the navigation is cancelled with a toast so the click
+ * never silently does nothing (rspack re-requests a failed chunk on the
+ * next import() call, so a later click retries from scratch).
+ */
+export async function lazyEnter(
+  importThunk: () => Promise<unknown>,
+  hooks: RouterHooks
+): Promise<boolean> {
+  let pendingShown = false;
+  const pendingTimer = setTimeout(() => {
+    pendingShown = true;
+    hooks.onPending(true);
+  }, PENDING_FEEDBACK_DELAY_MS);
+  try {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await importThunk();
+        return true;
+      } catch (err) {
+        const delay = RETRY_DELAYS_MS[attempt];
+        if (delay === undefined) {
+          console.error("Failed to load route chunk:", err);
+          notifyError(hooks.localize()("layout.page_load_failed"));
+          return false;
+        }
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+  } finally {
+    clearTimeout(pendingTimer);
+    if (pendingShown) hooks.onPending(false);
+  }
+}
+
+let prefetched = false;
+
+/**
+ * Warm the lazy route chunks once the browser is idle so a later Edit
+ * click doesn't pay the chunk download on a degraded connection.
+ * Failures are swallowed — the click path retries on its own.
+ */
+export function prefetchLazyRoutes(): void {
+  if (prefetched) return;
+  prefetched = true;
+  const warm = () => {
+    import("../../pages/device.js").catch(() => {});
+    import("../../pages/secrets.js").catch(() => {});
+  };
+  if ("requestIdleCallback" in window) {
+    requestIdleCallback(warm, { timeout: 5000 });
+  } else {
+    setTimeout(warm, 2000);
+  }
+}
+
+export function createRouter(
+  host: ReactiveControllerHost & HTMLElement,
+  hooks: RouterHooks
+): Router {
   return new Router(host, [
     {
       path: withBase("/"),
@@ -22,18 +96,12 @@ export function createRouter(host: ReactiveControllerHost & HTMLElement): Router
     },
     {
       path: withBase("/secrets"),
-      enter: async () => {
-        await import("../../pages/secrets.js");
-        return true;
-      },
+      enter: () => lazyEnter(() => import("../../pages/secrets.js"), hooks),
       render: () => html`<esphome-page-secrets></esphome-page-secrets>`,
     },
     {
       path: withBase("/device/:id"),
-      enter: async () => {
-        await import("../../pages/device.js");
-        return true;
-      },
+      enter: () => lazyEnter(() => import("../../pages/device.js"), hooks),
       render: ({ id }) =>
         html`<esphome-page-device .id=${decodeIdParam(id)}></esphome-page-device>`,
     },

--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -58,6 +58,7 @@ export async function lazyEnter(
   const release = () => {
     if (!counted) return;
     counted = false;
+    window.removeEventListener("popstate", onNavigatedAway);
     if (--pendingLoads === 0) hooks.onPending(false);
   };
   // An import can't be cancelled, so a navigation away mid-load would
@@ -105,7 +106,8 @@ export async function lazyEnter(
     }
   } finally {
     clearTimeout(pendingTimer);
-    window.removeEventListener("popstate", onNavigatedAway);
+    // release() also detaches the listener; when never counted, none
+    // was attached.
     release();
   }
 }

--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -27,8 +27,9 @@ export interface RouterHooks {
 }
 
 const PENDING_FEEDBACK_DELAY_MS = 200;
-// One retry, since output.chunkLoadTimeout already bounds each attempt.
-const RETRY_DELAYS_MS = [500];
+// Two attempts total, since output.chunkLoadTimeout already bounds each.
+const CHUNK_LOAD_ATTEMPTS = 2;
+const RETRY_DELAY_MS = 500;
 
 // Slow loads in flight at once; the pending hook fires on the 0↔1 edges so
 // overlapping navigations can't hide each other's progress bar.
@@ -58,14 +59,13 @@ export async function lazyEnter(
     if (++pendingLoads === 1) hooks.onPending(true);
   }, PENDING_FEEDBACK_DELAY_MS);
   try {
-    for (let attempt = 0; ; attempt++) {
+    for (let attempt = 1; ; attempt++) {
       try {
         await importThunk();
         return window.location.pathname === target;
       } catch (err) {
         if (window.location.pathname !== target) return false;
-        const delay = RETRY_DELAYS_MS[attempt];
-        if (delay === undefined) {
+        if (attempt >= CHUNK_LOAD_ATTEMPTS) {
           console.error("Failed to load route chunk:", err);
           notifyError(hooks.localize()("layout.page_load_failed"));
           // navigate() pushed this URL before the router ran enter, and a
@@ -76,7 +76,7 @@ export async function lazyEnter(
           if (hasPushedHistoryEntry()) popPushedEntrySilently();
           return false;
         }
-        await sleep(delay);
+        await sleep(RETRY_DELAY_MS);
       }
     }
   } finally {

--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -3,6 +3,7 @@ import { html, type ReactiveControllerHost } from "lit";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { withBase } from "../../util/base-path.js";
 import { notifyError } from "../../util/notify.js";
+import { sleep } from "../../util/sleep.js";
 
 // Decode the :id path param, falling back to the raw value on URIError so a
 // malformed % sequence doesn't crash the whole router — the device page's
@@ -17,8 +18,8 @@ function decodeIdParam(id: string | undefined): string {
 }
 
 export interface RouterHooks {
-  /** Flips true when a lazy route chunk has been in flight long enough to
-   *  deserve visible feedback, false when the load settles either way. */
+  /** Flips true when the first slow chunk load crosses the feedback delay,
+   *  false when the last one settles either way. */
   onPending(pending: boolean): void;
   /** Read at failure time — the shell's localize loads async after mount. */
   localize(): LocalizeFunc;
@@ -27,44 +28,51 @@ export interface RouterHooks {
 const PENDING_FEEDBACK_DELAY_MS = 200;
 const RETRY_DELAYS_MS = [500, 1500];
 
+// Slow loads in flight at once; the pending hook fires on the 0↔1 edges so
+// overlapping navigations can't hide each other's progress bar.
+let pendingLoads = 0;
+
 /**
  * Await a lazy route chunk with pending feedback and retries.
  *
  * On exhaustion the navigation is cancelled with a toast so the click
  * never silently does nothing (rspack re-requests a failed chunk on the
- * next import() call, so a later click retries from scratch).
+ * next import() call, so a later click retries from scratch). A chunk
+ * that lands after the user has navigated elsewhere resolves false —
+ * @lit-labs/router has no in-flight guard, so returning true here would
+ * commit the stale route over the one the URL now shows.
  */
 export async function lazyEnter(
   importThunk: () => Promise<unknown>,
   hooks: RouterHooks
 ): Promise<boolean> {
-  let pendingShown = false;
+  const target = window.location.pathname;
+  let counted = false;
   const pendingTimer = setTimeout(() => {
-    pendingShown = true;
-    hooks.onPending(true);
+    counted = true;
+    if (++pendingLoads === 1) hooks.onPending(true);
   }, PENDING_FEEDBACK_DELAY_MS);
   try {
     for (let attempt = 0; ; attempt++) {
       try {
         await importThunk();
-        return true;
+        return window.location.pathname === target;
       } catch (err) {
+        if (window.location.pathname !== target) return false;
         const delay = RETRY_DELAYS_MS[attempt];
         if (delay === undefined) {
           console.error("Failed to load route chunk:", err);
           notifyError(hooks.localize()("layout.page_load_failed"));
           return false;
         }
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await sleep(delay);
       }
     }
   } finally {
     clearTimeout(pendingTimer);
-    if (pendingShown) hooks.onPending(false);
+    if (counted && --pendingLoads === 0) hooks.onPending(false);
   }
 }
-
-let prefetched = false;
 
 /**
  * Warm the lazy route chunks once the browser is idle so a later Edit
@@ -72,8 +80,6 @@ let prefetched = false;
  * Failures are swallowed — the click path retries on its own.
  */
 export function prefetchLazyRoutes(): void {
-  if (prefetched) return;
-  prefetched = true;
   const warm = () => {
     import("../../pages/device.js").catch(() => {});
     import("../../pages/secrets.js").catch(() => {});

--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -28,6 +28,9 @@ export interface RouterHooks {
   onPending(pending: boolean): void;
   /** Read at failure time — the shell's localize loads async after mount. */
   localize(): LocalizeFunc;
+  /** Pre-auth exhaustion stays silent and leaves the URL alone; the shell
+   *  re-resolves it after sign-in, giving the chunk a fresh try. */
+  isAuthed(): boolean;
 }
 
 const PENDING_FEEDBACK_DELAY_MS = 200;
@@ -84,6 +87,10 @@ export async function lazyEnter(
         if (window.location.pathname !== target) return false;
         if (attempt >= CHUNK_LOAD_ATTEMPTS) {
           console.error("Failed to load route chunk:", err);
+          // Behind the login screen there is nothing to see or undo, and
+          // rewriting the URL here would lose the deep link the user is
+          // about to authenticate into.
+          if (!hooks.isAuthed()) return false;
           notifyError(hooks.localize()("layout.page_load_failed"));
           // A fresh navigate() push is undone so the address bar doesn't
           // describe a page that never mounted — silently, or the still-

--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -42,6 +42,17 @@ const RETRY_DELAY_MS = 500;
 // overlapping navigations can't hide each other's progress bar.
 let pendingLoads = 0;
 
+let preAuthExhausted = false;
+
+/** True once a chunk exhausted behind the login screen; reading resets,
+ *  so the shell's post-auth re-resolve fires only when there is a failed
+ *  route to recover. */
+export function consumePreAuthExhaustion(): boolean {
+  const was = preAuthExhausted;
+  preAuthExhausted = false;
+  return was;
+}
+
 /**
  * Await a lazy route chunk with pending feedback and retries.
  *
@@ -90,7 +101,10 @@ export async function lazyEnter(
           // Behind the login screen there is nothing to see or undo, and
           // rewriting the URL here would lose the deep link the user is
           // about to authenticate into.
-          if (!hooks.isAuthed()) return false;
+          if (!hooks.isAuthed()) {
+            preAuthExhausted = true;
+            return false;
+          }
           notifyError(hooks.localize()("layout.page_load_failed"));
           // A fresh navigate() push is undone so the address bar doesn't
           // describe a page that never mounted — silently, or the still-

--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -3,8 +3,8 @@ import { html, type ReactiveControllerHost } from "lit";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { withBase } from "../../util/base-path.js";
 import {
-  hasPushedHistoryEntry,
   isFreshNavigatePush,
+  isSameDocumentPush,
   navigate,
   popPushedEntrySilently,
 } from "../../util/navigation.js";
@@ -88,12 +88,13 @@ export async function lazyEnter(
           // A fresh navigate() push is undone so the address bar doesn't
           // describe a page that never mounted — silently, or the still-
           // mounted page's popstate guard re-prompts over a leave the user
-          // already answered. A Back/Forward entry is left alone (popping
-          // would move the user a second step back), and a cold deep link
-          // has nothing to undo, so it falls back to the dashboard rather
-          // than an empty outlet.
+          // already answered. A same-document Back/Forward entry is left
+          // alone (popping would move the user a second step back). Any
+          // other entry — cold deep link, reload — has nothing rendered
+          // behind it, so it falls back to the dashboard rather than an
+          // empty outlet.
           if (isFreshNavigatePush()) popPushedEntrySilently();
-          else if (!hasPushedHistoryEntry()) void navigate("/");
+          else if (!isSameDocumentPush()) void navigate("/");
           return false;
         }
         await sleep(RETRY_DELAY_MS);

--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -3,7 +3,7 @@ import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { ConfiguredDevice } from "../../api/types/devices.js";
 import type { ArchivedDevice, BulkActionResult } from "../../api/types/system.js";
 import type { LocalizeFunc } from "../../common/localize.js";
-import { withBase } from "../../util/base-path.js";
+import { navigate } from "../../util/navigation.js";
 import { fetchBoard } from "../../util/board-body-cache.js";
 import { downloadBlob } from "../../util/download-text.js";
 import { getErrorMessage } from "../../util/error-message.js";
@@ -21,8 +21,7 @@ import {
 import { chipNameToFilterLabel } from "../wizard/wizard-step-board-platforms.js";
 
 export function editDevice(device: ConfiguredDevice) {
-  window.history.pushState({}, "", withBase(`/device/${device.configuration}`));
-  window.dispatchEvent(new PopStateEvent("popstate"));
+  void navigate(`/device/${device.configuration}`);
 }
 
 /**

--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -21,7 +21,7 @@ import {
 import { chipNameToFilterLabel } from "../wizard/wizard-step-board-platforms.js";
 
 export function editDevice(device: ConfiguredDevice) {
-  void navigate(`/device/${device.configuration}`);
+  void navigate(`/device/${encodeURIComponent(device.configuration)}`);
 }
 
 /**

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -10,7 +10,7 @@ import { apiContext, localizeContext } from "../../context/index.js";
 import { primaryHeaderDialogStyles } from "../../styles/dialog-chrome.js";
 import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import { withBase } from "../../util/base-path.js";
+import { navigate } from "../../util/navigation.js";
 import { fetchBoard, getCachedBoard } from "../../util/board-body-cache.js";
 import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import { buildFeaturedId } from "../../util/featured-id.js";
@@ -490,12 +490,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     markJustCreated(configuration);
     markPendingHighlight(configuration);
     this.close();
-    window.history.pushState(
-      {},
-      "",
-      withBase(`/device/${encodeURIComponent(configuration)}`)
-    );
-    window.dispatchEvent(new PopStateEvent("popstate"));
+    void navigate(`/device/${encodeURIComponent(configuration)}`);
   }
 
   private async _onCreateEmptyConfig(

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -62,6 +62,12 @@ export const devicesLoadedContext = createContext<boolean>(
   Symbol("esphome-devices-loaded")
 );
 
+/** WS liveness. Consumers watch the false→true edge to redo work that
+ *  gave up while the socket was down. */
+export const apiConnectedContext = createContext<boolean>(
+  Symbol("esphome-api-connected")
+);
+
 /** Context for whether the frontend is running inside HA ingress. */
 export const isHaIngressContext = createContext<boolean>(Symbol("esphome-is-ha-ingress"));
 

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,5 +1,6 @@
 export {
   activeJobsContext,
+  apiConnectedContext,
   apiContext,
   buildOffloadAlertsContext,
   buildOffloadDiscoveredHostsContext,
@@ -12,7 +13,6 @@ export {
   desktopUpdateCapableContext,
   desktopVersionContext,
   devicesContext,
-  apiConnectedContext,
   devicesLoadedContext,
   experienceLevelContext,
   expertModeContext,

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -12,6 +12,7 @@ export {
   desktopUpdateCapableContext,
   desktopVersionContext,
   devicesContext,
+  apiConnectedContext,
   devicesLoadedContext,
   experienceLevelContext,
   expertModeContext,

--- a/src/pages/device-styles.ts
+++ b/src/pages/device-styles.ts
@@ -30,24 +30,15 @@ export const devicePageStyles = css`
     grid-template-columns: minmax(0, 5fr);
   }
 
-  .yaml-load-state {
-    grid-column: 1 / -1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
+  /* Load ladder in place of the editor: the grid holds a message and an
+     optional action button instead of the nav + editor columns, so drop
+     the column split and the 1px gap's border colour. */
+  .layout-grid.load-state {
+    grid-template-columns: 1fr;
+    align-content: center;
+    justify-items: center;
     gap: var(--wa-space-m);
     background: var(--wa-color-surface-default);
-    color: var(--wa-color-text-quiet);
-    font-size: var(--wa-font-size-s);
-  }
-
-  .yaml-load-state wa-spinner {
-    font-size: 28px;
-  }
-
-  .yaml-load-state p {
-    margin: 0;
   }
 
   .layout-grid.nav-collapsed .desktop-nav {

--- a/src/pages/device-styles.ts
+++ b/src/pages/device-styles.ts
@@ -30,6 +30,26 @@ export const devicePageStyles = css`
     grid-template-columns: minmax(0, 5fr);
   }
 
+  .yaml-load-state {
+    grid-column: 1 / -1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--wa-space-m);
+    background: var(--wa-color-surface-default);
+    color: var(--wa-color-text-quiet);
+    font-size: var(--wa-font-size-s);
+  }
+
+  .yaml-load-state wa-spinner {
+    font-size: 28px;
+  }
+
+  .yaml-load-state p {
+    margin: 0;
+  }
+
   .layout-grid.nav-collapsed .desktop-nav {
     display: none;
   }

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -56,6 +56,7 @@ import { showPendingChanges, showUpdateAvailable } from "../util/device-sync.js"
 import { deviceLayoutToPref, prefToDeviceLayout } from "../util/editor-layout.js";
 import { followActiveJob } from "../util/firmware-job-display.js";
 import { consumeJustCreated } from "../util/just-created.js";
+import { RECONNECTED_EVENT } from "../components/app-shell/connection-overlays.js";
 import { loadConfigWithRecovery } from "../util/load-with-recovery.js";
 import { renderAsyncState } from "../util/render-async-state.js";
 import { goBackOrHome, navigate, setLeaveGuard } from "../util/navigation.js";
@@ -626,6 +627,7 @@ export class ESPHomePageDevice extends LitElement {
     window.addEventListener("beforeunload", this._onBeforeUnload);
     window.addEventListener("popstate", this._onPopState, { capture: true });
     window.addEventListener("keydown", this._onKeydown);
+    window.addEventListener(RECONNECTED_EVENT, this._onReconnected);
     this._mql.addEventListener("change", this._onMqlChange);
   }
 
@@ -635,6 +637,7 @@ export class ESPHomePageDevice extends LitElement {
     window.removeEventListener("beforeunload", this._onBeforeUnload);
     window.removeEventListener("popstate", this._onPopState, { capture: true });
     window.removeEventListener("keydown", this._onKeydown);
+    window.removeEventListener(RECONNECTED_EVENT, this._onReconnected);
     this._mql.removeEventListener("change", this._onMqlChange);
     // Drop any in-flight unsaved-changes guard so its caller's
     // ``await`` doesn't dangle past unmount — resolve as "don't
@@ -830,6 +833,12 @@ export class ESPHomePageDevice extends LitElement {
   }
 
   private _retryLoadYaml = () => void this._loadYaml();
+
+  /** The socket is back; a load that gave up while it was down can go
+   *  again without the user hunting for the Retry button. */
+  private _onReconnected = () => {
+    if (this._yamlState === "error") this._retryLoadYaml();
+  };
 
   /**
    * Consume the one-shot ``?line=`` intent once the YAML has loaded.

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1,12 +1,14 @@
 import { consume } from "@lit/context";
 import { mdiArrowLeft, mdiChevronRight, mdiMenu } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
+import { cache } from "lit/directives/cache.js";
 import { customElement, property, query, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
-import type { ESPHomeAPI } from "../api/index.js";
+import { APIError, type ESPHomeAPI } from "../api/index.js";
 import type { BoardCatalogEntry } from "../api/types/boards.js";
 import type { ConfiguredDevice } from "../api/types/devices.js";
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
+import { ErrorCode } from "../api/types/protocol.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type { ESPHomeCommandDialog } from "../components/command-dialog.js";
 import type { ESPHomeBoardReselectDialog } from "../components/device/board-reselect-dialog.js";
@@ -322,9 +324,11 @@ export class ESPHomePageDevice extends LitElement {
 
   /** Initial-fetch gate for the current id: the editor and navigator
    *  render only once "ready", so a slow ``getConfig`` shows a spinner
-   *  instead of an empty editor, and a failed one shows a retry. */
+   *  instead of an empty editor. A transport failure offers a retry;
+   *  a NOT_FOUND config (deleted, renamed, stale bookmark) is terminal,
+   *  so it routes back to the dashboard instead. */
   @state()
-  private _yamlState: "loading" | "ready" | "error" = "loading";
+  private _yamlState: "loading" | "ready" | "error" | "missing" = "loading";
 
   @state()
   private _savedYaml = "";
@@ -673,7 +677,11 @@ export class ESPHomePageDevice extends LitElement {
       if (this._backendErrors.length) this._backendErrors = [];
       this._heldUnknownInstance = null;
       this._kickKnownKeys();
-      this._yamlState = "loading";
+      // The loading gate detaches the editor subtree, so the section
+      // editor's unmount announcement never reaches this page — drop the
+      // captured ref and its dirty bit here instead.
+      this._activeSection = null;
+      this._sectionDirty = false;
       void this._loadYaml();
     }
     // Devices context arrives async after connect; kick off the board
@@ -790,6 +798,7 @@ export class ESPHomePageDevice extends LitElement {
 
   private async _loadYaml() {
     const id = this.id;
+    this._yamlState = "loading";
     try {
       // Ready gates on (re)connect + auth, so a mount during a reconnect
       // window waits instead of throwing "WebSocket not connected".
@@ -802,14 +811,15 @@ export class ESPHomePageDevice extends LitElement {
       this._maybeResolveLineFromUrl();
     } catch (e) {
       console.error("Failed to load YAML:", e);
-      if (this.id === id) this._yamlState = "error";
+      if (this.id !== id) return;
+      this._yamlState =
+        e instanceof APIError && e.errorCode === ErrorCode.NOT_FOUND
+          ? "missing"
+          : "error";
     }
   }
 
-  private _retryLoadYaml = () => {
-    this._yamlState = "loading";
-    void this._loadYaml();
-  };
+  private _retryLoadYaml = () => void this._loadYaml();
 
   /**
    * Consume the one-shot ``?line=`` intent once the YAML has loaded.
@@ -1295,79 +1305,11 @@ export class ESPHomePageDevice extends LitElement {
           @install-device=${this._saveThenInstall}
           @update-device=${this._saveThenUpdate}
         >
-          ${
+          ${cache(
             this._yamlState === "ready"
-              ? html` ${this._renderNavigator("desktop-nav")}
-                  <esphome-device-editor
-                    .yaml=${this._yaml}
-                    .savedYaml=${this._savedYaml}
-                    .layout=${this._layout}
-                    ?navCollapsed=${this._navCollapsed}
-                    .deviceTitle=${deviceTitle}
-                    .board=${this._board}
-                    .highlightRange=${this._highlightRange}
-                    .scrollToHighlight=${this._scrollToHighlight}
-                    .configuration=${this.id}
-                    .selectedSection=${this._selectedSection}
-                    .selectedFromLine=${this._selectedFromLine}
-                    .focusFieldPath=${this._focusFieldPath}
-                    .focusYamlPath=${this._focusYamlPath}
-                    .backendErrors=${this._instanceBackendErrors(
-                      this._backendErrors,
-                      this._selectedSection,
-                      this._selectedFromLine
-                    )}
-                    .justCreated=${this._justCreated}
-                    @just-created-dismiss=${this._dismissJustCreated}
-                    @request-install=${this._saveThenInstall}
-                    @goto-line=${this._onEditorGoToLine}
-                    @change-board=${this._onChangeBoard}
-                    @open-logs=${this._onEditorOpenLogs}
-                    @clean-build=${this._onEditorCleanBuild}
-                    ?hasUnsavedEdits=${this._isDirty}
-                    ?saving=${this._saving}
-                    ?showModified=${this._device ? showPendingChanges(this._device) : false}
-                    ?showUpdate=${this._device ? showUpdateAvailable(this._device) : false}
-                    .installedVersion=${this._device?.runtime_state.deployed_version ?? ""}
-                    .availableVersion=${this._device?.current_version ?? ""}
-                    .webUiUrl=${this._device ? buildWebUiUrl(this._device) : ""}
-                    ?busy=${this._activeJobs.has(this.id)}
-                  >
-                    ${
-                      showEdgeTab || this._selectedSection
-                        ? html`<div slot="header-start" class="header-start-group">
-                            ${
-                              showEdgeTab
-                                ? html`<button
-                                    type="button"
-                                    class="ghost-icon-btn nav-toggle-btn"
-                                    ${tourAnchor("nav-toggle")}
-                                    @click=${this._onNavExpand}
-                                    title=${this._localize("device.show_navigator")}
-                                    aria-label=${this._localize("device.show_navigator")}
-                                  >
-                                    <wa-icon library="mdi" name="menu"></wa-icon>
-                                  </button>`
-                                : nothing
-                            }
-                            ${
-                              this._selectedSection
-                                ? html`<button
-                                    class="ghost-icon-btn back-btn"
-                                    @click=${this._onBack}
-                                    title=${backLabel}
-                                    aria-label=${backLabel}
-                                  >
-                                    <wa-icon library="mdi" name="arrow-left"></wa-icon>
-                                  </button>`
-                                : nothing
-                            }
-                          </div>`
-                        : nothing
-                    }
-                  </esphome-device-editor>`
+              ? this._renderEditor(deviceTitle, showEdgeTab, backLabel)
               : this._renderYamlLoadState()
-          }
+          )}
         </div>
         <esphome-unsaved-changes-dialog
           @discard=${this._onUnsavedDiscard}
@@ -1565,21 +1507,98 @@ export class ESPHomePageDevice extends LitElement {
     ></esphome-device-navigator>`;
   }
 
+  private _renderEditor(deviceTitle: string, showEdgeTab: boolean, backLabel: string) {
+    return html` ${this._renderNavigator("desktop-nav")}
+      <esphome-device-editor
+        .yaml=${this._yaml}
+        .savedYaml=${this._savedYaml}
+        .layout=${this._layout}
+        ?navCollapsed=${this._navCollapsed}
+        .deviceTitle=${deviceTitle}
+        .board=${this._board}
+        .highlightRange=${this._highlightRange}
+        .scrollToHighlight=${this._scrollToHighlight}
+        .configuration=${this.id}
+        .selectedSection=${this._selectedSection}
+        .selectedFromLine=${this._selectedFromLine}
+        .focusFieldPath=${this._focusFieldPath}
+        .focusYamlPath=${this._focusYamlPath}
+        .backendErrors=${this._instanceBackendErrors(
+          this._backendErrors,
+          this._selectedSection,
+          this._selectedFromLine
+        )}
+        .justCreated=${this._justCreated}
+        @just-created-dismiss=${this._dismissJustCreated}
+        @request-install=${this._saveThenInstall}
+        @goto-line=${this._onEditorGoToLine}
+        @change-board=${this._onChangeBoard}
+        @open-logs=${this._onEditorOpenLogs}
+        @clean-build=${this._onEditorCleanBuild}
+        ?hasUnsavedEdits=${this._isDirty}
+        ?saving=${this._saving}
+        ?showModified=${this._device ? showPendingChanges(this._device) : false}
+        ?showUpdate=${this._device ? showUpdateAvailable(this._device) : false}
+        .installedVersion=${this._device?.runtime_state.deployed_version ?? ""}
+        .availableVersion=${this._device?.current_version ?? ""}
+        .webUiUrl=${this._device ? buildWebUiUrl(this._device) : ""}
+        ?busy=${this._activeJobs.has(this.id)}
+      >
+        ${
+          showEdgeTab || this._selectedSection
+            ? html`<div slot="header-start" class="header-start-group">
+                ${
+                  showEdgeTab
+                    ? html`<button
+                        type="button"
+                        class="ghost-icon-btn nav-toggle-btn"
+                        ${tourAnchor("nav-toggle")}
+                        @click=${this._onNavExpand}
+                        title=${this._localize("device.show_navigator")}
+                        aria-label=${this._localize("device.show_navigator")}
+                      >
+                        <wa-icon library="mdi" name="menu"></wa-icon>
+                      </button>`
+                    : nothing
+                }
+                ${
+                  this._selectedSection
+                    ? html`<button
+                        class="ghost-icon-btn back-btn"
+                        @click=${this._onBack}
+                        title=${backLabel}
+                        aria-label=${backLabel}
+                      >
+                        <wa-icon library="mdi" name="arrow-left"></wa-icon>
+                      </button>`
+                    : nothing
+                }
+              </div>`
+            : nothing
+        }
+      </esphome-device-editor>`;
+  }
+
   private _renderYamlLoadState() {
+    if (this._yamlState === "missing") {
+      return html`<div class="yaml-load-state">
+        <p role="alert">${this._localize("device.load_not_found")}</p>
+        <wa-button size="small" @click=${() => navigate("/")}>
+          ${this._localize("device.back_to_dashboard")}
+        </wa-button>
+      </div>`;
+    }
+    if (this._yamlState === "error") {
+      return html`<div class="yaml-load-state">
+        <p role="alert">${this._localize("device.load_failed")}</p>
+        <wa-button size="small" @click=${this._retryLoadYaml}>
+          ${this._localize("command.retry")}
+        </wa-button>
+      </div>`;
+    }
     return html`<div class="yaml-load-state">
-      ${
-        this._yamlState === "error"
-          ? html`
-              <p>${this._localize("device.load_failed")}</p>
-              <wa-button size="small" @click=${this._retryLoadYaml}>
-                ${this._localize("command.retry")}
-              </wa-button>
-            `
-          : html`
-              <wa-spinner></wa-spinner>
-              <p>${this._localize("device.loading_config")}</p>
-            `
-      }
+      <wa-spinner></wa-spinner>
+      <p role="status">${this._localize("device.loading_config")}</p>
     </div>`;
   }
 

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -835,14 +835,19 @@ export class ESPHomePageDevice extends LitElement {
     }
   }
 
+  /** Bumped per load; a superseded loop self-cancels via ``abandoned``,
+   *  so an a → b → a switch can't commit the first load's stale reply. */
+  private _loadGen = 0;
+
   private async _loadYaml() {
     const id = this.id;
+    const gen = ++this._loadGen;
     this._yamlState = "loading";
     try {
       const yaml = await loadConfigWithRecovery(this._api, id, {
         // Unmount counts as abandoned too, or a slow load keeps fetching
         // (and re-rendering) against a page that is already gone.
-        abandoned: () => !this.isConnected || this.id !== id,
+        abandoned: () => !this.isConnected || this.id !== id || gen !== this._loadGen,
         attempts: LOAD_YAML_ATTEMPTS,
         timeoutMs: LOAD_YAML_TIMEOUT_MS,
       });

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -36,6 +36,7 @@ import {
   activeJobsContext,
   apiContext,
   devicesContext,
+  apiConnectedContext,
   devicesLoadedContext,
   localizeContext,
 } from "../context/index.js";
@@ -56,7 +57,6 @@ import { showPendingChanges, showUpdateAvailable } from "../util/device-sync.js"
 import { deviceLayoutToPref, prefToDeviceLayout } from "../util/editor-layout.js";
 import { followActiveJob } from "../util/firmware-job-display.js";
 import { consumeJustCreated } from "../util/just-created.js";
-import { RECONNECTED_EVENT } from "../components/app-shell/connection-overlays.js";
 import { loadConfigWithRecovery } from "../util/load-with-recovery.js";
 import { renderAsyncState } from "../util/render-async-state.js";
 import { goBackOrHome, navigate, setLeaveGuard } from "../util/navigation.js";
@@ -137,6 +137,11 @@ export class ESPHomePageDevice extends LitElement {
    *  ``_platformReady`` uses this to tell "context still loading"
    *  apart from "context delivered, our id isn't here" — a length
    *  check would strand the gate on a zero-device dashboard. */
+  /** WS liveness; the false→true edge re-runs a load that gave up. */
+  @consume({ context: apiConnectedContext, subscribe: true })
+  @state()
+  private _apiConnected = false;
+
   @consume({ context: devicesLoadedContext, subscribe: true })
   @state()
   private _devicesLoaded = false;
@@ -627,7 +632,6 @@ export class ESPHomePageDevice extends LitElement {
     window.addEventListener("beforeunload", this._onBeforeUnload);
     window.addEventListener("popstate", this._onPopState, { capture: true });
     window.addEventListener("keydown", this._onKeydown);
-    window.addEventListener(RECONNECTED_EVENT, this._onReconnected);
     this._mql.addEventListener("change", this._onMqlChange);
   }
 
@@ -637,7 +641,6 @@ export class ESPHomePageDevice extends LitElement {
     window.removeEventListener("beforeunload", this._onBeforeUnload);
     window.removeEventListener("popstate", this._onPopState, { capture: true });
     window.removeEventListener("keydown", this._onKeydown);
-    window.removeEventListener(RECONNECTED_EVENT, this._onReconnected);
     this._mql.removeEventListener("change", this._onMqlChange);
     // Drop any in-flight unsaved-changes guard so its caller's
     // ``await`` doesn't dangle past unmount — resolve as "don't
@@ -674,6 +677,16 @@ export class ESPHomePageDevice extends LitElement {
   };
 
   updated(changedProperties: Map<string, unknown>) {
+    // Socket is back: a load that gave up while it was down goes again
+    // without the user hunting for the Retry button. "missing" is a server
+    // answer, so it stays put.
+    if (
+      changedProperties.has("_apiConnected") &&
+      this._apiConnected &&
+      this._yamlState === "error"
+    ) {
+      this._retryLoadYaml();
+    }
     if (changedProperties.has("id") && this.id) {
       // Consume the wizard's "just-created" handoff once per id. Each
       // call to consumeJustCreated atomically reads + clears the flag,
@@ -814,7 +827,9 @@ export class ESPHomePageDevice extends LitElement {
     this._yamlState = "loading";
     try {
       const yaml = await loadConfigWithRecovery(this._api, id, {
-        abandoned: () => this.id !== id,
+        // Unmount counts as abandoned too, or a slow load keeps fetching
+        // (and re-rendering) against a page that is already gone.
+        abandoned: () => !this.isConnected || this.id !== id,
         attempts: LOAD_YAML_ATTEMPTS,
         timeoutMs: LOAD_YAML_TIMEOUT_MS,
       });
@@ -833,12 +848,6 @@ export class ESPHomePageDevice extends LitElement {
   }
 
   private _retryLoadYaml = () => void this._loadYaml();
-
-  /** The socket is back; a load that gave up while it was down can go
-   *  again without the user hunting for the Retry button. */
-  private _onReconnected = () => {
-    if (this._yamlState === "error") this._retryLoadYaml();
-  };
 
   /**
    * Consume the one-shot ``?line=`` intent once the YAML has loaded.
@@ -1327,21 +1336,9 @@ export class ESPHomePageDevice extends LitElement {
           @update-device=${this._saveThenUpdate}
         >
           ${cache(
-            renderAsyncState({
-              loading: this._yamlState === "loading",
-              loadingMessage: this._localize("device.loading_config"),
-              loadingLead: () => html`<wa-spinner></wa-spinner>`,
-              error:
-                this._yamlState === "ready"
-                  ? null
-                  : this._localize(
-                      this._yamlState === "missing"
-                        ? "device.load_not_found"
-                        : "device.load_failed"
-                    ),
-              errorActions: () => this._renderLoadFailure(),
-              content: () => this._renderEditor(deviceTitle, showEdgeTab, backLabel),
-            })
+            this._yamlState === "ready"
+              ? this._renderEditor(deviceTitle, showEdgeTab, backLabel)
+              : this._renderLoadState()
           )}
         </div>
         <esphome-unsaved-changes-dialog
@@ -1612,15 +1609,25 @@ export class ESPHomePageDevice extends LitElement {
       </esphome-device-editor>`;
   }
 
-  /** A gone config is terminal, so it offers a way out rather than a retry. */
-  private _renderLoadFailure() {
+  /** The editor's stand-in until the config lands. A gone config is
+   *  terminal, so it offers a way out rather than a retry. */
+  private _renderLoadState() {
     const missing = this._yamlState === "missing";
-    return html`<wa-button
-      size="small"
-      @click=${missing ? () => navigate("/") : this._retryLoadYaml}
-    >
-      ${this._localize(missing ? "device.back_to_dashboard" : "command.retry")}
-    </wa-button>`;
+    return renderAsyncState({
+      loading: this._yamlState === "loading",
+      loadingMessage: this._localize("device.loading_config"),
+      loadingLead: () => html`<wa-spinner></wa-spinner>`,
+      error: this._localize(missing ? "device.load_not_found" : "device.load_failed"),
+      errorActions: () =>
+        html`<wa-button
+          size="small"
+          @click=${missing ? () => navigate("/") : this._retryLoadYaml}
+        >
+          ${this._localize(missing ? "device.back_to_dashboard" : "command.retry")}
+        </wa-button>`,
+      // The ready branch renders the editor instead of reaching here.
+      content: () => nothing,
+    });
   }
 
   /** Advance the YAML buffer. Any mutation while an error-jump

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -843,23 +843,27 @@ export class ESPHomePageDevice extends LitElement {
     const id = this.id;
     const gen = ++this._loadGen;
     this._yamlState = "loading";
+    let yaml: string | null;
     try {
-      const yaml = await loadConfigWithRecovery(this._api, id, {
+      yaml = await loadConfigWithRecovery(this._api, id, {
         // Unmount counts as abandoned too, or a slow load keeps fetching
         // (and re-rendering) against a page that is already gone.
         abandoned: () => !this.isConnected || this.id !== id || gen !== this._loadGen,
         attempts: LOAD_YAML_ATTEMPTS,
         timeoutMs: LOAD_YAML_TIMEOUT_MS,
       });
-      if (yaml === null) return;
-      this._yaml = yaml;
-      this._savedYaml = yaml;
-      this._yamlState = "ready";
-      this._maybeResolveLineFromUrl();
     } catch (e) {
       console.error("Failed to load YAML:", e);
       this._yamlState = isApiErrorCode(e, ErrorCode.NOT_FOUND) ? "missing" : "error";
+      return;
     }
+    if (yaml === null) return;
+    this._yaml = yaml;
+    this._savedYaml = yaml;
+    this._yamlState = "ready";
+    // Outside the catch: a resolver throw must not repaint a loaded
+    // config as a load failure.
+    this._maybeResolveLineFromUrl();
   }
 
   private _retryLoadYaml = () => void this._loadYaml();

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -91,7 +91,9 @@ import {
   readUrlSections,
 } from "./device-url-state.js";
 
+import "@home-assistant/webawesome/dist/components/button/button.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 import "../components/command-dialog.js";
 import "../components/device/board-reselect-dialog.js";
 import "../components/device/device-editor.js";
@@ -317,6 +319,12 @@ export class ESPHomePageDevice extends LitElement {
    */
   @state()
   private _yaml = "";
+
+  /** Initial-fetch gate for the current id: the editor and navigator
+   *  render only once "ready", so a slow ``getConfig`` shows a spinner
+   *  instead of an empty editor, and a failed one shows a retry. */
+  @state()
+  private _yamlState: "loading" | "ready" | "error" = "loading";
 
   @state()
   private _savedYaml = "";
@@ -665,6 +673,7 @@ export class ESPHomePageDevice extends LitElement {
       if (this._backendErrors.length) this._backendErrors = [];
       this._heldUnknownInstance = null;
       this._kickKnownKeys();
+      this._yamlState = "loading";
       void this._loadYaml();
     }
     // Devices context arrives async after connect; kick off the board
@@ -780,15 +789,27 @@ export class ESPHomePageDevice extends LitElement {
   }
 
   private async _loadYaml() {
+    const id = this.id;
     try {
-      const yaml = await this._api.getConfig(this.id);
+      // Ready gates on (re)connect + auth, so a mount during a reconnect
+      // window waits instead of throwing "WebSocket not connected".
+      await this._api.ready;
+      const yaml = await this._api.getConfig(id);
+      if (this.id !== id) return;
       this._yaml = yaml;
       this._savedYaml = yaml;
+      this._yamlState = "ready";
       this._maybeResolveLineFromUrl();
     } catch (e) {
       console.error("Failed to load YAML:", e);
+      if (this.id === id) this._yamlState = "error";
     }
   }
+
+  private _retryLoadYaml = () => {
+    this._yamlState = "loading";
+    void this._loadYaml();
+  };
 
   /**
    * Consume the one-shot ``?line=`` intent once the YAML has loaded.
@@ -1246,7 +1267,7 @@ export class ESPHomePageDevice extends LitElement {
         @yaml-draft=${this._onYamlDraft}
         @nav-collapse=${this._onNavCollapse}
       >
-        ${this._renderNavigator("drawer-nav")}
+        ${this._yamlState === "ready" ? this._renderNavigator("drawer-nav") : nothing}
       </div>
 
       <div class="page">
@@ -1274,75 +1295,79 @@ export class ESPHomePageDevice extends LitElement {
           @install-device=${this._saveThenInstall}
           @update-device=${this._saveThenUpdate}
         >
-          ${this._renderNavigator("desktop-nav")}
-          <esphome-device-editor
-            .yaml=${this._yaml}
-            .savedYaml=${this._savedYaml}
-            .layout=${this._layout}
-            ?navCollapsed=${this._navCollapsed}
-            .deviceTitle=${deviceTitle}
-            .board=${this._board}
-            .highlightRange=${this._highlightRange}
-            .scrollToHighlight=${this._scrollToHighlight}
-            .configuration=${this.id}
-            .selectedSection=${this._selectedSection}
-            .selectedFromLine=${this._selectedFromLine}
-            .focusFieldPath=${this._focusFieldPath}
-            .focusYamlPath=${this._focusYamlPath}
-            .backendErrors=${this._instanceBackendErrors(
-              this._backendErrors,
-              this._selectedSection,
-              this._selectedFromLine
-            )}
-            .justCreated=${this._justCreated}
-            @just-created-dismiss=${this._dismissJustCreated}
-            @request-install=${this._saveThenInstall}
-            @goto-line=${this._onEditorGoToLine}
-            @change-board=${this._onChangeBoard}
-            @open-logs=${this._onEditorOpenLogs}
-            @clean-build=${this._onEditorCleanBuild}
-            ?hasUnsavedEdits=${this._isDirty}
-            ?saving=${this._saving}
-            ?showModified=${this._device ? showPendingChanges(this._device) : false}
-            ?showUpdate=${this._device ? showUpdateAvailable(this._device) : false}
-            .installedVersion=${this._device?.runtime_state.deployed_version ?? ""}
-            .availableVersion=${this._device?.current_version ?? ""}
-            .webUiUrl=${this._device ? buildWebUiUrl(this._device) : ""}
-            ?busy=${this._activeJobs.has(this.id)}
-          >
-            ${
-              showEdgeTab || this._selectedSection
-                ? html`<div slot="header-start" class="header-start-group">
+          ${
+            this._yamlState === "ready"
+              ? html` ${this._renderNavigator("desktop-nav")}
+                  <esphome-device-editor
+                    .yaml=${this._yaml}
+                    .savedYaml=${this._savedYaml}
+                    .layout=${this._layout}
+                    ?navCollapsed=${this._navCollapsed}
+                    .deviceTitle=${deviceTitle}
+                    .board=${this._board}
+                    .highlightRange=${this._highlightRange}
+                    .scrollToHighlight=${this._scrollToHighlight}
+                    .configuration=${this.id}
+                    .selectedSection=${this._selectedSection}
+                    .selectedFromLine=${this._selectedFromLine}
+                    .focusFieldPath=${this._focusFieldPath}
+                    .focusYamlPath=${this._focusYamlPath}
+                    .backendErrors=${this._instanceBackendErrors(
+                      this._backendErrors,
+                      this._selectedSection,
+                      this._selectedFromLine
+                    )}
+                    .justCreated=${this._justCreated}
+                    @just-created-dismiss=${this._dismissJustCreated}
+                    @request-install=${this._saveThenInstall}
+                    @goto-line=${this._onEditorGoToLine}
+                    @change-board=${this._onChangeBoard}
+                    @open-logs=${this._onEditorOpenLogs}
+                    @clean-build=${this._onEditorCleanBuild}
+                    ?hasUnsavedEdits=${this._isDirty}
+                    ?saving=${this._saving}
+                    ?showModified=${this._device ? showPendingChanges(this._device) : false}
+                    ?showUpdate=${this._device ? showUpdateAvailable(this._device) : false}
+                    .installedVersion=${this._device?.runtime_state.deployed_version ?? ""}
+                    .availableVersion=${this._device?.current_version ?? ""}
+                    .webUiUrl=${this._device ? buildWebUiUrl(this._device) : ""}
+                    ?busy=${this._activeJobs.has(this.id)}
+                  >
                     ${
-                      showEdgeTab
-                        ? html`<button
-                            type="button"
-                            class="ghost-icon-btn nav-toggle-btn"
-                            ${tourAnchor("nav-toggle")}
-                            @click=${this._onNavExpand}
-                            title=${this._localize("device.show_navigator")}
-                            aria-label=${this._localize("device.show_navigator")}
-                          >
-                            <wa-icon library="mdi" name="menu"></wa-icon>
-                          </button>`
+                      showEdgeTab || this._selectedSection
+                        ? html`<div slot="header-start" class="header-start-group">
+                            ${
+                              showEdgeTab
+                                ? html`<button
+                                    type="button"
+                                    class="ghost-icon-btn nav-toggle-btn"
+                                    ${tourAnchor("nav-toggle")}
+                                    @click=${this._onNavExpand}
+                                    title=${this._localize("device.show_navigator")}
+                                    aria-label=${this._localize("device.show_navigator")}
+                                  >
+                                    <wa-icon library="mdi" name="menu"></wa-icon>
+                                  </button>`
+                                : nothing
+                            }
+                            ${
+                              this._selectedSection
+                                ? html`<button
+                                    class="ghost-icon-btn back-btn"
+                                    @click=${this._onBack}
+                                    title=${backLabel}
+                                    aria-label=${backLabel}
+                                  >
+                                    <wa-icon library="mdi" name="arrow-left"></wa-icon>
+                                  </button>`
+                                : nothing
+                            }
+                          </div>`
                         : nothing
                     }
-                    ${
-                      this._selectedSection
-                        ? html`<button
-                            class="ghost-icon-btn back-btn"
-                            @click=${this._onBack}
-                            title=${backLabel}
-                            aria-label=${backLabel}
-                          >
-                            <wa-icon library="mdi" name="arrow-left"></wa-icon>
-                          </button>`
-                        : nothing
-                    }
-                  </div>`
-                : nothing
-            }
-          </esphome-device-editor>
+                  </esphome-device-editor>`
+              : this._renderYamlLoadState()
+          }
         </div>
         <esphome-unsaved-changes-dialog
           @discard=${this._onUnsavedDiscard}
@@ -1538,6 +1563,24 @@ export class ESPHomePageDevice extends LitElement {
       .selectedFromLine=${this._selectedFromLine}
       .errorCounts=${this._navErrorCounts(this._backendErrors, this._heldUnknownInstance)}
     ></esphome-device-navigator>`;
+  }
+
+  private _renderYamlLoadState() {
+    return html`<div class="yaml-load-state">
+      ${
+        this._yamlState === "error"
+          ? html`
+              <p>${this._localize("device.load_failed")}</p>
+              <wa-button size="small" @click=${this._retryLoadYaml}>
+                ${this._localize("command.retry")}
+              </wa-button>
+            `
+          : html`
+              <wa-spinner></wa-spinner>
+              <p>${this._localize("device.loading_config")}</p>
+            `
+      }
+    </div>`;
   }
 
   /** Advance the YAML buffer. Any mutation while an error-jump

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -39,6 +39,7 @@ import {
   devicesLoadedContext,
   localizeContext,
 } from "../context/index.js";
+import { loadMessageStyles } from "../styles/load-message.js";
 import { espHomeStyles } from "../styles/shared.js";
 import {
   backendErrorCounts,
@@ -55,7 +56,8 @@ import { showPendingChanges, showUpdateAvailable } from "../util/device-sync.js"
 import { deviceLayoutToPref, prefToDeviceLayout } from "../util/editor-layout.js";
 import { followActiveJob } from "../util/firmware-job-display.js";
 import { consumeJustCreated } from "../util/just-created.js";
-import { LoadAbandonedError, loadWithRecovery } from "../util/load-with-recovery.js";
+import { loadConfigWithRecovery } from "../util/load-with-recovery.js";
+import { renderAsyncState } from "../util/render-async-state.js";
 import { goBackOrHome, navigate, setLeaveGuard } from "../util/navigation.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -808,22 +810,17 @@ export class ESPHomePageDevice extends LitElement {
     const id = this.id;
     this._yamlState = "loading";
     try {
-      const yaml = await loadWithRecovery({
-        // Ready parks on a dropped socket, so a reconnect window waits
-        // rather than throwing "WebSocket not connected".
-        ready: () => this._api.ready,
-        // A dropped socket rejects every in-flight request at once, so
-        // without the retry a blip mid-fetch reads as a hard failure.
-        load: () => this._api.getConfig(id, LOAD_YAML_TIMEOUT_MS),
+      const yaml = await loadConfigWithRecovery(this._api, id, {
         abandoned: () => this.id !== id,
         attempts: LOAD_YAML_ATTEMPTS,
+        timeoutMs: LOAD_YAML_TIMEOUT_MS,
       });
+      if (yaml === null) return;
       this._yaml = yaml;
       this._savedYaml = yaml;
       this._yamlState = "ready";
       this._maybeResolveLineFromUrl();
     } catch (e) {
-      if (e instanceof LoadAbandonedError) return;
       console.error("Failed to load YAML:", e);
       this._yamlState =
         e instanceof APIError && e.errorCode === ErrorCode.NOT_FOUND
@@ -1260,7 +1257,7 @@ export class ESPHomePageDevice extends LitElement {
     void navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
   };
 
-  static styles = [espHomeStyles, devicePageStyles];
+  static styles = [espHomeStyles, loadMessageStyles, devicePageStyles];
 
   protected render() {
     const deviceTitle =
@@ -1295,7 +1292,9 @@ export class ESPHomePageDevice extends LitElement {
 
       <div class="page">
         <div
-          class="layout-grid ${this._navCollapsed ? "nav-collapsed" : ""}"
+          class="layout-grid ${this._navCollapsed ? "nav-collapsed" : ""} ${
+            this._yamlState === "ready" ? "" : "load-state"
+          }"
           @section-toggle=${this._onSectionToggle}
           @section-reveal=${this._onSectionReveal}
           @layout-change=${this._onLayoutChange}
@@ -1319,9 +1318,21 @@ export class ESPHomePageDevice extends LitElement {
           @update-device=${this._saveThenUpdate}
         >
           ${cache(
-            this._yamlState === "ready"
-              ? this._renderEditor(deviceTitle, showEdgeTab, backLabel)
-              : this._renderYamlLoadState()
+            renderAsyncState({
+              loading: this._yamlState === "loading",
+              loadingMessage: this._localize("device.loading_config"),
+              loadingLead: () => html`<wa-spinner></wa-spinner>`,
+              error:
+                this._yamlState === "ready"
+                  ? null
+                  : this._localize(
+                      this._yamlState === "missing"
+                        ? "device.load_not_found"
+                        : "device.load_failed"
+                    ),
+              errorActions: () => this._renderLoadFailure(),
+              content: () => this._renderEditor(deviceTitle, showEdgeTab, backLabel),
+            })
           )}
         </div>
         <esphome-unsaved-changes-dialog
@@ -1592,27 +1603,15 @@ export class ESPHomePageDevice extends LitElement {
       </esphome-device-editor>`;
   }
 
-  private _renderYamlLoadState() {
-    if (this._yamlState === "missing") {
-      return html`<div class="yaml-load-state">
-        <p role="alert">${this._localize("device.load_not_found")}</p>
-        <wa-button size="small" @click=${() => navigate("/")}>
-          ${this._localize("device.back_to_dashboard")}
-        </wa-button>
-      </div>`;
-    }
-    if (this._yamlState === "error") {
-      return html`<div class="yaml-load-state">
-        <p role="alert">${this._localize("device.load_failed")}</p>
-        <wa-button size="small" @click=${this._retryLoadYaml}>
-          ${this._localize("command.retry")}
-        </wa-button>
-      </div>`;
-    }
-    return html`<div class="yaml-load-state">
-      <wa-spinner></wa-spinner>
-      <p role="status">${this._localize("device.loading_config")}</p>
-    </div>`;
+  /** A gone config is terminal, so it offers a way out rather than a retry. */
+  private _renderLoadFailure() {
+    const missing = this._yamlState === "missing";
+    return html`<wa-button
+      size="small"
+      @click=${missing ? () => navigate("/") : this._retryLoadYaml}
+    >
+      ${this._localize(missing ? "device.back_to_dashboard" : "command.retry")}
+    </wa-button>`;
   }
 
   /** Advance the YAML buffer. Any mutation while an error-jump

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -59,7 +59,12 @@ import { followActiveJob } from "../util/firmware-job-display.js";
 import { consumeJustCreated } from "../util/just-created.js";
 import { loadConfigWithRecovery } from "../util/load-with-recovery.js";
 import { renderAsyncState } from "../util/render-async-state.js";
-import { goBackOrHome, navigate, setLeaveGuard } from "../util/navigation.js";
+import {
+  consumePopGuardSuppression,
+  goBackOrHome,
+  navigate,
+  setLeaveGuard,
+} from "../util/navigation.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { isTypingTarget } from "../util/typing-target.js";
@@ -601,6 +606,9 @@ export class ESPHomePageDevice extends LitElement {
   };
 
   private _onPopState = (e: PopStateEvent) => {
+    // A failed route chunk rolling back its own push is a return to
+    // this page, not a leave.
+    if (consumePopGuardSuppression()) return;
     if (this._allowingLeave) {
       this._allowingLeave = false;
       return;
@@ -708,6 +716,10 @@ export class ESPHomePageDevice extends LitElement {
       // captured ref and its dirty bit here instead.
       this._activeSection = null;
       this._sectionDirty = false;
+      // Discard leaves the buffer dirty; clear it or the prior device's
+      // YAML rides the reused element and Save writes it to this file.
+      this._yaml = "";
+      this._savedYaml = "";
       void this._loadYaml();
     }
     // Devices context arrives async after connect; kick off the board

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1947,9 +1947,8 @@ export class ESPHomePageDevice extends LitElement {
       rebased = null;
     }
     // The device switched mid-recompute: the continuation (and its
-    // toast) belongs to the previous device. ``_loadYaml`` doesn't
-    // clear ``_yaml`` before its fetch, so the buffer guard below
-    // can't catch this window.
+    // toast) belongs to the previous device. Bail before the buffer
+    // comparison below can route it to the superseded toast.
     if (detail.configuration !== this.id) return;
     // Land the re-base only if the pane didn't move again while it
     // was computed — stale coordinates no longer apply.

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -2,9 +2,10 @@ import { consume } from "@lit/context";
 import { mdiArrowLeft, mdiChevronRight, mdiMenu } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { cache } from "lit/directives/cache.js";
+import { classMap } from "lit/directives/class-map.js";
 import { customElement, property, query, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
-import { APIError, type ESPHomeAPI } from "../api/index.js";
+import { type ESPHomeAPI, isApiErrorCode } from "../api/index.js";
 import type { BoardCatalogEntry } from "../api/types/boards.js";
 import type { ConfiguredDevice } from "../api/types/devices.js";
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
@@ -34,9 +35,9 @@ import type { HighlightRange } from "../components/yaml-editor.js";
 import type { ESPHomeYamlValidationDialog } from "../components/yaml-validation-dialog.js";
 import {
   activeJobsContext,
+  apiConnectedContext,
   apiContext,
   devicesContext,
-  apiConnectedContext,
   devicesLoadedContext,
   localizeContext,
 } from "../context/index.js";
@@ -142,14 +143,14 @@ export class ESPHomePageDevice extends LitElement {
    *  ``_platformReady`` uses this to tell "context still loading"
    *  apart from "context delivered, our id isn't here" — a length
    *  check would strand the gate on a zero-device dashboard. */
+  @consume({ context: devicesLoadedContext, subscribe: true })
+  @state()
+  private _devicesLoaded = false;
+
   /** WS liveness; the false→true edge re-runs a load that gave up. */
   @consume({ context: apiConnectedContext, subscribe: true })
   @state()
   private _apiConnected = false;
-
-  @consume({ context: devicesLoadedContext, subscribe: true })
-  @state()
-  private _devicesLoaded = false;
 
   @consume({ context: apiContext })
   private _api!: ESPHomeAPI;
@@ -852,10 +853,7 @@ export class ESPHomePageDevice extends LitElement {
       this._maybeResolveLineFromUrl();
     } catch (e) {
       console.error("Failed to load YAML:", e);
-      this._yamlState =
-        e instanceof APIError && e.errorCode === ErrorCode.NOT_FOUND
-          ? "missing"
-          : "error";
+      this._yamlState = isApiErrorCode(e, ErrorCode.NOT_FOUND) ? "missing" : "error";
     }
   }
 
@@ -1322,9 +1320,11 @@ export class ESPHomePageDevice extends LitElement {
 
       <div class="page">
         <div
-          class="layout-grid ${this._navCollapsed ? "nav-collapsed" : ""} ${
-            this._yamlState === "ready" ? "" : "load-state"
-          }"
+          class=${classMap({
+            "layout-grid": true,
+            "nav-collapsed": this._navCollapsed,
+            "load-state": this._yamlState !== "ready",
+          })}
           @section-toggle=${this._onSectionToggle}
           @section-reveal=${this._onSectionReveal}
           @layout-change=${this._onLayoutChange}
@@ -1624,12 +1624,15 @@ export class ESPHomePageDevice extends LitElement {
   /** The editor's stand-in until the config lands. A gone config is
    *  terminal, so it offers a way out rather than a retry. */
   private _renderLoadState() {
+    const loading = this._yamlState === "loading";
     const missing = this._yamlState === "missing";
     return renderAsyncState({
-      loading: this._yamlState === "loading",
+      loading,
       loadingMessage: this._localize("device.loading_config"),
-      loadingLead: () => html`<wa-spinner></wa-spinner>`,
-      error: this._localize(missing ? "device.load_not_found" : "device.load_failed"),
+      loadingLead: html`<wa-spinner></wa-spinner>`,
+      error: loading
+        ? null
+        : this._localize(missing ? "device.load_not_found" : "device.load_failed"),
       errorActions: () =>
         html`<wa-button
           size="small"

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -55,6 +55,7 @@ import { showPendingChanges, showUpdateAvailable } from "../util/device-sync.js"
 import { deviceLayoutToPref, prefToDeviceLayout } from "../util/editor-layout.js";
 import { followActiveJob } from "../util/firmware-job-display.js";
 import { consumeJustCreated } from "../util/just-created.js";
+import { LoadAbandonedError, loadWithRecovery } from "../util/load-with-recovery.js";
 import { goBackOrHome, navigate, setLeaveGuard } from "../util/navigation.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -111,6 +112,13 @@ registerMdiIcons({
   "chevron-right": mdiChevronRight,
   menu: mdiMenu,
 });
+
+// The user is staring at a spinner, so the initial config fetch gets a
+// longer leash than the 10s command default: a big YAML over a degraded
+// link is slow, not broken. Attempts burn only while the socket is up
+// (``ready`` parks otherwise), so an outage never spends them.
+const LOAD_YAML_TIMEOUT_MS = 30_000;
+const LOAD_YAML_ATTEMPTS = 4;
 
 @customElement("esphome-page-device")
 export class ESPHomePageDevice extends LitElement {
@@ -800,18 +808,23 @@ export class ESPHomePageDevice extends LitElement {
     const id = this.id;
     this._yamlState = "loading";
     try {
-      // Ready gates on (re)connect + auth, so a mount during a reconnect
-      // window waits instead of throwing "WebSocket not connected".
-      await this._api.ready;
-      const yaml = await this._api.getConfig(id);
-      if (this.id !== id) return;
+      const yaml = await loadWithRecovery({
+        // Ready parks on a dropped socket, so a reconnect window waits
+        // rather than throwing "WebSocket not connected".
+        ready: () => this._api.ready,
+        // A dropped socket rejects every in-flight request at once, so
+        // without the retry a blip mid-fetch reads as a hard failure.
+        load: () => this._api.getConfig(id, LOAD_YAML_TIMEOUT_MS),
+        abandoned: () => this.id !== id,
+        attempts: LOAD_YAML_ATTEMPTS,
+      });
       this._yaml = yaml;
       this._savedYaml = yaml;
       this._yamlState = "ready";
       this._maybeResolveLineFromUrl();
     } catch (e) {
+      if (e instanceof LoadAbandonedError) return;
       console.error("Failed to load YAML:", e);
-      if (this.id !== id) return;
       this._yamlState =
         e instanceof APIError && e.errorCode === ErrorCode.NOT_FOUND
           ? "missing"

--- a/src/pages/secrets.styles.ts
+++ b/src/pages/secrets.styles.ts
@@ -182,12 +182,8 @@ export const secretsStyles = css`
     }
   }
 
-  .loading {
+  /* Placement only; the block itself comes from loadMessageStyles. */
+  .message {
     flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 32px;
-    color: var(--wa-color-text-quiet);
   }
 `;

--- a/src/pages/secrets.styles.ts
+++ b/src/pages/secrets.styles.ts
@@ -182,8 +182,19 @@ export const secretsStyles = css`
     }
   }
 
-  /* Placement only; the block itself comes from loadMessageStyles. */
+  /* Placement only; the block itself comes from loadMessageStyles. The
+     auto-margin pairing centers the ladder — the message alone, or the
+     message plus the Retry button, which sizes to content instead of
+     stretching to the card's width. */
   .message {
-    flex: 1;
+    margin-top: auto;
+  }
+  .message:last-child {
+    margin-bottom: auto;
+  }
+  .message ~ wa-button {
+    align-self: center;
+    margin-top: var(--wa-space-m);
+    margin-bottom: auto;
   }
 `;

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -8,8 +8,9 @@ import {
 } from "@mdi/js";
 import { html, LitElement } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
-import { apiErrorDetails } from "../api/api-error.js";
+import { apiErrorDetails, APIError } from "../api/api-error.js";
 import type { ESPHomeAPI } from "../api/index.js";
+import { ErrorCode } from "../api/types/protocol.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type { ESPHomeConfirmDialog } from "../components/confirm-dialog.js";
 import type { ESPHomeUnsavedChangesDialog } from "../components/unsaved-changes-dialog.js";
@@ -50,6 +51,10 @@ registerMdiIcons({
 
 const SECRETS_FILE = "secrets.yaml";
 
+// Transport attempts before the load surfaces as an error the user can
+// retry; attempts are only spent while the socket is up.
+const LOAD_ATTEMPTS = 4;
+
 const LAYOUT_STORAGE_KEY = "esphome-secrets-layout";
 const LAYOUTS: readonly SecretsLayout[] = ["form", "yaml"];
 
@@ -73,6 +78,9 @@ export class ESPHomePageSecrets extends LitElement {
 
   @state()
   private _loaded = false;
+
+  @state()
+  private _loadFailed = false;
 
   /** Stops the load retry loop once the page is gone. */
   private _unmounted = false;
@@ -115,6 +123,8 @@ export class ESPHomePageSecrets extends LitElement {
 
   async connectedCallback() {
     super.connectedCallback();
+    // A re-attached instance must not inherit the previous teardown's latch.
+    this._unmounted = false;
     const stored = this._readStoredLayout();
     if (stored) {
       this._layout = stored;
@@ -229,21 +239,29 @@ export class ESPHomePageSecrets extends LitElement {
   /**
    * Pull `secrets.yaml` from the server and reset both buffers.
    *
-   * Only a server reply (APIError, file missing) seeds the localized
-   * header template — a transport fault must not, or a reconnect-window
-   * mount would template over the real file and a save could wipe it.
-   * Transport faults retry once the connection is ready again.
+   * Only a NOT_FOUND reply seeds the localized header template. Any other
+   * failure leaves the buffers empty behind the error state: an editable
+   * blank buffer would parse to zero entries, which slips past the
+   * clear-all wipe confirm and lets the next save replace a file that is
+   * still intact on disk.
    */
   private async _loadFromServer() {
+    this._loadFailed = false;
     let yaml: string | null;
     try {
       yaml = await loadConfigWithRecovery(this._api, SECRETS_FILE, {
         abandoned: () => this._unmounted,
+        attempts: LOAD_ATTEMPTS,
       });
-    } catch {
-      // Only a server reply reaches here (transport faults retry), so
-      // this really is a missing file rather than an unreachable one.
-      yaml = this._localize("secrets.file_header");
+    } catch (err) {
+      if (err instanceof APIError && err.errorCode === ErrorCode.NOT_FOUND) {
+        // First run: no secrets.yaml yet, so offer the header as a start.
+        yaml = this._localize("secrets.file_header");
+      } else {
+        console.error("Failed to load secrets.yaml:", err);
+        this._loadFailed = true;
+        return;
+      }
     }
     // Null means the page is gone; leave the buffers untouched.
     if (yaml === null) return;
@@ -251,6 +269,8 @@ export class ESPHomePageSecrets extends LitElement {
     this._savedYaml = yaml;
     this._loaded = true;
   }
+
+  private _retryLoad = () => void this._loadFromServer();
 
   /** Another component (typically the onboarding wizard) just
    *  wrote `secrets.yaml`. Reload from the server so the editor
@@ -317,10 +337,14 @@ export class ESPHomePageSecrets extends LitElement {
         </div>
         <div class="editor-card">
           ${renderAsyncState({
-            loading: !this._loaded,
+            loading: !this._loaded && !this._loadFailed,
             loadingMessage: this._localize("secrets.loading"),
             loadingLead: () => html`<wa-spinner></wa-spinner>`,
-            error: null,
+            error: this._loadFailed ? this._localize("secrets.load_failed") : null,
+            errorActions: () =>
+              html`<wa-button size="small" @click=${this._retryLoad}>
+                ${this._localize("command.retry")}
+              </wa-button>`,
             content: () => html`
               <button
                 type="button"

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -8,7 +8,7 @@ import {
 } from "@mdi/js";
 import { html, LitElement, type PropertyValues } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
-import { apiErrorDetails, APIError } from "../api/api-error.js";
+import { apiErrorDetails, isApiErrorCode } from "../api/api-error.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import { ErrorCode } from "../api/types/protocol.js";
 import type { LocalizeFunc } from "../common/localize.js";
@@ -84,13 +84,9 @@ export class ESPHomePageSecrets extends LitElement {
   @state()
   private _loadState: "loading" | "ready" | "error" = "loading";
 
-  /** In-flight load, shared by the mount, the external-save reload, and
-   *  Retry so they can't run overlapping recovery loops. */
-  private _loadPromise: Promise<void> | null = null;
-
-  /** Set when a caller joins an in-flight load whose request may predate
-   *  the content it wants (external save); triggers one fresh read. */
-  private _reloadQueued = false;
+  /** Bumped per load; a superseded loop self-cancels via ``abandoned``,
+   *  so a fresh read (external save) never settles on a stale reply. */
+  private _loadGen = 0;
 
   // Mirrors the device editor's per-field reveal toggle. Default
   // hidden so values render as bullets the moment the page paints —
@@ -264,31 +260,17 @@ export class ESPHomePageSecrets extends LitElement {
    * clear-all wipe confirm and lets the next save replace a file that is
    * still intact on disk.
    */
-  private _loadFromServer(): Promise<void> {
-    if (this._loadPromise) {
-      this._reloadQueued = true;
-      return this._loadPromise;
-    }
-    this._loadPromise = this._runLoad().finally(() => {
-      this._loadPromise = null;
-      if (this._reloadQueued) {
-        this._reloadQueued = false;
-        void this._loadFromServer();
-      }
-    });
-    return this._loadPromise;
-  }
-
-  private async _runLoad() {
+  private async _loadFromServer(): Promise<void> {
+    const gen = ++this._loadGen;
     if (this._loadState === "error") this._loadState = "loading";
     let yaml: string | null;
     try {
       yaml = await loadConfigWithRecovery(this._api, SECRETS_FILE, {
-        abandoned: () => !this.isConnected,
+        abandoned: () => !this.isConnected || gen !== this._loadGen,
         attempts: LOAD_ATTEMPTS,
       });
     } catch (err) {
-      if (err instanceof APIError && err.errorCode === ErrorCode.NOT_FOUND) {
+      if (isApiErrorCode(err, ErrorCode.NOT_FOUND)) {
         // First run: no secrets.yaml yet, so offer the header as a start.
         yaml = this._localize("secrets.file_header");
       } else {
@@ -304,7 +286,8 @@ export class ESPHomePageSecrets extends LitElement {
         return;
       }
     }
-    // Null means the page is gone; leave the buffers untouched.
+    // Null means the page is gone or a newer load took over; leave the
+    // buffers to it.
     if (yaml === null) return;
     this._yaml = yaml;
     this._savedYaml = yaml;
@@ -380,7 +363,7 @@ export class ESPHomePageSecrets extends LitElement {
           ${renderAsyncState({
             loading: this._loadState === "loading",
             loadingMessage: this._localize("secrets.loading"),
-            loadingLead: () => html`<wa-spinner></wa-spinner>`,
+            loadingLead: html`<wa-spinner></wa-spinner>`,
             error:
               this._loadState === "error" ? this._localize("secrets.load_failed") : null,
             errorActions: () =>

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -8,7 +8,7 @@ import {
 } from "@mdi/js";
 import { html, LitElement } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
-import { apiErrorDetails } from "../api/api-error.js";
+import { apiErrorDetails, APIError } from "../api/api-error.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type { ESPHomeConfirmDialog } from "../components/confirm-dialog.js";
@@ -26,6 +26,7 @@ import { notifyError, notifySuccess } from "../util/notify.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { SaveShortcutController } from "../util/save-shortcut-controller.js";
 import { parseSecretsEntries } from "../util/secrets-entries.js";
+import { sleep } from "../util/sleep.js";
 import { UnsavedGuard } from "../util/unsaved-guard.js";
 import { secretsStyles } from "./secrets.styles.js";
 
@@ -46,6 +47,10 @@ registerMdiIcons({
 });
 
 const SECRETS_FILE = "secrets.yaml";
+
+// Backoff between transport-fault reloads of secrets.yaml; keeps the
+// retry loop from spinning when the socket is up but requests time out.
+const RELOAD_RETRY_DELAY_MS = 2000;
 
 const LAYOUT_STORAGE_KEY = "esphome-secrets-layout";
 const LAYOUTS: readonly SecretsLayout[] = ["form", "yaml"];
@@ -70,6 +75,9 @@ export class ESPHomePageSecrets extends LitElement {
 
   @state()
   private _loaded = false;
+
+  /** Stops the load retry loop once the page is gone. */
+  private _unmounted = false;
 
   // Mirrors the device editor's per-field reveal toggle. Default
   // hidden so values render as bullets the moment the page paints —
@@ -154,6 +162,7 @@ export class ESPHomePageSecrets extends LitElement {
   }
 
   disconnectedCallback() {
+    this._unmounted = true;
     setLeaveGuard(null);
     window.removeEventListener("beforeunload", this._onBeforeUnload);
     window.removeEventListener("popstate", this._onPopState, { capture: true });
@@ -219,18 +228,34 @@ export class ESPHomePageSecrets extends LitElement {
   private _onUnsavedSave = () => this._unsavedGuard.onSave();
   private _onUnsavedCancel = () => this._unsavedGuard.onCancel();
 
-  /** Pull `secrets.yaml` from the server and reset both buffers.
-   *  On read error (file missing) seeds the editor with the
-   *  localized header so the user has a starting point. */
+  /**
+   * Pull `secrets.yaml` from the server and reset both buffers.
+   *
+   * Only a server reply (APIError, file missing) seeds the localized
+   * header template — a transport fault must not, or a reconnect-window
+   * mount would template over the real file and a save could wipe it.
+   * Transport faults retry once the connection is ready again.
+   */
   private async _loadFromServer() {
-    try {
-      const yaml = await this._api.getConfig(SECRETS_FILE);
-      this._yaml = yaml;
-      this._savedYaml = yaml;
-    } catch {
-      const yaml = this._localize("secrets.file_header");
-      this._yaml = yaml;
-      this._savedYaml = yaml;
+    for (;;) {
+      await this._api.ready;
+      try {
+        const yaml = await this._api.getConfig(SECRETS_FILE);
+        this._yaml = yaml;
+        this._savedYaml = yaml;
+        break;
+      } catch (err) {
+        if (err instanceof APIError) {
+          const yaml = this._localize("secrets.file_header");
+          this._yaml = yaml;
+          this._savedYaml = yaml;
+          break;
+        }
+        console.warn("Failed to load secrets.yaml; retrying:", err);
+        await sleep(RELOAD_RETRY_DELAY_MS);
+        // The page may have unmounted during the backoff.
+        if (this._unmounted) return;
+      }
     }
     this._loaded = true;
   }

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -8,7 +8,7 @@ import {
 } from "@mdi/js";
 import { html, LitElement } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
-import { apiErrorDetails, APIError } from "../api/api-error.js";
+import { apiErrorDetails } from "../api/api-error.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type { ESPHomeConfirmDialog } from "../components/confirm-dialog.js";
@@ -22,11 +22,11 @@ import {
   type SecretsLayout,
 } from "../util/editor-layout.js";
 import { setLeaveGuard } from "../util/navigation.js";
+import { LoadAbandonedError, loadWithRecovery } from "../util/load-with-recovery.js";
 import { notifyError, notifySuccess } from "../util/notify.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { SaveShortcutController } from "../util/save-shortcut-controller.js";
 import { parseSecretsEntries } from "../util/secrets-entries.js";
-import { sleep } from "../util/sleep.js";
 import { UnsavedGuard } from "../util/unsaved-guard.js";
 import { secretsStyles } from "./secrets.styles.js";
 
@@ -47,10 +47,6 @@ registerMdiIcons({
 });
 
 const SECRETS_FILE = "secrets.yaml";
-
-// Backoff between transport-fault reloads of secrets.yaml; keeps the
-// retry loop from spinning when the socket is up but requests time out.
-const RELOAD_RETRY_DELAY_MS = 2000;
 
 const LAYOUT_STORAGE_KEY = "esphome-secrets-layout";
 const LAYOUTS: readonly SecretsLayout[] = ["form", "yaml"];
@@ -237,26 +233,22 @@ export class ESPHomePageSecrets extends LitElement {
    * Transport faults retry once the connection is ready again.
    */
   private async _loadFromServer() {
-    for (;;) {
-      await this._api.ready;
-      try {
-        const yaml = await this._api.getConfig(SECRETS_FILE);
-        this._yaml = yaml;
-        this._savedYaml = yaml;
-        break;
-      } catch (err) {
-        if (err instanceof APIError) {
-          const yaml = this._localize("secrets.file_header");
-          this._yaml = yaml;
-          this._savedYaml = yaml;
-          break;
-        }
-        console.warn("Failed to load secrets.yaml; retrying:", err);
-        await sleep(RELOAD_RETRY_DELAY_MS);
-        // The page may have unmounted during the backoff.
-        if (this._unmounted) return;
-      }
+    let yaml: string;
+    try {
+      yaml = await loadWithRecovery({
+        ready: () => this._api.ready,
+        load: () => this._api.getConfig(SECRETS_FILE),
+        abandoned: () => this._unmounted,
+      });
+    } catch (err) {
+      // Abandoned means the page is gone; leave the buffers untouched.
+      if (err instanceof LoadAbandonedError) return;
+      // Only a server reply reaches here (transport faults retry), so
+      // this really is a missing file rather than an unreachable one.
+      yaml = this._localize("secrets.file_header");
     }
+    this._yaml = yaml;
+    this._savedYaml = yaml;
     this._loaded = true;
   }
 

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -14,6 +14,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 import type { ESPHomeConfirmDialog } from "../components/confirm-dialog.js";
 import type { ESPHomeUnsavedChangesDialog } from "../components/unsaved-changes-dialog.js";
 import { apiContext, localizeContext } from "../context/index.js";
+import { loadMessageStyles } from "../styles/load-message.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { withBase } from "../util/base-path.js";
 import {
@@ -22,9 +23,10 @@ import {
   type SecretsLayout,
 } from "../util/editor-layout.js";
 import { setLeaveGuard } from "../util/navigation.js";
-import { LoadAbandonedError, loadWithRecovery } from "../util/load-with-recovery.js";
+import { loadConfigWithRecovery } from "../util/load-with-recovery.js";
 import { notifyError, notifySuccess } from "../util/notify.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import { renderAsyncState } from "../util/render-async-state.js";
 import { SaveShortcutController } from "../util/save-shortcut-controller.js";
 import { parseSecretsEntries } from "../util/secrets-entries.js";
 import { UnsavedGuard } from "../util/unsaved-guard.js";
@@ -233,20 +235,18 @@ export class ESPHomePageSecrets extends LitElement {
    * Transport faults retry once the connection is ready again.
    */
   private async _loadFromServer() {
-    let yaml: string;
+    let yaml: string | null;
     try {
-      yaml = await loadWithRecovery({
-        ready: () => this._api.ready,
-        load: () => this._api.getConfig(SECRETS_FILE),
+      yaml = await loadConfigWithRecovery(this._api, SECRETS_FILE, {
         abandoned: () => this._unmounted,
       });
-    } catch (err) {
-      // Abandoned means the page is gone; leave the buffers untouched.
-      if (err instanceof LoadAbandonedError) return;
+    } catch {
       // Only a server reply reaches here (transport faults retry), so
       // this really is a missing file rather than an unreachable one.
       yaml = this._localize("secrets.file_header");
     }
+    // Null means the page is gone; leave the buffers untouched.
+    if (yaml === null) return;
     this._yaml = yaml;
     this._savedYaml = yaml;
     this._loaded = true;
@@ -265,7 +265,7 @@ export class ESPHomePageSecrets extends LitElement {
     void this._loadFromServer();
   };
 
-  static styles = [espHomeStyles, secretsStyles];
+  static styles = [espHomeStyles, loadMessageStyles, secretsStyles];
 
   protected render() {
     const revealLabel = this._localize(
@@ -316,41 +316,43 @@ export class ESPHomePageSecrets extends LitElement {
           </button>
         </div>
         <div class="editor-card">
-          ${
-            this._loaded
-              ? html`
-                  <button
-                    type="button"
-                    class="save-button"
-                    ?disabled=${this._saving || this._yaml === this._savedYaml}
-                    @click=${this._save}
-                  >
-                    <wa-icon library="mdi" name="content-save"></wa-icon>
-                    ${
-                      this._saving
-                        ? this._localize("secrets.saving")
-                        : this._localize("secrets.save")
-                    }
-                  </button>
-                  <div class="editor-pane">
-                    ${
-                      this._layout === "form"
-                        ? html`<esphome-secrets-structured-editor
-                            .value=${this._yaml}
-                            .revealSensitive=${this._revealSensitive}
-                            @yaml-change=${this._onYamlChange}
-                          ></esphome-secrets-structured-editor>`
-                        : html`<esphome-yaml-editor
-                            .value=${this._yaml}
-                            .maskAllValues=${true}
-                            .revealSensitive=${this._revealSensitive}
-                            @yaml-change=${this._onYamlChange}
-                          ></esphome-yaml-editor>`
-                    }
-                  </div>
-                `
-              : html`<div class="loading"><wa-spinner></wa-spinner></div>`
-          }
+          ${renderAsyncState({
+            loading: !this._loaded,
+            loadingMessage: this._localize("secrets.loading"),
+            loadingLead: () => html`<wa-spinner></wa-spinner>`,
+            error: null,
+            content: () => html`
+              <button
+                type="button"
+                class="save-button"
+                ?disabled=${this._saving || this._yaml === this._savedYaml}
+                @click=${this._save}
+              >
+                <wa-icon library="mdi" name="content-save"></wa-icon>
+                ${
+                  this._saving
+                    ? this._localize("secrets.saving")
+                    : this._localize("secrets.save")
+                }
+              </button>
+              <div class="editor-pane">
+                ${
+                  this._layout === "form"
+                    ? html`<esphome-secrets-structured-editor
+                        .value=${this._yaml}
+                        .revealSensitive=${this._revealSensitive}
+                        @yaml-change=${this._onYamlChange}
+                      ></esphome-secrets-structured-editor>`
+                    : html`<esphome-yaml-editor
+                        .value=${this._yaml}
+                        .maskAllValues=${true}
+                        .revealSensitive=${this._revealSensitive}
+                        @yaml-change=${this._onYamlChange}
+                      ></esphome-yaml-editor>`
+                }
+              </div>
+            `,
+          })}
         </div>
       </div>
       <esphome-unsaved-changes-dialog

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -23,7 +23,7 @@ import {
   secretsLayoutToPref,
   type SecretsLayout,
 } from "../util/editor-layout.js";
-import { setLeaveGuard } from "../util/navigation.js";
+import { consumePopGuardSuppression, setLeaveGuard } from "../util/navigation.js";
 import { loadConfigWithRecovery } from "../util/load-with-recovery.js";
 import { notifyError, notifySuccess } from "../util/notify.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -233,6 +233,9 @@ export class ESPHomePageSecrets extends LitElement {
   // bypassing ``navigate``; re-assert our URL and run the guard, then replay
   // the back once the user has decided.
   private _onPopState = (e: PopStateEvent) => {
+    // A failed route chunk rolling back its own push is a return to
+    // this page, not a leave.
+    if (consumePopGuardSuppression()) return;
     if (this._allowingLeave) {
       this._allowingLeave = false;
       return;
@@ -290,7 +293,14 @@ export class ESPHomePageSecrets extends LitElement {
         yaml = this._localize("secrets.file_header");
       } else {
         console.error("Failed to load secrets.yaml:", err);
-        this._loadState = "error";
+        // A reload over a rendered buffer keeps the content on screen
+        // and surfaces the staleness; only a load with nothing behind
+        // it gets the error panel.
+        if (this._loadState === "ready") {
+          notifyError(this._localize("secrets.reload_failed"));
+        } else {
+          this._loadState = "error";
+        }
         return;
       }
     }

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -88,6 +88,10 @@ export class ESPHomePageSecrets extends LitElement {
    *  Retry so they can't run overlapping recovery loops. */
   private _loadPromise: Promise<void> | null = null;
 
+  /** Set when a caller joins an in-flight load whose request may predate
+   *  the content it wants (external save); triggers one fresh read. */
+  private _reloadQueued = false;
+
   // Mirrors the device editor's per-field reveal toggle. Default
   // hidden so values render as bullets the moment the page paints —
   // anyone glancing at the screen sees masks, not the raw secrets.
@@ -258,8 +262,16 @@ export class ESPHomePageSecrets extends LitElement {
    * still intact on disk.
    */
   private _loadFromServer(): Promise<void> {
-    this._loadPromise ??= this._runLoad().finally(() => {
+    if (this._loadPromise) {
+      this._reloadQueued = true;
+      return this._loadPromise;
+    }
+    this._loadPromise = this._runLoad().finally(() => {
       this._loadPromise = null;
+      if (this._reloadQueued) {
+        this._reloadQueued = false;
+        void this._loadFromServer();
+      }
     });
     return this._loadPromise;
   }

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -6,7 +6,7 @@ import {
   mdiEyeOff,
   mdiFormTextbox,
 } from "@mdi/js";
-import { html, LitElement } from "lit";
+import { html, LitElement, type PropertyValues } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import { apiErrorDetails, APIError } from "../api/api-error.js";
 import type { ESPHomeAPI } from "../api/index.js";
@@ -14,7 +14,7 @@ import { ErrorCode } from "../api/types/protocol.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type { ESPHomeConfirmDialog } from "../components/confirm-dialog.js";
 import type { ESPHomeUnsavedChangesDialog } from "../components/unsaved-changes-dialog.js";
-import { apiContext, localizeContext } from "../context/index.js";
+import { apiConnectedContext, apiContext, localizeContext } from "../context/index.js";
 import { loadMessageStyles } from "../styles/load-message.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { withBase } from "../util/base-path.js";
@@ -67,6 +67,11 @@ export class ESPHomePageSecrets extends LitElement {
   @consume({ context: apiContext })
   private _api!: ESPHomeAPI;
 
+  /** WS liveness; the false→true edge re-runs a load that gave up. */
+  @consume({ context: apiConnectedContext, subscribe: true })
+  @state()
+  private _apiConnected = false;
+
   @state()
   private _yaml = "";
 
@@ -77,13 +82,11 @@ export class ESPHomePageSecrets extends LitElement {
   private _saving = false;
 
   @state()
-  private _loaded = false;
+  private _loadState: "loading" | "ready" | "error" = "loading";
 
-  @state()
-  private _loadFailed = false;
-
-  /** Stops the load retry loop once the page is gone. */
-  private _unmounted = false;
+  /** In-flight load, shared by the mount, the external-save reload, and
+   *  Retry so they can't run overlapping recovery loops. */
+  private _loadPromise: Promise<void> | null = null;
 
   // Mirrors the device editor's per-field reveal toggle. Default
   // hidden so values render as bullets the moment the page paints —
@@ -123,8 +126,6 @@ export class ESPHomePageSecrets extends LitElement {
 
   async connectedCallback() {
     super.connectedCallback();
-    // A re-attached instance must not inherit the previous teardown's latch.
-    this._unmounted = false;
     const stored = this._readStoredLayout();
     if (stored) {
       this._layout = stored;
@@ -140,6 +141,18 @@ export class ESPHomePageSecrets extends LitElement {
       this._onExternalSecretsSaved as EventListener
     );
     await this._loadFromServer();
+  }
+
+  protected updated(changed: PropertyValues) {
+    // Socket is back: a load that gave up while it was down goes again
+    // without the user hunting for the Retry button.
+    if (
+      changed.has("_apiConnected") &&
+      this._apiConnected &&
+      this._loadState === "error"
+    ) {
+      void this._loadFromServer();
+    }
   }
 
   private _readStoredLayout(): SecretsLayout | null {
@@ -170,7 +183,6 @@ export class ESPHomePageSecrets extends LitElement {
   }
 
   disconnectedCallback() {
-    this._unmounted = true;
     setLeaveGuard(null);
     window.removeEventListener("beforeunload", this._onBeforeUnload);
     window.removeEventListener("popstate", this._onPopState, { capture: true });
@@ -245,12 +257,19 @@ export class ESPHomePageSecrets extends LitElement {
    * clear-all wipe confirm and lets the next save replace a file that is
    * still intact on disk.
    */
-  private async _loadFromServer() {
-    this._loadFailed = false;
+  private _loadFromServer(): Promise<void> {
+    this._loadPromise ??= this._runLoad().finally(() => {
+      this._loadPromise = null;
+    });
+    return this._loadPromise;
+  }
+
+  private async _runLoad() {
+    if (this._loadState === "error") this._loadState = "loading";
     let yaml: string | null;
     try {
       yaml = await loadConfigWithRecovery(this._api, SECRETS_FILE, {
-        abandoned: () => this._unmounted,
+        abandoned: () => !this.isConnected,
         attempts: LOAD_ATTEMPTS,
       });
     } catch (err) {
@@ -259,7 +278,7 @@ export class ESPHomePageSecrets extends LitElement {
         yaml = this._localize("secrets.file_header");
       } else {
         console.error("Failed to load secrets.yaml:", err);
-        this._loadFailed = true;
+        this._loadState = "error";
         return;
       }
     }
@@ -267,7 +286,7 @@ export class ESPHomePageSecrets extends LitElement {
     if (yaml === null) return;
     this._yaml = yaml;
     this._savedYaml = yaml;
-    this._loaded = true;
+    this._loadState = "ready";
   }
 
   private _retryLoad = () => void this._loadFromServer();
@@ -337,10 +356,11 @@ export class ESPHomePageSecrets extends LitElement {
         </div>
         <div class="editor-card">
           ${renderAsyncState({
-            loading: !this._loaded && !this._loadFailed,
+            loading: this._loadState === "loading",
             loadingMessage: this._localize("secrets.loading"),
             loadingLead: () => html`<wa-spinner></wa-spinner>`,
-            error: this._loadFailed ? this._localize("secrets.load_failed") : null,
+            error:
+              this._loadState === "error" ? this._localize("secrets.load_failed") : null,
             errorActions: () =>
               html`<wa-button size="small" @click=${this._retryLoad}>
                 ${this._localize("command.retry")}

--- a/src/styles/load-message.ts
+++ b/src/styles/load-message.ts
@@ -20,4 +20,8 @@ export const loadMessageStyles = css`
   .message wa-spinner {
     font-size: 32px;
   }
+
+  .message.error {
+    color: var(--wa-color-danger-text-normal);
+  }
 `;

--- a/src/styles/load-message.ts
+++ b/src/styles/load-message.ts
@@ -1,0 +1,23 @@
+import { css } from "lit";
+
+/**
+ * ``renderAsyncState``'s message block as a full-page load state: a
+ * centered spinner-over-text column. Consumers add the placement rule
+ * (grid area, flex child) for their own layout.
+ */
+export const loadMessageStyles = css`
+  .message {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--wa-space-m);
+    color: var(--wa-color-text-quiet);
+    font-size: var(--wa-font-size-s);
+    text-align: center;
+  }
+
+  .message wa-spinner {
+    font-size: 32px;
+  }
+`;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1674,7 +1674,8 @@
     "duplicate_key": "A secret with this name already exists.",
     "file_header": "# Secrets — store sensitive values here and reference them\n# in your device configurations using !secret <key>\n#\n# Example:\n#   wifi_ssid: \"your-network-name\"\n#   wifi_password: \"your-password\"\n",
     "loading": "Loading secrets…",
-    "load_failed": "Secrets could not be loaded. Check your connection and retry."
+    "load_failed": "Secrets could not be loaded. Check your connection and retry.",
+    "reload_failed": "Couldn't refresh secrets after an external change; the editor may be out of date."
   },
   "auth": {
     "connecting": "Connecting…",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1671,7 +1671,8 @@
     "empty": "No secrets yet. Add one below or switch to YAML.",
     "invalid_key": "Names may use letters, numbers, dots, dashes and underscores, and can't start with a number.",
     "duplicate_key": "A secret with this name already exists.",
-    "file_header": "# Secrets — store sensitive values here and reference them\n# in your device configurations using !secret <key>\n#\n# Example:\n#   wifi_ssid: \"your-network-name\"\n#   wifi_password: \"your-password\"\n"
+    "file_header": "# Secrets — store sensitive values here and reference them\n# in your device configurations using !secret <key>\n#\n# Example:\n#   wifi_ssid: \"your-network-name\"\n#   wifi_password: \"your-password\"\n",
+    "loading": "Loading secrets…"
   },
   "auth": {
     "connecting": "Connecting…",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1051,7 +1051,9 @@
     "unsaved_message": "You have unsaved changes in this device. If you leave without saving, they will be lost.",
     "leave_anyway": "Leave anyway",
     "discard_changes": "Discard",
-    "save_and_leave": "Save"
+    "save_and_leave": "Save",
+    "loading_config": "Loading configuration…",
+    "load_failed": "The configuration could not be loaded. Check your connection and retry."
   },
   "naming": {
     "hostname_disclosure": "Hostname: {hostname}",
@@ -1246,7 +1248,9 @@
     "close": "Close",
     "more_options_with_count": "More options ({count, plural, one {# firmware task active} other {# firmware tasks active}})",
     "editor": "Editor",
-    "preview_badge": "Beta"
+    "preview_badge": "Beta",
+    "page_load_failed": "The page failed to load. Check your connection and try again.",
+    "reconnecting": "Connection lost. Reconnecting…"
   },
   "feedback": {
     "title": "Found a bug? Have an idea?",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1053,7 +1053,9 @@
     "discard_changes": "Discard",
     "save_and_leave": "Save",
     "loading_config": "Loading configuration…",
-    "load_failed": "The configuration could not be loaded. Check your connection and retry."
+    "load_failed": "The configuration could not be loaded. Check your connection and retry.",
+    "load_not_found": "This configuration no longer exists. It may have been deleted or renamed.",
+    "back_to_dashboard": "Back to devices"
   },
   "naming": {
     "hostname_disclosure": "Hostname: {hostname}",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -391,7 +391,7 @@
     "compile_selected_aria": "Compile {count} selected without installing",
     "builder_stack_heading": "Device builder",
     "builder_stack_tagline": "create and manage your devices",
-    "logs_serial_probe_timeout": "Could not check for serial ports in time; showing wireless logs."
+    "logs_serial_probe_failed": "Could not check for serial ports; showing wireless logs."
   },
   "command": {
     "install_title": "Install — {name}",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -390,7 +390,8 @@
     "update_selected_aria": "Update {count} selected",
     "compile_selected_aria": "Compile {count} selected without installing",
     "builder_stack_heading": "Device builder",
-    "builder_stack_tagline": "create and manage your devices"
+    "builder_stack_tagline": "create and manage your devices",
+    "logs_serial_probe_timeout": "Could not check for serial ports in time; showing wireless logs."
   },
   "command": {
     "install_title": "Install — {name}",
@@ -1672,7 +1673,8 @@
     "invalid_key": "Names may use letters, numbers, dots, dashes and underscores, and can't start with a number.",
     "duplicate_key": "A secret with this name already exists.",
     "file_header": "# Secrets — store sensitive values here and reference them\n# in your device configurations using !secret <key>\n#\n# Example:\n#   wifi_ssid: \"your-network-name\"\n#   wifi_password: \"your-password\"\n",
-    "loading": "Loading secrets…"
+    "loading": "Loading secrets…",
+    "load_failed": "Secrets could not be loaded. Check your connection and retry."
   },
   "auth": {
     "connecting": "Connecting…",

--- a/src/util/load-with-recovery.ts
+++ b/src/util/load-with-recovery.ts
@@ -23,7 +23,7 @@ export interface LoadConfigOptions {
  * server answered, so it is final and rethrown. Waiting on ``api.ready``
  * parks for the whole outage, so attempts are only spent while the socket
  * is up. Returns ``null`` once ``abandoned()`` goes true, including for a
- * reply that lands after the caller moved on.
+ * reply or failure that lands after the caller moved on.
  */
 export async function loadConfigWithRecovery(
   api: ESPHomeAPI,
@@ -38,8 +38,8 @@ export async function loadConfigWithRecovery(
       const yaml = await api.getConfig(configuration, opts.timeoutMs);
       return opts.abandoned?.() ? null : yaml;
     } catch (err) {
-      if (err instanceof APIError || attempt >= opts.attempts) throw err;
       if (opts.abandoned?.()) return null;
+      if (err instanceof APIError || attempt >= opts.attempts) throw err;
       console.warn(`Load failed (attempt ${attempt}); retrying:`, err);
       await sleep(RETRY_DELAY_MS);
     }

--- a/src/util/load-with-recovery.ts
+++ b/src/util/load-with-recovery.ts
@@ -2,81 +2,46 @@ import { APIError } from "../api/api-error.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import { sleep } from "./sleep.js";
 
-export interface LoadWithRecoveryOptions<T> {
-  /** Parks while the socket is down, so an outage costs no attempts. */
-  ready: () => Promise<void>;
-  load: () => Promise<T>;
+const RETRY_DELAY_MS = 1500;
+
+export interface LoadConfigOptions {
   /** True once the result is no longer wanted (unmounted, id moved on). */
   abandoned?: () => boolean;
-  /** Transport attempts before the failure is surfaced; default unlimited. */
-  attempts?: number;
-  retryDelayMs?: number;
-}
-
-/** Thrown when ``abandoned()`` goes true; callers drop it silently. */
-export class LoadAbandonedError extends Error {
-  constructor() {
-    super("Load abandoned");
-    this.name = "LoadAbandonedError";
-  }
-}
-
-const DEFAULT_RETRY_DELAY_MS = 1500;
-
-/**
- * Run a fetch that survives a flaky link.
- *
- * A transport fault (socket closed mid-request, command timeout) retries
- * after a backoff rather than surfacing: the request is one the user is
- * waiting on, and the socket auto-reconnects. An ``APIError`` means the
- * server answered, so it is final and rethrown immediately.
- */
-export async function loadWithRecovery<T>(opts: LoadWithRecoveryOptions<T>): Promise<T> {
-  const limit = opts.attempts ?? Infinity;
-  for (let attempt = 1; ; attempt++) {
-    await opts.ready();
-    if (opts.abandoned?.()) throw new LoadAbandonedError();
-    try {
-      const value = await opts.load();
-      // The caller may have moved on while this was in flight; a late
-      // result committed then would render another id's config.
-      if (opts.abandoned?.()) throw new LoadAbandonedError();
-      return value;
-    } catch (err) {
-      if (err instanceof LoadAbandonedError) throw err;
-      if (err instanceof APIError || attempt >= limit) throw err;
-      console.warn(`Load failed (attempt ${attempt}); retrying:`, err);
-      await sleep(opts.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS);
-      if (opts.abandoned?.()) throw new LoadAbandonedError();
-    }
-  }
+  /** Transport attempts before the failure surfaces. */
+  attempts: number;
+  /** Overrides the command default, which is short for a large config. */
+  timeoutMs?: number;
 }
 
 /**
  * Read a YAML config for a page the user is waiting on, surviving a flaky
- * link. Returns ``null`` when the caller abandoned the load (page gone, id
- * moved on); an ``APIError`` still throws so callers can tell a missing
- * config from an unreachable one.
+ * link.
+ *
+ * A transport fault (socket closed mid-request, command timeout) retries
+ * after a backoff rather than surfacing: the request is one the user is
+ * waiting on, and the socket auto-reconnects. An ``APIError`` means the
+ * server answered, so it is final and rethrown. Waiting on ``api.ready``
+ * parks for the whole outage, so attempts are only spent while the socket
+ * is up. Returns ``null`` once ``abandoned()`` goes true, including for a
+ * reply that lands after the caller moved on.
  */
 export async function loadConfigWithRecovery(
   api: ESPHomeAPI,
   configuration: string,
-  opts: {
-    abandoned?: () => boolean;
-    attempts?: number;
-    /** Overrides the command default, which is short for a large config. */
-    timeoutMs?: number;
-  } = {}
+  opts: LoadConfigOptions
 ): Promise<string | null> {
-  try {
-    return await loadWithRecovery({
-      ready: () => api.ready,
-      load: () => api.getConfig(configuration, opts.timeoutMs),
-      abandoned: opts.abandoned,
-      attempts: opts.attempts,
-    });
-  } catch (err) {
-    if (err instanceof LoadAbandonedError) return null;
-    throw err;
+  for (let attempt = 1; ; attempt++) {
+    if (opts.abandoned?.()) return null;
+    await api.ready;
+    if (opts.abandoned?.()) return null;
+    try {
+      const yaml = await api.getConfig(configuration, opts.timeoutMs);
+      return opts.abandoned?.() ? null : yaml;
+    } catch (err) {
+      if (err instanceof APIError || attempt >= opts.attempts) throw err;
+      if (opts.abandoned?.()) return null;
+      console.warn(`Load failed (attempt ${attempt}); retrying:`, err);
+      await sleep(RETRY_DELAY_MS);
+    }
   }
 }

--- a/src/util/load-with-recovery.ts
+++ b/src/util/load-with-recovery.ts
@@ -1,4 +1,5 @@
 import { APIError } from "../api/api-error.js";
+import type { ESPHomeAPI } from "../api/index.js";
 import { sleep } from "./sleep.js";
 
 export interface LoadWithRecoveryOptions<T> {
@@ -36,12 +37,46 @@ export async function loadWithRecovery<T>(opts: LoadWithRecoveryOptions<T>): Pro
     await opts.ready();
     if (opts.abandoned?.()) throw new LoadAbandonedError();
     try {
-      return await opts.load();
+      const value = await opts.load();
+      // The caller may have moved on while this was in flight; a late
+      // result committed then would render another id's config.
+      if (opts.abandoned?.()) throw new LoadAbandonedError();
+      return value;
     } catch (err) {
+      if (err instanceof LoadAbandonedError) throw err;
       if (err instanceof APIError || attempt >= limit) throw err;
       console.warn(`Load failed (attempt ${attempt}); retrying:`, err);
       await sleep(opts.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS);
       if (opts.abandoned?.()) throw new LoadAbandonedError();
     }
+  }
+}
+
+/**
+ * Read a YAML config for a page the user is waiting on, surviving a flaky
+ * link. Returns ``null`` when the caller abandoned the load (page gone, id
+ * moved on); an ``APIError`` still throws so callers can tell a missing
+ * config from an unreachable one.
+ */
+export async function loadConfigWithRecovery(
+  api: ESPHomeAPI,
+  configuration: string,
+  opts: {
+    abandoned?: () => boolean;
+    attempts?: number;
+    /** Overrides the command default, which is short for a large config. */
+    timeoutMs?: number;
+  } = {}
+): Promise<string | null> {
+  try {
+    return await loadWithRecovery({
+      ready: () => api.ready,
+      load: () => api.getConfig(configuration, opts.timeoutMs),
+      abandoned: opts.abandoned,
+      attempts: opts.attempts,
+    });
+  } catch (err) {
+    if (err instanceof LoadAbandonedError) return null;
+    throw err;
   }
 }

--- a/src/util/load-with-recovery.ts
+++ b/src/util/load-with-recovery.ts
@@ -1,0 +1,47 @@
+import { APIError } from "../api/api-error.js";
+import { sleep } from "./sleep.js";
+
+export interface LoadWithRecoveryOptions<T> {
+  /** Parks while the socket is down, so an outage costs no attempts. */
+  ready: () => Promise<void>;
+  load: () => Promise<T>;
+  /** True once the result is no longer wanted (unmounted, id moved on). */
+  abandoned?: () => boolean;
+  /** Transport attempts before the failure is surfaced; default unlimited. */
+  attempts?: number;
+  retryDelayMs?: number;
+}
+
+/** Thrown when ``abandoned()`` goes true; callers drop it silently. */
+export class LoadAbandonedError extends Error {
+  constructor() {
+    super("Load abandoned");
+    this.name = "LoadAbandonedError";
+  }
+}
+
+const DEFAULT_RETRY_DELAY_MS = 1500;
+
+/**
+ * Run a fetch that survives a flaky link.
+ *
+ * A transport fault (socket closed mid-request, command timeout) retries
+ * after a backoff rather than surfacing: the request is one the user is
+ * waiting on, and the socket auto-reconnects. An ``APIError`` means the
+ * server answered, so it is final and rethrown immediately.
+ */
+export async function loadWithRecovery<T>(opts: LoadWithRecoveryOptions<T>): Promise<T> {
+  const limit = opts.attempts ?? Infinity;
+  for (let attempt = 1; ; attempt++) {
+    await opts.ready();
+    if (opts.abandoned?.()) throw new LoadAbandonedError();
+    try {
+      return await opts.load();
+    } catch (err) {
+      if (err instanceof APIError || attempt >= limit) throw err;
+      console.warn(`Load failed (attempt ${attempt}); retrying:`, err);
+      await sleep(opts.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS);
+      if (opts.abandoned?.()) throw new LoadAbandonedError();
+    }
+  }
+}

--- a/src/util/logs-launch.ts
+++ b/src/util/logs-launch.ts
@@ -1,9 +1,9 @@
-import type { ESPHomeAPI } from "../api/index.js";
+import { CommandTimeoutError, type ESPHomeAPI } from "../api/index.js";
 import type { ConfiguredDevice } from "../api/types/devices.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";
 import { resolveLogBaudRate } from "./log-baud-rate.js";
-import { notifyError } from "./notify.js";
+import { notifyError, notifyInfo } from "./notify.js";
 import {
   attachSerialLogStream,
   openNetworkLogsFallback,
@@ -46,9 +46,13 @@ export async function launchLogs(
     } catch (err) {
       // Lockstep deployment means this command exists, so a rejection is a real
       // WS/backend fault or the bounded probe timing out on a degraded link;
-      // log it but still fall through to OTA logs so the user isn't left
-      // without any path.
+      // either way fall through to OTA logs so the user isn't left without any
+      // path. A timeout is not an answer, though: say so rather than let the
+      // serial option silently disappear for someone who has a serial device.
       console.warn("getSerialPorts failed; falling back to OTA logs", err);
+      if (err instanceof CommandTimeoutError) {
+        notifyInfo(host.localize("dashboard.logs_serial_probe_timeout"));
+      }
       hasServerPorts = false;
     }
   }

--- a/src/util/logs-launch.ts
+++ b/src/util/logs-launch.ts
@@ -1,4 +1,4 @@
-import { CommandTimeoutError, type ESPHomeAPI } from "../api/index.js";
+import type { ESPHomeAPI } from "../api/index.js";
 import type { ConfiguredDevice } from "../api/types/devices.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";
@@ -47,12 +47,11 @@ export async function launchLogs(
       // Lockstep deployment means this command exists, so a rejection is a real
       // WS/backend fault or the bounded probe timing out on a degraded link;
       // either way fall through to OTA logs so the user isn't left without any
-      // path. A timeout is not an answer, though: say so rather than let the
-      // serial option silently disappear for someone who has a serial device.
+      // path. Neither failure is an answer, though: say the probe was skipped
+      // rather than let the serial option silently disappear for someone who
+      // has a serial device.
       console.warn("getSerialPorts failed; falling back to OTA logs", err);
-      if (err instanceof CommandTimeoutError) {
-        notifyInfo(host.localize("dashboard.logs_serial_probe_timeout"));
-      }
+      notifyInfo(host.localize("dashboard.logs_serial_probe_failed"));
       hasServerPorts = false;
     }
   }

--- a/src/util/logs-launch.ts
+++ b/src/util/logs-launch.ts
@@ -19,6 +19,10 @@ export interface LogsLaunchHost {
   readonly localize: LocalizeFunc;
 }
 
+// Upper bound on the serial-port probe so a degraded link opens OTA logs
+// after a short beat instead of blocking silently on the 10s command timeout.
+const SERIAL_PORT_PROBE_TIMEOUT_MS = 2500;
+
 /**
  * Open live logs, offering the OTA-vs-serial picker when a serial path exists.
 
@@ -37,7 +41,13 @@ export async function launchLogs(
     // Only pay the backend round-trip when WebSerial can't already provide a
     // serial path.
     try {
-      hasServerPorts = (await host.api.getSerialPorts()).length > 0;
+      const ports = await Promise.race([
+        host.api.getSerialPorts(),
+        new Promise<null>((resolve) =>
+          setTimeout(() => resolve(null), SERIAL_PORT_PROBE_TIMEOUT_MS)
+        ),
+      ]);
+      hasServerPorts = (ports?.length ?? 0) > 0;
     } catch (err) {
       // Lockstep deployment means this command exists, so a rejection is a real
       // WS/backend fault, not version drift; log it but still fall through to

--- a/src/util/logs-launch.ts
+++ b/src/util/logs-launch.ts
@@ -41,17 +41,13 @@ export async function launchLogs(
     // Only pay the backend round-trip when WebSerial can't already provide a
     // serial path.
     try {
-      const ports = await Promise.race([
-        host.api.getSerialPorts(),
-        new Promise<null>((resolve) =>
-          setTimeout(() => resolve(null), SERIAL_PORT_PROBE_TIMEOUT_MS)
-        ),
-      ]);
-      hasServerPorts = (ports?.length ?? 0) > 0;
+      hasServerPorts =
+        (await host.api.getSerialPorts(SERIAL_PORT_PROBE_TIMEOUT_MS)).length > 0;
     } catch (err) {
       // Lockstep deployment means this command exists, so a rejection is a real
-      // WS/backend fault, not version drift; log it but still fall through to
-      // OTA logs so the user isn't left without any path.
+      // WS/backend fault or the bounded probe timing out on a degraded link;
+      // log it but still fall through to OTA logs so the user isn't left
+      // without any path.
       console.warn("getSerialPorts failed; falling back to OTA logs", err);
       hasServerPorts = false;
     }

--- a/src/util/navigation.ts
+++ b/src/util/navigation.ts
@@ -8,11 +8,15 @@ export function setLeaveGuard(guard: LeaveGuard | null): void {
   activeGuard = guard;
 }
 
+// history.state survives a reload while module state doesn't, so the
+// counter alone can't tell a fresh push from a pre-reload entry whose
+// number happens to collide; the token scopes the stamp to this document.
+const DOC_TOKEN = Math.random().toString(36).slice(2);
 let pushCounter = 0;
 
 export async function navigate(url: string): Promise<void> {
   if (!(await runLeaveGuard())) return;
-  window.history.pushState({ n: ++pushCounter }, "", withBase(url));
+  window.history.pushState({ d: DOC_TOKEN, n: ++pushCounter }, "", withBase(url));
   window.dispatchEvent(new PopStateEvent("popstate"));
 }
 
@@ -35,19 +39,28 @@ export async function runLeaveGuard(): Promise<boolean> {
   }
 }
 
-/** True when the current entry came from ``navigate()`` (which stamps a
- *  state object) rather than a fresh page load, so there is something to
- *  pop. */
+/** True when the current entry carries a non-null object state (a
+ *  ``navigate()`` stamp or a guard's re-push) rather than a fresh page
+ *  load, so there is a same-session entry to pop back to. */
 export function hasPushedHistoryEntry(): boolean {
   return window.history.state !== null && typeof window.history.state === "object";
 }
 
-/** True when the current entry is the latest ``navigate()`` push — just
- *  pushed by the click being handled, so undoing it is safe. False for
- *  an entry reached via Back/Forward or a fresh page load. */
+/** True when the current entry was pushed by this document's
+ *  ``navigate()`` — false after a reload, whose entry keeps the stamp of
+ *  the document that made it. */
+export function isSameDocumentPush(): boolean {
+  const state = window.history.state as { d?: string } | null;
+  return state?.d === DOC_TOKEN;
+}
+
+/** True when the current entry is this document's latest ``navigate()``
+ *  push — just pushed by the click being handled, so undoing it is safe.
+ *  False for an entry reached via Back/Forward, a reload, or a fresh
+ *  page load. */
 export function isFreshNavigatePush(): boolean {
-  const state = window.history.state as { n?: number } | null;
-  return typeof state?.n === "number" && state.n === pushCounter;
+  const state = window.history.state as { d?: string; n?: number } | null;
+  return state?.d === DOC_TOKEN && state.n === pushCounter;
 }
 
 let popGuardSuppressed = false;

--- a/src/util/navigation.ts
+++ b/src/util/navigation.ts
@@ -8,9 +8,11 @@ export function setLeaveGuard(guard: LeaveGuard | null): void {
   activeGuard = guard;
 }
 
+let pushCounter = 0;
+
 export async function navigate(url: string): Promise<void> {
   if (!(await runLeaveGuard())) return;
-  window.history.pushState({}, "", withBase(url));
+  window.history.pushState({ n: ++pushCounter }, "", withBase(url));
   window.dispatchEvent(new PopStateEvent("popstate"));
 }
 
@@ -33,10 +35,19 @@ export async function runLeaveGuard(): Promise<boolean> {
   }
 }
 
-/** True when the current entry came from ``navigate()`` (which stamps
- *  ``{}``) rather than a fresh page load, so there is something to pop. */
+/** True when the current entry came from ``navigate()`` (which stamps a
+ *  state object) rather than a fresh page load, so there is something to
+ *  pop. */
 export function hasPushedHistoryEntry(): boolean {
   return window.history.state !== null && typeof window.history.state === "object";
+}
+
+/** True when the current entry is the latest ``navigate()`` push — just
+ *  pushed by the click being handled, so undoing it is safe. False for
+ *  an entry reached via Back/Forward or a fresh page load. */
+export function isFreshNavigatePush(): boolean {
+  const state = window.history.state as { n?: number } | null;
+  return typeof state?.n === "number" && state.n === pushCounter;
 }
 
 let popGuardSuppressed = false;
@@ -67,7 +78,7 @@ export function consumePopGuardSuppression(): boolean {
  * Leave the current page the way the header back arrow does. Prefer popping
  * the history stack so the previous URL — and therefore the dashboard's
  * filter / search state encoded in its query string — is restored verbatim.
- * ``history.state`` is set to ``{}`` by ``navigate()`` on every pushState;
+ * ``history.state`` is stamped by ``navigate()`` on every pushState;
  * ``null`` means a fresh page load (deep link / refresh) so there's nothing
  * useful to pop and we fall back to ``navigate("/")`` to stay inside the SPA.
  */

--- a/src/util/navigation.ts
+++ b/src/util/navigation.ts
@@ -41,8 +41,14 @@ export async function runLeaveGuard(): Promise<boolean> {
  * ``null`` means a fresh page load (deep link / refresh) so there's nothing
  * useful to pop and we fall back to ``navigate("/")`` to stay inside the SPA.
  */
+/** True when the current entry came from ``navigate()`` (which stamps
+ *  ``{}``) rather than a fresh page load, so there is something to pop. */
+export function hasPushedHistoryEntry(): boolean {
+  return window.history.state !== null && typeof window.history.state === "object";
+}
+
 export async function goBackOrHome(): Promise<void> {
-  if (window.history.state !== null && typeof window.history.state === "object") {
+  if (hasPushedHistoryEntry()) {
     // history.back() fires a raw popstate the router commits (unmounting the
     // page) before the device editor's popstate guard can veto it, so honour
     // the leave guard here — same gate navigate() applies. navigate("/") runs

--- a/src/util/navigation.ts
+++ b/src/util/navigation.ts
@@ -47,6 +47,22 @@ export function hasPushedHistoryEntry(): boolean {
   return window.history.state !== null && typeof window.history.state === "object";
 }
 
+let popGuardSuppressed = false;
+
+/** Pop a ``navigate()``-pushed entry without re-running page popstate
+ *  guards — the user already answered them for the failed navigation. */
+export function popPushedEntrySilently(): void {
+  popGuardSuppressed = true;
+  window.history.back();
+}
+
+/** One-shot check page popstate guards consume before intercepting. */
+export function consumePopGuardSuppression(): boolean {
+  const suppressed = popGuardSuppressed;
+  popGuardSuppressed = false;
+  return suppressed;
+}
+
 export async function goBackOrHome(): Promise<void> {
   if (hasPushedHistoryEntry()) {
     // history.back() fires a raw popstate the router commits (unmounting the

--- a/src/util/navigation.ts
+++ b/src/util/navigation.ts
@@ -33,14 +33,6 @@ export async function runLeaveGuard(): Promise<boolean> {
   }
 }
 
-/**
- * Leave the current page the way the header back arrow does. Prefer popping
- * the history stack so the previous URL — and therefore the dashboard's
- * filter / search state encoded in its query string — is restored verbatim.
- * ``history.state`` is set to ``{}`` by ``navigate()`` on every pushState;
- * ``null`` means a fresh page load (deep link / refresh) so there's nothing
- * useful to pop and we fall back to ``navigate("/")`` to stay inside the SPA.
- */
 /** True when the current entry came from ``navigate()`` (which stamps
  *  ``{}``) rather than a fresh page load, so there is something to pop. */
 export function hasPushedHistoryEntry(): boolean {
@@ -53,6 +45,14 @@ let popGuardSuppressed = false;
  *  guards — the user already answered them for the failed navigation. */
 export function popPushedEntrySilently(): void {
   popGuardSuppressed = true;
+  // The rollback's own popstate clears the arming even when no guarded
+  // page is mounted to consume it (dashboard), so it can't strand and
+  // skip a later real leave prompt. Page guards register on connect, so
+  // they run first and still consume it in time.
+  window.addEventListener("popstate", () => void consumePopGuardSuppression(), {
+    capture: true,
+    once: true,
+  });
   window.history.back();
 }
 
@@ -63,6 +63,14 @@ export function consumePopGuardSuppression(): boolean {
   return suppressed;
 }
 
+/**
+ * Leave the current page the way the header back arrow does. Prefer popping
+ * the history stack so the previous URL — and therefore the dashboard's
+ * filter / search state encoded in its query string — is restored verbatim.
+ * ``history.state`` is set to ``{}`` by ``navigate()`` on every pushState;
+ * ``null`` means a fresh page load (deep link / refresh) so there's nothing
+ * useful to pop and we fall back to ``navigate("/")`` to stay inside the SPA.
+ */
 export async function goBackOrHome(): Promise<void> {
   if (hasPushedHistoryEntry()) {
     // history.back() fires a raw popstate the router commits (unmounting the

--- a/src/util/render-async-state.ts
+++ b/src/util/render-async-state.ts
@@ -16,7 +16,7 @@ export interface RenderAsyncStateOptions {
   loadingMessage: string;
   /** Visual shown above the loading message, e.g. a spinner. Supplied by the
    *  consumer so this module needn't pull in a component dependency. */
-  loadingLead?: () => TemplateResult;
+  loadingLead?: TemplateResult;
   // Any falsy value (``""`` / ``null`` / ``undefined``) means "no error", so a
   // ``string | null`` field can be passed straight through without coercion.
   error: string | null | undefined;
@@ -28,7 +28,7 @@ export function renderAsyncState(
   opts: RenderAsyncStateOptions
 ): TemplateResult | typeof nothing {
   if (opts.loading) {
-    const lead = opts.loadingLead?.() ?? nothing;
+    const lead = opts.loadingLead ?? nothing;
     return html`<div class="message" role="status">${lead}${opts.loadingMessage}</div>`;
   }
   if (opts.error) {

--- a/src/util/render-async-state.ts
+++ b/src/util/render-async-state.ts
@@ -14,6 +14,9 @@ import { html, nothing, type TemplateResult } from "lit";
 export interface RenderAsyncStateOptions {
   loading: boolean;
   loadingMessage: string;
+  /** Visual shown above the loading message, e.g. a spinner. Supplied by the
+   *  consumer so this module needn't pull in a component dependency. */
+  loadingLead?: () => TemplateResult;
   // Any falsy value (``""`` / ``null`` / ``undefined``) means "no error", so a
   // ``string | null`` field can be passed straight through without coercion.
   error: string | null | undefined;
@@ -25,7 +28,8 @@ export function renderAsyncState(
   opts: RenderAsyncStateOptions
 ): TemplateResult | typeof nothing {
   if (opts.loading) {
-    return html`<div class="message" role="status">${opts.loadingMessage}</div>`;
+    const lead = opts.loadingLead?.() ?? nothing;
+    return html`<div class="message" role="status">${lead}${opts.loadingMessage}</div>`;
   }
   if (opts.error) {
     return html`<div class="message error" role="alert">${opts.error}</div>

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { APIError } from "../../src/api/api-error.js";
+import { APIError, CommandTimeoutError } from "../../src/api/api-error.js";
 import { ESPHomeAPI } from "../../src/api/esphome-api.js";
 import {
   MockWebSocket,
@@ -180,7 +180,12 @@ describe("ESPHomeAPI — sendCommand", () => {
 
     const cmd = api.sendCommand("slow", undefined, 500);
     vi.advanceTimersByTime(500);
-    await expect(cmd).rejects.toThrow(/timed out after 500ms/);
+    // The instance is what retry/probe callers branch on; the substring
+    // is what the lenient-save paths string-match.
+    await expect(cmd).rejects.toSatisfy(
+      (err) =>
+        err instanceof CommandTimeoutError && /timed out after 500ms/.test(err.message)
+    );
   });
 
   it("throws when the socket is not open", async () => {

--- a/test/components/app-shell/connection-overlays.test.ts
+++ b/test/components/app-shell/connection-overlays.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  ReconnectPillGate,
   renderReconnectPill,
   renderRouteLoadingBar,
 } from "../../../src/components/app-shell/connection-overlays.js";
@@ -8,8 +9,8 @@ import { identityLocalize, renderInto } from "../../_dom.js";
 import type { LocalizeFunc } from "../../../src/common/localize.js";
 
 /**
- * Pins the overlays' assistive-tech contract: the bar is decorative,
- * the pill announces.
+ * Pins the overlays' assistive-tech contract (the bar is decorative,
+ * the pill announces) and the pill's timer gate.
  */
 
 describe("connection overlays", () => {
@@ -28,5 +29,54 @@ describe("connection overlays", () => {
     expect(pill).not.toBeNull();
     expect(pill!.getAttribute("role")).toBe("status");
     expect(pill!.textContent).toContain("layout.reconnecting");
+  });
+});
+
+describe("ReconnectPillGate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const makeGate = () => {
+    const changes: boolean[] = [];
+    return { changes, gate: new ReconnectPillGate(800, (v) => changes.push(v)) };
+  };
+
+  it("stays silent for a blip shorter than the delay", () => {
+    const { changes, gate } = makeGate();
+    gate.disconnected();
+    vi.advanceTimersByTime(799);
+    gate.connected();
+    vi.advanceTimersByTime(2000);
+
+    // Never true — a sub-delay blip must not flash the pill nor fire
+    // its role="status" announcement.
+    expect(changes).toEqual([false]);
+  });
+
+  it("shows once the outage crosses the delay", () => {
+    const { changes, gate } = makeGate();
+    gate.disconnected();
+    vi.advanceTimersByTime(800);
+    expect(changes).toEqual([true]);
+
+    gate.connected();
+    expect(changes).toEqual([true, false]);
+  });
+
+  it("keeps the first outage's clock across repeat disconnects", () => {
+    const { changes, gate } = makeGate();
+    gate.disconnected();
+    vi.advanceTimersByTime(500);
+    // A reconnect attempt failing re-fires onDisconnected; the pill is
+    // still due 800ms after the outage began, not 800ms after the retry.
+    gate.disconnected();
+    vi.advanceTimersByTime(300);
+
+    expect(changes).toEqual([true]);
   });
 });

--- a/test/components/app-shell/connection-overlays.test.ts
+++ b/test/components/app-shell/connection-overlays.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import {
+  renderReconnectPill,
+  renderRouteLoadingBar,
+} from "../../../src/components/app-shell/connection-overlays.js";
+import { identityLocalize, renderInto } from "../../_dom.js";
+import type { LocalizeFunc } from "../../../src/common/localize.js";
+
+/**
+ * Pins the overlays' assistive-tech contract: the bar is decorative,
+ * the pill announces.
+ */
+
+describe("connection overlays", () => {
+  it("hides the route loading bar from assistive tech", () => {
+    const bar = renderInto(renderRouteLoadingBar()).querySelector(".route-loading-bar");
+    expect(bar).not.toBeNull();
+    // Purely visual feedback; the failure toast is the announced channel.
+    expect(bar!.getAttribute("aria-hidden")).toBe("true");
+    expect(bar!.hasAttribute("role")).toBe(false);
+  });
+
+  it("announces the reconnect pill as a status", () => {
+    const pill = renderInto(
+      renderReconnectPill(identityLocalize as LocalizeFunc)
+    ).querySelector(".reconnect-pill");
+    expect(pill).not.toBeNull();
+    expect(pill!.getAttribute("role")).toBe("status");
+    expect(pill!.textContent).toContain("layout.reconnecting");
+  });
+});

--- a/test/components/app-shell/router-lazy-enter.test.ts
+++ b/test/components/app-shell/router-lazy-enter.test.ts
@@ -18,13 +18,14 @@ import { identityLocalize } from "../../_dom.js";
  * no runtime surface to test.)
  */
 
-function makeHooks(): { pendingCalls: boolean[]; hooks: RouterHooks } {
+function makeHooks(authed = true): { pendingCalls: boolean[]; hooks: RouterHooks } {
   const pendingCalls: boolean[] = [];
   return {
     pendingCalls,
     hooks: {
       onPending: (pending: boolean) => pendingCalls.push(pending),
       localize: () => identityLocalize as LocalizeFunc,
+      isAuthed: () => authed,
     },
   };
 }
@@ -208,6 +209,25 @@ describe("lazyEnter", () => {
     // The still-mounted page's guard consumes this and lets the rollback
     // popstate through instead of re-prompting a leave already answered.
     expect(consumePopGuardSuppression()).toBe(true);
+  });
+
+  it("keeps a pre-auth failure silent and leaves the deep link intact", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const back = vi.spyOn(window.history, "back").mockImplementation(() => {});
+    const { hooks } = makeHooks(false);
+    // A cold deep link failing behind the login screen: the shell
+    // re-resolves the URL after sign-in, so nothing may be rewritten.
+    window.history.pushState(null, "", "/device/kitchen.yaml");
+    const result = lazyEnter(
+      vi.fn().mockRejectedValue(new Error("chunk load failed")),
+      hooks
+    );
+
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(result).resolves.toBe(false);
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(back).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe("/device/kitchen.yaml");
   });
 
   it("leaves a same-document Back/Forward entry alone when its chunk fails", async () => {

--- a/test/components/app-shell/router-lazy-enter.test.ts
+++ b/test/components/app-shell/router-lazy-enter.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+import toast from "sonner-js";
+import type { LocalizeFunc } from "../../../src/common/localize.js";
+import {
+  lazyEnter,
+  prefetchLazyRoutes,
+  type RouterHooks,
+} from "../../../src/components/app-shell/router.js";
+
+/**
+ * Pins the lazy-route chunk loader: pending feedback only after the
+ * delay, retries on a failed import, cancelled navigation + toast on
+ * exhaustion, and idle-scheduled prefetch that never double-schedules.
+ */
+
+function makeHooks(): { pendingCalls: boolean[]; hooks: RouterHooks } {
+  const pendingCalls: boolean[] = [];
+  return {
+    pendingCalls,
+    hooks: {
+      onPending: (pending: boolean) => pendingCalls.push(pending),
+      localize: () => ((key: string) => key) as LocalizeFunc,
+    },
+  };
+}
+
+describe("lazyEnter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("resolves without pending feedback when the chunk is fast", async () => {
+    const { pendingCalls, hooks } = makeHooks();
+    const result = lazyEnter(() => Promise.resolve(), hooks);
+    await expect(result).resolves.toBe(true);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(pendingCalls).toEqual([]);
+  });
+
+  it("shows pending feedback only after the delay and clears it on resolve", async () => {
+    const { pendingCalls, hooks } = makeHooks();
+    let resolveImport!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      resolveImport = resolve;
+    });
+    const result = lazyEnter(() => gate, hooks);
+
+    await vi.advanceTimersByTimeAsync(199);
+    expect(pendingCalls).toEqual([]);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(pendingCalls).toEqual([true]);
+
+    resolveImport();
+    await expect(result).resolves.toBe(true);
+    expect(pendingCalls).toEqual([true, false]);
+  });
+
+  it("retries a failed import and succeeds without a toast", async () => {
+    const { hooks } = makeHooks();
+    const importThunk = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("chunk load failed"))
+      .mockResolvedValueOnce(undefined);
+    const result = lazyEnter(importThunk, hooks);
+
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(result).resolves.toBe(true);
+    expect(importThunk).toHaveBeenCalledTimes(2);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("cancels the navigation with a toast once the retries are exhausted", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { pendingCalls, hooks } = makeHooks();
+    const importThunk = vi.fn().mockRejectedValue(new Error("chunk load failed"));
+    const result = lazyEnter(importThunk, hooks);
+
+    await vi.advanceTimersByTimeAsync(500 + 1500);
+    await expect(result).resolves.toBe(false);
+    expect(importThunk).toHaveBeenCalledTimes(3);
+    expect(toast.error).toHaveBeenCalledWith("layout.page_load_failed", {
+      richColors: true,
+    });
+    // The pending bar cleared even though the load never succeeded.
+    expect(pendingCalls).toEqual([true, false]);
+  });
+});
+
+describe("prefetchLazyRoutes", () => {
+  it("schedules the warm-up once across repeated calls", () => {
+    const requestIdleCallback = vi.fn();
+    vi.stubGlobal("requestIdleCallback", requestIdleCallback);
+    try {
+      prefetchLazyRoutes();
+      prefetchLazyRoutes();
+      expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/test/components/app-shell/router-lazy-enter.test.ts
+++ b/test/components/app-shell/router-lazy-enter.test.ts
@@ -8,7 +8,7 @@ vi.mock("sonner-js", () => ({
 import toast from "sonner-js";
 import type { LocalizeFunc } from "../../../src/common/localize.js";
 import { lazyEnter, type RouterHooks } from "../../../src/components/app-shell/router.js";
-import { consumePopGuardSuppression } from "../../../src/util/navigation.js";
+import { consumePopGuardSuppression, navigate } from "../../../src/util/navigation.js";
 import { identityLocalize } from "../../_dom.js";
 
 /**
@@ -159,6 +159,8 @@ describe("lazyEnter", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const back = vi.spyOn(window.history, "back").mockImplementation(() => {});
     const { pendingCalls, hooks } = makeHooks();
+    // The click's own navigate() push is the entry the rollback undoes.
+    await navigate("/device/kitchen.yaml");
     const importThunk = vi.fn().mockRejectedValue(new Error("chunk load failed"));
     const result = lazyEnter(importThunk, hooks);
 
@@ -179,6 +181,7 @@ describe("lazyEnter", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(window.history, "back").mockImplementation(() => {});
     const { hooks } = makeHooks();
+    await navigate("/device/kitchen.yaml");
     const result = lazyEnter(
       vi.fn().mockRejectedValue(new Error("chunk load failed")),
       hooks
@@ -189,5 +192,41 @@ describe("lazyEnter", () => {
     // The still-mounted page's guard consumes this and lets the rollback
     // popstate through instead of re-prompting a leave already answered.
     expect(consumePopGuardSuppression()).toBe(true);
+  });
+
+  it("leaves a Back/Forward entry alone when its chunk fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const back = vi.spyOn(window.history, "back").mockImplementation(() => {});
+    const { hooks } = makeHooks();
+    // beforeEach's raw pushState models an entry the triggering click did
+    // not push — the user arrived here via Back/Forward.
+    const result = lazyEnter(
+      vi.fn().mockRejectedValue(new Error("chunk load failed")),
+      hooks
+    );
+
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(result).resolves.toBe(false);
+    // Popping would move the user a second step back.
+    expect(back).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the dashboard when a deep link's chunk fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const back = vi.spyOn(window.history, "back").mockImplementation(() => {});
+    const { hooks } = makeHooks();
+    // A cold deep link has no navigate() stamp and nothing to undo.
+    window.history.pushState(null, "", "/device/kitchen.yaml");
+    const result = lazyEnter(
+      vi.fn().mockRejectedValue(new Error("chunk load failed")),
+      hooks
+    );
+
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(result).resolves.toBe(false);
+    expect(back).not.toHaveBeenCalled();
+    // The fallback lands on the dashboard instead of an empty outlet.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(window.location.pathname).toBe("/");
   });
 });

--- a/test/components/app-shell/router-lazy-enter.test.ts
+++ b/test/components/app-shell/router-lazy-enter.test.ts
@@ -12,8 +12,9 @@ import { identityLocalize } from "../../_dom.js";
 
 /**
  * Pins the lazy-route chunk loader: pending feedback only after the
- * delay, retries on a failed import, cancelled navigation + toast on
- * exhaustion, and idle-scheduled prefetch.
+ * delay, retries on a failed import, and cancelled navigation + toast
+ * on exhaustion. (Prefetch is a build-level webpackPrefetch hint with
+ * no runtime surface to test.)
  */
 
 function makeHooks(): { pendingCalls: boolean[]; hooks: RouterHooks } {
@@ -31,6 +32,9 @@ describe("lazyEnter", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     window.history.pushState({}, "", "/device/kitchen.yaml");
+    // Module-factory mock, so restoreAllMocks never clears its history;
+    // without this the not.toHaveBeenCalled cells are order-dependent.
+    vi.mocked(toast.error).mockClear();
   });
 
   afterEach(() => {

--- a/test/components/app-shell/router-lazy-enter.test.ts
+++ b/test/components/app-shell/router-lazy-enter.test.ts
@@ -139,8 +139,22 @@ describe("lazyEnter", () => {
     expect(pendingCalls).toEqual([true, false]);
   });
 
+  it("does not show the bar for a navigation abandoned before the delay", async () => {
+    const { pendingCalls, hooks } = makeHooks();
+    const result = lazyEnter(() => new Promise<void>(() => {}), hooks);
+
+    window.history.pushState({}, "", "/");
+    await vi.advanceTimersByTimeAsync(400);
+
+    // The import can't be cancelled, but the feedback shouldn't advertise
+    // progress on a page the user already left.
+    expect(pendingCalls).toEqual([]);
+    void result;
+  });
+
   it("cancels the navigation with a toast once the retries are exhausted", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
+    const back = vi.spyOn(window.history, "back").mockImplementation(() => {});
     const { pendingCalls, hooks } = makeHooks();
     const importThunk = vi.fn().mockRejectedValue(new Error("chunk load failed"));
     const result = lazyEnter(importThunk, hooks);
@@ -153,6 +167,9 @@ describe("lazyEnter", () => {
     });
     // The pending bar cleared even though the load never succeeded.
     expect(pendingCalls).toEqual([true, false]);
+    // navigate() had already pushed the URL; undo it so the address bar
+    // doesn't describe a page that never mounted.
+    expect(back).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/test/components/app-shell/router-lazy-enter.test.ts
+++ b/test/components/app-shell/router-lazy-enter.test.ts
@@ -142,6 +142,22 @@ describe("lazyEnter", () => {
     expect(pendingCalls).toEqual([true, false]);
   });
 
+  it("drops the bar when the user navigates away mid-load", async () => {
+    const { pendingCalls, hooks } = makeHooks();
+    const result = lazyEnter(() => new Promise<void>(() => {}), hooks);
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(pendingCalls).toEqual([true]);
+
+    // The user gave up and clicked elsewhere; the stale chunk stays in
+    // flight (up to chunkLoadTimeout) and must not pin the bar there.
+    window.history.pushState({}, "", "/");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+
+    expect(pendingCalls).toEqual([true, false]);
+    void result;
+  });
+
   it("does not show the bar for a navigation abandoned before the delay", async () => {
     const { pendingCalls, hooks } = makeHooks();
     const result = lazyEnter(() => new Promise<void>(() => {}), hooks);

--- a/test/components/app-shell/router-lazy-enter.test.ts
+++ b/test/components/app-shell/router-lazy-enter.test.ts
@@ -12,11 +12,12 @@ import {
   prefetchLazyRoutes,
   type RouterHooks,
 } from "../../../src/components/app-shell/router.js";
+import { identityLocalize } from "../../_dom.js";
 
 /**
  * Pins the lazy-route chunk loader: pending feedback only after the
  * delay, retries on a failed import, cancelled navigation + toast on
- * exhaustion, and idle-scheduled prefetch that never double-schedules.
+ * exhaustion, and idle-scheduled prefetch.
  */
 
 function makeHooks(): { pendingCalls: boolean[]; hooks: RouterHooks } {
@@ -25,7 +26,7 @@ function makeHooks(): { pendingCalls: boolean[]; hooks: RouterHooks } {
     pendingCalls,
     hooks: {
       onPending: (pending: boolean) => pendingCalls.push(pending),
-      localize: () => ((key: string) => key) as LocalizeFunc,
+      localize: () => identityLocalize as LocalizeFunc,
     },
   };
 }
@@ -33,22 +34,25 @@ function makeHooks(): { pendingCalls: boolean[]; hooks: RouterHooks } {
 describe("lazyEnter", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    window.history.pushState({}, "", "/device/kitchen.yaml");
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    window.history.pushState({}, "", "/");
   });
 
-  it("resolves without pending feedback when the chunk is fast", async () => {
+  it("resolves without showing pending when the chunk is fast", async () => {
     const { pendingCalls, hooks } = makeHooks();
     const result = lazyEnter(() => Promise.resolve(), hooks);
     await expect(result).resolves.toBe(true);
     await vi.advanceTimersByTimeAsync(1000);
+    // Never crossed the delay, so it never joined the pending count.
     expect(pendingCalls).toEqual([]);
   });
 
-  it("shows pending feedback only after the delay and clears it on resolve", async () => {
+  it("shows pending only after the delay and clears it on resolve", async () => {
     const { pendingCalls, hooks } = makeHooks();
     let resolveImport!: () => void;
     const gate = new Promise<void>((resolve) => {
@@ -80,6 +84,61 @@ describe("lazyEnter", () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
+  it("refuses to commit a chunk that lands after the user navigated away", async () => {
+    const { hooks } = makeHooks();
+    let resolveImport!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      resolveImport = resolve;
+    });
+    const result = lazyEnter(() => gate, hooks);
+
+    // User gave up on the slow route and went back to the dashboard.
+    window.history.pushState({}, "", "/");
+    resolveImport();
+
+    await expect(result).resolves.toBe(false);
+  });
+
+  it("abandons the retry loop when the location moves on mid-backoff", async () => {
+    const { hooks } = makeHooks();
+    const importThunk = vi.fn().mockRejectedValue(new Error("chunk load failed"));
+    const result = lazyEnter(importThunk, hooks);
+
+    window.history.pushState({}, "", "/somewhere-else");
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await expect(result).resolves.toBe(false);
+    // Bailed on the first failure instead of burning both retries.
+    expect(importThunk).toHaveBeenCalledTimes(1);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("keeps the bar up until the last overlapping load settles", async () => {
+    const { pendingCalls, hooks } = makeHooks();
+    let resolveFirst!: () => void;
+    let resolveSecond!: () => void;
+    const first = lazyEnter(
+      () => new Promise<void>((resolve) => (resolveFirst = resolve)),
+      hooks
+    );
+    const second = lazyEnter(
+      () => new Promise<void>((resolve) => (resolveSecond = resolve)),
+      hooks
+    );
+
+    await vi.advanceTimersByTimeAsync(200);
+    // Both crossed the delay; the bar is shown once, not twice.
+    expect(pendingCalls).toEqual([true]);
+
+    resolveFirst();
+    await first;
+    expect(pendingCalls).toEqual([true]);
+
+    resolveSecond();
+    await second;
+    expect(pendingCalls).toEqual([true, false]);
+  });
+
   it("cancels the navigation with a toast once the retries are exhausted", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const { pendingCalls, hooks } = makeHooks();
@@ -98,11 +157,10 @@ describe("lazyEnter", () => {
 });
 
 describe("prefetchLazyRoutes", () => {
-  it("schedules the warm-up once across repeated calls", () => {
+  it("defers the warm-up to an idle callback", () => {
     const requestIdleCallback = vi.fn();
     vi.stubGlobal("requestIdleCallback", requestIdleCallback);
     try {
-      prefetchLazyRoutes();
       prefetchLazyRoutes();
       expect(requestIdleCallback).toHaveBeenCalledTimes(1);
     } finally {

--- a/test/components/app-shell/router-lazy-enter.test.ts
+++ b/test/components/app-shell/router-lazy-enter.test.ts
@@ -210,12 +210,16 @@ describe("lazyEnter", () => {
     expect(consumePopGuardSuppression()).toBe(true);
   });
 
-  it("leaves a Back/Forward entry alone when its chunk fails", async () => {
+  it("leaves a same-document Back/Forward entry alone when its chunk fails", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const back = vi.spyOn(window.history, "back").mockImplementation(() => {});
     const { hooks } = makeHooks();
-    // beforeEach's raw pushState models an entry the triggering click did
-    // not push — the user arrived here via Back/Forward.
+    await navigate("/device/kitchen.yaml");
+    const earlierEntryState = window.history.state;
+    await navigate("/device/other.yaml");
+    // Simulate Back into the earlier entry: this document's stamp, but
+    // no longer the latest push.
+    window.history.pushState(earlierEntryState, "", "/device/kitchen.yaml");
     const result = lazyEnter(
       vi.fn().mockRejectedValue(new Error("chunk load failed")),
       hooks
@@ -225,6 +229,26 @@ describe("lazyEnter", () => {
     await expect(result).resolves.toBe(false);
     // Popping would move the user a second step back.
     expect(back).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe("/device/kitchen.yaml");
+  });
+
+  it("falls back to the dashboard when a reloaded entry's chunk fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const back = vi.spyOn(window.history, "back").mockImplementation(() => {});
+    const { hooks } = makeHooks();
+    // A reload keeps the pre-reload document's stamp while this document
+    // has committed nothing — same empty outlet as a cold deep link.
+    window.history.pushState({ d: "pre-reload-doc", n: 5 }, "", "/device/kitchen.yaml");
+    const result = lazyEnter(
+      vi.fn().mockRejectedValue(new Error("chunk load failed")),
+      hooks
+    );
+
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(result).resolves.toBe(false);
+    expect(back).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(window.location.pathname).toBe("/");
   });
 
   it("falls back to the dashboard when a deep link's chunk fails", async () => {

--- a/test/components/app-shell/router-lazy-enter.test.ts
+++ b/test/components/app-shell/router-lazy-enter.test.ts
@@ -7,7 +7,11 @@ vi.mock("sonner-js", () => ({
 
 import toast from "sonner-js";
 import type { LocalizeFunc } from "../../../src/common/localize.js";
-import { lazyEnter, type RouterHooks } from "../../../src/components/app-shell/router.js";
+import {
+  consumePreAuthExhaustion,
+  lazyEnter,
+  type RouterHooks,
+} from "../../../src/components/app-shell/router.js";
 import { consumePopGuardSuppression, navigate } from "../../../src/util/navigation.js";
 import { identityLocalize } from "../../_dom.js";
 
@@ -37,8 +41,9 @@ describe("lazyEnter", () => {
     // Module-factory mock, so restoreAllMocks never clears its history;
     // without this the not.toHaveBeenCalled cells are order-dependent.
     vi.mocked(toast.error).mockClear();
-    // Module state in navigation.ts; drain any leftover arming.
+    // Module state in navigation.ts / router.ts; drain leftover arming.
     consumePopGuardSuppression();
+    consumePreAuthExhaustion();
   });
 
   afterEach(() => {
@@ -228,6 +233,9 @@ describe("lazyEnter", () => {
     expect(toast.error).not.toHaveBeenCalled();
     expect(back).not.toHaveBeenCalled();
     expect(window.location.pathname).toBe("/device/kitchen.yaml");
+    // The shell's post-auth re-resolve reads this exactly once.
+    expect(consumePreAuthExhaustion()).toBe(true);
+    expect(consumePreAuthExhaustion()).toBe(false);
   });
 
   it("leaves a same-document Back/Forward entry alone when its chunk fails", async () => {

--- a/test/components/app-shell/router-lazy-enter.test.ts
+++ b/test/components/app-shell/router-lazy-enter.test.ts
@@ -8,6 +8,7 @@ vi.mock("sonner-js", () => ({
 import toast from "sonner-js";
 import type { LocalizeFunc } from "../../../src/common/localize.js";
 import { lazyEnter, type RouterHooks } from "../../../src/components/app-shell/router.js";
+import { consumePopGuardSuppression } from "../../../src/util/navigation.js";
 import { identityLocalize } from "../../_dom.js";
 
 /**
@@ -35,6 +36,8 @@ describe("lazyEnter", () => {
     // Module-factory mock, so restoreAllMocks never clears its history;
     // without this the not.toHaveBeenCalled cells are order-dependent.
     vi.mocked(toast.error).mockClear();
+    // Module state in navigation.ts; drain any leftover arming.
+    consumePopGuardSuppression();
   });
 
   afterEach(() => {
@@ -170,5 +173,21 @@ describe("lazyEnter", () => {
     // navigate() had already pushed the URL; undo it so the address bar
     // doesn't describe a page that never mounted.
     expect(back).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses the popstate guard for its own rollback", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(window.history, "back").mockImplementation(() => {});
+    const { hooks } = makeHooks();
+    const result = lazyEnter(
+      vi.fn().mockRejectedValue(new Error("chunk load failed")),
+      hooks
+    );
+
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(result).resolves.toBe(false);
+    // The still-mounted page's guard consumes this and lets the rollback
+    // popstate through instead of re-prompting a leave already answered.
+    expect(consumePopGuardSuppression()).toBe(true);
   });
 });

--- a/test/components/app-shell/router-lazy-enter.test.ts
+++ b/test/components/app-shell/router-lazy-enter.test.ts
@@ -122,6 +122,20 @@ describe("lazyEnter", () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
+  it("skips the retry import when the user leaves during the backoff", async () => {
+    const { hooks } = makeHooks();
+    const importThunk = vi.fn().mockRejectedValue(new Error("chunk load failed"));
+    const result = lazyEnter(importThunk, hooks);
+
+    // First failure processed while still on the route; backoff armed.
+    await vi.advanceTimersByTimeAsync(100);
+    window.history.pushState({}, "", "/");
+    await vi.advanceTimersByTimeAsync(1000);
+
+    await expect(result).resolves.toBe(false);
+    expect(importThunk).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps the bar up until the last overlapping load settles", async () => {
     const { pendingCalls, hooks } = makeHooks();
     let resolveFirst!: () => void;

--- a/test/components/app-shell/router-lazy-enter.test.ts
+++ b/test/components/app-shell/router-lazy-enter.test.ts
@@ -7,11 +7,7 @@ vi.mock("sonner-js", () => ({
 
 import toast from "sonner-js";
 import type { LocalizeFunc } from "../../../src/common/localize.js";
-import {
-  lazyEnter,
-  prefetchLazyRoutes,
-  type RouterHooks,
-} from "../../../src/components/app-shell/router.js";
+import { lazyEnter, type RouterHooks } from "../../../src/components/app-shell/router.js";
 import { identityLocalize } from "../../_dom.js";
 
 /**
@@ -105,7 +101,7 @@ describe("lazyEnter", () => {
     const result = lazyEnter(importThunk, hooks);
 
     window.history.pushState({}, "", "/somewhere-else");
-    await vi.advanceTimersByTimeAsync(2000);
+    await vi.advanceTimersByTimeAsync(1000);
 
     await expect(result).resolves.toBe(false);
     // Bailed on the first failure instead of burning both retries.
@@ -159,9 +155,9 @@ describe("lazyEnter", () => {
     const importThunk = vi.fn().mockRejectedValue(new Error("chunk load failed"));
     const result = lazyEnter(importThunk, hooks);
 
-    await vi.advanceTimersByTimeAsync(500 + 1500);
+    await vi.advanceTimersByTimeAsync(500);
     await expect(result).resolves.toBe(false);
-    expect(importThunk).toHaveBeenCalledTimes(3);
+    expect(importThunk).toHaveBeenCalledTimes(2);
     expect(toast.error).toHaveBeenCalledWith("layout.page_load_failed", {
       richColors: true,
     });
@@ -170,18 +166,5 @@ describe("lazyEnter", () => {
     // navigate() had already pushed the URL; undo it so the address bar
     // doesn't describe a page that never mounted.
     expect(back).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("prefetchLazyRoutes", () => {
-  it("defers the warm-up to an idle callback", () => {
-    const requestIdleCallback = vi.fn();
-    vi.stubGlobal("requestIdleCallback", requestIdleCallback);
-    try {
-      prefetchLazyRoutes();
-      expect(requestIdleCallback).toHaveBeenCalledTimes(1);
-    } finally {
-      vi.unstubAllGlobals();
-    }
   });
 });

--- a/test/components/app-shell/router-lazy-enter.test.ts
+++ b/test/components/app-shell/router-lazy-enter.test.ts
@@ -247,8 +247,9 @@ describe("lazyEnter", () => {
     await vi.advanceTimersByTimeAsync(500);
     await expect(result).resolves.toBe(false);
     expect(back).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(0);
+    // Replaced in place — no broken entry left underneath for Back.
     expect(window.location.pathname).toBe("/");
+    expect(window.history.state).toBeNull();
   });
 
   it("falls back to the dashboard when a deep link's chunk fails", async () => {
@@ -265,8 +266,8 @@ describe("lazyEnter", () => {
     await vi.advanceTimersByTimeAsync(500);
     await expect(result).resolves.toBe(false);
     expect(back).not.toHaveBeenCalled();
-    // The fallback lands on the dashboard instead of an empty outlet.
-    await vi.advanceTimersByTimeAsync(0);
+    // Replaced in place — no broken entry left underneath for Back.
     expect(window.location.pathname).toBe("/");
+    expect(window.history.state).toBeNull();
   });
 });

--- a/test/components/dashboard/open-logs.test.ts
+++ b/test/components/dashboard/open-logs.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
 import type { ESPHomeAPI } from "../../../src/api/index.js";
 import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
 import { openLogs } from "../../../src/components/dashboard/install.js";
@@ -16,6 +21,7 @@ function makeDevice(): ConfiguredDevice {
 interface StubHost {
   _api: Pick<ESPHomeAPI, "getSerialPorts">;
   _logsDialog: { configuration?: string; name?: string; open: ReturnType<typeof vi.fn> };
+  _localize: (key: string) => string;
   _installMethodDevice?: ConfiguredDevice;
   _installMethodMode?: "install" | "logs";
   _installMethodOpen: boolean;
@@ -25,6 +31,7 @@ function makeHost(getSerialPorts: () => Promise<unknown>): StubHost {
   return {
     _api: { getSerialPorts: vi.fn(getSerialPorts) } as unknown as StubHost["_api"],
     _logsDialog: { open: vi.fn() },
+    _localize: (key) => key,
     _installMethodOpen: false,
   };
 }
@@ -82,6 +89,7 @@ describe("openLogs", () => {
   });
 
   it("falls back to OTA logs when the serial-port lookup fails", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     const restore = withWebSerial(false);
     try {
       const host = makeHost(async () => {

--- a/test/pages/_mock-device-children.ts
+++ b/test/pages/_mock-device-children.ts
@@ -13,7 +13,9 @@ import { vi } from "vitest";
 vi.mock("sonner-js", () => ({
   default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
+vi.mock("@home-assistant/webawesome/dist/components/button/button.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 vi.mock("../../src/components/command-dialog.js", () => ({}));
 vi.mock("../../src/components/device/device-editor.js", () => ({}));
 vi.mock("../../src/components/device/device-navigator.js", () => ({}));

--- a/test/pages/device-yaml-loading.test.ts
+++ b/test/pages/device-yaml-loading.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+/**
+ * Pins the initial-YAML loading gate: a slow getConfig shows the
+ * spinner panel instead of an empty editor, a failed one shows the
+ * retry panel, and Retry recovers into the mounted editor.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import "./_mock-device-children.js";
+vi.mock("../../src/components/device/board-reselect-dialog.js", () => ({}));
+
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import { ESPHomePageDevice } from "../../src/pages/device.js";
+import { flushMicrotasks } from "../_dom.js";
+
+interface Deferred {
+  resolve(value: string): void;
+  reject(error: Error): void;
+  promise: Promise<string>;
+}
+
+function makeDeferred(): Deferred {
+  let resolve!: (value: string) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<string>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { resolve, reject, promise };
+}
+
+function makeApi(getConfig: ReturnType<typeof vi.fn>): ESPHomeAPI {
+  return {
+    ready: Promise.resolve(),
+    getConfig,
+    getPreferences: vi.fn().mockResolvedValue({ navigator_visible: true }),
+  } as unknown as ESPHomeAPI;
+}
+
+async function mountPage(api: ESPHomeAPI): Promise<ESPHomePageDevice> {
+  const page = new ESPHomePageDevice();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._api = api;
+  page.id = "kitchen.yaml";
+  document.body.appendChild(page);
+  await page.updateComplete;
+  await flushMicrotasks(8);
+  await page.updateComplete;
+  return page;
+}
+
+const editorIn = (page: ESPHomePageDevice) =>
+  page.shadowRoot!.querySelector("esphome-device-editor");
+const loadPanelIn = (page: ESPHomePageDevice) =>
+  page.shadowRoot!.querySelector(".yaml-load-state");
+
+describe("device page initial YAML loading gate", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("shows the loading panel instead of an empty editor while getConfig is in flight", async () => {
+    const deferred = makeDeferred();
+    const page = await mountPage(makeApi(vi.fn().mockReturnValue(deferred.promise)));
+
+    expect(editorIn(page)).toBeNull();
+    const panel = loadPanelIn(page);
+    expect(panel).not.toBeNull();
+    expect(panel!.querySelector("wa-spinner")).not.toBeNull();
+
+    deferred.resolve("wifi:\n  ssid: x\n");
+    await flushMicrotasks(8);
+    await page.updateComplete;
+
+    expect(loadPanelIn(page)).toBeNull();
+    const editor = editorIn(page);
+    expect(editor).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((editor as any).yaml).toBe("wifi:\n  ssid: x\n");
+  });
+
+  it("shows the retry panel when getConfig fails and recovers on Retry", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const getConfig = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("WebSocket connection closed"))
+      .mockResolvedValueOnce("wifi:\n  ssid: x\n");
+    const page = await mountPage(makeApi(getConfig));
+
+    expect(editorIn(page)).toBeNull();
+    const panel = loadPanelIn(page);
+    expect(panel).not.toBeNull();
+    const retry = panel!.querySelector("wa-button");
+    expect(retry).not.toBeNull();
+    expect(panel!.querySelector("wa-spinner")).toBeNull();
+
+    (retry as HTMLElement).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await flushMicrotasks(8);
+    await page.updateComplete;
+
+    expect(getConfig).toHaveBeenCalledTimes(2);
+    expect(loadPanelIn(page)).toBeNull();
+    expect(editorIn(page)).not.toBeNull();
+  });
+
+  it("waits for api.ready before fetching the config", async () => {
+    let releaseReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      releaseReady = resolve;
+    });
+    const getConfig = vi.fn().mockResolvedValue("wifi:\n  ssid: x\n");
+    const api = {
+      ready,
+      getConfig,
+      getPreferences: vi.fn().mockResolvedValue({ navigator_visible: true }),
+    } as unknown as ESPHomeAPI;
+    const page = await mountPage(api);
+
+    expect(getConfig).not.toHaveBeenCalled();
+    expect(loadPanelIn(page)).not.toBeNull();
+
+    releaseReady();
+    await flushMicrotasks(8);
+    await page.updateComplete;
+
+    expect(getConfig).toHaveBeenCalledWith("kitchen.yaml");
+    expect(editorIn(page)).not.toBeNull();
+  });
+});

--- a/test/pages/device-yaml-loading.test.ts
+++ b/test/pages/device-yaml-loading.test.ts
@@ -9,9 +9,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import "./_mock-device-children.js";
 vi.mock("../../src/components/device/board-reselect-dialog.js", () => ({}));
 
-import type { ESPHomeAPI } from "../../src/api/index.js";
+import { APIError, type ESPHomeAPI } from "../../src/api/index.js";
+import { ErrorCode } from "../../src/api/types/protocol.js";
 import { ESPHomePageDevice } from "../../src/pages/device.js";
-import { flushMicrotasks } from "../_dom.js";
+import { flushMicrotasks, mount } from "../_dom.js";
 
 interface Deferred {
   resolve(value: string): void;
@@ -38,12 +39,10 @@ function makeApi(getConfig: ReturnType<typeof vi.fn>): ESPHomeAPI {
 }
 
 async function mountPage(api: ESPHomeAPI): Promise<ESPHomePageDevice> {
-  const page = new ESPHomePageDevice();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (page as any)._api = api;
-  page.id = "kitchen.yaml";
-  document.body.appendChild(page);
-  await page.updateComplete;
+  const page = await mount(new ESPHomePageDevice(), {
+    _api: api,
+    id: "kitchen.yaml",
+  } as Partial<ESPHomePageDevice>);
   await flushMicrotasks(8);
   await page.updateComplete;
   return page;
@@ -102,6 +101,27 @@ describe("device page initial YAML loading gate", () => {
     expect(getConfig).toHaveBeenCalledTimes(2);
     expect(loadPanelIn(page)).toBeNull();
     expect(editorIn(page)).not.toBeNull();
+  });
+
+  it("offers a way back instead of a retry when the config is gone", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const getConfig = vi
+      .fn()
+      .mockRejectedValue(new APIError(ErrorCode.NOT_FOUND, "no such device"));
+    const page = await mountPage(makeApi(getConfig));
+
+    const panel = loadPanelIn(page);
+    expect(panel).not.toBeNull();
+    // A deleted config can't be retried into existence.
+    expect(panel!.textContent).toContain("device.load_not_found");
+    const button = panel!.querySelector("wa-button");
+    expect(button!.textContent).toContain("device.back_to_dashboard");
+
+    (button as HTMLElement).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await flushMicrotasks(4);
+
+    expect(getConfig).toHaveBeenCalledTimes(1);
+    expect(window.location.pathname).toBe("/");
   });
 
   it("waits for api.ready before fetching the config", async () => {

--- a/test/pages/device-yaml-loading.test.ts
+++ b/test/pages/device-yaml-loading.test.ts
@@ -83,6 +83,27 @@ describe("device page initial YAML loading gate", () => {
     expect((editor as any).yaml).toBe("wifi:\n  ssid: x\n");
   });
 
+  it("clears the prior device's buffer on an id change", async () => {
+    const getConfig = vi
+      .fn()
+      .mockResolvedValueOnce("esphome:\n  name: kitchen\n")
+      .mockImplementationOnce(() => new Promise<string>(() => {}));
+    const page = await mountPage(makeApi(getConfig));
+    const view = page as unknown as { _yaml: string; _savedYaml: string };
+    expect(view._yaml).toBe("esphome:\n  name: kitchen\n");
+
+    // Discard leaves the buffer dirty; the element is then reused for
+    // the next device, whose load hangs.
+    view._yaml = "esphome:\n  name: kitchen-edited\n";
+    page.id = "porch.yaml";
+    await page.updateComplete;
+
+    // The prior device's dirty YAML must not survive where Save could
+    // write it into porch.yaml.
+    expect(view._yaml).toBe("");
+    expect(view._savedYaml).toBe("");
+  });
+
   it("keeps the spinner and retries when the socket drops mid-fetch", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.useFakeTimers();

--- a/test/pages/device-yaml-loading.test.ts
+++ b/test/pages/device-yaml-loading.test.ts
@@ -11,7 +11,6 @@ vi.mock("../../src/components/device/board-reselect-dialog.js", () => ({}));
 
 import { APIError, type ESPHomeAPI } from "../../src/api/index.js";
 import { ErrorCode } from "../../src/api/types/protocol.js";
-import { RECONNECTED_EVENT } from "../../src/components/app-shell/connection-overlays.js";
 import { ESPHomePageDevice } from "../../src/pages/device.js";
 import { flushMicrotasks, mount } from "../_dom.js";
 
@@ -194,7 +193,10 @@ describe("device page initial YAML loading gate", () => {
       expect(loadPanelIn(page)!.textContent).toContain("device.load_failed");
 
       getConfig.mockResolvedValueOnce("wifi:\n  ssid: x\n");
-      window.dispatchEvent(new Event(RECONNECTED_EVENT));
+      // The shell provides this through context; the false→true edge is
+      // the signal that the socket is usable again.
+      (page as unknown as { _apiConnected: boolean })._apiConnected = true;
+      page.requestUpdate();
       await flushMicrotasks(8);
       await page.updateComplete;
 

--- a/test/pages/device-yaml-loading.test.ts
+++ b/test/pages/device-yaml-loading.test.ts
@@ -11,6 +11,7 @@ vi.mock("../../src/components/device/board-reselect-dialog.js", () => ({}));
 
 import { APIError, type ESPHomeAPI } from "../../src/api/index.js";
 import { ErrorCode } from "../../src/api/types/protocol.js";
+import { RECONNECTED_EVENT } from "../../src/components/app-shell/connection-overlays.js";
 import { ESPHomePageDevice } from "../../src/pages/device.js";
 import { flushMicrotasks, mount } from "../_dom.js";
 
@@ -176,6 +177,32 @@ describe("device page initial YAML loading gate", () => {
 
     expect(getConfig).toHaveBeenCalledTimes(1);
     expect(window.location.pathname).toBe("/");
+  });
+
+  it("retries on its own when the socket comes back", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+    try {
+      const getConfig = vi
+        .fn()
+        .mockRejectedValue(new Error("WebSocket connection closed"));
+      const page = await mountPage(makeApi(getConfig));
+      await vi.advanceTimersByTimeAsync(1500 * 4);
+      await flushMicrotasks(8);
+      await page.updateComplete;
+      expect(loadPanelIn(page)!.textContent).toContain("device.load_failed");
+
+      getConfig.mockResolvedValueOnce("wifi:\n  ssid: x\n");
+      window.dispatchEvent(new Event(RECONNECTED_EVENT));
+      await flushMicrotasks(8);
+      await page.updateComplete;
+
+      // No click needed: the shell said the socket is usable again.
+      expect(editorIn(page)).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("waits for api.ready before fetching the config", async () => {

--- a/test/pages/device-yaml-loading.test.ts
+++ b/test/pages/device-yaml-loading.test.ts
@@ -103,6 +103,32 @@ describe("device page initial YAML loading gate", () => {
     expect(view._savedYaml).toBe("");
   });
 
+  it("drops a stale reply when the id changes away and back mid-flight", async () => {
+    const settlers: Array<(yaml: string) => void> = [];
+    const getConfig = vi.fn(
+      () => new Promise<string>((resolve) => settlers.push(resolve))
+    );
+    const page = await mountPage(makeApi(getConfig));
+    const view = page as unknown as { _yaml: string; _yamlState: string };
+
+    page.id = "porch.yaml";
+    await page.updateComplete;
+    page.id = "kitchen.yaml";
+    await page.updateComplete;
+
+    // The first load's reply lands after the round trip; the id matches
+    // again, so only the generation tells it apart from the live load.
+    settlers[0]("esphome:\n  name: stale\n");
+    await flushMicrotasks(8);
+    expect(view._yaml).toBe("");
+    expect(view._yamlState).toBe("loading");
+
+    settlers[2]("esphome:\n  name: fresh\n");
+    await flushMicrotasks(8);
+    expect(view._yaml).toBe("esphome:\n  name: fresh\n");
+    expect(view._yamlState).toBe("ready");
+  });
+
   it("keeps the spinner and retries when the socket drops mid-fetch", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.useFakeTimers();

--- a/test/pages/device-yaml-loading.test.ts
+++ b/test/pages/device-yaml-loading.test.ts
@@ -79,28 +79,78 @@ describe("device page initial YAML loading gate", () => {
     expect((editor as any).yaml).toBe("wifi:\n  ssid: x\n");
   });
 
-  it("shows the retry panel when getConfig fails and recovers on Retry", async () => {
+  it("keeps the spinner and retries when the socket drops mid-fetch", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+    try {
+      // A dropped socket rejects every in-flight request at once, so this
+      // arrives in milliseconds — the panel must not flash for it.
+      const getConfig = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("WebSocket connection closed"))
+        .mockResolvedValueOnce("wifi:\n  ssid: x\n");
+      const page = await mountPage(makeApi(getConfig));
+
+      const panel = loadPanelIn(page);
+      expect(panel).not.toBeNull();
+      expect(panel!.querySelector("wa-spinner")).not.toBeNull();
+      expect(panel!.querySelector("wa-button")).toBeNull();
+
+      await vi.advanceTimersByTimeAsync(1500);
+      await flushMicrotasks(8);
+      await page.updateComplete;
+
+      expect(getConfig).toHaveBeenCalledTimes(2);
+      expect(loadPanelIn(page)).toBeNull();
+      expect(editorIn(page)).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows the retry panel once the transport attempts are spent", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+    try {
+      const getConfig = vi
+        .fn()
+        .mockRejectedValue(new Error("WebSocket connection closed"));
+      const page = await mountPage(makeApi(getConfig));
+
+      await vi.advanceTimersByTimeAsync(1500 * 4);
+      await flushMicrotasks(8);
+      await page.updateComplete;
+
+      expect(getConfig).toHaveBeenCalledTimes(4);
+      const panel = loadPanelIn(page);
+      expect(panel!.querySelector("wa-spinner")).toBeNull();
+      expect(panel!.textContent).toContain("device.load_failed");
+
+      // Retry re-arms the whole recovery loop from scratch.
+      getConfig.mockResolvedValueOnce("wifi:\n  ssid: x\n");
+      (panel!.querySelector("wa-button") as HTMLElement).dispatchEvent(
+        new MouseEvent("click", { bubbles: true })
+      );
+      await flushMicrotasks(8);
+      await page.updateComplete;
+
+      expect(editorIn(page)).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("surfaces a server-side failure without burning retries", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const getConfig = vi
       .fn()
-      .mockRejectedValueOnce(new Error("WebSocket connection closed"))
-      .mockResolvedValueOnce("wifi:\n  ssid: x\n");
+      .mockRejectedValue(new APIError(ErrorCode.INTERNAL_ERROR, "boom"));
     const page = await mountPage(makeApi(getConfig));
 
-    expect(editorIn(page)).toBeNull();
-    const panel = loadPanelIn(page);
-    expect(panel).not.toBeNull();
-    const retry = panel!.querySelector("wa-button");
-    expect(retry).not.toBeNull();
-    expect(panel!.querySelector("wa-spinner")).toBeNull();
-
-    (retry as HTMLElement).dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    await flushMicrotasks(8);
-    await page.updateComplete;
-
-    expect(getConfig).toHaveBeenCalledTimes(2);
-    expect(loadPanelIn(page)).toBeNull();
-    expect(editorIn(page)).not.toBeNull();
+    // The server answered, so retrying the same request is pointless.
+    expect(getConfig).toHaveBeenCalledTimes(1);
+    expect(loadPanelIn(page)!.textContent).toContain("device.load_failed");
   });
 
   it("offers a way back instead of a retry when the config is gone", async () => {
@@ -144,7 +194,8 @@ describe("device page initial YAML loading gate", () => {
     await flushMicrotasks(8);
     await page.updateComplete;
 
-    expect(getConfig).toHaveBeenCalledWith("kitchen.yaml");
+    // The initial fetch carries its own longer bound, not the 10s default.
+    expect(getConfig).toHaveBeenCalledWith("kitchen.yaml", 30_000);
     expect(editorIn(page)).not.toBeNull();
   });
 });

--- a/test/pages/device-yaml-loading.test.ts
+++ b/test/pages/device-yaml-loading.test.ts
@@ -50,8 +50,12 @@ async function mountPage(api: ESPHomeAPI): Promise<ESPHomePageDevice> {
 
 const editorIn = (page: ESPHomePageDevice) =>
   page.shadowRoot!.querySelector("esphome-device-editor");
+// renderAsyncState's ladder: a .message block, plus a sibling action
+// button on the failure branches.
 const loadPanelIn = (page: ESPHomePageDevice) =>
-  page.shadowRoot!.querySelector(".yaml-load-state");
+  page.shadowRoot!.querySelector(".message");
+const loadActionIn = (page: ESPHomePageDevice) =>
+  page.shadowRoot!.querySelector(".message ~ wa-button");
 
 describe("device page initial YAML loading gate", () => {
   afterEach(() => {
@@ -94,7 +98,7 @@ describe("device page initial YAML loading gate", () => {
       const panel = loadPanelIn(page);
       expect(panel).not.toBeNull();
       expect(panel!.querySelector("wa-spinner")).not.toBeNull();
-      expect(panel!.querySelector("wa-button")).toBeNull();
+      expect(loadActionIn(page)).toBeNull();
 
       await vi.advanceTimersByTimeAsync(1500);
       await flushMicrotasks(8);
@@ -129,7 +133,7 @@ describe("device page initial YAML loading gate", () => {
 
       // Retry re-arms the whole recovery loop from scratch.
       getConfig.mockResolvedValueOnce("wifi:\n  ssid: x\n");
-      (panel!.querySelector("wa-button") as HTMLElement).dispatchEvent(
+      (loadActionIn(page) as HTMLElement).dispatchEvent(
         new MouseEvent("click", { bubbles: true })
       );
       await flushMicrotasks(8);
@@ -164,7 +168,7 @@ describe("device page initial YAML loading gate", () => {
     expect(panel).not.toBeNull();
     // A deleted config can't be retried into existence.
     expect(panel!.textContent).toContain("device.load_not_found");
-    const button = panel!.querySelector("wa-button");
+    const button = loadActionIn(page);
     expect(button!.textContent).toContain("device.back_to_dashboard");
 
     (button as HTMLElement).dispatchEvent(new MouseEvent("click", { bubbles: true }));

--- a/test/pages/device-yaml-loading.test.ts
+++ b/test/pages/device-yaml-loading.test.ts
@@ -60,7 +60,6 @@ const loadActionIn = (page: ESPHomePageDevice) =>
 describe("device page initial YAML loading gate", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    document.body.innerHTML = "";
   });
 
   it("shows the loading panel instead of an empty editor while getConfig is in flight", async () => {

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -45,6 +45,7 @@ interface PageView {
   _layout: "form" | "yaml";
   _readStoredLayout(): "form" | "yaml" | null;
   _seedLayoutFromBackend(): Promise<void>;
+  _loadFromServer(): Promise<void>;
   _setLayout(layout: "form" | "yaml"): void;
   _onYamlChange(e: CustomEvent<{ value: string }>): void;
   _confirmLeave(): Promise<boolean>;
@@ -273,6 +274,46 @@ describe("esphome-page-secrets clear-all wipe confirm (#1568)", () => {
     page.disconnectedCallback();
 
     expect(settle).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("esphome-page-secrets initial load", () => {
+  test("seeds the header template only when the server says the file is missing", async () => {
+    const page = makePage();
+    page._api = {
+      ready: Promise.resolve(),
+      getConfig: vi.fn().mockRejectedValue(new APIError("not_found", "missing")),
+    } as unknown as ESPHomeAPI;
+
+    await page._loadFromServer();
+
+    expect(page._yaml).not.toBe("");
+    expect(page._savedYaml).toBe(page._yaml);
+    expect(page._loaded).toBe(true);
+  });
+
+  test("retries a transport failure instead of templating over the real file", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+    try {
+      const page = makePage();
+      const getConfig = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("WebSocket connection closed"))
+        .mockResolvedValueOnce("wifi_password: hunter2\n");
+      page._api = { ready: Promise.resolve(), getConfig } as unknown as ESPHomeAPI;
+
+      const loaded = page._loadFromServer();
+      await vi.advanceTimersByTimeAsync(2000);
+      await loaded;
+
+      // The real file wins; the blank template never reached the buffer.
+      expect(getConfig).toHaveBeenCalledTimes(2);
+      expect(page._yaml).toBe("wifi_password: hunter2\n");
+      expect(page._savedYaml).toBe("wifi_password: hunter2\n");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -352,6 +352,26 @@ describe("esphome-page-secrets initial load", () => {
     }
   });
 
+  test("a failed background reload keeps the rendered editor and toasts", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const getConfig = vi
+      .fn()
+      .mockResolvedValueOnce("wifi_password: hunter2\n")
+      .mockRejectedValueOnce(new APIError("internal_error", "boom"));
+    const page = await mountWithApi(getConfig);
+    expect(page._loadState).toBe("ready");
+    vi.mocked(toast.error).mockClear();
+
+    await page._loadFromServer();
+    await flushMicrotasks(8);
+
+    // The content is still in memory; demoting to the error panel would
+    // hide it behind an unnecessary Retry.
+    expect(page._loadState).toBe("ready");
+    expect(page._yaml).toBe("wifi_password: hunter2\n");
+    expect(toast.error).toHaveBeenCalled();
+  });
+
   test("an external save landing mid-load queues one fresh read", async () => {
     let settleFirst!: (yaml: string) => void;
     const getConfig = vi

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -46,6 +46,7 @@ interface PageView {
   _readStoredLayout(): "form" | "yaml" | null;
   _seedLayoutFromBackend(): Promise<void>;
   _loadFromServer(): Promise<void>;
+  _loadFailed: boolean;
   _setLayout(layout: "form" | "yaml"): void;
   _onYamlChange(e: CustomEvent<{ value: string }>): void;
   _confirmLeave(): Promise<boolean>;
@@ -290,6 +291,24 @@ describe("esphome-page-secrets initial load", () => {
     expect(page._yaml).not.toBe("");
     expect(page._savedYaml).toBe(page._yaml);
     expect(page._loaded).toBe(true);
+  });
+
+  test("does not template over the real file on a non-not-found server error", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const page = makePage();
+    page._api = {
+      ready: Promise.resolve(),
+      getConfig: vi.fn().mockRejectedValue(new APIError("internal_error", "boom")),
+    } as unknown as ESPHomeAPI;
+
+    await page._loadFromServer();
+
+    // An editable blank buffer here would parse to zero entries, slipping
+    // past the clear-all wipe confirm on the next save.
+    expect(page._yaml).toBe("");
+    expect(page._savedYaml).toBe("");
+    expect(page._loaded).toBe(false);
+    expect(page._loadFailed).toBe(true);
   });
 
   test("retries a transport failure instead of templating over the real file", async () => {

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -6,6 +6,7 @@ import toast from "sonner-js";
 import { APIError } from "../../src/api/api-error.js";
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import { ESPHomePageSecrets } from "../../src/pages/secrets.js";
+import { flushMicrotasks } from "../_dom.js";
 import {
   extractAttributeBindings,
   findTemplatesByAnchor,
@@ -14,6 +15,17 @@ import {
 vi.mock("sonner-js", () => ({
   default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
+
+// The load cells below mount the page for real, which upgrades these
+// children; Web Awesome's form-associated base and CodeMirror both crash
+// under happy-dom, and the render-only cells only inspect tag names.
+vi.mock("@home-assistant/webawesome/dist/components/button/button.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("../../src/components/confirm-dialog.js", () => ({}));
+vi.mock("../../src/components/secrets/secrets-structured-editor.js", () => ({}));
+vi.mock("../../src/components/unsaved-changes-dialog.js", () => ({}));
+vi.mock("../../src/components/yaml-editor.js", () => ({}));
 
 // Capture the save-shortcut callback the page wires so the gating closure
 // can be exercised without mounting (and binding a real window listener).
@@ -37,7 +49,7 @@ vi.mock("../../src/util/save-shortcut-controller.js", () => ({
  */
 
 interface PageView {
-  _loaded: boolean;
+  _loadState: "loading" | "ready" | "error";
   _yaml: string;
   _savedYaml: string;
   _saving: boolean;
@@ -46,7 +58,6 @@ interface PageView {
   _readStoredLayout(): "form" | "yaml" | null;
   _seedLayoutFromBackend(): Promise<void>;
   _loadFromServer(): Promise<void>;
-  _loadFailed: boolean;
   _setLayout(layout: "form" | "yaml"): void;
   _onYamlChange(e: CustomEvent<{ value: string }>): void;
   _confirmLeave(): Promise<boolean>;
@@ -62,7 +73,7 @@ interface PageView {
 
 function makePage(overrides: Partial<PageView> = {}): PageView {
   const page = new ESPHomePageSecrets() as unknown as PageView;
-  page._loaded = false;
+  page._loadState = "loading";
   page._yaml = "";
   page._savedYaml = "";
   page._saving = false;
@@ -72,7 +83,7 @@ function makePage(overrides: Partial<PageView> = {}): PageView {
 
 describe("esphome-page-secrets editor gating", () => {
   test("while loading: spinner is rendered, no editor, no save button", () => {
-    const tree = makePage({ _loaded: false }).render();
+    const tree = makePage({ _loadState: "loading" }).render();
     expect(findTemplatesByAnchor(tree, "<wa-spinner")).toHaveLength(1);
     expect(findTemplatesByAnchor(tree, "<esphome-yaml-editor")).toHaveLength(0);
     expect(findTemplatesByAnchor(tree, 'class="save-button"')).toHaveLength(0);
@@ -80,7 +91,7 @@ describe("esphome-page-secrets editor gating", () => {
 
   test("after load: editor is rendered with the loaded buffer, spinner gone", () => {
     const tree = makePage({
-      _loaded: true,
+      _loadState: "ready",
       _yaml: "wifi_password: hunter2\n",
       _savedYaml: "wifi_password: hunter2\n",
     }).render();
@@ -103,16 +114,16 @@ describe("esphome-page-secrets save-button disabled state", () => {
 
   test("disabled when buffer equals saved (no dirty state)", () => {
     const yaml = "wifi_password: hunter2\n";
-    expect(saveDisabled(makePage({ _loaded: true, _yaml: yaml, _savedYaml: yaml }))).toBe(
-      true
-    );
+    expect(
+      saveDisabled(makePage({ _loadState: "ready", _yaml: yaml, _savedYaml: yaml }))
+    ).toBe(true);
   });
 
   test("enabled when buffer differs from saved AND is non-empty", () => {
     expect(
       saveDisabled(
         makePage({
-          _loaded: true,
+          _loadState: "ready",
           _yaml: "wifi_password: new\n",
           _savedYaml: "wifi_password: old\n",
         })
@@ -126,7 +137,7 @@ describe("esphome-page-secrets save-button disabled state", () => {
     expect(
       saveDisabled(
         makePage({
-          _loaded: true,
+          _loadState: "ready",
           _yaml: "",
           _savedYaml: "wifi_password: hunter2\n",
         })
@@ -138,7 +149,7 @@ describe("esphome-page-secrets save-button disabled state", () => {
     expect(
       saveDisabled(
         makePage({
-          _loaded: true,
+          _loadState: "ready",
           _yaml: "   \n\n",
           _savedYaml: "wifi_password: hunter2\n",
         })
@@ -152,7 +163,7 @@ describe("esphome-page-secrets save-button disabled state", () => {
       resolveUpdate = r;
     });
     const page = makePage({
-      _loaded: true,
+      _loadState: "ready",
       _yaml: "wifi_password: new\n",
       _savedYaml: "wifi_password: old\n",
     });
@@ -179,7 +190,7 @@ describe("esphome-page-secrets clear-all wipe confirm (#1568)", () => {
   test("_save() clearing every secret confirms, then sends allow_wipe", async () => {
     const updateConfig = vi.fn().mockResolvedValue(undefined);
     const page = makePage({
-      _loaded: true,
+      _loadState: "ready",
       _yaml: "",
       _savedYaml: "wifi_password: hunter2\n",
     });
@@ -197,7 +208,7 @@ describe("esphome-page-secrets clear-all wipe confirm (#1568)", () => {
   test("_save() cancelled wipe writes nothing and keeps the saved buffer", async () => {
     const updateConfig = vi.fn().mockResolvedValue(undefined);
     const page = makePage({
-      _loaded: true,
+      _loadState: "ready",
       _yaml: "",
       _savedYaml: "wifi_password: hunter2\n",
     });
@@ -215,7 +226,7 @@ describe("esphome-page-secrets clear-all wipe confirm (#1568)", () => {
   test("_save() with secrets remaining does not confirm and omits allow_wipe", async () => {
     const updateConfig = vi.fn().mockResolvedValue(undefined);
     const page = makePage({
-      _loaded: true,
+      _loadState: "ready",
       _yaml: "wifi_password: new\n",
       _savedYaml: "wifi_password: old\n",
     });
@@ -232,7 +243,7 @@ describe("esphome-page-secrets clear-all wipe confirm (#1568)", () => {
   test("_save() editing an already-entry-less file does not confirm or send allow_wipe", async () => {
     const updateConfig = vi.fn().mockResolvedValue(undefined);
     const page = makePage({
-      _loaded: true,
+      _loadState: "ready",
       _yaml: "# new comment\n",
       _savedYaml: "# old comment\n",
     });
@@ -251,7 +262,7 @@ describe("esphome-page-secrets clear-all wipe confirm (#1568)", () => {
   test("_save() blanking an already-entry-less file sends allow_wipe without confirming", async () => {
     const updateConfig = vi.fn().mockResolvedValue(undefined);
     const page = makePage({
-      _loaded: true,
+      _loadState: "ready",
       _yaml: "",
       _savedYaml: "# only a comment\n",
     });
@@ -268,7 +279,7 @@ describe("esphome-page-secrets clear-all wipe confirm (#1568)", () => {
   });
 
   test("disconnect settles an open wipe confirm as cancelled (no dangling promise)", () => {
-    const page = makePage({ _loaded: true });
+    const page = makePage({ _loadState: "ready" });
     const settle = vi.fn();
     page._settlePendingWipe = settle;
 
@@ -279,57 +290,87 @@ describe("esphome-page-secrets clear-all wipe confirm (#1568)", () => {
 });
 
 describe("esphome-page-secrets initial load", () => {
-  test("seeds the header template only when the server says the file is missing", async () => {
-    const page = makePage();
-    page._api = {
+  // These drive the real mount path: the load aborts when the element is
+  // detached, so a bare constructor never reaches the server.
+  async function mountWithApi(getConfig: ReturnType<typeof vi.fn>): Promise<PageView> {
+    const page = new ESPHomePageSecrets();
+    (page as unknown as { _api: ESPHomeAPI })._api = {
       ready: Promise.resolve(),
-      getConfig: vi.fn().mockRejectedValue(new APIError("not_found", "missing")),
+      getConfig,
+      getPreferences: vi.fn().mockResolvedValue({}),
     } as unknown as ESPHomeAPI;
+    document.body.appendChild(page);
+    await flushMicrotasks(8);
+    return page as unknown as PageView;
+  }
 
-    await page._loadFromServer();
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("seeds the header template only when the server says the file is missing", async () => {
+    const page = await mountWithApi(
+      vi.fn().mockRejectedValue(new APIError("not_found", "missing"))
+    );
 
     expect(page._yaml).not.toBe("");
     expect(page._savedYaml).toBe(page._yaml);
-    expect(page._loaded).toBe(true);
+    expect(page._loadState).toBe("ready");
   });
 
   test("does not template over the real file on a non-not-found server error", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const page = makePage();
-    page._api = {
-      ready: Promise.resolve(),
-      getConfig: vi.fn().mockRejectedValue(new APIError("internal_error", "boom")),
-    } as unknown as ESPHomeAPI;
-
-    await page._loadFromServer();
+    const page = await mountWithApi(
+      vi.fn().mockRejectedValue(new APIError("internal_error", "boom"))
+    );
 
     // An editable blank buffer here would parse to zero entries, slipping
     // past the clear-all wipe confirm on the next save.
     expect(page._yaml).toBe("");
     expect(page._savedYaml).toBe("");
-    expect(page._loaded).toBe(false);
-    expect(page._loadFailed).toBe(true);
+    expect(page._loadState).toBe("error");
   });
 
   test("retries a transport failure instead of templating over the real file", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.useFakeTimers();
     try {
-      const page = makePage();
       const getConfig = vi
         .fn()
         .mockRejectedValueOnce(new Error("WebSocket connection closed"))
         .mockResolvedValueOnce("wifi_password: hunter2\n");
-      page._api = { ready: Promise.resolve(), getConfig } as unknown as ESPHomeAPI;
-
-      const loaded = page._loadFromServer();
+      const page = await mountWithApi(getConfig);
       await vi.advanceTimersByTimeAsync(2000);
-      await loaded;
+      await flushMicrotasks(8);
 
       // The real file wins; the blank template never reached the buffer.
       expect(getConfig).toHaveBeenCalledTimes(2);
       expect(page._yaml).toBe("wifi_password: hunter2\n");
       expect(page._savedYaml).toBe("wifi_password: hunter2\n");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("re-runs a failed load when the socket comes back", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+    try {
+      const getConfig = vi
+        .fn()
+        .mockRejectedValue(new Error("WebSocket connection closed"));
+      const page = await mountWithApi(getConfig);
+      await vi.advanceTimersByTimeAsync(1500 * 4);
+      await flushMicrotasks(8);
+      expect(page._loadState).toBe("error");
+
+      getConfig.mockResolvedValueOnce("wifi_password: hunter2\n");
+      (page as unknown as { _apiConnected: boolean })._apiConnected = true;
+      (page as unknown as { requestUpdate(): void }).requestUpdate();
+      await flushMicrotasks(8);
+
+      expect(page._loadState).toBe("ready");
     } finally {
       vi.useRealTimers();
     }
@@ -341,7 +382,7 @@ describe("esphome-page-secrets save toast ordering", () => {
     vi.mocked(toast.success).mockClear();
     vi.mocked(toast.error).mockClear();
     const page = makePage({
-      _loaded: true,
+      _loadState: "ready",
       _yaml: "wifi_password: new\n",
       _savedYaml: "wifi_password: old\n",
     });
@@ -362,7 +403,7 @@ describe("esphome-page-secrets save toast ordering", () => {
     vi.mocked(toast.success).mockClear();
     vi.mocked(toast.error).mockClear();
     const page = makePage({
-      _loaded: true,
+      _loadState: "ready",
       _yaml: "wifi_ssid: home\nxx:xxx\n",
       _savedYaml: "wifi_ssid: old\n",
     });
@@ -387,7 +428,7 @@ describe("esphome-page-secrets save toast ordering", () => {
     vi.mocked(toast.error).mockClear();
     let resolveUpdate!: () => void;
     const page = makePage({
-      _loaded: true,
+      _loadState: "ready",
       _yaml: "wifi_password: new\n",
       _savedYaml: "wifi_password: old\n",
     });
@@ -422,7 +463,7 @@ describe("esphome-page-secrets save toast ordering", () => {
     vi.mocked(toast.success).mockClear();
     vi.mocked(toast.error).mockClear();
     const page = makePage({
-      _loaded: true,
+      _loadState: "ready",
       _yaml: "wifi_password: new\n",
       _savedYaml: "wifi_password: old\n",
     });
@@ -441,7 +482,7 @@ describe("esphome-page-secrets save toast ordering", () => {
 
   test("_save() fires secrets-saved on the timeout-as-success path", async () => {
     const page = makePage({
-      _loaded: true,
+      _loadState: "ready",
       _yaml: "wifi_password: new\n",
       _savedYaml: "wifi_password: old\n",
     });
@@ -462,7 +503,7 @@ describe("esphome-page-secrets save toast ordering", () => {
 
   test("_save() does not fire secrets-saved on a real failure", async () => {
     const page = makePage({
-      _loaded: true,
+      _loadState: "ready",
       _yaml: "wifi_password: new\n",
       _savedYaml: "wifi_password: old\n",
     });
@@ -487,7 +528,7 @@ describe("esphome-page-secrets Cmd/Ctrl+S save shortcut wiring", () => {
     // Reset first so the assertion proves THIS construction wired the
     // shortcut, not a stale callback captured by an earlier test.
     capturedRef.onSave = undefined;
-    const page = makePage({ _loaded: true, ...overrides });
+    const page = makePage({ _loadState: "ready", ...overrides });
     const updateConfig = vi.fn().mockResolvedValue(undefined);
     page._api = { updateConfig } as unknown as ESPHomeAPI;
     // The page's field initializer constructed the (mocked) controller and
@@ -590,7 +631,7 @@ describe("esphome-page-secrets layout persistence", () => {
 
   test("the active editor binds the shared buffer across a layout switch", () => {
     const page = makePage({
-      _loaded: true,
+      _loadState: "ready",
       _layout: "form",
       _yaml: "wifi_ssid: home\n",
     });
@@ -622,14 +663,14 @@ describe("esphome-page-secrets layout persistence", () => {
 describe("esphome-page-secrets unsaved-changes leave guard", () => {
   function dirtyPage(): PageView {
     return makePage({
-      _loaded: true,
+      _loadState: "ready",
       _yaml: "wifi_ssid: new\n",
       _savedYaml: "wifi_ssid: old\n",
     });
   }
 
   test("a clean buffer leaves immediately without prompting", async () => {
-    const page = makePage({ _loaded: true, _yaml: "a: 1\n", _savedYaml: "a: 1\n" });
+    const page = makePage({ _loadState: "ready", _yaml: "a: 1\n", _savedYaml: "a: 1\n" });
     expect(await page._confirmLeave()).toBe(true);
   });
 

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import toast from "sonner-js";
 
+import "../_mock-webawesome.js";
 import { APIError } from "../../src/api/api-error.js";
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import { ESPHomePageSecrets } from "../../src/pages/secrets.js";
@@ -19,9 +20,8 @@ vi.mock("sonner-js", () => ({
 // The load cells below mount the page for real, which upgrades these
 // children; Web Awesome's form-associated base and CodeMirror both crash
 // under happy-dom, and the render-only cells only inspect tag names.
+// (_mock-webawesome covers icon/spinner; button isn't in the shared set.)
 vi.mock("@home-assistant/webawesome/dist/components/button/button.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 vi.mock("../../src/components/confirm-dialog.js", () => ({}));
 vi.mock("../../src/components/secrets/secrets-structured-editor.js", () => ({}));
 vi.mock("../../src/components/unsaved-changes-dialog.js", () => ({}));
@@ -304,10 +304,6 @@ describe("esphome-page-secrets initial load", () => {
     return page as unknown as PageView;
   }
 
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   test("seeds the header template only when the server says the file is missing", async () => {
     const page = await mountWithApi(
       vi.fn().mockRejectedValue(new APIError("not_found", "missing"))
@@ -372,7 +368,7 @@ describe("esphome-page-secrets initial load", () => {
     expect(toast.error).toHaveBeenCalled();
   });
 
-  test("an external save landing mid-load queues one fresh read", async () => {
+  test("an external save landing mid-load supersedes it with a fresh read", async () => {
     let settleFirst!: (yaml: string) => void;
     const getConfig = vi
       .fn()
@@ -381,7 +377,8 @@ describe("esphome-page-secrets initial load", () => {
     const page = await mountWithApi(getConfig);
 
     // The wizard wrote secrets.yaml while the mount's read was in
-    // flight; that reply predates the write, so joining it isn't enough.
+    // flight; that reply predates the write, so a fresh read must win
+    // and the stale one must be dropped even though it settles later.
     void page._loadFromServer();
     settleFirst("wifi_password: stale\n");
     await flushMicrotasks(8);

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+vi.mock("sonner-js", () => ({
+  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
 import toast from "sonner-js";
 
 import "../_mock-webawesome.js";
@@ -12,10 +16,6 @@ import {
   extractAttributeBindings,
   findTemplatesByAnchor,
 } from "../_lit-template-walker.js";
-
-vi.mock("sonner-js", () => ({
-  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
-}));
 
 // The load cells below mount the page for real, which upgrades these
 // children; Web Awesome's form-associated base and CodeMirror both crash

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -352,6 +352,25 @@ describe("esphome-page-secrets initial load", () => {
     }
   });
 
+  test("an external save landing mid-load queues one fresh read", async () => {
+    let settleFirst!: (yaml: string) => void;
+    const getConfig = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<string>((r) => (settleFirst = r)))
+      .mockResolvedValueOnce("wifi_password: fresh\n");
+    const page = await mountWithApi(getConfig);
+
+    // The wizard wrote secrets.yaml while the mount's read was in
+    // flight; that reply predates the write, so joining it isn't enough.
+    void page._loadFromServer();
+    settleFirst("wifi_password: stale\n");
+    await flushMicrotasks(8);
+
+    expect(getConfig).toHaveBeenCalledTimes(2);
+    expect(page._yaml).toBe("wifi_password: fresh\n");
+    expect(page._savedYaml).toBe("wifi_password: fresh\n");
+  });
+
   test("re-runs a failed load when the socket comes back", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/test/util/load-with-recovery.test.ts
+++ b/test/util/load-with-recovery.test.ts
@@ -103,6 +103,26 @@ describe("loadConfigWithRecovery", () => {
     await expect(result).resolves.toBeNull();
   });
 
+  it("drops a rejection that lands after the caller moved on", async () => {
+    let abandoned = false;
+    let fail!: (err: Error) => void;
+    const getConfig = vi.fn(
+      () => new Promise<string>((_resolve, reject) => (fail = reject))
+    );
+    const result = loadConfigWithRecovery(makeApi(getConfig), "kitchen.yaml", {
+      attempts: 4,
+      abandoned: () => abandoned,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    // A reused element has moved to the next id; the old load's terminal
+    // failure must not paint an error state over it.
+    abandoned = true;
+    fail(new APIError("not_found", "gone"));
+
+    await expect(result).resolves.toBeNull();
+  });
+
   it("stops retrying once the caller loses interest", async () => {
     const getConfig = vi.fn().mockRejectedValue(new Error("WebSocket closed"));
     let abandoned = false;

--- a/test/util/load-with-recovery.test.ts
+++ b/test/util/load-with-recovery.test.ts
@@ -1,16 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { APIError } from "../../src/api/api-error.js";
-import {
-  LoadAbandonedError,
-  loadWithRecovery,
-} from "../../src/util/load-with-recovery.js";
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import { loadConfigWithRecovery } from "../../src/util/load-with-recovery.js";
 
 /**
  * Pins the flaky-link fetch policy: transport faults retry, server
  * replies are final, and an outage costs no attempts.
  */
 
-describe("loadWithRecovery", () => {
+function makeApi(
+  getConfig: ReturnType<typeof vi.fn>,
+  ready: Promise<void> = Promise.resolve()
+): ESPHomeAPI {
+  return { ready, getConfig } as unknown as ESPHomeAPI;
+}
+
+describe("loadConfigWithRecovery", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -21,60 +26,60 @@ describe("loadWithRecovery", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns the value without retrying when the first attempt works", async () => {
-    const load = vi.fn().mockResolvedValue("yaml");
+  it("returns the config without retrying when the first attempt works", async () => {
+    const getConfig = vi.fn().mockResolvedValue("yaml");
     await expect(
-      loadWithRecovery({ ready: () => Promise.resolve(), load })
+      loadConfigWithRecovery(makeApi(getConfig), "kitchen.yaml", { attempts: 4 })
     ).resolves.toBe("yaml");
-    expect(load).toHaveBeenCalledTimes(1);
+    expect(getConfig).toHaveBeenCalledTimes(1);
   });
 
   it("retries a transport fault after the backoff", async () => {
-    const load = vi
+    const getConfig = vi
       .fn()
       .mockRejectedValueOnce(new Error("WebSocket connection closed"))
       .mockResolvedValueOnce("yaml");
-    const result = loadWithRecovery({ ready: () => Promise.resolve(), load });
+    const result = loadConfigWithRecovery(makeApi(getConfig), "kitchen.yaml", {
+      attempts: 4,
+    });
 
     await vi.advanceTimersByTimeAsync(1500);
     await expect(result).resolves.toBe("yaml");
-    expect(load).toHaveBeenCalledTimes(2);
+    expect(getConfig).toHaveBeenCalledTimes(2);
   });
 
   it("rethrows an APIError immediately — the server already answered", async () => {
     const err = new APIError("not_found", "gone");
-    const load = vi.fn().mockRejectedValue(err);
-    await expect(loadWithRecovery({ ready: () => Promise.resolve(), load })).rejects.toBe(
-      err
-    );
-    expect(load).toHaveBeenCalledTimes(1);
+    const getConfig = vi.fn().mockRejectedValue(err);
+    await expect(
+      loadConfigWithRecovery(makeApi(getConfig), "kitchen.yaml", { attempts: 4 })
+    ).rejects.toBe(err);
+    expect(getConfig).toHaveBeenCalledTimes(1);
   });
 
   it("surfaces the transport fault once the attempt budget is spent", async () => {
-    const load = vi.fn().mockRejectedValue(new Error("timed out"));
+    const getConfig = vi.fn().mockRejectedValue(new Error("timed out"));
     // Attach the rejection handler before pumping timers, or the failure
     // lands unhandled mid-advance.
     const settled = expect(
-      loadWithRecovery({ ready: () => Promise.resolve(), load, attempts: 3 })
+      loadConfigWithRecovery(makeApi(getConfig), "kitchen.yaml", { attempts: 3 })
     ).rejects.toThrow("timed out");
 
     await vi.advanceTimersByTimeAsync(1500 * 3);
     await settled;
-    expect(load).toHaveBeenCalledTimes(3);
+    expect(getConfig).toHaveBeenCalledTimes(3);
   });
 
   it("spends no attempts while the connection is down", async () => {
     let release!: () => void;
     const parked = new Promise<void>((resolve) => (release = resolve));
-    const load = vi.fn().mockResolvedValue("yaml");
-    const result = loadWithRecovery({
-      ready: () => parked,
-      load,
+    const getConfig = vi.fn().mockResolvedValue("yaml");
+    const result = loadConfigWithRecovery(makeApi(getConfig, parked), "kitchen.yaml", {
       attempts: 1,
     });
 
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(load).not.toHaveBeenCalled();
+    expect(getConfig).not.toHaveBeenCalled();
 
     release();
     await expect(result).resolves.toBe("yaml");
@@ -83,14 +88,11 @@ describe("loadWithRecovery", () => {
   it("drops a value that resolves after the caller moved on", async () => {
     let abandoned = false;
     let settle!: (v: string) => void;
-    const load = vi.fn(() => new Promise<string>((resolve) => (settle = resolve)));
-    const settled = expect(
-      loadWithRecovery({
-        ready: () => Promise.resolve(),
-        load,
-        abandoned: () => abandoned,
-      })
-    ).rejects.toBeInstanceOf(LoadAbandonedError);
+    const getConfig = vi.fn(() => new Promise<string>((resolve) => (settle = resolve)));
+    const result = loadConfigWithRecovery(makeApi(getConfig), "kitchen.yaml", {
+      attempts: 4,
+      abandoned: () => abandoned,
+    });
 
     await vi.advanceTimersByTimeAsync(0);
     // The id moved on (or the page unmounted) mid-flight; the late reply
@@ -98,25 +100,23 @@ describe("loadWithRecovery", () => {
     abandoned = true;
     settle("stale yaml");
 
-    await settled;
+    await expect(result).resolves.toBeNull();
   });
 
-  it("abandons instead of retrying once the caller loses interest", async () => {
-    const load = vi.fn().mockRejectedValue(new Error("WebSocket closed"));
+  it("stops retrying once the caller loses interest", async () => {
+    const getConfig = vi.fn().mockRejectedValue(new Error("WebSocket closed"));
     let abandoned = false;
-    const settled = expect(
-      loadWithRecovery({
-        ready: () => Promise.resolve(),
-        load,
-        abandoned: () => abandoned,
-      })
-    ).rejects.toBeInstanceOf(LoadAbandonedError);
+    const result = loadConfigWithRecovery(makeApi(getConfig), "kitchen.yaml", {
+      attempts: 4,
+      abandoned: () => abandoned,
+    });
 
     await vi.advanceTimersByTimeAsync(0);
     abandoned = true;
     await vi.advanceTimersByTimeAsync(1500);
 
-    await settled;
-    expect(load).toHaveBeenCalledTimes(1);
+    await expect(result).resolves.toBeNull();
+    // Bailed before spending the backoff, not after it.
+    expect(getConfig).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/util/load-with-recovery.test.ts
+++ b/test/util/load-with-recovery.test.ts
@@ -80,6 +80,27 @@ describe("loadWithRecovery", () => {
     await expect(result).resolves.toBe("yaml");
   });
 
+  it("drops a value that resolves after the caller moved on", async () => {
+    let abandoned = false;
+    let settle!: (v: string) => void;
+    const load = vi.fn(() => new Promise<string>((resolve) => (settle = resolve)));
+    const settled = expect(
+      loadWithRecovery({
+        ready: () => Promise.resolve(),
+        load,
+        abandoned: () => abandoned,
+      })
+    ).rejects.toBeInstanceOf(LoadAbandonedError);
+
+    await vi.advanceTimersByTimeAsync(0);
+    // The id moved on (or the page unmounted) mid-flight; the late reply
+    // must not be committed over the newer load's state.
+    abandoned = true;
+    settle("stale yaml");
+
+    await settled;
+  });
+
   it("abandons instead of retrying once the caller loses interest", async () => {
     const load = vi.fn().mockRejectedValue(new Error("WebSocket closed"));
     let abandoned = false;

--- a/test/util/load-with-recovery.test.ts
+++ b/test/util/load-with-recovery.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { APIError } from "../../src/api/api-error.js";
+import {
+  LoadAbandonedError,
+  loadWithRecovery,
+} from "../../src/util/load-with-recovery.js";
+
+/**
+ * Pins the flaky-link fetch policy: transport faults retry, server
+ * replies are final, and an outage costs no attempts.
+ */
+
+describe("loadWithRecovery", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("returns the value without retrying when the first attempt works", async () => {
+    const load = vi.fn().mockResolvedValue("yaml");
+    await expect(
+      loadWithRecovery({ ready: () => Promise.resolve(), load })
+    ).resolves.toBe("yaml");
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a transport fault after the backoff", async () => {
+    const load = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("WebSocket connection closed"))
+      .mockResolvedValueOnce("yaml");
+    const result = loadWithRecovery({ ready: () => Promise.resolve(), load });
+
+    await vi.advanceTimersByTimeAsync(1500);
+    await expect(result).resolves.toBe("yaml");
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("rethrows an APIError immediately — the server already answered", async () => {
+    const err = new APIError("not_found", "gone");
+    const load = vi.fn().mockRejectedValue(err);
+    await expect(loadWithRecovery({ ready: () => Promise.resolve(), load })).rejects.toBe(
+      err
+    );
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the transport fault once the attempt budget is spent", async () => {
+    const load = vi.fn().mockRejectedValue(new Error("timed out"));
+    // Attach the rejection handler before pumping timers, or the failure
+    // lands unhandled mid-advance.
+    const settled = expect(
+      loadWithRecovery({ ready: () => Promise.resolve(), load, attempts: 3 })
+    ).rejects.toThrow("timed out");
+
+    await vi.advanceTimersByTimeAsync(1500 * 3);
+    await settled;
+    expect(load).toHaveBeenCalledTimes(3);
+  });
+
+  it("spends no attempts while the connection is down", async () => {
+    let release!: () => void;
+    const parked = new Promise<void>((resolve) => (release = resolve));
+    const load = vi.fn().mockResolvedValue("yaml");
+    const result = loadWithRecovery({
+      ready: () => parked,
+      load,
+      attempts: 1,
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(load).not.toHaveBeenCalled();
+
+    release();
+    await expect(result).resolves.toBe("yaml");
+  });
+
+  it("abandons instead of retrying once the caller loses interest", async () => {
+    const load = vi.fn().mockRejectedValue(new Error("WebSocket closed"));
+    let abandoned = false;
+    const settled = expect(
+      loadWithRecovery({
+        ready: () => Promise.resolve(),
+        load,
+        abandoned: () => abandoned,
+      })
+    ).rejects.toBeInstanceOf(LoadAbandonedError);
+
+    await vi.advanceTimersByTimeAsync(0);
+    abandoned = true;
+    await vi.advanceTimersByTimeAsync(1500);
+
+    await settled;
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/util/logs-launch.test.ts
+++ b/test/util/logs-launch.test.ts
@@ -91,22 +91,23 @@ describe("launchLogs", () => {
     }
   });
 
-  it("opens OTA logs after the probe timeout when the lookup hangs", async () => {
+  it("bounds the serial-port probe so a hung lookup still opens OTA logs", async () => {
     const restore = withWebSerial(false);
-    vi.useFakeTimers();
     try {
-      const host = makeHost(() => new Promise(() => {}));
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      const host = makeHost(async () => {
+        throw new Error('Command "config/serial_ports" timed out after 2500ms');
+      });
       const openPicker = vi.fn();
-      const launched = launchLogs(host, makeDevice(), openPicker);
+      await launchLogs(host, makeDevice(), openPicker);
 
-      await vi.advanceTimersByTimeAsync(2500);
-      await launched;
-
+      // The probe passes the short bound down to the command layer, so the
+      // wire timeout is what fires on a degraded link.
+      expect(host.api.getSerialPorts).toHaveBeenCalledWith(2500);
       expect(openPicker).not.toHaveBeenCalled();
       expect(host.logsDialog.open).toHaveBeenCalledTimes(1);
       expect(host.logsDialog.configuration).toBe("kitchen.yaml");
     } finally {
-      vi.useRealTimers();
       restore();
     }
   });

--- a/test/util/logs-launch.test.ts
+++ b/test/util/logs-launch.test.ts
@@ -90,6 +90,26 @@ describe("launchLogs", () => {
       restore();
     }
   });
+
+  it("opens OTA logs after the probe timeout when the lookup hangs", async () => {
+    const restore = withWebSerial(false);
+    vi.useFakeTimers();
+    try {
+      const host = makeHost(() => new Promise(() => {}));
+      const openPicker = vi.fn();
+      const launched = launchLogs(host, makeDevice(), openPicker);
+
+      await vi.advanceTimersByTimeAsync(2500);
+      await launched;
+
+      expect(openPicker).not.toHaveBeenCalled();
+      expect(host.logsDialog.open).toHaveBeenCalledTimes(1);
+      expect(host.logsDialog.configuration).toBe("kitchen.yaml");
+    } finally {
+      vi.useRealTimers();
+      restore();
+    }
+  });
 });
 
 describe("launchLogsWithMethod", () => {

--- a/test/util/logs-launch.test.ts
+++ b/test/util/logs-launch.test.ts
@@ -1,4 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+import toast from "sonner-js";
+import { CommandTimeoutError } from "../../src/api/index.js";
 import type { ConfiguredDevice } from "../../src/api/types/devices.js";
 import type { LogsLaunchHost } from "../../src/util/logs-launch.js";
 import { launchLogs, launchLogsWithMethod } from "../../src/util/logs-launch.js";
@@ -96,7 +103,7 @@ describe("launchLogs", () => {
     try {
       vi.spyOn(console, "warn").mockImplementation(() => {});
       const host = makeHost(async () => {
-        throw new Error('Command "config/serial_ports" timed out after 2500ms');
+        throw new CommandTimeoutError("config/serial_ports", 2500);
       });
       const openPicker = vi.fn();
       await launchLogs(host, makeDevice(), openPicker);
@@ -107,6 +114,24 @@ describe("launchLogs", () => {
       expect(openPicker).not.toHaveBeenCalled();
       expect(host.logsDialog.open).toHaveBeenCalledTimes(1);
       expect(host.logsDialog.configuration).toBe("kitchen.yaml");
+      // A timeout isn't an answer: say the probe was skipped rather than
+      // let the serial option silently vanish for a user who has one.
+      expect(toast.info).toHaveBeenCalledWith(
+        "dashboard.logs_serial_probe_timeout",
+        expect.anything()
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("stays quiet when the server genuinely reports no serial ports", async () => {
+    vi.mocked(toast.info).mockClear();
+    const restore = withWebSerial(false);
+    try {
+      const host = makeHost(async () => []);
+      await launchLogs(host, makeDevice(), vi.fn());
+      expect(toast.info).not.toHaveBeenCalled();
     } finally {
       restore();
     }

--- a/test/util/logs-launch.test.ts
+++ b/test/util/logs-launch.test.ts
@@ -117,7 +117,28 @@ describe("launchLogs", () => {
       // A timeout isn't an answer: say the probe was skipped rather than
       // let the serial option silently vanish for a user who has one.
       expect(toast.info).toHaveBeenCalledWith(
-        "dashboard.logs_serial_probe_timeout",
+        "dashboard.logs_serial_probe_failed",
+        expect.anything()
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("says the probe was skipped when the socket drops mid-probe", async () => {
+    vi.mocked(toast.info).mockClear();
+    const restore = withWebSerial(false);
+    try {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      const host = makeHost(async () => {
+        throw new Error("WebSocket connection closed");
+      });
+      await launchLogs(host, makeDevice(), vi.fn());
+
+      // A transport fault is no more an answer than a timeout.
+      expect(host.logsDialog.open).toHaveBeenCalledTimes(1);
+      expect(toast.info).toHaveBeenCalledWith(
+        "dashboard.logs_serial_probe_failed",
         expect.anything()
       );
     } finally {

--- a/test/util/navigation.test.ts
+++ b/test/util/navigation.test.ts
@@ -81,7 +81,7 @@ describe("navigate", () => {
 
     expect(pushStateSpy).toHaveBeenCalledTimes(1);
     expect(pushStateSpy).toHaveBeenCalledWith(
-      { n: expect.any(Number) },
+      { d: expect.any(String), n: expect.any(Number) },
       "",
       "/dashboard"
     );
@@ -133,7 +133,11 @@ describe("navigate", () => {
 
     await navigate("/");
 
-    expect(pushStateSpy).toHaveBeenCalledWith({ n: expect.any(Number) }, "", "/");
+    expect(pushStateSpy).toHaveBeenCalledWith(
+      { d: expect.any(String), n: expect.any(Number) },
+      "",
+      "/"
+    );
     const popstateCalls = dispatchSpy.mock.calls.filter(
       (call) => (call[0] as Event).type === "popstate"
     );
@@ -149,7 +153,7 @@ describe("navigate", () => {
 
     expect(guard).not.toHaveBeenCalled();
     expect(pushStateSpy).toHaveBeenCalledWith(
-      { n: expect.any(Number) },
+      { d: expect.any(String), n: expect.any(Number) },
       "",
       "/dashboard"
     );
@@ -169,7 +173,11 @@ describe("navigate", () => {
 
     expect(stale).not.toHaveBeenCalled();
     expect(fresh).toHaveBeenCalledTimes(1);
-    expect(pushStateSpy).toHaveBeenCalledWith({ n: expect.any(Number) }, "", "/");
+    expect(pushStateSpy).toHaveBeenCalledWith(
+      { d: expect.any(String), n: expect.any(Number) },
+      "",
+      "/"
+    );
   });
 
   it("awaits an asynchronous guard before pushing state", async () => {
@@ -196,7 +204,7 @@ describe("navigate", () => {
     await navPromise;
 
     expect(pushStateSpy).toHaveBeenCalledWith(
-      { n: expect.any(Number) },
+      { d: expect.any(String), n: expect.any(Number) },
       "",
       "/dashboard"
     );
@@ -357,7 +365,11 @@ describe("goBackOrHome", () => {
     expect(backSpy).not.toHaveBeenCalled();
     // navigate() owns the guard on this branch — exactly one prompt.
     expect(guard).toHaveBeenCalledTimes(1);
-    expect(pushStateSpy).toHaveBeenCalledWith({ n: expect.any(Number) }, "", "/");
+    expect(pushStateSpy).toHaveBeenCalledWith(
+      { d: expect.any(String), n: expect.any(Number) },
+      "",
+      "/"
+    );
   });
 
   it("fallback navigation honours a blocking guard", async () => {

--- a/test/util/navigation.test.ts
+++ b/test/util/navigation.test.ts
@@ -80,7 +80,11 @@ describe("navigate", () => {
     await navigate("/dashboard");
 
     expect(pushStateSpy).toHaveBeenCalledTimes(1);
-    expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/dashboard");
+    expect(pushStateSpy).toHaveBeenCalledWith(
+      { n: expect.any(Number) },
+      "",
+      "/dashboard"
+    );
     const popstateCalls = dispatchSpy.mock.calls.filter(
       (call) => (call[0] as Event).type === "popstate"
     );
@@ -129,7 +133,7 @@ describe("navigate", () => {
 
     await navigate("/");
 
-    expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/");
+    expect(pushStateSpy).toHaveBeenCalledWith({ n: expect.any(Number) }, "", "/");
     const popstateCalls = dispatchSpy.mock.calls.filter(
       (call) => (call[0] as Event).type === "popstate"
     );
@@ -144,7 +148,11 @@ describe("navigate", () => {
     await navigate("/dashboard");
 
     expect(guard).not.toHaveBeenCalled();
-    expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/dashboard");
+    expect(pushStateSpy).toHaveBeenCalledWith(
+      { n: expect.any(Number) },
+      "",
+      "/dashboard"
+    );
   });
 
   it("uses the latest registered guard when multiple are set in sequence", async () => {
@@ -161,7 +169,7 @@ describe("navigate", () => {
 
     expect(stale).not.toHaveBeenCalled();
     expect(fresh).toHaveBeenCalledTimes(1);
-    expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/");
+    expect(pushStateSpy).toHaveBeenCalledWith({ n: expect.any(Number) }, "", "/");
   });
 
   it("awaits an asynchronous guard before pushing state", async () => {
@@ -187,7 +195,11 @@ describe("navigate", () => {
     resolveGuard?.(true);
     await navPromise;
 
-    expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/dashboard");
+    expect(pushStateSpy).toHaveBeenCalledWith(
+      { n: expect.any(Number) },
+      "",
+      "/dashboard"
+    );
   });
 });
 
@@ -345,7 +357,7 @@ describe("goBackOrHome", () => {
     expect(backSpy).not.toHaveBeenCalled();
     // navigate() owns the guard on this branch — exactly one prompt.
     expect(guard).toHaveBeenCalledTimes(1);
-    expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/");
+    expect(pushStateSpy).toHaveBeenCalledWith({ n: expect.any(Number) }, "", "/");
   });
 
   it("fallback navigation honours a blocking guard", async () => {

--- a/test/util/render-async-state.test.ts
+++ b/test/util/render-async-state.test.ts
@@ -25,7 +25,23 @@ describe("renderAsyncState", () => {
       renderAsyncState({ loading: true, loadingMessage: "checking", error: "", content })
     );
     expect(t.strings.join("")).toMatch(/^<div class="message" role="status">.*<\/div>$/);
-    expect(t.values).toEqual(["checking"]);
+    // No loadingLead supplied, so its slot renders nothing.
+    expect(t.values).toEqual([nothing, "checking"]);
+  });
+
+  it("renders the loading lead ahead of the message", () => {
+    const t = asTemplate(
+      renderAsyncState({
+        loading: true,
+        loadingMessage: "checking",
+        loadingLead: () => html`<wa-spinner></wa-spinner>`,
+        error: "",
+        content,
+      })
+    );
+    expect(t.values).toHaveLength(2);
+    expect(asTemplate(t.values[0]).strings.join("")).toContain("<wa-spinner>");
+    expect(t.values[1]).toBe("checking");
   });
 
   it("prefers the loading branch when both loading and error are set", () => {
@@ -38,7 +54,7 @@ describe("renderAsyncState", () => {
       })
     );
     expect(t.strings.join("")).toContain('role="status"');
-    expect(t.values).toEqual(["checking"]);
+    expect(t.values).toEqual([nothing, "checking"]);
   });
 
   it("renders an alert-role message on error", () => {

--- a/test/util/render-async-state.test.ts
+++ b/test/util/render-async-state.test.ts
@@ -34,7 +34,7 @@ describe("renderAsyncState", () => {
       renderAsyncState({
         loading: true,
         loadingMessage: "checking",
-        loadingLead: () => html`<wa-spinner></wa-spinner>`,
+        loadingLead: html`<wa-spinner></wa-spinner>`,
         error: "",
         content,
       })


### PR DESCRIPTION
# What does this implement/fix?

On a flaky connection, clicking Edit gave no feedback while the lazy device page chunk downloaded, and a failed chunk load cancelled the navigation silently. The editor then mounted with an empty buffer until getConfig returned, and any failure left a blank page with no way forward. This PR makes every wait visible and every failure recoverable.

**Navigation.** Both lazy routes go through a shared `lazyEnter`. It shows a thin progress bar in the header once a chunk load runs past 200ms, retries once, and toasts if the load still fails so the click never silently does nothing. A chunk that lands after the user has navigated elsewhere resolves false rather than yanking them into a stale route, an exhausted load undoes its own history push so the address bar cannot describe a page that never mounted, and overlapping loads share a pending count so they cannot hide each other's bar. Route chunks now carry `webpackPrefetch`, so the browser fills its cache at idle priority without executing 600KB of module side effects on every app start, and `output.chunkLoadTimeout` drops from the 120s default to 30s so a stalled request cannot stretch the retry loop into minutes; the setting is global, so the value leaves headroom for the imports that have no retry path and for a slow-but-working download. The two route navigations that hand-rolled their own pushState, the dashboard's Edit action and the wizard's post-create redirect, now go through `navigate()`; the failure rollback depends on its history stamp, and they pick up the leave guard for free.

**Config loads.** The device page mounts the editor and navigator only after the YAML arrives, with a spinner while it loads. Both page loads run through one `loadConfigWithRecovery`, which waits on `api.ready` so opening a page during a reconnect window waits for the socket instead of throwing, and retries transport faults with a backoff rather than surfacing them. That last part is the reason the panel used to appear almost instantly: a dropped socket rejects every in flight request at once, so a blip mid fetch read as a hard failure within milliseconds. Attempts are only spent while the socket is up, so an outage of any length keeps the spinner and then loads on its own, and a reply that lands after the caller moved on is dropped rather than committed under the new device's id. The initial fetch also carries a 30s bound instead of the 10s command default, since a large YAML on a degraded link is slow rather than broken. When the attempts do run out, both pages show a retry panel and then re-run themselves on the next successful connect, so the failure heals without a click.

A config that no longer exists is treated differently everywhere: the server answered, so it is terminal. The device page gets a "no longer exists" state with a way back to the dashboard instead of an unwinnable Retry, and the secrets page seeds its blank header template only for that specific reply. Previously any server error seeded it, which templated over a real secrets.yaml; because the seeded buffer parses to zero entries, the clear all wipe confirmation was bypassed and the next save could replace a file that was still intact on disk.

**Elsewhere in the shell.** A reconnecting pill appears when the WebSocket drops, gated behind an 800ms timer so a momentary blip is silent both visually and for screen readers. The logs button's serial port probe passes a 2.5s bound to `sendCommand`'s existing per call timeout, and any probe failure, timeout or transport fault, tells the user the check was skipped rather than silently losing the serial option. Timeouts now reject with a typed `CommandTimeoutError` (message unchanged, so existing string matches keep working) for callers that need to tell "we gave up waiting" from "there is nothing there".

Verified live against the dev stack with CDP throttling: holding the device chunk shows the bar; throttling to 2KB/s and then dropping the network mid fetch keeps the spinner up and loads the YAML unattended once the network returns; killing the backend shows the pill alongside the spinner; and a deep link to a config that does not exist shows the terminal state. Install needed no change, as its dialog already opens instantly with a ports spinner.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1514

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

