### PR TITLE
Intercept dirty Back before the router commits the route

### DIFF
--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -141,9 +141,7 @@ export function createRouter(
   host: ReactiveControllerHost & HTMLElement,
   hooks: RouterHooks
 ): Router {
-  // Before the Router exists: its popstate listener must register after
-  // the leave-guard interceptor's, or a dirty Back commits the route
-  // change ahead of the guard's veto (#1520).
+  // Ordering is load-bearing; see installLeaveGuardInterceptor's doc.
   installLeaveGuardInterceptor();
   return new Router(host, [
     {

--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -3,6 +3,7 @@ import { html, type ReactiveControllerHost } from "lit";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { withBase } from "../../util/base-path.js";
 import {
+  installLeaveGuardInterceptor,
   isFreshNavigatePush,
   isSameDocumentPush,
   popPushedEntrySilently,
@@ -140,6 +141,10 @@ export function createRouter(
   host: ReactiveControllerHost & HTMLElement,
   hooks: RouterHooks
 ): Router {
+  // Before the Router exists: its popstate listener must register after
+  // the leave-guard interceptor's, or a dirty Back commits the route
+  // change ahead of the guard's veto (#1520).
+  installLeaveGuardInterceptor();
   return new Router(host, [
     {
       path: withBase("/"),

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -633,10 +633,9 @@ export class ESPHomePageDevice extends LitElement {
       return;
     }
     /* Otherwise leave the editor via the header back arrow's guarded
-       path. A raw history.back() here loses the dirty buffer: the
-       router's popstate listener commits the leave before this page's
-       ``_onPopState`` can veto it, so the unsaved-changes prompt must
-       run before the navigation, not after. */
+       path, which prompts before the pop — nicer than a raw
+       history.back(), which the popstate interceptor would catch only
+       after the URL changed, via re-push. */
     e.preventDefault();
     void goBackOrHome();
   };

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -632,10 +632,7 @@ export class ESPHomePageDevice extends LitElement {
       this._drawerOpen = false;
       return;
     }
-    /* Otherwise leave the editor via the header back arrow's guarded
-       path, which prompts before the pop — nicer than a raw
-       history.back(), which the popstate interceptor would catch only
-       after the URL changed, via re-push. */
+    // Otherwise leave via goBackOrHome(), which prompts before the pop.
     e.preventDefault();
     void goBackOrHome();
   };

--- a/src/util/navigation.ts
+++ b/src/util/navigation.ts
@@ -30,11 +30,11 @@ export async function navigate(url: string): Promise<void> {
 /**
  * Run the active page-leave guard. Resolves ``true`` when it's safe to leave
  * (no guard, or the guard resolved "proceed"). Used by ``navigate`` and by
- * back-navigations that bypass it but still must honour the guard — the header
- * back arrow's ``history.back()``, whose raw popstate the router commits before
- * the device editor's own popstate guard can veto it. A guard that throws
- * resolves ``false``: navigating through unsaved state on a broken guard
- * would lose it silently, so staying put is the fail-safe.
+ * the header back arrow's ``history.back()``, which prompts before the pop
+ * rather than leaving it to the popstate interceptor's after-the-pop
+ * re-push. A guard that throws resolves ``false``: navigating through
+ * unsaved state on a broken guard would lose it silently, so staying put
+ * is the fail-safe.
  */
 export async function runLeaveGuard(): Promise<boolean> {
   if (!activeGuard) return true;
@@ -106,11 +106,44 @@ export interface PopLeaveGuardOptions {
   url: () => string;
 }
 
+let activeLeaveGuardController: PopLeaveGuardController | null = null;
+let interceptorInstalled = false;
+
+function claimPopstateDelivery(controller: PopLeaveGuardController): void {
+  activeLeaveGuardController = controller;
+}
+
+/** Release only while *controller* still holds delivery — a departing
+ *  page must not disarm a successor that already claimed it. */
+function releasePopstateDelivery(controller: PopLeaveGuardController): void {
+  if (activeLeaveGuardController === controller) activeLeaveGuardController = null;
+}
+
+/**
+ * Install the single popstate listener that delivers to the active
+ * ``PopLeaveGuardController``. Must run before the router is constructed:
+ * popstate targets ``window``, where listeners fire in registration order
+ * (the capture flag confers no priority), so registering ahead of the
+ * router's listener is the only way an interception can veto the
+ * router's route commit (#1520). Idempotent.
+ */
+export function installLeaveGuardInterceptor(): void {
+  if (interceptorInstalled) return;
+  interceptorInstalled = true;
+  window.addEventListener(
+    "popstate",
+    (e) => activeLeaveGuardController?.handlePopState(e),
+    { capture: true }
+  );
+}
+
 /**
  * Owns a page's popstate leave-guard: intercepts a dirty Back/Forward,
  * re-asserts the page URL, runs the confirm flow, and replays the pop on
  * proceed. Registers the confirm flow as the active leave guard for the
- * host's connected lifetime.
+ * host's connected lifetime; popstate delivery arrives through the
+ * module's single interceptor, which registers ahead of the router so
+ * ``stopImmediatePropagation`` genuinely blocks the route commit.
  */
 export class PopLeaveGuardController implements ReactiveController {
   /* The allow flag is flipped inside the wrapped guard BEFORE its caller
@@ -142,12 +175,12 @@ export class PopLeaveGuardController implements ReactiveController {
 
   hostConnected(): void {
     setLeaveGuard(this._guard);
-    window.addEventListener("popstate", this.handlePopState, { capture: true });
+    claimPopstateDelivery(this);
   }
 
   hostDisconnected(): void {
     clearLeaveGuard(this._guard);
-    window.removeEventListener("popstate", this.handlePopState, { capture: true });
+    releasePopstateDelivery(this);
     this._allowingLeave = false;
   }
 
@@ -186,10 +219,11 @@ export class PopLeaveGuardController implements ReactiveController {
  */
 export async function goBackOrHome(): Promise<void> {
   if (hasPushedHistoryEntry()) {
-    // history.back() fires a raw popstate the router commits (unmounting the
-    // page) before the device editor's popstate guard can veto it, so honour
-    // the leave guard here — same gate navigate() applies. navigate("/") runs
-    // the guard itself, so the fallback isn't double-prompted.
+    // Prompt before popping: the user answers while the URL still shows
+    // their page. The popstate interceptor would catch a raw back too,
+    // but only after the pop, via re-push; and the allow flag the guard
+    // sets lets this pop fall through it. navigate("/") runs the guard
+    // itself, so the fallback isn't double-prompted.
     if (!(await runLeaveGuard())) return;
     window.history.back();
     return;

--- a/src/util/navigation.ts
+++ b/src/util/navigation.ts
@@ -28,13 +28,11 @@ export async function navigate(url: string): Promise<void> {
 }
 
 /**
- * Run the active page-leave guard. Resolves ``true`` when it's safe to leave
- * (no guard, or the guard resolved "proceed"). Used by ``navigate`` and by
- * the header back arrow's ``history.back()``, which prompts before the pop
- * rather than leaving it to the popstate interceptor's after-the-pop
- * re-push. A guard that throws resolves ``false``: navigating through
- * unsaved state on a broken guard would lose it silently, so staying put
- * is the fail-safe.
+ * Run the active page-leave guard. Resolves ``true`` when it's safe to
+ * leave (no guard, or the guard resolved "proceed"). Used by ``navigate``
+ * and by ``goBackOrHome``. A guard that throws resolves ``false``:
+ * navigating through unsaved state on a broken guard would lose it
+ * silently, so staying put is the fail-safe.
  */
 export async function runLeaveGuard(): Promise<boolean> {
   if (!activeGuard) return true;
@@ -107,34 +105,32 @@ export interface PopLeaveGuardOptions {
 }
 
 let activeLeaveGuardController: PopLeaveGuardController | null = null;
-let interceptorInstalled = false;
 
 function claimPopstateDelivery(controller: PopLeaveGuardController): void {
   activeLeaveGuardController = controller;
 }
 
-/** Release only while *controller* still holds delivery — a departing
- *  page must not disarm a successor that already claimed it. */
+/** Ownership check, as in ``clearLeaveGuard``. */
 function releasePopstateDelivery(controller: PopLeaveGuardController): void {
   if (activeLeaveGuardController === controller) activeLeaveGuardController = null;
 }
 
+const popstateInterceptor = (e: PopStateEvent) =>
+  activeLeaveGuardController?.handlePopState(e);
+
 /**
  * Install the single popstate listener that delivers to the active
- * ``PopLeaveGuardController``. Must run before the router is constructed:
- * popstate targets ``window``, where listeners fire in registration order
- * (the capture flag confers no priority), so registering ahead of the
- * router's listener is the only way an interception can veto the
- * router's route commit (#1520). Idempotent.
+ * ``PopLeaveGuardController``. Must run before the router registers its
+ * own popstate listener: popstate targets ``window``, where listeners
+ * fire in registration order (the capture flag confers no priority), so
+ * registering ahead of the router's is the only way an interception can
+ * veto the route commit (#1520). Idempotent — the DOM dedupes an
+ * identical (type, listener, capture) triple. ``capture`` matches the
+ * module's transient rollback drain so the interceptor never sorts
+ * behind it in environments that order capture-first at target.
  */
 export function installLeaveGuardInterceptor(): void {
-  if (interceptorInstalled) return;
-  interceptorInstalled = true;
-  window.addEventListener(
-    "popstate",
-    (e) => activeLeaveGuardController?.handlePopState(e),
-    { capture: true }
-  );
+  window.addEventListener("popstate", popstateInterceptor, { capture: true });
 }
 
 /**
@@ -142,8 +138,7 @@ export function installLeaveGuardInterceptor(): void {
  * re-asserts the page URL, runs the confirm flow, and replays the pop on
  * proceed. Registers the confirm flow as the active leave guard for the
  * host's connected lifetime; popstate delivery arrives through the
- * module's single interceptor, which registers ahead of the router so
- * ``stopImmediatePropagation`` genuinely blocks the route commit.
+ * module interceptor.
  */
 export class PopLeaveGuardController implements ReactiveController {
   /* The allow flag is flipped inside the wrapped guard BEFORE its caller
@@ -153,6 +148,7 @@ export class PopLeaveGuardController implements ReactiveController {
    *
    *   - ``navigate()`` on ``canLeave=true`` does ``pushState +
    *     dispatchEvent(popstate)`` synchronously after the guard resolves.
+   *   - ``goBackOrHome()`` calls ``history.back()`` after the guard.
    *   - The intercepted-pop replay below calls ``history.back()``.
    *
    * Microtasks run to completion, so no popstate task can interleave
@@ -184,7 +180,8 @@ export class PopLeaveGuardController implements ReactiveController {
     this._allowingLeave = false;
   }
 
-  readonly handlePopState = (e: PopStateEvent) => {
+  /** Called by the module interceptor for every window popstate. */
+  handlePopState(e: PopStateEvent): void {
     // A failed route chunk rolling back its own push is a return to the
     // page, not a leave.
     if (consumePopGuardSuppression()) return;
@@ -206,7 +203,7 @@ export class PopLeaveGuardController implements ReactiveController {
       // The entry was already re-pushed, so staying put is the fail-safe
       // on an unexpected guard failure.
       .catch((err) => console.error("Leave confirmation failed:", err));
-  };
+  }
 }
 
 /**
@@ -220,10 +217,9 @@ export class PopLeaveGuardController implements ReactiveController {
 export async function goBackOrHome(): Promise<void> {
   if (hasPushedHistoryEntry()) {
     // Prompt before popping: the user answers while the URL still shows
-    // their page. The popstate interceptor would catch a raw back too,
-    // but only after the pop, via re-push; and the allow flag the guard
-    // sets lets this pop fall through it. navigate("/") runs the guard
-    // itself, so the fallback isn't double-prompted.
+    // their page, rather than through the interceptor's after-the-pop
+    // re-push. navigate("/") runs the guard itself, so the fallback
+    // isn't double-prompted.
     if (!(await runLeaveGuard())) return;
     window.history.back();
     return;

--- a/test/components/app-shell/router-interceptor.test.ts
+++ b/test/components/app-shell/router-interceptor.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from "vitest";
+import type { ReactiveController } from "lit";
+import type { LocalizeFunc } from "../../../src/common/localize.js";
+import { createRouter } from "../../../src/components/app-shell/router.js";
+import { PopLeaveGuardController } from "../../../src/util/navigation.js";
+import { identityLocalize } from "../../_dom.js";
+
+/**
+ * Pins createRouter's interceptor wiring: the leave-guard veto must land
+ * before the Router's own popstate listener commits a route. The guard
+ * suite installs the interceptor itself, so only this file catches the
+ * install call going missing.
+ */
+
+class FakeShell extends HTMLElement {
+  controllers: ReactiveController[] = [];
+  addController(c: ReactiveController) {
+    this.controllers.push(c);
+  }
+  removeController() {}
+  requestUpdate() {}
+  updateComplete = Promise.resolve(true);
+  connect() {
+    for (const c of this.controllers) c.hostConnected?.();
+  }
+}
+customElements.define("fake-shell", FakeShell);
+
+describe("createRouter interceptor wiring", () => {
+  it("the guard's veto lands before the Router's popstate handler", () => {
+    const shell = new FakeShell();
+    const router = createRouter(shell as never, {
+      onPending: () => {},
+      localize: () => identityLocalize as LocalizeFunc,
+      isAuthed: () => true,
+    });
+    // Mocked before connect: happy-dom lacks URLPattern, and only the
+    // dispatch path matters here.
+    const goto = vi.spyOn(router, "goto").mockResolvedValue(undefined);
+    // Router registers its popstate listener here, after the install.
+    shell.connect();
+    goto.mockClear();
+
+    const guardHost = new FakeShell();
+    let isDirty = true;
+    new PopLeaveGuardController(guardHost as never, {
+      confirmLeave: () => Promise.resolve(false),
+      isDirty: () => isDirty,
+      url: () => "/device/kitchen.yaml",
+    });
+    guardHost.connect();
+
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    // Dirty pop: the interceptor's stopImmediatePropagation beat the
+    // router — without the createRouter install, goto commits first.
+    expect(goto).not.toHaveBeenCalled();
+
+    isDirty = false;
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    // Clean pop falls through to the router as usual.
+    expect(goto).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/components/esphome-layout-back-button.test.ts
+++ b/test/components/esphome-layout-back-button.test.ts
@@ -38,11 +38,11 @@ describe("esphome-layout dashboard-route detection", () => {
   });
 });
 
-// The header back arrow pops history via history.back(), whose raw popstate the
-// router commits before the device editor's popstate guard can veto it. _goHome
-// therefore runs the active leave guard up front (like navigate() does) and
-// only pops when it resolves "proceed". Pin that gate so a dirty editor can't
-// be navigated away from without the prompt.
+// The header back arrow pops history via history.back(). _goHome runs the
+// active leave guard up front (like navigate() does) and only pops when it
+// resolves "proceed", so the prompt shows while the URL still names the
+// page instead of through the interceptor's after-the-pop re-push. Pin that
+// gate so a dirty editor can't be navigated away from without the prompt.
 describe("esphome-layout back arrow leave guard", () => {
   afterEach(() => {
     setLeaveGuard(null);

--- a/test/pages/device-escape-leave.test.ts
+++ b/test/pages/device-escape-leave.test.ts
@@ -12,8 +12,8 @@ import { setLeaveGuard } from "../../src/util/navigation.js";
  * Pin the Escape-to-leave path against esphome/device-builder#2259: with a
  * dirty buffer, Escape must run the unsaved-changes guard BEFORE popping
  * history. The old raw ``history.back()`` lost the buffer to the router's
- * popstate listener, which unmounts the page before the device page's own
- * popstate guard can veto.
+ * popstate listener in the pre-interceptor era; prompting first also shows
+ * the dialog while the URL still names the page.
  */
 
 interface EscapeView {

--- a/test/util/navigation.test.ts
+++ b/test/util/navigation.test.ts
@@ -212,9 +212,9 @@ describe("navigate", () => {
 /**
  * ``runLeaveGuard`` is the guard-only gate for back-navigations that bypass
  * ``navigate()`` but must still honour the leave guard — the header back
- * arrow's ``history.back()``, whose raw popstate the router commits before the
- * device editor's own popstate guard can veto it. It must mirror the gating
- * half of ``navigate()`` without touching history.
+ * arrow's ``history.back()``, which prompts before the pop rather than
+ * relying on the interceptor's after-the-pop re-push. It must mirror the
+ * gating half of ``navigate()`` without touching history.
  */
 describe("runLeaveGuard", () => {
   afterEach(() => {
@@ -287,9 +287,9 @@ describe("runLeaveGuard", () => {
 
 /**
  * ``goBackOrHome`` is the shared header-back-arrow / Escape-key leave path.
- * It must run the guard BEFORE ``history.back()`` — issue
- * esphome/device-builder#2259 was Escape calling raw ``history.back()`` and
- * losing the dirty buffer to the router's popstate listener.
+ * It must run the guard BEFORE ``history.back()`` — prompting while the URL
+ * still shows the page (issue esphome/device-builder#2259 was Escape calling
+ * raw ``history.back()`` and losing the buffer in the pre-interceptor era).
  */
 describe("goBackOrHome", () => {
   let pushStateSpy: ReturnType<typeof vi.fn>;

--- a/test/util/pop-leave-guard-controller.test.ts
+++ b/test/util/pop-leave-guard-controller.test.ts
@@ -4,10 +4,15 @@ import type { ReactiveController } from "lit";
 import {
   PopLeaveGuardController,
   consumePopGuardSuppression,
+  installLeaveGuardInterceptor,
   popPushedEntrySilently,
   runLeaveGuard,
 } from "../../src/util/navigation.js";
 import { flushMicrotasks } from "../_dom.js";
+
+// Production installs this in createRouter, before the router's own
+// popstate listener registers; delivery to the controller runs through it.
+installLeaveGuardInterceptor();
 
 /**
  * Pins the centralized popstate leave-guard: suppression first, one-shot
@@ -170,5 +175,55 @@ describe("PopLeaveGuardController", () => {
     // Ownership check: only the active guard's owner may clear it.
     expect(second.confirm).toHaveBeenCalledTimes(1);
     expect(first.confirm).not.toHaveBeenCalled();
+
+    // The answered guard's own pop falls through; the next one shows
+    // popstate delivery follows the successor too.
+    window.dispatchEvent(popState());
+    window.dispatchEvent(popState());
+    expect(second.dirty).toHaveBeenCalledTimes(1);
+    expect(first.dirty).not.toHaveBeenCalled();
+  });
+
+  it("intercepts ahead of a router-style popstate listener", async () => {
+    let isDirty = true;
+    connect({ dirty: () => isDirty });
+    // Bubble listener registered after the interceptor, mirroring
+    // @lit-labs/router's registration at app-shell connect. popstate
+    // targets window, so registration order alone decides delivery.
+    const routerListener = vi.fn();
+    window.addEventListener("popstate", routerListener);
+    try {
+      window.dispatchEvent(popState());
+      // Dirty pop: the veto lands before the router can commit.
+      expect(routerListener).not.toHaveBeenCalled();
+      expect(pushState).toHaveBeenCalledWith({}, "", "/secrets");
+
+      await runLeaveGuard();
+      window.dispatchEvent(popState());
+      // An answered leave's own pop falls through to the router.
+      expect(routerListener).toHaveBeenCalledTimes(1);
+
+      popPushedEntrySilently();
+      window.dispatchEvent(popState());
+      // A suppressed rollback pop reaches the router too.
+      expect(routerListener).toHaveBeenCalledTimes(2);
+
+      isDirty = false;
+      window.dispatchEvent(popState());
+      // And so does a clean pop.
+      expect(routerListener).toHaveBeenCalledTimes(3);
+    } finally {
+      window.removeEventListener("popstate", routerListener);
+    }
+  });
+
+  it("installs the interceptor once", () => {
+    installLeaveGuardInterceptor();
+    installLeaveGuardInterceptor();
+    const { dirty } = connect();
+
+    window.dispatchEvent(popState());
+    // A duplicate listener would double-consult the dirty check.
+    expect(dirty).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/util/pop-leave-guard-controller.test.ts
+++ b/test/util/pop-leave-guard-controller.test.ts
@@ -223,10 +223,22 @@ describe("PopLeaveGuardController", () => {
   it("installs the interceptor once", () => {
     installLeaveGuardInterceptor();
     installLeaveGuardInterceptor();
-    const { dirty } = connect();
+    // Clean pop: nothing stops propagation, so a duplicate listener
+    // would consult the dirty check twice.
+    const { dirty } = connect({ dirty: () => false });
 
     window.dispatchEvent(popState());
-    // A duplicate listener would double-consult the dirty check.
     expect(dirty).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases delivery when the last controller disconnects", () => {
+    const { host, dirty } = connect();
+    host.disconnect();
+
+    const e = popState();
+    window.dispatchEvent(e);
+    // A stale slot would veto dashboard pops with an unmounted page.
+    expect(dirty).not.toHaveBeenCalled();
+    expect(e.stopImmediatePropagation).not.toHaveBeenCalled();
   });
 });

--- a/test/util/pop-leave-guard-controller.test.ts
+++ b/test/util/pop-leave-guard-controller.test.ts
@@ -10,15 +10,15 @@ import {
 } from "../../src/util/navigation.js";
 import { flushMicrotasks } from "../_dom.js";
 
+/**
+ * Pins the centralized popstate leave-guard: suppression first, one-shot
+ * allow fall-through, dirty intercept with same-task re-push, replay only
+ * on confirm, and interception ordering ahead of the router's listener.
+ */
+
 // Production installs this in createRouter, before the router's own
 // popstate listener registers; delivery to the controller runs through it.
 installLeaveGuardInterceptor();
-
-/**
- * Pins the centralized popstate leave-guard: suppression first, one-shot
- * allow fall-through, dirty intercept with same-task re-push, and replay
- * only on confirm.
- */
 
 class FakeHost {
   private _controllers: ReactiveController[] = [];
@@ -175,10 +175,13 @@ describe("PopLeaveGuardController", () => {
     // Ownership check: only the active guard's owner may clear it.
     expect(second.confirm).toHaveBeenCalledTimes(1);
     expect(first.confirm).not.toHaveBeenCalled();
+  });
 
-    // The answered guard's own pop falls through; the next one shows
-    // popstate delivery follows the successor too.
-    window.dispatchEvent(popState());
+  it("delivers popstate to the successor controller", () => {
+    const first = connect();
+    const second = connect();
+    first.host.disconnect();
+
     window.dispatchEvent(popState());
     expect(second.dirty).toHaveBeenCalledTimes(1);
     expect(first.dirty).not.toHaveBeenCalled();


### PR DESCRIPTION
# What does this implement/fix?

With unsaved changes, pressing the browser's Back button left the page silently: no prompt, buffer discarded, dashboard rendered. The in app leave paths were fine because they run the guard explicitly; the raw browser chrome path relied on the popstate interception, and that interception was structurally dead, since before #1518 too.

The mechanism, verified against the shipped `@lit-labs/router` source and live probes: popstate targets `window`, and for a window targeted event every listener runs in registration order, the capture flag confers no priority. The router registers its popstate listener at app shell connect, first in the whole app, and its handler calls `goto(location.pathname)` synchronously; the dashboard route has no `enter`, so the route commit happens inside the router's handler before the page guard's listener (registered last, at page connect) ever runs. `stopImmediatePropagation` cannot suppress a listener that already ran. Three comments in the tree already described this exact ordering as the reason the in app paths pre run the guard.

The fix registers one interception listener ahead of the router: `installLeaveGuardInterceptor()` in `navigation.ts` adds a single popstate listener that delegates to the active `PopLeaveGuardController`, and `createRouter()` installs it before constructing the `Router`, so the ordering holds by construction. The controller stops adding its own listener and instead claims and releases delivery on connect and disconnect, with the same ownership check the guard registry uses. The handler itself is unchanged; its `stopImmediatePropagation` now genuinely blocks the router, so a dirty Back holds the URL, prompts, and replays on proceed, and the page no longer unmounts mid confirm. `goBackOrHome` keeps its prompt before pop path (better UX than intercept then re push); the comments that documented the dead veto are rewritten to describe the working design.

New suite coverage closes the gap that let this stay green: a router style bubble listener registered after the interceptor is never called on a dirty pop and is called on allowed, suppressed, and clean pops; interceptor installation is idempotent; delivery follows the active controller across page swaps. Verified live against the dev stack with a real Edit click navigation and an in page `history.back()`: before the fix the probe shows the silent leave, after it the URL holds with the prompt pending, Cancel stays, and Discard replays to the dashboard without a bounce. The in app back arrow flow is unchanged.

**Related issue or feature (if applicable):**

- fixes #1520

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
