### PR TITLE
Move hasMaterialValue into the util layer

### DIFF
--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -25,8 +25,10 @@ import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../api/types/config-entries.js";
 import { isEntryVisible } from "../../util/config-validation.js";
-import { asMappingList, asRecord, isPlainObject } from "../../util/nested-values.js";
-import { YamlRawValue } from "../../util/yaml-serialize.js";
+import { hasMaterialValue } from "../../util/material-value.js";
+import { asMappingList, asRecord } from "../../util/nested-values.js";
+
+export { hasMaterialValue };
 
 /**
  * Entry keys the form keeps visible even when ``requiredOnly`` is
@@ -148,48 +150,6 @@ export function renderFilterOptions(
   // ``scopeValues([])``) still inherits the board's variant.
   opts.rootValues = seedBoardImpliedRootValues(opts.rootValues, source);
   return opts;
-}
-
-/**
- * True when ``entry`` carries a value the user has set (typically
- * loaded from YAML). For leaves, any non-``undefined`` value counts
- * — the YAML parser only adds a key to ``values`` when it's
- * actually present in the document, so "present in ``values``"
- * is the visibility signal we want. Note this is a visibility
- * predicate, not a serialization predicate: an explicit empty
- * scalar (``key: ""``) or null may render once and then be
- * dropped on save by ``serializeYamlValues``, which is fine —
- * the next reload will hide the field.
- *
- * For NESTED entries, recurse into the sub-dict and report true if
- * any descendant leaf is set; an advanced group with at least one
- * filled child needs to render so the child is reachable.
- */
-export function hasMaterialValue(
-  entry: ConfigEntry,
-  values: Record<string, unknown>
-): boolean {
-  const value = values[entry.key];
-  if (entry.type === ConfigEntryType.NESTED) {
-    if (entry.multi_value) {
-      // Repeatable nested mapping (``esphome.devices`` /
-      // ``esphome.areas``): any non-empty array of items counts.
-      // We don't recurse — items are user-added, and a freshly
-      // added empty ``{}`` still represents user intent (the row
-      // exists because they clicked Add). A ``YamlRawValue`` at
-      // this key (the parser preserved the block byte-for-byte
-      // because the items didn't fit the flat-mapping contract)
-      // also counts — the user's YAML must keep showing without
-      // a trip through the Advanced toggle.
-      if (value instanceof YamlRawValue) return true;
-      return Array.isArray(value) && value.length > 0;
-    }
-    // A scalar at a NESTED key is a shorthand the user set in YAML (e.g.
-    // a pin ``mode: OUTPUT``); it's material even though it can't recurse.
-    if (!isPlainObject(value)) return value !== undefined;
-    return (entry.config_entries ?? []).some((child) => hasMaterialValue(child, value));
-  }
-  return value !== undefined;
 }
 
 export function filterRenderable(

--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -4,10 +4,10 @@
  * validation-error map.
  */
 
-import { hasMaterialValue } from "../components/device/config-entry-render-filter.js";
 import type { ConfigEntry } from "../api/types/config-entries.js";
 import { ConfigEntryType } from "../api/types/config-entries.js";
 import type { ValidationError } from "./config-validation.js";
+import { hasMaterialValue } from "./material-value.js";
 import { asRecord, getIn, isIndexSegment } from "./nested-values.js";
 import { PIN_WIRING_KEYS } from "./pin/wiring-presets.js";
 

--- a/src/util/material-value.ts
+++ b/src/util/material-value.ts
@@ -1,0 +1,50 @@
+/** "Has the user set a value here?" — the visibility half of the
+ *  advanced/hidden gating rules, shared by the render filter and the
+ *  caret-follow reveal. */
+
+import type { ConfigEntry } from "../api/types/config-entries.js";
+import { ConfigEntryType } from "../api/types/config-entries.js";
+import { isPlainObject } from "./nested-values.js";
+import { YamlRawValue } from "./yaml-serialize.js";
+
+/**
+ * True when ``entry`` carries a value the user has set (typically
+ * loaded from YAML). For leaves, any non-``undefined`` value counts
+ * — the YAML parser only adds a key to ``values`` when it's
+ * actually present in the document, so "present in ``values``"
+ * is the visibility signal we want. Note this is a visibility
+ * predicate, not a serialization predicate: an explicit empty
+ * scalar (``key: ""``) or null may render once and then be
+ * dropped on save by ``serializeYamlValues``, which is fine —
+ * the next reload will hide the field.
+ *
+ * For NESTED entries, recurse into the sub-dict and report true if
+ * any descendant leaf is set; an advanced group with at least one
+ * filled child needs to render so the child is reachable.
+ */
+export function hasMaterialValue(
+  entry: ConfigEntry,
+  values: Record<string, unknown>
+): boolean {
+  const value = values[entry.key];
+  if (entry.type === ConfigEntryType.NESTED) {
+    if (entry.multi_value) {
+      // Repeatable nested mapping (``esphome.devices`` /
+      // ``esphome.areas``): any non-empty array of items counts.
+      // We don't recurse — items are user-added, and a freshly
+      // added empty ``{}`` still represents user intent (the row
+      // exists because they clicked Add). A ``YamlRawValue`` at
+      // this key (the parser preserved the block byte-for-byte
+      // because the items didn't fit the flat-mapping contract)
+      // also counts — the user's YAML must keep showing without
+      // a trip through the Advanced toggle.
+      if (value instanceof YamlRawValue) return true;
+      return Array.isArray(value) && value.length > 0;
+    }
+    // A scalar at a NESTED key is a shorthand the user set in YAML (e.g.
+    // a pin ``mode: OUTPUT``); it's material even though it can't recurse.
+    if (!isPlainObject(value)) return value !== undefined;
+    return (entry.config_entries ?? []).some((child) => hasMaterialValue(child, value));
+  }
+  return value !== undefined;
+}


### PR DESCRIPTION
# What does this implement/fix?

`hasMaterialValue` is a DOM-free predicate that lived in the component layer, and `src/util/config-entry-tree.ts` importing it gave the util layer a runtime edge into components. It now lives in `src/util/material-value.ts`; `config-entry-render-filter.ts` re-exports it so its existing consumers don't churn, and `config-entry-tree.ts` imports it from util. Function body and doc comment move verbatim, no behavior change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2409

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
