### PR TITLE
Add a one-line helper for renamed-key migration entries

### DIFF
--- a/src/components/device/deprecation-notice.ts
+++ b/src/components/device/deprecation-notice.ts
@@ -8,8 +8,10 @@
  *
  * The rewrite is pure and draft-only: clicking the CTA emits
  * `apply-section-values` so the host splices the replacement into the unsaved
- * YAML buffer — no dialog, no backend call. Adding an option is a single
- * registry entry + its copy.
+ * YAML buffer — no dialog, no backend call. A bespoke migration (ethernet) is
+ * a full `DeprecatedOption` plus its copy; a plain `cv.rename_key` field is a
+ * one-liner with shared copy, e.g.
+ * `"sensor.sgp4x": [renamedOption("voc", "voc_index", "2026.8.0")]`.
  */
 import { consume } from "@lit/context";
 import { mdiUpdate } from "@mdi/js";
@@ -19,7 +21,7 @@ import type { ConfigEntry } from "../../api/types/config-entries.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import { isEntryVisible } from "../../util/config-validation.js";
+import { isEntryVisible, isValuePresent } from "../../util/config-validation.js";
 import { notifySuccess } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import {
@@ -38,9 +40,36 @@ export interface DeprecatedOption {
   key: string;
   /** `device.<copyPrefix>_*` localization keys for this option's copy. */
   copyPrefix: string;
+  /** ICU params for the copy keys (shared templated copy). */
+  copyParams?: Record<string, string | number>;
   /** Derives the replacement `setIn` changes (`value: undefined` removes the
    *  key); `null` when the current value isn't migratable (nudge hidden). */
   migrate: (value: unknown) => { path: string[]; value: unknown }[] | null;
+}
+
+/**
+ * Plain `cv.rename_key` field: move the value verbatim (nested mappings and
+ * raw blocks included), overwriting any value already under *newKey* — the
+ * same old-spelling-wins collision policy as the clk migration below.
+ * Shared templated copy.
+ */
+export function renamedOption(
+  oldKey: string,
+  newKey: string,
+  removedIn: string
+): DeprecatedOption {
+  return {
+    key: oldKey,
+    copyPrefix: "renamed_option",
+    copyParams: { old: oldKey, new: newKey, version: removedIn },
+    migrate: (value) =>
+      isValuePresent(value)
+        ? [
+            { path: [newKey], value },
+            { path: [oldKey], value: undefined },
+          ]
+        : null,
+  };
 }
 
 /** Deprecated flat `clk_mode: GPIO<n>_(IN|OUT)` encodes the RMII clock pin
@@ -136,9 +165,11 @@ export class ESPHomeDeprecationNotice extends LitElement {
         <div class="notice" role="note">
           <wa-icon library="mdi" name="update"></wa-icon>
           <div class="body">
-            <p>${this._localize(`device.${option.copyPrefix}_notice`)}</p>
+            <p>
+              ${this._localize(`device.${option.copyPrefix}_notice`, option.copyParams)}
+            </p>
             <button type="button" class="cta" @click=${() => this._onMigrate(changes)}>
-              ${this._localize(`device.${option.copyPrefix}_migrate`)}
+              ${this._localize(`device.${option.copyPrefix}_migrate`, option.copyParams)}
             </button>
           </div>
         </div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1016,6 +1016,8 @@
     "deprecation_applied": "Save and install the device to apply the migrated config.",
     "ethernet_clk_mode_notice": "This config uses the deprecated clk_mode option, which will be removed in ESPHome 2026.9.0. It can be migrated to the new clk format automatically.",
     "ethernet_clk_mode_migrate": "Migrate",
+    "renamed_option_notice": "This config uses the deprecated {old} option, which will be removed in ESPHome {version}. It can be renamed to {new} automatically.",
+    "renamed_option_migrate": "Migrate",
     "entry_render_error_title": "Could not render this field",
     "show_yaml_editor": "Show YAML editor",
     "save_error": "Failed to save",

--- a/test/components/device/deprecation-notice.test.ts
+++ b/test/components/device/deprecation-notice.test.ts
@@ -13,7 +13,12 @@ vi.mock("sonner-js", () => ({
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import toast from "sonner-js";
-import { ESPHomeDeprecationNotice } from "../../../src/components/device/deprecation-notice.js";
+import {
+  DEPRECATED_OPTIONS,
+  ESPHomeDeprecationNotice,
+  renamedOption,
+} from "../../../src/components/device/deprecation-notice.js";
+import enMessages from "../../../src/translations/en.json";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 async function mount(
@@ -111,5 +116,90 @@ describe("deprecation-notice — migrate", () => {
       path: ["clk"],
       value: { pin: "GPIO0", mode: "CLK_EXT_IN" },
     });
+  });
+});
+
+describe("registry copy coverage", () => {
+  // Every registry entry's copyPrefix must resolve to en.json copy, so a
+  // future one-line rename entry can't ship with a typo'd or missing key.
+  const device = (enMessages as { device: Record<string, string> }).device;
+  const prefixes = [
+    ...new Set(
+      Object.values(DEPRECATED_OPTIONS)
+        .flat()
+        .map((o) => o.copyPrefix)
+    ),
+    "renamed_option",
+  ];
+  it.each(prefixes)("defines notice and migrate copy for %s", (prefix) => {
+    expect(device[`${prefix}_notice`], `missing device.${prefix}_notice`).toBeTruthy();
+    expect(device[`${prefix}_migrate`], `missing device.${prefix}_migrate`).toBeTruthy();
+  });
+});
+
+describe("renamedOption", () => {
+  const option = renamedOption("voc", "voc_index", "2026.8.0");
+
+  it("targets the old key with shared templated copy", () => {
+    expect(option.key).toBe("voc");
+    expect(option.copyPrefix).toBe("renamed_option");
+    expect(option.copyParams).toEqual({
+      old: "voc",
+      new: "voc_index",
+      version: "2026.8.0",
+    });
+  });
+
+  it("moves a scalar verbatim and removes the old key", () => {
+    expect(option.migrate("high")).toEqual([
+      { path: ["voc_index"], value: "high" },
+      { path: ["voc"], value: undefined },
+    ]);
+  });
+
+  it("moves a nested mapping verbatim", () => {
+    const value = { name: "VOC", algorithm_tuning: { index_offset: 100 } };
+    expect(option.migrate(value)).toEqual([
+      { path: ["voc_index"], value },
+      { path: ["voc"], value: undefined },
+    ]);
+  });
+
+  it("hides the nudge for a not-materially-present value", () => {
+    expect(option.migrate(undefined)).toBeNull();
+    expect(option.migrate(null)).toBeNull();
+    expect(option.migrate("")).toBeNull();
+  });
+});
+
+describe("deprecation-notice — renamedOption entry end to end", () => {
+  afterEach(() => {
+    delete DEPRECATED_OPTIONS["sensor.testrename"];
+  });
+
+  it("renders with templated copy and emits the two-change rename", async () => {
+    DEPRECATED_OPTIONS["sensor.testrename"] = [
+      renamedOption("voc", "voc_index", "2026.8.0"),
+    ];
+    const { el, inner, changes } = await mount("sensor.testrename", {
+      voc: { name: "VOC" },
+      voc_index: { name: "stale" },
+    });
+    inner._localize = (key: string, params?: Record<string, unknown>) =>
+      `${key}|${JSON.stringify(params)}`;
+    await el.requestUpdate();
+    const notice = el.shadowRoot!.querySelector(".notice");
+    expect(notice).not.toBeNull();
+    expect(notice!.textContent).toContain(
+      'device.renamed_option_notice|{"old":"voc","new":"voc_index","version":"2026.8.0"}'
+    );
+    el.shadowRoot!.querySelector<HTMLButtonElement>(".cta")!.click();
+    // The old spelling wins over a pre-existing new key, mirroring clk.
+    expect(changes).toEqual([
+      [
+        { path: ["voc_index"], value: { name: "VOC" } },
+        { path: ["voc"], value: undefined },
+      ],
+    ]);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Generalizes the renamed-key migration affordance so a plain `cv.rename_key` field costs one registry line. `renamedOption(old, new, removedIn)` builds a `DeprecatedOption` that moves the value verbatim (nested mappings and raw blocks included), keeps the old-spelling-wins collision policy the clk migration established, and hides the nudge for a not-materially-present value. Copy is shared and ICU-templated (`{old}`, `{new}`, `{version}`), so a new rename needs zero new en.json keys; `DeprecatedOption` gains optional `copyParams` and the render passes them through, with the bespoke ethernet entry unchanged. A registry copy-coverage test pins every entry's `_notice` / `_migrate` keys to en.json so a typo'd prefix fails CI.

No entries are added yet on purpose: the pending sgp4x/sen5x/sen6x `voc`→`voc_index` / `nox`→`nox_index` renames aren't in esphome or the catalog, so nudging users to the new spelling today would produce configs current esphome rejects. Each lands as one line when the catalog sync brings them (the backend's `_HANDLED_RENAME_KEYS` canary from esphome/device-builder#2420 is the arrival signal). The api `services` rename stays out of this registry; it is block-shaped and handled by #1534 plus the backend respell on write.

When the canary fires, the whole change in `DEPRECATED_OPTIONS` (src/components/device/deprecation-notice.ts) is:

```ts
"sensor.sgp4x": [
  renamedOption("voc", "voc_index", "2026.8.0"),
  renamedOption("nox", "nox_index", "2026.8.0"),
],
"sensor.sen5x": [
  renamedOption("voc", "voc_index", "2026.8.0"),
  renamedOption("nox", "nox_index", "2026.8.0"),
],
"sensor.sen6x": [
  renamedOption("voc", "voc_index", "2026.8.0"),
  renamedOption("nox", "nox_index", "2026.8.0"),
],
```

plus extending the backend `_HANDLED_RENAME_KEYS` allowlist. No new en.json copy, the copy-coverage test picks the entries up automatically; verify the removal version really shipped as 2026.8.0 before committing the third argument.

**Superseded (2026-07-29):** migrations consolidated on the one-click `editor/migrate_config` engine (esphome/device-builder#2432 + #1538). Future renames land as backend rules in `controllers/migrations.py` plus detection in `src/util/config-migrations.ts`, not as `DEPRECATED_OPTIONS` entries; the section-nudge machinery is slated for retirement in esphome/device-builder#2437. The recipe above is kept for the record only.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1535

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).


