### PR TITLE
Emit nested component action fields as dotted sections

### DIFF
--- a/src/util/action-field-path.ts
+++ b/src/util/action-field-path.ts
@@ -12,7 +12,7 @@ import type { YamlPathSegment } from "./yaml-ast.js";
  */
 
 /** Dotted `field` string for a config-entry path. */
-export function joinActionFieldPath(path: string[]): string {
+export function joinActionFieldPath(path: Array<string | number>): string {
   return path.join(".");
 }
 

--- a/src/util/yaml-ast.ts
+++ b/src/util/yaml-ast.ts
@@ -26,6 +26,7 @@
  * caller doesn't need a fallback for "the parse failed".
  */
 import { syntaxTree } from "@codemirror/language";
+import { isAutomationKey } from "./yaml-section-lexer.js";
 import type { EditorState } from "@codemirror/state";
 import type { SyntaxNode } from "@lezer/common";
 
@@ -126,15 +127,7 @@ export function isUnderThenItem(state: EditorState, pos: number): boolean {
  *  ``close_action``, lock ``unlock_action``, …). Covers every
  *  list-of-actions body in the ESPHome schema; broader than the
  *  legacy ``then``-only carve-out. */
-const RE_AUTOMATION_KEY = /^(?:then|else|on_[a-z0-9_]*|[a-z0-9_]+_action)$/;
-
-/** True for pair keys whose value is a list of actions: ``then`` /
- *  ``else`` / ``on_*`` / ``*_action``. The indent-based completion
- *  fallback uses this when the Lezer parse mis-nests an empty trailing
- *  ``- `` and ``isUnderAutomationItem`` can't see the enclosing key. */
-export function isAutomationKey(key: string): boolean {
-  return RE_AUTOMATION_KEY.test(key);
-}
+export { isAutomationKey } from "./yaml-section-lexer.js";
 
 /**
  * True when *pos* is inside a list ``Item`` whose enclosing Pair

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -347,7 +347,19 @@ function _actionFieldPath(
     ? hostLine.slice(hostDash[0].length).match(_BARE_MAPPING_KEY_RE)
     : null;
   if (hostInlineKey) stack.push({ indent: childIndent, seg: hostInlineKey[1] });
-  for (let j = host.fromLine; j <= targetIdx; j++) {
+  // A block scalar opened inline on the dash line hides its body from
+  // the loop's opener check — refuse a target inside it, start past it.
+  let walkStart = host.fromLine;
+  if (
+    hostDash &&
+    !hostInlineKey &&
+    BLOCK_SCALAR_RE.test(hostLine.slice(hostDash[0].length))
+  ) {
+    const end = _blockScalarBodyEnd(lines, host.fromLine, childIndent);
+    if (targetIdx < end) return null;
+    walkStart = end;
+  }
+  for (let j = walkStart; j <= targetIdx; j++) {
     const line = lines[j];
     if (isBlankOrCommentLine(line)) continue;
     let indent = lineIndent(line);
@@ -379,14 +391,17 @@ function _actionFieldPath(
         if (typeof frame.seg === "string" && isAutomationKey(frame.seg)) return null;
       }
       const segments: Array<string | number> = stack.map((frame) => frame.seg);
-      // A container key the bare-key regex couldn't name (quoted,
-      // hyphenated) drops its frame while its dashes still count; an
-      // index without a preceding key can't route, so fall back to no
-      // row rather than a wrong one.
-      const orphanIndex = segments.some(
-        (seg, idx) => typeof seg === "number" && typeof segments[idx - 1] !== "string"
+      // Refuse paths the dotted encoding can't carry: an index whose
+      // container key the bare-key regex couldn't name (quoted,
+      // hyphenated — the frame dropped while its dashes still count),
+      // or a segment containing a dot, which the lossless-join
+      // invariant of ``action-field-path.ts`` forbids.
+      const unencodable = segments.some(
+        (seg, idx) =>
+          (typeof seg === "number" && typeof segments[idx - 1] !== "string") ||
+          (typeof seg === "string" && seg.includes("."))
       );
-      if (orphanIndex) return null;
+      if (unencodable) return null;
       segments.push(field);
       return segments;
     }

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -7,11 +7,13 @@
 
 import { joinActionFieldPath } from "./action-field-path.js";
 import {
+  BLOCK_SCALAR_RE,
   endsBlockAtIndent,
   isAutomationKey,
   isBlankOrCommentLine,
   LIST_ITEM_START_RE,
 } from "./yaml-section-lexer.js";
+import { _blockScalarBodyEnd } from "./yaml-section-list.js";
 import {
   instanceComponentId,
   lineIndent,
@@ -377,12 +379,25 @@ function _actionFieldPath(
         if (typeof frame.seg === "string" && isAutomationKey(frame.seg)) return null;
       }
       const segments: Array<string | number> = stack.map((frame) => frame.seg);
-      // A container key the bare-key regex couldn't name drops its
-      // frame while its dashes still count; an index-first path can't
-      // route, so fall back to no row rather than an unroutable one.
-      if (typeof segments[0] === "number") return null;
+      // A container key the bare-key regex couldn't name (quoted,
+      // hyphenated) drops its frame while its dashes still count; an
+      // index without a preceding key can't route, so fall back to no
+      // row rather than a wrong one.
+      const orphanIndex = segments.some(
+        (seg, idx) => typeof seg === "number" && typeof segments[idx - 1] !== "string"
+      );
+      if (orphanIndex) return null;
       segments.push(field);
       return segments;
+    }
+    // A block scalar's body is opaque text: a ``*_action``-looking line
+    // inside it is not a field, and its content must not misframe the
+    // walk — refuse a target inside it, skip past it otherwise.
+    if (BLOCK_SCALAR_RE.test(rest)) {
+      const end = _blockScalarBodyEnd(lines, j + 1, indent);
+      if (targetIdx < end) return null;
+      j = end - 1;
+      continue;
     }
     const blockKey = rest.match(_BARE_MAPPING_KEY_RE);
     if (blockKey) stack.push({ indent, seg: blockKey[1] });

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -332,11 +332,19 @@ function _actionFieldPath(
   targetIndent: number,
   field: string
 ): Array<string | number> | null {
-  const childIndent = listItemChildIndent(lines[host.fromLine - 1] ?? "");
+  const hostLine = lines[host.fromLine - 1] ?? "";
+  const childIndent = listItemChildIndent(hostLine);
   if (targetIndent < childIndent) return null;
   // Walk the instance body accumulating the enclosing frames: block
   // mapping keys by indent, list items as counted dash indices.
   const stack: Array<{ indent: number; seg: string | number }> = [];
+  // A bare inline first key on the instance dash line (``- valves:``)
+  // opens a block the loop below never sees — seed its frame.
+  const hostDash = hostLine.match(_DASH_LEADER_RE);
+  const hostInlineKey = hostDash
+    ? hostLine.slice(hostDash[0].length).match(_BARE_MAPPING_KEY_RE)
+    : null;
+  if (hostInlineKey) stack.push({ indent: childIndent, seg: hostInlineKey[1] });
   for (let j = host.fromLine; j <= targetIdx; j++) {
     const line = lines[j];
     if (isBlankOrCommentLine(line)) continue;
@@ -346,7 +354,10 @@ function _actionFieldPath(
     while (stack.length) {
       const top = stack[stack.length - 1];
       if (top.indent < indent) break;
-      if (dash && top.indent === indent && typeof top.seg === "number") break;
+      // A dash keeps its same-indent frames: the sibling index it
+      // increments, and — in the zero-indent sequence style — the
+      // parent key whose column the dashes share.
+      if (dash && top.indent === indent) break;
       stack.pop();
     }
     if (dash) {

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -190,10 +190,13 @@ function _parseYamlAutomations(yaml: string): YamlSection[] {
   // Component action-list config fields (``open_action:`` …). These are
   // ``type: trigger`` config fields whose value is a bare action list —
   // editable as trigger-less automations, parallel to the inline ``on_*``
-  // pass above. Matched by the ``*_action`` suffix and gated to a direct
-  // child of a component instance, so an ``on_*`` key (different suffix)
-  // and a ``*_action`` nested inside another action body (deeper indent,
-  // edited within that automation's tree) are both excluded.
+  // pass above. Matched by the ``*_action`` suffix at any depth inside a
+  // component instance; the field is addressed on the instance by its
+  // dotted path (list items as indices — ``valves.0.run_duration_number.
+  // set_action``), the backend's ``component_action`` encoding. A key
+  // inside a trigger or action body (``on_*`` / another ``*_action`` /
+  // ``then``-family ancestor) is edited within that automation's tree
+  // and excluded.
   for (let i = 0; i < lines.length; i++) {
     const match = lines[i].match(_COMPONENT_ACTION_FIELD_RE);
     if (!match) continue;
@@ -204,20 +207,22 @@ function _parseYamlAutomations(yaml: string): YamlSection[] {
     if (field.startsWith("on_")) continue;
     const fromLine = i + 1;
     const host = smallestContainingSection(sections, fromLine);
-    const scope = host && _resolveHandlerScope(lines, sections, host, i, indent, false);
-    if (!host || !scope) continue;
-    const componentId = scope.componentId;
+    if (!host) continue;
+    const segments = _actionFieldPath(lines, host, i, indent, field);
+    if (!segments) continue;
+    const componentId = instanceComponentId(sections, host);
     if (!componentId) continue;
+    const dotted = segments.join(".");
     const labelHead = host.name || componentId;
     automations.push({
-      key: `automation:component_action:${componentId}:${field}`,
-      displayLabel: `${labelHead} → ${field}`,
+      key: `automation:component_action:${componentId}:${dotted}`,
+      displayLabel: `${labelHead} → ${dotted}`,
       fromLine,
       toLine: _findBlockEnd(lines, i, indent),
       id: componentId,
       name: host.name,
       parentKey: host.parentKey ?? host.key,
-      actionField: field,
+      actionField: dotted,
     });
   }
 
@@ -303,6 +308,89 @@ function _parseYamlAutomations(yaml: string): YamlSection[] {
   }
 
   return automations;
+}
+
+/** Ancestor keys that place a ``*_action`` line inside an automation
+ *  body rather than the instance's config tree. */
+const _AUTOMATION_BODY_KEYS = new Set(["then", "else", "actions"]);
+
+const _BLOCK_KEY_RE = /^([A-Za-z0-9_.]+):\s*(?:#.*)?$/;
+const _VALUED_KEY_RE = /^[A-Za-z0-9_.]+:\s+\S/;
+
+/**
+ * Concrete path segments from *host*'s body to the ``*_action`` key at
+ * *targetIdx*, list items as 0-based indices — the backend's
+ * ``component_action`` addressing. ``null`` when the field sits inside
+ * a trigger or automation body (edited within that automation's tree)
+ * or the structure doesn't resolve.
+ */
+function _actionFieldPath(
+  lines: string[],
+  host: YamlSection,
+  targetIdx: number,
+  targetIndent: number,
+  field: string
+): Array<string | number> | null {
+  const childIndent = listItemChildIndent(lines[host.fromLine - 1] ?? "");
+  if (targetIndent < childIndent) return null;
+  if (targetIndent === childIndent) return [field];
+  // Walk the instance body accumulating the enclosing frames: block
+  // mapping keys by indent, list items as counted dash indices.
+  const stack: Array<{ indent: number; seg: string | number }> = [];
+  for (let j = host.fromLine; j <= targetIdx; j++) {
+    const line = lines[j];
+    if (isBlankOrCommentLine(line)) continue;
+    let indent = lineIndent(line);
+    let rest = line.slice(indent);
+    const dash = line.match(/^(\s*)-(\s+|$)/);
+    if (dash) {
+      while (stack.length) {
+        const top = stack[stack.length - 1];
+        if (
+          top.indent < indent ||
+          (top.indent === indent && typeof top.seg === "number")
+        ) {
+          break;
+        }
+        stack.pop();
+      }
+      const top = stack[stack.length - 1];
+      if (top && top.indent === indent && typeof top.seg === "number") {
+        top.seg += 1;
+      } else {
+        stack.push({ indent, seg: 0 });
+      }
+      rest = line.slice(dash[0].length);
+      if (!rest.trim()) continue;
+      // An inline first key sits at the item's content column.
+      indent = dash[0].length;
+    } else {
+      while (stack.length && stack[stack.length - 1].indent >= indent) stack.pop();
+    }
+    if (j === targetIdx) {
+      for (const frame of stack) {
+        if (typeof frame.seg !== "string") continue;
+        if (
+          frame.seg.startsWith("on_") ||
+          frame.seg.endsWith("_action") ||
+          _AUTOMATION_BODY_KEYS.has(frame.seg)
+        ) {
+          return null;
+        }
+      }
+      return [...stack.map((frame) => frame.seg), field];
+    }
+    const blockKey = rest.match(_BLOCK_KEY_RE);
+    if (blockKey) {
+      stack.push({ indent, seg: blockKey[1] });
+    } else if (!_VALUED_KEY_RE.test(rest) && indent < targetIndent && !dash) {
+      // A non-key, non-item construct shallower than the target (flow
+      // collection, block scalar) hides the structure — refuse rather
+      // than emit a wrong path.
+      return null;
+    }
+  }
+  return null;
 }
 
 /** Resolve a handler at ``indent`` to its target instance: the host for a

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -377,6 +377,10 @@ function _actionFieldPath(
         if (typeof frame.seg === "string" && isAutomationKey(frame.seg)) return null;
       }
       const segments: Array<string | number> = stack.map((frame) => frame.seg);
+      // A container key the bare-key regex couldn't name drops its
+      // frame while its dashes still count; an index-first path can't
+      // route, so fall back to no row rather than an unroutable one.
+      if (typeof segments[0] === "number") return null;
       segments.push(field);
       return segments;
     }

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -5,8 +5,10 @@
  * unaffected; import from there or from here directly.
  */
 
+import { joinActionFieldPath } from "./action-field-path.js";
 import {
   endsBlockAtIndent,
+  isAutomationKey,
   isBlankOrCommentLine,
   LIST_ITEM_START_RE,
 } from "./yaml-section-lexer.js";
@@ -212,7 +214,7 @@ function _parseYamlAutomations(yaml: string): YamlSection[] {
     if (!segments) continue;
     const componentId = instanceComponentId(sections, host);
     if (!componentId) continue;
-    const dotted = segments.join(".");
+    const dotted = joinActionFieldPath(segments);
     const labelHead = host.name || componentId;
     automations.push({
       key: `automation:component_action:${componentId}:${dotted}`,
@@ -310,19 +312,18 @@ function _parseYamlAutomations(yaml: string): YamlSection[] {
   return automations;
 }
 
-/** Ancestor keys that place a ``*_action`` line inside an automation
- *  body rather than the instance's config tree. */
-const _AUTOMATION_BODY_KEYS = new Set(["then", "else", "actions"]);
-
-const _BLOCK_KEY_RE = /^([A-Za-z0-9_.]+):\s*(?:#.*)?$/;
-const _VALUED_KEY_RE = /^[A-Za-z0-9_.]+:\s+\S/;
+/** A dash item's leader — the match length is the item's content column. */
+const _DASH_LEADER_RE = /^\s*-(\s+|$)/;
 
 /**
  * Concrete path segments from *host*'s body to the ``*_action`` key at
  * *targetIdx*, list items as 0-based indices — the backend's
  * ``component_action`` addressing. ``null`` when the field sits inside
- * a trigger or automation body (edited within that automation's tree)
- * or the structure doesn't resolve.
+ * an automation body (an ``isAutomationKey`` ancestor — edited within
+ * that automation's tree) or the structure doesn't resolve. Best-effort
+ * like the rest of this fallback: block scalars and flow collections
+ * aren't modelled, so a key-shaped line inside one can misframe until
+ * backend parse corrects it.
  */
 function _actionFieldPath(
   lines: string[],
@@ -333,7 +334,6 @@ function _actionFieldPath(
 ): Array<string | number> | null {
   const childIndent = listItemChildIndent(lines[host.fromLine - 1] ?? "");
   if (targetIndent < childIndent) return null;
-  if (targetIndent === childIndent) return [field];
   // Walk the instance body accumulating the enclosing frames: block
   // mapping keys by indent, list items as counted dash indices.
   const stack: Array<{ indent: number; seg: string | number }> = [];
@@ -342,18 +342,14 @@ function _actionFieldPath(
     if (isBlankOrCommentLine(line)) continue;
     let indent = lineIndent(line);
     let rest = line.slice(indent);
-    const dash = line.match(/^(\s*)-(\s+|$)/);
+    const dash = line.match(_DASH_LEADER_RE);
+    while (stack.length) {
+      const top = stack[stack.length - 1];
+      if (top.indent < indent) break;
+      if (dash && top.indent === indent && typeof top.seg === "number") break;
+      stack.pop();
+    }
     if (dash) {
-      while (stack.length) {
-        const top = stack[stack.length - 1];
-        if (
-          top.indent < indent ||
-          (top.indent === indent && typeof top.seg === "number")
-        ) {
-          break;
-        }
-        stack.pop();
-      }
       const top = stack[stack.length - 1];
       if (top && top.indent === indent && typeof top.seg === "number") {
         top.seg += 1;
@@ -364,46 +360,30 @@ function _actionFieldPath(
       if (!rest.trim()) continue;
       // An inline first key sits at the item's content column.
       indent = dash[0].length;
-    } else {
-      while (stack.length && stack[stack.length - 1].indent >= indent) stack.pop();
     }
     if (j === targetIdx) {
       for (const frame of stack) {
-        if (typeof frame.seg !== "string") continue;
-        if (
-          frame.seg.startsWith("on_") ||
-          frame.seg.endsWith("_action") ||
-          _AUTOMATION_BODY_KEYS.has(frame.seg)
-        ) {
-          return null;
-        }
+        if (typeof frame.seg === "string" && isAutomationKey(frame.seg)) return null;
       }
-      return [...stack.map((frame) => frame.seg), field];
+      const segments: Array<string | number> = stack.map((frame) => frame.seg);
+      segments.push(field);
+      return segments;
     }
-    const blockKey = rest.match(_BLOCK_KEY_RE);
-    if (blockKey) {
-      stack.push({ indent, seg: blockKey[1] });
-    } else if (!_VALUED_KEY_RE.test(rest) && indent < targetIndent && !dash) {
-      // A non-key, non-item construct shallower than the target (flow
-      // collection, block scalar) hides the structure — refuse rather
-      // than emit a wrong path.
-      return null;
-    }
+    const blockKey = rest.match(_BARE_MAPPING_KEY_RE);
+    if (blockKey) stack.push({ indent, seg: blockKey[1] });
   }
   return null;
 }
 
 /** Resolve a handler at ``indent`` to its target instance: the host for a
- *  direct child, or (when ``allowSubEntity``) the host's ided sub-entity for a
- *  deeper handler. ``null`` when no addressable target. The ``*_action`` field
- *  pass passes ``false`` — those fields are direct-child-only. */
+ *  direct child, or the host's ided sub-entity for a deeper handler.
+ *  ``null`` when no addressable target. */
 function _resolveHandlerScope(
   lines: string[],
   sections: YamlSection[],
   host: YamlSection,
   handlerIdx: number,
-  indent: number,
-  allowSubEntity = true
+  indent: number
 ): { componentId: string; displayName?: string; parentComponentId?: string } | null {
   const childIndent = listItemChildIndent(lines[host.fromLine - 1] ?? "");
   if (indent === childIndent) {
@@ -412,7 +392,7 @@ function _resolveHandlerScope(
       displayName: host.name ?? undefined,
     };
   }
-  if (allowSubEntity && indent > childIndent) {
+  if (indent > childIndent) {
     const sub = _subEntity(lines, handlerIdx, childIndent);
     if (sub) {
       const parentComponentId = instanceComponentId(sections, host);

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -339,6 +339,15 @@ export const isChildListItemLine = (line: string, parentIndent: string): boolean
   return tail === "-" || tail.startsWith("- ");
 };
 
+const RE_AUTOMATION_KEY = /^(?:then|else|on_[a-z0-9_]*|[a-z0-9_]+_action)$/;
+
+/** True for pair keys whose value is a list of actions: ``then`` /
+ *  ``else`` / ``on_*`` / ``*_action``. The one definition every walker
+ *  shares, so "what encloses an automation body" can't drift. */
+export function isAutomationKey(key: string): boolean {
+  return RE_AUTOMATION_KEY.test(key);
+}
+
 /**
  * The one rule for "where does a block end". True when *line* terminates a
  * block whose opener key sits at *openerIndent* columns. Blank and
@@ -351,15 +360,6 @@ export const isChildListItemLine = (line: string, parentIndent: string): boolean
  * sequence and comment cases are handled in one place instead of being
  * relearned (and mis-learned) per call site.
  */
-const RE_AUTOMATION_KEY = /^(?:then|else|on_[a-z0-9_]*|[a-z0-9_]+_action)$/;
-
-/** True for pair keys whose value is a list of actions: ``then`` /
- *  ``else`` / ``on_*`` / ``*_action``. The one definition every walker
- *  shares, so "what encloses an automation body" can't drift. */
-export function isAutomationKey(key: string): boolean {
-  return RE_AUTOMATION_KEY.test(key);
-}
-
 export const endsBlockAtIndent = (line: string, openerIndent: number): boolean => {
   if (isBlankOrCommentLine(line)) return false;
   const lineIndent = _leadingIndent(line).length;

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -351,6 +351,15 @@ export const isChildListItemLine = (line: string, parentIndent: string): boolean
  * sequence and comment cases are handled in one place instead of being
  * relearned (and mis-learned) per call site.
  */
+const RE_AUTOMATION_KEY = /^(?:then|else|on_[a-z0-9_]*|[a-z0-9_]+_action)$/;
+
+/** True for pair keys whose value is a list of actions: ``then`` /
+ *  ``else`` / ``on_*`` / ``*_action``. The one definition every walker
+ *  shares, so "what encloses an automation body" can't drift. */
+export function isAutomationKey(key: string): boolean {
+  return RE_AUTOMATION_KEY.test(key);
+}
+
 export const endsBlockAtIndent = (line: string, openerIndent: number): boolean => {
   if (isBlankOrCommentLine(line)) return false;
   const lineIndent = _leadingIndent(line).length;

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -1529,6 +1529,20 @@ describe("nested component_action sections (#1543)", () => {
     ]);
   });
 
+  it("drops a field whose container key the walk cannot name", () => {
+    // A quoted container key isn't a bare mapping key, so its frame is
+    // missing; an index-first path can't route — no row beats a broken
+    // one.
+    const yaml = `sprinkler:
+  - id: lawn
+    "valves":
+      - run_duration_number:
+          set_action:
+            - logger.log: changed
+`;
+    expect(componentActionItems(yaml)).toEqual([]);
+  });
+
   it("uses an index-free path when the list is written as one mapping", () => {
     const yaml = `sprinkler:
   - id: lawn

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -1452,3 +1452,93 @@ describe("resolveCurrentSectionLine", () => {
     expect(resolveCurrentSectionLine(yaml, "wifi", 3)).toBeUndefined();
   });
 });
+
+describe("nested component_action sections (#1543)", () => {
+  const sprinklerYaml = `sprinkler:
+  - id: lawn
+    main_switch: Lawn Sprinklers
+    repeat_number:
+      id: lawn_repeat
+      set_action:
+        - logger.log: repeat changed
+    valves:
+      - valve_switch: Front Yard
+        run_duration_number:
+          id: front_duration
+          set_action:
+            - logger.log: front changed
+      - valve_switch: Back Yard
+        run_duration_number:
+          set_action:
+            - logger.log: back changed
+`;
+
+  it("emits nested action fields with concrete dotted paths, in line order", () => {
+    const items = parseYamlAutomations(sprinklerYaml).filter((s) =>
+      s.key.startsWith("automation:component_action:")
+    );
+    expect(items.map((s) => s.actionField)).toEqual([
+      "repeat_number.set_action",
+      "valves.0.run_duration_number.set_action",
+      "valves.1.run_duration_number.set_action",
+    ]);
+    for (const item of items) {
+      expect(item.id).toBe("lawn");
+      expect(item.key).toBe(`automation:component_action:lawn:${item.actionField}`);
+    }
+  });
+
+  it("routes a caret inside a nested action body to its automation row", () => {
+    const line =
+      sprinklerYaml.split("\n").findIndex((l) => l.includes("back changed")) + 1;
+    const hit = sectionAtLine(sprinklerYaml, line);
+    expect(hit?.key).toBe(
+      "automation:component_action:lawn:valves.1.run_duration_number.set_action"
+    );
+  });
+
+  it("uses an index-free path when the list is written as one mapping", () => {
+    const yaml = `sprinkler:
+  - id: lawn
+    valves:
+      valve_switch: Only Zone
+      run_duration_number:
+        set_action:
+          - logger.log: changed
+`;
+    const items = parseYamlAutomations(yaml).filter((s) =>
+      s.key.startsWith("automation:component_action:")
+    );
+    expect(items.map((s) => s.actionField)).toEqual([
+      "valves.run_duration_number.set_action",
+    ]);
+  });
+
+  it("still excludes *_action keys inside trigger and automation bodies", () => {
+    const yaml = `binary_sensor:
+  - platform: gpio
+    id: btn
+    on_press:
+      - if:
+          condition:
+            lambda: "return true;"
+          then:
+            - light.turn_on: some_action_ref
+      - script.execute: run_action
+    filters:
+      - delayed_on: 10ms
+cover:
+  - platform: feedback
+    id: gate
+    open_action:
+      - if:
+          then:
+            - switch.turn_on: relay
+`;
+    const items = parseYamlAutomations(yaml).filter((s) =>
+      s.key.startsWith("automation:component_action:")
+    );
+    // Only the real top-level field; nothing from inside bodies.
+    expect(items.map((s) => s.actionField)).toEqual(["open_action"]);
+  });
+});

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -1494,6 +1494,41 @@ describe("nested component_action sections (#1543)", () => {
     );
   });
 
+  it("keeps the parent key for a zero-indent sequence", () => {
+    // The dashes share ``valves:``'s own column — a common style the
+    // repo's block-boundary rule already treats as the key's body.
+    const yaml = `sprinkler:
+  - id: lawn
+    valves:
+    - valve_switch: Front Yard
+      run_duration_number:
+        set_action:
+          - logger.log: front changed
+    - valve_switch: Back Yard
+      run_duration_number:
+        set_action:
+          - logger.log: back changed
+`;
+    expect(componentActionItems(yaml).map((s) => s.actionField)).toEqual([
+      "valves.0.run_duration_number.set_action",
+      "valves.1.run_duration_number.set_action",
+    ]);
+  });
+
+  it("seeds a bare inline first key on the instance dash line", () => {
+    const yaml = `sprinkler:
+  - valves:
+      - valve_switch: Front Yard
+        run_duration_number:
+          set_action:
+            - logger.log: changed
+    id: lawn
+`;
+    expect(componentActionItems(yaml).map((s) => s.actionField)).toEqual([
+      "valves.0.run_duration_number.set_action",
+    ]);
+  });
+
   it("uses an index-free path when the list is written as one mapping", () => {
     const yaml = `sprinkler:
   - id: lawn
@@ -1528,7 +1563,9 @@ cover:
     open_action:
       - if:
           then:
-            - switch.turn_on: relay
+            - cover.control:
+                stop_action:
+                  - switch.turn_on: relay
 `;
     const items = componentActionItems(yaml);
     // Only the real top-level field; nothing from inside bodies.

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -21,6 +21,11 @@ beforeEach(() => {
   _clearYamlSectionsMemo();
 });
 
+const componentActionItems = (yaml: string) =>
+  parseYamlAutomations(yaml).filter((s) =>
+    s.key.startsWith("automation:component_action:")
+  );
+
 describe("parseYamlTopLevelSections", () => {
   it("returns empty for empty input", () => {
     expect(parseYamlTopLevelSections("")).toEqual([]);
@@ -1161,9 +1166,7 @@ describe("parseYamlAutomations", () => {
     stop_action:
       - switch.turn_on: relay_stop
 `;
-    const items = parseYamlAutomations(yaml).filter((s) =>
-      s.key.startsWith("automation:component_action:")
-    );
+    const items = componentActionItems(yaml);
     expect(items.map((s) => s.key)).toEqual([
       "automation:component_action:my_gate:open_action",
       "automation:component_action:my_gate:close_action",
@@ -1179,9 +1182,7 @@ describe("parseYamlAutomations", () => {
     open_action:
       - switch.turn_on: relay_open
 `;
-    const [item] = parseYamlAutomations(yaml).filter((s) =>
-      s.key.startsWith("automation:component_action:")
-    );
+    const [item] = componentActionItems(yaml);
     expect(item.key).toBe("automation:component_action:cover_0:open_action");
   });
 
@@ -1203,9 +1204,7 @@ binary_sensor:
             - some_action:
                 - logger.log: nested
 `;
-    const actionRows = parseYamlAutomations(yaml).filter((s) =>
-      s.key.startsWith("automation:component_action:")
-    );
+    const actionRows = componentActionItems(yaml);
     expect(actionRows).toEqual([]);
   });
 
@@ -1474,9 +1473,7 @@ describe("nested component_action sections (#1543)", () => {
 `;
 
   it("emits nested action fields with concrete dotted paths, in line order", () => {
-    const items = parseYamlAutomations(sprinklerYaml).filter((s) =>
-      s.key.startsWith("automation:component_action:")
-    );
+    const items = componentActionItems(sprinklerYaml);
     expect(items.map((s) => s.actionField)).toEqual([
       "repeat_number.set_action",
       "valves.0.run_duration_number.set_action",
@@ -1506,9 +1503,7 @@ describe("nested component_action sections (#1543)", () => {
         set_action:
           - logger.log: changed
 `;
-    const items = parseYamlAutomations(yaml).filter((s) =>
-      s.key.startsWith("automation:component_action:")
-    );
+    const items = componentActionItems(yaml);
     expect(items.map((s) => s.actionField)).toEqual([
       "valves.run_duration_number.set_action",
     ]);
@@ -1535,9 +1530,7 @@ cover:
           then:
             - switch.turn_on: relay
 `;
-    const items = parseYamlAutomations(yaml).filter((s) =>
-      s.key.startsWith("automation:component_action:")
-    );
+    const items = componentActionItems(yaml);
     // Only the real top-level field; nothing from inside bodies.
     expect(items.map((s) => s.actionField)).toEqual(["open_action"]);
   });

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -1571,6 +1571,32 @@ describe("nested component_action sections (#1543)", () => {
     ]);
   });
 
+  it("ignores a block scalar opened inline on the instance dash line", () => {
+    const yaml = `sprinkler:
+  - notes: |
+      set_action:
+        - not a real field
+    id: lawn
+    repeat_number:
+      set_action:
+        - logger.log: real
+`;
+    expect(componentActionItems(yaml).map((s) => s.actionField)).toEqual([
+      "repeat_number.set_action",
+    ]);
+  });
+
+  it("refuses a container key containing a dot", () => {
+    // ``a.b:`` would make the dotted field encoding lossy.
+    const yaml = `sprinkler:
+  - id: lawn
+    weird.container:
+      set_action:
+        - logger.log: changed
+`;
+    expect(componentActionItems(yaml)).toEqual([]);
+  });
+
   it("uses an index-free path when the list is written as one mapping", () => {
     const yaml = `sprinkler:
   - id: lawn

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -1543,6 +1543,34 @@ describe("nested component_action sections (#1543)", () => {
     expect(componentActionItems(yaml)).toEqual([]);
   });
 
+  it("drops an orphaned index when a mid-path container key is unnameable", () => {
+    const yaml = `sprinkler:
+  - id: lawn
+    valves:
+      - "zones":
+          - run_duration_number:
+              set_action:
+                - logger.log: changed
+`;
+    expect(componentActionItems(yaml)).toEqual([]);
+  });
+
+  it("ignores *_action-shaped text inside a block scalar", () => {
+    const yaml = `sprinkler:
+  - id: lawn
+    main_switch: Lawn
+    notes: |
+      set_action:
+        - not a real field
+    repeat_number:
+      set_action:
+        - logger.log: real
+`;
+    expect(componentActionItems(yaml).map((s) => s.actionField)).toEqual([
+      "repeat_number.set_action",
+    ]);
+  });
+
   it("uses an index-free path when the list is written as one mapping", () => {
     const yaml = `sprinkler:
   - id: lawn


### PR DESCRIPTION
# What does this implement/fix?

The fallback YAML parser's `component_action` pass was gated to direct children of a component instance, so a nested action field (sprinkler's `repeat_number.set_action`, a per valve `run_duration_number.set_action`) produced no section: no navigator row, and a caret inside its body routed to the enclosing component section instead of the automation editor, even though #1539's routing and labels already speak the dotted encoding.

The depth gate is replaced by a path reconstruction: when the line scan hits a `*_action:` key inside an instance, a frame stack walk over the instance body rebuilds the concrete path, mapping keys by indent and list items as counted dash indices, and the section is keyed on the backend's dotted `component_action` encoding (`automation:component_action:lawn:valves.1.run_duration_number.set_action`). A field inside a trigger or automation body (an `on_*`, another `*_action`, or a `then` family ancestor) is excluded, which preserves the old exclusions by meaning rather than by depth; direct children keep byte identical keys, so pinned selections survive. `sectionAtLine`'s smallest span rule then routes carets to the new sections with no changes, the navigator labels them through the dotted aware `actionFieldLabel` ("Valves #2 → Run duration number → Set action"), and edit and delete round trip through the merged backend support (esphome/device-builder#2433).

Verified against the live dashboard with a two valve sprinkler: both nested fields list in the Automations navigator with container chain labels, clicking valve #2's row opens the automation editor with that valve's actions hydrated and the YAML pane highlighting exactly its `set_action:` block, and the flat cover fields and `on_press` rows are unchanged.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1543

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
