### PR TITLE
Remove the dead findFirstErrorTarget walker

### DIFF
--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -1,12 +1,10 @@
 /**
  * Recursive walkers over a `ConfigEntry[]` tree: reveal advanced fields
- * under the caret and locate the first entry referenced by a
- * validation-error map.
+ * under the caret.
  */
 
 import type { ConfigEntry } from "../api/types/config-entries.js";
 import { ConfigEntryType } from "../api/types/config-entries.js";
-import type { ValidationError } from "./config-validation.js";
 import { hasMaterialValue } from "./material-value.js";
 import { asRecord, getIn, isIndexSegment } from "./nested-values.js";
 import { PIN_WIRING_KEYS } from "./pin/wiring-presets.js";
@@ -94,36 +92,4 @@ export function pathIsAdvanced(
     level = entry.config_entries ?? [];
   }
   return advanced;
-}
-
-/**
- * Walk the entries in render order and return the first error target.
- * `path` is the dotted path of the failing leaf field;
- * `hasAdvancedAncestor` is true when the leaf itself or any
- * NESTED entry along the way is `advanced`.
- */
-export function findFirstErrorTarget(
-  entries: ConfigEntry[],
-  errors: Map<string, ValidationError>,
-  pathPrefix: string[] = [],
-  ancestorAdvanced = false
-): { path: string[]; hasAdvancedAncestor: boolean } | null {
-  for (const entry of entries) {
-    const path = [...pathPrefix, entry.key];
-    const advancedHere = ancestorAdvanced || entry.advanced;
-    if (entry.type === ConfigEntryType.NESTED) {
-      const found = findFirstErrorTarget(
-        entry.config_entries ?? [],
-        errors,
-        path,
-        advancedHere
-      );
-      if (found) return found;
-      continue;
-    }
-    if (errors.has(path.join("."))) {
-      return { path, hasAdvancedAncestor: advancedHere };
-    }
-  }
-  return null;
 }


### PR DESCRIPTION
# What does this implement/fix?

`findFirstErrorTarget` in `src/util/config-entry-tree.ts` was exported with zero callers and zero tests, and it still computed `hasAdvancedAncestor` with the values-blind rule the same file's `pathIsAdvanced` was corrected away from, so wiring it up later would reinherit the fixed bug. Deleted along with its now-unused `ValidationError` import; the module docstring drops the mention.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2410

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
