### PR TITLE
Extract the page YAML-load ladder into a controller

### DIFF
--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -336,7 +336,7 @@ export class ESPHomePageDevice extends LitElement {
    *  instead of an empty editor. A transport failure offers a retry;
    *  a NOT_FOUND config (deleted, renamed, stale bookmark) is terminal,
    *  so it routes back to the dashboard instead. */
-  readonly _load = new ConfigLoadController(this, {
+  protected readonly _load = new ConfigLoadController(this, {
     api: () => this._api,
     connected: () => this._apiConnected,
     configuration: () => this.id,

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -5,7 +5,7 @@ import { cache } from "lit/directives/cache.js";
 import { classMap } from "lit/directives/class-map.js";
 import { customElement, property, query, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
-import { type ESPHomeAPI, isApiErrorCode } from "../api/index.js";
+import type { ESPHomeAPI } from "../api/index.js";
 import type { BoardCatalogEntry } from "../api/types/boards.js";
 import type { ConfiguredDevice } from "../api/types/devices.js";
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
@@ -57,7 +57,7 @@ import { showPendingChanges, showUpdateAvailable } from "../util/device-sync.js"
 import { deviceLayoutToPref, prefToDeviceLayout } from "../util/editor-layout.js";
 import { followActiveJob } from "../util/firmware-job-display.js";
 import { consumeJustCreated } from "../util/just-created.js";
-import { loadConfigWithRecovery } from "../util/load-with-recovery.js";
+import { ConfigLoadController } from "../util/config-load-controller.js";
 import { renderAsyncState } from "../util/render-async-state.js";
 import { goBackOrHome, navigate, PopLeaveGuardController } from "../util/navigation.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
@@ -115,13 +115,6 @@ registerMdiIcons({
   "chevron-right": mdiChevronRight,
   menu: mdiMenu,
 });
-
-// The user is staring at a spinner, so the initial config fetch gets a
-// longer leash than the 10s command default: a big YAML over a degraded
-// link is slow, not broken. Attempts burn only while the socket is up
-// (``ready`` parks otherwise), so an outage never spends them.
-const LOAD_YAML_TIMEOUT_MS = 30_000;
-const LOAD_YAML_ATTEMPTS = 4;
 
 @customElement("esphome-page-device")
 export class ESPHomePageDevice extends LitElement {
@@ -224,7 +217,7 @@ export class ESPHomePageDevice extends LitElement {
    *  ``_maybeResolveLineFromUrl`` once the YAML is loaded. Kept apart
    *  from ``_selectedFromLine`` — that field is durable section-instance
    *  state the URL round-trips, so parking the intent there would
-   *  re-derive focus on every later ``_loadYaml`` (board swap). */
+   *  re-derive focus on every later load (board swap). */
   private _pendingUrlLine?: number = this._readUrlLine();
 
   /** Instance-relative field path the YAML cursor is on, for the form to
@@ -343,8 +336,24 @@ export class ESPHomePageDevice extends LitElement {
    *  instead of an empty editor. A transport failure offers a retry;
    *  a NOT_FOUND config (deleted, renamed, stale bookmark) is terminal,
    *  so it routes back to the dashboard instead. */
-  @state()
-  private _yamlState: "loading" | "ready" | "error" | "missing" = "loading";
+  readonly _load = new ConfigLoadController(this, {
+    api: () => this._api,
+    connected: () => this._apiConnected,
+    configuration: () => this.id,
+    // The user is staring at a spinner, so the initial fetch gets a
+    // longer leash than the 10s command default: a big YAML over a
+    // degraded link is slow, not broken.
+    attempts: 4,
+    timeoutMs: 30_000,
+    commit: (yaml) => {
+      this._yaml = yaml;
+      this._savedYaml = yaml;
+    },
+    // Outside the failure path: a resolver throw must not repaint a
+    // loaded config as a load failure.
+    onReady: () => this._maybeResolveLineFromUrl(),
+    onApiError: (err) => (err.errorCode === ErrorCode.NOT_FOUND ? "missing" : undefined),
+  });
 
   @state()
   private _savedYaml = "";
@@ -633,16 +642,6 @@ export class ESPHomePageDevice extends LitElement {
   };
 
   updated(changedProperties: Map<string, unknown>) {
-    // Socket is back: a load that gave up while it was down goes again
-    // without the user hunting for the Retry button. "missing" is a server
-    // answer, so it stays put.
-    if (
-      changedProperties.has("_apiConnected") &&
-      this._apiConnected &&
-      this._yamlState === "error"
-    ) {
-      this._retryLoadYaml();
-    }
     if (changedProperties.has("id") && this.id) {
       // Consume the wizard's "just-created" handoff once per id. Each
       // call to consumeJustCreated atomically reads + clears the flag,
@@ -668,7 +667,7 @@ export class ESPHomePageDevice extends LitElement {
       // YAML rides the reused element and Save writes it to this file.
       this._yaml = "";
       this._savedYaml = "";
-      void this._loadYaml();
+      void this._load.start();
     }
     // Devices context arrives async after connect; kick off the board
     // fetch as soon as we have a `board_id` (and re-fetch only when it
@@ -781,39 +780,6 @@ export class ESPHomePageDevice extends LitElement {
       }
     }
   }
-
-  /** Bumped per load; a superseded loop self-cancels via ``abandoned``,
-   *  so an a → b → a switch can't commit the first load's stale reply. */
-  private _loadGen = 0;
-
-  private async _loadYaml() {
-    const id = this.id;
-    const gen = ++this._loadGen;
-    this._yamlState = "loading";
-    let yaml: string | null;
-    try {
-      yaml = await loadConfigWithRecovery(this._api, id, {
-        // Unmount counts as abandoned too, or a slow load keeps fetching
-        // (and re-rendering) against a page that is already gone.
-        abandoned: () => !this.isConnected || this.id !== id || gen !== this._loadGen,
-        attempts: LOAD_YAML_ATTEMPTS,
-        timeoutMs: LOAD_YAML_TIMEOUT_MS,
-      });
-    } catch (e) {
-      console.error("Failed to load YAML:", e);
-      this._yamlState = isApiErrorCode(e, ErrorCode.NOT_FOUND) ? "missing" : "error";
-      return;
-    }
-    if (yaml === null) return;
-    this._yaml = yaml;
-    this._savedYaml = yaml;
-    this._yamlState = "ready";
-    // Outside the catch: a resolver throw must not repaint a loaded
-    // config as a load failure.
-    this._maybeResolveLineFromUrl();
-  }
-
-  private _retryLoadYaml = () => void this._loadYaml();
 
   /**
    * Consume the one-shot ``?line=`` intent once the YAML has loaded.
@@ -1271,7 +1237,7 @@ export class ESPHomePageDevice extends LitElement {
         @yaml-draft=${this._onYamlDraft}
         @nav-collapse=${this._onNavCollapse}
       >
-        ${this._yamlState === "ready" ? this._renderNavigator("drawer-nav") : nothing}
+        ${this._load.state === "ready" ? this._renderNavigator("drawer-nav") : nothing}
       </div>
 
       <div class="page">
@@ -1279,7 +1245,7 @@ export class ESPHomePageDevice extends LitElement {
           class=${classMap({
             "layout-grid": true,
             "nav-collapsed": this._navCollapsed,
-            "load-state": this._yamlState !== "ready",
+            "load-state": this._load.state !== "ready",
           })}
           @section-toggle=${this._onSectionToggle}
           @section-reveal=${this._onSectionReveal}
@@ -1304,7 +1270,7 @@ export class ESPHomePageDevice extends LitElement {
           @update-device=${this._saveThenUpdate}
         >
           ${cache(
-            this._yamlState === "ready"
+            this._load.state === "ready"
               ? this._renderEditor(deviceTitle, showEdgeTab, backLabel)
               : this._renderLoadState()
           )}
@@ -1580,8 +1546,8 @@ export class ESPHomePageDevice extends LitElement {
   /** The editor's stand-in until the config lands. A gone config is
    *  terminal, so it offers a way out rather than a retry. */
   private _renderLoadState() {
-    const loading = this._yamlState === "loading";
-    const missing = this._yamlState === "missing";
+    const loading = this._load.state === "loading";
+    const missing = this._load.state === "missing";
     return renderAsyncState({
       loading,
       loadingMessage: this._localize("device.loading_config"),
@@ -1592,7 +1558,7 @@ export class ESPHomePageDevice extends LitElement {
       errorActions: () =>
         html`<wa-button
           size="small"
-          @click=${missing ? () => navigate("/") : this._retryLoadYaml}
+          @click=${missing ? () => navigate("/") : this._load.retry}
         >
           ${this._localize(missing ? "device.back_to_dashboard" : "command.retry")}
         </wa-button>`,

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -6,9 +6,9 @@ import {
   mdiEyeOff,
   mdiFormTextbox,
 } from "@mdi/js";
-import { html, LitElement, type PropertyValues } from "lit";
+import { html, LitElement } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
-import { apiErrorDetails, isApiErrorCode } from "../api/api-error.js";
+import { apiErrorDetails } from "../api/api-error.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import { ErrorCode } from "../api/types/protocol.js";
 import type { LocalizeFunc } from "../common/localize.js";
@@ -24,7 +24,7 @@ import {
   type SecretsLayout,
 } from "../util/editor-layout.js";
 import { PopLeaveGuardController } from "../util/navigation.js";
-import { loadConfigWithRecovery } from "../util/load-with-recovery.js";
+import { ConfigLoadController } from "../util/config-load-controller.js";
 import { notifyError, notifySuccess } from "../util/notify.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { renderAsyncState } from "../util/render-async-state.js";
@@ -50,10 +50,6 @@ registerMdiIcons({
 });
 
 const SECRETS_FILE = "secrets.yaml";
-
-// Transport attempts before the load surfaces as an error the user can
-// retry; attempts are only spent while the socket is up.
-const LOAD_ATTEMPTS = 4;
 
 const LAYOUT_STORAGE_KEY = "esphome-secrets-layout";
 const LAYOUTS: readonly SecretsLayout[] = ["form", "yaml"];
@@ -81,12 +77,27 @@ export class ESPHomePageSecrets extends LitElement {
   @state()
   private _saving = false;
 
-  @state()
-  private _loadState: "loading" | "ready" | "error" = "loading";
-
-  /** Bumped per load; a superseded loop self-cancels via ``abandoned``,
-   *  so a fresh read (external save) never settles on a stale reply. */
-  private _loadGen = 0;
+  readonly _load = new ConfigLoadController(this, {
+    api: () => this._api,
+    connected: () => this._apiConnected,
+    configuration: () => SECRETS_FILE,
+    attempts: 4,
+    commit: (yaml) => {
+      this._yaml = yaml;
+      this._savedYaml = yaml;
+    },
+    // Only a NOT_FOUND reply seeds the header template (first run, no
+    // secrets.yaml yet). Any other failure must not: an editable blank
+    // buffer parses to zero entries, which slips past the clear-all wipe
+    // confirm and lets the next save replace a file still intact on disk.
+    onApiError: (err) =>
+      err.errorCode === ErrorCode.NOT_FOUND
+        ? { seed: this._localize("secrets.file_header") }
+        : undefined,
+    // A reload over a rendered buffer keeps the content on screen and
+    // surfaces the staleness instead of the error panel.
+    onRefreshFailed: () => notifyError(this._localize("secrets.reload_failed")),
+  });
 
   // Mirrors the device editor's per-field reveal toggle. Default
   // hidden so values render as bullets the moment the page paints —
@@ -140,19 +151,7 @@ export class ESPHomePageSecrets extends LitElement {
       "secrets-saved",
       this._onExternalSecretsSaved as EventListener
     );
-    await this._loadFromServer();
-  }
-
-  protected updated(changed: PropertyValues) {
-    // Socket is back: a load that gave up while it was down goes again
-    // without the user hunting for the Retry button.
-    if (
-      changed.has("_apiConnected") &&
-      this._apiConnected &&
-      this._loadState === "error"
-    ) {
-      void this._loadFromServer();
-    }
+    await this._load.start();
   }
 
   private _readStoredLayout(): SecretsLayout | null {
@@ -221,51 +220,6 @@ export class ESPHomePageSecrets extends LitElement {
   private _onUnsavedSave = () => this._unsavedGuard.onSave();
   private _onUnsavedCancel = () => this._unsavedGuard.onCancel();
 
-  /**
-   * Pull `secrets.yaml` from the server and reset both buffers.
-   *
-   * Only a NOT_FOUND reply seeds the localized header template. Any other
-   * failure leaves the buffers empty behind the error state: an editable
-   * blank buffer would parse to zero entries, which slips past the
-   * clear-all wipe confirm and lets the next save replace a file that is
-   * still intact on disk.
-   */
-  private async _loadFromServer(): Promise<void> {
-    const gen = ++this._loadGen;
-    if (this._loadState === "error") this._loadState = "loading";
-    let yaml: string | null;
-    try {
-      yaml = await loadConfigWithRecovery(this._api, SECRETS_FILE, {
-        abandoned: () => !this.isConnected || gen !== this._loadGen,
-        attempts: LOAD_ATTEMPTS,
-      });
-    } catch (err) {
-      if (isApiErrorCode(err, ErrorCode.NOT_FOUND)) {
-        // First run: no secrets.yaml yet, so offer the header as a start.
-        yaml = this._localize("secrets.file_header");
-      } else {
-        console.error("Failed to load secrets.yaml:", err);
-        // A reload over a rendered buffer keeps the content on screen
-        // and surfaces the staleness; only a load with nothing behind
-        // it gets the error panel.
-        if (this._loadState === "ready") {
-          notifyError(this._localize("secrets.reload_failed"));
-        } else {
-          this._loadState = "error";
-        }
-        return;
-      }
-    }
-    // Null means the page is gone or a newer load took over; leave the
-    // buffers to it.
-    if (yaml === null) return;
-    this._yaml = yaml;
-    this._savedYaml = yaml;
-    this._loadState = "ready";
-  }
-
-  private _retryLoad = () => void this._loadFromServer();
-
   /** Another component (typically the onboarding wizard) just
    *  wrote `secrets.yaml`. Reload from the server so the editor
    *  doesn't show stale content. Skip when this page initiated
@@ -276,7 +230,7 @@ export class ESPHomePageSecrets extends LitElement {
   private _onExternalSecretsSaved = (e: CustomEvent<{ source: EventTarget }>) => {
     if (e.detail?.source === this) return;
     if (this._yaml !== this._savedYaml) return;
-    void this._loadFromServer();
+    void this._load.refresh();
   };
 
   static styles = [espHomeStyles, loadMessageStyles, secretsStyles];
@@ -331,13 +285,13 @@ export class ESPHomePageSecrets extends LitElement {
         </div>
         <div class="editor-card">
           ${renderAsyncState({
-            loading: this._loadState === "loading",
+            loading: this._load.state === "loading",
             loadingMessage: this._localize("secrets.loading"),
             loadingLead: html`<wa-spinner></wa-spinner>`,
             error:
-              this._loadState === "error" ? this._localize("secrets.load_failed") : null,
+              this._load.state === "error" ? this._localize("secrets.load_failed") : null,
             errorActions: () =>
-              html`<wa-button size="small" @click=${this._retryLoad}>
+              html`<wa-button size="small" @click=${this._load.retry}>
                 ${this._localize("command.retry")}
               </wa-button>`,
             content: () => html`

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -76,7 +76,7 @@ export class ESPHomePageSecrets extends LitElement {
   @state()
   private _saving = false;
 
-  readonly _load = new ConfigLoadController(this, {
+  protected readonly _load = new ConfigLoadController(this, {
     api: () => this._api,
     connected: () => this._apiConnected,
     configuration: () => SECRETS_FILE,

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -17,7 +17,6 @@ import type { ESPHomeUnsavedChangesDialog } from "../components/unsaved-changes-
 import { apiConnectedContext, apiContext, localizeContext } from "../context/index.js";
 import { loadMessageStyles } from "../styles/load-message.js";
 import { espHomeStyles } from "../styles/shared.js";
-
 import {
   prefToSecretsLayout,
   secretsLayoutToPref,

--- a/src/util/config-load-controller.ts
+++ b/src/util/config-load-controller.ts
@@ -1,0 +1,120 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { APIError } from "../api/api-error.js";
+import type { ESPHomeAPI } from "../api/index.js";
+import { loadConfigWithRecovery } from "./load-with-recovery.js";
+
+export type ConfigLoadState = "loading" | "ready" | "error" | "missing";
+
+export interface ConfigLoadOptions {
+  api: () => ESPHomeAPI;
+  /** WS liveness; the false→true edge re-runs a load that gave up. */
+  connected: () => boolean;
+  configuration: () => string;
+  /** Transport attempts before the failure surfaces; spent only while
+   *  the socket is up (``loadConfigWithRecovery`` parks otherwise). */
+  attempts: number;
+  timeoutMs?: number;
+  /** Write the loaded YAML into the host's buffers. */
+  commit: (yaml: string) => void;
+  /** Runs after a successful load, outside the failure path. */
+  onReady?: () => void;
+  /** Terminal server reply: ``{seed}`` commits substitute content as
+   *  success, ``"missing"`` parks terminally, undefined errors. */
+  onApiError?: (err: APIError) => { seed: string } | "missing" | undefined;
+  /** A failure over a ready buffer; the content stays rendered. */
+  onRefreshFailed?: () => void;
+}
+
+/**
+ * Owns a page's YAML-load ladder: supersession, transport retries, and
+ * the reconnect re-run.
+ */
+export class ConfigLoadController implements ReactiveController {
+  state: ConfigLoadState = "loading";
+
+  retry = () => void this.start();
+
+  private _gen = 0;
+  private _active = false;
+  private _prevConnected = false;
+
+  constructor(
+    private readonly _host: ReactiveControllerHost,
+    private readonly _opts: ConfigLoadOptions
+  ) {
+    _host.addController(this);
+  }
+
+  hostConnected(): void {
+    this._active = true;
+  }
+
+  hostDisconnected(): void {
+    this._active = false;
+  }
+
+  hostUpdated(): void {
+    const connected = this._opts.connected();
+    // Socket is back: a load that gave up while it was down goes again
+    // without the user hunting for the Retry button. "missing" is a
+    // server answer, so it stays put.
+    if (connected && !this._prevConnected && this.state === "error") {
+      void this.start();
+    }
+    this._prevConnected = connected;
+  }
+
+  /** Foreground load: the ladder replaces the content until it settles. */
+  start(): Promise<void> {
+    return this._load(false);
+  }
+
+  /** Background reload: a ready buffer stays rendered; a failure over it
+   *  surfaces through ``onRefreshFailed`` instead of the error panel. */
+  refresh(): Promise<void> {
+    return this._load(true);
+  }
+
+  private async _load(background: boolean): Promise<void> {
+    const configuration = this._opts.configuration();
+    const gen = ++this._gen;
+    if (!background || this.state !== "ready") this._setState("loading");
+    let yaml: string | null;
+    try {
+      yaml = await loadConfigWithRecovery(this._opts.api(), configuration, {
+        // Unmount and a changed target count as abandoned too, or a slow
+        // load keeps fetching against a page that has moved on.
+        abandoned: () =>
+          !this._active ||
+          this._opts.configuration() !== configuration ||
+          gen !== this._gen,
+        attempts: this._opts.attempts,
+        timeoutMs: this._opts.timeoutMs,
+      });
+    } catch (err) {
+      const handled = err instanceof APIError ? this._opts.onApiError?.(err) : undefined;
+      if (handled === "missing") {
+        this._setState("missing");
+        return;
+      }
+      if (handled === undefined) {
+        console.error(`Failed to load ${configuration}:`, err);
+        if (this.state === "ready") this._opts.onRefreshFailed?.();
+        else this._setState("error");
+        return;
+      }
+      yaml = handled.seed;
+    }
+    // Null means the page moved on; leave the buffers to the newer load.
+    if (yaml === null) return;
+    this._opts.commit(yaml);
+    this._setState("ready");
+    this._opts.onReady?.();
+  }
+
+  private _setState(state: ConfigLoadState): void {
+    if (this.state === state) return;
+    this.state = state;
+    this._host.requestUpdate();
+  }
+}

--- a/src/util/config-load-controller.ts
+++ b/src/util/config-load-controller.ts
@@ -47,6 +47,9 @@ export class ConfigLoadController implements ReactiveController {
 
   hostConnected(): void {
     this._active = true;
+    // Seed the edge detector so an error landing before the first host
+    // update can't misread an already-up socket as a reconnect.
+    this._prevConnected = this._opts.connected();
   }
 
   hostDisconnected(): void {

--- a/src/util/config-load-controller.ts
+++ b/src/util/config-load-controller.ts
@@ -97,6 +97,7 @@ export class ConfigLoadController implements ReactiveController {
     } catch (err) {
       const handled = err instanceof APIError ? this._opts.onApiError?.(err) : undefined;
       if (handled === "missing") {
+        console.error(`Failed to load ${configuration}:`, err);
         this._setState("missing");
         return;
       }

--- a/test/pages/device-yaml-loading.test.ts
+++ b/test/pages/device-yaml-loading.test.ts
@@ -109,7 +109,10 @@ describe("device page initial YAML loading gate", () => {
       () => new Promise<string>((resolve) => settlers.push(resolve))
     );
     const page = await mountPage(makeApi(getConfig));
-    const view = page as unknown as { _yaml: string; _yamlState: string };
+    const view = page as unknown as {
+      _yaml: string;
+      _load: { state: string };
+    };
 
     page.id = "porch.yaml";
     await page.updateComplete;
@@ -121,12 +124,12 @@ describe("device page initial YAML loading gate", () => {
     settlers[0]("esphome:\n  name: stale\n");
     await flushMicrotasks(8);
     expect(view._yaml).toBe("");
-    expect(view._yamlState).toBe("loading");
+    expect(view._load.state).toBe("loading");
 
     settlers[2]("esphome:\n  name: fresh\n");
     await flushMicrotasks(8);
     expect(view._yaml).toBe("esphome:\n  name: fresh\n");
-    expect(view._yamlState).toBe("ready");
+    expect(view._load.state).toBe("ready");
   });
 
   it("keeps the spinner and retries when the socket drops mid-fetch", async () => {

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -49,7 +49,11 @@ vi.mock("../../src/util/save-shortcut-controller.js", () => ({
  */
 
 interface PageView {
-  _loadState: "loading" | "ready" | "error";
+  _load: {
+    state: "loading" | "ready" | "error" | "missing";
+    start(): Promise<void>;
+    refresh(): Promise<void>;
+  };
   _yaml: string;
   _savedYaml: string;
   _saving: boolean;
@@ -57,7 +61,6 @@ interface PageView {
   _layout: "form" | "yaml";
   _readStoredLayout(): "form" | "yaml" | null;
   _seedLayoutFromBackend(): Promise<void>;
-  _loadFromServer(): Promise<void>;
   _setLayout(layout: "form" | "yaml"): void;
   _onYamlChange(e: CustomEvent<{ value: string }>): void;
   _confirmLeave(): Promise<boolean>;
@@ -71,13 +74,19 @@ interface PageView {
   render(): unknown;
 }
 
-function makePage(overrides: Partial<PageView> = {}): PageView {
+function makePage(
+  overrides: Partial<PageView> & {
+    /** Routed into the load controller's public state field. */
+    _loadState?: "loading" | "ready" | "error";
+  } = {}
+): PageView {
+  const { _loadState, ...rest } = overrides;
   const page = new ESPHomePageSecrets() as unknown as PageView;
-  page._loadState = "loading";
+  page._load.state = _loadState ?? "loading";
   page._yaml = "";
   page._savedYaml = "";
   page._saving = false;
-  Object.assign(page, overrides);
+  Object.assign(page, rest);
   return page;
 }
 
@@ -311,7 +320,7 @@ describe("esphome-page-secrets initial load", () => {
 
     expect(page._yaml).not.toBe("");
     expect(page._savedYaml).toBe(page._yaml);
-    expect(page._loadState).toBe("ready");
+    expect(page._load.state).toBe("ready");
   });
 
   test("does not template over the real file on a non-not-found server error", async () => {
@@ -324,7 +333,7 @@ describe("esphome-page-secrets initial load", () => {
     // past the clear-all wipe confirm on the next save.
     expect(page._yaml).toBe("");
     expect(page._savedYaml).toBe("");
-    expect(page._loadState).toBe("error");
+    expect(page._load.state).toBe("error");
   });
 
   test("retries a transport failure instead of templating over the real file", async () => {
@@ -355,15 +364,15 @@ describe("esphome-page-secrets initial load", () => {
       .mockResolvedValueOnce("wifi_password: hunter2\n")
       .mockRejectedValueOnce(new APIError("internal_error", "boom"));
     const page = await mountWithApi(getConfig);
-    expect(page._loadState).toBe("ready");
+    expect(page._load.state).toBe("ready");
     vi.mocked(toast.error).mockClear();
 
-    await page._loadFromServer();
+    await page._load.refresh();
     await flushMicrotasks(8);
 
     // The content is still in memory; demoting to the error panel would
     // hide it behind an unnecessary Retry.
-    expect(page._loadState).toBe("ready");
+    expect(page._load.state).toBe("ready");
     expect(page._yaml).toBe("wifi_password: hunter2\n");
     expect(toast.error).toHaveBeenCalled();
   });
@@ -379,7 +388,7 @@ describe("esphome-page-secrets initial load", () => {
     // The wizard wrote secrets.yaml while the mount's read was in
     // flight; that reply predates the write, so a fresh read must win
     // and the stale one must be dropped even though it settles later.
-    void page._loadFromServer();
+    void page._load.refresh();
     settleFirst("wifi_password: stale\n");
     await flushMicrotasks(8);
 
@@ -399,14 +408,14 @@ describe("esphome-page-secrets initial load", () => {
       const page = await mountWithApi(getConfig);
       await vi.advanceTimersByTimeAsync(1500 * 4);
       await flushMicrotasks(8);
-      expect(page._loadState).toBe("error");
+      expect(page._load.state).toBe("error");
 
       getConfig.mockResolvedValueOnce("wifi_password: hunter2\n");
       (page as unknown as { _apiConnected: boolean })._apiConnected = true;
       (page as unknown as { requestUpdate(): void }).requestUpdate();
       await flushMicrotasks(8);
 
-      expect(page._loadState).toBe("ready");
+      expect(page._load.state).toBe("ready");
     } finally {
       vi.useRealTimers();
     }

--- a/test/util/config-load-controller.test.ts
+++ b/test/util/config-load-controller.test.ts
@@ -143,6 +143,19 @@ describe("ConfigLoadController", () => {
     expect(controller.state).toBe("missing");
   });
 
+  it("does not treat the initial connected state as a reconnect edge", async () => {
+    const getConfig = vi.fn().mockRejectedValue(new Error("WebSocket closed"));
+    const { host, controller } = makeLoad({ getConfig });
+    await controller.start();
+    expect(controller.state).toBe("error");
+
+    host.update();
+    await flushMicrotasks(4);
+    // The socket was up the whole time — no edge, no extra retry.
+    expect(getConfig).toHaveBeenCalledTimes(1);
+    expect(controller.state).toBe("error");
+  });
+
   it("re-runs a failed load on the reconnect edge", async () => {
     let connected = true;
     const getConfig = vi.fn().mockRejectedValueOnce(new Error("WebSocket closed"));

--- a/test/util/config-load-controller.test.ts
+++ b/test/util/config-load-controller.test.ts
@@ -122,6 +122,8 @@ describe("ConfigLoadController", () => {
     await controller.start();
     expect(commit).toHaveBeenCalledWith("# header\n");
     expect(controller.state).toBe("ready");
+    // The seed is a first-run outcome, not a failure; it stays log-free.
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   it("parks terminally on a missing reply; a reconnect leaves it alone", async () => {
@@ -133,6 +135,11 @@ describe("ConfigLoadController", () => {
     });
     await controller.start();
     expect(controller.state).toBe("missing");
+    // The terminal panel doesn't name the file; the console entry does.
+    expect(console.error).toHaveBeenCalledWith(
+      "Failed to load kitchen.yaml:",
+      expect.any(APIError)
+    );
 
     connected = false;
     host.update();

--- a/test/util/config-load-controller.test.ts
+++ b/test/util/config-load-controller.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactiveController } from "lit";
+import { APIError } from "../../src/api/api-error.js";
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import { ConfigLoadController } from "../../src/util/config-load-controller.js";
+import { flushMicrotasks } from "../_dom.js";
+
+/**
+ * Pins the shared load ladder: start vs refresh semantics, server-reply
+ * routing, supersession, and the reconnect re-run.
+ */
+
+class FakeHost {
+  private _controllers: ReactiveController[] = [];
+  addController(c: ReactiveController) {
+    this._controllers.push(c);
+  }
+  removeController() {}
+  requestUpdate() {}
+  updateComplete = Promise.resolve(true);
+  connect() {
+    for (const c of this._controllers) c.hostConnected?.();
+  }
+  update() {
+    for (const c of this._controllers) c.hostUpdated?.();
+  }
+  disconnect() {
+    for (const c of this._controllers) c.hostDisconnected?.();
+  }
+}
+
+function makeApi(getConfig: ReturnType<typeof vi.fn>): ESPHomeAPI {
+  return { ready: Promise.resolve(), getConfig } as unknown as ESPHomeAPI;
+}
+
+function makeLoad(overrides: {
+  getConfig: ReturnType<typeof vi.fn>;
+  configuration?: () => string;
+  connected?: () => boolean;
+  onApiError?: (err: APIError) => { seed: string } | "missing" | undefined;
+  onRefreshFailed?: () => void;
+  onReady?: () => void;
+}) {
+  const host = new FakeHost();
+  const commit = vi.fn();
+  const controller = new ConfigLoadController(host, {
+    api: () => makeApi(overrides.getConfig),
+    connected: overrides.connected ?? (() => true),
+    configuration: overrides.configuration ?? (() => "kitchen.yaml"),
+    attempts: 1,
+    commit,
+    onReady: overrides.onReady,
+    onApiError: overrides.onApiError,
+    onRefreshFailed: overrides.onRefreshFailed,
+  });
+  host.connect();
+  return { host, controller, commit };
+}
+
+describe("ConfigLoadController", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("commits a loaded config and flips to ready, then onReady", async () => {
+    const order: string[] = [];
+    const { controller, commit } = makeLoad({
+      getConfig: vi.fn().mockResolvedValue("yaml"),
+      onReady: () => order.push("ready-hook"),
+    });
+    commit.mockImplementation(() => order.push("commit"));
+
+    await controller.start();
+
+    expect(commit).toHaveBeenCalledWith("yaml");
+    expect(controller.state).toBe("ready");
+    expect(order).toEqual(["commit", "ready-hook"]);
+  });
+
+  it("a failed start lands in the error state", async () => {
+    const { controller } = makeLoad({
+      getConfig: vi.fn().mockRejectedValue(new Error("WebSocket closed")),
+    });
+    await controller.start();
+    expect(controller.state).toBe("error");
+  });
+
+  it("a failed refresh over a ready buffer keeps it rendered and notifies", async () => {
+    const onRefreshFailed = vi.fn();
+    const getConfig = vi.fn().mockResolvedValueOnce("yaml");
+    const { controller, commit } = makeLoad({ getConfig, onRefreshFailed });
+    await controller.start();
+
+    getConfig.mockRejectedValueOnce(new Error("WebSocket closed"));
+    await controller.refresh();
+
+    expect(controller.state).toBe("ready");
+    expect(onRefreshFailed).toHaveBeenCalledTimes(1);
+    expect(commit).toHaveBeenCalledTimes(1);
+  });
+
+  it("a failed refresh with nothing rendered still errors", async () => {
+    const onRefreshFailed = vi.fn();
+    const { controller } = makeLoad({
+      getConfig: vi.fn().mockRejectedValue(new Error("WebSocket closed")),
+      onRefreshFailed,
+    });
+    await controller.refresh();
+    expect(controller.state).toBe("error");
+    expect(onRefreshFailed).not.toHaveBeenCalled();
+  });
+
+  it("routes a seeding server reply to a ready commit", async () => {
+    const { controller, commit } = makeLoad({
+      getConfig: vi.fn().mockRejectedValue(new APIError("not_found", "missing")),
+      onApiError: () => ({ seed: "# header\n" }),
+    });
+    await controller.start();
+    expect(commit).toHaveBeenCalledWith("# header\n");
+    expect(controller.state).toBe("ready");
+  });
+
+  it("parks terminally on a missing reply; a reconnect leaves it alone", async () => {
+    let connected = true;
+    const { host, controller } = makeLoad({
+      getConfig: vi.fn().mockRejectedValue(new APIError("not_found", "gone")),
+      connected: () => connected,
+      onApiError: () => "missing",
+    });
+    await controller.start();
+    expect(controller.state).toBe("missing");
+
+    connected = false;
+    host.update();
+    connected = true;
+    host.update();
+    await flushMicrotasks(4);
+    // A server answer is final; only the error state re-runs.
+    expect(controller.state).toBe("missing");
+  });
+
+  it("re-runs a failed load on the reconnect edge", async () => {
+    let connected = true;
+    const getConfig = vi.fn().mockRejectedValueOnce(new Error("WebSocket closed"));
+    const { host, controller } = makeLoad({ getConfig, connected: () => connected });
+    await controller.start();
+    expect(controller.state).toBe("error");
+
+    getConfig.mockResolvedValueOnce("yaml");
+    connected = false;
+    host.update();
+    connected = true;
+    host.update();
+    await flushMicrotasks(4);
+
+    expect(controller.state).toBe("ready");
+  });
+
+  it("drops a reply for a configuration the host moved past", async () => {
+    let configuration = "a.yaml";
+    let settle!: (yaml: string) => void;
+    const getConfig = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<string>((r) => (settle = r)))
+      .mockImplementation(() => new Promise<string>(() => {}));
+    const { controller, commit } = makeLoad({
+      getConfig,
+      configuration: () => configuration,
+    });
+
+    const first = controller.start();
+    // Let the first load reach its getConfig before the host moves on.
+    await flushMicrotasks(2);
+    configuration = "b.yaml";
+    void controller.start();
+    settle("stale");
+    await first;
+
+    expect(commit).not.toHaveBeenCalled();
+    expect(controller.state).toBe("loading");
+  });
+
+  it("a superseded load never commits over the newer one", async () => {
+    let settleFirst!: (yaml: string) => void;
+    const getConfig = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<string>((r) => (settleFirst = r)))
+      .mockResolvedValueOnce("fresh");
+    const { controller, commit } = makeLoad({ getConfig });
+
+    const first = controller.start();
+    await flushMicrotasks(2);
+    await controller.start();
+    settleFirst("stale");
+    await first;
+
+    expect(commit).toHaveBeenCalledTimes(1);
+    expect(commit).toHaveBeenCalledWith("fresh");
+  });
+});

--- a/test/util/config-load-controller.test.ts
+++ b/test/util/config-load-controller.test.ts
@@ -173,6 +173,21 @@ describe("ConfigLoadController", () => {
     expect(controller.state).toBe("ready");
   });
 
+  it("drops a reply that lands after the host disconnected", async () => {
+    let settle!: (yaml: string) => void;
+    const getConfig = vi.fn(() => new Promise<string>((r) => (settle = r)));
+    const { host, controller, commit } = makeLoad({ getConfig });
+
+    const load = controller.start();
+    await flushMicrotasks(2);
+    host.disconnect();
+    settle("late");
+    await load;
+
+    // The page is gone; a late reply must not write into its buffers.
+    expect(commit).not.toHaveBeenCalled();
+  });
+
   it("drops a reply for a configuration the host moved past", async () => {
     let configuration = "a.yaml";
     let settle!: (yaml: string) => void;


### PR DESCRIPTION
# What does this implement/fix?

Second of the two consolidations from #1516, following #1518. The YAML load state machine was duplicated between the device and secrets pages: the state union, the supersession generation, the attempt constants, the reconnect retry block in `updated()` (byte identical comment included), and the retry thunk, with asymmetries a reader could not tell were deliberate.

The ladder now lives in `ConfigLoadController` (shaped like `RemoteBuildIdentityController`: host first constructor, getter callbacks, a plain public `state` field repainted via `requestUpdate`). It owns the generation supersession, the `loadConfigWithRecovery` invocation, and the reconnect edge in `hostUpdated` (re runs only from the error state; a terminal `missing` sticks). The one real page asymmetry is encoded in the `start()` vs `refresh()` split: everything foreground replaces the content with the ladder, while secrets' external save reload keeps a ready buffer rendered and surfaces a failure through `onRefreshFailed` instead of the error panel. The page specific residue stays at the call sites as hooks: the device's terminal `missing` state and post load line resolution, secrets' NOT_FOUND seeding of the header template and the reload toast. Both pages delete their copies; `device.ts` shrinks accordingly (the file size flag from the #1515 review).

Behaviour preserving with one log only delta: the load failure console message now names the configuration (`Failed to load kitchen.yaml:`) instead of the per page wording. The pinning suites (nine device yaml loading cells, five secrets initial load cells) pass with their assertions unchanged; the harnesses read the state off the controller's public field. The controller gets its own focused suite for the start/refresh split, server reply routing, supersession, and the reconnect edge.

Also folds in the one cosmetic nit from #1518's final review round: the stray blank line the `withBase` import removal left in secrets.ts's import block.

**Related issue or feature (if applicable):**

- fixes #1516

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
