### PR TITLE
Read the legacy api services block spelling

### DIFF
--- a/src/components/device/automation-editor/automation-focus.ts
+++ b/src/components/device/automation-editor/automation-focus.ts
@@ -53,12 +53,18 @@ export function automationRelativePath(
 ): YamlPathSegment[] | null {
   const anchor = location && handlerAnchor(location);
   if (!anchor) return null;
-  let at = path.indexOf(anchor.keys[0]);
-  while (at >= 0 && !anchor.keys.every((k, i) => path[at + i] === k)) {
-    at = path.indexOf(anchor.keys[0], at + 1);
+  let rest: YamlPathSegment[] | null = null;
+  for (const keys of anchor.keyPaths) {
+    let at = path.indexOf(keys[0]);
+    while (at >= 0 && !keys.every((k, i) => path[at + i] === k)) {
+      at = path.indexOf(keys[0], at + 1);
+    }
+    if (at >= 0) {
+      rest = path.slice(at + keys.length);
+      break;
+    }
   }
-  if (at < 0) return null;
-  const rest = path.slice(at + anchor.keys.length);
+  if (rest === null) return null;
   if (anchor.index === undefined) return rest;
   if (anchor.index === "any") {
     return typeof rest[0] === "number" ? rest.slice(1) : null;
@@ -155,19 +161,27 @@ export function createFocusResolver(): typeof resolveFocus {
  */
 function handlerAnchor(
   location: AutomationLocation
-): { keys: string[]; index?: number | "any" } | null {
+): { keyPaths: string[][]; index?: number | "any" } | null {
   switch (location.kind) {
     case "device_on":
     case "component_on":
-      return { keys: [location.trigger], index: location.index };
+      return { keyPaths: [[location.trigger]], index: location.index };
     case "component_action":
-      return { keys: [location.field] };
+      return { keyPaths: [[location.field]] };
     case "interval":
-      return { keys: ["interval"], index: location.index };
+      return { keyPaths: [["interval"]], index: location.index };
     case "script":
-      return { keys: ["script"], index: "any" };
+      return { keyPaths: [["script"]], index: "any" };
     case "api_action":
-      return { keys: ["api", "actions"], index: "any" };
+      // Both block spellings: the caret must follow into a legacy
+      // services block before the first canonicalizing write.
+      return {
+        keyPaths: [
+          ["api", "actions"],
+          ["api", "services"],
+        ],
+        index: "any",
+      };
     default:
       // light_effect mounts a different editor.
       return null;

--- a/src/components/device/automation-editor/automation-focus.ts
+++ b/src/components/device/automation-editor/automation-focus.ts
@@ -20,6 +20,7 @@ import type {
   ConditionNode,
 } from "../../../api/types/automations.js";
 import type { YamlPathSegment } from "../../../util/yaml-ast.js";
+import { API_ACTIONS_BLOCK_KEYS } from "../../../util/yaml-automations.js";
 
 export type { YamlPathSegment };
 
@@ -176,10 +177,7 @@ function handlerAnchor(
       // Both block spellings: the caret must follow into a legacy
       // services block before the first canonicalizing write.
       return {
-        keyPaths: [
-          ["api", "actions"],
-          ["api", "services"],
-        ],
+        keyPaths: API_ACTIONS_BLOCK_KEYS.map((key) => ["api", key]),
         index: "any",
       };
     default:

--- a/src/components/device/device-section-config/reveal.ts
+++ b/src/components/device/device-section-config/reveal.ts
@@ -7,6 +7,7 @@ import { resolveSectionEntries } from "../../../util/section-entry-overrides.js"
 import { unitAdvancedGate } from "../config-entry-form-plan.js";
 import type { ESPHomeDeviceSectionConfig } from "../device-section-config.js";
 import { scrollFlashRow } from "../field-highlight.js";
+import { API_ACTIONS_BLOCK_KEYS } from "../../../util/yaml-automations.js";
 
 /**
  * When a backend error lands on an advanced field that's currently
@@ -48,7 +49,7 @@ export function revealAdvancedForFocus(
 export function maybeFlashApiActionsList(host: ESPHomeDeviceSectionConfig): void {
   if (host.sectionKey !== "api") return;
   const head = host.focusFieldPath?.[0];
-  if (head !== "actions" && head !== "services") return;
+  if (!API_ACTIONS_BLOCK_KEYS.some((key) => key === head)) return;
   const key = JSON.stringify(host.focusFieldPath);
   if (key === host._apiListFlashKey) return;
   const list = host.shadowRoot?.querySelector<HTMLElement>(

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -28,10 +28,20 @@ import {
  * would surface a spurious row here until backend parse corrects it.
  */
 const _COMPONENT_ACTION_FIELD_RE = /^(\s+)([a-z0-9_]+_action):/;
+/**
+ * Accepted spellings of the api action-list block key, canonical
+ * first — matches the backend's BLOCK_KEYS constant. Consume this
+ * everywhere the pair is needed so a new site can't forget the
+ * legacy spelling.
+ */
+export const API_ACTIONS_BLOCK_KEYS = ["actions", "services"] as const;
 /** An inline ``on_*:`` trigger handler: group 1 the indent, group 2 the key. */
 const _ON_HANDLER_RE = /^(\s+)(on_[a-zA-Z_]+):/;
 /** A bare mapping-key line (``temperature:``) — key, no value, optional comment. */
 const _BARE_MAPPING_KEY_RE = /^ *([A-Za-z_][\w.]*):\s*(#.*)?$/;
+/** A dash line with inline content — the match length is the item's
+ *  content column. */
+const _DASH_CONTENT_RE = /^\s*-\s+(?=\S)/;
 
 /**
  * Synchronous fallback parser for automation sections. The navigator
@@ -257,8 +267,18 @@ function _parseYamlAutomations(yaml: string): YamlSection[] {
     // The block key has a legacy spelling alongside the item-level one
     // below; both match the backend's BLOCK_KEYS / ITEM_KEYS constants.
     const actionsBlock =
-      _findChildBlock(lines, apiBlock.fromLine, apiBlock.toLine, "actions") ??
-      _findChildBlock(lines, apiBlock.fromLine, apiBlock.toLine, "services");
+      _findChildBlock(
+        lines,
+        apiBlock.fromLine,
+        apiBlock.toLine,
+        API_ACTIONS_BLOCK_KEYS[0]
+      ) ??
+      _findChildBlock(
+        lines,
+        apiBlock.fromLine,
+        apiBlock.toLine,
+        API_ACTIONS_BLOCK_KEYS[1]
+      );
     if (actionsBlock) {
       const items = _enumerateListItems(
         lines,
@@ -517,11 +537,19 @@ function _readKeyOnLine(lines: string[], fromLine: number, key: string): string 
   const m = target.match(new RegExp(`^\\s*-\\s*${value}`));
   if (m) return m[1];
   const dashIndent = _dashIndent(target);
+  // Siblings of the item's own mapping all sit at one column: the
+  // dash line's content column, or the first body line's for a bare
+  // dash. Pinning to it keeps a same-named key nested deeper in the
+  // body (a homeassistant.action call, a then block) from winning.
+  let childIndent = target.match(_DASH_CONTENT_RE)?.[0].length ?? null;
   const siblingRe = new RegExp(`^\\s+${value}`);
   for (let i = fromLine; i < lines.length; i++) {
     const line = lines[i];
     if (line.trim() === "") continue;
-    if (lineIndent(line) <= dashIndent) break;
+    const indent = lineIndent(line);
+    if (indent <= dashIndent) break;
+    childIndent ??= indent;
+    if (indent !== childIndent) continue;
     const kv = line.match(siblingRe);
     if (kv) return kv[1];
   }

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -254,12 +254,11 @@ function _parseYamlAutomations(yaml: string): YamlSection[] {
   // ``service:``) value is the stable discriminator.
   const apiBlock = _findTopLevelBlock(lines, "api");
   if (apiBlock) {
-    const actionsBlock = _findChildBlock(
-      lines,
-      apiBlock.fromLine,
-      apiBlock.toLine,
-      "actions"
-    );
+    // The block key has a legacy spelling alongside the item-level one
+    // below; both match the backend's BLOCK_KEYS / ITEM_KEYS constants.
+    const actionsBlock =
+      _findChildBlock(lines, apiBlock.fromLine, apiBlock.toLine, "actions") ??
+      _findChildBlock(lines, apiBlock.fromLine, apiBlock.toLine, "services");
     if (actionsBlock) {
       const items = _enumerateListItems(
         lines,

--- a/test/components/device/automation-editor/automation-focus.test.ts
+++ b/test/components/device/automation-editor/automation-focus.test.ts
@@ -152,6 +152,16 @@ describe("automationRelativePath", () => {
     expect(automationRelativePath(["api", "actions"], loc)).toBeNull();
   });
 
+  it("slices an api action under the legacy services anchor", () => {
+    const loc = { kind: "api_action", action_name: "ring" } as const;
+    expect(
+      automationRelativePath(["api", "services", 1, "then", 0, "logger.log"], loc)
+    ).toEqual(["then", 0, "logger.log"]);
+    // The bare block key matches the anchor with an empty tail; the
+    // index policy then rejects it, not the match loop.
+    expect(automationRelativePath(["api", "services"], loc)).toBeNull();
+  });
+
   it("scans past a lone first-key occurrence to the full anchor sequence", () => {
     // A param key equal to the anchor's first key must not block a later
     // full-sequence match.

--- a/test/util/yaml-automations.test.ts
+++ b/test/util/yaml-automations.test.ts
@@ -176,6 +176,24 @@ describe("parseYamlAutomations — top-level callable blocks", () => {
     expect(action?.parentKey).toBe("api");
   });
 
+  it("enumerates a legacy `services:` block like `actions:`", () => {
+    const yaml = [
+      "api:",
+      "  services:",
+      "    - service: start_va",
+      "      then:",
+      "        - logger.log: go",
+      "    - service: stop_va",
+      "      then:",
+      "        - logger.log: halt",
+      "",
+    ].join("\n");
+    expect(keys(yaml)).toEqual([
+      "automation:api_action:start_va",
+      "automation:api_action:stop_va",
+    ]);
+  });
+
   it("falls back to the legacy `service:` key for an api action name", () => {
     const yaml = [
       "api:",

--- a/test/util/yaml-automations.test.ts
+++ b/test/util/yaml-automations.test.ts
@@ -194,6 +194,19 @@ describe("parseYamlAutomations — top-level callable blocks", () => {
     ]);
   });
 
+  it("names a legacy item by its own key, not a nested homeassistant.action", () => {
+    const yaml = [
+      "api:",
+      "  services:",
+      "    - service: start_va",
+      "      then:",
+      "        - homeassistant.action:",
+      "            action: script.turn_on",
+      "",
+    ].join("\n");
+    expect(keys(yaml)).toEqual(["automation:api_action:start_va"]);
+  });
+
   it("falls back to the legacy `service:` key for an api action name", () => {
     const yaml = [
       "api:",


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#2420. The api actions manage list and the navigator use the frontend's synchronous YAML parser, which only looked for an `actions:` block; actions under the legacy `api: services:` spelling rendered as "No API actions defined yet." The block lookup now falls back to `services` (the item-level `service:` fallback already existed), and the caret-follow anchor accepts the legacy block path so cursor sync works before the backend's first canonicalizing write.

Replaces the closed #1527, which grew far past the problem.

**Related issue or feature (if applicable):**

- related to esphome/device-builder#2396

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
