### PR TITLE
Expand maybe_simple_value shorthands at section load

### DIFF
--- a/src/api/types/config-entries.ts
+++ b/src/api/types/config-entries.ts
@@ -132,6 +132,14 @@ export interface ConfigEntry {
   unit_options: string[] | null;
   /** When True the field accepts a list of values. */
   multi_value: boolean;
+  /**
+   * For NESTED entries validated by esphome's `maybe_simple_value`: the
+   * child key a bare scalar value expands into
+   * (`microphone: mic_id` == `microphone: {microphone: mic_id}`).
+   * With `multi_value` each list item may also be a bare scalar. Null
+   * (or absent) = no scalar shorthand.
+   */
+  maybe_key?: string | null;
   /** When True accepts either a literal value OR a !lambda block. */
   templatable: boolean;
   /**

--- a/src/components/device/device-section-config/loading.ts
+++ b/src/components/device/device-section-config/loading.ts
@@ -1,6 +1,7 @@
 import type { ConfigEntry, RequiredGroup } from "../../../api/types/config-entries.js";
 import { fetchComponent } from "../../../util/component-name-cache.js";
 import { normalizeHexValues } from "../../../util/hex-int.js";
+import { normalizeMaybeValues } from "../../../util/maybe-values.js";
 import { loadCatalog } from "../../../util/yaml-completion-catalog.js";
 import { platformDomains } from "../../../util/yaml-completion-items.js";
 import { parseYamlSectionValues } from "../../../util/yaml-section-reader.js";
@@ -94,7 +95,14 @@ export async function loadConfig(host: ESPHomeDeviceSectionConfig): Promise<void
     // save preserves the user's hex notation even when they only edited
     // an unrelated field. Without this, i2c addresses round-trip from
     // 0x76 to 118 on the next save.
-    host._values = normalizeHexValues(parsedValues, host._config.entries);
+    // Expand maybe_simple_value shorthands (a bare `microphone: mic_id`)
+    // into the canonical mapping/list shape the renderers and dotted-path
+    // edits address; left as a scalar it renders as an empty list and the
+    // first edit clobbers it (#2397).
+    host._values = normalizeMaybeValues(
+      normalizeHexValues(parsedValues, host._config.entries),
+      host._config.entries
+    );
     host._resolvedFromLine = resolvedFromLine;
     host._presentComponents = parseTopLevelComponents(yaml);
   } catch (e) {

--- a/src/util/config-entry-defaults.ts
+++ b/src/util/config-entry-defaults.ts
@@ -36,6 +36,7 @@ export function makeConfigEntry(overrides: Partial<ConfigEntry> = {}): ConfigEnt
     unit_options: null,
     help_link: null,
     multi_value: false,
+    maybe_key: null,
     hidden: false,
     advanced: false,
     translation_key: null,

--- a/src/util/maybe-values.ts
+++ b/src/util/maybe-values.ts
@@ -5,10 +5,13 @@
  * multi_value a non-list value stands for a one-item list whose items may
  * themselves be bare scalars. Run once at section load so the stored
  * form state always holds the canonical mapping/list shape - the
- * renderers, dotted-path reads, and edits all address that shape, and a
- * scalar left in place would render as an empty list and be clobbered by
- * the first edit. The YAML keeps its shorthand until the section is next
- * written (canonicalize-on-edit, same policy as legacy key respelling).
+ * renderers, dotted-path reads, and edits all address that shape. A
+ * scalar left in place at a multi_value entry would render as an empty
+ * list and be clobbered by the first edit; at a single nested entry it
+ * would fall to the read-only value-set-in-YAML notice instead of
+ * populating the group. The YAML keeps its shorthand until the section
+ * is next written (canonicalize-on-edit, same policy as legacy key
+ * respelling).
  */
 import type { ConfigEntry } from "../api/types/config-entries.js";
 import { ConfigEntryType } from "../api/types/config-entries.js";

--- a/src/util/maybe-values.ts
+++ b/src/util/maybe-values.ts
@@ -1,0 +1,112 @@
+/**
+ * Expansion of esphome's 'maybe_simple_value' shorthand in parsed
+ * section values, driven by the catalog's ConfigEntry.maybe_key: a bare
+ * scalar at a NESTED entry stands for '{[maybe_key]: scalar}', and with
+ * multi_value a non-list value stands for a one-item list whose items may
+ * themselves be bare scalars. Run once at section load so the stored
+ * form state always holds the canonical mapping/list shape - the
+ * renderers, dotted-path reads, and edits all address that shape, and a
+ * scalar left in place would render as an empty list and be clobbered by
+ * the first edit. The YAML keeps its shorthand until the section is next
+ * written (canonicalize-on-edit, same policy as legacy key respelling).
+ */
+import type { ConfigEntry } from "../api/types/config-entries.js";
+import { ConfigEntryType } from "../api/types/config-entries.js";
+import { isPlainObject } from "./nested-values.js";
+
+/**
+ * Expand maybe_simple_value shorthands in *values* against *entries*.
+ *
+ * Returns the input identity-equal when nothing needed expanding;
+ * otherwise a fresh clone preserving the input's prototype (the section
+ * parser hands back null-prototype maps as a __proto__ defence, and a
+ * plain spread would silently re-open that).
+ */
+export function normalizeMaybeValues(
+  values: Record<string, unknown>,
+  entries: ConfigEntry[]
+): Record<string, unknown> {
+  const [changed, next] = normalizeChildren(values, entries);
+  return changed ? (next as Record<string, unknown>) : values;
+}
+
+/** A YAML scalar the shorthand applies to; excludes mappings, lists, and
+ *  parser wrappers like YamlRawValue (object-typed, passed through). */
+function isScalarValue(value: unknown): boolean {
+  const t = typeof value;
+  return t === "string" || t === "number" || t === "boolean" || t === "bigint";
+}
+
+/** A parsed YAML mapping. Stricter than isPlainObject: class instances
+ *  (YamlRawValue and friends) must pass through untouched, or the
+ *  renderers' raw-block bail-outs stop seeing them. */
+function isMappingValue(value: unknown): value is Record<string, unknown> {
+  if (!isPlainObject(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function cloneContainer(source: Record<string, unknown>): Record<string, unknown> {
+  return Object.create(
+    Object.getPrototypeOf(source),
+    Object.getOwnPropertyDescriptors(source)
+  );
+}
+
+function normalizeChildren(
+  container: Record<string, unknown>,
+  entries: ConfigEntry[]
+): [boolean, unknown] {
+  let out: Record<string, unknown> | null = null;
+  for (const entry of entries) {
+    if (entry.type !== ConfigEntryType.NESTED) continue;
+    const value = container[entry.key];
+    if (value === undefined || value === null) continue;
+    const [changed, next] = normalizeEntryValue(entry, value);
+    if (!changed) continue;
+    out ??= cloneContainer(container);
+    out[entry.key] = next;
+  }
+  return out ? [true, out] : [false, container];
+}
+
+function normalizeEntryValue(entry: ConfigEntry, value: unknown): [boolean, unknown] {
+  const maybeKey = entry.maybe_key ?? null;
+  const children = entry.config_entries ?? [];
+  if (!entry.multi_value) {
+    return normalizeItem(value, maybeKey, children);
+  }
+  if (Array.isArray(value)) {
+    let items: unknown[] | null = null;
+    value.forEach((item, i) => {
+      const [changed, next] = normalizeItem(item, maybeKey, children);
+      if (!changed) return;
+      items ??= [...value];
+      items[i] = next;
+    });
+    return items ? [true, items] : [false, value];
+  }
+  // A non-list value at a multi_value maybe entry is ensure_list's
+  // single-item shorthand: a bare scalar or a bare mapping.
+  if (maybeKey && (isScalarValue(value) || isMappingValue(value))) {
+    const [, item] = normalizeItem(value, maybeKey, children);
+    return [true, [item]];
+  }
+  return [false, value];
+}
+
+function normalizeItem(
+  item: unknown,
+  maybeKey: string | null,
+  children: ConfigEntry[]
+): [boolean, unknown] {
+  if (maybeKey && isScalarValue(item)) {
+    return [true, { [maybeKey]: item }];
+  }
+  if (isMappingValue(item)) {
+    // Descend regardless of maybeKey: a shorthand can sit on a nested
+    // descendant (sprinkler's valves[].valve_switch).
+    return normalizeChildren(item, children);
+  }
+  return [false, item];
+}

--- a/test/components/device/render-nested-list-field.test.ts
+++ b/test/components/device/render-nested-list-field.test.ts
@@ -27,6 +27,7 @@ import type { RenderCtx } from "../../../src/components/device/config-entry-rend
 import { renderNestedListField } from "../../../src/components/device/config-entry-renderers.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
 import { YamlRawValue } from "../../../src/util/yaml-serialize.js";
+import { normalizeMaybeValues } from "../../../src/util/maybe-values.js";
 import { makeRenderCtx } from "./_renderer-fixtures.js";
 
 function makeListEntry(): ConfigEntry {
@@ -208,5 +209,29 @@ describe("renderNestedListField", () => {
     // No Add / Remove translation keys — those buttons aren't rendered.
     expect(json).not.toContain("device.multi_value_add");
     expect(json).not.toContain("device.multi_value_remove");
+  });
+
+  it("renders a load-normalized maybe_simple_value scalar as a populated row (#2397)", () => {
+    // The end-to-end shape for ``voice_assistant: {microphone: mic_id}``:
+    // normalizeMaybeValues expands the scalar at section load, and the
+    // renderer sees the canonical one-item list — not the empty hint.
+    const entry = makeConfigEntry({
+      key: "microphone",
+      type: ConfigEntryType.NESTED,
+      multi_value: true,
+      maybe_key: "microphone",
+      config_entries: [
+        makeConfigEntry({ key: "microphone", type: ConfigEntryType.ID }),
+        makeConfigEntry({ key: "gain_factor", type: ConfigEntryType.INTEGER }),
+      ],
+    });
+    const values = normalizeMaybeValues({ microphone: "onju_microphone" }, [entry]);
+    const { ctx, renderEntry } = makeCtx(values);
+    const tpl = renderNestedListField(entry, ["microphone"], ctx);
+    const paths = renderEntry.mock.calls.map((c) => c[1] as string[]);
+    expect(paths).toContainEqual(["microphone", "0", "microphone"]);
+    expect(ctx.getAt(["microphone", "0", "microphone"])).toBe("onju_microphone");
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(json).not.toContain("device.multi_value_empty");
   });
 });

--- a/test/util/maybe-values.test.ts
+++ b/test/util/maybe-values.test.ts
@@ -1,0 +1,119 @@
+/**
+ * normalizeMaybeValues expands esphome's maybe_simple_value shorthand
+ * against ConfigEntry.maybe_key at section load (#2397): a bare scalar
+ * at a NESTED entry becomes the keyed mapping, and with multi_value a
+ * non-list value becomes a one-item list. Everything else must pass
+ * through identity-equal.
+ */
+import { describe, expect, it } from "vitest";
+
+import { ConfigEntryType } from "../../src/api/types/config-entries.js";
+import { makeConfigEntry } from "../../src/util/config-entry-defaults.js";
+import { normalizeMaybeValues } from "../../src/util/maybe-values.js";
+
+const microphoneEntry = (overrides: Record<string, unknown> = {}) =>
+  makeConfigEntry({
+    key: "microphone",
+    type: ConfigEntryType.NESTED,
+    multi_value: true,
+    maybe_key: "microphone",
+    config_entries: [
+      makeConfigEntry({ key: "microphone", type: ConfigEntryType.ID }),
+      makeConfigEntry({ key: "gain_factor", type: ConfigEntryType.INTEGER }),
+    ],
+    ...overrides,
+  });
+
+describe("normalizeMaybeValues", () => {
+  it("expands a bare scalar at a multi_value maybe entry into a one-item list", () => {
+    const out = normalizeMaybeValues({ microphone: "onju_microphone" }, [
+      microphoneEntry(),
+    ]);
+    expect(out.microphone).toEqual([{ microphone: "onju_microphone" }]);
+  });
+
+  it("expands bare scalars inside an existing list", () => {
+    const out = normalizeMaybeValues({ microphone: ["mic_a", { microphone: "mic_b" }] }, [
+      microphoneEntry(),
+    ]);
+    expect(out.microphone).toEqual([{ microphone: "mic_a" }, { microphone: "mic_b" }]);
+  });
+
+  it("wraps a bare mapping at a multi_value maybe entry", () => {
+    const out = normalizeMaybeValues(
+      { microphone: { microphone: "mic_a", gain_factor: 2 } },
+      [microphoneEntry()]
+    );
+    expect(out.microphone).toEqual([{ microphone: "mic_a", gain_factor: 2 }]);
+  });
+
+  it("expands a bare scalar at a single nested maybe entry into the keyed mapping", () => {
+    const entry = microphoneEntry({ multi_value: false });
+    const out = normalizeMaybeValues({ microphone: "mww_microphone" }, [entry]);
+    expect(out.microphone).toEqual({ microphone: "mww_microphone" });
+  });
+
+  it("expands a shorthand on a nested descendant (the sprinkler valves shape)", () => {
+    const valves = makeConfigEntry({
+      key: "valves",
+      type: ConfigEntryType.NESTED,
+      multi_value: true,
+      config_entries: [
+        makeConfigEntry({
+          key: "valve_switch",
+          type: ConfigEntryType.NESTED,
+          maybe_key: "name",
+          config_entries: [
+            makeConfigEntry({ key: "name", type: ConfigEntryType.STRING }),
+          ],
+        }),
+      ],
+    });
+    const out = normalizeMaybeValues({ valves: [{ valve_switch: "Front Lawn" }] }, [
+      valves,
+    ]);
+    expect(out.valves).toEqual([{ valve_switch: { name: "Front Lawn" } }]);
+  });
+
+  it("returns the input identity-equal when nothing needs expanding", () => {
+    const canonical = { microphone: [{ microphone: "mic_a" }], name: "va" };
+    expect(normalizeMaybeValues(canonical, [microphoneEntry()])).toBe(canonical);
+  });
+
+  it("leaves a scalar at a multi_value entry without maybe_key untouched", () => {
+    const values = { microphone: "onju_microphone" };
+    const entry = microphoneEntry({ maybe_key: null });
+    expect(normalizeMaybeValues(values, [entry])).toBe(values);
+  });
+
+  it("passes non-plain objects (parser wrappers) through untouched", () => {
+    class RawBlock {}
+    const raw = new RawBlock();
+    const values = { microphone: raw };
+    expect(normalizeMaybeValues(values, [microphoneEntry()])).toBe(values);
+  });
+
+  it("passes a parser wrapper inside a list through untouched", () => {
+    class RawBlock {}
+    const values = { microphone: [new RawBlock()] };
+    expect(normalizeMaybeValues(values, [microphoneEntry()])).toBe(values);
+  });
+
+  it("preserves a null prototype on the cloned container", () => {
+    const values = Object.create(null) as Record<string, unknown>;
+    values.microphone = "onju_microphone";
+    const out = normalizeMaybeValues(values, [microphoneEntry()]);
+    expect(out).not.toBe(values);
+    expect(Object.getPrototypeOf(out)).toBeNull();
+    expect(out.microphone).toEqual([{ microphone: "onju_microphone" }]);
+  });
+
+  it("does not mutate the input container or list", () => {
+    const list = ["mic_a"];
+    const values = { microphone: list };
+    const out = normalizeMaybeValues(values, [microphoneEntry()]);
+    expect(values.microphone).toBe(list);
+    expect(list).toEqual(["mic_a"]);
+    expect(out.microphone).toEqual([{ microphone: "mic_a" }]);
+  });
+});

--- a/test/util/maybe-values.test.ts
+++ b/test/util/maybe-values.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 import { ConfigEntryType } from "../../src/api/types/config-entries.js";
 import { makeConfigEntry } from "../../src/util/config-entry-defaults.js";
 import { normalizeMaybeValues } from "../../src/util/maybe-values.js";
+import { YamlRawValue } from "../../src/util/yaml-serialize.js";
 
 const microphoneEntry = (overrides: Record<string, unknown> = {}) =>
   makeConfigEntry({
@@ -86,16 +87,16 @@ describe("normalizeMaybeValues", () => {
     expect(normalizeMaybeValues(values, [entry])).toBe(values);
   });
 
-  it("passes non-plain objects (parser wrappers) through untouched", () => {
-    class RawBlock {}
-    const raw = new RawBlock();
-    const values = { microphone: raw };
+  it("passes YamlRawValue through untouched", () => {
+    // The renderers' raw-block bail-outs are literal instanceof checks;
+    // wrapping the instance would stop them firing and clobber the
+    // user's preserved YAML on the next save.
+    const values = { microphone: new YamlRawValue(["    - dotted.key: 1"]) };
     expect(normalizeMaybeValues(values, [microphoneEntry()])).toBe(values);
   });
 
-  it("passes a parser wrapper inside a list through untouched", () => {
-    class RawBlock {}
-    const values = { microphone: [new RawBlock()] };
+  it("passes a YamlRawValue inside a list through untouched", () => {
+    const values = { microphone: [new YamlRawValue(["    - dotted.key: 1"])] };
     expect(normalizeMaybeValues(values, [microphoneEntry()])).toBe(values);
   });
 


### PR DESCRIPTION
# What does this implement/fix?

Frontend half of esphome/device-builder#2397. esphome accepts `voice_assistant.microphone` as either a bare id or a list of source mappings (`cv.ensure_list(cv.maybe_simple_value(..., key="microphone"))`), but the structured editor rendered the field list-only: for `microphone: onju_microphone` it showed "No items yet — click + to add one", and clicking Add would have replaced the scalar with `[{}]`.

The backend companion PR (esphome/device-builder#2443) carries the schema's shorthand marker through the catalog as `ConfigEntry.maybe_key` (the child key a bare scalar expands into; with `multi_value`, list items may also be bare scalars). This PR consumes it: a new `normalizeMaybeValues` pass runs once at section load, next to the existing hex normalization, expanding shorthands into the canonical mapping/list shape the renderers, dotted-path reads, and edits all address. Expanding at load (rather than per-renderer) is load-bearing: child fields read and write through `ctx.getAt`/`emitChange` against the stored values, so a display-only coercion would leave the child inputs blank and the first edit would clobber the scalar.

The walk descends nested entries so shorthands on descendants (sprinkler's `valves[].valve_switch: "Name"`) expand too, keeps identity when nothing changes, preserves the parser's null-prototype defence when cloning, and passes parser wrappers (`YamlRawValue`) through untouched so the raw-block bail-outs keep seeing them. The YAML keeps its shorthand until the section is next written; a section edit canonicalizes to the equivalent block-list form (same canonicalize-on-edit policy as legacy key respelling).

Verified live against a dev backend running the companion branch: `microphone: onju_microphone` renders as a populated "Microphone 1" group; the untouched YAML keeps the scalar; editing a sibling field and saving writes `microphone:` / `- microphone: onju_microphone`, which `esphome config` validates.

Scope note: the automation editor feeds catalog entries into the same form without this normalization, so maybe_simple_value shorthands in action/trigger params keep the old behavior there; that surface is a follow-up.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2397
- companion backend PR: esphome/device-builder#2443

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

