### PR TITLE
Stop offering legacy registry aliases and the legacy service field

### DIFF
--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -33,7 +33,7 @@
  * (conditions don't have a target — they're tested against the
  * whole device state).
  */
-import { LEGACY_AUTOMATION_IDS } from "./hydrate-available-bodies.js";
+import { LEGACY_AUTOMATION_IDS } from "./legacy-automation-ids.js";
 import { consume } from "@lit/context";
 import { mdiClose, mdiMagnify, mdiPlus } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -33,6 +33,7 @@
  * (conditions don't have a target — they're tested against the
  * whole device state).
  */
+import { LEGACY_AUTOMATION_IDS } from "./hydrate-available-bodies.js";
 import { consume } from "@lit/context";
 import { mdiClose, mdiMagnify, mdiPlus } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
@@ -363,7 +364,9 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
   }
 
   private _renderActiveTab() {
-    const filtered = this._applyQuery(this.items);
+    const filtered = this._applyQuery(
+      this.items.filter((item) => !LEGACY_AUTOMATION_IDS.has(item.id))
+    );
     switch (this._activeTab) {
       case "by-target":
         return this._renderByTarget(filtered);

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -137,8 +137,10 @@ export async function loadAndHydrateAvailable(
     if (options?.isStale?.()) return { status: "stale" };
     overrideLegacyActionEntries(available);
     // Fresh array refs so identity-based ``hasChanged`` consumers
-    // re-render with the hydrated entries (entries' object identity
-    // is preserved so per-entry caches stay valid).
+    // re-render with the hydrated entries. The list entries keep their
+    // object identity; the legacy override above remaps two actions'
+    // ``config_entries`` before any consumer renders, so no cache ever
+    // holds a pre-override object.
     const refreshed: AvailableAutomations = {
       ...available,
       triggers: [...available.triggers],

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -16,6 +16,7 @@ import {
   type HydrationResult,
 } from "../../../util/automation-body-hydration.js";
 import { getErrorMessage } from "../../../util/error-message.js";
+import { LEGACY_AUTOMATION_IDS } from "./legacy-automation-ids.js";
 
 /** Which catalog lists to hydrate bodies for. A consumer that renders
  *  only some of them (the trigger-less editors never show triggers)
@@ -61,15 +62,6 @@ export async function hydrateAvailableBodies(
   }
   return result;
 }
-
-/** Legacy registry aliases kept for reading existing configs — never
- *  offered for new nodes; the migrate nudge (backend
- *  ``editor/migrate_config`` rules) respells them. Enforced by the
- *  action/condition catalog picker only (the trigger picker filters
- *  its own list). */
-export const LEGACY_AUTOMATION_IDS: ReadonlySet<string> = new Set([
-  "homeassistant.service",
-]);
 
 // Derived so a new alias can't reach the field override without also
 // leaving the picker.

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -62,6 +62,25 @@ export async function hydrateAvailableBodies(
   return result;
 }
 
+/** Legacy registry aliases kept for reading existing configs — never
+ *  offered for new nodes; the migrate nudge respells them. */
+export const LEGACY_AUTOMATION_IDS: ReadonlySet<string> = new Set([
+  "homeassistant.service",
+]);
+
+const _HA_ACTION_IDS = new Set(["homeassistant.action", "homeassistant.service"]);
+
+/** Hide the legacy ``service`` field so a new node can only author the
+ *  canonical ``action``; a value already in the YAML still renders. */
+function overrideLegacyActionEntries(available: AvailableAutomations): void {
+  for (const action of available.actions) {
+    if (!_HA_ACTION_IDS.has(action.id)) continue;
+    action.config_entries = action.config_entries.map((entry) =>
+      entry.key === "service" ? { ...entry, hidden: true } : entry
+    );
+  }
+}
+
 /** Discriminated outcome of :func:`loadAndHydrateAvailable`. */
 export type LoadAndHydrateOutcome =
   | { status: "ok"; available: AvailableAutomations; hydration: HydrationResult }
@@ -116,6 +135,7 @@ export async function loadAndHydrateAvailable(
       options?.lists
     );
     if (options?.isStale?.()) return { status: "stale" };
+    overrideLegacyActionEntries(available);
     // Fresh array refs so identity-based ``hasChanged`` consumers
     // re-render with the hydrated entries (entries' object identity
     // is preserved so per-entry caches stay valid).

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -63,7 +63,10 @@ export async function hydrateAvailableBodies(
 }
 
 /** Legacy registry aliases kept for reading existing configs — never
- *  offered for new nodes; the migrate nudge respells them. */
+ *  offered for new nodes; the migrate nudge respells them. Enforced by
+ *  the action/condition catalog picker only (the trigger picker filters
+ *  its own list); the migration-side twin of these ids lives in
+ *  ``src/util/config-migrations.ts``. */
 export const LEGACY_AUTOMATION_IDS: ReadonlySet<string> = new Set([
   "homeassistant.service",
 ]);

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -142,8 +142,10 @@ export async function loadAndHydrateAvailable(
     // Fresh array refs so identity-based ``hasChanged`` consumers
     // re-render with the hydrated entries. The list entries keep their
     // object identity; the legacy override above remaps two actions'
-    // ``config_entries`` before any consumer renders, so no cache ever
-    // holds a pre-override object.
+    // ``config_entries`` before the refreshed refs reach state, so no
+    // cache ever holds a pre-override object. (A form mounted off the
+    // ``onPaint`` object mid-hydration can transiently see the legacy
+    // field; the refreshed refs force the corrective re-render.)
     const refreshed: AvailableAutomations = {
       ...available,
       triggers: [...available.triggers],

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -63,15 +63,17 @@ export async function hydrateAvailableBodies(
 }
 
 /** Legacy registry aliases kept for reading existing configs — never
- *  offered for new nodes; the migrate nudge respells them. Enforced by
- *  the action/condition catalog picker only (the trigger picker filters
- *  its own list); the migration-side twin of these ids lives in
- *  ``src/util/config-migrations.ts``. */
+ *  offered for new nodes; the migrate nudge (backend
+ *  ``editor/migrate_config`` rules) respells them. Enforced by the
+ *  action/condition catalog picker only (the trigger picker filters
+ *  its own list). */
 export const LEGACY_AUTOMATION_IDS: ReadonlySet<string> = new Set([
   "homeassistant.service",
 ]);
 
-const _HA_ACTION_IDS = new Set(["homeassistant.action", "homeassistant.service"]);
+// Derived so a new alias can't reach the field override without also
+// leaving the picker.
+const _HA_ACTION_IDS = new Set(["homeassistant.action", ...LEGACY_AUTOMATION_IDS]);
 
 /** Hide the legacy ``service`` field so a new node can only author the
  *  canonical ``action``; a value already in the YAML still renders. */

--- a/src/components/device/automation-editor/legacy-automation-ids.ts
+++ b/src/components/device/automation-editor/legacy-automation-ids.ts
@@ -1,0 +1,8 @@
+/** Legacy registry aliases kept for reading existing configs — never
+ *  offered for new nodes; the migrate nudge (backend
+ *  ``editor/migrate_config`` rules) respells them. Enforced by the
+ *  action/condition catalog picker only (the trigger picker filters
+ *  its own list). */
+export const LEGACY_AUTOMATION_IDS: ReadonlySet<string> = new Set([
+  "homeassistant.service",
+]);

--- a/src/components/device/config-entry-renderers/constraint-banners.ts
+++ b/src/components/device/config-entry-renderers/constraint-banners.ts
@@ -47,27 +47,29 @@ export function collectUnsatisfiedConstraints(
   // hidden / depends_on / platform, or simply not a rendered entry), matching
   // the cluster box — otherwise the prompt nags about fields the user can't set.
   const byKey = new Map(entries.map((e) => [e.key, e]));
-  const anyVisible = (keys: string[]): boolean =>
-    keys.some((k) => {
-      const entry = byKey.get(k);
-      return (
-        entry !== undefined &&
-        (getIn(values, [k]) !== undefined ||
-          isEntryVisible(
-            entry,
-            values,
-            presentComponents,
-            targetPlatform,
-            undefined,
-            entries
-          ))
-      );
-    });
+  const keyVisible = (k: string): boolean => {
+    const entry = byKey.get(k);
+    return (
+      entry !== undefined &&
+      (getIn(values, [k]) !== undefined ||
+        isEntryVisible(
+          entry,
+          values,
+          presentComponents,
+          targetPlatform,
+          undefined,
+          entries
+        ))
+    );
+  };
+  const anyVisible = (keys: string[]): boolean => keys.some(keyVisible);
   for (const group of requiredGroups) {
     if (group.keys.some((k) => clusteredKeys.has(k))) continue;
     if (!anyVisible(group.keys)) continue;
     if (evaluateGroup(group.kind, group.keys, values)) continue;
-    messages.push({ kind: group.kind, keys: formatKeys(group.keys) });
+    // Name only the keys the user can see — a hidden alias shouldn't be
+    // prompted for.
+    messages.push({ kind: group.kind, keys: formatKeys(group.keys.filter(keyVisible)) });
   }
   // buildConstraintClusters folds every *non-exclusive* inclusive group into
   // a cluster (whose members land in clusteredKeys), so this loop only fires

--- a/src/components/device/config-entry-renderers/constraint-banners.ts
+++ b/src/components/device/config-entry-renderers/constraint-banners.ts
@@ -63,10 +63,11 @@ export function collectUnsatisfiedConstraints(
     );
   };
   const anyVisible = (keys: string[]): boolean => keys.some(keyVisible);
-  // For the zero-present kinds, name only the keys the user can see — a
-  // hidden alias shouldn't be prompted for. The all/none kinds exist to
-  // name the *missing* member, visible or not, so they keep every key.
-  const namedKeys = (kind: string, keys: string[]): string[] =>
+  // The all/none kinds exist to name the *missing* member, visible or
+  // not, so they keep every key; the rest prompt the user to set (or
+  // unset) something, so they name only keys the user can see — a
+  // hidden alias shouldn't be prompted for.
+  const namedKeys = (kind: ConstraintKind, keys: string[]): string[] =>
     kind === "all_or_none" || kind === "none_or_all" ? keys : keys.filter(keyVisible);
   for (const group of requiredGroups) {
     if (group.keys.some((k) => clusteredKeys.has(k))) continue;
@@ -94,6 +95,8 @@ export function collectUnsatisfiedConstraints(
     if (evaluateGroup("all_or_none", keys, values)) continue;
     messages.push({
       kind: "all_or_none",
+      // No-op for this loop's fixed kind; routed through so the naming
+      // rule lives in one place.
       keys: formatKeys(namedKeys("all_or_none", keys)),
     });
   }

--- a/src/components/device/config-entry-renderers/constraint-banners.ts
+++ b/src/components/device/config-entry-renderers/constraint-banners.ts
@@ -63,13 +63,19 @@ export function collectUnsatisfiedConstraints(
     );
   };
   const anyVisible = (keys: string[]): boolean => keys.some(keyVisible);
+  // For the zero-present kinds, name only the keys the user can see — a
+  // hidden alias shouldn't be prompted for. The all/none kinds exist to
+  // name the *missing* member, visible or not, so they keep every key.
+  const namedKeys = (kind: string, keys: string[]): string[] =>
+    kind === "all_or_none" || kind === "none_or_all" ? keys : keys.filter(keyVisible);
   for (const group of requiredGroups) {
     if (group.keys.some((k) => clusteredKeys.has(k))) continue;
     if (!anyVisible(group.keys)) continue;
     if (evaluateGroup(group.kind, group.keys, values)) continue;
-    // Name only the keys the user can see — a hidden alias shouldn't be
-    // prompted for.
-    messages.push({ kind: group.kind, keys: formatKeys(group.keys.filter(keyVisible)) });
+    messages.push({
+      kind: group.kind,
+      keys: formatKeys(namedKeys(group.kind, group.keys)),
+    });
   }
   // buildConstraintClusters folds every *non-exclusive* inclusive group into
   // a cluster (whose members land in clusteredKeys), so this loop only fires
@@ -86,7 +92,10 @@ export function collectUnsatisfiedConstraints(
     if (keys.some((k) => clusteredKeys.has(k))) continue;
     if (!anyVisible(keys)) continue;
     if (evaluateGroup("all_or_none", keys, values)) continue;
-    messages.push({ kind: "all_or_none", keys: formatKeys(keys) });
+    messages.push({
+      kind: "all_or_none",
+      keys: formatKeys(namedKeys("all_or_none", keys)),
+    });
   }
   return messages;
 }

--- a/test/components/device/automation-editor/automation-action-node-legacy-alias.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-legacy-alias.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that an existing legacy-alias node still resolves its catalog def
+ * and renders the params form — the picker filter must never reach the
+ * node-level lookup.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-condition-tree.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/catalog-picker-dialog.js",
+  () => ({})
+);
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}));
+
+import type {
+  ActionNode,
+  AutomationAction,
+} from "../../../../src/api/types/automations.js";
+import type { ConfigEntry } from "../../../../src/api/types/config-entries.js";
+import { ESPHomeAutomationActionNode } from "../../../../src/components/device/automation-editor/automation-action-node.js";
+
+const LEGACY_DEF = {
+  id: "homeassistant.service",
+  name: "Homeassistant → Service",
+  description: "",
+  config_entries: [
+    { key: "action", type: "string", label: "Action", required: false },
+    { key: "service", type: "string", label: "Service", required: false, hidden: true },
+  ] as unknown as ConfigEntry[],
+  accepts_action_list: [],
+} as unknown as AutomationAction;
+
+describe("automation-action-node — legacy alias compatibility", () => {
+  it("renders the params form for an existing homeassistant.service node", async () => {
+    const el = new ESPHomeAutomationActionNode();
+    el.value = { action_id: "homeassistant.service", params: {} } as ActionNode;
+    el.catalog = [LEGACY_DEF];
+    document.body.appendChild(el);
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector("esphome-config-entry-form")).not.toBeNull();
+    expect(el.shadowRoot!.querySelector(".ae-row-unknown")).toBeNull();
+  });
+});

--- a/test/components/device/automation-editor/catalog-picker-dialog.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog.test.ts
@@ -232,4 +232,25 @@ describe("catalog-picker-dialog tab strip", () => {
       "device.automation_pick_tab_building_blocks",
     ]);
   });
+
+  it("never offers legacy registry aliases", async () => {
+    const dialog = await mountDialog({
+      items: [
+        action({
+          id: "homeassistant.action",
+          name: "HA Action",
+          domain: "homeassistant",
+        }),
+        action({
+          id: "homeassistant.service",
+          name: "HA Service",
+          domain: "homeassistant",
+        }),
+      ],
+      tab: "by-type",
+    });
+    const text = dialog.shadowRoot!.textContent ?? "";
+    expect(text).toContain("HA Action");
+    expect(text).not.toContain("HA Service");
+  });
 });

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -167,32 +167,37 @@ describe("loadAndHydrateAvailable", () => {
     const slim = {
       ...emptySlim(),
       actions: [
-        {
-          id: "homeassistant.action",
-          name: "Action",
-          domain: "homeassistant",
-          config_entries: [entryOf("action"), entryOf("service"), entryOf("data")],
-        },
-        {
-          id: "homeassistant.service",
-          name: "Service",
-          domain: "homeassistant",
-          config_entries: [entryOf("action"), entryOf("service")],
-        },
-        {
-          id: "logger.log",
-          name: "Log",
-          domain: "logger",
-          config_entries: [entryOf("format")],
-        },
+        { id: "homeassistant.action", name: "Action", domain: "homeassistant" },
+        { id: "homeassistant.service", name: "Service", domain: "homeassistant" },
+        { id: "logger.log", name: "Log", domain: "logger" },
       ],
     } as unknown as AvailableAutomations;
+    const bodies: Record<string, unknown> = {
+      "actions/homeassistant.action": {
+        config_entries: [entryOf("action"), entryOf("service"), entryOf("data")],
+      },
+      "actions/homeassistant.service": {
+        config_entries: [entryOf("action"), entryOf("service")],
+      },
+      "actions/logger.log": { config_entries: [entryOf("format")] },
+    };
     const api = {
       getAvailableAutomations: vi.fn().mockResolvedValue(slim),
+      getAutomationBodies: vi.fn(
+        async (refs: { type: string; id: string }[]) =>
+          Object.fromEntries(
+            refs.map((ref) => [`${ref.type}/${ref.id}`, bodies[`${ref.type}/${ref.id}`]])
+          ) as Record<string, never>
+      ),
     } as unknown as ESPHomeAPI;
 
     const outcome = await loadAndHydrateAvailable(api, "device.yaml");
     if (outcome.status !== "ok") throw new Error(outcome.status);
+    // Clean hydration — the override must apply to hydrated bodies, not
+    // to fixtures surviving a failed fetch.
+    expect(outcome.hydration).toEqual(
+      expect.objectContaining({ missingBody: 0, missingField: 0, rejected: 0 })
+    );
     const byId = new Map(outcome.available.actions.map((a) => [a.id, a]));
     for (const id of ["homeassistant.action", "homeassistant.service"]) {
       const entries = byId.get(id)!.config_entries;

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -157,6 +157,48 @@ describe("loadAndHydrateAvailable", () => {
       devices: [],
     }) as unknown as AvailableAutomations;
 
+  it("hides the legacy service field on the homeassistant actions", async () => {
+    const entryOf = (key: string) => ({ key, type: "string", label: key });
+    const slim = {
+      ...emptySlim(),
+      actions: [
+        {
+          id: "homeassistant.action",
+          name: "Action",
+          domain: "homeassistant",
+          config_entries: [entryOf("action"), entryOf("service"), entryOf("data")],
+        },
+        {
+          id: "homeassistant.service",
+          name: "Service",
+          domain: "homeassistant",
+          config_entries: [entryOf("action"), entryOf("service")],
+        },
+        {
+          id: "logger.log",
+          name: "Log",
+          domain: "logger",
+          config_entries: [entryOf("format")],
+        },
+      ],
+    } as unknown as AvailableAutomations;
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(slim),
+    } as unknown as ESPHomeAPI;
+
+    const outcome = await loadAndHydrateAvailable(api, "device.yaml");
+    if (outcome.status !== "ok") throw new Error(outcome.status);
+    const byId = new Map(outcome.available.actions.map((a) => [a.id, a]));
+    for (const id of ["homeassistant.action", "homeassistant.service"]) {
+      const entries = byId.get(id)!.config_entries;
+      expect(entries.find((e) => e.key === "service")?.hidden).toBe(true);
+      expect(entries.find((e) => e.key === "action")?.hidden).toBeUndefined();
+    }
+    expect(
+      byId.get("logger.log")!.config_entries.find((e) => e.key === "format")?.hidden
+    ).toBeUndefined();
+  });
+
   it("issues exactly one getAvailableAutomations call per invocation", async () => {
     const slim = emptySlim();
     const getAvailableAutomations = vi.fn().mockResolvedValue(slim);

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
 
 import toast from "sonner-js";
+import { _clearAutomationBodyCache } from "../../../../src/util/automation-body-cache.js";
 import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type {
   AutomationAction,
@@ -148,6 +149,10 @@ describe("hydrateAvailableBodies", () => {
 });
 
 describe("loadAndHydrateAvailable", () => {
+  afterEach(() => {
+    _clearAutomationBodyCache();
+  });
+
   const emptySlim = (): AvailableAutomations =>
     ({
       triggers: [],

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -184,10 +184,10 @@ describe("loadAndHydrateAvailable", () => {
     const api = {
       getAvailableAutomations: vi.fn().mockResolvedValue(slim),
       getAutomationBodies: vi.fn(
-        async (refs: { type: string; id: string }[]) =>
+        async (refs: { type: string; id: string }[]): Promise<Record<string, unknown>> =>
           Object.fromEntries(
             refs.map((ref) => [`${ref.type}/${ref.id}`, bodies[`${ref.type}/${ref.id}`]])
-          ) as Record<string, never>
+          )
       ),
     } as unknown as ESPHomeAPI;
 

--- a/test/components/device/constraint-banners.test.ts
+++ b/test/components/device/constraint-banners.test.ts
@@ -112,4 +112,16 @@ describe("collectUnsatisfiedConstraints", () => {
     const messages = collect({ entries, requiredGroups: groups });
     expect(messages).toEqual([{ kind: "exactly_one", keys: "action" }]);
   });
+
+  it("keeps every key in an all-or-none prompt, hidden members included", () => {
+    const entries = [
+      { key: "cert", type: "string", label: "Cert" },
+      { key: "key", type: "string", label: "Key", hidden: true },
+    ] as unknown as ConfigEntry[];
+    const groups = [
+      { kind: "all_or_none", keys: ["cert", "key"] },
+    ] as unknown as RequiredGroup[];
+    const messages = collect({ entries, requiredGroups: groups, values: { cert: "x" } });
+    expect(messages).toEqual([{ kind: "all_or_none", keys: "cert,key" }]);
+  });
 });

--- a/test/components/device/constraint-banners.test.ts
+++ b/test/components/device/constraint-banners.test.ts
@@ -100,4 +100,16 @@ describe("collectUnsatisfiedConstraints", () => {
       { kind: "all_or_none", keys: "cert,key" },
     ]);
   });
+
+  it("names only visible keys when a group member is hidden and empty", () => {
+    const entries = [
+      { key: "action", type: "string", label: "Action" },
+      { key: "service", type: "string", label: "Service", hidden: true },
+    ] as unknown as ConfigEntry[];
+    const groups = [
+      { kind: "exactly_one", keys: ["service", "action"] },
+    ] as RequiredGroup[];
+    const messages = collect({ entries, requiredGroups: groups });
+    expect(messages).toEqual([{ kind: "exactly_one", keys: "action" }]);
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Stops the editor authoring fresh legacy spellings, so the migrate command isn't fighting the authoring surfaces. Three changes, all frontend-side with no catalog regeneration: the catalog picker no longer offers legacy registry aliases (`homeassistant.service` disappears as a choice; existing nodes still resolve and render normally), and the legacy `service` field on both homeassistant action forms is marked hidden after catalog hydration — a value already in the YAML still renders per the standard hidden semantics, but a new node only offers the canonical `action` field.

Third, the shared constraint-banner renderer now names only visible keys in its zero-present prompts (`exactly_one` / `at_least_one`), so the homeassistant forms prompt "Set exactly one of: Action" instead of naming the hidden field; the all/none kinds keep every key since their prompt exists to name the missing member, and both banner code paths share the rule.

The alias set and the entry override live together in `hydrate-available-bodies.ts`; the picker filters at its single consumption point. Cached body objects are never mutated — the override maps the hydrated clones, and a form mounted mid-hydration self-corrects on the refreshed refs.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2431

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
