### PR TITLE
Skip the caret-follow advanced reveal for fields that already render

### DIFF
--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -710,10 +710,9 @@ export class ESPHomeConfigEntryForm extends LitElement {
     if (this.entries.length === 0) return;
     const key = fieldKeyAttr(this.focusFieldPath);
     if (key === this._focusRevealKey) return;
+    if (!pathIsAdvanced(this.entries, this.focusFieldPath, this.values)) return;
     this._focusRevealKey = key;
-    if (pathIsAdvanced(this.entries, this.focusFieldPath)) {
-      this._emitAdvancedToggle(true);
-    }
+    this._emitAdvancedToggle(true);
   }
 
   /**

--- a/src/components/device/device-section-config/reveal.ts
+++ b/src/components/device/device-section-config/reveal.ts
@@ -72,7 +72,7 @@ function autoRevealAdvanced(
   if (host._showAdvanced || !host._config) return;
   if (host._autoRevealedSections.has(host.sectionKey)) return;
   const entries = resolveSectionEntries(host.sectionKey, host._config.entries);
-  if (!paths.some((path) => pathIsAdvanced(entries, path))) return;
+  if (!paths.some((path) => pathIsAdvanced(entries, path, host._values))) return;
   host._autoRevealedSections.add(host.sectionKey);
   host._setShowAdvanced(true);
 }

--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -4,10 +4,11 @@
  * validation-error map.
  */
 
+import { hasMaterialValue } from "../components/device/config-entry-render-filter.js";
 import type { ConfigEntry } from "../api/types/config-entries.js";
 import { ConfigEntryType } from "../api/types/config-entries.js";
 import type { ValidationError } from "./config-validation.js";
-import { isIndexSegment } from "./nested-values.js";
+import { asRecord, isIndexSegment, isPlainObject } from "./nested-values.js";
 import { PIN_WIRING_KEYS } from "./pin/wiring-presets.js";
 
 /** A pick-one group/cluster with any visible board-locked member is the
@@ -44,17 +45,27 @@ export function anyAdvancedEntry(entries: ConfigEntry[]): boolean {
 /**
  * Whether the entry at *path* — or any NESTED ancestor along it — is
  * `advanced`. Used to reveal a section's hidden advanced fields when the
- * caret or a backend error lands on one. List-index segments are skipped:
- * the schema nests an item's fields directly under the list entry, with
- * no index level. Returns false if the path doesn't resolve.
+ * caret or a backend error lands on one. List-index segments descend the
+ * value scope only: the schema nests an item's fields directly under the
+ * list entry, with no index level. When *values* is given, an advanced
+ * entry whose scope carries a material value doesn't gate — it renders
+ * without the toggle. Returns false if the path doesn't resolve.
  */
-export function pathIsAdvanced(entries: ConfigEntry[], path: string[]): boolean {
+export function pathIsAdvanced(
+  entries: ConfigEntry[],
+  path: string[],
+  values?: Record<string, unknown>
+): boolean {
   let level = entries;
+  let scope: unknown = values;
   let advanced = false;
   let prevWasPin = false;
   let inPinWiring = false;
   for (const key of path) {
-    if (isIndexSegment(key)) continue;
+    if (isIndexSegment(key)) {
+      scope = Array.isArray(scope) ? scope[Number(key)] : undefined;
+      continue;
+    }
     const entry = level.find((e) => e.key === key);
     if (!entry) return false;
     // A hidden entry never renders, so opening the advanced section
@@ -65,9 +76,16 @@ export function pathIsAdvanced(entries: ConfigEntry[], path: string[]): boolean 
     // anything; keep walking so the hidden check above still covers the
     // rest of the path.
     if (prevWasPin && PIN_WIRING_KEYS.has(entry.key)) inPinWiring = true;
-    if (entry.advanced && !inPinWiring) advanced = true;
+    if (
+      entry.advanced &&
+      !inPinWiring &&
+      (values === undefined || !hasMaterialValue(entry, asRecord(scope)))
+    ) {
+      advanced = true;
+    }
     prevWasPin = entry.type === ConfigEntryType.PIN;
     level = entry.config_entries ?? [];
+    scope = isPlainObject(scope) ? scope[key] : undefined;
   }
   return advanced;
 }

--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -8,7 +8,7 @@ import { hasMaterialValue } from "../components/device/config-entry-render-filte
 import type { ConfigEntry } from "../api/types/config-entries.js";
 import { ConfigEntryType } from "../api/types/config-entries.js";
 import type { ValidationError } from "./config-validation.js";
-import { asRecord, isIndexSegment, isPlainObject } from "./nested-values.js";
+import { asRecord, getIn, isIndexSegment } from "./nested-values.js";
 import { PIN_WIRING_KEYS } from "./pin/wiring-presets.js";
 
 /** A pick-one group/cluster with any visible board-locked member is the
@@ -44,32 +44,29 @@ export function anyAdvancedEntry(entries: ConfigEntry[]): boolean {
 
 /**
  * Whether the entry at *path* — or any NESTED ancestor along it — is
- * `advanced`. Used to reveal a section's hidden advanced fields when the
- * caret or a backend error lands on one. List-index segments descend the
- * value scope only: the schema nests an item's fields directly under the
- * list entry, with no index level. When *values* is given, an advanced
- * entry whose scope carries a material value doesn't gate — it renders
- * without the toggle. Returns false if the path doesn't resolve.
+ * advanced-gated given the current *values*: an advanced entry whose scope
+ * carries a material value doesn't gate, since it renders without the
+ * toggle. Used to reveal a section's hidden advanced fields when the caret
+ * or a backend error lands on one. List-index segments descend the value
+ * scope only: the schema nests an item's fields directly under the list
+ * entry, with no index level. Returns false if the path doesn't resolve.
  */
 export function pathIsAdvanced(
   entries: ConfigEntry[],
   path: string[],
-  values?: Record<string, unknown>
+  values: Record<string, unknown>
 ): boolean {
   let level = entries;
-  let scope: unknown = values;
   let advanced = false;
   let prevWasPin = false;
   let inPinWiring = false;
-  for (const key of path) {
-    if (isIndexSegment(key)) {
-      scope = Array.isArray(scope) ? scope[Number(key)] : undefined;
-      continue;
-    }
+  for (let i = 0; i < path.length; i++) {
+    const key = path[i];
+    if (isIndexSegment(key)) continue;
     const entry = level.find((e) => e.key === key);
     if (!entry) return false;
-    // A hidden entry never renders, so opening the advanced section
-    // can't show it — don't reveal for one.
+    // A hidden entry with a value already paints, one without a value
+    // never does; either way revealing can't help — no values check.
     if (entry.hidden) return false;
     // A pin's wiring section renders its fields regardless of the global
     // toggle, so advanced marks at or below the wiring keys don't gate
@@ -77,15 +74,15 @@ export function pathIsAdvanced(
     // rest of the path.
     if (prevWasPin && PIN_WIRING_KEYS.has(entry.key)) inPinWiring = true;
     if (
+      !advanced &&
       entry.advanced &&
       !inPinWiring &&
-      (values === undefined || !hasMaterialValue(entry, asRecord(scope)))
+      !hasMaterialValue(entry, asRecord(getIn(values, path.slice(0, i))))
     ) {
       advanced = true;
     }
     prevWasPin = entry.type === ConfigEntryType.PIN;
     level = entry.config_entries ?? [];
-    scope = isPlainObject(scope) ? scope[key] : undefined;
   }
   return advanced;
 }

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -638,23 +638,6 @@ describe("config-entry-form advanced-section", () => {
     expect(count).toBe(1);
   });
 
-  it("does not ask for a focus target that already renders inline", () => {
-    const form = new ESPHomeConfigEntryForm();
-    form.entries = [BASIC, ADVANCED];
-    form.values = { reboot_timeout: "5min" };
-    form.advancedSection = true;
-    form.gateAdvanced = true;
-    form.showAdvanced = false;
-    form.focusFieldPath = ["reboot_timeout"];
-    let emitted = false;
-    form.addEventListener("advanced-toggle", () => {
-      emitted = true;
-    });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (form as any).updated(new Map());
-    expect(emitted).toBe(false);
-  });
-
   it("keeps the focus-reveal shot after a skipped value-bearing target", () => {
     const form = new ESPHomeConfigEntryForm();
     form.entries = [BASIC, ADVANCED];

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -638,6 +638,43 @@ describe("config-entry-form advanced-section", () => {
     expect(count).toBe(1);
   });
 
+  it("does not ask for a focus target that already renders inline", () => {
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [BASIC, ADVANCED];
+    form.values = { reboot_timeout: "5min" };
+    form.advancedSection = true;
+    form.gateAdvanced = true;
+    form.showAdvanced = false;
+    form.focusFieldPath = ["reboot_timeout"];
+    let emitted = false;
+    form.addEventListener("advanced-toggle", () => {
+      emitted = true;
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any).updated(new Map());
+    expect(emitted).toBe(false);
+  });
+
+  it("keeps the focus-reveal shot after a skipped value-bearing target", () => {
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [BASIC, ADVANCED];
+    form.values = { reboot_timeout: "5min" };
+    form.advancedSection = true;
+    form.gateAdvanced = true;
+    form.showAdvanced = false;
+    form.focusFieldPath = ["reboot_timeout"];
+    let count = 0;
+    form.addEventListener("advanced-toggle", () => count++);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any).updated(new Map());
+    expect(count).toBe(0);
+    // Value cleared in YAML: the same target is hidden again, so it reveals.
+    form.values = {};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any).updated(new Map());
+    expect(count).toBe(1);
+  });
+
   it("emits advanced-toggle when the control is clicked", () => {
     const form = new ESPHomeConfigEntryForm();
     form.entries = [BASIC, ADVANCED];

--- a/test/components/device/section-config-advanced-reveal.test.ts
+++ b/test/components/device/section-config-advanced-reveal.test.ts
@@ -57,14 +57,7 @@ describe("device-section-config — advanced reveal on caret-follow", () => {
     expect(inner._showAdvanced).toBe(false);
   });
 
-  it("does not reveal when the focused advanced field already has a value", () => {
-    const inner = makeHost(["hide_timestamp"]);
-    inner._values = { hide_timestamp: "5s" };
-    inner._revealAdvancedForFocus(focusChanged());
-    expect(inner._showAdvanced).toBe(false);
-  });
-
-  it("keeps the once-per-section shot after a skipped reveal", () => {
+  it("keeps the once-per-section shot after a skipped value-bearing reveal", () => {
     const inner = makeHost(["hide_timestamp"]);
     inner._values = { hide_timestamp: "5s" };
     inner._revealAdvancedForFocus(focusChanged());

--- a/test/components/device/section-config-advanced-reveal.test.ts
+++ b/test/components/device/section-config-advanced-reveal.test.ts
@@ -57,6 +57,23 @@ describe("device-section-config — advanced reveal on caret-follow", () => {
     expect(inner._showAdvanced).toBe(false);
   });
 
+  it("does not reveal when the focused advanced field already has a value", () => {
+    const inner = makeHost(["hide_timestamp"]);
+    inner._values = { hide_timestamp: "5s" };
+    inner._revealAdvancedForFocus(focusChanged());
+    expect(inner._showAdvanced).toBe(false);
+  });
+
+  it("keeps the once-per-section shot after a skipped reveal", () => {
+    const inner = makeHost(["hide_timestamp"]);
+    inner._values = { hide_timestamp: "5s" };
+    inner._revealAdvancedForFocus(focusChanged());
+    expect(inner._showAdvanced).toBe(false);
+    inner._values = {};
+    inner._revealAdvancedForFocus(focusChanged());
+    expect(inner._showAdvanced).toBe(true);
+  });
+
   it("ignores updates where neither focusFieldPath nor _config changed", () => {
     const inner = makeHost(["hide_timestamp"]);
     inner._revealAdvancedForFocus(new Map()); // e.g. an unrelated re-render

--- a/test/components/device/section-config-backend-errors.test.ts
+++ b/test/components/device/section-config-backend-errors.test.ts
@@ -145,6 +145,13 @@ describe("device-section-config — backend field errors", () => {
     expect(inner._showAdvanced).toBe(true);
   });
 
+  it("does not reveal when the errored advanced field already has a value", () => {
+    const inner = makeHost(instanceErrors({ pin: "pin broken" }));
+    inner._values = { pin: "GPIO4" };
+    inner._revealAdvancedForErrors(backendErrorsChanged());
+    expect(inner._showAdvanced).toBe(false);
+  });
+
   it("does not reveal advanced settings for a plain-field error", () => {
     const inner = makeHost(instanceErrors({ update_interval: "x" }));
     inner._revealAdvancedForErrors(backendErrorsChanged());

--- a/test/util/config-entry-tree.test.ts
+++ b/test/util/config-entry-tree.test.ts
@@ -81,6 +81,44 @@ describe("pathIsAdvanced", () => {
     expect(pathIsAdvanced([advancedPin], ["pin", "mode", "input"])).toBe(true);
   });
 
+  it("is false for an advanced leaf that already carries a value", () => {
+    expect(pathIsAdvanced(entries, ["hide_timestamp"], { hide_timestamp: "5s" })).toBe(
+      false
+    );
+  });
+
+  it("stays true when only an unrelated key carries a value", () => {
+    expect(pathIsAdvanced(entries, ["hide_timestamp"], { name: "x" })).toBe(true);
+  });
+
+  it("ungates a plain leaf once its advanced ancestor has a value", () => {
+    expect(
+      pathIsAdvanced(entries, ["calibrate", "method"], { calibrate: { method: "gauss" } })
+    ).toBe(false);
+    expect(pathIsAdvanced(entries, ["calibrate", "method"], {})).toBe(true);
+  });
+
+  it("keeps gating an empty advanced leaf beside a valued sibling", () => {
+    expect(
+      pathIsAdvanced(entries, ["filters", "multiply"], { filters: { offset: 1 } })
+    ).toBe(true);
+  });
+
+  it("descends the value scope through list-index segments", () => {
+    const pins = {
+      key: "pins",
+      type: ConfigEntryType.NESTED,
+      label: "pins",
+      advanced: true,
+      multi_value: true,
+      config_entries: [entry("id", true)],
+    } as ConfigEntry;
+    expect(pathIsAdvanced([pins], ["pins", "0", "id"], { pins: [{ id: "x" }] })).toBe(
+      false
+    );
+    expect(pathIsAdvanced([pins], ["pins", "0", "id"], {})).toBe(true);
+  });
+
   it("still short-circuits on a hidden flag under a pin's mode group", () => {
     // The wiring exception suppresses advanced marks, not the hidden
     // walk — a hidden flag never renders, so don't reveal for it.

--- a/test/util/config-entry-tree.test.ts
+++ b/test/util/config-entry-tree.test.ts
@@ -28,7 +28,7 @@ describe("pathIsAdvanced", () => {
   ];
 
   it("is true for an advanced leaf", () => {
-    expect(pathIsAdvanced(entries, ["hide_timestamp"])).toBe(true);
+    expect(pathIsAdvanced(entries, ["hide_timestamp"], {})).toBe(true);
   });
 
   it("is false for a hidden entry — revealing advanced can't show it", () => {
@@ -39,25 +39,25 @@ describe("pathIsAdvanced", () => {
       advanced: true,
       hidden: true,
     } as ConfigEntry;
-    expect(pathIsAdvanced([...entries, hidden], ["actions"])).toBe(false);
-    expect(pathIsAdvanced([...entries, hidden], ["actions", "then"])).toBe(false);
+    expect(pathIsAdvanced([...entries, hidden], ["actions"], {})).toBe(false);
+    expect(pathIsAdvanced([...entries, hidden], ["actions", "then"], {})).toBe(false);
   });
 
   it("is false for a plain leaf", () => {
-    expect(pathIsAdvanced(entries, ["name"])).toBe(false);
+    expect(pathIsAdvanced(entries, ["name"], {})).toBe(false);
   });
 
   it("is true when an advanced ancestor gates a plain leaf", () => {
-    expect(pathIsAdvanced(entries, ["calibrate", "method"])).toBe(true);
+    expect(pathIsAdvanced(entries, ["calibrate", "method"], {})).toBe(true);
   });
 
   it("is true for an advanced leaf under a plain ancestor", () => {
-    expect(pathIsAdvanced(entries, ["filters", "multiply"])).toBe(true);
+    expect(pathIsAdvanced(entries, ["filters", "multiply"], {})).toBe(true);
   });
 
   it("is false when the path doesn't resolve", () => {
-    expect(pathIsAdvanced(entries, ["bogus"])).toBe(false);
-    expect(pathIsAdvanced(entries, [])).toBe(false);
+    expect(pathIsAdvanced(entries, ["bogus"], {})).toBe(false);
+    expect(pathIsAdvanced(entries, [], {})).toBe(false);
   });
 
   it("ignores the catalog-advanced marks under a pin's wiring fields", () => {
@@ -73,12 +73,12 @@ describe("pathIsAdvanced", () => {
         entry("inverted", true),
       ],
     } as ConfigEntry;
-    expect(pathIsAdvanced([pin], ["pin", "mode", "input"])).toBe(false);
-    expect(pathIsAdvanced([pin], ["pin", "mode"])).toBe(false);
-    expect(pathIsAdvanced([pin], ["pin", "inverted"])).toBe(false);
+    expect(pathIsAdvanced([pin], ["pin", "mode", "input"], {})).toBe(false);
+    expect(pathIsAdvanced([pin], ["pin", "mode"], {})).toBe(false);
+    expect(pathIsAdvanced([pin], ["pin", "inverted"], {})).toBe(false);
     // An advanced pin entry itself still gates its wiring fields.
     const advancedPin = { ...pin, advanced: true } as ConfigEntry;
-    expect(pathIsAdvanced([advancedPin], ["pin", "mode", "input"])).toBe(true);
+    expect(pathIsAdvanced([advancedPin], ["pin", "mode", "input"], {})).toBe(true);
   });
 
   it("is false for an advanced leaf that already carries a value", () => {
@@ -106,12 +106,8 @@ describe("pathIsAdvanced", () => {
 
   it("descends the value scope through list-index segments", () => {
     const pins = {
-      key: "pins",
-      type: ConfigEntryType.NESTED,
-      label: "pins",
-      advanced: true,
+      ...nested("pins", true, [entry("id", true)]),
       multi_value: true,
-      config_entries: [entry("id", true)],
     } as ConfigEntry;
     expect(pathIsAdvanced([pins], ["pins", "0", "id"], { pins: [{ id: "x" }] })).toBe(
       false
@@ -134,7 +130,7 @@ describe("pathIsAdvanced", () => {
         ]),
       ],
     } as ConfigEntry;
-    expect(pathIsAdvanced([pin], ["pin", "mode", "secret"])).toBe(false);
-    expect(pathIsAdvanced([pin], ["pin", "mode", "input"])).toBe(true);
+    expect(pathIsAdvanced([pin], ["pin", "mode", "secret"], {})).toBe(false);
+    expect(pathIsAdvanced([pin], ["pin", "mode", "input"], {})).toBe(true);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Clicking a YAML line for an advanced field that already has a value (`id`, `entity_category`, `disabled_by_default` on a `button.factory_reset`) flipped "Show advanced settings" on. Those fields already paint inline when they carry a value, so the reveal only surfaced every empty advanced field, and the form-level reveal path could re-open the toggle after a deliberate collapse.

`pathIsAdvanced` now takes the current values and treats a value-bearing advanced entry as already rendered; both reveal paths (section caret-follow and form focus) pass their values, and the form path no longer consumes its one-shot on a skipped target, so clearing the value in YAML and clicking the line again still reveals. Backend-error reveals get the same treatment through the shared helper. A genuinely hidden advanced field (no value yet) still auto-reveals so scroll-to-field keeps working.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2398

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
