### PR TITLE
Skip validation for lambda values on typed templatable fields

### DIFF
--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -1,3 +1,4 @@
+import { isLambdaValue } from "../api/types/automations.js";
 import type {
   ConfigEntry,
   ConfigPrimitive,
@@ -256,6 +257,11 @@ export function validateEntry(entry: ConfigEntry, raw: unknown): ValidationError
   // here; skip all validation (range, options, not-a-number) for the literal
   // or a mid-edit partial (#1391).
   if (isSubstitutionString(raw)) return null;
+
+  // A !lambda on a templatable field resolves at runtime the same way;
+  // the typed branches would stringify it to "[object Object]" and flag
+  // a valid value as not-a-number.
+  if (isLambdaValue(raw)) return null;
 
   if (entry.type === ConfigEntryType.INTEGER && entry.display_format === "hex") {
     // BigInt-route the hex-typed integer check so cv.hex_uint64_t

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -953,3 +953,16 @@ describe("clearPathErrors", () => {
     expect(clearPathErrors(errs(), "other")).toBeNull();
   });
 });
+
+it("never flags a lambda value on a typed templatable field", () => {
+  // A !lambda resolves at runtime; the typed branches would stringify
+  // it to "[object Object]" and reject a valid value.
+  const lambda = { _lambda: "return 153;" };
+  expect(
+    validateEntry(
+      makeEntry({ type: ConfigEntryType.FLOAT_WITH_UNIT, range: [153, 500] }),
+      lambda
+    )
+  ).toBeNull();
+  expect(validateEntry(makeEntry({ type: ConfigEntryType.INTEGER }), lambda)).toBeNull();
+});


### PR DESCRIPTION
# What does this implement/fix?

`validateEntry` skips `${substitution}` values but not `!lambda` ones, so a lambda on a typed templatable field flows into the typed branches, stringifies to `[object Object]`, and flags a valid value as "Must be a number"; latent while most templatable fields shipped untyped, and widely exposed once device-builder#2411 types them (`float_with_unit`, bounded integers, `mac_address`). Add the `isLambdaValue` skip beside the substitution skip, same rationale, the value resolves at runtime; the templatable renderer already discriminates modes by value shape, so rendering was never affected.

**Related issue or feature (if applicable):**

- part of the catalog typing arc landing in esphome/device-builder#2411

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
