### PR TITLE
Show the wiring presets for a substitution pin number

### DIFF
--- a/src/components/device/pin/renderer.ts
+++ b/src/components/device/pin/renderer.ts
@@ -535,8 +535,9 @@ function renderSubstitutionPin(
   // yields its channel token (compared against the board's token
   // designations), never a board GPIO its channel number could alias. A
   // plain pin's alias spelling ("SDA") resolves through the board table.
-  // An unresolvable reference guards nothing (the wiring is unknowable,
-  // and the presets gate already withholds cards).
+  // An unresolvable reference guards nothing and yields no board pin —
+  // the cards render without the input-only guardrail, same as a
+  // literal the catalog doesn't list.
   const pins = ctx.board?.pins ?? [];
   const resolvedNumber = resolveSubstitutions(number, ctx.substitutions);
   const resolved =
@@ -551,6 +552,9 @@ function renderSubstitutionPin(
       : designationMatches(boardPins.tokens, resolved) ||
         (entry.suggestions ?? []).some((s) => s === resolved));
   const guarded = boardPreset && !fieldDisabled;
+  // A long-form expander value resolves to a channel token, never a GPIO.
+  const boardPin =
+    typeof resolved === "number" ? (pins.find((p) => p.gpio === resolved) ?? null) : null;
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx, { path })}
@@ -574,7 +578,7 @@ function renderSubstitutionPin(
         path,
         ctx,
         rawValue,
-        boardPin: null,
+        boardPin,
         guarded,
       })}
     </div>

--- a/src/components/device/pin/wiring.ts
+++ b/src/components/device/pin/wiring.ts
@@ -18,7 +18,6 @@ import {
 } from "../../../api/types/config-entries.js";
 import { isPlainObject } from "../../../util/nested-values.js";
 import { isExpanderPinValue } from "../../../util/pin/gpio.js";
-import { isSubstitutionString } from "../../../util/substitutions.js";
 import {
   applyPresetToPin,
   modeFlagsOf,
@@ -116,18 +115,14 @@ export function renderPinWiring(opts: PinWiringOptions): TemplateResult | typeof
   // And only when a card pick can't lose data — a ``${var}`` mode or
   // inverted, or a readable flag outside the guided set (``analog``),
   // must fall through to the raw disclosure (a pick would clobber the
-  // reference / delete the flag), and a ``${var}`` number (either form)
-  // leaves the actual GPIO unknown, so the input-only guardrail could
-  // not vouch for the cards.
-  const numberValue = isLongForm
-    ? (rawValue as Record<string, unknown>).number
-    : rawValue;
+  // reference / delete the flag). A ``${var}`` number is fine: a pick
+  // never writes the number, and the caller resolves it against the
+  // file's substitutions to feed the board guardrail.
   const presets =
     modeChild &&
     ctx.sectionKey.endsWith(".gpio") &&
     !isExpanderPinValue(rawValue) &&
-    wiringValuesPresetSafe(modeValue, invertedValue) &&
-    !isSubstitutionString(numberValue)
+    wiringValuesPresetSafe(modeValue, invertedValue)
       ? presetsForPinMode(entry.pin_mode)
       : [];
   const usePresets = presets.length > 0;

--- a/test/components/device/pin/wiring.test.ts
+++ b/test/components/device/pin/wiring.test.ts
@@ -253,6 +253,22 @@ describe("pin wiring preset cards", () => {
     expect(cardById(result, "ground_switch")?.["aria-disabled"]).toBe("false");
   });
 
+  it("skips the guardrail when the reference resolves to an uncatalogued GPIO", () => {
+    // The lookup must return null, not fall back to some board pin —
+    // against a board that could banner if it did.
+    const result = renderPinField(
+      wiringPinEntry(PinMode.INPUT),
+      ["pin"],
+      openCtx(
+        { number: "${my_pin}", mode: {} },
+        { yaml: "substitutions:\n  my_pin: GPIO99\n" },
+        inputOnlyBoard()
+      )
+    );
+    expect(findTemplatesByAnchor(result, "pin-wiring-banner")).toHaveLength(0);
+    expect(cardById(result, "ground_switch")?.["aria-disabled"]).toBe("false");
+  });
+
   it("keeps the raw disclosure for an expander channel with a substitution number", () => {
     const result = renderPinField(
       wiringPinEntry(PinMode.INPUT),
@@ -361,6 +377,16 @@ describe("pin wiring preset cards", () => {
 
   it("opening the wiring summary does not rewrite a short-form pin", () => {
     const ctx = openCtx("GPIO2", { nestedOpenSections: new Set<string>() });
+    const result = renderPinField(wiringPinEntry(PinMode.INPUT), ["pin"], ctx);
+
+    (disclosureToggle(result)["@click"] as () => void)();
+
+    expect(ctx.toggleNested).toHaveBeenCalledWith("pin:pin-advanced");
+    expect(ctx.emitChange).not.toHaveBeenCalled();
+  });
+
+  it("opening the wiring summary does not rewrite a scalar reference pin", () => {
+    const ctx = openCtx("${my_pin}", { nestedOpenSections: new Set<string>() });
     const result = renderPinField(wiringPinEntry(PinMode.INPUT), ["pin"], ctx);
 
     (disclosureToggle(result)["@click"] as () => void)();

--- a/test/components/device/pin/wiring.test.ts
+++ b/test/components/device/pin/wiring.test.ts
@@ -242,11 +242,12 @@ describe("pin wiring preset cards", () => {
 
   it("renders enabled cards without the guardrail for an unresolvable reference", () => {
     // Same posture as a literal the catalog doesn't list: no board pin,
-    // no input-only vouching, cards stay usable.
+    // no input-only vouching, cards stay usable. The board carries an
+    // input-only pin so the no-banner assertion isn't vacuous.
     const result = renderPinField(
       wiringPinEntry(PinMode.INPUT),
       ["pin"],
-      openCtx({ number: "${from_package}", mode: {} })
+      openCtx({ number: "${from_package}", mode: {} }, {}, inputOnlyBoard())
     );
     expect(findTemplatesByAnchor(result, "pin-wiring-banner")).toHaveLength(0);
     expect(cardById(result, "ground_switch")?.["aria-disabled"]).toBe("false");

--- a/test/components/device/pin/wiring.test.ts
+++ b/test/components/device/pin/wiring.test.ts
@@ -217,23 +217,48 @@ describe("pin wiring preset cards", () => {
     expect(cards(result)).toHaveLength(0);
   });
 
-  it("keeps the raw disclosure when the pin number is a substitution", () => {
-    // The GPIO is unknown, so the input-only guardrail can't vouch for
-    // the cards; the raw disclosure edits the reference safely.
+  it("renders the preset cards when the pin number is a substitution", () => {
+    // A pick never writes the number, so the reference is safe under
+    // the cards; the text input above keeps editing it.
     const result = renderPinField(
       wiringPinEntry(PinMode.INPUT),
       ["pin"],
       openCtx({ number: "${my_pin}", mode: {} })
     );
-    expect(cards(result)).toHaveLength(0);
+    expect(new Set(cards(result).map((c) => c["data-preset"]))).toEqual(
+      new Set(["ground_switch", "vcc_switch", "driven_signal", "custom"])
+    );
 
-    // Same rule for the scalar form.
+    // Same for the scalar form.
     const scalar = renderPinField(
       wiringPinEntry(PinMode.INPUT),
       ["pin"],
       openCtx("${my_pin}")
     );
-    expect(cards(scalar)).toHaveLength(0);
+    expect(new Set(cards(scalar).map((c) => c["data-preset"]))).toEqual(
+      new Set(["ground_switch", "vcc_switch", "driven_signal", "custom"])
+    );
+  });
+
+  it("renders enabled cards without the guardrail for an unresolvable reference", () => {
+    // Same posture as a literal the catalog doesn't list: no board pin,
+    // no input-only vouching, cards stay usable.
+    const result = renderPinField(
+      wiringPinEntry(PinMode.INPUT),
+      ["pin"],
+      openCtx({ number: "${from_package}", mode: {} })
+    );
+    expect(findTemplatesByAnchor(result, "pin-wiring-banner")).toHaveLength(0);
+    expect(cardById(result, "ground_switch")?.["aria-disabled"]).toBe("false");
+  });
+
+  it("keeps the raw disclosure for an expander channel with a substitution number", () => {
+    const result = renderPinField(
+      wiringPinEntry(PinMode.INPUT),
+      ["pin"],
+      openCtx({ pca9554: "hub", number: "${ch}", mode: {} })
+    );
+    expect(cards(result)).toHaveLength(0);
   });
 
   it("marks the platform-default card active on an untouched pin", () => {
@@ -264,6 +289,19 @@ describe("pin wiring preset cards", () => {
 
     expect(ctx.emitChange).toHaveBeenCalledWith(["pin"], {
       number: "GPIO2",
+      mode: { input: true, pullup: true },
+      inverted: true,
+    });
+  });
+
+  it("preserves the substitution reference on a preset pick", () => {
+    const ctx = openCtx("${my_pin}");
+    const result = renderPinField(wiringPinEntry(PinMode.INPUT), ["pin"], ctx);
+
+    (cardById(result, "ground_switch")!["@click"] as () => void)();
+
+    expect(ctx.emitChange).toHaveBeenCalledWith(["pin"], {
+      number: "${my_pin}",
       mode: { input: true, pullup: true },
       inverted: true,
     });
@@ -495,6 +533,21 @@ describe("pin wiring input-only guardrail", () => {
     expect(findTemplatesByAnchor(result, "pin-wiring-banner").length).toBeGreaterThan(0);
     expect(cardById(result, "ground_switch")?.["aria-disabled"]).toBe("true");
     expect(cardById(result, "vcc_switch")?.["aria-disabled"]).toBe("true");
+    expect(cardById(result, "driven_signal")?.["aria-disabled"]).toBe("false");
+  });
+
+  it("banners when a substitution resolves to an input-only pin", () => {
+    const result = renderPinField(
+      wiringPinEntry(PinMode.INPUT),
+      ["pin"],
+      openCtx(
+        { number: "${my_pin}" },
+        { yaml: "substitutions:\n  my_pin: GPIO34\n" },
+        inputOnlyBoard()
+      )
+    );
+    expect(findTemplatesByAnchor(result, "pin-wiring-banner").length).toBeGreaterThan(0);
+    expect(cardById(result, "ground_switch")?.["aria-disabled"]).toBe("true");
     expect(cardById(result, "driven_signal")?.["aria-disabled"]).toBe("false");
   });
 


### PR DESCRIPTION
# What does this implement/fix?

Follow up to the guided wiring presets: a pin entered directly got the new wiring preset cards, but a pin spelled as a substitution (`pin: ${my_pin}` or `pin: { number: ${my_pin} }`) still fell back to the raw mode disclosure, which reads as two different editors for the same field.

The gate existed because the cards' input-only guardrail wants the actual GPIO, and a reference hides it. But `renderSubstitutionPin` already resolves the reference against the file's substitutions block for the board wiring guard; it just discarded the result before the panel. This change looks up the board pin from that resolved GPIO and passes it through, then drops the substitution term from the presets predicate. A preset pick never writes the number, so the reference stays intact (`{number: "${my_pin}", mode: {...}}`), and editing the substitutions block re-arms or releases the input-only guardrail live. An unresolvable reference (defined in a package or include) renders enabled cards with no guardrail, the same posture as a literal GPIO the board catalog doesn't list; the external marker on the resolve chip already flags it.

The raw disclosure is unchanged for everything it still owns: `${var}` mode flags or inverted, flags outside the guided set like `analog`, expander channels, directionless pins, and non gpio platforms. One side effect worth naming: opening the disclosure on a scalar `pin: ${var}` no longer promotes it to long form (that used to rewrite the YAML from a read only gesture); the promotion now happens only on a preset or Custom pick, matching literal pins.

Verified against the live dashboard: cards render for both reference forms, a pick preserves the reference, changing the substitution to GPIO34 banners and disables the output presets immediately, and an unresolved reference keeps usable cards.

**Related issue or feature (if applicable):**

- follow-up to https://github.com/orgs/esphome/discussions/3794

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
