### PR TITLE
Document the no-wireless transport copy rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,14 @@ for the full flow. The load-bearing rules:
 - When you remove a `_localize("foo")` call site, delete the key
   from `en.json` at the same time (the next `upload --cleanup`
   prunes it from Lokalise). No legacy keys retained.
+- **Transport copy never says "wireless".** Devices run Ethernet
+  and Thread too, so "wireless logs" / "installed wirelessly"
+  misdescribes them; say "over the network" (or OTA where the
+  surrounding UI already uses it). Outside contributors have had
+  to correct this twice (#1409, #1521), both times for a string
+  that shipped inside an unrelated PR. Key *names* are frozen API
+  (`logs_method_wireless` keeps its name); the rule is about
+  user-visible values.
 - The language picker is data-driven: each locale's autonym +
   flag come from its file's top-level `language` / `flag` keys,
   surfaced via a generated manifest


### PR DESCRIPTION
# What does this implement/fix?

Adds a copy rule to CLAUDE.md: user-facing transport copy never says "wireless". Devices run Ethernet and Thread too, so "wireless logs" and "installed wirelessly" misdescribe them; the house wording is "over the network", or OTA where the surrounding UI already uses it.

The rule earns its place by recurrence: outside contributors have corrected this twice, #1409 and #1521, and both times the string had shipped inside an unrelated PR (#1521 fixed copy introduced by #1515). Writing it into the instructions file is what stops the third round. Key names stay frozen (`logs_method_wireless` keeps its name); the rule is about user-visible values only.

**Related issue or feature (if applicable):**

- fixes n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
