### PR TITLE
Flag wrong typed values in the add-component form as they land

### DIFF
--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -193,6 +193,9 @@ export class ESPHomeAddComponentForm extends LitElement {
     if (changedProperties.has("component") || !this._initialized) {
       if (this.component) {
         this._initialized = true;
+        // A pending live check belongs to the previous component's
+        // entries; validating across the retarget could mis-flag.
+        clearTimeout(this._liveValidateTimer);
         this._initValues();
         // Reset block message on retarget — without this, a "submit
         // bailed" notice from the previous component (in the dep-flow

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -13,6 +13,7 @@ import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js"
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { ComponentNameResolverController } from "../../util/component-name-resolver-controller.js";
+import { entryAtPath } from "../../util/config-entry-tree.js";
 import {
   clearPathErrors,
   validateEntries,
@@ -34,7 +35,6 @@ import {
 } from "./add-component-deps.js";
 import { coerceFields } from "./add-component-form-coerce.js";
 import { addFormRenderablePaths } from "./add-component-form-filter.js";
-import { entryAtPath } from "../../util/config-entry-tree.js";
 import { overlayOptions, overlayRequired } from "./add-component-form-overlays.js";
 import { buildInitialValues } from "./add-component-form-seed.js";
 import { addComponentFormStyles } from "./add-component-form.styles.js";
@@ -135,11 +135,6 @@ export class ESPHomeAddComponentForm extends LitElement {
 
   private _liveValidateTimer: ReturnType<typeof setTimeout> | undefined;
 
-  override disconnectedCallback(): void {
-    super.disconnectedCallback();
-    clearTimeout(this._liveValidateTimer);
-  }
-
   /** Missing deps a present component already provides; resolved async,
    *  subtracted from the banner. See `depsSatisfiedByProvides`. */
   @state()
@@ -148,6 +143,11 @@ export class ESPHomeAddComponentForm extends LitElement {
   /** Bumps per resolution so a superseded `(component, yaml)` result can't
    *  overwrite a newer one. */
   private _providesSeq = 0;
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    clearTimeout(this._liveValidateTimer);
+  }
 
   /** Resolves dep ids (``i2c``) to their catalog name (``I²C Bus``)
    * for the missing-deps banner. Owns the cache subscription so a
@@ -513,6 +513,9 @@ export class ESPHomeAddComponentForm extends LitElement {
   }
 
   private _onSubmit() {
+    // Submit computes the full error map itself; a pending live check
+    // would only re-add a subset of it.
+    clearTimeout(this._liveValidateTimer);
     // Reset the local block message at the top of every submit
     // attempt so a stale notice from a previous click can't render
     // alongside a fresh result. Both bail paths below set their

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -7,7 +7,6 @@ import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../api/types/components.js";
 import type { ConfigEntry } from "../../api/types/config-entries.js";
-import {} from "../../api/types/config-entries.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
@@ -23,7 +22,7 @@ import {
 import { resolveFeaturedComponentId } from "../../util/featured-id.js";
 import { fireEvent } from "../../util/fire-event.js";
 import { renderMarkdown } from "../../util/markdown.js";
-import { setIn } from "../../util/nested-values.js";
+import { getIn, setIn } from "../../util/nested-values.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import {
   parseTopLevelComponents,
@@ -129,6 +128,17 @@ export class ESPHomeAddComponentForm extends LitElement {
 
   @state()
   private _showYaml = false;
+
+  /** Debounce for the live typed-value check: the renderers emit
+   *  partial text per keystroke, so validation waits for a pause. */
+  private static readonly LIVE_VALIDATE_DEBOUNCE_MS = 200;
+
+  private _liveValidateTimer: ReturnType<typeof setTimeout> | undefined;
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    clearTimeout(this._liveValidateTimer);
+  }
 
   /** Missing deps a present component already provides; resolved async,
    *  subtracted from the banner. See `depsSatisfiedByProvides`. */
@@ -465,15 +475,20 @@ export class ESPHomeAddComponentForm extends LitElement {
     // user input is a fresh signal that supersedes the previous bail;
     // the next submit attempt re-evaluates from scratch.
     const cleared = clearPathErrors(this._errors, path.join("."));
-    // A wrong *typed* value flags immediately (range/type/options via
-    // validateValueAt); required-empty stays a submit-only signal, so
-    // untouched fields keep the no-nag behavior.
-    const live = validateValueAt(this._entries, path, value);
-    if (cleared || live.size) {
-      const next = cleared ?? new Map(this._errors);
+    if (cleared) this._errors = cleared;
+    // A wrong *typed* value flags once typing pauses (range/type/options
+    // via validateValueAt); the renderers emit partial text per
+    // keystroke ("0x", "1e"), so an immediate check would flash errors
+    // mid-entry. Required-empty stays a submit-only signal, so untouched
+    // fields keep the no-nag behavior.
+    clearTimeout(this._liveValidateTimer);
+    this._liveValidateTimer = setTimeout(() => {
+      const live = validateValueAt(this._entries, path, getIn(this._values, path));
+      if (!live.size) return;
+      const next = new Map(this._errors);
       for (const [key, err] of live) next.set(key, err);
       this._errors = next;
-    }
+    }, ESPHomeAddComponentForm.LIVE_VALIDATE_DEBOUNCE_MS);
     if (this._localBlockMessage) this._localBlockMessage = "";
   }
 

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -475,25 +475,37 @@ export class ESPHomeAddComponentForm extends LitElement {
     // A wrong *typed* value flags once typing pauses (range/type/options
     // via validateValueAt); the renderers emit partial text per
     // keystroke ("0x", "1e"), so appearing immediately would flash
-    // errors mid-entry. The error state is one-directional while
-    // typing: a now-valid value clears instantly (correction feels
-    // immediate), a still-wrong value keeps the shown error steady —
-    // clearing and re-adding per keystroke made it blink — and the
-    // message refreshes in one swap at the pause. Required-empty stays
-    // a submit-only signal, so untouched fields keep the no-nag
-    // behavior.
+    // errors mid-entry. While typing, the display only ever improves in
+    // place: cleared and corrected keys drop instantly, a key already
+    // painted stays painted with its message kept current (clearing and
+    // re-adding per keystroke made it blink; deferring the clear left
+    // stale messages when a later edit cancelled the timer), and a
+    // newly wrong key appears only at the pause. Required-empty stays a
+    // submit-only signal, so untouched fields keep the no-nag behavior.
     clearTimeout(this._liveValidateTimer);
-    if (validateValueAt(this._entries, path, value).size === 0) {
-      const cleared = clearPathErrors(this._errors, path.join("."));
+    const pathKey = path.join(".");
+    const live = validateValueAt(this._entries, path, value);
+    const shown = this._errors;
+    const cleared = clearPathErrors(shown, pathKey);
+    if (live.size === 0) {
       if (cleared) this._errors = cleared;
     } else {
+      const next = cleared ?? new Map(shown);
+      let changed = cleared !== null;
+      for (const [key, err] of live) {
+        if (shown.has(key)) {
+          next.set(key, err);
+          changed = true;
+        }
+      }
+      if (changed) this._errors = next;
       this._liveValidateTimer = setTimeout(() => {
-        const live = validateValueAt(this._entries, path, getIn(this._values, path));
-        const cleared = clearPathErrors(this._errors, path.join("."));
-        if (!cleared && !live.size) return;
-        const next = cleared ?? new Map(this._errors);
-        for (const [key, err] of live) next.set(key, err);
-        this._errors = next;
+        const settled = validateValueAt(this._entries, path, getIn(this._values, path));
+        const swept = clearPathErrors(this._errors, pathKey);
+        if (!swept && !settled.size) return;
+        const merged = swept ?? new Map(this._errors);
+        for (const [key, err] of settled) merged.set(key, err);
+        this._errors = merged;
       }, ESPHomeAddComponentForm.LIVE_VALIDATE_DEBOUNCE_MS);
     }
     // The hidden-validation block message: any user input is a fresh

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -7,7 +7,7 @@ import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../api/types/components.js";
 import type { ConfigEntry } from "../../api/types/config-entries.js";
-import { ConfigEntryType } from "../../api/types/config-entries.js";
+import {} from "../../api/types/config-entries.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
@@ -35,6 +35,7 @@ import {
 } from "./add-component-deps.js";
 import { coerceFields } from "./add-component-form-coerce.js";
 import { addFormRenderablePaths } from "./add-component-form-filter.js";
+import { entryAtPath } from "../../util/config-entry-tree.js";
 import { overlayOptions, overlayRequired } from "./add-component-form-overlays.js";
 import { buildInitialValues } from "./add-component-form-seed.js";
 import { addComponentFormStyles } from "./add-component-form.styles.js";
@@ -424,16 +425,7 @@ export class ESPHomeAddComponentForm extends LitElement {
    * required`` is more useful than ``Auth: This field is required``.
    */
   private _labelForErrorKey(errKey: string): string {
-    const segments = errKey.split(".");
-    let entries: ConfigEntry[] | null = this._entries;
-    let entry: ConfigEntry | undefined;
-    for (const seg of segments) {
-      if (!entries) break;
-      entry = entries.find((e) => e.key === seg);
-      if (!entry) break;
-      entries =
-        entry.type === ConfigEntryType.NESTED ? (entry.config_entries ?? []) : null;
-    }
+    const entry = entryAtPath(this._entries, errKey.split("."));
     return entry ? resolveEntryLabel(entry, this._localize) : errKey;
   }
 
@@ -473,13 +465,12 @@ export class ESPHomeAddComponentForm extends LitElement {
     // user input is a fresh signal that supersedes the previous bail;
     // the next submit attempt re-evaluates from scratch.
     const cleared = clearPathErrors(this._errors, path.join("."));
-    if (cleared) this._errors = cleared;
     // A wrong *typed* value flags immediately (range/type/options via
     // validateValueAt); required-empty stays a submit-only signal, so
     // untouched fields keep the no-nag behavior.
     const live = validateValueAt(this._entries, path, value);
-    if (live.size) {
-      const next = new Map(cleared ?? this._errors);
+    if (cleared || live.size) {
+      const next = cleared ?? new Map(this._errors);
       for (const [key, err] of live) next.set(key, err);
       this._errors = next;
     }

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -472,26 +472,33 @@ export class ESPHomeAddComponentForm extends LitElement {
   private _onValueChange(e: CustomEvent<ConfigEntryValueChange>) {
     const { path, value } = e.detail;
     this._values = setIn(this._values, path, value);
-    // Clear any error on the path the user just edited — including
-    // per-item keys under it, or the offending row's error sticks until
-    // the next submit. Same for the hidden-validation block message: any
-    // user input is a fresh signal that supersedes the previous bail;
-    // the next submit attempt re-evaluates from scratch.
-    const cleared = clearPathErrors(this._errors, path.join("."));
-    if (cleared) this._errors = cleared;
     // A wrong *typed* value flags once typing pauses (range/type/options
     // via validateValueAt); the renderers emit partial text per
-    // keystroke ("0x", "1e"), so an immediate check would flash errors
-    // mid-entry. Required-empty stays a submit-only signal, so untouched
-    // fields keep the no-nag behavior.
+    // keystroke ("0x", "1e"), so appearing immediately would flash
+    // errors mid-entry. The error state is one-directional while
+    // typing: a now-valid value clears instantly (correction feels
+    // immediate), a still-wrong value keeps the shown error steady —
+    // clearing and re-adding per keystroke made it blink — and the
+    // message refreshes in one swap at the pause. Required-empty stays
+    // a submit-only signal, so untouched fields keep the no-nag
+    // behavior.
     clearTimeout(this._liveValidateTimer);
-    this._liveValidateTimer = setTimeout(() => {
-      const live = validateValueAt(this._entries, path, getIn(this._values, path));
-      if (!live.size) return;
-      const next = new Map(this._errors);
-      for (const [key, err] of live) next.set(key, err);
-      this._errors = next;
-    }, ESPHomeAddComponentForm.LIVE_VALIDATE_DEBOUNCE_MS);
+    if (validateValueAt(this._entries, path, value).size === 0) {
+      const cleared = clearPathErrors(this._errors, path.join("."));
+      if (cleared) this._errors = cleared;
+    } else {
+      this._liveValidateTimer = setTimeout(() => {
+        const live = validateValueAt(this._entries, path, getIn(this._values, path));
+        const cleared = clearPathErrors(this._errors, path.join("."));
+        if (!cleared && !live.size) return;
+        const next = cleared ?? new Map(this._errors);
+        for (const [key, err] of live) next.set(key, err);
+        this._errors = next;
+      }, ESPHomeAddComponentForm.LIVE_VALIDATE_DEBOUNCE_MS);
+    }
+    // The hidden-validation block message: any user input is a fresh
+    // signal that supersedes the previous bail; the next submit attempt
+    // re-evaluates from scratch.
     if (this._localBlockMessage) this._localBlockMessage = "";
   }
 

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -17,6 +17,7 @@ import { ComponentNameResolverController } from "../../util/component-name-resol
 import {
   clearPathErrors,
   validateEntries,
+  validateValueAt,
   type ValidationError,
 } from "../../util/config-validation.js";
 import { resolveFeaturedComponentId } from "../../util/featured-id.js";
@@ -473,6 +474,15 @@ export class ESPHomeAddComponentForm extends LitElement {
     // the next submit attempt re-evaluates from scratch.
     const cleared = clearPathErrors(this._errors, path.join("."));
     if (cleared) this._errors = cleared;
+    // A wrong *typed* value flags immediately (range/type/options via
+    // validateValueAt); required-empty stays a submit-only signal, so
+    // untouched fields keep the no-nag behavior.
+    const live = validateValueAt(this._entries, path, value);
+    if (live.size) {
+      const next = new Map(cleared ?? this._errors);
+      for (const [key, err] of live) next.set(key, err);
+      this._errors = next;
+    }
     if (this._localBlockMessage) this._localBlockMessage = "";
   }
 

--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -41,18 +41,6 @@ export function anyAdvancedEntry(entries: ConfigEntry[]): boolean {
 }
 
 /**
- * Whether the entry at *path* — or any NESTED ancestor along it — is
- * advanced-gated given the current *values*: an advanced entry whose scope
- * carries a material value doesn't gate, since it renders without the
- * toggle. Used to reveal a section's hidden advanced fields when the caret
- * or a backend error lands on one. List-index segments descend the value
- * scope only: the schema nests an item's fields directly under the list
- * entry, with no index level. When *unitGate* answers for the top-level
- * key, its verdict on the whole render unit (exclusive group / constraint
- * cluster, which paints atomically) replaces the per-entry rule. Returns
- * false if the path doesn't resolve.
- */
-/**
  * The `ConfigEntry` a config-entry path resolves to, or `undefined`.
  *
  * Index segments skip a level (a list item shares its field's entry),
@@ -73,6 +61,18 @@ export function entryAtPath(
   return entry;
 }
 
+/**
+ * Whether the entry at *path* — or any NESTED ancestor along it — is
+ * advanced-gated given the current *values*: an advanced entry whose scope
+ * carries a material value doesn't gate, since it renders without the
+ * toggle. Used to reveal a section's hidden advanced fields when the caret
+ * or a backend error lands on one. List-index segments descend the value
+ * scope only: the schema nests an item's fields directly under the list
+ * entry, with no index level. When *unitGate* answers for the top-level
+ * key, its verdict on the whole render unit (exclusive group / constraint
+ * cluster, which paints atomically) replaces the per-entry rule. Returns
+ * false if the path doesn't resolve.
+ */
 export function pathIsAdvanced(
   entries: ConfigEntry[],
   path: string[],

--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -52,6 +52,27 @@ export function anyAdvancedEntry(entries: ConfigEntry[]): boolean {
  * cluster, which paints atomically) replaces the per-entry rule. Returns
  * false if the path doesn't resolve.
  */
+/**
+ * The `ConfigEntry` a config-entry path resolves to, or `undefined`.
+ *
+ * Index segments skip a level (a list item shares its field's entry),
+ * the same rule `pathIsAdvanced` walks with.
+ */
+export function entryAtPath(
+  entries: ConfigEntry[],
+  path: string[]
+): ConfigEntry | undefined {
+  let level = entries;
+  let entry: ConfigEntry | undefined;
+  for (const key of path) {
+    if (isIndexSegment(key)) continue;
+    entry = level.find((e) => e.key === key);
+    if (!entry) return undefined;
+    level = entry.config_entries ?? [];
+  }
+  return entry;
+}
+
 export function pathIsAdvanced(
   entries: ConfigEntry[],
   path: string[],

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -434,12 +434,6 @@ export function validateEntries(
 }
 
 /**
- * Recurse through `entries`, validating each leaf and descending into
- * NESTED entries. Errors are keyed by the dotted path so callers can
- * look them up by `path.join(".")` (matching how
- * `device-section-config.ts` reads them in `_errorAt`).
- */
-/**
  * Per-item checks for a scalar `multi_value` list, keyed `"<pathKey>.<idx>"`.
  *
  * A list-of-dicts the schema bundle couldn't type as nested renders
@@ -464,6 +458,12 @@ function _validateScalarItems(
   });
 }
 
+/**
+ * Recurse through `entries`, validating each leaf and descending into
+ * NESTED entries. Errors are keyed by the dotted path so callers can
+ * look them up by `path.join(".")` (matching how
+ * `device-section-config.ts` reads them in `_errorAt`).
+ */
 function _validateEntriesRecursive(
   entries: ConfigEntry[],
   values: Record<string, unknown>,

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -12,7 +12,12 @@ import {
 import { parseFloatWithUnit } from "./float-with-unit.js";
 import { parseHexInt } from "./hex-int.js";
 import { parseIntInput } from "./int-input.js";
-import { asMappingList, asRecord, isPrimitiveOrNullish } from "./nested-values.js";
+import {
+  asMappingList,
+  asRecord,
+  isIndexSegment,
+  isPrimitiveOrNullish,
+} from "./nested-values.js";
 import { isSecretRef } from "./secret-ref.js";
 import { isSubstitutionString, looksLikeSubstitution } from "./substitutions.js";
 import { parseYamlBoolean, YamlRawValue } from "./yaml-serialize.js";
@@ -375,6 +380,53 @@ export function validateEntry(entry: ConfigEntry, raw: unknown): ValidationError
   }
 
   return null;
+}
+
+/**
+ * Live validation for one just-edited path: the entry's typed checks
+ * (range, type, options) without the required-empty nag.
+ *
+ * Resolves the `ConfigEntry` by walking `path` (index segments skip a
+ * level, matching the renderers' item paths); an unresolvable path or a
+ * clean value yields an empty map. A scalar `multi_value` array is
+ * checked per item, keyed `"<path>.<idx>"` like submit-time validation.
+ * Required-empty stays a submit-only signal so untouched-then-cleared
+ * fields don't nag mid-form.
+ */
+export function validateValueAt(
+  entries: ConfigEntry[],
+  path: string[],
+  value: unknown
+): Map<string, ValidationError> {
+  const errors = new Map<string, ValidationError>();
+  let level = entries;
+  let entry: ConfigEntry | undefined;
+  for (const key of path) {
+    if (isIndexSegment(key)) continue;
+    entry = level.find((e) => e.key === key);
+    if (!entry) return errors;
+    level = entry.config_entries ?? [];
+  }
+  if (!entry) return errors;
+  const pathKey = path.join(".");
+  if (entry.multi_value && Array.isArray(value)) {
+    if (value.every(isPrimitiveOrNullish)) {
+      value.forEach((item, idx) => {
+        if (!isValuePresent(item)) return;
+        const err = validateEntry(entry!, item);
+        if (err && err.code !== "validation.required") {
+          const fullPath = `${pathKey}.${idx}`;
+          errors.set(fullPath, { ...err, key: fullPath });
+        }
+      });
+    }
+    return errors;
+  }
+  const err = validateEntry(entry, value);
+  if (err && err.code !== "validation.required") {
+    errors.set(pathKey, { ...err, key: pathKey });
+  }
+  return errors;
 }
 
 export function validateEntries(

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -9,15 +9,11 @@ import {
   isApiEncryptionKeyField,
   isValidApiEncryptionKey,
 } from "./api-encryption-key.js";
+import { entryAtPath } from "./config-entry-tree.js";
 import { parseFloatWithUnit } from "./float-with-unit.js";
 import { parseHexInt } from "./hex-int.js";
 import { parseIntInput } from "./int-input.js";
-import {
-  asMappingList,
-  asRecord,
-  isIndexSegment,
-  isPrimitiveOrNullish,
-} from "./nested-values.js";
+import { asMappingList, asRecord, isPrimitiveOrNullish } from "./nested-values.js";
 import { isSecretRef } from "./secret-ref.js";
 import { isSubstitutionString, looksLikeSubstitution } from "./substitutions.js";
 import { parseYamlBoolean, YamlRawValue } from "./yaml-serialize.js";
@@ -386,12 +382,14 @@ export function validateEntry(entry: ConfigEntry, raw: unknown): ValidationError
  * Live validation for one just-edited path: the entry's typed checks
  * (range, type, options) without the required-empty nag.
  *
- * Resolves the `ConfigEntry` by walking `path` (index segments skip a
- * level, matching the renderers' item paths); an unresolvable path or a
- * clean value yields an empty map. A scalar `multi_value` array is
- * checked per item, keyed `"<path>.<idx>"` like submit-time validation.
- * Required-empty stays a submit-only signal so untouched-then-cleared
- * fields don't nag mid-form.
+ * Deliberately edit-scoped: only the changed path is checked, so a
+ * wrong seeded default stays quiet until submit — the same fresh-signal
+ * rule that keeps untouched required fields nag-free. Assumes the
+ * edited path was rendered (visibility gates are not re-evaluated) and
+ * covers `validateEntry`'s per-value checks only, not the traversal's
+ * section-scoped post-checks. An unresolvable path or an empty value
+ * yields an empty map; a scalar `multi_value` array is checked per
+ * item, keyed `"<path>.<idx>"` like submit-time validation.
  */
 export function validateValueAt(
   entries: ConfigEntry[],
@@ -399,33 +397,18 @@ export function validateValueAt(
   value: unknown
 ): Map<string, ValidationError> {
   const errors = new Map<string, ValidationError>();
-  let level = entries;
-  let entry: ConfigEntry | undefined;
-  for (const key of path) {
-    if (isIndexSegment(key)) continue;
-    entry = level.find((e) => e.key === key);
-    if (!entry) return errors;
-    level = entry.config_entries ?? [];
-  }
+  const entry = entryAtPath(entries, path);
   if (!entry) return errors;
   const pathKey = path.join(".");
   if (entry.multi_value && Array.isArray(value)) {
-    if (value.every(isPrimitiveOrNullish)) {
-      value.forEach((item, idx) => {
-        if (!isValuePresent(item)) return;
-        const err = validateEntry(entry!, item);
-        if (err && err.code !== "validation.required") {
-          const fullPath = `${pathKey}.${idx}`;
-          errors.set(fullPath, { ...err, key: fullPath });
-        }
-      });
-    }
+    _validateScalarItems(entry, value, pathKey, errors);
     return errors;
   }
+  // Emptiness is a submit-only concern (required is the only check
+  // that fires on an empty value).
+  if (!isValuePresent(value)) return errors;
   const err = validateEntry(entry, value);
-  if (err && err.code !== "validation.required") {
-    errors.set(pathKey, { ...err, key: pathKey });
-  }
+  if (err) errors.set(pathKey, { ...err, key: pathKey });
   return errors;
 }
 
@@ -456,6 +439,31 @@ export function validateEntries(
  * look them up by `path.join(".")` (matching how
  * `device-section-config.ts` reads them in `_errorAt`).
  */
+/**
+ * Per-item checks for a scalar `multi_value` list, keyed `"<pathKey>.<idx>"`.
+ *
+ * A list-of-dicts the schema bundle couldn't type as nested renders
+ * YAML-only (the renderer's whole-field bail); per-item scalar checks
+ * would flag rows the form never shows. ESPHome's own validate_yaml
+ * owns those, same as MAP values.
+ */
+function _validateScalarItems(
+  entry: ConfigEntry,
+  items: unknown[],
+  pathKey: string,
+  errors: Map<string, ValidationError>
+): void {
+  if (!items.every(isPrimitiveOrNullish)) return;
+  items.forEach((item, idx) => {
+    if (!isValuePresent(item)) return;
+    const err = validateEntry(entry, item);
+    if (err) {
+      const fullPath = `${pathKey}.${idx}`;
+      errors.set(fullPath, { ...err, key: fullPath });
+    }
+  });
+}
+
 function _validateEntriesRecursive(
   entries: ConfigEntry[],
   values: Record<string, unknown>,
@@ -600,20 +608,7 @@ function _validateEntriesRecursive(
         }
         continue;
       }
-      // A list-of-dicts the schema bundle couldn't type as nested renders
-      // YAML-only (the renderer's whole-field bail); per-item scalar
-      // checks would flag rows the form never shows. ESPHome's own
-      // validate_yaml owns those, same as MAP values.
-      if (raw.every(isPrimitiveOrNullish)) {
-        raw.forEach((item, idx) => {
-          if (!isValuePresent(item)) return;
-          const err = validateEntry(entry, item);
-          if (err) {
-            const fullPath = [...pathPrefix, entry.key, String(idx)].join(".");
-            errors.set(fullPath, { ...err, key: fullPath });
-          }
-        });
-      }
+      _validateScalarItems(entry, raw, [...pathPrefix, entry.key].join("."), errors);
       continue;
     }
 

--- a/test/components/device/add-component-form-error-clear.test.ts
+++ b/test/components/device/add-component-form-error-clear.test.ts
@@ -5,7 +5,7 @@ import "../../_mock-webawesome.js";
 
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
-import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+import { makeConfigEntry } from "../../util/_make-config-entry.js";
 
 /**
  * Pins that editing a field clears its per-item error keys too (#1348):

--- a/test/components/device/add-component-form-error-clear.test.ts
+++ b/test/components/device/add-component-form-error-clear.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import "../../_mock-webawesome.js";
 
@@ -22,6 +22,16 @@ const changeEvent = (path: string[], value: unknown) =>
   new CustomEvent("value-change", { detail: { path, value } });
 
 describe("esphome-add-component-form error clearing", () => {
+  // The clear is synchronous; fake timers keep the debounced live check
+  // from outliving the case.
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("clears per-item keys under the edited field path", () => {
     const form = new ESPHomeAddComponentForm() as unknown as ErrorClearView;
     form.component = {

--- a/test/components/device/add-component-form-error-clear.test.ts
+++ b/test/components/device/add-component-form-error-clear.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 
 import "../../_mock-webawesome.js";
 
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
 
 /**
  * Pins that editing a field clears its per-item error keys too (#1348):
@@ -11,6 +13,7 @@ import { ESPHomeAddComponentForm } from "../../../src/components/device/add-comp
  * must not survive as a stale red ring.
  */
 interface ErrorClearView {
+  component: unknown;
   _errors: Map<string, { key: string; code: string }>;
   _onValueChange(e: CustomEvent): void;
 }
@@ -21,6 +24,18 @@ const changeEvent = (path: string[], value: unknown) =>
 describe("esphome-add-component-form error clearing", () => {
   it("clears per-item keys under the edited field path", () => {
     const form = new ESPHomeAddComponentForm() as unknown as ErrorClearView;
+    form.component = {
+      id: "remote_receiver",
+      name: "Remote Receiver",
+      config_entries: [
+        makeConfigEntry({
+          key: "codes",
+          type: ConfigEntryType.INTEGER,
+          multi_value: true,
+        }),
+        makeConfigEntry({ key: "other", type: ConfigEntryType.STRING, required: true }),
+      ],
+    };
     form._errors = new Map([
       ["codes.0", { key: "codes.0", code: "validation.not_a_number" }],
       ["codes.1", { key: "codes.1", code: "validation.max" }],

--- a/test/components/device/add-component-form-live-validation.test.ts
+++ b/test/components/device/add-component-form-live-validation.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+
+import "../../_mock-webawesome.js";
+
+import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+
+/**
+ * Pins #1528: a wrong *typed* value flags as soon as it lands in the
+ * values dict, while required-empty stays a submit-only signal.
+ */
+interface LiveValidationView {
+  component: ComponentCatalogEntry;
+  _errors: Map<string, { key: string; code: string }>;
+  _onValueChange(e: CustomEvent): void;
+}
+
+const changeEvent = (path: string[], value: unknown) =>
+  new CustomEvent("value-change", { detail: { path, value } });
+
+function makeForm(): LiveValidationView {
+  const form = new ESPHomeAddComponentForm() as unknown as LiveValidationView;
+  form.component = {
+    id: "canbus.esp32_can",
+    name: "ESP32 CAN",
+    config_entries: [
+      makeConfigEntry({
+        key: "can_id",
+        type: ConfigEntryType.INTEGER,
+        required: true,
+        range: [0, 536870911],
+      }),
+      makeConfigEntry({ key: "bit_rate", type: ConfigEntryType.STRING, required: true }),
+    ],
+  } as unknown as ComponentCatalogEntry;
+  return form;
+}
+
+describe("esphome-add-component-form live validation", () => {
+  it("flags an out-of-range typed value before any submit", () => {
+    const form = makeForm();
+    form._onValueChange(changeEvent(["can_id"], 4434343434343434));
+    expect(form._errors.get("can_id")?.code).toBe("validation.max");
+  });
+
+  it("clears the flag once the value is corrected", () => {
+    const form = makeForm();
+    form._onValueChange(changeEvent(["can_id"], 4434343434343434));
+    form._onValueChange(changeEvent(["can_id"], 42));
+    expect(form._errors.has("can_id")).toBe(false);
+  });
+
+  it("does not nag a required field emptied mid-form", () => {
+    const form = makeForm();
+    form._onValueChange(changeEvent(["can_id"], ""));
+    expect(form._errors.size).toBe(0);
+  });
+
+  it("keeps an unrelated submit-time error while editing elsewhere", () => {
+    const form = makeForm();
+    form._errors = new Map([
+      ["bit_rate", { key: "bit_rate", code: "validation.required" }],
+    ]);
+    form._onValueChange(changeEvent(["can_id"], 4434343434343434));
+    expect(form._errors.get("bit_rate")?.code).toBe("validation.required");
+    expect(form._errors.get("can_id")?.code).toBe("validation.max");
+  });
+});

--- a/test/components/device/add-component-form-live-validation.test.ts
+++ b/test/components/device/add-component-form-live-validation.test.ts
@@ -94,23 +94,28 @@ describe("esphome-add-component-form live validation", () => {
     expect(form._errors.get("can_id")?.code).toBe("validation.max");
   });
 
-  it("labels a per-item error key through index segments", () => {
+  it("labels an error key with an index mid-path from its leaf entry", () => {
+    // The old walker stopped at the list container; resolving through
+    // the index segment reaches the leaf's own label.
     const form = makeForm() as unknown as {
       component: unknown;
       _labelForErrorKey(key: string): string;
     };
     form.component = {
-      id: "remote_receiver",
-      name: "Remote Receiver",
+      id: "servo",
+      name: "Servo",
       config_entries: [
         makeConfigEntry({
-          key: "codes",
-          label: "Codes",
-          type: ConfigEntryType.INTEGER,
+          key: "servos",
+          label: "Servos",
+          type: ConfigEntryType.NESTED,
           multi_value: true,
+          config_entries: [
+            makeConfigEntry({ key: "pin", label: "Pin", type: ConfigEntryType.INTEGER }),
+          ],
         }),
       ],
     };
-    expect(form._labelForErrorKey("codes.0")).toBe("Codes");
+    expect(form._labelForErrorKey("servos.0.pin")).toBe("Pin");
   });
 });

--- a/test/components/device/add-component-form-live-validation.test.ts
+++ b/test/components/device/add-component-form-live-validation.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import "../../_mock-webawesome.js";
 
@@ -40,22 +40,46 @@ function makeForm(): LiveValidationView {
 }
 
 describe("esphome-add-component-form live validation", () => {
-  it("flags an out-of-range typed value before any submit", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("flags an out-of-range typed value once typing pauses, before any submit", () => {
     const form = makeForm();
     form._onValueChange(changeEvent(["can_id"], 4434343434343434));
+    // Nothing mid-typing — the renderers emit partial text per keystroke.
+    expect(form._errors.size).toBe(0);
+    vi.advanceTimersByTime(250);
     expect(form._errors.get("can_id")?.code).toBe("validation.max");
+  });
+
+  it("never flashes an error for a partial value overwritten within the pause", () => {
+    const form = makeForm();
+    // A hex field's keystroke sequence: "0x" (unparseable) then the
+    // complete value — only the settled value is ever validated.
+    form._onValueChange(changeEvent(["can_id"], "0x"));
+    form._onValueChange(changeEvent(["can_id"], 42));
+    vi.advanceTimersByTime(250);
+    expect(form._errors.size).toBe(0);
   });
 
   it("clears the flag once the value is corrected", () => {
     const form = makeForm();
     form._onValueChange(changeEvent(["can_id"], 4434343434343434));
+    vi.advanceTimersByTime(250);
     form._onValueChange(changeEvent(["can_id"], 42));
+    vi.advanceTimersByTime(250);
     expect(form._errors.has("can_id")).toBe(false);
   });
 
   it("does not nag a required field emptied mid-form", () => {
     const form = makeForm();
     form._onValueChange(changeEvent(["can_id"], ""));
+    vi.advanceTimersByTime(250);
     expect(form._errors.size).toBe(0);
   });
 
@@ -65,7 +89,28 @@ describe("esphome-add-component-form live validation", () => {
       ["bit_rate", { key: "bit_rate", code: "validation.required" }],
     ]);
     form._onValueChange(changeEvent(["can_id"], 4434343434343434));
+    vi.advanceTimersByTime(250);
     expect(form._errors.get("bit_rate")?.code).toBe("validation.required");
     expect(form._errors.get("can_id")?.code).toBe("validation.max");
+  });
+
+  it("labels a per-item error key through index segments", () => {
+    const form = makeForm() as unknown as {
+      component: unknown;
+      _labelForErrorKey(key: string): string;
+    };
+    form.component = {
+      id: "remote_receiver",
+      name: "Remote Receiver",
+      config_entries: [
+        makeConfigEntry({
+          key: "codes",
+          label: "Codes",
+          type: ConfigEntryType.INTEGER,
+          multi_value: true,
+        }),
+      ],
+    };
+    expect(form._labelForErrorKey("codes.0")).toBe("Codes");
   });
 });

--- a/test/components/device/add-component-form-live-validation.test.ts
+++ b/test/components/device/add-component-form-live-validation.test.ts
@@ -67,13 +67,25 @@ describe("esphome-add-component-form live validation", () => {
     expect(form._errors.size).toBe(0);
   });
 
-  it("clears the flag once the value is corrected", () => {
+  it("clears the flag the instant the value is corrected", () => {
     const form = makeForm();
     form._onValueChange(changeEvent(["can_id"], 4434343434343434));
     vi.advanceTimersByTime(250);
     form._onValueChange(changeEvent(["can_id"], 42));
-    vi.advanceTimersByTime(250);
+    // No pause needed — correction is synchronous.
     expect(form._errors.has("can_id")).toBe(false);
+  });
+
+  it("keeps a shown error steady while the value is still wrong", () => {
+    const form = makeForm();
+    form._onValueChange(changeEvent(["can_id"], 4434343434343434));
+    vi.advanceTimersByTime(250);
+    // Another wrong keystroke must not blink the error away.
+    form._onValueChange(changeEvent(["can_id"], -1));
+    expect(form._errors.get("can_id")?.code).toBe("validation.max");
+    vi.advanceTimersByTime(250);
+    // The message swaps to the settled value's failure at the pause.
+    expect(form._errors.get("can_id")?.code).toBe("validation.min");
   });
 
   it("does not nag a required field emptied mid-form", () => {

--- a/test/components/device/add-component-form-live-validation.test.ts
+++ b/test/components/device/add-component-form-live-validation.test.ts
@@ -76,16 +76,27 @@ describe("esphome-add-component-form live validation", () => {
     expect(form._errors.has("can_id")).toBe(false);
   });
 
-  it("keeps a shown error steady while the value is still wrong", () => {
+  it("keeps a shown error painted while the value is still wrong", () => {
     const form = makeForm();
     form._onValueChange(changeEvent(["can_id"], 4434343434343434));
     vi.advanceTimersByTime(250);
-    // Another wrong keystroke must not blink the error away.
+    // Another wrong keystroke must not blink the error away — the
+    // painted key refreshes in place, immediately.
     form._onValueChange(changeEvent(["can_id"], -1));
-    expect(form._errors.get("can_id")?.code).toBe("validation.max");
-    vi.advanceTimersByTime(250);
-    // The message swaps to the settled value's failure at the pause.
     expect(form._errors.get("can_id")?.code).toBe("validation.min");
+    vi.advanceTimersByTime(250);
+    expect(form._errors.get("can_id")?.code).toBe("validation.min");
+  });
+
+  it("never strands a stale message when a later edit cancels the timer", () => {
+    // A submit-set required error, an invalid replacement, then an edit
+    // elsewhere inside the pause: the field must not keep saying
+    // "required" while visibly holding text.
+    const form = makeForm();
+    form._errors = new Map([["can_id", { key: "can_id", code: "validation.required" }]]);
+    form._onValueChange(changeEvent(["can_id"], 4434343434343434));
+    form._onValueChange(changeEvent(["bit_rate"], "125kbps"));
+    expect(form._errors.get("can_id")?.code).toBe("validation.max");
   });
 
   it("does not nag a required field emptied mid-form", () => {

--- a/test/components/device/add-component-form-live-validation.test.ts
+++ b/test/components/device/add-component-form-live-validation.test.ts
@@ -6,7 +6,7 @@ import "../../_mock-webawesome.js";
 import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
-import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+import { makeConfigEntry } from "../../util/_make-config-entry.js";
 
 /**
  * Pins #1528: a wrong *typed* value flags as soon as it lands in the

--- a/test/util/config-entry-tree.test.ts
+++ b/test/util/config-entry-tree.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import type { ConfigEntry } from "../../src/api/types/config-entries.js";
 import { ConfigEntryType } from "../../src/api/types/config-entries.js";
-import { pathIsAdvanced } from "../../src/util/config-entry-tree.js";
+import { entryAtPath, pathIsAdvanced } from "../../src/util/config-entry-tree.js";
 
 function entry(key: string, advanced: boolean): ConfigEntry {
   return { key, type: ConfigEntryType.STRING, label: key, advanced } as ConfigEntry;
@@ -154,5 +154,41 @@ describe("pathIsAdvanced", () => {
     } as ConfigEntry;
     expect(pathIsAdvanced([pin], ["pin", "mode", "secret"], {})).toBe(false);
     expect(pathIsAdvanced([pin], ["pin", "mode", "input"], {})).toBe(true);
+  });
+});
+
+describe("entryAtPath", () => {
+  const pin = {
+    key: "pin",
+    type: ConfigEntryType.INTEGER,
+  } as ConfigEntry;
+  const servos = {
+    key: "servos",
+    type: ConfigEntryType.NESTED,
+    multi_value: true,
+    config_entries: [pin],
+  } as ConfigEntry;
+
+  it("resolves through nested groups and index segments", () => {
+    expect(entryAtPath([servos], ["servos"])).toBe(servos);
+    expect(entryAtPath([servos], ["servos", "0", "pin"])).toBe(pin);
+  });
+
+  it("descends config_entries regardless of entry type", () => {
+    // A PIN-style entry carries sub-entries without being NESTED; the
+    // walk reaches them the same way the renderers' paths do.
+    const number = { key: "number", type: ConfigEntryType.INTEGER } as ConfigEntry;
+    const gpio = {
+      key: "gpio",
+      type: ConfigEntryType.PIN,
+      config_entries: [number],
+    } as ConfigEntry;
+    expect(entryAtPath([gpio], ["gpio", "number"])).toBe(number);
+  });
+
+  it("returns undefined for unresolved and empty paths", () => {
+    expect(entryAtPath([servos], [])).toBeUndefined();
+    expect(entryAtPath([servos], ["nope"])).toBeUndefined();
+    expect(entryAtPath([servos], ["0"])).toBeUndefined();
   });
 });

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -1044,7 +1044,7 @@ describe("validateValueAt", () => {
       options: [
         { label: "A", value: "a" },
         { label: "B", value: "b" },
-      ] as ConfigValueOption[],
+      ],
     });
     const errors = validateValueAt([mode], ["mode"], "c");
     expect(errors.get("mode")?.code).toBe("validation.invalid_option");

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -10,6 +10,7 @@ import {
   validateDeviceName,
   validateEntries,
   validateEntry,
+  validateValueAt,
 } from "../../src/util/config-validation.js";
 import { YamlRawValue } from "../../src/util/yaml-serialize.js";
 import { makeConfigEntry as makeEntry } from "./_make-config-entry.js";
@@ -978,4 +979,74 @@ it("never flags a lambda value on a typed templatable field", () => {
     )
   ).toBeNull();
   expect(validateEntry(makeEntry({ type: ConfigEntryType.INTEGER }), lambda)).toBeNull();
+});
+
+describe("validateValueAt", () => {
+  const canId = makeEntry({
+    key: "can_id",
+    type: ConfigEntryType.INTEGER,
+    required: true,
+    range: [0, 536870911],
+  });
+
+  it("flags an out-of-range typed value on a flat path", () => {
+    const errors = validateValueAt([canId], ["can_id"], 4434343434343434);
+    expect(errors.get("can_id")?.code).toBe("validation.max");
+  });
+
+  it("stays quiet for an in-range value and for an emptied required field", () => {
+    expect(validateValueAt([canId], ["can_id"], 42).size).toBe(0);
+    // Required-empty is a submit-only signal.
+    expect(validateValueAt([canId], ["can_id"], "").size).toBe(0);
+  });
+
+  it("resolves a nested path through a group", () => {
+    const group = makeEntry({
+      key: "advanced",
+      type: ConfigEntryType.NESTED,
+      config_entries: [canId],
+    });
+    const errors = validateValueAt([group], ["advanced", "can_id"], -1);
+    expect(errors.get("advanced.can_id")?.code).toBe("validation.min");
+  });
+
+  it("skips index segments when resolving the entry", () => {
+    const codes = makeEntry({
+      key: "codes",
+      type: ConfigEntryType.INTEGER,
+      multi_value: true,
+      range: [0, 10],
+    });
+    const errors = validateValueAt([codes], ["codes", "1"], 99);
+    expect(errors.get("codes.1")?.code).toBe("validation.max");
+  });
+
+  it("keys a scalar multi_value array per offending item", () => {
+    const codes = makeEntry({
+      key: "codes",
+      type: ConfigEntryType.INTEGER,
+      multi_value: true,
+      range: [0, 10],
+    });
+    const errors = validateValueAt([codes], ["codes"], [3, 99, ""]);
+    expect([...errors.keys()]).toEqual(["codes.1"]);
+    expect(errors.get("codes.1")?.code).toBe("validation.max");
+  });
+
+  it("returns nothing for an unknown path", () => {
+    expect(validateValueAt([canId], ["nope"], 5).size).toBe(0);
+  });
+
+  it("flags a value outside the options list", () => {
+    const mode = makeEntry({
+      key: "mode",
+      type: ConfigEntryType.STRING,
+      options: [
+        { label: "A", value: "a" },
+        { label: "B", value: "b" },
+      ] as ConfigValueOption[],
+    });
+    const errors = validateValueAt([mode], ["mode"], "c");
+    expect(errors.get("mode")?.code).toBe("validation.invalid_option");
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Typing an out of range value into the add component form gave no feedback until Add was pressed: `_onValueChange` only cleared errors on the edited path (the deliberate fresh signal rule that avoids nagging untouched required fields), and `validateEntries` ran solely in the submit handler, so a 16 digit `can_id` against ESP32 CAN's `[0, 536870911]` range sat unflagged.

The edited path now live validates through a new `validateValueAt(entries, path, value)`: it resolves the `ConfigEntry` by walking the path (index segments skip a level, matching the renderers' item paths), runs the entry's typed checks, and drops `validation.required` results, so range, type, and option errors flag once typing pauses while emptiness stays a submit only signal. A scalar `multi_value` array is checked per item with the same `"<path>.<idx>"` keys submit time validation uses. Untouched fields keep the no nag behavior by construction, live validation only writes keys under the edited path, and errors a failed submit set elsewhere survive. The check runs behind a 200 ms pause (the section form's draft flush cadence): the renderers emit partial text per keystroke (`0x`, `1e`), so an immediate check would flash errors mid entry; only the settled value is validated, and a partial overwritten within the pause never flags. The error state is one directional while typing: a now valid value clears instantly, a still wrong value keeps the shown error steady with its message refreshed in one swap at the pause, so nothing blinks per keystroke. `_labelForErrorKey` now resolves through the shared `entryAtPath` walk, so a key with an index mid path (`servos.0.pin`) labels from its leaf entry instead of stopping at the list container.

The section form is deliberately untouched: it already live validates through its 200 ms draft flush, and its required on clear nag is pinned intentional behavior for editing existing configs, so the issue's "same treatment" note is already satisfied there.

Verified against the live dashboard: adding ESP32 CAN and typing `4434343434343434` into Can ID shows "Must be at most 536870911" inline with no submit, correcting clears it, and the empty required pin fields stay quiet until Add.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1528

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
