### PR TITLE
Centralize the popstate leave guard in a controller

### DIFF
--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -51,7 +51,6 @@ import {
   resolveBackendErrors,
   type BackendFieldError,
 } from "../util/backend-field-errors.js";
-import { withBase } from "../util/base-path.js";
 import { fetchBoard } from "../util/board-body-cache.js";
 import { applyBoardChange, openBoardReselect } from "../util/board-change.js";
 import { showPendingChanges, showUpdateAvailable } from "../util/device-sync.js";
@@ -60,12 +59,7 @@ import { followActiveJob } from "../util/firmware-job-display.js";
 import { consumeJustCreated } from "../util/just-created.js";
 import { loadConfigWithRecovery } from "../util/load-with-recovery.js";
 import { renderAsyncState } from "../util/render-async-state.js";
-import {
-  consumePopGuardSuppression,
-  goBackOrHome,
-  navigate,
-  setLeaveGuard,
-} from "../util/navigation.js";
+import { goBackOrHome, navigate, PopLeaveGuardController } from "../util/navigation.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { isTypingTarget } from "../util/typing-target.js";
@@ -462,8 +456,18 @@ export class ESPHomePageDevice extends LitElement {
    *  lets the logic be unit-tested in node without happy-dom. */
   private _unsavedGuard = new UnsavedGuard();
 
-  /** When true, the next popstate is allowed to fall through to the router. */
-  private _allowingLeave = false;
+  readonly _leaveGuard = new PopLeaveGuardController(this, {
+    confirmLeave: () => this._confirmLeave(),
+    // Fails conservative via ``_sectionDirty`` (round pending) plus
+    // ``lastFlushFailed`` (round settled as failed), same as beforeunload
+    // (#1503); the flush kick rides here so it runs only for a real
+    // leave, after the controller's suppression checks.
+    isDirty: () => {
+      this._kickSectionFlush();
+      return this._isDirty || (this._activeSection?.lastFlushFailed ?? false);
+    },
+    url: () => `/device/${this.id}`,
+  });
 
   private get _isYamlDirty(): boolean {
     return this._yaml !== this._savedYaml;
@@ -494,29 +498,6 @@ export class ESPHomePageDevice extends LitElement {
     return this._isYamlDirty || this._sectionDirty;
   }
 
-  /* ``_allowingLeave`` is flipped BEFORE the guard Promise
-   * resolves so the page-leave callers see a coherent state on
-   * the next microtask:
-   *
-   *   - The browser-back path ``.then``s on the resolved
-   *     Promise and calls ``history.back()`` itself.
-   *   - ``navigate()`` (in-app Back / logo click) on
-   *     ``canLeave=true`` does ``pushState + dispatchEvent(popstate)``
-   *     synchronously. That synthetic popstate would otherwise
-   *     be re-intercepted by ``_onPopState`` (because ``_isDirty``
-   *     stays true — Discard doesn't revert the buffer) and
-   *     bounced back to the device URL, leaving the user stuck.
-   *     Flipping the flag here short-circuits that.
-   *
-   * The flip happens inside the page-leave save lambda (so it
-   * lands synchronously before the guard's resolve when the
-   * user picks Save) and again in ``_confirmLeave`` after the
-   * await (so it covers the Discard path too — Discard doesn't
-   * route through the save lambda). The redundant write on Save
-   * is idempotent. The section-switch guard never sets the flag
-   * — its ``save`` returns to the page synchronously after the
-   * await without leaving the page.
-   */
   private _onUnsavedDiscard = () => this._unsavedGuard.onDiscard();
   private _onUnsavedSave = () => this._unsavedGuard.onSave();
   private _onUnsavedCancel = () => this._unsavedGuard.onCancel();
@@ -584,11 +565,9 @@ export class ESPHomePageDevice extends LitElement {
           notifyError(this._localize("device.leave_last_change_unsaved"));
           return false;
         }
-        this._allowingLeave = true;
         return true;
       },
     });
-    if (ok) this._allowingLeave = true;
     return ok;
   };
 
@@ -606,49 +585,17 @@ export class ESPHomePageDevice extends LitElement {
     }
   };
 
-  private _onPopState = (e: PopStateEvent) => {
-    // A failed route chunk rolling back its own push is a return to
-    // this page, not a leave.
-    if (consumePopGuardSuppression()) return;
-    if (this._allowingLeave) {
-      this._allowingLeave = false;
-      return;
-    }
-    // Synchronous by contract (the popped entry must be re-pushed
-    // in the same task); the dirty pre-check fails conservative via
-    // ``_sectionDirty`` (round pending) plus ``lastFlushFailed``
-    // (round settled as failed), same as beforeunload (#1503).
-    this._kickSectionFlush();
-    if (!this._isDirty && !this._activeSection?.lastFlushFailed) return;
-    e.stopImmediatePropagation();
-    window.history.pushState({}, "", withBase(`/device/${this.id}`));
-    this._confirmLeave()
-      .then((canLeave) => {
-        if (canLeave) {
-          this._allowingLeave = true;
-          window.history.back();
-        }
-      })
-      // The entry was already re-pushed, so staying put is the
-      // fail-safe on an unexpected guard failure.
-      .catch((err) => console.error("Leave confirmation failed:", err));
-  };
-
   async connectedCallback() {
     super.connectedCallback();
     void this._loadPreferences();
-    setLeaveGuard(this._confirmLeave);
     window.addEventListener("beforeunload", this._onBeforeUnload);
-    window.addEventListener("popstate", this._onPopState, { capture: true });
     window.addEventListener("keydown", this._onKeydown);
     this._mql.addEventListener("change", this._onMqlChange);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    setLeaveGuard(null);
     window.removeEventListener("beforeunload", this._onBeforeUnload);
-    window.removeEventListener("popstate", this._onPopState, { capture: true });
     window.removeEventListener("keydown", this._onKeydown);
     this._mql.removeEventListener("change", this._onMqlChange);
     // Drop any in-flight unsaved-changes guard so its caller's

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -456,7 +456,7 @@ export class ESPHomePageDevice extends LitElement {
    *  lets the logic be unit-tested in node without happy-dom. */
   private _unsavedGuard = new UnsavedGuard();
 
-  readonly _leaveGuard = new PopLeaveGuardController(this, {
+  protected readonly _leaveGuard = new PopLeaveGuardController(this, {
     confirmLeave: () => this._confirmLeave(),
     // Fails conservative via ``_sectionDirty`` (round pending) plus
     // ``lastFlushFailed`` (round settled as failed), same as beforeunload

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -115,7 +115,7 @@ export class ESPHomePageSecrets extends LitElement {
     }
   });
 
-  readonly _leaveGuard = new PopLeaveGuardController(this, {
+  protected readonly _leaveGuard = new PopLeaveGuardController(this, {
     confirmLeave: () => this._confirmLeave(),
     isDirty: () => this._isDirty,
     url: () => "/secrets",

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -17,13 +17,13 @@ import type { ESPHomeUnsavedChangesDialog } from "../components/unsaved-changes-
 import { apiConnectedContext, apiContext, localizeContext } from "../context/index.js";
 import { loadMessageStyles } from "../styles/load-message.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { withBase } from "../util/base-path.js";
+
 import {
   prefToSecretsLayout,
   secretsLayoutToPref,
   type SecretsLayout,
 } from "../util/editor-layout.js";
-import { consumePopGuardSuppression, setLeaveGuard } from "../util/navigation.js";
+import { PopLeaveGuardController } from "../util/navigation.js";
 import { loadConfigWithRecovery } from "../util/load-with-recovery.js";
 import { notifyError, notifySuccess } from "../util/notify.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -115,9 +115,11 @@ export class ESPHomePageSecrets extends LitElement {
     }
   });
 
-  // Set true once the leave guard has cleared a navigation, so the
-  // synthetic popstate it triggers isn't re-intercepted.
-  private _allowingLeave = false;
+  readonly _leaveGuard = new PopLeaveGuardController(this, {
+    confirmLeave: () => this._confirmLeave(),
+    isDirty: () => this._isDirty,
+    url: () => "/secrets",
+  });
 
   // Resolver for an in-flight wipe confirm, settled (as cancelled) on
   // disconnect so the awaiting _save() can't hang if the page unmounts
@@ -133,9 +135,7 @@ export class ESPHomePageSecrets extends LitElement {
       // No local choice (new browser): restore from the backend pref.
       void this._seedLayoutFromBackend();
     }
-    setLeaveGuard(this._confirmLeave);
     window.addEventListener("beforeunload", this._onBeforeUnload);
-    window.addEventListener("popstate", this._onPopState, { capture: true });
     window.addEventListener(
       "secrets-saved",
       this._onExternalSecretsSaved as EventListener
@@ -183,9 +183,7 @@ export class ESPHomePageSecrets extends LitElement {
   }
 
   disconnectedCallback() {
-    setLeaveGuard(null);
     window.removeEventListener("beforeunload", this._onBeforeUnload);
-    window.removeEventListener("popstate", this._onPopState, { capture: true });
     this._unsavedGuard.cancelPending();
     // A wipe confirm open at unmount resolves as cancelled, never dangling.
     this._settlePendingWipe?.(false);
@@ -203,17 +201,11 @@ export class ESPHomePageSecrets extends LitElement {
   // In-app navigation (nav links, header back arrow, command palette) runs
   // this through ``runLeaveGuard``; prompt to save / discard when dirty.
   private _confirmLeave = async (): Promise<boolean> => {
-    const ok = await this._unsavedGuard.run({
+    return this._unsavedGuard.run({
       dirty: this._isDirty,
       open: () => this._unsavedDialog?.open(),
-      save: async () => {
-        const saved = await this._save();
-        if (saved) this._allowingLeave = true;
-        return saved;
-      },
+      save: () => this._save(),
     });
-    if (ok) this._allowingLeave = true;
-    return ok;
   };
 
   // Native tab / window close: a dirty buffer triggers the browser's own
@@ -223,28 +215,6 @@ export class ESPHomePageSecrets extends LitElement {
       e.preventDefault();
       e.returnValue = "";
     }
-  };
-
-  // The browser back/forward buttons fire popstate straight at the router,
-  // bypassing ``navigate``; re-assert our URL and run the guard, then replay
-  // the back once the user has decided.
-  private _onPopState = (e: PopStateEvent) => {
-    // A failed route chunk rolling back its own push is a return to
-    // this page, not a leave.
-    if (consumePopGuardSuppression()) return;
-    if (this._allowingLeave) {
-      this._allowingLeave = false;
-      return;
-    }
-    if (!this._isDirty) return;
-    e.stopImmediatePropagation();
-    window.history.pushState({}, "", withBase("/secrets"));
-    void this._confirmLeave().then((canLeave) => {
-      if (canLeave) {
-        this._allowingLeave = true;
-        window.history.back();
-      }
-    });
   };
 
   private _onUnsavedDiscard = () => this._unsavedGuard.onDiscard();

--- a/src/util/navigation.ts
+++ b/src/util/navigation.ts
@@ -11,7 +11,7 @@ export function setLeaveGuard(guard: LeaveGuard | null): void {
 
 /** Clear only while *guard* is still the active one — a departing page
  *  must not disarm a successor that already registered. */
-export function clearLeaveGuard(guard: LeaveGuard): void {
+function clearLeaveGuard(guard: LeaveGuard): void {
   if (activeGuard === guard) activeGuard = null;
 }
 

--- a/src/util/navigation.ts
+++ b/src/util/navigation.ts
@@ -9,6 +9,12 @@ export function setLeaveGuard(guard: LeaveGuard | null): void {
   activeGuard = guard;
 }
 
+/** Clear only while *guard* is still the active one — a departing page
+ *  must not disarm a successor that already registered. */
+export function clearLeaveGuard(guard: LeaveGuard): void {
+  if (activeGuard === guard) activeGuard = null;
+}
+
 // history.state survives a reload while module state doesn't, so the
 // counter alone can't tell a fresh push from a pre-reload entry whose
 // number happens to collide; the token scopes the stamp to this document.
@@ -140,7 +146,7 @@ export class PopLeaveGuardController implements ReactiveController {
   }
 
   hostDisconnected(): void {
-    setLeaveGuard(null);
+    clearLeaveGuard(this._guard);
     window.removeEventListener("popstate", this.handlePopState, { capture: true });
     this._allowingLeave = false;
   }

--- a/src/util/navigation.ts
+++ b/src/util/navigation.ts
@@ -43,7 +43,7 @@ export async function runLeaveGuard(): Promise<boolean> {
 /** True when the current entry carries a non-null object state (a
  *  ``navigate()`` stamp or a guard's re-push) rather than a fresh page
  *  load, so there is a same-session entry to pop back to. */
-export function hasPushedHistoryEntry(): boolean {
+function hasPushedHistoryEntry(): boolean {
   return window.history.state !== null && typeof window.history.state === "object";
 }
 
@@ -81,7 +81,8 @@ export function popPushedEntrySilently(): void {
   window.history.back();
 }
 
-/** One-shot check page popstate guards consume before intercepting. */
+/** One-shot check the pop-guard controller consumes before intercepting.
+ *  Exported for tests; production consumers live in this module. */
 export function consumePopGuardSuppression(): boolean {
   const suppressed = popGuardSuppressed;
   popGuardSuppressed = false;

--- a/src/util/navigation.ts
+++ b/src/util/navigation.ts
@@ -1,3 +1,4 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { withBase } from "./base-path.js";
 
 export type LeaveGuard = () => Promise<boolean>;
@@ -85,6 +86,87 @@ export function consumePopGuardSuppression(): boolean {
   const suppressed = popGuardSuppressed;
   popGuardSuppressed = false;
   return suppressed;
+}
+
+export interface PopLeaveGuardOptions {
+  /** The page's confirm-dialog flow; also registered as the active leave
+   *  guard for ``navigate()`` / ``goBackOrHome()``. */
+  confirmLeave: () => Promise<boolean>;
+  /** Read at popstate time, after the suppression and allow checks; may
+   *  have side effects (the device page kicks its section flush here). */
+  isDirty: () => boolean;
+  /** Un-based path re-asserted while the prompt is open. */
+  url: () => string;
+}
+
+/**
+ * Owns a page's popstate leave-guard: intercepts a dirty Back/Forward,
+ * re-asserts the page URL, runs the confirm flow, and replays the pop on
+ * proceed. Registers the confirm flow as the active leave guard for the
+ * host's connected lifetime.
+ */
+export class PopLeaveGuardController implements ReactiveController {
+  /* The allow flag is flipped inside the wrapped guard BEFORE its caller
+   * resumes, so the callers' own popstates fall through instead of being
+   * re-intercepted while the buffer is still dirty (Discard doesn't
+   * revert it):
+   *
+   *   - ``navigate()`` on ``canLeave=true`` does ``pushState +
+   *     dispatchEvent(popstate)`` synchronously after the guard resolves.
+   *   - The intercepted-pop replay below calls ``history.back()``.
+   *
+   * Microtasks run to completion, so no popstate task can interleave
+   * between the confirm resolving and the flag write. */
+  private _allowingLeave = false;
+
+  private readonly _guard: LeaveGuard;
+
+  constructor(
+    host: ReactiveControllerHost,
+    private readonly _opts: PopLeaveGuardOptions
+  ) {
+    this._guard = async () => {
+      const ok = await this._opts.confirmLeave();
+      if (ok) this._allowingLeave = true;
+      return ok;
+    };
+    host.addController(this);
+  }
+
+  hostConnected(): void {
+    setLeaveGuard(this._guard);
+    window.addEventListener("popstate", this.handlePopState, { capture: true });
+  }
+
+  hostDisconnected(): void {
+    setLeaveGuard(null);
+    window.removeEventListener("popstate", this.handlePopState, { capture: true });
+    this._allowingLeave = false;
+  }
+
+  readonly handlePopState = (e: PopStateEvent) => {
+    // A failed route chunk rolling back its own push is a return to the
+    // page, not a leave.
+    if (consumePopGuardSuppression()) return;
+    if (this._allowingLeave) {
+      this._allowingLeave = false;
+      return;
+    }
+    // Only now: the dirty check may side-effect (section-flush kick).
+    if (!this._opts.isDirty()) return;
+    e.stopImmediatePropagation();
+    // Synchronous by contract: the popped entry is re-pushed in the same
+    // task. Plain ``{}`` state — a navigate() stamp here would let the
+    // router's rollback treat a guard re-push as a fresh push.
+    window.history.pushState({}, "", withBase(this._opts.url()));
+    this._guard()
+      .then((canLeave) => {
+        if (canLeave) window.history.back();
+      })
+      // The entry was already re-pushed, so staying put is the fail-safe
+      // on an unexpected guard failure.
+      .catch((err) => console.error("Leave confirmation failed:", err));
+  };
 }
 
 /**

--- a/test/pages/device-escape-leave.test.ts
+++ b/test/pages/device-escape-leave.test.ts
@@ -34,7 +34,7 @@ interface EscapeView {
   } | null;
   _onKeydown(e: KeyboardEvent): void;
   _onBeforeUnload(e: BeforeUnloadEvent): void;
-  _onPopState(e: PopStateEvent): void;
+  _leaveGuard: { handlePopState(e: PopStateEvent): void };
   _onUnsavedDiscard(): void;
   _onUnsavedCancel(): void;
   _confirmLeave(): Promise<boolean>;
@@ -393,7 +393,7 @@ describe("leave guard flush ordering (#1503)", () => {
     page._activeSection = section;
 
     const stopImmediatePropagation = vi.fn();
-    page._onPopState({
+    page._leaveGuard.handlePopState({
       stopImmediatePropagation,
     } as unknown as PopStateEvent);
     await flush();

--- a/test/pages/device-escape-leave.test.ts
+++ b/test/pages/device-escape-leave.test.ts
@@ -49,8 +49,9 @@ function makePage(): { page: EscapeView; dialogOpen: ReturnType<typeof vi.fn> } 
   // ``_unsavedDialog`` is a @query getter on the prototype; shadow it so the
   // guard's ``open`` lands on the spy without mounting the component tree.
   Object.defineProperty(page, "_unsavedDialog", { value: { open: dialogOpen } });
-  // Mirror connectedCallback's registration — the piece of mounting the
-  // Escape path actually depends on.
+  // Register the raw confirm as the leave guard — production registers
+  // the controller's wrapped guard, but these cells only exercise the
+  // confirm flow, not the allow-flag handshake.
   setLeaveGuard(page._confirmLeave);
   return { page, dialogOpen };
 }

--- a/test/util/navigation.test.ts
+++ b/test/util/navigation.test.ts
@@ -21,12 +21,11 @@
  * The MasterOfNone bug (Discard does nothing on the in-app Back
  * button while the visual editor's Save left ``_isDirty=true``)
  * traced to the synthetic popstate that ``navigate()`` fires
- * being re-intercepted by the device-page's popstate guard. The
- * fix landed in ``pages/device.ts`` (``_onLeaveDiscard`` /
- * ``_onLeaveSave`` flip ``_allowingLeave=true`` before resolving),
- * but the tests here pin the underlying ``navigate`` contract so
- * a future refactor that drops the synthetic popstate or skips
- * the guard surfaces immediately.
+ * being re-intercepted by the page's popstate guard. That guard
+ * (now ``PopLeaveGuardController``) sets its allow flag before the
+ * guard Promise resolves, but the tests here pin the underlying
+ * ``navigate`` contract so a future refactor that drops the
+ * synthetic popstate or skips the guard surfaces immediately.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -124,10 +123,9 @@ describe("navigate", () => {
     // Mirrors the Discard-from-unsaved-changes-dialog flow: the
     // page's guard opens a dialog, the user clicks Discard, the
     // dialog resolves the Promise to true, and ``navigate`` then
-    // pushes the new URL synchronously. The device-page popstate
-    // listener is supposed to short-circuit on the synthetic
-    // popstate that follows (via ``_allowingLeave``), which is
-    // the bit the MasterOfNone bug missed.
+    // pushes the new URL synchronously. PopLeaveGuardController
+    // short-circuits on the synthetic popstate that follows (its
+    // allow flag), which is the bit the MasterOfNone bug missed.
     const guard = vi.fn(() => Promise.resolve(true));
     setLeaveGuard(guard);
 

--- a/test/util/pop-leave-guard-controller.test.ts
+++ b/test/util/pop-leave-guard-controller.test.ts
@@ -149,15 +149,26 @@ describe("PopLeaveGuardController", () => {
   });
 
   it("resets the allow flag when the host disconnects", async () => {
-    const first = connect();
+    const { host } = connect();
     await runLeaveGuard();
-    first.host.disconnect();
+    host.disconnect();
+    host.connect();
 
-    const second = connect();
     const e = popState();
     window.dispatchEvent(e);
-    // A fresh page must not inherit the previous page's answered leave.
+    // A remounted page must not inherit its previous mount's answered
+    // leave — the pop intercepts instead of falling through.
     expect(e.stopImmediatePropagation).toHaveBeenCalledTimes(1);
-    void second;
+  });
+
+  it("a departing controller doesn't disarm a successor's guard", async () => {
+    const first = connect();
+    const second = connect();
+    first.host.disconnect();
+
+    await expect(runLeaveGuard()).resolves.toBe(true);
+    // Ownership check: only the active guard's owner may clear it.
+    expect(second.confirm).toHaveBeenCalledTimes(1);
+    expect(first.confirm).not.toHaveBeenCalled();
   });
 });

--- a/test/util/pop-leave-guard-controller.test.ts
+++ b/test/util/pop-leave-guard-controller.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactiveController } from "lit";
+import {
+  PopLeaveGuardController,
+  consumePopGuardSuppression,
+  popPushedEntrySilently,
+  runLeaveGuard,
+} from "../../src/util/navigation.js";
+import { flushMicrotasks } from "../_dom.js";
+
+/**
+ * Pins the centralized popstate leave-guard: suppression first, one-shot
+ * allow fall-through, dirty intercept with same-task re-push, and replay
+ * only on confirm.
+ */
+
+class FakeHost {
+  private _controllers: ReactiveController[] = [];
+  addController(c: ReactiveController) {
+    this._controllers.push(c);
+  }
+  removeController() {}
+  requestUpdate() {}
+  updateComplete = Promise.resolve(true);
+  connect() {
+    for (const c of this._controllers) c.hostConnected?.();
+  }
+  disconnect() {
+    for (const c of this._controllers) c.hostDisconnected?.();
+  }
+}
+
+function makeGuard(opts?: { dirty?: () => boolean; confirm?: () => Promise<boolean> }) {
+  const host = new FakeHost();
+  const confirm = vi.fn(opts?.confirm ?? (() => Promise.resolve(true)));
+  const dirty = vi.fn(opts?.dirty ?? (() => true));
+  const controller = new PopLeaveGuardController(host, {
+    confirmLeave: confirm,
+    isDirty: dirty,
+    url: () => "/secrets",
+  });
+  host.connect();
+  return { host, confirm, dirty, controller };
+}
+
+function popState(): PopStateEvent {
+  const e = new PopStateEvent("popstate");
+  vi.spyOn(e, "stopImmediatePropagation");
+  return e;
+}
+
+describe("PopLeaveGuardController", () => {
+  let hosts: FakeHost[];
+  let pushState: ReturnType<typeof vi.spyOn>;
+  let back: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    hosts = [];
+    consumePopGuardSuppression();
+    pushState = vi.spyOn(window.history, "pushState").mockImplementation(() => {});
+    back = vi.spyOn(window.history, "back").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    for (const host of hosts) host.disconnect();
+    vi.restoreAllMocks();
+  });
+
+  const connect = (opts?: Parameters<typeof makeGuard>[0]) => {
+    const made = makeGuard(opts);
+    hosts.push(made.host);
+    return made;
+  };
+
+  it("registers the confirm flow as the active leave guard for its lifetime", async () => {
+    const { host, confirm } = connect();
+    await expect(runLeaveGuard()).resolves.toBe(true);
+    expect(confirm).toHaveBeenCalledTimes(1);
+
+    host.disconnect();
+    await expect(runLeaveGuard()).resolves.toBe(true);
+    // Guard cleared with the host, so leaving no longer consults it.
+    expect(confirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("intercepts a dirty pop, re-pushes in the same task, and replays on confirm", async () => {
+    const { confirm } = connect();
+    const e = popState();
+    window.dispatchEvent(e);
+
+    expect(e.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    // Plain {} state: a navigate() stamp here would read as a fresh push
+    // to the router's rollback.
+    expect(pushState).toHaveBeenCalledWith({}, "", "/secrets");
+    await flushMicrotasks(4);
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(back).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays put when the confirm resolves false", async () => {
+    connect({ confirm: () => Promise.resolve(false) });
+    window.dispatchEvent(popState());
+    await flushMicrotasks(4);
+    expect(back).not.toHaveBeenCalled();
+  });
+
+  it("logs and stays put when the confirm rejects", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    connect({ confirm: () => Promise.reject(new Error("boom")) });
+    window.dispatchEvent(popState());
+    await flushMicrotasks(4);
+    expect(back).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith("Leave confirmation failed:", expect.any(Error));
+  });
+
+  it("lets a clean pop fall through untouched", () => {
+    connect({ dirty: () => false });
+    const e = popState();
+    window.dispatchEvent(e);
+    expect(e.stopImmediatePropagation).not.toHaveBeenCalled();
+    expect(pushState).not.toHaveBeenCalled();
+  });
+
+  it("consumes the rollback suppression before the dirty check", () => {
+    const { dirty } = connect();
+    popPushedEntrySilently();
+    const e = popState();
+    window.dispatchEvent(e);
+
+    // A suppressed pop is a return to the page: no intercept, and the
+    // side-effectful dirty check must not run.
+    expect(dirty).not.toHaveBeenCalled();
+    expect(e.stopImmediatePropagation).not.toHaveBeenCalled();
+    expect(consumePopGuardSuppression()).toBe(false);
+  });
+
+  it("allows exactly one pop through after an answered guard", async () => {
+    const { dirty } = connect();
+    await runLeaveGuard();
+
+    window.dispatchEvent(popState());
+    // The answered leave's own popstate falls through without re-checking.
+    expect(dirty).not.toHaveBeenCalled();
+
+    const second = popState();
+    window.dispatchEvent(second);
+    expect(second.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the allow flag when the host disconnects", async () => {
+    const first = connect();
+    await runLeaveGuard();
+    first.host.disconnect();
+
+    const second = connect();
+    const e = popState();
+    window.dispatchEvent(e);
+    // A fresh page must not inherit the previous page's answered leave.
+    expect(e.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    void second;
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

First of the two consolidations from #1516. The device and secrets pages each hand rolled the same capture phase popstate leave guard: consume the router rollback suppression, check an `_allowingLeave` flag, dirty check, `stopImmediatePropagation`, re push their own URL, run the confirm dialog, replay `history.back()` on proceed. The copies had already drifted (only device caught a guard rejection), and the suppression flag was a cross module handshake that existed only because interception lived in the pages while the rollback lived in the router.

The guard now lives in one place: `PopLeaveGuardController` in `navigation.ts`. A page constructs it with three callbacks (`confirmLeave`, `isDirty`, `url`); the controller registers the confirm flow as the active leave guard for the host's connected lifetime, owns the allow flag handshake (set inside the wrapped guard before its caller resumes, so `navigate()`'s synthetic popstate and the intercepted pop replay both fall through instead of re prompting), and consumes the rollback suppression before anything else. Both pages delete their `_onPopState`, their `_allowingLeave` flag and all its writes, and their manual guard registration; a future guarded page gets the precedence right by registering instead of re deriving it. `hasPushedHistoryEntry` loses its export (its last external importer is gone) and `consumePopGuardSuppression`'s remaining production consumers are all inside `navigation.ts`.

Deliberate edges, none behavioural in practice: secrets' confirm rejection is now logged and stays put instead of surfacing as an unhandled rejection (device's existing policy); guard registration timing moves inside the pages' `super.` lifecycle calls, which is a synchronous block with no observable window. The two traps the old code enforced are preserved and now pinned by the controller's own suite: the re push keeps plain `{}` state so the router's rollback never mistakes a guard re push for a fresh `navigate()` push, and the side effectful dirty check (device kicks its section flush there) runs only after the suppression and allow checks.

**Related issue or feature (if applicable):**

- part of #1516

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
