### PR TITLE
Unify the per-entry advanced-gate rule behind one predicate

### DIFF
--- a/src/components/device/config-entry-form-plan.ts
+++ b/src/components/device/config-entry-form-plan.ts
@@ -1,7 +1,7 @@
 import type { ConfigEntry, RequiredGroup } from "../../api/types/config-entries.js";
+import { hasMaterialValue } from "../../util/material-value.js";
 import {
   filterRenderable,
-  hasMaterialValue,
   type RenderFilterOptions,
 } from "./config-entry-render-filter.js";
 import {

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -52,6 +52,7 @@ import {
 } from "../../util/pin/registry-modes-cache.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { nearestScrollContainer } from "../../util/scroll-container.js";
+import { advancedGated } from "../../util/material-value.js";
 import { SessionBlobCacheController } from "../../util/session-blob-cache-controller.js";
 import { isSubstitutionString, parseSubstitutions } from "../../util/substitutions.js";
 import {
@@ -554,7 +555,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
   /** True when a pre-filled advanced field forces the section open — it can't be
    *  collapsed while a value is set, matching the legacy material-value rule. */
   private _advancedForceOpen(): boolean {
-    return this.entries.some((e) => e.advanced && hasMaterialValue(e, this.values));
+    return this.entries.some((e) => e.advanced && !advancedGated(e, this.values));
   }
 
   /** The force-open kernel: a pre-filled advanced field opens the section, but

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -44,6 +44,7 @@ import { getErrorMessage } from "../../util/error-message.js";
 import { overlayBoardLockedPresets } from "../../util/featured-locks.js";
 import { fetchAllComponents } from "../../util/fetch-all-components.js";
 import { fireEvent } from "../../util/fire-event.js";
+import { hasMaterialValue } from "../../util/material-value.js";
 import { getIn, isPrimitiveOrNullish } from "../../util/nested-values.js";
 import {
   fetchPinRegistryModes,
@@ -57,7 +58,6 @@ import { isSubstitutionString, parseSubstitutions } from "../../util/substitutio
 import {
   _isStructuralType,
   filterRenderable,
-  hasMaterialValue,
   renderFilterOptions,
 } from "./config-entry-render-filter.js";
 import {

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -52,7 +52,6 @@ import {
 } from "../../util/pin/registry-modes-cache.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { nearestScrollContainer } from "../../util/scroll-container.js";
-import { advancedGated } from "../../util/material-value.js";
 import { SessionBlobCacheController } from "../../util/session-blob-cache-controller.js";
 import { isSubstitutionString, parseSubstitutions } from "../../util/substitutions.js";
 import {
@@ -555,7 +554,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
   /** True when a pre-filled advanced field forces the section open — it can't be
    *  collapsed while a value is set, matching the legacy material-value rule. */
   private _advancedForceOpen(): boolean {
-    return this.entries.some((e) => e.advanced && !advancedGated(e, this.values));
+    return this.entries.some((e) => e.advanced && hasMaterialValue(e, this.values));
   }
 
   /** The force-open kernel: a pre-filled advanced field opens the section, but

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -25,10 +25,8 @@ import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../api/types/config-entries.js";
 import { isEntryVisible } from "../../util/config-validation.js";
-import { advancedGated, hasMaterialValue } from "../../util/material-value.js";
+import { advancedGated } from "../../util/material-value.js";
 import { asMappingList, asRecord } from "../../util/nested-values.js";
-
-export { hasMaterialValue };
 
 /**
  * Entry keys the form keeps visible even when ``requiredOnly`` is

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -25,7 +25,7 @@ import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../api/types/config-entries.js";
 import { isEntryVisible } from "../../util/config-validation.js";
-import { hasMaterialValue } from "../../util/material-value.js";
+import { advancedGated, hasMaterialValue } from "../../util/material-value.js";
 import { asMappingList, asRecord } from "../../util/nested-values.js";
 
 export { hasMaterialValue };
@@ -171,7 +171,7 @@ export function filterRenderable(
     ) {
       continue;
     }
-    if (entry.advanced && !opts.showAdvanced && !hasMaterialValue(entry, values)) {
+    if (!opts.showAdvanced && advancedGated(entry, values)) {
       continue;
     }
     if (entry.type === ConfigEntryType.NESTED) {

--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -5,7 +5,7 @@
 
 import type { ConfigEntry } from "../api/types/config-entries.js";
 import { ConfigEntryType } from "../api/types/config-entries.js";
-import { hasMaterialValue } from "./material-value.js";
+import { advancedGated } from "./material-value.js";
 import { asRecord, getIn, isIndexSegment } from "./nested-values.js";
 import { PIN_WIRING_KEYS } from "./pin/wiring-presets.js";
 
@@ -82,9 +82,8 @@ export function pathIsAdvanced(
       if (unitGated) advanced = true;
     } else if (
       !advanced &&
-      entry.advanced &&
       !inPinWiring &&
-      !hasMaterialValue(entry, asRecord(getIn(values, path.slice(0, i))))
+      advancedGated(entry, asRecord(getIn(values, path.slice(0, i))))
     ) {
       advanced = true;
     }

--- a/src/util/material-value.ts
+++ b/src/util/material-value.ts
@@ -22,14 +22,6 @@ import { YamlRawValue } from "./yaml-serialize.js";
  * any descendant leaf is set; an advanced group with at least one
  * filled child needs to render so the child is reachable.
  */
-/** The gate rule: an advanced entry hides behind the toggle unless valued. */
-export function advancedGated(
-  entry: ConfigEntry,
-  values: Record<string, unknown>
-): boolean {
-  return !!entry.advanced && !hasMaterialValue(entry, values);
-}
-
 export function hasMaterialValue(
   entry: ConfigEntry,
   values: Record<string, unknown>
@@ -55,4 +47,12 @@ export function hasMaterialValue(
     return (entry.config_entries ?? []).some((child) => hasMaterialValue(child, value));
   }
   return value !== undefined;
+}
+
+/** The gate rule: an advanced entry hides behind the toggle unless valued. */
+export function advancedGated(
+  entry: ConfigEntry,
+  values: Record<string, unknown>
+): boolean {
+  return !!entry.advanced && !hasMaterialValue(entry, values);
 }

--- a/src/util/material-value.ts
+++ b/src/util/material-value.ts
@@ -22,6 +22,14 @@ import { YamlRawValue } from "./yaml-serialize.js";
  * any descendant leaf is set; an advanced group with at least one
  * filled child needs to render so the child is reachable.
  */
+/** The gate rule: an advanced entry hides behind the toggle unless valued. */
+export function advancedGated(
+  entry: ConfigEntry,
+  values: Record<string, unknown>
+): boolean {
+  return !!entry.advanced && !hasMaterialValue(entry, values);
+}
+
 export function hasMaterialValue(
   entry: ConfigEntry,
   values: Record<string, unknown>

--- a/test/util/material-value.test.ts
+++ b/test/util/material-value.test.ts
@@ -1,34 +1,29 @@
 /** Unit tests for `advancedGated`. */
 import { describe, expect, it } from "vitest";
 
-import type { ConfigEntry } from "../../src/api/types/config-entries.js";
-import { ConfigEntryType } from "../../src/api/types/config-entries.js";
 import { advancedGated } from "../../src/util/material-value.js";
-
-const entry = (key: string, extra: Partial<ConfigEntry> = {}): ConfigEntry =>
-  ({ key, type: ConfigEntryType.STRING, label: key, ...extra }) as ConfigEntry;
+import { makeConfigEntry, makeNestedEntry } from "./_make-config-entry.js";
 
 describe("advancedGated", () => {
   it("gates an advanced entry without a value", () => {
-    expect(advancedGated(entry("a", { advanced: true }), {})).toBe(true);
+    expect(advancedGated(makeConfigEntry({ key: "a", advanced: true }), {})).toBe(true);
   });
 
   it("does not gate a valued advanced entry", () => {
-    expect(advancedGated(entry("a", { advanced: true }), { a: "x" })).toBe(false);
+    expect(advancedGated(makeConfigEntry({ key: "a", advanced: true }), { a: "x" })).toBe(
+      false
+    );
   });
 
   it("never gates a plain entry", () => {
-    expect(advancedGated(entry("a"), {})).toBe(false);
+    expect(advancedGated(makeConfigEntry({ key: "a" }), {})).toBe(false);
   });
 
   it("follows hasMaterialValue into nested children", () => {
     const nested = {
-      key: "grp",
-      type: ConfigEntryType.NESTED,
-      label: "grp",
+      ...makeNestedEntry("grp", [makeConfigEntry({ key: "child" })]),
       advanced: true,
-      config_entries: [entry("child")],
-    } as ConfigEntry;
+    };
     expect(advancedGated(nested, { grp: { child: 1 } })).toBe(false);
     expect(advancedGated(nested, {})).toBe(true);
   });

--- a/test/util/material-value.test.ts
+++ b/test/util/material-value.test.ts
@@ -1,0 +1,35 @@
+/** Unit tests for `advancedGated`. */
+import { describe, expect, it } from "vitest";
+
+import type { ConfigEntry } from "../../src/api/types/config-entries.js";
+import { ConfigEntryType } from "../../src/api/types/config-entries.js";
+import { advancedGated } from "../../src/util/material-value.js";
+
+const entry = (key: string, extra: Partial<ConfigEntry> = {}): ConfigEntry =>
+  ({ key, type: ConfigEntryType.STRING, label: key, ...extra }) as ConfigEntry;
+
+describe("advancedGated", () => {
+  it("gates an advanced entry without a value", () => {
+    expect(advancedGated(entry("a", { advanced: true }), {})).toBe(true);
+  });
+
+  it("does not gate a valued advanced entry", () => {
+    expect(advancedGated(entry("a", { advanced: true }), { a: "x" })).toBe(false);
+  });
+
+  it("never gates a plain entry", () => {
+    expect(advancedGated(entry("a"), {})).toBe(false);
+  });
+
+  it("follows hasMaterialValue into nested children", () => {
+    const nested = {
+      key: "grp",
+      type: ConfigEntryType.NESTED,
+      label: "grp",
+      advanced: true,
+      config_entries: [entry("child")],
+    } as ConfigEntry;
+    expect(advancedGated(nested, { grp: { child: 1 } })).toBe(false);
+    expect(advancedGated(nested, {})).toBe(true);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The per-entry rule "an advanced entry hides behind the toggle unless it carries a material value" was spelled out independently in the render filter and `pathIsAdvanced`, the same drift class that produced the reveal bugs. A single `advancedGated(entry, values)` now lives beside `hasMaterialValue` in `src/util/material-value.ts`; the filter tests `!showAdvanced && advancedGated(...)` and `pathIsAdvanced`'s per-entry branch calls it directly. The form's `_advancedForceOpen` keeps its direct `e.advanced && hasMaterialValue(...)` form per review feedback; it reads the intent plainly and cannot drift since the gate is defined over the same predicate.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2414

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
