### PR TITLE
Preserve hex input nibble width through the round-trip

### DIFF
--- a/src/util/hex-int.ts
+++ b/src/util/hex-int.ts
@@ -20,12 +20,13 @@
  * - **Form input → emit**: `parseHexInt("0x76" | "0X76" | "118")`
  *   → canonical `"0x..."` string. Both hex (with explicit `0x`
  *   prefix) and decimal input are accepted; the user can type
- *   whichever is most natural for the value at hand. Parsing is
- *   `BigInt`-backed, so 64-bit values like a DS18B20 ROM
- *   (`0xbe030c9794184728`, range up to `2^64 - 1` per the catalog)
- *   round-trip without IEEE-754 precision loss (#944). Empty
- *   string → `null` (so optional entries get stripped from the
- *   payload by the form's coerce pass).
+ *   whichever is most natural for the value at hand. Hex input
+ *   is pure string slicing (width kept, casing lowered) and
+ *   decimal is `BigInt`-backed, so 64-bit values like a DS18B20
+ *   ROM (`0xbe030c9794184728`, range up to `2^64 - 1` per the
+ *   catalog) round-trip without IEEE-754 precision loss (#944).
+ *   Empty string → `null` (so optional entries get stripped from
+ *   the payload by the form's coerce pass).
  *
  * Round-trip preservation: when the YAML had `address: 0x76`, the
  * form shows `0x76` and the user can save without forcing the

--- a/src/util/hex-int.ts
+++ b/src/util/hex-int.ts
@@ -11,11 +11,12 @@
  *
  * - **YAML → form display**: any integer (`118`, `0x76`, `"0x76"`)
  *   resolves to a canonical hex string. We render it as
- *   `formatHexInt(value)` → `"0x76"` (lowercase, no padding —
- *   `value.toString(16)`-style; ESPHome's own `cv.hex_int`
- *   formatter uses uppercase, but the dashboard standardised on
- *   lowercase for user-facing display since that's what HA docs
- *   and most i2c datasheets use).
+ *   `formatHexInt(value)` → `"0x76"` (lowercase, keeping the
+ *   input's nibble width — a leading-zero wide key like a 128-bit
+ *   `0x0abc...` Thread credential stays full width; ESPHome's own
+ *   `cv.hex_int` formatter uses uppercase, but the dashboard
+ *   standardised on lowercase for user-facing display since that's
+ *   what HA docs and most i2c datasheets use).
  * - **Form input → emit**: `parseHexInt("0x76" | "0X76" | "118")`
  *   → canonical `"0x..."` string. Both hex (with explicit `0x`
  *   prefix) and decimal input are accepted; the user can type
@@ -43,8 +44,9 @@
  * hex string.
  *
  * Accepts:
- *  - hex with `0x` / `0X` prefix (`"0x76"`, `"0X1A"`);
- *  - non-negative decimal (`"118"`);
+ *  - hex with `0x` / `0X` prefix (`"0x76"`, `"0X1A"`) — the
+ *    digit count is preserved, so `"0X0AB"` → `"0x0ab"`;
+ *  - non-negative decimal (`"118"`) — minimum-width hex out;
  *  - leading/trailing whitespace around either form.
  *
  * Returns `null` for empty input, negative numbers, or any value
@@ -79,18 +81,26 @@
 // unprefixed hex letters — falls through to ``return null``.
 const ACCEPTED_INPUT_RE = /^(?:0[xX][0-9a-fA-F]+|\d+)$/;
 
-// What ``parseHexInt`` / ``formatHexInt`` emit — minimum-width
-// lowercase ``"0x..."``. Tighter than the input regex on purpose:
-// ``"0x076"`` is rejected here so the canonical-form fast path in
-// ``formatHexInt`` / ``normalizeHexValues`` agrees bit-for-bit
-// with what the BigInt slow path would produce (which strips the
-// leading zero). Without this tightening the two paths return
-// different strings for the same input.
-const CANONICAL_HEX_RE = /^0x(?:[1-9a-f][0-9a-f]*|0)$/;
+// What ``parseHexInt`` / ``formatHexInt`` emit — lowercase
+// ``"0x..."`` at whatever nibble width the input carried. Leading
+// zeros are canonical: a hex-prefixed input keeps its digit count
+// through the parse (only the casing normalises), so the fast path
+// here agrees bit-for-bit with the slow path's output. Width
+// preservation is load-bearing for wide keys — openthread's 128-bit
+// ``network_key`` / ``pskc`` / ``ext_pan_id`` must stay pasteable
+// into Thread commissioning tooling that expects the full 32-nibble
+// form, so a leading-zero key must not shorten on an unrelated save.
+const CANONICAL_HEX_RE = /^0x[0-9a-f]+$/;
 
 export function parseHexInt(raw: string): string | null {
   const trimmed = raw.trim();
   if (!ACCEPTED_INPUT_RE.test(trimmed)) return null;
+  // Hex-prefixed input keeps its nibble width (see CANONICAL_HEX_RE);
+  // only decimal input takes the BigInt route, whose minimum-width
+  // hex is the only width there is.
+  if (trimmed[0] === "0" && (trimmed[1] === "x" || trimmed[1] === "X")) {
+    return "0x" + trimmed.slice(2).toLowerCase();
+  }
   return "0x" + BigInt(trimmed).toString(16);
 }
 
@@ -197,14 +207,15 @@ export function normalizeHexValues(
 /**
  * Format an arbitrary form value as a hex literal for display.
  *
- * Returns `"0x" + value.toString(16)` — the minimum-width
- * lowercase form. `0` → `"0x0"`, `0x76` → `"0x76"`,
- * `0xff00` → `"0xff00"`. Intentionally not zero-padded: i2c
- * addresses and register addresses are read at whatever width
- * the underlying integer needs, and forcing a fixed
- * width (e.g. always `0x00`-style for 8-bit) would mismatch
- * larger hex types (`hex_uint16_t`, `hex_uint32_t`) sharing
- * this formatter.
+ * Numbers and bigints return `"0x" + value.toString(16)` — the
+ * minimum-width lowercase form (`0` → `"0x0"`, `0xff00` →
+ * `"0xff00"`); there is no width to preserve. Strings keep their
+ * nibble width through `parseHexInt`, so a leading-zero wide key
+ * survives re-render. Numeric values are intentionally not
+ * zero-padded to a fixed width: i2c and register addresses are
+ * read at whatever width the underlying integer needs, and a
+ * fixed 8-bit pad would mismatch the larger hex types
+ * (`hex_uint16_t`, `hex_uint32_t`) sharing this formatter.
  *
  * Lowercase to match the `0x76` form Home Assistant docs and
  * most i2c datasheets use. ESPHome's own `cv.hex_int` formatter

--- a/src/util/hex-int.ts
+++ b/src/util/hex-int.ts
@@ -54,12 +54,14 @@
  * decides whether to clear the field, surface a validation
  * error, etc.
  *
- * Backed by `BigInt`, not `Number`, so 64-bit values like a
- * DS18B20 ROM (`0xbe030c9794184728`) and the catalog's full
- * `cv.hex_uint64_t` range (up to `2^64 - 1`) survive the
- * round-trip. `Number.parseInt(s, 16)` rounded to the nearest
- * representable double for any hex over 2^53, silently mutating
- * the user's value on save (#944).
+ * Hex input never round-trips through a numeric type at all —
+ * pure string slicing — so 64-bit values like a DS18B20 ROM
+ * (`0xbe030c9794184728`) survive verbatim. Decimal input is
+ * `BigInt`-backed, not `Number`-backed, so the catalog's full
+ * `cv.hex_uint64_t` range (up to `2^64 - 1`) survives too;
+ * `Number.parseInt(s, 16)` rounded to the nearest representable
+ * double for any hex over 2^53, silently mutating the user's
+ * value on save (#944).
  *
  * **Bare hex without `0x` is intentionally rejected.** The i2c
  * address `76` would otherwise be ambiguous — could be the user
@@ -108,9 +110,10 @@ export function parseHexInt(raw: string): string | null {
  * Walk a values dict and rewrite every hex-typed entry's value to
  * its canonical lowercase ``"0x..."`` string form. Numeric (number
  * or bigint) values stringify through ``formatHexInt``; string
- * values (including uppercase, leading-zero, and decimal-typed-as-
- * string shapes) round-trip through ``parseHexInt``; already-
- * canonical strings short-circuit without allocating a copy.
+ * values (uppercase — including uppercase leading-zero — and
+ * decimal-typed-as-string shapes) round-trip through
+ * ``parseHexInt``; already-canonical strings, leading zeros
+ * included, short-circuit without allocating a copy.
  *
  * Why: the form's values dict carries heterogeneous types
  * (``parseYamlSectionValues`` hands hex literals back as raw

--- a/src/util/int-input.ts
+++ b/src/util/int-input.ts
@@ -12,8 +12,8 @@ const HEX_INT_RE = /^0x[0-9a-f]+$/i;
 export function parseIntInput(raw: unknown): bigint | null {
   const v = String(raw ?? "").trim();
   // The regexes admit only ``BigInt``-parseable literals, so call it directly
-  // (mirrors ``parseHexInt``) — a future regex change that breaks that
-  // invariant should throw loudly, not be swallowed into a silent null.
+  // — a future regex change that breaks that invariant should throw loudly,
+  // not be swallowed into a silent null.
   if (!DECIMAL_INT_RE.test(v) && !HEX_INT_RE.test(v)) return null;
   return BigInt(v);
 }

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -274,6 +274,19 @@ describe("validateEntry", () => {
     expect(validateEntry(entry, "0x76")).toBeNull();
   });
 
+  it("range-checks the padded canonical hex form by value, not width", () => {
+    // Leading zeros are canonical since the width-preserving
+    // round-trip; the BigInt comparison must keep ignoring them.
+    const entry = makeEntry({
+      type: ConfigEntryType.INTEGER,
+      display_format: "hex",
+      range: [0x08, 0x77],
+    });
+    expect(validateEntry(entry, "0x0076")).toBeNull();
+    expect(validateEntry(entry, "0x0007")?.code).toBe("validation.min");
+    expect(validateEntry(entry, "0x0078")?.code).toBe("validation.max");
+  });
+
   it("accepts floats on FLOAT fields", () => {
     const entry = makeEntry({ type: ConfigEntryType.FLOAT });
     expect(validateEntry(entry, 3.5)).toBeNull();

--- a/test/util/hex-int.test.ts
+++ b/test/util/hex-int.test.ts
@@ -62,6 +62,8 @@ describe("parseHexInt", () => {
     expect(parseHexInt("0x00112233445566778899aabbccddeeff")).toBe(
       "0x00112233445566778899aabbccddeeff"
     );
+    // The uppercase-prefix arm keeps padding too, casing lowered.
+    expect(parseHexInt("0X0AB")).toBe("0x0ab");
   });
 
   it("keeps zero at its typed width, decimal zero minimal", () => {

--- a/test/util/hex-int.test.ts
+++ b/test/util/hex-int.test.ts
@@ -282,9 +282,9 @@ describe("normalizeHexValues", () => {
     expect(normalizeHexValues({ network_key: key }, entries)).toEqual({
       network_key: key,
     });
-    expect(
-      normalizeHexValues({ network_key: key.toUpperCase().replace("0X", "0x") }, entries)
-    ).toEqual({ network_key: key });
+    expect(normalizeHexValues({ network_key: key.toUpperCase() }, entries)).toEqual({
+      network_key: key,
+    });
   });
 
   it("rewrites bigint hex values to canonical 0x-strings", () => {

--- a/test/util/hex-int.test.ts
+++ b/test/util/hex-int.test.ts
@@ -53,23 +53,26 @@ describe("parseHexInt", () => {
     expect(parseHexInt("18446744073709551615")).toBe("0xffffffffffffffff");
   });
 
-  it("strips leading zeros from hex input", () => {
-    // ``BigInt("0x076").toString(16)`` is ``"76"``; the canonical
-    // form is unique so the form's display, the values dict, and
-    // on-disk YAML all agree on a single shape.
-    expect(parseHexInt("0x076")).toBe("0x76");
-    expect(parseHexInt("0x00be030c9794184728")).toBe("0xbe030c9794184728");
+  it("preserves the nibble width of hex input", () => {
+    // A leading-zero wide key (openthread's 128-bit network_key /
+    // pskc / ext_pan_id) must stay pasteable into Thread
+    // commissioning tooling that expects the full 32-nibble form.
+    expect(parseHexInt("0x076")).toBe("0x076");
+    expect(parseHexInt("0x00be030c9794184728")).toBe("0x00be030c9794184728");
+    expect(parseHexInt("0x00112233445566778899aabbccddeeff")).toBe(
+      "0x00112233445566778899aabbccddeeff"
+    );
   });
 
-  it("canonicalises zero to 0x0 regardless of input shape", () => {
+  it("keeps zero at its typed width, decimal zero minimal", () => {
     // Pin the zero corner of CANONICAL_HEX_RE so a future tweak to
-    // the regex can't desynchronise the slow path's BigInt(0) output
-    // from the canonical-form gate ``formatHexInt`` /
-    // ``normalizeHexValues`` use to skip rewriting.
+    // the regex can't desynchronise the slow path's output from the
+    // canonical-form gate ``formatHexInt`` / ``normalizeHexValues``
+    // use to skip rewriting.
     expect(parseHexInt("0")).toBe("0x0");
     expect(parseHexInt("0x0")).toBe("0x0");
-    expect(parseHexInt("0x00")).toBe("0x0");
-    expect(parseHexInt("0x000")).toBe("0x0");
+    expect(parseHexInt("0x00")).toBe("0x00");
+    expect(parseHexInt("0x000")).toBe("0x000");
   });
 
   it("trims surrounding whitespace", () => {
@@ -141,21 +144,21 @@ describe("formatHexInt", () => {
     expect(formatHexInt("0xffffffffffffffff")).toBe("0xffffffffffffffff");
   });
 
-  it("canonicalises non-canonical hex strings (leading zeros)", () => {
-    // ``"0x076"`` matches the input regex but not the canonical-form
-    // gate, so the slow path strips the leading zero. Both formatters
-    // must agree on the output for a single value.
-    expect(formatHexInt("0x076")).toBe("0x76");
-    expect(formatHexInt("0x00be030c9794184728")).toBe("0xbe030c9794184728");
+  it("keeps leading-zero hex strings at their input width", () => {
+    // Leading zeros are canonical now; both formatters must agree on
+    // the width-preserved output for a single value so the
+    // ``normalizeHexValues`` fast-path skip stays consistent with a
+    // subsequent re-format.
+    expect(formatHexInt("0x076")).toBe("0x076");
+    expect(formatHexInt("0x00be030c9794184728")).toBe("0x00be030c9794184728");
+    expect(formatHexInt("0x00112233445566778899aabbccddeeff")).toBe(
+      "0x00112233445566778899aabbccddeeff"
+    );
   });
 
   it("agrees with parseHexInt at the zero edge", () => {
-    // ``formatHexInt`` must not return ``"0x00"`` for a string that
-    // ``parseHexInt`` canonicalises to ``"0x0"``; otherwise the
-    // ``normalizeHexValues`` fast-path skip would diverge from a
-    // subsequent re-format.
     expect(formatHexInt("0x0")).toBe("0x0");
-    expect(formatHexInt("0x00")).toBe("0x0");
+    expect(formatHexInt("0x00")).toBe("0x00");
     expect(formatHexInt(0)).toBe("0x0");
   });
 
@@ -258,15 +261,28 @@ describe("normalizeHexValues", () => {
     });
   });
 
-  it("strips leading zeros from non-canonical hex strings", () => {
-    // Without canonicalisation here the fast path returns the
-    // string verbatim while a later edit re-renders the value
-    // through ``parseHexInt`` and the leading zero disappears; the
-    // values dict and on-disk YAML would silently disagree.
+  it("keeps leading-zero hex strings full width, identity-equal", () => {
+    // Leading zeros are canonical: the fast path skips the rewrite
+    // and every later re-render agrees, so a wide key with a zero
+    // leading nibble never shortens on an unrelated save.
     const entries = [entry("address", { display_format: "hex" })];
-    expect(normalizeHexValues({ address: "0x076" }, entries)).toEqual({
-      address: "0x76",
+    const values = { address: "0x076" };
+    expect(normalizeHexValues(values, entries)).toBe(values);
+  });
+
+  it("round-trips a leading-zero 128-bit Thread credential at full width", () => {
+    // The #2390 shape: openthread's network_key parses as a hex
+    // integer; an unrelated save must re-serialize the untouched
+    // credential at the full 32-nibble width commissioning tooling
+    // expects, including from the uppercase YAML spelling.
+    const entries = [entry("network_key", { display_format: "hex" })];
+    const key = "0x00112233445566778899aabbccddeeff";
+    expect(normalizeHexValues({ network_key: key }, entries)).toEqual({
+      network_key: key,
     });
+    expect(
+      normalizeHexValues({ network_key: key.toUpperCase().replace("0X", "0x") }, entries)
+    ).toEqual({ network_key: key });
   });
 
   it("rewrites bigint hex values to canonical 0x-strings", () => {

--- a/test/util/hex-int.test.ts
+++ b/test/util/hex-int.test.ts
@@ -64,6 +64,9 @@ describe("parseHexInt", () => {
     );
     // The uppercase-prefix arm keeps padding too, casing lowered.
     expect(parseHexInt("0X0AB")).toBe("0x0ab");
+    // Decimal is the diverging branch: leading zeros carry no hex
+    // width, so the BigInt route emits the minimal form.
+    expect(parseHexInt("0118")).toBe("0x76");
   });
 
   it("keeps zero at its typed width, decimal zero minimal", () => {


### PR DESCRIPTION
# What does this implement/fix?

A hex typed field's canonical form was minimum width: `normalizeHexValues` routed any leading zero hex string through `BigInt`, which strips the zeros, and `CANONICAL_HEX_RE` rejected the padded form so every later render shortened it again. For openthread's 128 bit `network_key` / `pskc` / `ext_pan_id` that meant a key with a zero leading nibble re-serialized shortened on an unrelated save; the value stayed numerically identical but the on disk credential was no longer pasteable into Thread commissioning tooling that expects the full 32 nibble form.

Leading zeros are canonical now: `parseHexInt` keeps a hex prefixed input's digit count and normalises only the casing, `CANONICAL_HEX_RE` accepts the padded form so the fast paths in `formatHexInt` and `normalizeHexValues` agree with the slow path, and decimal input still takes the `BigInt` route since it carries no width to preserve. Range validation is unaffected; it compares through `BigInt`, which ignores leading zeros. User typed hex also keeps its width, so `0x076` no longer snaps to `0x76` mid edit.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2390

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
