### PR TITLE
Gate the caret-follow reveal on the whole render unit

### DIFF
--- a/src/components/device/config-entry-form-plan.ts
+++ b/src/components/device/config-entry-form-plan.ts
@@ -49,6 +49,31 @@ export function buildFormRenderPlan(
 }
 
 /**
+ * Resolver from a top-level entry key to its render unit's members (exclusive
+ * group or constraint cluster), undefined for plain entries. Feeds
+ * ``pathIsAdvanced`` so reveal decisions match unit placement.
+ */
+export function unitMembersByKey(
+  entries: ConfigEntry[],
+  requiredGroups: RequiredGroup[]
+): (key: string) => ConfigEntry[] | undefined {
+  const byKey = new Map<string, ConfigEntry[]>();
+  const { clusters } = buildConstraintClusters(entries, requiredGroups);
+  for (const cluster of clusters) {
+    for (const member of cluster.members) byKey.set(member.key, cluster.members);
+  }
+  const groups = new Map<string, ConfigEntry[]>();
+  for (const entry of entries) {
+    if (!entry.exclusive_group) continue;
+    const members = groups.get(entry.exclusive_group) ?? [];
+    members.push(entry);
+    groups.set(entry.exclusive_group, members);
+    byKey.set(entry.key, members);
+  }
+  return (key) => byKey.get(key);
+}
+
+/**
  * Whether the plan paints anything the user can act on: an unlocked plain
  * field, an exclusive-group dropdown, or a cluster box with an unlocked member.
  *

--- a/src/components/device/config-entry-form-plan.ts
+++ b/src/components/device/config-entry-form-plan.ts
@@ -1,6 +1,7 @@
 import type { ConfigEntry, RequiredGroup } from "../../api/types/config-entries.js";
 import {
   filterRenderable,
+  hasMaterialValue,
   type RenderFilterOptions,
 } from "./config-entry-render-filter.js";
 import {
@@ -48,29 +49,37 @@ export function buildFormRenderPlan(
   return { ordered, clusters, memberKeys, clusterByFirstKey, visible };
 }
 
+/** Every member advanced — an atomic unit can't straddle the boundary. */
+export function unitAllAdvanced(members: ConfigEntry[]): boolean {
+  return members.length > 0 && members.every((m) => !!m.advanced);
+}
+
+/** Any member valued — one value paints the whole unit inline. */
+export function unitHasMaterialValue(
+  members: ConfigEntry[],
+  values: Record<string, unknown>
+): boolean {
+  return members.some((m) => hasMaterialValue(m, values));
+}
+
 /**
- * Resolver from a top-level entry key to its render unit's members (exclusive
- * group or constraint cluster), undefined for plain entries. Feeds
- * ``pathIsAdvanced`` so reveal decisions match unit placement.
+ * Per-key gate: whether the render unit (exclusive group / constraint
+ * cluster) containing *key* is advanced-gated — every member advanced and
+ * none valued — or undefined for keys outside any unit. Feeds
+ * ``pathIsAdvanced`` so the caret-follow reveal can't drift from the
+ * form's unit placement.
  */
-export function unitMembersByKey(
+export function unitAdvancedGate(
   entries: ConfigEntry[],
-  requiredGroups: RequiredGroup[]
-): (key: string) => ConfigEntry[] | undefined {
-  const byKey = new Map<string, ConfigEntry[]>();
-  const { clusters } = buildConstraintClusters(entries, requiredGroups);
-  for (const cluster of clusters) {
-    for (const member of cluster.members) byKey.set(member.key, cluster.members);
-  }
-  const groups = new Map<string, ConfigEntry[]>();
-  for (const entry of entries) {
-    if (!entry.exclusive_group) continue;
-    const members = groups.get(entry.exclusive_group) ?? [];
-    members.push(entry);
-    groups.set(entry.exclusive_group, members);
-    byKey.set(entry.key, members);
-  }
-  return (key) => byKey.get(key);
+  requiredGroups: RequiredGroup[],
+  values: Record<string, unknown>
+): (key: string) => boolean | undefined {
+  const memberFor = unitMembersByKey(entries, requiredGroups);
+  return (key) => {
+    const members = memberFor(key);
+    if (!members) return undefined;
+    return unitAllAdvanced(members) && !unitHasMaterialValue(members, values);
+  };
 }
 
 /**
@@ -106,4 +115,25 @@ export function planNeedsUserInput(
         Array.isArray(item) && anyActionable(item) && !choicePinned(item, isVisible)
     )
   );
+}
+
+function unitMembersByKey(
+  entries: ConfigEntry[],
+  requiredGroups: RequiredGroup[]
+): (key: string) => ConfigEntry[] | undefined {
+  const byKey = new Map<string, ConfigEntry[]>();
+  const { clusters } = buildConstraintClusters(entries, requiredGroups);
+  for (const cluster of clusters) {
+    for (const member of cluster.members) byKey.set(member.key, cluster.members);
+  }
+  const groups = new Map<string, ConfigEntry[]>();
+  for (const entry of entries) {
+    if (!entry.exclusive_group) continue;
+    // Every member shares one array, so earlier keys see later joiners.
+    const members = groups.get(entry.exclusive_group) ?? [];
+    members.push(entry);
+    groups.set(entry.exclusive_group, members);
+    byKey.set(entry.key, members);
+  }
+  return (key) => byKey.get(key);
 }

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -79,7 +79,12 @@ import "@home-assistant/webawesome/dist/components/switch/switch.js";
 import "@home-assistant/webawesome/dist/components/tooltip/tooltip.js";
 import "../mdi-icon-picker.js";
 import "../options-combobox.js";
-import { buildFormRenderPlan, unitMembersByKey } from "./config-entry-form-plan.js";
+import {
+  buildFormRenderPlan,
+  unitAdvancedGate,
+  unitAllAdvanced,
+  unitHasMaterialValue,
+} from "./config-entry-form-plan.js";
 import {
   fieldRendererStyles,
   formatConstraintKeys,
@@ -482,11 +487,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
     let gatedAdvanced = advanced;
     if (this.gateAdvanced) {
       const unitPrefilled = (item: ConfigEntry | ConfigEntry[]): boolean => {
-        if (Array.isArray(item))
-          return item.some((e) => hasMaterialValue(e, this.values));
+        if (Array.isArray(item)) return unitHasMaterialValue(item, this.values);
         if (plan.memberKeys.has(item.key)) {
           const cluster = plan.clusterByFirstKey.get(item.key);
-          return !!cluster?.members.some((m) => hasMaterialValue(m, this.values));
+          return !!cluster && unitHasMaterialValue(cluster.members, this.values);
         }
         return hasMaterialValue(item, this.values);
       };
@@ -566,11 +570,11 @@ export class ESPHomeConfigEntryForm extends LitElement {
   private _advancedUnitClassifier(plan: ReturnType<typeof buildFormRenderPlan>) {
     const clusterAllAdvanced = new Map<string, boolean>();
     for (const cluster of plan.clusters) {
-      const all = cluster.members.every((m) => m.advanced);
+      const all = unitAllAdvanced(cluster.members);
       for (const m of cluster.members) clusterAllAdvanced.set(m.key, all);
     }
     return (item: ConfigEntry | ConfigEntry[]): boolean => {
-      if (Array.isArray(item)) return item.length > 0 && item.every((e) => e.advanced);
+      if (Array.isArray(item)) return unitAllAdvanced(item);
       if (plan.memberKeys.has(item.key)) return clusterAllAdvanced.get(item.key) ?? false;
       return !!item.advanced;
     };
@@ -710,8 +714,8 @@ export class ESPHomeConfigEntryForm extends LitElement {
     if (this.entries.length === 0) return;
     const key = fieldKeyAttr(this.focusFieldPath);
     if (key === this._focusRevealKey) return;
-    const unitFor = unitMembersByKey(this.entries, this.requiredGroups);
-    if (!pathIsAdvanced(this.entries, this.focusFieldPath, this.values, unitFor)) {
+    const unitGate = unitAdvancedGate(this.entries, this.requiredGroups, this.values);
+    if (!pathIsAdvanced(this.entries, this.focusFieldPath, this.values, unitGate)) {
       return;
     }
     this._focusRevealKey = key;

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -79,7 +79,7 @@ import "@home-assistant/webawesome/dist/components/switch/switch.js";
 import "@home-assistant/webawesome/dist/components/tooltip/tooltip.js";
 import "../mdi-icon-picker.js";
 import "../options-combobox.js";
-import { buildFormRenderPlan } from "./config-entry-form-plan.js";
+import { buildFormRenderPlan, unitMembersByKey } from "./config-entry-form-plan.js";
 import {
   fieldRendererStyles,
   formatConstraintKeys,
@@ -710,7 +710,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
     if (this.entries.length === 0) return;
     const key = fieldKeyAttr(this.focusFieldPath);
     if (key === this._focusRevealKey) return;
-    if (!pathIsAdvanced(this.entries, this.focusFieldPath, this.values)) return;
+    const unitFor = unitMembersByKey(this.entries, this.requiredGroups);
+    if (!pathIsAdvanced(this.entries, this.focusFieldPath, this.values, unitFor)) {
+      return;
+    }
     this._focusRevealKey = key;
     this._emitAdvancedToggle(true);
   }

--- a/src/components/device/device-section-config/reveal.ts
+++ b/src/components/device/device-section-config/reveal.ts
@@ -4,6 +4,7 @@
  */
 import { pathIsAdvanced } from "../../../util/config-entry-tree.js";
 import { resolveSectionEntries } from "../../../util/section-entry-overrides.js";
+import { unitMembersByKey } from "../config-entry-form-plan.js";
 import type { ESPHomeDeviceSectionConfig } from "../device-section-config.js";
 import { scrollFlashRow } from "../field-highlight.js";
 
@@ -72,7 +73,10 @@ function autoRevealAdvanced(
   if (host._showAdvanced || !host._config) return;
   if (host._autoRevealedSections.has(host.sectionKey)) return;
   const entries = resolveSectionEntries(host.sectionKey, host._config.entries);
-  if (!paths.some((path) => pathIsAdvanced(entries, path, host._values))) return;
+  const unitFor = unitMembersByKey(entries, host._config.required_groups ?? []);
+  if (!paths.some((path) => pathIsAdvanced(entries, path, host._values, unitFor))) {
+    return;
+  }
   host._autoRevealedSections.add(host.sectionKey);
   host._setShowAdvanced(true);
 }

--- a/src/components/device/device-section-config/reveal.ts
+++ b/src/components/device/device-section-config/reveal.ts
@@ -4,7 +4,7 @@
  */
 import { pathIsAdvanced } from "../../../util/config-entry-tree.js";
 import { resolveSectionEntries } from "../../../util/section-entry-overrides.js";
-import { unitMembersByKey } from "../config-entry-form-plan.js";
+import { unitAdvancedGate } from "../config-entry-form-plan.js";
 import type { ESPHomeDeviceSectionConfig } from "../device-section-config.js";
 import { scrollFlashRow } from "../field-highlight.js";
 
@@ -73,8 +73,12 @@ function autoRevealAdvanced(
   if (host._showAdvanced || !host._config) return;
   if (host._autoRevealedSections.has(host.sectionKey)) return;
   const entries = resolveSectionEntries(host.sectionKey, host._config.entries);
-  const unitFor = unitMembersByKey(entries, host._config.required_groups ?? []);
-  if (!paths.some((path) => pathIsAdvanced(entries, path, host._values, unitFor))) {
+  const unitGate = unitAdvancedGate(
+    entries,
+    host._config.required_groups ?? [],
+    host._values
+  );
+  if (!paths.some((path) => pathIsAdvanced(entries, path, host._values, unitGate))) {
     return;
   }
   host._autoRevealedSections.add(host.sectionKey);

--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -49,16 +49,16 @@ export function anyAdvancedEntry(entries: ConfigEntry[]): boolean {
  * toggle. Used to reveal a section's hidden advanced fields when the caret
  * or a backend error lands on one. List-index segments descend the value
  * scope only: the schema nests an item's fields directly under the list
- * entry, with no index level. When *unitFor* resolves the top-level key to
- * a render unit (exclusive group / constraint cluster), the unit gates as
- * a whole — every member advanced and none valued — since it renders
- * atomically. Returns false if the path doesn't resolve.
+ * entry, with no index level. When *unitGate* answers for the top-level
+ * key, its verdict on the whole render unit (exclusive group / constraint
+ * cluster, which paints atomically) replaces the per-entry rule. Returns
+ * false if the path doesn't resolve.
  */
 export function pathIsAdvanced(
   entries: ConfigEntry[],
   path: string[],
   values: Record<string, unknown>,
-  unitFor?: (key: string) => ConfigEntry[] | undefined
+  unitGate?: (key: string) => boolean | undefined
 ): boolean {
   let level = entries;
   let advanced = false;
@@ -77,17 +77,11 @@ export function pathIsAdvanced(
     // anything; keep walking so the hidden check above still covers the
     // rest of the path.
     if (prevWasPin && PIN_WIRING_KEYS.has(entry.key)) inPinWiring = true;
-    // Units only form at a form's top level, so the resolver applies to
-    // the first segment alone.
-    const unit = i === 0 ? unitFor?.(key) : undefined;
-    if (unit) {
-      if (
-        !advanced &&
-        unit.every((m) => m.advanced) &&
-        !unit.some((m) => hasMaterialValue(m, values))
-      ) {
-        advanced = true;
-      }
+    // Units only form at a form's top level, so the gate applies to the
+    // first segment alone.
+    const unitGated = i === 0 ? unitGate?.(key) : undefined;
+    if (unitGated !== undefined) {
+      if (unitGated) advanced = true;
     } else if (
       !advanced &&
       entry.advanced &&

--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -49,12 +49,16 @@ export function anyAdvancedEntry(entries: ConfigEntry[]): boolean {
  * toggle. Used to reveal a section's hidden advanced fields when the caret
  * or a backend error lands on one. List-index segments descend the value
  * scope only: the schema nests an item's fields directly under the list
- * entry, with no index level. Returns false if the path doesn't resolve.
+ * entry, with no index level. When *unitFor* resolves the top-level key to
+ * a render unit (exclusive group / constraint cluster), the unit gates as
+ * a whole — every member advanced and none valued — since it renders
+ * atomically. Returns false if the path doesn't resolve.
  */
 export function pathIsAdvanced(
   entries: ConfigEntry[],
   path: string[],
-  values: Record<string, unknown>
+  values: Record<string, unknown>,
+  unitFor?: (key: string) => ConfigEntry[] | undefined
 ): boolean {
   let level = entries;
   let advanced = false;
@@ -73,7 +77,18 @@ export function pathIsAdvanced(
     // anything; keep walking so the hidden check above still covers the
     // rest of the path.
     if (prevWasPin && PIN_WIRING_KEYS.has(entry.key)) inPinWiring = true;
-    if (
+    // Units only form at a form's top level, so the resolver applies to
+    // the first segment alone.
+    const unit = i === 0 ? unitFor?.(key) : undefined;
+    if (unit) {
+      if (
+        !advanced &&
+        unit.every((m) => m.advanced) &&
+        !unit.some((m) => hasMaterialValue(m, values))
+      ) {
+        advanced = true;
+      }
+    } else if (
       !advanced &&
       entry.advanced &&
       !inPinWiring &&

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -668,6 +668,34 @@ describe("config-entry-form advanced-section", () => {
     expect(count).toBe(1);
   });
 
+  it("does not ask for an exclusive-group member its sibling's value inlines", () => {
+    const ex = (key: string) =>
+      makeConfigEntry({
+        key,
+        type: ConfigEntryType.STRING,
+        label: key,
+        advanced: true,
+        exclusive_group: "g",
+      });
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [BASIC, ex("first"), ex("second")];
+    form.values = { second: "set" };
+    form.advancedSection = true;
+    form.gateAdvanced = true;
+    form.showAdvanced = false;
+    form.focusFieldPath = ["first"];
+    let count = 0;
+    form.addEventListener("advanced-toggle", () => count++);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any).updated(new Map());
+    expect(count).toBe(0);
+    // A wholly-empty all-advanced group is gated — the reveal fires.
+    form.values = {};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any).updated(new Map());
+    expect(count).toBe(1);
+  });
+
   it("keeps the focus-reveal shot after a skipped value-bearing target", () => {
     const form = new ESPHomeConfigEntryForm();
     form.entries = [BASIC, ADVANCED];

--- a/test/components/device/config-entry-form-advanced-section.test.ts
+++ b/test/components/device/config-entry-form-advanced-section.test.ts
@@ -638,6 +638,36 @@ describe("config-entry-form advanced-section", () => {
     expect(count).toBe(1);
   });
 
+  it("does not ask for an empty member of a cluster another member fills", () => {
+    // The whole cluster paints inline off the sibling's value, so the
+    // empty member is already on screen.
+    const clu = (key: string) =>
+      makeConfigEntry({
+        key,
+        type: ConfigEntryType.STRING,
+        label: key,
+        advanced: true,
+        group: "grp",
+      });
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [BASIC, clu("a"), clu("b")];
+    form.values = { a: "set" };
+    form.advancedSection = true;
+    form.gateAdvanced = true;
+    form.showAdvanced = false;
+    form.focusFieldPath = ["b"];
+    let count = 0;
+    form.addEventListener("advanced-toggle", () => count++);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any).updated(new Map());
+    expect(count).toBe(0);
+    // A wholly-empty all-advanced cluster is gated — the reveal fires.
+    form.values = {};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any).updated(new Map());
+    expect(count).toBe(1);
+  });
+
   it("keeps the focus-reveal shot after a skipped value-bearing target", () => {
     const form = new ESPHomeConfigEntryForm();
     form.entries = [BASIC, ADVANCED];

--- a/test/components/device/config-entry-form-plan.test.ts
+++ b/test/components/device/config-entry-form-plan.test.ts
@@ -1,0 +1,42 @@
+/** Unit tests for `unitAdvancedGate`. */
+import { describe, expect, it } from "vitest";
+
+import type { ConfigEntry } from "../../../src/api/types/config-entries.js";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { unitAdvancedGate } from "../../../src/components/device/config-entry-form-plan.js";
+import { makeConfigEntry } from "../../util/_make-config-entry.js";
+
+const entry = (key: string, extra: Partial<ConfigEntry> = {}): ConfigEntry =>
+  makeConfigEntry({ key, type: ConfigEntryType.STRING, label: key, ...extra });
+
+describe("unitAdvancedGate", () => {
+  it("gates a constraint cluster only while every member is advanced and unvalued", () => {
+    const entries = [
+      entry("a", { advanced: true, group: "grp" }),
+      entry("b", { advanced: true, group: "grp" }),
+      entry("plain"),
+    ];
+    expect(unitAdvancedGate(entries, [], {})("b")).toBe(true);
+    expect(unitAdvancedGate(entries, [], { a: "set" })("b")).toBe(false);
+    expect(unitAdvancedGate(entries, [], {})("plain")).toBeUndefined();
+  });
+
+  it("does not gate a mixed cluster — it renders in the basic bucket", () => {
+    const entries = [
+      entry("a", { group: "grp" }),
+      entry("b", { advanced: true, group: "grp" }),
+    ];
+    expect(unitAdvancedGate(entries, [], {})("b")).toBe(false);
+  });
+
+  it("answers for every exclusive-group member, first included", () => {
+    // The first member's mapping must see later joiners of the group.
+    const entries = [
+      entry("first", { advanced: true, exclusive_group: "g" }),
+      entry("second", { advanced: true, exclusive_group: "g" }),
+    ];
+    expect(unitAdvancedGate(entries, [], { second: "set" })("first")).toBe(false);
+    expect(unitAdvancedGate(entries, [], {})("first")).toBe(true);
+    expect(unitAdvancedGate(entries, [], {})("second")).toBe(true);
+  });
+});

--- a/test/components/device/section-config-advanced-reveal.test.ts
+++ b/test/components/device/section-config-advanced-reveal.test.ts
@@ -67,6 +67,25 @@ describe("device-section-config — advanced reveal on caret-follow", () => {
     expect(inner._showAdvanced).toBe(true);
   });
 
+  it("does not reveal for an empty member of a cluster another member fills", () => {
+    const clu = (key: string) =>
+      ({
+        key,
+        type: ConfigEntryType.STRING,
+        label: key,
+        advanced: true,
+        group: "grp",
+      }) as ConfigEntry;
+    const inner = makeHost(["b"]);
+    inner._config = { entries: [clu("a"), clu("b")] };
+    inner._values = { a: "set" };
+    inner._revealAdvancedForFocus(focusChanged());
+    expect(inner._showAdvanced).toBe(false);
+    inner._values = {};
+    inner._revealAdvancedForFocus(focusChanged());
+    expect(inner._showAdvanced).toBe(true);
+  });
+
   it("ignores updates where neither focusFieldPath nor _config changed", () => {
     const inner = makeHost(["hide_timestamp"]);
     inner._revealAdvancedForFocus(new Map()); // e.g. an unrelated re-render

--- a/test/util/config-entry-tree.test.ts
+++ b/test/util/config-entry-tree.test.ts
@@ -115,31 +115,26 @@ describe("pathIsAdvanced", () => {
     expect(pathIsAdvanced([pins], ["pins", "0", "id"], {})).toBe(true);
   });
 
-  it("gates a unit only when every member is advanced and none is valued", () => {
+  it("lets the unit gate override per-entry gating at the top level", () => {
     const a = entry("a", true);
-    const b = entry("b", true);
-    const unitFor = (key: string) => (key === "a" || key === "b" ? [a, b] : undefined);
-    expect(pathIsAdvanced([a, b], ["b"], {}, unitFor)).toBe(true);
-    // A valued sibling paints the whole unit inline.
-    expect(pathIsAdvanced([a, b], ["b"], { a: "set" }, unitFor)).toBe(false);
-    // A mixed unit never lands in the advanced bucket.
-    const plain = entry("a", false);
-    const mixedFor = (key: string) =>
-      key === "a" || key === "b" ? [plain, b] : undefined;
-    expect(pathIsAdvanced([plain, b], ["b"], {}, mixedFor)).toBe(false);
-    // Keys the resolver doesn't know keep per-entry gating.
-    expect(pathIsAdvanced([a, b, entry("c", true)], ["c"], {}, unitFor)).toBe(true);
+    const gate = (verdict: boolean | undefined) => (key: string) =>
+      key === "a" ? verdict : undefined;
+    // Gate false: the unit paints inline even though the entry alone gates.
+    expect(pathIsAdvanced([a], ["a"], {}, gate(false))).toBe(false);
+    // Gate true: the unit is gated even though the entry alone is valued.
+    expect(pathIsAdvanced([a], ["a"], { a: "x" }, gate(true))).toBe(true);
+    // No verdict: per-entry gating applies.
+    expect(pathIsAdvanced([a], ["a"], {}, gate(undefined))).toBe(true);
   });
 
-  it("consults the unit resolver for the top-level segment only", () => {
+  it("consults the unit gate for the top-level segment only", () => {
     const wrap = nested("wrap", false, [entry("a", true)]);
-    const unitFor = (key: string) =>
-      key === "a" ? [entry("a", true), entry("z", true)] : undefined;
+    const gate = (key: string) => (key === "a" ? true : undefined);
     // "a" at depth 1 is a plain advanced leaf; its own scope decides.
-    expect(pathIsAdvanced([wrap], ["wrap", "a"], { wrap: { a: "set" } }, unitFor)).toBe(
+    expect(pathIsAdvanced([wrap], ["wrap", "a"], { wrap: { a: "set" } }, gate)).toBe(
       false
     );
-    expect(pathIsAdvanced([wrap], ["wrap", "a"], {}, unitFor)).toBe(true);
+    expect(pathIsAdvanced([wrap], ["wrap", "a"], {}, gate)).toBe(true);
   });
 
   it("still short-circuits on a hidden flag under a pin's mode group", () => {

--- a/test/util/config-entry-tree.test.ts
+++ b/test/util/config-entry-tree.test.ts
@@ -115,6 +115,33 @@ describe("pathIsAdvanced", () => {
     expect(pathIsAdvanced([pins], ["pins", "0", "id"], {})).toBe(true);
   });
 
+  it("gates a unit only when every member is advanced and none is valued", () => {
+    const a = entry("a", true);
+    const b = entry("b", true);
+    const unitFor = (key: string) => (key === "a" || key === "b" ? [a, b] : undefined);
+    expect(pathIsAdvanced([a, b], ["b"], {}, unitFor)).toBe(true);
+    // A valued sibling paints the whole unit inline.
+    expect(pathIsAdvanced([a, b], ["b"], { a: "set" }, unitFor)).toBe(false);
+    // A mixed unit never lands in the advanced bucket.
+    const plain = entry("a", false);
+    const mixedFor = (key: string) =>
+      key === "a" || key === "b" ? [plain, b] : undefined;
+    expect(pathIsAdvanced([plain, b], ["b"], {}, mixedFor)).toBe(false);
+    // Keys the resolver doesn't know keep per-entry gating.
+    expect(pathIsAdvanced([a, b, entry("c", true)], ["c"], {}, unitFor)).toBe(true);
+  });
+
+  it("consults the unit resolver for the top-level segment only", () => {
+    const wrap = nested("wrap", false, [entry("a", true)]);
+    const unitFor = (key: string) =>
+      key === "a" ? [entry("a", true), entry("z", true)] : undefined;
+    // "a" at depth 1 is a plain advanced leaf; its own scope decides.
+    expect(pathIsAdvanced([wrap], ["wrap", "a"], { wrap: { a: "set" } }, unitFor)).toBe(
+      false
+    );
+    expect(pathIsAdvanced([wrap], ["wrap", "a"], {}, unitFor)).toBe(true);
+  });
+
   it("still short-circuits on a hidden flag under a pin's mode group", () => {
     // The wiring exception suppresses advanced marks, not the hidden
     // walk — a hidden flag never renders, so don't reveal for it.


### PR DESCRIPTION
# What does this implement/fix?

Clicking the YAML line of an empty advanced field inside an exclusive group or constraint cluster still flipped "Show advanced settings" on, even though the whole unit already paints inline when any member has a value. The reveal predicate judged the target entry alone while the form places units atomically, so the two could disagree.

The plan module now owns the unit rule once: `unitAllAdvanced` and `unitHasMaterialValue` are the shared halves, `unitAdvancedGate` composes them into a per-key verdict, and the form's `unitPrefilled` and `_advancedUnitClassifier` are rewired onto the same halves. `pathIsAdvanced` takes the gate as an injected predicate (avoiding a util-to-components cycle) and both reveal paths pass it; when the top-level key belongs to a unit, the gate's verdict replaces the per-entry rule. A wholly empty all-advanced unit still reveals so the group's control surfaces, and mixed units, which always render in the basic bucket, no longer trigger a reveal either.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2408

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
