### PR TITLE
Submit the Add Component form view on Enter

### DIFF
--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -175,13 +175,14 @@ export class ESPHomeBaseDialog extends LitElement {
    *  :class:`EnterController` already skips Enter on
    *  buttons/links/textareas/selects and mid-IME composition. The callback
    *  must self-guard against repeat/invalid — a held Enter can re-fire until
-   *  ``open`` flips false.
+   *  ``open`` flips false; the keydown is passed so guards can check
+   *  ``e.repeat``.
    *
    *  Don't set this on a dialog that opens a *nested* dialog while it stays
    *  open: the listener is window-level and the controllers claim Enter in
    *  open order, not z-order, so a stacked inner dialog wouldn't reliably win
    *  the Enter (see :class:`EnterController`). */
-  @property({ attribute: false }) confirmOnEnter?: () => void;
+  @property({ attribute: false }) confirmOnEnter?: (e: KeyboardEvent) => void;
 
   /** Whether a consumer has slotted footer content. Gates the
    *  forwarding ``<slot name="footer">`` — see ``willUpdate``. */
@@ -190,7 +191,7 @@ export class ESPHomeBaseDialog extends LitElement {
   // Reads the live ``confirmOnEnter`` at fire time, so a fresh arrow each
   // render is fine; toggled from ``willUpdate`` and torn down by the
   // controller's ``hostDisconnected``.
-  private _enter = new EnterController(this, () => this.confirmOnEnter?.());
+  private _enter = new EnterController(this, (e) => this.confirmOnEnter?.(e));
 
   // wa-dialog turns its footer chrome (border-top + padding) on by
   // testing for a direct ``[slot="footer"]`` child element, not for

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -747,8 +747,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
   }
 
   // Armed only in the form view; the catalog has no selection for Enter
-  // to act on.
+  // to act on. The form's own submitting guard lags a render behind
+  // `_submitting`, so a key-repeat Enter is dropped here first.
   private _onEnterSubmit = () => {
+    if (this._submitting) return;
     this._form?.requestSubmit();
   };
 

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -273,6 +273,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
         ?open=${this._dialog.open}
         ?busy=${this._submitting}
         .label=${title}
+        .confirmOnEnter=${isForm ? this._onEnterSubmit : undefined}
         @request-close=${this._dialog.onRequestClose}
         @add-component=${this._onComponentSelected}
         @add-bundle=${this._onBundleSelected}
@@ -744,6 +745,12 @@ export class ESPHomeAddComponentDialog extends LitElement {
     e.stopPropagation();
     return this._submitComponent(e.detail.fields);
   }
+
+  // Armed only in the form view; the catalog has no selection for Enter
+  // to act on.
+  private _onEnterSubmit = () => {
+    this._form?.requestSubmit();
+  };
 
   /**
    * Add the selected component with ``fields`` and run the post-add

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -747,10 +747,12 @@ export class ESPHomeAddComponentDialog extends LitElement {
   }
 
   // Armed only in the form view; the catalog has no selection for Enter
-  // to act on. The form's own submitting guard lags a render behind
-  // `_submitting`, so a key-repeat Enter is dropped here first.
-  private _onEnterSubmit = () => {
-    if (this._submitting) return;
+  // to act on. `e.repeat` guards the bundle-advance / detour-return
+  // boundary, where a fresh form mounts with `_submitting` already
+  // cleared while Enter is still held; `_submitting` guards the
+  // in-flight window before the form sees the updated prop.
+  private _onEnterSubmit = (e: KeyboardEvent) => {
+    if (e.repeat || this._submitting) return;
     this._form?.requestSubmit();
   };
 

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -114,6 +114,12 @@ export class ESPHomeAddComponentForm extends LitElement {
     return { ...this._values };
   }
 
+  /** Keyboard-submit entry: same guarded path as the Add button. */
+  requestSubmit(): void {
+    if (this.submitting) return;
+    this._onSubmit();
+  }
+
   @state()
   private _errors: Map<string, ValidationError> = new Map();
 

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -123,11 +123,12 @@ export class ESPHomeAddComponentForm extends LitElement {
   @state()
   private _errors: Map<string, ValidationError> = new Map();
 
-  /** Surface text for the rare path where ``_onSubmit`` would return
-   * silently (validation errors on entries hidden from the rendered
-   * form, or a defensive missing-deps fallback). The dialog's
-   * ``submitError`` is reserved for API failures — this is the
-   * pre-API "the form refused to submit and here's why" lane. */
+  /** Surface text where ``_onSubmit`` blocks without visible field
+   * errors (hidden-entry validation, missing deps) — routine via
+   * ``requestSubmit`` (Enter), which bypasses the Add button's
+   * disabled gate. The dialog's ``submitError`` is reserved for API
+   * failures — this is the pre-API "the form refused to submit and
+   * here's why" lane. */
   @state()
   private _localBlockMessage = "";
 
@@ -506,15 +507,13 @@ export class ESPHomeAddComponentForm extends LitElement {
     // own message; the success path leaves it cleared.
     this._localBlockMessage = "";
     const presentComponents = parseTopLevelComponents(this.yaml);
-    // Block submit when a declared dependency isn't satisfied. The
-    // button should already be disabled in that case, but defend here
-    // too in case the YAML changed under us between renders.
+    // Block submit when a declared dependency isn't satisfied. The Add
+    // button is disabled in that case, but Enter (requestSubmit) still
+    // lands here.
     const missingDeps = this._missingDeps(presentComponents);
     if (missingDeps.length > 0) {
-      // Should be unreachable — the button-disabled predicate uses the
-      // same check. If we get here, the YAML changed under us between
-      // renders. Surface a visible message that names the missing
-      // domain(s) so the user can act, instead of returning silently.
+      // Surface a visible message that names the missing domain(s) so
+      // the user can act, instead of returning silently.
       this._localBlockMessage = `${this._localize("device.missing_dependencies_title", {
         name: this.component.name,
       })} (${missingDeps.join(", ")})`;

--- a/test/_press-enter.ts
+++ b/test/_press-enter.ts
@@ -1,14 +1,15 @@
 /** Dispatch a plain Enter keydown on the window, the event shape the
  *  dialogs' EnterController listens for. Pass `{ repeat: true }` to simulate
- *  an OS key-repeat (a held key). */
-export function pressEnter(options: { repeat?: boolean } = {}): void {
-  window.dispatchEvent(
-    new KeyboardEvent("keydown", {
-      key: "Enter",
-      bubbles: true,
-      cancelable: true,
-      composed: true,
-      repeat: options.repeat ?? false,
-    })
-  );
+ *  an OS key-repeat (a held key). Returns the event so callers can assert
+ *  whether a controller claimed it (`defaultPrevented`). */
+export function pressEnter(options: { repeat?: boolean } = {}): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    key: "Enter",
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    repeat: options.repeat ?? false,
+  });
+  window.dispatchEvent(event);
+  return event;
 }

--- a/test/components/device/add-component-dialog-enter.test.ts
+++ b/test/components/device/add-component-dialog-enter.test.ts
@@ -5,7 +5,7 @@
  * base-dialog's confirmOnEnter (issue esphome/device-builder#2400): armed
  * only while the form view is showing, routed through the form's
  * requestSubmit(), and inert in the catalog view (no selection for Enter
- * to act on) and while closed.
+ * to act on), while closed, on OS key-repeat, and during an in-flight add.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -24,8 +24,8 @@ vi.mock("../../../src/components/device/component-catalog.js", () => {
 });
 
 // Stub the form so the dialog's _form query resolves to an element whose
-// requestSubmit() calls we can count; the real form's guard has its own test
-// (add-component-form-request-submit.test.ts).
+// requestSubmit() calls we can count; the real form's behaviour has its own
+// suite (add-component-form-request-submit.test.ts).
 const requestSubmitCalls: HTMLElement[] = [];
 vi.mock("../../../src/components/device/add-component-form.js", () => {
   class StubForm extends HTMLElement {
@@ -40,7 +40,7 @@ vi.mock("../../../src/components/device/add-component-form.js", () => {
 });
 
 import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
-import { mount } from "../../_dom.js";
+import { baseDialogSettled, mount } from "../../_dom.js";
 import { pressEnter } from "../../_press-enter.js";
 
 beforeEach(() => {
@@ -50,7 +50,7 @@ beforeEach(() => {
 async function enterFormView(el: ESPHomeAddComponentDialog): Promise<void> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (el as any)._selected = { name: "Restart Button", category: "button" };
-  await el.updateComplete;
+  await baseDialogSettled(el);
 }
 
 describe("add-component-dialog Enter-to-submit (#2400)", () => {
@@ -65,7 +65,7 @@ describe("add-component-dialog Enter-to-submit (#2400)", () => {
   it("Enter in the catalog view does nothing", async () => {
     const el = await mount(new ESPHomeAddComponentDialog());
     el.open();
-    await el.updateComplete;
+    await baseDialogSettled(el);
     pressEnter();
     expect(requestSubmitCalls).toHaveLength(0);
   });
@@ -77,13 +77,21 @@ describe("add-component-dialog Enter-to-submit (#2400)", () => {
     expect(requestSubmitCalls).toHaveLength(0);
   });
 
-  it("drops a key-repeat Enter while a submit is in flight", async () => {
+  it("drops an OS key-repeat Enter (held key across a view swap)", async () => {
+    const el = await mount(new ESPHomeAddComponentDialog());
+    el.open();
+    await enterFormView(el);
+    pressEnter({ repeat: true });
+    expect(requestSubmitCalls).toHaveLength(0);
+  });
+
+  it("drops Enter while a submit is in flight", async () => {
     const el = await mount(new ESPHomeAddComponentDialog());
     el.open();
     await enterFormView(el);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (el as any)._submitting = true;
-    pressEnter({ repeat: true });
+    pressEnter();
     expect(requestSubmitCalls).toHaveLength(0);
   });
 
@@ -93,7 +101,7 @@ describe("add-component-dialog Enter-to-submit (#2400)", () => {
     await enterFormView(el);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (el as any)._selected = null;
-    await el.updateComplete;
+    await baseDialogSettled(el);
     pressEnter();
     expect(requestSubmitCalls).toHaveLength(0);
   });

--- a/test/components/device/add-component-dialog-enter.test.ts
+++ b/test/components/device/add-component-dialog-enter.test.ts
@@ -77,6 +77,16 @@ describe("add-component-dialog Enter-to-submit (#2400)", () => {
     expect(requestSubmitCalls).toHaveLength(0);
   });
 
+  it("drops a key-repeat Enter while a submit is in flight", async () => {
+    const el = await mount(new ESPHomeAddComponentDialog());
+    el.open();
+    await enterFormView(el);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._submitting = true;
+    pressEnter({ repeat: true });
+    expect(requestSubmitCalls).toHaveLength(0);
+  });
+
   it("stops firing after leaving the form view via back", async () => {
     const el = await mount(new ESPHomeAddComponentDialog());
     el.open();

--- a/test/components/device/add-component-dialog-enter.test.ts
+++ b/test/components/device/add-component-dialog-enter.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The add-component dialog submits the form view on a plain Enter via the
+ * base-dialog's confirmOnEnter (issue esphome/device-builder#2400): armed
+ * only while the form view is showing, routed through the form's
+ * requestSubmit(), and inert in the catalog view (no selection for Enter
+ * to act on) and while closed.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import "../../_mock-webawesome.js";
+
+// Stub the catalog with the two methods open()/openWithSearch() call on it.
+vi.mock("../../../src/components/device/component-catalog.js", () => {
+  class StubCatalog extends HTMLElement {
+    load(): void {}
+    filterByDomain(): void {}
+  }
+  if (!customElements.get("esphome-component-catalog")) {
+    customElements.define("esphome-component-catalog", StubCatalog);
+  }
+  return {};
+});
+
+// Stub the form so the dialog's _form query resolves to an element whose
+// requestSubmit() calls we can count; the real form's guard has its own test
+// (add-component-form-request-submit.test.ts).
+const requestSubmitCalls: HTMLElement[] = [];
+vi.mock("../../../src/components/device/add-component-form.js", () => {
+  class StubForm extends HTMLElement {
+    requestSubmit(): void {
+      requestSubmitCalls.push(this);
+    }
+  }
+  if (!customElements.get("esphome-add-component-form")) {
+    customElements.define("esphome-add-component-form", StubForm);
+  }
+  return {};
+});
+
+import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
+import { mount } from "../../_dom.js";
+import { pressEnter } from "../../_press-enter.js";
+
+beforeEach(() => {
+  requestSubmitCalls.length = 0;
+});
+
+async function enterFormView(el: ESPHomeAddComponentDialog): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._selected = { name: "Restart Button", category: "button" };
+  await el.updateComplete;
+}
+
+describe("add-component-dialog Enter-to-submit (#2400)", () => {
+  it("Enter in the form view submits through the form", async () => {
+    const el = await mount(new ESPHomeAddComponentDialog());
+    el.open();
+    await enterFormView(el);
+    pressEnter();
+    expect(requestSubmitCalls).toHaveLength(1);
+  });
+
+  it("Enter in the catalog view does nothing", async () => {
+    const el = await mount(new ESPHomeAddComponentDialog());
+    el.open();
+    await el.updateComplete;
+    pressEnter();
+    expect(requestSubmitCalls).toHaveLength(0);
+  });
+
+  it("Enter while closed does nothing", async () => {
+    const el = await mount(new ESPHomeAddComponentDialog());
+    await enterFormView(el);
+    pressEnter();
+    expect(requestSubmitCalls).toHaveLength(0);
+  });
+
+  it("stops firing after leaving the form view via back", async () => {
+    const el = await mount(new ESPHomeAddComponentDialog());
+    el.open();
+    await enterFormView(el);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._selected = null;
+    await el.updateComplete;
+    pressEnter();
+    expect(requestSubmitCalls).toHaveLength(0);
+  });
+});

--- a/test/components/device/add-component-dialog-enter.test.ts
+++ b/test/components/device/add-component-dialog-enter.test.ts
@@ -62,11 +62,14 @@ describe("add-component-dialog Enter-to-submit (#2400)", () => {
     expect(requestSubmitCalls).toHaveLength(1);
   });
 
-  it("Enter in the catalog view does nothing", async () => {
+  it("Enter in the catalog view is not even claimed", async () => {
     const el = await mount(new ESPHomeAddComponentDialog());
     el.open();
     await baseDialogSettled(el);
-    pressEnter();
+    // An unclaimed (no preventDefault) Enter proves the listener is
+    // detached, not merely bound to an undefined callback.
+    const event = pressEnter();
+    expect(event.defaultPrevented).toBe(false);
     expect(requestSubmitCalls).toHaveLength(0);
   });
 
@@ -95,14 +98,15 @@ describe("add-component-dialog Enter-to-submit (#2400)", () => {
     expect(requestSubmitCalls).toHaveLength(0);
   });
 
-  it("stops firing after leaving the form view via back", async () => {
+  it("detaches the listener after leaving the form view via back", async () => {
     const el = await mount(new ESPHomeAddComponentDialog());
     el.open();
     await enterFormView(el);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (el as any)._selected = null;
     await baseDialogSettled(el);
-    pressEnter();
+    const event = pressEnter();
+    expect(event.defaultPrevented).toBe(false);
     expect(requestSubmitCalls).toHaveLength(0);
   });
 });

--- a/test/components/device/add-component-form-request-submit.test.ts
+++ b/test/components/device/add-component-form-request-submit.test.ts
@@ -63,6 +63,46 @@ describe("add-component-form requestSubmit (#2400)", () => {
     expect(((form as any)._errors as Map<string, unknown>).size).toBeGreaterThan(0);
   });
 
+  it("blocks on a missing dependency with a visible message", () => {
+    const needsBus = {
+      id: "sensor.ags10",
+      name: "AGS10",
+      dependencies: ["i2c"],
+      config_entries: [makeConfigEntry({ key: "name", type: ConfigEntryType.STRING })],
+    } as unknown as ComponentCatalogEntry;
+    const { form, submits } = makeForm(needsBus);
+    form.requestSubmit();
+    expect(submits).toHaveLength(0);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const message = (form as any)._localBlockMessage as string;
+    expect(message).toContain("device.missing_dependencies_title");
+    expect(message).toContain("i2c");
+  });
+
+  it("blocks on a hidden-entry validation error with the dedicated message", () => {
+    // The failing entry is advanced + optional, so required-only mode
+    // never renders it; the error must surface as the block message
+    // instead of bailing silently.
+    const hiddenBad = {
+      id: "sensor.example",
+      config_entries: [
+        makeConfigEntry({
+          key: "frequency",
+          type: ConfigEntryType.INTEGER,
+          advanced: true,
+        }),
+      ],
+    } as unknown as ComponentCatalogEntry;
+    const { form, submits } = makeForm(hiddenBad);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any)._values = { frequency: "not-a-number" };
+    form.requestSubmit();
+    expect(submits).toHaveLength(0);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const message = (form as any)._localBlockMessage as string;
+    expect(message).toContain("device.add_component_hidden_validation_error");
+  });
+
   it("ignores a request while a submit is in flight", () => {
     const { form, submits } = makeForm();
     const onSubmit = vi.fn();

--- a/test/components/device/add-component-form-request-submit.test.ts
+++ b/test/components/device/add-component-form-request-submit.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * requestSubmit() (the dialog's Enter path, #2400) runs the same submit
+ * path as the Add button but self-guards on an in-flight submit — the
+ * button's ?disabled only protects the click path.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import "../../_mock-webawesome.js";
+
+import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+
+function makeForm(): {
+  form: ESPHomeAddComponentForm;
+  onSubmit: ReturnType<typeof vi.fn>;
+} {
+  const form = new ESPHomeAddComponentForm();
+  const onSubmit = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (form as any)._onSubmit = onSubmit;
+  return { form, onSubmit };
+}
+
+describe("add-component-form requestSubmit guard (#2400)", () => {
+  it("runs the submit path when idle", () => {
+    const { form, onSubmit } = makeForm();
+    form.requestSubmit();
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a request while a submit is in flight", () => {
+    const { form, onSubmit } = makeForm();
+    form.submitting = true;
+    form.requestSubmit();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/device/add-component-form-request-submit.test.ts
+++ b/test/components/device/add-component-form-request-submit.test.ts
@@ -3,36 +3,74 @@
  *
  * requestSubmit() (the dialog's Enter path, #2400) runs the same submit
  * path as the Add button but self-guards on an in-flight submit — the
- * button's ?disabled only protects the click path.
+ * button's ?disabled only protects the click path. Unlike the button,
+ * Enter reaches _onSubmit even when the form is incomplete, so the
+ * validation branches surface the block instead of silently ignoring
+ * the key.
  */
 import { describe, expect, it, vi } from "vitest";
 
 import "../../_mock-webawesome.js";
 
+import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+import { identityLocalize } from "../../_dom.js";
+import { makeConfigEntry } from "../../util/_make-config-entry.js";
 
-function makeForm(): {
+function makeForm(component?: ComponentCatalogEntry): {
   form: ESPHomeAddComponentForm;
-  onSubmit: ReturnType<typeof vi.fn>;
+  submits: Record<string, unknown>[];
 } {
   const form = new ESPHomeAddComponentForm();
-  const onSubmit = vi.fn();
+  const submits: Record<string, unknown>[] = [];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (form as any)._onSubmit = onSubmit;
-  return { form, onSubmit };
+  const internals = form as any;
+  internals.component =
+    component ??
+    ({
+      id: "button.restart",
+      config_entries: [makeConfigEntry({ key: "name", type: ConfigEntryType.STRING })],
+    } as unknown as ComponentCatalogEntry);
+  internals.yaml = "";
+  internals._localize = identityLocalize;
+  form.addEventListener("form-submit", (e) => {
+    submits.push((e as CustomEvent<{ fields: Record<string, unknown> }>).detail.fields);
+  });
+  return { form, submits };
 }
 
-describe("add-component-form requestSubmit guard (#2400)", () => {
-  it("runs the submit path when idle", () => {
-    const { form, onSubmit } = makeForm();
+describe("add-component-form requestSubmit (#2400)", () => {
+  it("fires form-submit with the coerced fields on a complete form", () => {
+    const { form, submits } = makeForm();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any)._values = { name: "Enter Test" };
     form.requestSubmit();
-    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(submits).toEqual([{ name: "Enter Test" }]);
+  });
+
+  it("blocks an incomplete form and surfaces the errors instead", () => {
+    const required = {
+      id: "button.restart",
+      config_entries: [
+        makeConfigEntry({ key: "name", type: ConfigEntryType.STRING, required: true }),
+      ],
+    } as unknown as ComponentCatalogEntry;
+    const { form, submits } = makeForm(required);
+    form.requestSubmit();
+    expect(submits).toHaveLength(0);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(((form as any)._errors as Map<string, unknown>).size).toBeGreaterThan(0);
   });
 
   it("ignores a request while a submit is in flight", () => {
-    const { form, onSubmit } = makeForm();
+    const { form, submits } = makeForm();
+    const onSubmit = vi.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (form as any)._onSubmit = onSubmit;
     form.submitting = true;
     form.requestSubmit();
     expect(onSubmit).not.toHaveBeenCalled();
+    expect(submits).toHaveLength(0);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Pressing Enter in the Add Component dialog's form view (the per-component config form with the Back/Add buttons) did nothing; the add was only reachable by clicking the Add button. The dialog never bound the base dialog's `confirmOnEnter`, so the shared Enter-to-submit machinery (issue #1269) was never armed for it.

This binds `confirmOnEnter` while the form view is showing, routed through a new `requestSubmit()` on the form that self-guards on an in-flight submit (the Add button's `?disabled` only protects the click path) and otherwise runs the same submit path as the button, including its missing-deps and validation surfacing. On success the existing flow closes the dialog, so Enter now behaves exactly like clicking Add.

The catalog view stays inert on Enter on purpose: cards are click-only and there is no selection concept, so "which card does Enter add?" is undefined. Keyboard selection for the catalog would be a separate feature.

Verified live against a dev backend: Enter in the search field leaves the catalog open and unchanged; Enter in the form view adds the component to the draft and closes the dialog.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2400

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
