### PR TITLE
Adopt under the factory broadcast name and auto-start the rename flow

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -1,11 +1,12 @@
 import { consume } from "@lit/context";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { customElement, property, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { AdoptableDevice } from "../api/types/devices.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
 import type { AdoptedDetail } from "./dashboard/actions-ui.js";
+import type { ESPHomeDeviceNameInputs } from "./shared/device-name-inputs.js";
 import {
   dialogActionButtonStyles,
   dialogActionsRowStyles,
@@ -13,21 +14,18 @@ import {
 import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
-import type { ValidationError } from "../util/config-validation.js";
-import { validateDeviceName } from "../util/config-validation.js";
 import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { EnterController } from "../util/enter-controller.js";
 import { fireEvent } from "../util/fire-event.js";
 import { formatApiError } from "../util/format-api-error.js";
 import { markJustCreated } from "../util/just-created.js";
 import { previewPackageImportUrl } from "../util/package-import-url.js";
-import { renderInlineError } from "../util/render-error.js";
 import { fetchSecretKeys, hasSharedWifiSecret } from "../util/secrets-cache.js";
-import { HOSTNAME_MAX_LEN } from "../util/slugify-hostname.js";
 import { wifiFieldsStyles } from "./onboarding/wifi-fields-styles.js";
 import { isWifiPasswordTooShort, renderWifiFields } from "./onboarding/wifi-fields.js";
 
 import "./base-dialog.js";
+import "./shared/device-name-inputs.js";
 
 @customElement("esphome-adopt-dialog")
 export class ESPHomeAdoptDialog extends LitElement {
@@ -44,9 +42,10 @@ export class ESPHomeAdoptDialog extends LitElement {
   // rename step, after the import already landed.
   @property({ attribute: false }) takenHostnames: ReadonlySet<string> = new Set();
 
+  @query("esphome-device-name-inputs")
+  private _nameInputs?: ESPHomeDeviceNameInputs;
+
   @state() private _device: AdoptableDevice | null = null;
-  @state() private _name = "";
-  @state() private _friendlyName = "";
   // Default on — the legacy dashboard added an encryption key to
   // every adopted device unconditionally and the lack of a way to
   // opt out was the actual annoyance. Keep the secure-by-default
@@ -235,15 +234,6 @@ export class ESPHomeAdoptDialog extends LitElement {
 
   open(device: AdoptableDevice) {
     this._device = device;
-    /* Default to the discovered hostname verbatim — including the
-       MAC-suffix factory firmware appends. The import always lands
-       under this broadcast name (the only hostname the running
-       device answers to); an edited name is applied afterwards via
-       the rename flow, which flashes the device before the old name
-       is dropped. Defaulting to a stripped form silently dropped
-       the disambiguator on devices like ``apollo-plt-1-983300``. */
-    this._name = device.name;
-    this._friendlyName = device.friendly_name || "";
     this._encryption = true;
     this._busy = false;
     this._error = null;
@@ -251,6 +241,18 @@ export class ESPHomeAdoptDialog extends LitElement {
     this._password = "";
     this._hasWifiSecrets = undefined;
     this._dialog.open = true;
+    /* Seed the shared name pair after the open render mounts it.
+       The hostname seeds to the discovered broadcast verbatim —
+       including the MAC-suffix factory firmware appends — and
+       latched, so friendly-name edits don't silently become a
+       rename. The import always lands under this broadcast name
+       (the only hostname the running device answers to); an edited
+       hostname is applied afterwards via the rename flow, which
+       flashes the device before the old name is dropped. */
+    void this.updateComplete.then(() => {
+      this._nameInputs?.reset(device.friendly_name || "", device.name);
+      this.requestUpdate();
+    });
     // A Wi-Fi device whose install has no shared wifi_ssid/wifi_password
     // would import a config referencing an undefined !secret and fail to
     // validate (esphome/device-builder#1742). Probe the shared secrets so
@@ -292,35 +294,32 @@ export class ESPHomeAdoptDialog extends LitElement {
     );
   }
 
-  private _nameError(nameTrimmed: string): ValidationError | null {
-    const base = validateDeviceName(nameTrimmed);
-    if (base) return base;
-    // The unedited factory default is exempt from the edited-name
-    // rules: its own importable row is in the taken set, and the
-    // broadcast name is compile-time valid.
-    if (!this._device || nameTrimmed === this._device.name) return null;
-    // An edited name becomes a ``devices/rename`` target after the
-    // dialog closes, so apply the rename backend's stricter rules up
-    // front — a late failure would leave the device adopted under
-    // the factory name with only a transient toast.
-    if (nameTrimmed.length > HOSTNAME_MAX_LEN) {
-      return {
-        key: "name",
-        code: "validation.max_length",
-        params: { max: HOSTNAME_MAX_LEN },
-      };
+  // The name pair's validity is the shared component's: charset,
+  // esphome's 31-char hostname cap, edge hyphens, and the taken set.
+  // The unedited factory default is exempt from the taken check — its
+  // own importable row is in the set, and the broadcast name is
+  // compile-time valid. Memoized per (set, device): the child re-fires
+  // ``device-name-changed`` whenever its ``takenHostnames`` reference
+  // changes, so a fresh Set per render would loop the update cycle.
+  private _takenCache?: {
+    src: ReadonlySet<string>;
+    factory: string;
+    out: ReadonlySet<string>;
+  };
+
+  private get _takenMinusFactory(): ReadonlySet<string> {
+    const device = this._device;
+    if (!device || !this.takenHostnames.has(device.name)) return this.takenHostnames;
+    if (
+      this._takenCache?.src === this.takenHostnames &&
+      this._takenCache.factory === device.name
+    ) {
+      return this._takenCache.out;
     }
-    if (nameTrimmed.startsWith("-") || nameTrimmed.endsWith("-")) {
-      return { key: "name", code: "naming.hostname_edge_hyphen" };
-    }
-    if (this.takenHostnames.has(nameTrimmed)) {
-      return {
-        key: "name",
-        code: "naming.hostname_taken",
-        params: { hostname: nameTrimmed },
-      };
-    }
-    return null;
+    const out = new Set(this.takenHostnames);
+    out.delete(device.name);
+    this._takenCache = { src: this.takenHostnames, factory: device.name, out };
+    return out;
   }
 
   close = () => {
@@ -342,11 +341,13 @@ export class ESPHomeAdoptDialog extends LitElement {
        user had to click Take Control twice for the dialog to
        actually appear. */
     const device = this._device;
-    const nameTrimmed = this._name.trim();
-    const nameErr = nameTrimmed ? this._nameError(nameTrimmed) : null;
-    const renamed = !!device && !!nameTrimmed && nameTrimmed !== device.name;
+    const hostname = this._nameInputs?.hostname ?? "";
+    const renamed = !!device && hostname.length > 0 && hostname !== device.name;
     const canSubmit =
-      !!device && !!nameTrimmed && !nameErr && !this._busy && !this._wifiBlocking;
+      !!device &&
+      (this._nameInputs?.canSubmit ?? false) &&
+      !this._busy &&
+      !this._wifiBlocking;
     const displayName = device ? device.friendly_name || device.name : "";
 
     return html`
@@ -367,47 +368,19 @@ export class ESPHomeAdoptDialog extends LitElement {
 
                 ${this._renderSource(device.package_import_url)}
 
-                <div class="field">
-                  <label for="adopt-name">
-                    ${this._localize("dashboard.adopt_field_name")}
-                  </label>
-                  <input
-                    id="adopt-name"
-                    type="text"
-                    class=${nameErr ? "invalid" : ""}
-                    .value=${this._name}
-                    ?disabled=${this._busy}
-                    @input=${(e: Event) => {
-                      this._name = (e.target as HTMLInputElement).value;
-                    }}
-                  />
-                  ${renderInlineError(
-                    nameErr ? this._localize(nameErr.code, nameErr.params) : undefined
-                  )}
-                  ${
-                    renamed && !nameErr
-                      ? html`<div class="name-hint">
-                          ${this._localize("dashboard.adopt_rename_hint")}
-                        </div>`
-                      : nothing
-                  }
-                </div>
-
-                <div class="field">
-                  <label for="adopt-friendly-name">
-                    ${this._localize("dashboard.adopt_field_friendly_name")}
-                  </label>
-                  <input
-                    id="adopt-friendly-name"
-                    type="text"
-                    .value=${this._friendlyName}
-                    ?disabled=${this._busy}
-                    @input=${(e: Event) => {
-                      this._friendlyName = (e.target as HTMLInputElement).value;
-                    }}
-                  />
-                </div>
-
+                <esphome-device-name-inputs
+                  autofocus
+                  .friendlyLabelKey=${"dashboard.adopt_field_friendly_name"}
+                  .takenHostnames=${this._takenMinusFactory}
+                  @device-name-changed=${() => this.requestUpdate()}
+                ></esphome-device-name-inputs>
+                ${
+                  renamed
+                    ? html`<div class="name-hint">
+                        ${this._localize("dashboard.adopt_rename_hint")}
+                      </div>`
+                    : nothing
+                }
                 ${
                   this._collectWifi
                     ? html`
@@ -512,12 +485,13 @@ export class ESPHomeAdoptDialog extends LitElement {
 
   private _submit = async () => {
     if (this._busy) return; // Enter bypasses the disabled button; guard re-entry
-    if (!this._device || !this._api) return;
-    const name = this._name.trim();
-    const friendlyName = this._friendlyName.trim();
-    // Enter bypasses the disabled button; re-run the full name gate so
-    // nothing can slip through to a post-close rename failure.
-    if (!name || this._nameError(name)) return;
+    if (!this._device || !this._api || !this._nameInputs) return;
+    // Enter bypasses the disabled button; re-run the shared pair's full
+    // gate (charset, 31-char cap, edge hyphens, taken set) so nothing
+    // can slip through to a post-close rename failure.
+    if (!this._nameInputs.canSubmit) return;
+    const name = this._nameInputs.hostname;
+    const friendlyName = this._nameInputs.friendlyName;
     // Enter bypasses the disabled button; re-check the Wi-Fi gate so a
     // held Enter can't import before the secret store (or with bad creds).
     if (this._wifiBlocking) return;

--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -222,10 +222,11 @@ export class ESPHomeAdoptDialog extends LitElement {
   open(device: AdoptableDevice) {
     this._device = device;
     /* Default to the discovered hostname verbatim — including the
-       MAC-suffix factory firmware appends. The backend writes the
-       new YAML with ``name_add_mac_suffix: False`` so whatever the
-       user picks sticks; users who want a cleaner name can edit the
-       suffix off, but defaulting to a stripped form silently dropped
+       MAC-suffix factory firmware appends. The import always lands
+       under this broadcast name (the only hostname the running
+       device answers to); an edited name is applied afterwards via
+       the rename flow, which flashes the device before the old name
+       is dropped. Defaulting to a stripped form silently dropped
        the disambiguator on devices like ``apollo-plt-1-983300``. */
     this._name = device.name;
     this._friendlyName = device.friendly_name || "";
@@ -485,8 +486,16 @@ export class ESPHomeAdoptDialog extends LitElement {
       // when False keeps the call site clean and avoids relying on
       // the upstream ``import_config`` branch's ``if encryption:``
       // truthiness check accepting the literal string "false".
+      // Always import under the factory broadcast name — the only
+      // hostname the running device answers to. An edited name is
+      // applied by the rename flow the dashboard starts off the
+      // ``adopted`` event: its OTA tail flashes the device at the
+      // factory identity before the old name is dropped, and a
+      // failed rename keeps the device adopted under the factory
+      // name instead of stranding a hostname nothing broadcasts.
+      const factoryName = this._device.name;
       const args: Parameters<ESPHomeAPI["importDevice"]>[0] = {
-        name,
+        name: factoryName,
         project_name: this._device.project_name,
         package_import_url: this._device.package_import_url,
       };
@@ -497,14 +506,16 @@ export class ESPHomeAdoptDialog extends LitElement {
       // derivation the dashboard's ``_onAdopted`` handler uses so
       // both the welcome-banner flag (consumed on first device-editor
       // mount) and the highlight signal key off the same string.
-      // Pre-rename flag survives a rename only if the user opens
-      // the editor first — if they rename before opening, the rename
-      // flow drops the flag (see ``clearJustCreated`` call in
-      // ``_executeRename``); they've already engaged with the device
-      // so the welcome banner would just be noise.
-      markJustCreated(`${name}.yaml`);
+      // The rename flow drops the flag (``clearJustCreated`` in
+      // ``performRename``), so an adopt-with-rename skips the welcome
+      // banner — the follow-job dialog already has the user engaged.
+      markJustCreated(`${factoryName}.yaml`);
       this.close();
-      fireEvent(this, "adopted", { name, friendlyName });
+      fireEvent(this, "adopted", {
+        name: factoryName,
+        friendlyName,
+        renameTo: name !== factoryName ? name : null,
+      });
     } catch (err) {
       this._error = formatApiError(err, this._localize, "dashboard.adopt_error_generic");
     } finally {

--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -189,6 +189,13 @@ export class ESPHomeAdoptDialog extends LitElement {
         color: var(--wa-color-text-quiet);
       }
 
+      /* The shared name pair carries no outer margins (its hosts own
+         the rhythm); without this the hostname row sits flush on the
+         encryption checkbox. */
+      .name-pair {
+        margin-bottom: var(--wa-space-m);
+      }
+
       .name-hint {
         font-size: var(--wa-font-size-xs);
         color: var(--wa-color-text-quiet);
@@ -368,19 +375,21 @@ export class ESPHomeAdoptDialog extends LitElement {
 
                 ${this._renderSource(device.package_import_url)}
 
-                <esphome-device-name-inputs
-                  autofocus
-                  .friendlyLabelKey=${"dashboard.adopt_field_friendly_name"}
-                  .takenHostnames=${this._takenMinusFactory}
-                  @device-name-changed=${() => this.requestUpdate()}
-                ></esphome-device-name-inputs>
-                ${
-                  renamed
-                    ? html`<div class="name-hint">
-                        ${this._localize("dashboard.adopt_rename_hint")}
-                      </div>`
-                    : nothing
-                }
+                <div class="name-pair">
+                  <esphome-device-name-inputs
+                    autofocus
+                    .friendlyLabelKey=${"dashboard.adopt_field_friendly_name"}
+                    .takenHostnames=${this._takenMinusFactory}
+                    @device-name-changed=${() => this.requestUpdate()}
+                  ></esphome-device-name-inputs>
+                  ${
+                    renamed
+                      ? html`<div class="name-hint">
+                          ${this._localize("dashboard.adopt_rename_hint")}
+                        </div>`
+                      : nothing
+                  }
+                </div>
                 ${
                   this._collectWifi
                     ? html`

--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -250,12 +250,13 @@ export class ESPHomeAdoptDialog extends LitElement {
     this._dialog.open = true;
     /* Seed the shared name pair after the open render mounts it.
        The hostname seeds to the discovered broadcast verbatim —
-       including the MAC-suffix factory firmware appends — and
-       latched, so friendly-name edits don't silently become a
-       rename. The import always lands under this broadcast name
-       (the only hostname the running device answers to); an edited
-       hostname is applied afterwards via the rename flow, which
-       flashes the device before the old name is dropped. */
+       including the MAC-suffix factory firmware appends — and holds
+       until the user types: a friendly-name edit re-derives it like
+       the create/rename flows. The import always lands under the
+       broadcast name (the only hostname the running device answers
+       to); a changed hostname is applied afterwards via the rename
+       flow, which flashes the device before the old name is
+       dropped. */
     void this.updateComplete.then(() => {
       this._nameInputs?.reset(device.friendly_name || "", device.name);
       this.requestUpdate();

--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -5,6 +5,7 @@ import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { AdoptableDevice } from "../api/types/devices.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
+import type { AdoptedDetail } from "./dashboard/actions-ui.js";
 import {
   dialogActionButtonStyles,
   dialogActionsRowStyles,
@@ -12,6 +13,7 @@ import {
 import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
+import type { ValidationError } from "../util/config-validation.js";
 import { validateDeviceName } from "../util/config-validation.js";
 import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { EnterController } from "../util/enter-controller.js";
@@ -21,6 +23,7 @@ import { markJustCreated } from "../util/just-created.js";
 import { previewPackageImportUrl } from "../util/package-import-url.js";
 import { renderInlineError } from "../util/render-error.js";
 import { fetchSecretKeys, hasSharedWifiSecret } from "../util/secrets-cache.js";
+import { HOSTNAME_MAX_LEN } from "../util/slugify-hostname.js";
 import { wifiFieldsStyles } from "./onboarding/wifi-fields-styles.js";
 import { isWifiPasswordTooShort, renderWifiFields } from "./onboarding/wifi-fields.js";
 
@@ -289,6 +292,37 @@ export class ESPHomeAdoptDialog extends LitElement {
     );
   }
 
+  private _nameError(nameTrimmed: string): ValidationError | null {
+    const base = validateDeviceName(nameTrimmed);
+    if (base) return base;
+    // The unedited factory default is exempt from the edited-name
+    // rules: its own importable row is in the taken set, and the
+    // broadcast name is compile-time valid.
+    if (!this._device || nameTrimmed === this._device.name) return null;
+    // An edited name becomes a ``devices/rename`` target after the
+    // dialog closes, so apply the rename backend's stricter rules up
+    // front — a late failure would leave the device adopted under
+    // the factory name with only a transient toast.
+    if (nameTrimmed.length > HOSTNAME_MAX_LEN) {
+      return {
+        key: "name",
+        code: "validation.max_length",
+        params: { max: HOSTNAME_MAX_LEN },
+      };
+    }
+    if (nameTrimmed.startsWith("-") || nameTrimmed.endsWith("-")) {
+      return { key: "name", code: "naming.hostname_edge_hyphen" };
+    }
+    if (this.takenHostnames.has(nameTrimmed)) {
+      return {
+        key: "name",
+        code: "naming.hostname_taken",
+        params: { hostname: nameTrimmed },
+      };
+    }
+    return null;
+  }
+
   close = () => {
     /* Arrow function so ``@click=${this.close}`` from the cancel
        button keeps ``this`` bound to the dialog. With a plain method,
@@ -309,18 +343,10 @@ export class ESPHomeAdoptDialog extends LitElement {
        actually appear. */
     const device = this._device;
     const nameTrimmed = this._name.trim();
-    const nameErr = nameTrimmed ? validateDeviceName(nameTrimmed) : null;
+    const nameErr = nameTrimmed ? this._nameError(nameTrimmed) : null;
     const renamed = !!device && !!nameTrimmed && nameTrimmed !== device.name;
-    // The unedited factory default is exempt — its own importable row
-    // is in the taken set.
-    const nameTaken = renamed && this.takenHostnames.has(nameTrimmed);
     const canSubmit =
-      !!device &&
-      !!nameTrimmed &&
-      !nameErr &&
-      !nameTaken &&
-      !this._busy &&
-      !this._wifiBlocking;
+      !!device && !!nameTrimmed && !nameErr && !this._busy && !this._wifiBlocking;
     const displayName = device ? device.friendly_name || device.name : "";
 
     return html`
@@ -348,7 +374,7 @@ export class ESPHomeAdoptDialog extends LitElement {
                   <input
                     id="adopt-name"
                     type="text"
-                    class=${nameErr || nameTaken ? "invalid" : ""}
+                    class=${nameErr ? "invalid" : ""}
                     .value=${this._name}
                     ?disabled=${this._busy}
                     @input=${(e: Event) => {
@@ -356,16 +382,10 @@ export class ESPHomeAdoptDialog extends LitElement {
                     }}
                   />
                   ${renderInlineError(
-                    nameErr
-                      ? this._localize(nameErr.code, nameErr.params)
-                      : nameTaken
-                        ? this._localize("naming.hostname_taken", {
-                            hostname: nameTrimmed,
-                          })
-                        : undefined
+                    nameErr ? this._localize(nameErr.code, nameErr.params) : undefined
                   )}
                   ${
-                    renamed && !nameErr && !nameTaken
+                    renamed && !nameErr
                       ? html`<div class="name-hint">
                           ${this._localize("dashboard.adopt_rename_hint")}
                         </div>`
@@ -495,10 +515,9 @@ export class ESPHomeAdoptDialog extends LitElement {
     if (!this._device || !this._api) return;
     const name = this._name.trim();
     const friendlyName = this._friendlyName.trim();
-    if (!name || validateDeviceName(name)) return;
-    // Enter bypasses the disabled button; re-check the taken gate so a
-    // collision can't slip through to a post-close rename failure.
-    if (name !== this._device.name && this.takenHostnames.has(name)) return;
+    // Enter bypasses the disabled button; re-run the full name gate so
+    // nothing can slip through to a post-close rename failure.
+    if (!name || this._nameError(name)) return;
     // Enter bypasses the disabled button; re-check the Wi-Fi gate so a
     // held Enter can't import before the secret store (or with bad creds).
     if (this._wifiBlocking) return;
@@ -550,12 +569,13 @@ export class ESPHomeAdoptDialog extends LitElement {
       const { configuration } = await this._api.importDevice(args);
       markJustCreated(configuration);
       this.close();
-      fireEvent(this, "adopted", {
+      const detail: AdoptedDetail = {
         name: factoryName,
         configuration,
         friendlyName,
         renameTo: name !== factoryName ? name : null,
-      });
+      };
+      fireEvent(this, "adopted", detail);
     } catch (err) {
       this._error = formatApiError(err, this._localize, "dashboard.adopt_error_generic");
     } finally {

--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -248,17 +248,21 @@ export class ESPHomeAdoptDialog extends LitElement {
     this._password = "";
     this._hasWifiSecrets = undefined;
     this._dialog.open = true;
-    /* Seed the shared name pair after the open render mounts it.
-       The hostname seeds to the discovered broadcast verbatim —
-       including the MAC-suffix factory firmware appends — and holds
-       until the user types: a friendly-name edit re-derives it like
-       the create/rename flows. The import always lands under the
-       broadcast name (the only hostname the running device answers
-       to); a changed hostname is applied afterwards via the rename
-       flow, which flashes the device before the old name is
-       dropped. */
+    /* Seed the shared name pair. The hostname seeds to the
+       discovered broadcast verbatim — including the MAC-suffix
+       factory firmware appends — and holds until the user types: a
+       friendly-name edit re-derives it like the create/rename
+       flows. The import always lands under the broadcast name (the
+       only hostname the running device answers to); a changed
+       hostname is applied afterwards via the rename flow, which
+       flashes the device before the old name is dropped. Seed
+       synchronously when the pair is already mounted (a re-open
+       would otherwise render one frame of the previous device's
+       state) and again after the open render mounts it fresh. */
+    const seed = () => this._nameInputs?.reset(device.friendly_name || "", device.name);
+    seed();
     void this.updateComplete.then(() => {
-      this._nameInputs?.reset(device.friendly_name || "", device.name);
+      seed();
       this.requestUpdate();
     });
     // A Wi-Fi device whose install has no shared wifi_ssid/wifi_password
@@ -385,7 +389,7 @@ export class ESPHomeAdoptDialog extends LitElement {
                   ></esphome-device-name-inputs>
                   ${
                     renamed
-                      ? html`<div class="name-hint">
+                      ? html`<div class="name-hint" role="status">
                           ${this._localize("dashboard.adopt_rename_hint")}
                         </div>`
                       : nothing

--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -1,6 +1,6 @@
 import { consume } from "@lit/context";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, state } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { AdoptableDevice } from "../api/types/devices.js";
 import type { LocalizeFunc } from "../common/localize.js";
@@ -35,6 +35,11 @@ export class ESPHomeAdoptDialog extends LitElement {
   @consume({ context: apiContext })
   @state()
   private _api?: ESPHomeAPI;
+
+  // Hostnames already in use (configured devices + other discovered
+  // broadcasts); an edited name colliding here would only fail at the
+  // rename step, after the import already landed.
+  @property({ attribute: false }) takenHostnames: ReadonlySet<string> = new Set();
 
   @state() private _device: AdoptableDevice | null = null;
   @state() private _name = "";
@@ -182,6 +187,12 @@ export class ESPHomeAdoptDialog extends LitElement {
         color: var(--wa-color-text-quiet);
       }
 
+      .name-hint {
+        font-size: var(--wa-font-size-xs);
+        color: var(--wa-color-text-quiet);
+        margin-top: var(--wa-space-2xs);
+      }
+
       /* Adoption's commit affordance is success-green rather than the
          standard primary tint (dialogActionButtonStyles); per that
          module's guidance, divergent colour intents stay local. This
@@ -299,8 +310,17 @@ export class ESPHomeAdoptDialog extends LitElement {
     const device = this._device;
     const nameTrimmed = this._name.trim();
     const nameErr = nameTrimmed ? validateDeviceName(nameTrimmed) : null;
+    const renamed = !!device && !!nameTrimmed && nameTrimmed !== device.name;
+    // The unedited factory default is exempt — its own importable row
+    // is in the taken set.
+    const nameTaken = renamed && this.takenHostnames.has(nameTrimmed);
     const canSubmit =
-      !!device && !!nameTrimmed && !nameErr && !this._busy && !this._wifiBlocking;
+      !!device &&
+      !!nameTrimmed &&
+      !nameErr &&
+      !nameTaken &&
+      !this._busy &&
+      !this._wifiBlocking;
     const displayName = device ? device.friendly_name || device.name : "";
 
     return html`
@@ -328,7 +348,7 @@ export class ESPHomeAdoptDialog extends LitElement {
                   <input
                     id="adopt-name"
                     type="text"
-                    class=${nameErr ? "invalid" : ""}
+                    class=${nameErr || nameTaken ? "invalid" : ""}
                     .value=${this._name}
                     ?disabled=${this._busy}
                     @input=${(e: Event) => {
@@ -336,8 +356,21 @@ export class ESPHomeAdoptDialog extends LitElement {
                     }}
                   />
                   ${renderInlineError(
-                    nameErr ? this._localize(nameErr.code, nameErr.params) : undefined
+                    nameErr
+                      ? this._localize(nameErr.code, nameErr.params)
+                      : nameTaken
+                        ? this._localize("naming.hostname_taken", {
+                            hostname: nameTrimmed,
+                          })
+                        : undefined
                   )}
+                  ${
+                    renamed && !nameErr && !nameTaken
+                      ? html`<div class="name-hint">
+                          ${this._localize("dashboard.adopt_rename_hint")}
+                        </div>`
+                      : nothing
+                  }
                 </div>
 
                 <div class="field">
@@ -463,6 +496,9 @@ export class ESPHomeAdoptDialog extends LitElement {
     const name = this._name.trim();
     const friendlyName = this._friendlyName.trim();
     if (!name || validateDeviceName(name)) return;
+    // Enter bypasses the disabled button; re-check the taken gate so a
+    // collision can't slip through to a post-close rename failure.
+    if (name !== this._device.name && this.takenHostnames.has(name)) return;
     // Enter bypasses the disabled button; re-check the Wi-Fi gate so a
     // held Enter can't import before the secret store (or with bad creds).
     if (this._wifiBlocking) return;
@@ -493,6 +529,10 @@ export class ESPHomeAdoptDialog extends LitElement {
       // factory identity before the old name is dropped, and a
       // failed rename keeps the device adopted under the factory
       // name instead of stranding a hostname nothing broadcasts.
+      // The factory name is assumed valid unvalidated: esphome
+      // enforces the same hostname charset on ``name:`` at compile
+      // time, so a genuine factory image can't broadcast a
+      // non-conforming name.
       const factoryName = this._device.name;
       const args: Parameters<ESPHomeAPI["importDevice"]>[0] = {
         name: factoryName,
@@ -501,18 +541,18 @@ export class ESPHomeAdoptDialog extends LitElement {
       };
       if (friendlyName) args.friendly_name = friendlyName;
       if (this._encryption) args.encryption = "true";
-      await this._api.importDevice(args);
-      // Configuration filenames are ``<name>.yaml``; mirror the same
-      // derivation the dashboard's ``_onAdopted`` handler uses so
-      // both the welcome-banner flag (consumed on first device-editor
-      // mount) and the highlight signal key off the same string.
-      // The rename flow drops the flag (``clearJustCreated`` in
+      // The response carries the authoritative YAML path the backend
+      // wrote; it feeds the welcome-banner flag, the highlight, and
+      // the rename's ``configuration`` argument. The rename flow
+      // drops the just-created flag (``clearJustCreated`` in
       // ``performRename``), so an adopt-with-rename skips the welcome
       // banner — the follow-job dialog already has the user engaged.
-      markJustCreated(`${factoryName}.yaml`);
+      const { configuration } = await this._api.importDevice(args);
+      markJustCreated(configuration);
       this.close();
       fireEvent(this, "adopted", {
         name: factoryName,
+        configuration,
         friendlyName,
         renameTo: name !== factoryName ? name : null,
       });

--- a/src/components/dashboard/actions-ui.ts
+++ b/src/components/dashboard/actions-ui.ts
@@ -97,6 +97,26 @@ export async function executeRename(
   await performRename(host, device.configuration, device.name, newName, false);
 }
 
+/** Post-adopt follow-up: highlight the fresh card, then start the rename for an edited name. */
+export async function adoptFollowUp(
+  host: ESPHomePageDashboard,
+  detail: {
+    name: string;
+    configuration: string;
+    friendlyName: string;
+    renameTo: string | null;
+  }
+): Promise<void> {
+  // ``configuration`` is the backend-reported YAML the import landed
+  // under (the factory broadcast name); the rename flow re-keys the
+  // card when the OTA tail succeeds, and a failed rename leaves the
+  // device adopted under the factory name.
+  host._highlightFreshDevice(detail.configuration);
+  if (detail.renameTo) {
+    await performRename(host, detail.configuration, detail.name, detail.renameTo, false);
+  }
+}
+
 /** Call ``devices/rename`` and surface the result (job-follow, success, or error). */
 export async function performRename(
   host: ESPHomePageDashboard,

--- a/src/components/dashboard/actions-ui.ts
+++ b/src/components/dashboard/actions-ui.ts
@@ -94,24 +94,25 @@ export async function executeRename(
     host._openConfirm({ kind: "rename-config-only", device, newName });
     return;
   }
-  await performRename(host, device, newName, false);
+  await performRename(host, device.configuration, device.name, newName, false);
 }
 
 /** Call ``devices/rename`` and surface the result (job-follow, success, or error). */
 export async function performRename(
   host: ESPHomePageDashboard,
-  device: ConfiguredDevice,
+  configuration: string,
+  currentName: string,
   newName: string,
   configOnly: boolean
 ): Promise<void> {
   let response: RenameDeviceResponse;
   try {
-    response = await host._api.renameDevice(device.configuration, newName, configOnly);
+    response = await host._api.renameDevice(configuration, newName, configOnly);
   } catch (err) {
     const reason = getErrorMessage(err);
     notifyError(
       host._localize("dashboard.action_rename_failed", {
-        name: device.name,
+        name: currentName,
         reason,
       })
     );

--- a/src/components/dashboard/actions-ui.ts
+++ b/src/components/dashboard/actions-ui.ts
@@ -97,20 +97,27 @@ export async function executeRename(
   await performRename(host, device.configuration, device.name, newName, false);
 }
 
+/** Payload of the adopt dialog's ``adopted`` event — the one shape the
+ *  dialog fires, ``_onAdopted`` annotates, and this module consumes. */
+export interface AdoptedDetail {
+  name: string;
+  configuration: string;
+  friendlyName: string;
+  renameTo: string | null;
+}
+
 /** Post-adopt follow-up: highlight the fresh card, then start the rename for an edited name. */
 export async function adoptFollowUp(
   host: ESPHomePageDashboard,
-  detail: {
-    name: string;
-    configuration: string;
-    friendlyName: string;
-    renameTo: string | null;
-  }
+  detail: AdoptedDetail
 ): Promise<void> {
   // ``configuration`` is the backend-reported YAML the import landed
   // under (the factory broadcast name); the rename flow re-keys the
   // card when the OTA tail succeeds, and a failed rename leaves the
-  // device adopted under the factory name.
+  // device adopted under the factory name. Always the OTA path —
+  // ``executeRename``'s offline config-only route is deliberately
+  // excluded here: a config-only rewrite would strand a hostname the
+  // running factory firmware never broadcasts.
   host._highlightFreshDevice(detail.configuration);
   if (detail.renameTo) {
     await performRename(host, detail.configuration, detail.name, detail.renameTo, false);

--- a/src/components/dashboard/render-dialogs.ts
+++ b/src/components/dashboard/render-dialogs.ts
@@ -169,7 +169,13 @@ export function executeConfirm(
       void host._archiveDevice(pending.device);
       return;
     case "rename-config-only":
-      void performRename(host, pending.device, pending.newName, true);
+      void performRename(
+        host,
+        pending.device.configuration,
+        pending.device.name,
+        pending.newName,
+        true
+      );
       return;
     case "clear-queued-update":
       void clearQueuedUpdate(pending.device, host._api, host._localize);

--- a/src/components/dashboard/render-dialogs.ts
+++ b/src/components/dashboard/render-dialogs.ts
@@ -235,7 +235,10 @@ export function renderDialogs(host: ESPHomePageDashboard): TemplateResult {
         host._labelDialogEditing = null;
       }}
     ></esphome-label-dialog>
-    <esphome-adopt-dialog @adopted=${host._onAdopted}></esphome-adopt-dialog>
+    <esphome-adopt-dialog
+      .takenHostnames=${takenHostnameSet(host._devices, host._importableDevices)}
+      @adopted=${host._onAdopted}
+    ></esphome-adopt-dialog>
     <esphome-api-key-dialog></esphome-api-key-dialog>
     <esphome-create-config-dialog
       .takenHostnames=${takenHostnameSet(host._devices, host._importableDevices)}

--- a/src/components/shared/device-name-inputs.ts
+++ b/src/components/shared/device-name-inputs.ts
@@ -190,10 +190,13 @@ export class ESPHomeDeviceNameInputs extends LitElement {
     return this.hostname.length > 0 && !this.validity.err;
   }
 
-  reset(prefillFriendly = "") {
+  reset(prefillFriendly = "", prefillHostname = "") {
     this._friendly = prefillFriendly;
-    this._hostname = slugifyHostname(prefillFriendly);
-    this._hostnameEdited = false;
+    this._hostname = prefillHostname || slugifyHostname(prefillFriendly);
+    // A seeded hostname is an existing identity (adopt's factory
+    // broadcast), not a derived slug — latch it so friendly-name
+    // edits don't silently turn into a rename.
+    this._hostnameEdited = prefillHostname.length > 0;
     this._open = false;
   }
 

--- a/src/components/shared/device-name-inputs.ts
+++ b/src/components/shared/device-name-inputs.ts
@@ -192,11 +192,12 @@ export class ESPHomeDeviceNameInputs extends LitElement {
 
   reset(prefillFriendly = "", prefillHostname = "") {
     this._friendly = prefillFriendly;
+    // A seeded hostname (adopt's factory broadcast) is the initial
+    // value only — derivation stays live, so a friendly-name edit
+    // recalcs it like the create/rename flows, and a direct hostname
+    // edit latches as usual.
     this._hostname = prefillHostname || slugifyHostname(prefillFriendly);
-    // A seeded hostname is an existing identity (adopt's factory
-    // broadcast), not a derived slug — latch it so friendly-name
-    // edits don't silently turn into a rename.
-    this._hostnameEdited = prefillHostname.length > 0;
+    this._hostnameEdited = false;
     this._open = false;
   }
 

--- a/src/components/shared/device-name-inputs.ts
+++ b/src/components/shared/device-name-inputs.ts
@@ -87,6 +87,10 @@ export class ESPHomeDeviceNameInputs extends LitElement {
   @state()
   private _hostnameEdited = false;
 
+  // Derivation fallback when the friendly name slugs to nothing (adopt's
+  // factory broadcast); empty for the create/clone flows.
+  private _hostnameFallback = "";
+
   @state()
   private _open = false;
 
@@ -195,8 +199,11 @@ export class ESPHomeDeviceNameInputs extends LitElement {
     // A seeded hostname (adopt's factory broadcast) is the initial
     // value only — derivation stays live, so a friendly-name edit
     // recalcs it like the create/rename flows, and a direct hostname
-    // edit latches as usual.
+    // edit latches as usual. The seed doubles as the derivation
+    // fallback: a cleared friendly name returns to it instead of
+    // stranding an empty hostname behind a disabled submit.
     this._hostname = prefillHostname || slugifyHostname(prefillFriendly);
+    this._hostnameFallback = prefillHostname;
     this._hostnameEdited = false;
     this._open = false;
   }
@@ -271,7 +278,7 @@ export class ESPHomeDeviceNameInputs extends LitElement {
                 // stranding an empty field behind a required-hostname error.
                 this._hostname = this._hostnameEdited
                   ? value
-                  : slugifyHostname(this._friendly);
+                  : slugifyHostname(this._friendly) || this._hostnameFallback;
                 // Typing here is an explicit override; keep the panel open
                 // once the edit clears the error that force-opened it, or
                 // the field unmounts mid-keystroke.
@@ -307,7 +314,7 @@ export class ESPHomeDeviceNameInputs extends LitElement {
   private _onFriendlyInput = (e: Event) => {
     this._friendly = (e.target as HTMLInputElement).value;
     if (!this._hostnameEdited) {
-      this._hostname = slugifyHostname(this._friendly);
+      this._hostname = slugifyHostname(this._friendly) || this._hostnameFallback;
     }
     this._autoOpenOnWarning();
     this._notify();

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -23,11 +23,11 @@ import type { ArchivedDevice } from "../api/types/system.js";
 import { DashboardView } from "../api/types/system.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
+  adoptFollowUp,
   deleteLabel,
   executeClone,
   executeFriendlyName,
   executeRename,
-  performRename,
   scheduleScrollIntoView,
   toggleIgnore,
 } from "../components/dashboard/actions-ui.js";
@@ -930,22 +930,13 @@ export class ESPHomePageDashboard extends LitElement {
   }
 
   _onAdopted = (
-    e: CustomEvent<{ name: string; friendlyName: string; renameTo: string | null }>
-  ) => {
-    // ``name`` is the factory broadcast the import landed under; the
-    // rename flow re-keys the card when the OTA tail succeeds, and a
-    // failed rename leaves the device adopted under the factory name.
-    this._highlightFreshDevice(`${e.detail.name}.yaml`);
-    if (e.detail.renameTo) {
-      void performRename(
-        this,
-        `${e.detail.name}.yaml`,
-        e.detail.name,
-        e.detail.renameTo,
-        false
-      );
-    }
-  };
+    e: CustomEvent<{
+      name: string;
+      configuration: string;
+      friendlyName: string;
+      renameTo: string | null;
+    }>
+  ) => void adoptFollowUp(this, e.detail);
 
   /** Post-clone reveal (#2246): the search that matched the source would
    *  hide the fresh clone, so clear it (no refocus — attention belongs on

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -24,6 +24,7 @@ import { DashboardView } from "../api/types/system.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
   adoptFollowUp,
+  type AdoptedDetail,
   deleteLabel,
   executeClone,
   executeFriendlyName,
@@ -929,14 +930,7 @@ export class ESPHomePageDashboard extends LitElement {
     this._tryConsumePendingScroll();
   }
 
-  _onAdopted = (
-    e: CustomEvent<{
-      name: string;
-      configuration: string;
-      friendlyName: string;
-      renameTo: string | null;
-    }>
-  ) => void adoptFollowUp(this, e.detail);
+  _onAdopted = (e: CustomEvent<AdoptedDetail>) => void adoptFollowUp(this, e.detail);
 
   /** Post-clone reveal (#2246): the search that matched the source would
    *  hide the fresh clone, so clear it (no refocus — attention belongs on

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -27,6 +27,7 @@ import {
   executeClone,
   executeFriendlyName,
   executeRename,
+  performRename,
   scheduleScrollIntoView,
   toggleIgnore,
 } from "../components/dashboard/actions-ui.js";
@@ -928,8 +929,22 @@ export class ESPHomePageDashboard extends LitElement {
     this._tryConsumePendingScroll();
   }
 
-  _onAdopted = (e: CustomEvent<{ name: string; friendlyName: string }>) => {
+  _onAdopted = (
+    e: CustomEvent<{ name: string; friendlyName: string; renameTo: string | null }>
+  ) => {
+    // ``name`` is the factory broadcast the import landed under; the
+    // rename flow re-keys the card when the OTA tail succeeds, and a
+    // failed rename leaves the device adopted under the factory name.
     this._highlightFreshDevice(`${e.detail.name}.yaml`);
+    if (e.detail.renameTo) {
+      void performRename(
+        this,
+        `${e.detail.name}.yaml`,
+        e.detail.name,
+        e.detail.renameTo,
+        false
+      );
+    }
   };
 
   /** Post-clone reveal (#2246): the search that matched the source would

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -20,6 +20,7 @@
     "adopt_description": "Taking control of {name} creates a local ESPHome configuration. From now on you manage updates from the dashboard — vendor-provided firmware updates won't apply automatically.",
     "adopt_source_label": "Configuration source",
     "adopt_field_name": "Device name (hostname)",
+    "adopt_rename_hint": "Changing the hostname will build and install new firmware over the network.",
     "adopt_field_friendly_name": "Friendly name (optional)",
     "adopt_encryption_title": "Enable API encryption",
     "adopt_encryption_hint": "Generates a fresh key for the Native API. Recommended; required for Home Assistant integration.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -19,7 +19,6 @@
     "adopt_title": "Take control",
     "adopt_description": "Taking control of {name} creates a local ESPHome configuration. From now on you manage updates from the dashboard — vendor-provided firmware updates won't apply automatically.",
     "adopt_source_label": "Configuration source",
-    "adopt_field_name": "Device name (hostname)",
     "adopt_rename_hint": "Changing the hostname will build and install new firmware over the network.",
     "adopt_field_friendly_name": "Friendly name (optional)",
     "adopt_encryption_title": "Enable API encryption",

--- a/test/components/adopt-dialog.test.ts
+++ b/test/components/adopt-dialog.test.ts
@@ -127,7 +127,7 @@ describe("adopt-then-rename (#2412)", () => {
     });
   });
 
-  it("keeps the factory hostname when only the friendly name is edited", async () => {
+  it("re-derives the hostname from a friendly-name edit", async () => {
     const { priv, importDevice } = await makeDialog([]);
     const adopted = vi.fn();
     (priv as EventTarget).addEventListener("adopted", adopted);
@@ -143,12 +143,13 @@ describe("adopt-then-rename (#2412)", () => {
 
     await priv._submit();
 
-    // The seeded broadcast hostname is latched — a friendly-name edit
-    // must not silently turn adoption into a rename.
+    // Same idiom as create/rename: the seeded broadcast hostname holds
+    // only until the user types, then derivation takes over and the
+    // recalced name rides the rename flow.
     expect(importDevice).toHaveBeenCalledWith(
       expect.objectContaining({ name: "foo-1234", friendly_name: "Kitchen Sensor" })
     );
-    expect(adopted.mock.calls[0][0].detail.renameTo).toBe(null);
+    expect(adopted.mock.calls[0][0].detail.renameTo).toBe("kitchen-sensor");
   });
 
   it("refuses to submit an edited name that is already taken", async () => {

--- a/test/components/adopt-dialog.test.ts
+++ b/test/components/adopt-dialog.test.ts
@@ -152,6 +152,31 @@ describe("adopt-then-rename (#2412)", () => {
     expect(adopted.mock.calls[0][0].detail.renameTo).toBe("kitchen-sensor");
   });
 
+  it("returns the hostname to the factory broadcast when the friendly name is cleared", async () => {
+    const { priv, importDevice } = await makeDialog([]);
+    const adopted = vi.fn();
+    (priv as EventTarget).addEventListener("adopted", adopted);
+    await openSettled(priv, ethernetDevice());
+    const inputs = await deviceNameInputsOf(priv);
+    const friendly = inputs.shadowRoot!.querySelector<HTMLInputElement>(
+      "#device-friendly-name"
+    )!;
+    friendly.value = "";
+    friendly.dispatchEvent(new Event("input"));
+    await inputs.updateComplete;
+    await priv.updateComplete;
+
+    await priv._submit();
+
+    // The seed doubles as the derivation fallback — an empty friendly
+    // name must not strand an empty hostname behind a disabled submit.
+    expect(importDevice).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "foo-1234" })
+    );
+    expect(adopted).toHaveBeenCalledTimes(1);
+    expect(adopted.mock.calls[0][0].detail.renameTo).toBe(null);
+  });
+
   it("refuses to submit an edited name that is already taken", async () => {
     const { priv, importDevice } = await makeDialog([]);
     priv.takenHostnames = new Set(["foo-1234", "kitchen"]);

--- a/test/components/adopt-dialog.test.ts
+++ b/test/components/adopt-dialog.test.ts
@@ -93,6 +93,7 @@ describe("adopt-then-rename (#2412)", () => {
     expect(importDevice).toHaveBeenCalledWith(
       expect.objectContaining({ name: "foo-1234" })
     );
+    expect(adopted).toHaveBeenCalledTimes(1);
     expect(adopted.mock.calls[0][0].detail).toEqual({
       name: "foo-1234",
       configuration: "foo-1234.yaml",
@@ -106,6 +107,26 @@ describe("adopt-then-rename (#2412)", () => {
     priv.open(ethernetDevice());
     priv.takenHostnames = new Set(["foo-1234", "kitchen"]);
     priv._name = "kitchen";
+
+    await priv._submit();
+
+    expect(importDevice).not.toHaveBeenCalled();
+  });
+
+  it("refuses an edited name past the 31-char hostname cap", async () => {
+    const { priv, importDevice } = makeDialog([]);
+    priv.open(ethernetDevice());
+    priv._name = "a".repeat(32); // passes the shared 63-char check
+
+    await priv._submit();
+
+    expect(importDevice).not.toHaveBeenCalled();
+  });
+
+  it("refuses an edited name with an edge hyphen", async () => {
+    const { priv, importDevice } = makeDialog([]);
+    priv.open(ethernetDevice());
+    priv._name = "-kitchen"; // charset-valid, backend refuses it
 
     await priv._submit();
 

--- a/test/components/adopt-dialog.test.ts
+++ b/test/components/adopt-dialog.test.ts
@@ -76,6 +76,7 @@ describe("adopt-then-rename (#2412)", () => {
     expect(adopted).toHaveBeenCalledTimes(1);
     expect(adopted.mock.calls[0][0].detail).toEqual({
       name: "foo-1234",
+      configuration: "foo-1234.yaml",
       friendlyName: "Foo",
       renameTo: "kitchen",
     });
@@ -94,9 +95,32 @@ describe("adopt-then-rename (#2412)", () => {
     );
     expect(adopted.mock.calls[0][0].detail).toEqual({
       name: "foo-1234",
+      configuration: "foo-1234.yaml",
       friendlyName: "Foo",
       renameTo: null,
     });
+  });
+
+  it("refuses to submit an edited name that is already taken", async () => {
+    const { priv, importDevice } = makeDialog([]);
+    priv.open(ethernetDevice());
+    priv.takenHostnames = new Set(["foo-1234", "kitchen"]);
+    priv._name = "kitchen";
+
+    await priv._submit();
+
+    expect(importDevice).not.toHaveBeenCalled();
+  });
+
+  it("exempts the unedited factory name from the taken set", async () => {
+    const { priv, importDevice } = makeDialog([]);
+    priv.open(ethernetDevice());
+    // The device's own importable row puts its broadcast name in the set.
+    priv.takenHostnames = new Set(["foo-1234"]);
+
+    await priv._submit();
+
+    expect(importDevice).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/test/components/adopt-dialog.test.ts
+++ b/test/components/adopt-dialog.test.ts
@@ -8,8 +8,11 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import "../_mock-webawesome.js";
+
 import type { AdoptableDevice } from "../../src/api/types/devices.js";
 import { ESPHomeAdoptDialog } from "../../src/components/adopt-dialog.js";
+import { deviceNameInputsOf, flush, mount } from "../_dom.js";
 import { _resetSecretKeysCache } from "../../src/util/secrets-cache.js";
 
 const DEVICE = {
@@ -27,29 +30,51 @@ const ethernetDevice = (): AdoptableDevice =>
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Priv = any;
 
-function makeDialog(secretKeys: string[]): {
+async function makeDialog(secretKeys: string[]): Promise<{
   priv: Priv;
   getSecretKeys: ReturnType<typeof vi.fn>;
   setWifiCredentials: ReturnType<typeof vi.fn>;
   importDevice: ReturnType<typeof vi.fn>;
-} {
+}> {
   const getSecretKeys = vi.fn(async () => secretKeys);
   const setWifiCredentials = vi.fn(async () => {});
   const importDevice = vi.fn(async () => ({ configuration: "foo-1234.yaml" }));
-  const el = new ESPHomeAdoptDialog();
+  const el = await mount(new ESPHomeAdoptDialog());
   const priv = el as Priv;
   priv._api = { getSecretKeys, setWifiCredentials, importDevice };
   return { priv, getSecretKeys, setWifiCredentials, importDevice };
 }
 
+/** Open the dialog and settle the deferred name-pair seed. */
+async function openSettled(priv: Priv, device: AdoptableDevice): Promise<void> {
+  priv.open(device);
+  await priv.updateComplete;
+  await flush();
+  await priv.updateComplete;
+}
+
+/** Type into the nested hostname field (expanding the disclosure). */
+async function typeHostname(priv: Priv, value: string): Promise<void> {
+  const inputs = await deviceNameInputsOf(priv);
+  const toggle =
+    inputs.shadowRoot!.querySelector<HTMLButtonElement>(".disclosure-toggle");
+  if (toggle && !toggle.disabled) {
+    toggle.click();
+    await inputs.updateComplete;
+  }
+  const field = inputs.shadowRoot!.querySelector<HTMLInputElement>("#device-hostname")!;
+  field.value = value;
+  field.dispatchEvent(new Event("input"));
+  await inputs.updateComplete;
+  await priv.updateComplete;
+}
+
 describe("adopt-dialog re-entry guard", () => {
   it("_submit ignores re-entry while an import is in flight", async () => {
+    const { priv } = await makeDialog([]);
     const importDevice = vi.fn(() => new Promise<void>(() => {})); // stays in flight
-    const el = new ESPHomeAdoptDialog();
-    const priv = el as Priv;
     priv._api = { importDevice };
-    priv._device = DEVICE;
-    priv._name = "foo-1234";
+    await openSettled(priv, ethernetDevice());
 
     void priv._submit();
     await priv._submit();
@@ -60,11 +85,11 @@ describe("adopt-dialog re-entry guard", () => {
 
 describe("adopt-then-rename (#2412)", () => {
   it("imports under the factory name and requests a rename for an edited name", async () => {
-    const { priv, importDevice } = makeDialog([]);
+    const { priv, importDevice } = await makeDialog([]);
     const adopted = vi.fn();
     (priv as EventTarget).addEventListener("adopted", adopted);
-    priv.open(ethernetDevice());
-    priv._name = "kitchen";
+    await openSettled(priv, ethernetDevice());
+    await typeHostname(priv, "kitchen");
 
     await priv._submit();
 
@@ -83,10 +108,10 @@ describe("adopt-then-rename (#2412)", () => {
   });
 
   it("requests no rename when the name is unedited", async () => {
-    const { priv, importDevice } = makeDialog([]);
+    const { priv, importDevice } = await makeDialog([]);
     const adopted = vi.fn();
     (priv as EventTarget).addEventListener("adopted", adopted);
-    priv.open(ethernetDevice());
+    await openSettled(priv, ethernetDevice());
 
     await priv._submit();
 
@@ -102,11 +127,35 @@ describe("adopt-then-rename (#2412)", () => {
     });
   });
 
+  it("keeps the factory hostname when only the friendly name is edited", async () => {
+    const { priv, importDevice } = await makeDialog([]);
+    const adopted = vi.fn();
+    (priv as EventTarget).addEventListener("adopted", adopted);
+    await openSettled(priv, ethernetDevice());
+    const inputs = await deviceNameInputsOf(priv);
+    const friendly = inputs.shadowRoot!.querySelector<HTMLInputElement>(
+      "#device-friendly-name"
+    )!;
+    friendly.value = "Kitchen Sensor";
+    friendly.dispatchEvent(new Event("input"));
+    await inputs.updateComplete;
+    await priv.updateComplete;
+
+    await priv._submit();
+
+    // The seeded broadcast hostname is latched — a friendly-name edit
+    // must not silently turn adoption into a rename.
+    expect(importDevice).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "foo-1234", friendly_name: "Kitchen Sensor" })
+    );
+    expect(adopted.mock.calls[0][0].detail.renameTo).toBe(null);
+  });
+
   it("refuses to submit an edited name that is already taken", async () => {
-    const { priv, importDevice } = makeDialog([]);
-    priv.open(ethernetDevice());
+    const { priv, importDevice } = await makeDialog([]);
     priv.takenHostnames = new Set(["foo-1234", "kitchen"]);
-    priv._name = "kitchen";
+    await openSettled(priv, ethernetDevice());
+    await typeHostname(priv, "kitchen");
 
     await priv._submit();
 
@@ -114,9 +163,9 @@ describe("adopt-then-rename (#2412)", () => {
   });
 
   it("refuses an edited name past the 31-char hostname cap", async () => {
-    const { priv, importDevice } = makeDialog([]);
-    priv.open(ethernetDevice());
-    priv._name = "a".repeat(32); // passes the shared 63-char check
+    const { priv, importDevice } = await makeDialog([]);
+    await openSettled(priv, ethernetDevice());
+    await typeHostname(priv, "a".repeat(32));
 
     await priv._submit();
 
@@ -124,9 +173,9 @@ describe("adopt-then-rename (#2412)", () => {
   });
 
   it("refuses an edited name with an edge hyphen", async () => {
-    const { priv, importDevice } = makeDialog([]);
-    priv.open(ethernetDevice());
-    priv._name = "-kitchen"; // charset-valid, backend refuses it
+    const { priv, importDevice } = await makeDialog([]);
+    await openSettled(priv, ethernetDevice());
+    await typeHostname(priv, "-kitchen");
 
     await priv._submit();
 
@@ -134,10 +183,10 @@ describe("adopt-then-rename (#2412)", () => {
   });
 
   it("exempts the unedited factory name from the taken set", async () => {
-    const { priv, importDevice } = makeDialog([]);
-    priv.open(ethernetDevice());
+    const { priv, importDevice } = await makeDialog([]);
     // The device's own importable row puts its broadcast name in the set.
     priv.takenHostnames = new Set(["foo-1234"]);
+    await openSettled(priv, ethernetDevice());
 
     await priv._submit();
 
@@ -151,32 +200,32 @@ describe("adopt-dialog wifi step (#1742)", () => {
   });
 
   it("collects wifi for a wifi device with no shared secret", async () => {
-    const { priv, getSecretKeys } = makeDialog([]);
-    priv.open(wifiDevice());
+    const { priv, getSecretKeys } = await makeDialog([]);
+    await openSettled(priv, wifiDevice());
     await vi.waitFor(() => expect(priv._hasWifiSecrets).toBe(false));
     expect(getSecretKeys).toHaveBeenCalledTimes(1);
     expect(priv._collectWifi).toBe(true);
   });
 
   it("skips the wifi step when the shared secret already exists", async () => {
-    const { priv } = makeDialog(["wifi_ssid", "wifi_password"]);
-    priv.open(wifiDevice());
+    const { priv } = await makeDialog(["wifi_ssid", "wifi_password"]);
+    await openSettled(priv, wifiDevice());
     await vi.waitFor(() => expect(priv._hasWifiSecrets).toBe(true));
     expect(priv._collectWifi).toBe(false);
   });
 
   it("never probes secrets or collects wifi for an ethernet device", async () => {
-    const { priv, getSecretKeys } = makeDialog([]);
-    priv.open(ethernetDevice());
+    const { priv, getSecretKeys } = await makeDialog([]);
+    await openSettled(priv, ethernetDevice());
     expect(getSecretKeys).not.toHaveBeenCalled();
     expect(priv._collectWifi).toBe(false);
   });
 
   it("stores the typed credentials before importing and fires secrets-saved", async () => {
-    const { priv, setWifiCredentials, importDevice } = makeDialog([]);
+    const { priv, setWifiCredentials, importDevice } = await makeDialog([]);
     const savedListener = vi.fn();
     window.addEventListener("secrets-saved", savedListener);
-    priv.open(wifiDevice());
+    await openSettled(priv, wifiDevice());
     await vi.waitFor(() => expect(priv._collectWifi).toBe(true));
     // Whitespace in an SSID is significant; the raw value is stored verbatim.
     priv._ssid = " My Home Wifi ";
@@ -193,8 +242,8 @@ describe("adopt-dialog wifi step (#1742)", () => {
   });
 
   it("_submit re-checks the wifi gate so Enter can't skip the store", async () => {
-    const { priv, setWifiCredentials, importDevice } = makeDialog([]);
-    priv.open(wifiDevice());
+    const { priv, setWifiCredentials, importDevice } = await makeDialog([]);
+    await openSettled(priv, wifiDevice());
     await vi.waitFor(() => expect(priv._collectWifi).toBe(true));
     // SSID still empty: the Enter path (calls _submit directly, bypassing
     // the disabled button) must refuse rather than import an unresolved
@@ -206,11 +255,11 @@ describe("adopt-dialog wifi step (#1742)", () => {
   });
 
   it("does not store credentials when the shared secret already exists", async () => {
-    const { priv, setWifiCredentials, importDevice } = makeDialog([
+    const { priv, setWifiCredentials, importDevice } = await makeDialog([
       "wifi_ssid",
       "wifi_password",
     ]);
-    priv.open(wifiDevice());
+    await openSettled(priv, wifiDevice());
     await vi.waitFor(() => expect(priv._hasWifiSecrets).toBe(true));
 
     await priv._submit();
@@ -227,9 +276,9 @@ describe("adopt-dialog wifi step (#1742)", () => {
     );
     const setWifiCredentials = vi.fn(async () => {});
     const importDevice = vi.fn(async () => ({ configuration: "foo-1234.yaml" }));
-    const priv = new ESPHomeAdoptDialog() as Priv;
+    const priv = (await mount(new ESPHomeAdoptDialog())) as Priv;
     priv._api = { getSecretKeys, setWifiCredentials, importDevice };
-    priv.open(wifiDevice());
+    await openSettled(priv, wifiDevice());
 
     // A fast Enter (calls _submit directly) before the probe resolves must
     // neither store a half-known secret nor import an unresolved !secret.
@@ -241,8 +290,8 @@ describe("adopt-dialog wifi step (#1742)", () => {
   });
 
   it("blocks submit when the password is too short", async () => {
-    const { priv, setWifiCredentials, importDevice } = makeDialog([]);
-    priv.open(wifiDevice());
+    const { priv, setWifiCredentials, importDevice } = await makeDialog([]);
+    await openSettled(priv, wifiDevice());
     await vi.waitFor(() => expect(priv._collectWifi).toBe(true));
     priv._ssid = "My Home Wifi";
     priv._password = "short"; // 1–7 chars trips isWifiPasswordTooShort
@@ -255,8 +304,8 @@ describe("adopt-dialog wifi step (#1742)", () => {
   });
 
   it("allows an open network (empty password) and stores it verbatim", async () => {
-    const { priv, setWifiCredentials, importDevice } = makeDialog([]);
-    priv.open(wifiDevice());
+    const { priv, setWifiCredentials, importDevice } = await makeDialog([]);
+    await openSettled(priv, wifiDevice());
     await vi.waitFor(() => expect(priv._collectWifi).toBe(true));
     priv._ssid = "OpenNet";
     priv._password = ""; // empty is not "too short" — open network
@@ -269,11 +318,11 @@ describe("adopt-dialog wifi step (#1742)", () => {
   });
 
   it("keeps the dialog open and skips import when storing the secret fails", async () => {
-    const { priv, importDevice } = makeDialog([]);
+    const { priv, importDevice } = await makeDialog([]);
     priv._api.setWifiCredentials = vi.fn(async () => {
       throw new Error("disk full");
     });
-    priv.open(wifiDevice());
+    await openSettled(priv, wifiDevice());
     await vi.waitFor(() => expect(priv._collectWifi).toBe(true));
     priv._ssid = "My Home Wifi";
     priv._password = "hunter2hunter";
@@ -289,8 +338,11 @@ describe("adopt-dialog wifi step (#1742)", () => {
   });
 
   it("does not collect wifi when the device advertised no network", async () => {
-    const { priv, getSecretKeys } = makeDialog([]);
-    priv.open({ ...DEVICE, network: "" } as unknown as AdoptableDevice);
+    const { priv, getSecretKeys } = await makeDialog([]);
+    await openSettled(priv, {
+      ...DEVICE,
+      network: "",
+    } as unknown as AdoptableDevice);
 
     expect(getSecretKeys).not.toHaveBeenCalled();
     expect(priv._collectWifi).toBe(false);

--- a/test/components/adopt-dialog.test.ts
+++ b/test/components/adopt-dialog.test.ts
@@ -58,6 +58,48 @@ describe("adopt-dialog re-entry guard", () => {
   });
 });
 
+describe("adopt-then-rename (#2412)", () => {
+  it("imports under the factory name and requests a rename for an edited name", async () => {
+    const { priv, importDevice } = makeDialog([]);
+    const adopted = vi.fn();
+    (priv as EventTarget).addEventListener("adopted", adopted);
+    priv.open(ethernetDevice());
+    priv._name = "kitchen";
+
+    await priv._submit();
+
+    // The running device only answers to its factory broadcast name;
+    // the edited name rides the adopted event for the rename flow.
+    expect(importDevice).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "foo-1234" })
+    );
+    expect(adopted).toHaveBeenCalledTimes(1);
+    expect(adopted.mock.calls[0][0].detail).toEqual({
+      name: "foo-1234",
+      friendlyName: "Foo",
+      renameTo: "kitchen",
+    });
+  });
+
+  it("requests no rename when the name is unedited", async () => {
+    const { priv, importDevice } = makeDialog([]);
+    const adopted = vi.fn();
+    (priv as EventTarget).addEventListener("adopted", adopted);
+    priv.open(ethernetDevice());
+
+    await priv._submit();
+
+    expect(importDevice).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "foo-1234" })
+    );
+    expect(adopted.mock.calls[0][0].detail).toEqual({
+      name: "foo-1234",
+      friendlyName: "Foo",
+      renameTo: null,
+    });
+  });
+});
+
 describe("adopt-dialog wifi step (#1742)", () => {
   beforeEach(() => {
     _resetSecretKeysCache();

--- a/test/components/dashboard/actions-ui.test.ts
+++ b/test/components/dashboard/actions-ui.test.ts
@@ -4,6 +4,7 @@ import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
 import { DeviceState } from "../../../src/api/types/devices.js";
 import type { LocalizeFunc } from "../../../src/common/localize.js";
 import {
+  adoptFollowUp,
   executeClone,
   executeRename,
   openLogsWithMethod,
@@ -168,6 +169,56 @@ describe("openLogsWithMethod web-serial", () => {
     expect(logsDialog.openPassive).toHaveBeenCalledTimes(1);
     expect(logsDialog.open).not.toHaveBeenCalled();
     expect(toastInfo).not.toHaveBeenCalled();
+  });
+});
+
+describe("adoptFollowUp", () => {
+  function makeAdoptHost(renameDevice: ESPHomeAPI["renameDevice"]) {
+    const highlight = vi.fn();
+    const followJob = vi.fn();
+    const host = makeDashboardHost({
+      _api: { renameDevice } as unknown as ESPHomeAPI,
+      _localize: localize,
+      _highlightFreshDevice: highlight,
+      _commandDialog: { followJob },
+      _devices: [],
+    });
+    return { host, highlight, followJob };
+  }
+
+  it("starts an OTA rename against the imported configuration for an edited name", async () => {
+    const renameDevice = vi.fn(async () => ({
+      configuration: "kitchen.yaml",
+      job: { job_id: "j1", job_type: "compile" },
+      tail_job: { job_id: "j2", job_type: "rename" },
+    })) as unknown as ESPHomeAPI["renameDevice"];
+    const { host, highlight, followJob } = makeAdoptHost(renameDevice);
+
+    await adoptFollowUp(host, {
+      name: "foo-1234",
+      configuration: "foo-1234.yaml",
+      friendlyName: "Foo",
+      renameTo: "kitchen",
+    });
+
+    expect(highlight).toHaveBeenCalledWith("foo-1234.yaml");
+    expect(renameDevice).toHaveBeenCalledWith("foo-1234.yaml", "kitchen", false);
+    expect(followJob).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts no rename when the name was unedited", async () => {
+    const renameDevice = vi.fn() as unknown as ESPHomeAPI["renameDevice"];
+    const { host, highlight } = makeAdoptHost(renameDevice);
+
+    await adoptFollowUp(host, {
+      name: "foo-1234",
+      configuration: "foo-1234.yaml",
+      friendlyName: "Foo",
+      renameTo: null,
+    });
+
+    expect(highlight).toHaveBeenCalledWith("foo-1234.yaml");
+    expect(renameDevice).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

The Take control dialog lets the user edit the device hostname, but adoption only wrote a YAML under the chosen name — nothing renamed the running device. The factory firmware keeps broadcasting its MAC-suffixed name until first flash, so a renamed adopt's first OTA targeted a hostname nobody answers to and could strand the device (asleep at adopt, DHCP re-lease, or the cache-args race fixed backend-side in esphome/device-builder#2417).

The dialog UX is unchanged; the orchestration behind it now composes two existing commands:

- `devices/import` is always called with the **factory broadcast name** — the only hostname the running device answers to — so the adopted config is reachable from the moment it exists.
- When the dialog name was edited, the `adopted` event carries `renameTo` and the dashboard immediately starts the existing rename flow (`devices/rename`, OTA path). Its compile + flash chain targets the factory identity, the command dialog follows the job ("Rename — old → new"), and on success the swap re-keys the card to the chosen name.
- If the rename fails at any point (device unreachable, compile error), the backend's revert keeps the device adopted under its factory name — nothing is stranded, and the user can rename later from the card. A failed rename enqueue surfaces through the existing rename-failed toast.

`performRename` now takes `(configuration, currentName)` instead of a `ConfiguredDevice` so the adopt path can invoke it before the device row exists in frontend state; both existing callers are updated. The orchestration lives in `adoptFollowUp` (actions-ui) with the payload typed once as `AdoptedDetail`, and the import response's `configuration` is carried through the event as the authoritative YAML path.

The dialog's name fields are now the shared `esphome-device-name-inputs` pair the clone and create flows use: friendly name primary, hostname behind the disclosure, with the shared validation (charset, esphome's 31-char hostname cap, edge hyphens, taken-hostname collisions from the same `takenHostnameSet`) — all failures that would otherwise surface only after the dialog closed, as a rename error on an already-adopted device. The hostname seeds to the factory broadcast verbatim (`reset` gained a `prefillHostname` seed) and derivation stays live, matching the create/rename idiom: typing a friendly name recalcs the hostname (maintainer-directed), the rename hint announces the escalation (`role="status"`), and clearing the friendly name falls back to the factory broadcast instead of stranding an empty hostname. The factory name itself is exempt from the taken set since its own importable row is in it. A `dashboard.adopt_rename_hint` line under the fields tells the user at decision time that changing the hostname builds and installs new firmware over the network.

Verified live against a Bonjour-registered fake importable, through the final shared-pair UI: the dialog opens friendly-name-first with "Hostname: athom-fake-7e11aa" collapsed behind the disclosure; editing the hostname to `kitchen-co2` shows the install hint; submit landed the YAML under the factory name and the command dialog followed the chain ("Rename — Athom Fake CO2 (athom-fake-7e11aa → kitchen-co2)") with the compile streaming. The failure path was verified end-to-end in an earlier pass: the tail flashed at the factory device's resolved address, failed against the fake device, and the backend reverted — factory YAML kept.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2412

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
