### PR TITLE
Carry the full field path in edit-action-field routing

### DIFF
--- a/src/components/device/automation-editor/automation-focus.ts
+++ b/src/components/device/automation-editor/automation-focus.ts
@@ -162,13 +162,21 @@ export function createFocusResolver(): typeof resolveFocus {
  */
 function handlerAnchor(
   location: AutomationLocation
-): { keyPaths: string[][]; index?: number | "any" } | null {
+): { keyPaths: YamlPathSegment[][]; index?: number | "any" } | null {
   switch (location.kind) {
     case "device_on":
     case "component_on":
       return { keyPaths: [[location.trigger]], index: location.index };
     case "component_action":
-      return { keyPaths: [[location.field]] };
+      // ``field`` is a dotted path for a nested action list
+      // (``valves.0.run_duration_number.set_action``); the caret must
+      // follow the whole chain to the leaf, with decimal segments as
+      // the numeric indices the cursor path carries.
+      return {
+        keyPaths: [
+          location.field.split(".").map((seg) => (/^\d+$/.test(seg) ? Number(seg) : seg)),
+        ],
+      };
     case "interval":
       return { keyPaths: [["interval"]], index: location.index };
     case "script":

--- a/src/components/device/automation-editor/automation-focus.ts
+++ b/src/components/device/automation-editor/automation-focus.ts
@@ -12,6 +12,7 @@
  * tail degrades to the deepest resolved node.
  */
 import memoizeOne from "memoize-one";
+import { splitActionFieldPath } from "../../../util/action-field-path.js";
 
 import type {
   ActionNode,
@@ -170,13 +171,8 @@ function handlerAnchor(
     case "component_action":
       // ``field`` is a dotted path for a nested action list
       // (``valves.0.run_duration_number.set_action``); the caret must
-      // follow the whole chain to the leaf, with decimal segments as
-      // the numeric indices the cursor path carries.
-      return {
-        keyPaths: [
-          location.field.split(".").map((seg) => (/^\d+$/.test(seg) ? Number(seg) : seg)),
-        ],
-      };
+      // follow the whole chain to the leaf.
+      return { keyPaths: [splitActionFieldPath(location.field)] };
     case "interval":
       return { keyPaths: [["interval"]], index: location.index };
     case "script":

--- a/src/components/device/automation-editor/serialise.ts
+++ b/src/components/device/automation-editor/serialise.ts
@@ -220,8 +220,10 @@ export function locationFromSectionKey(key: string): AutomationLocation | null {
     }
     case "component_action":
       // `automation:component_action:<component_id>:<field>` — exactly 4
-      // colon-free tokens (id is `[a-z0-9_]`, field is `*_action`); no
-      // index part, so reject any trailing segments rather than ignore them.
+      // colon-free tokens (id is `[a-z0-9_]`, field is a dotted path of
+      // schema keys and list indices, e.g.
+      // `valves.0.run_duration_number.set_action`); no index part, so
+      // reject any trailing segments rather than ignore them.
       return parts.length === 4 && parts[2] && parts[3]
         ? { kind: "component_action", component_id: parts[2], field: parts[3] }
         : null;

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -1000,16 +1000,17 @@ export class ESPHomeConfigEntryForm extends LitElement {
       case ConfigEntryType.TRIGGER:
         // A component action-list config field (cover ``open_action`` …):
         // a bare action list edited in the automation editor, not inline.
-        // The form knows only the field key, so emit ``edit-action-field``
-        // and let the section host resolve the component instance and
-        // route to the automation editor.
+        // The form emits ``edit-action-field`` with the full path (a
+        // nested field's segments include list indices) and the section
+        // host resolves the component instance and routes to the
+        // automation editor.
         return html`<div class="field" data-field-key=${fieldKeyAttr(path)}>
           ${labelFor(entry, ctx)}
           <button
             type="button"
             class="edit-actions-button"
             ?disabled=${ctx.disabled}
-            @click=${() => this._emitEditActionField(entry.key)}
+            @click=${() => this._emitEditActionField(path)}
           >
             ${ctx.localize("device.automation_action_field_edit")}
           </button>
@@ -1138,11 +1139,11 @@ export class ESPHomeConfigEntryForm extends LitElement {
 
   /** A TRIGGER (action-list) field's "Edit actions" was clicked. The
    *  host resolves the component instance and routes to the automation
-   *  editor — the form only knows the field key. */
-  private _emitEditActionField(field: string) {
+   *  editor — the form only knows the field's path. */
+  private _emitEditActionField(path: string[]) {
     this.dispatchEvent(
-      new CustomEvent<{ field: string }>("edit-action-field", {
-        detail: { field },
+      new CustomEvent<{ path: string[] }>("edit-action-field", {
+        detail: { path },
         bubbles: true,
         composed: true,
       })

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -546,17 +546,19 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
   /**
    * Route an in-form "Edit actions" click (from a ``TRIGGER`` config
    * field like cover ``open_action``) to the automation editor. The
-   * form knows only the field key; resolve this instance's component id
-   * and build the ``component_action`` section key here.
+   * form emits the field's full path (segments are schema keys and
+   * list indices, never containing dots); resolve this instance's
+   * component id and build the dotted ``component_action`` section key
+   * the backend addresses nested fields with.
    */
-  _onEditActionField = (e: CustomEvent<{ field: string }>) => {
+  _onEditActionField = (e: CustomEvent<{ path: string[] }>) => {
     e.stopPropagation();
     const componentId = this._resolveComponentId();
     if (componentId === null) return;
     const sectionKey = sectionKeyFromLocation({
       kind: "component_action",
       component_id: componentId,
-      field: e.detail.field,
+      field: e.detail.path.join("."),
     });
     fireEvent(this, "section-select", { sectionKey });
   };

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -1,4 +1,5 @@
 import { consume } from "@lit/context";
+import { joinActionFieldPath } from "../../util/action-field-path.js";
 import {
   mdiAlertCircleOutline,
   mdiDelete,
@@ -546,8 +547,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
   /**
    * Route an in-form "Edit actions" click (from a ``TRIGGER`` config
    * field like cover ``open_action``) to the automation editor. The
-   * form emits the field's full path (segments are schema keys and
-   * list indices, never containing dots); resolve this instance's
+   * form emits the field's full path; resolve this instance's
    * component id and build the dotted ``component_action`` section key
    * the backend addresses nested fields with.
    */
@@ -558,7 +558,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
     const sectionKey = sectionKeyFromLocation({
       kind: "component_action",
       component_id: componentId,
-      field: e.detail.path.join("."),
+      field: joinActionFieldPath(e.detail.path),
     });
     fireEvent(this, "section-select", { sectionKey });
   };

--- a/src/util/action-field-label.ts
+++ b/src/util/action-field-label.ts
@@ -1,6 +1,6 @@
 import type { LocalizeFunc } from "../common/localize.js";
 
-import { actionFieldLeaf } from "./action-field-path.js";
+import { splitActionFieldPath } from "./action-field-path.js";
 
 /**
  * Friendly label for a component action-list field key
@@ -13,16 +13,33 @@ import { actionFieldLeaf } from "./action-field-path.js";
  * and feed it to the ``device.action_field_label`` template so the
  * surrounding word and order localize. The stem itself is an English
  * schema identifier (like a component name) and stays as-is.
+ *
+ * A nested field's containers prefix the label so sibling fields with
+ * the same leaf stay distinct (``repeat_number.set_action`` →
+ * "Repeat number → Set action"); a list index folds into its container
+ * (``valves.0.…`` → "Valves #1 → …"), matching the backend's parse
+ * labels.
  */
 export function actionFieldLabel(field: string, localize: LocalizeFunc): string {
-  // A nested field is a dotted path (``valves.0.run_duration_number.
-  // set_action``); the leaf segment names the action list.
-  const leaf = actionFieldLeaf(field);
+  const segments = splitActionFieldPath(field);
+  const leaf = String(segments[segments.length - 1] ?? field);
+  const containers: string[] = [];
+  for (const seg of segments.slice(0, -1)) {
+    if (typeof seg === "number") {
+      containers[containers.length - 1] =
+        `${containers[containers.length - 1]} #${seg + 1}`;
+    } else {
+      containers.push(humanize(seg));
+    }
+  }
   const base = leaf.endsWith("_action") ? leaf.slice(0, -"_action".length) : leaf;
-  // ``|| "action"`` keeps ``words`` non-empty (a bare ``_action`` key the
-  // parser can't actually produce, or an empty field), so the
-  // sentence-case below is always safe — no dead empty-string branch.
-  const words = (base || leaf).replace(/_/g, " ").trim() || "action";
-  const name = words[0].toUpperCase() + words.slice(1);
-  return localize("device.action_field_label", { name });
+  const name = humanize(base || leaf) || "Action";
+  const leafLabel = localize("device.action_field_label", { name });
+  return [...containers, leafLabel].join(" → ");
+}
+
+/** Sentence-case a schema key: underscores → spaces, first letter up. */
+function humanize(key: string): string {
+  const words = key.replace(/_/g, " ").trim();
+  return words ? words[0].toUpperCase() + words.slice(1) : "";
 }

--- a/src/util/action-field-label.ts
+++ b/src/util/action-field-label.ts
@@ -13,11 +13,15 @@ import type { LocalizeFunc } from "../common/localize.js";
  * schema identifier (like a component name) and stays as-is.
  */
 export function actionFieldLabel(field: string, localize: LocalizeFunc): string {
-  const base = field.endsWith("_action") ? field.slice(0, -"_action".length) : field;
+  // A nested field is a dotted path (``valves.0.run_duration_number.
+  // set_action``); the leaf segment names the action list.
+  const segments = field.split(".");
+  const leaf = segments[segments.length - 1] || field;
+  const base = leaf.endsWith("_action") ? leaf.slice(0, -"_action".length) : leaf;
   // ``|| "action"`` keeps ``words`` non-empty (a bare ``_action`` key the
   // parser can't actually produce, or an empty field), so the
   // sentence-case below is always safe — no dead empty-string branch.
-  const words = (base || field).replace(/_/g, " ").trim() || "action";
+  const words = (base || leaf).replace(/_/g, " ").trim() || "action";
   const name = words[0].toUpperCase() + words.slice(1);
   return localize("device.action_field_label", { name });
 }

--- a/src/util/action-field-label.ts
+++ b/src/util/action-field-label.ts
@@ -26,6 +26,8 @@ export function actionFieldLabel(field: string, localize: LocalizeFunc): string 
   const containers: string[] = [];
   for (const seg of segments.slice(0, -1)) {
     if (typeof seg === "number") {
+      // A field path always starts with a schema key, so an index has a
+      // container to fold into; an index-first path can't occur.
       containers[containers.length - 1] =
         `${containers[containers.length - 1]} #${seg + 1}`;
     } else {

--- a/src/util/action-field-label.ts
+++ b/src/util/action-field-label.ts
@@ -1,5 +1,7 @@
 import type { LocalizeFunc } from "../common/localize.js";
 
+import { actionFieldLeaf } from "./action-field-path.js";
+
 /**
  * Friendly label for a component action-list field key
  * (``open_action`` → "Open action").
@@ -15,8 +17,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 export function actionFieldLabel(field: string, localize: LocalizeFunc): string {
   // A nested field is a dotted path (``valves.0.run_duration_number.
   // set_action``); the leaf segment names the action list.
-  const segments = field.split(".");
-  const leaf = segments[segments.length - 1] || field;
+  const leaf = actionFieldLeaf(field);
   const base = leaf.endsWith("_action") ? leaf.slice(0, -"_action".length) : leaf;
   // ``|| "action"`` keeps ``words`` non-empty (a bare ``_action`` key the
   // parser can't actually produce, or an empty field), so the

--- a/src/util/action-field-path.ts
+++ b/src/util/action-field-path.ts
@@ -1,0 +1,27 @@
+import { isIndexSegment } from "./nested-values.js";
+
+/**
+ * The one owner of the dotted `component_action` field encoding.
+ *
+ * A field is the dot-join of a config-entry path: schema keys and list
+ * indices, never containing dots (unlike user map keys, which is why
+ * `fieldKeyAttr` uses JSON instead), so the join is lossless. The
+ * backend addresses nested action lists with the same encoding
+ * (`valves.0.run_duration_number.set_action`).
+ */
+
+/** Dotted `field` string for a config-entry path. */
+export function joinActionFieldPath(path: string[]): string {
+  return path.join(".");
+}
+
+/** Path segments of a dotted field, indices as the numbers cursor paths carry. */
+export function splitActionFieldPath(field: string): (string | number)[] {
+  return field.split(".").map((seg) => (isIndexSegment(seg) ? Number(seg) : seg));
+}
+
+/** The leaf key naming the action list (`…set_action` → `set_action`). */
+export function actionFieldLeaf(field: string): string {
+  const segments = field.split(".");
+  return segments[segments.length - 1];
+}

--- a/src/util/action-field-path.ts
+++ b/src/util/action-field-path.ts
@@ -1,4 +1,5 @@
 import { isIndexSegment } from "./nested-values.js";
+import type { YamlPathSegment } from "./yaml-ast.js";
 
 /**
  * The one owner of the dotted `component_action` field encoding.
@@ -16,12 +17,6 @@ export function joinActionFieldPath(path: string[]): string {
 }
 
 /** Path segments of a dotted field, indices as the numbers cursor paths carry. */
-export function splitActionFieldPath(field: string): (string | number)[] {
+export function splitActionFieldPath(field: string): YamlPathSegment[] {
   return field.split(".").map((seg) => (isIndexSegment(seg) ? Number(seg) : seg));
-}
-
-/** The leaf key naming the action list (`…set_action` → `set_action`). */
-export function actionFieldLeaf(field: string): string {
-  const segments = field.split(".");
-  return segments[segments.length - 1];
 }

--- a/test/components/device/automation-editor/automation-focus.test.ts
+++ b/test/components/device/automation-editor/automation-focus.test.ts
@@ -97,6 +97,28 @@ describe("automationRelativePath", () => {
     ).toEqual([0, "logger.log"]);
   });
 
+  it("slices a nested component_action on its whole field chain", () => {
+    expect(
+      automationRelativePath(
+        [
+          "sprinkler",
+          0,
+          "valves",
+          0,
+          "run_duration_number",
+          "set_action",
+          1,
+          "switch.turn_on",
+        ],
+        {
+          kind: "component_action",
+          component_id: "lawn",
+          field: "valves.0.run_duration_number.set_action",
+        }
+      )
+    ).toEqual([1, "switch.turn_on"]);
+  });
+
   it("slices interval by index", () => {
     expect(
       automationRelativePath(["interval", 2, "then", 0], { kind: "interval", index: 2 })

--- a/test/components/device/automation-editor/section-key.test.ts
+++ b/test/components/device/automation-editor/section-key.test.ts
@@ -85,6 +85,19 @@ describe("locationFromSectionKey", () => {
     expect(locationFromSectionKey("automation:nope")).toBeNull();
   });
 
+  it("round-trips a dotted nested component_action field", () => {
+    const location = {
+      kind: "component_action" as const,
+      component_id: "lawn",
+      field: "valves.0.run_duration_number.set_action",
+    };
+    const key = sectionKeyFromLocation(location);
+    expect(key).toBe(
+      "automation:component_action:lawn:valves.0.run_duration_number.set_action"
+    );
+    expect(locationFromSectionKey(key)).toEqual(location);
+  });
+
   it("rejects malformed keys", () => {
     expect(locationFromSectionKey("automation:device_on:")).toBeNull();
     expect(locationFromSectionKey("automation:component_on:my_button")).toBeNull();

--- a/test/components/device/config-entry-form-trigger-field.test.ts
+++ b/test/components/device/config-entry-form-trigger-field.test.ts
@@ -3,8 +3,8 @@
  *
  * A ``TRIGGER`` config entry (a component action-list field such as
  * cover ``open_action``) renders an "Edit actions" button that emits
- * ``edit-action-field`` with the field key, so the section host can
- * route it to the automation editor.
+ * ``edit-action-field`` with the field's full path, so the section host
+ * can route nested fields to the automation editor.
  */
 import { describe, expect, it, vi } from "vitest";
 
@@ -17,7 +17,7 @@ import { ESPHomeConfigEntryForm } from "../../../src/components/device/config-en
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
 
 describe("config-entry-form TRIGGER field", () => {
-  it("emits edit-action-field with the field key when clicked", async () => {
+  it("emits edit-action-field with the field path when clicked", async () => {
     const form = new ESPHomeConfigEntryForm();
     form.entries = [
       makeConfigEntry({ key: "open_action", type: ConfigEntryType.TRIGGER }),
@@ -26,15 +26,45 @@ describe("config-entry-form TRIGGER field", () => {
     document.body.append(form);
     await form.updateComplete;
 
-    let field: string | undefined;
+    let path: string[] | undefined;
     form.addEventListener("edit-action-field", (e) => {
-      field = (e as CustomEvent<{ field: string }>).detail.field;
+      path = (e as CustomEvent<{ path: string[] }>).detail.path;
     });
 
     const button =
       form.shadowRoot?.querySelector<HTMLButtonElement>(".edit-actions-button");
     expect(button).not.toBeNull();
     button?.click();
-    expect(field).toBe("open_action");
+    expect(path).toEqual(["open_action"]);
+  });
+
+  it("emits the full path for a TRIGGER nested below a group", async () => {
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [
+      makeConfigEntry({
+        key: "repeat_number",
+        type: ConfigEntryType.NESTED,
+        config_entries: [
+          makeConfigEntry({ key: "set_action", type: ConfigEntryType.TRIGGER }),
+        ],
+      }),
+    ];
+    form.values = { repeat_number: { set_action: [] } };
+    // Open the group the way the renderer tracks it (path-joined key).
+    (form as unknown as { _nestedOpenSections: Set<string> })._nestedOpenSections =
+      new Set(["repeat_number"]);
+    document.body.append(form);
+    await form.updateComplete;
+
+    let path: string[] | undefined;
+    form.addEventListener("edit-action-field", (e) => {
+      path = (e as CustomEvent<{ path: string[] }>).detail.path;
+    });
+
+    const button =
+      form.shadowRoot?.querySelector<HTMLButtonElement>(".edit-actions-button");
+    expect(button).not.toBeNull();
+    button?.click();
+    expect(path).toEqual(["repeat_number", "set_action"]);
   });
 });

--- a/test/components/device/section-config-action-fields.test.ts
+++ b/test/components/device/section-config-action-fields.test.ts
@@ -69,9 +69,27 @@ describe("device-section-config — component action fields", () => {
     });
 
     inner._onEditActionField(
-      new CustomEvent("edit-action-field", { detail: { field: "open_action" } })
+      new CustomEvent("edit-action-field", { detail: { path: ["open_action"] } })
     );
 
     expect(selected).toBe("automation:component_action:my_gate:open_action");
+  });
+
+  it("joins a nested field path into the dotted section key", () => {
+    const { c, inner } = makeHost();
+    let selected: string | undefined;
+    c.addEventListener("section-select", (e) => {
+      selected = (e as CustomEvent<{ sectionKey: string }>).detail.sectionKey;
+    });
+
+    inner._onEditActionField(
+      new CustomEvent("edit-action-field", {
+        detail: { path: ["valves", "0", "run_duration_number", "set_action"] },
+      })
+    );
+
+    expect(selected).toBe(
+      "automation:component_action:my_gate:valves.0.run_duration_number.set_action"
+    );
   });
 });

--- a/test/util/action-field-label.test.ts
+++ b/test/util/action-field-label.test.ts
@@ -32,6 +32,13 @@ describe("actionFieldLabel", () => {
     expect(actionFieldLabel("sequence", localize)).toBe("Sequence action");
   });
 
+  it("labels a dotted nested field from its leaf segment", () => {
+    expect(actionFieldLabel("valves.0.run_duration_number.set_action", localize)).toBe(
+      "Set action"
+    );
+    expect(actionFieldLabel("repeat_number.set_action", localize)).toBe("Set action");
+  });
+
   it("falls back without throwing on an empty field", () => {
     // Not reachable from the call sites (the parser only passes matched
     // `*_action` keys), but the util must not crash if reused.

--- a/test/util/action-field-label.test.ts
+++ b/test/util/action-field-label.test.ts
@@ -32,11 +32,17 @@ describe("actionFieldLabel", () => {
     expect(actionFieldLabel("sequence", localize)).toBe("Sequence action");
   });
 
-  it("labels a dotted nested field from its leaf segment", () => {
+  it("prefixes a dotted nested field with its container chain", () => {
     expect(actionFieldLabel("valves.0.run_duration_number.set_action", localize)).toBe(
-      "Set action"
+      "Valves #1 → Run duration number → Set action"
     );
-    expect(actionFieldLabel("repeat_number.set_action", localize)).toBe("Set action");
+    expect(actionFieldLabel("repeat_number.set_action", localize)).toBe(
+      "Repeat number → Set action"
+    );
+    // Sibling leaves stay distinct — the sprinkler collision case.
+    expect(actionFieldLabel("multiplier_number.set_action", localize)).toBe(
+      "Multiplier number → Set action"
+    );
   });
 
   it("falls back without throwing on an empty field", () => {


### PR DESCRIPTION
# What does this implement/fix?

Second of three parts for esphome/device-builder#2392 (nested action lists cannot route to the automation editor). The TRIGGER field renderer emitted `edit-action-field` with only the leaf key, so an action list nested below a component's top level, sprinkler's `repeat_number.set_action` or a per valve `run_duration_number.set_action`, could not reach the automation editor.

The event now carries the field's full path (the renderer already threads it; segments are schema keys and stringified list indices, never containing dots), and the section host joins it into the dotted `component_action` field the backend addresses nested fields with (esphome/device-builder#2433). The section key format is unchanged, dots live inside the existing fourth segment and round-trip through `locationFromSectionKey`. Cursor driven focus follows the whole chain to the leaf, with decimal segments mapped to the numeric indices the cursor path carries. The YAML fallback parser's top level only `component_action` pass is deliberately unchanged; nested fields do not surface in the manage table at all (it reads that parser directly), and the in form edit button is their sole route. A nested field's header label prefixes the container chain, `Valves #1 → Run duration number → Set action`, so sibling `set_action` fields stay distinct.

No visible change until the catalog ships nested TRIGGER entries (the third part, the sync gate lift); direct child fields behave exactly as before.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder/issues/2392

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
