### PR TITLE
Surface the backend's package-resolution warning after adopt

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1084,14 +1084,16 @@ export class ESPHomeAPI {
     });
   }
 
-  /** Import/adopt a discovered device. */
+  /** Import/adopt a discovered device. `warning` is set when the YAML
+   *  was kept despite a validation failure confined to remote package
+   *  resolution (a stale factory-broadcast URL). */
   async importDevice(args: {
     name: string;
     project_name?: string;
     package_import_url?: string;
     friendly_name?: string;
     encryption?: string;
-  }): Promise<{ configuration: string }> {
+  }): Promise<{ configuration: string; warning?: string }> {
     return this.sendCommand("devices/import", args);
   }
 

--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -560,7 +560,14 @@ export class ESPHomeAdoptDialog extends LitElement {
       this.close();
       // The import succeeded but the device's remote package didn't
       // resolve; the backend kept the file for an in-editor repair.
-      if (warning) notifyWarning(warning);
+      // Long duration: the adopt-with-rename path opens the follow-job
+      // dialog right away, and this toast is the only repair signal.
+      if (warning) {
+        notifyWarning(this._localize("dashboard.adopt_package_warning"), {
+          description: warning,
+          duration: 8000,
+        });
+      }
       const detail: AdoptedDetail = {
         name: factoryName,
         configuration,

--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -556,11 +556,11 @@ export class ESPHomeAdoptDialog extends LitElement {
       // ``performRename``), so an adopt-with-rename skips the welcome
       // banner — the follow-job dialog already has the user engaged.
       const { configuration, warning } = await this._api.importDevice(args);
+      markJustCreated(configuration);
+      this.close();
       // The import succeeded but the device's remote package didn't
       // resolve; the backend kept the file for an in-editor repair.
       if (warning) notifyWarning(warning);
-      markJustCreated(configuration);
-      this.close();
       const detail: AdoptedDetail = {
         name: factoryName,
         configuration,

--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -19,6 +19,7 @@ import { EnterController } from "../util/enter-controller.js";
 import { fireEvent } from "../util/fire-event.js";
 import { formatApiError } from "../util/format-api-error.js";
 import { markJustCreated } from "../util/just-created.js";
+import { notifyWarning } from "../util/notify.js";
 import { previewPackageImportUrl } from "../util/package-import-url.js";
 import { fetchSecretKeys, hasSharedWifiSecret } from "../util/secrets-cache.js";
 import { wifiFieldsStyles } from "./onboarding/wifi-fields-styles.js";
@@ -554,7 +555,10 @@ export class ESPHomeAdoptDialog extends LitElement {
       // drops the just-created flag (``clearJustCreated`` in
       // ``performRename``), so an adopt-with-rename skips the welcome
       // banner — the follow-job dialog already has the user engaged.
-      const { configuration } = await this._api.importDevice(args);
+      const { configuration, warning } = await this._api.importDevice(args);
+      // The import succeeded but the device's remote package didn't
+      // resolve; the backend kept the file for an in-editor repair.
+      if (warning) notifyWarning(warning);
       markJustCreated(configuration);
       this.close();
       const detail: AdoptedDetail = {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -26,6 +26,7 @@
     "adopt_submit": "Take control",
     "adopt_submit_busy": "Taking control…",
     "adopt_error_generic": "Failed to take control of this device",
+    "adopt_package_warning": "Adopted, but its remote package needs a repair in the editor",
     "add_new_device": "Add new device",
     "add_new_device_hint": "Create a new ESPHome configuration",
     "esphome_web": "ESPHome web",

--- a/test/components/adopt-dialog.test.ts
+++ b/test/components/adopt-dialog.test.ts
@@ -8,6 +8,10 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("../../src/util/notify.js", () => ({
+  notifyWarning: vi.fn(),
+}));
+
 import "../_mock-webawesome.js";
 
 import type { AdoptableDevice } from "../../src/api/types/devices.js";
@@ -105,6 +109,27 @@ describe("adopt-then-rename (#2412)", () => {
       friendlyName: "Foo",
       renameTo: "kitchen",
     });
+  });
+
+  it("surfaces the backend's package-resolution warning and still adopts", async () => {
+    const { notifyWarning } = await import("../../src/util/notify.js");
+    vi.mocked(notifyWarning).mockClear();
+    const { priv, importDevice } = await makeDialog([]);
+    importDevice.mockResolvedValue({
+      configuration: "foo-1234.yaml",
+      warning: "Imported, but the remote package didn't resolve",
+    });
+    const adopted = vi.fn();
+    (priv as EventTarget).addEventListener("adopted", adopted);
+    await openSettled(priv, ethernetDevice());
+
+    await priv._submit();
+
+    expect(notifyWarning).toHaveBeenCalledWith(
+      "Imported, but the remote package didn't resolve"
+    );
+    expect(adopted).toHaveBeenCalledTimes(1);
+    expect(priv._error).toBeNull();
   });
 
   it("requests no rename when the name is unedited", async () => {

--- a/test/components/adopt-dialog.test.ts
+++ b/test/components/adopt-dialog.test.ts
@@ -125,9 +125,10 @@ describe("adopt-then-rename (#2412)", () => {
 
     await priv._submit();
 
-    expect(notifyWarning).toHaveBeenCalledWith(
-      "Imported, but the remote package didn't resolve"
-    );
+    expect(notifyWarning).toHaveBeenCalledWith("dashboard.adopt_package_warning", {
+      description: "Imported, but the remote package didn't resolve",
+      duration: 8000,
+    });
     expect(adopted).toHaveBeenCalledTimes(1);
     expect(priv._error).toBeNull();
   });


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#2442. When a device's factory broadcast `package_import_url` no longer resolves (the GL-S10 case), the backend now keeps the adoption YAML and returns `devices/import` with a `warning` instead of refusing. This surfaces that warning as a toast after the dialog closes, so the user knows to repair the `packages:` path in the editor; the adopt flow itself proceeds unchanged.

**Related issue or feature (if applicable):**

- related to esphome/device-builder#2424

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
