### PR TITLE
Prefill the entity name from the catalog title in the add-component dialog

### DIFF
--- a/src/components/device/add-component-form-seed.ts
+++ b/src/components/device/add-component-form-seed.ts
@@ -12,10 +12,7 @@ import {
   collectExistingIds,
   generateDefaultComponentId,
 } from "../../util/default-component-id.js";
-import {
-  collectExistingNames,
-  suggestEntityName,
-} from "../../util/default-entity-name.js";
+import { suggestEntityName } from "../../util/default-entity-name.js";
 import { resolveEntryLabel } from "../../util/entry-label.js";
 import { isFeaturedId } from "../../util/featured-id.js";
 import { getIn, setIn } from "../../util/nested-values.js";
@@ -205,13 +202,7 @@ export function buildInitialValues(ctx: SeedContext): Record<string, unknown> {
     (e) => e.key === "name" && e.type === ConfigEntryType.STRING
   );
   if (nameEntry && next["name"] === undefined) {
-    // Names collide per platform (unlike globally-unique ids), so the
-    // pool is scoped to the component's own top-level section.
-    const seededName = suggestEntityName(
-      component.id,
-      component.name,
-      collectExistingNames(yaml, component.id.split(".", 1)[0])
-    );
+    const seededName = suggestEntityName(component.id, component.name, yaml);
     if (seededName !== null) next = { ...next, name: seededName };
   }
 

--- a/src/components/device/add-component-form-seed.ts
+++ b/src/components/device/add-component-form-seed.ts
@@ -205,10 +205,12 @@ export function buildInitialValues(ctx: SeedContext): Record<string, unknown> {
     (e) => e.key === "name" && e.type === ConfigEntryType.STRING
   );
   if (nameEntry && next["name"] === undefined) {
+    // Names collide per platform (unlike globally-unique ids), so the
+    // pool is scoped to the component's own top-level section.
     const seededName = suggestEntityName(
       component.id,
       component.name,
-      collectExistingNames(yaml)
+      collectExistingNames(yaml, component.id.split(".", 1)[0])
     );
     if (seededName !== null) next = { ...next, name: seededName };
   }

--- a/src/components/device/add-component-form-seed.ts
+++ b/src/components/device/add-component-form-seed.ts
@@ -12,6 +12,10 @@ import {
   collectExistingIds,
   generateDefaultComponentId,
 } from "../../util/default-component-id.js";
+import {
+  collectExistingNames,
+  suggestEntityName,
+} from "../../util/default-entity-name.js";
 import { resolveEntryLabel } from "../../util/entry-label.js";
 import { isFeaturedId } from "../../util/featured-id.js";
 import { getIn, setIn } from "../../util/nested-values.js";
@@ -155,12 +159,13 @@ export function seedDefaults(
  * Build the initial form `_values` for the current component:
  *  1. Seed required entries' default values (recursively).
  *  2. Auto-generate a unique `id` for the top-level id field.
- *  3. Seed pin entries from the board manifest.
- *  4. Restore the values the user typed before a "+ Add <dep>" detour
+ *  3. Suggest an entity name for platform components.
+ *  4. Seed pin entries from the board manifest.
+ *  5. Restore the values the user typed before a "+ Add <dep>" detour
  *     (over the seeded defaults, under the prefills below).
- *  5. If we were just brought back from a "+ Add <domain>" detour,
+ *  6. If we were just brought back from a "+ Add <domain>" detour,
  *     prefill the field that points at that domain with the new id.
- *  6. Overlay constraint-derived prefill fields last.
+ *  7. Overlay constraint-derived prefill fields last.
  */
 export function buildInitialValues(ctx: SeedContext): Record<string, unknown> {
   const {
@@ -194,6 +199,18 @@ export function buildInitialValues(ctx: SeedContext): Record<string, unknown> {
       collectExistingIds(yaml)
     );
     if (seeded !== null) next = { ...next, id: seeded };
+  }
+
+  const nameEntry = entries.find(
+    (e) => e.key === "name" && e.type === ConfigEntryType.STRING
+  );
+  if (nameEntry && next["name"] === undefined) {
+    const seededName = suggestEntityName(
+      component.id,
+      component.name,
+      collectExistingNames(yaml)
+    );
+    if (seededName !== null) next = { ...next, name: seededName };
   }
 
   // Seed pin entries from the board's manifest when the board has

--- a/src/util/default-component-id.ts
+++ b/src/util/default-component-id.ts
@@ -1,5 +1,5 @@
-import { isFeaturedId } from "./featured-id.js";
-import { readInstanceScalar } from "./yaml-sections-core.js";
+import { isPlatformComponentId } from "./featured-id.js";
+import { collectInstanceScalars } from "./yaml-sections-core.js";
 
 /**
  * Auto-generate a default `id:` value for a component being added
@@ -30,12 +30,10 @@ export function generateDefaultComponentId(
   multiConf: boolean,
   existing: ReadonlySet<string>
 ): string | null {
-  // A featured id (`featured.<board>.<local>`) carries dots but wraps one
-  // underlying component, so judge singleton-ness by `multiConf` alone —
-  // the dotted form would otherwise always read as a platform entry and a
+  // A featured wrap judges singleton-ness by `multiConf` alone — the dotted
+  // form would otherwise always read as a platform entry and a
   // single-instance wrap (ethernet, wifi) would wrongly get an id.
-  const looksPlatform = isFeaturedId(componentId) ? false : componentId.includes(".");
-  const isSingleton = !multiConf && !looksPlatform;
+  const isSingleton = !multiConf && !isPlatformComponentId(componentId);
   if (isSingleton) return null;
 
   // Normalise to a valid ESPHome id ([a-zA-Z_][a-zA-Z0-9_]*): a featured
@@ -50,20 +48,7 @@ export function generateDefaultComponentId(
   return candidate;
 }
 
-/**
- * Scan the YAML for every `id:` line and return the set of values.
- * Best-effort line scan via the shared `readInstanceScalar`, deliberately
- * simple (we only need a uniqueness check, not a full parse).
- */
+/** Scan the YAML for every `id:` line and return the set of values. */
 export function collectExistingIds(yaml: string): Set<string> {
-  const ids = new Set<string>();
-  if (!yaml) return ids;
-  for (const line of yaml.split("\n")) {
-    // A real component id is always indented under a block; `readInstanceScalar`
-    // leaves indent-gating to callers, so skip a column-0 `id:`.
-    if (!/^\s/.test(line)) continue;
-    const id = readInstanceScalar(line, "id");
-    if (id !== null) ids.add(id);
-  }
-  return ids;
+  return collectInstanceScalars(yaml, "id");
 }

--- a/src/util/default-entity-name.ts
+++ b/src/util/default-entity-name.ts
@@ -1,3 +1,4 @@
+import { parseCatalogId } from "./config-entry-yaml-scan.js";
 import { isPlatformComponentId } from "./featured-id.js";
 import { collectInstanceScalars } from "./yaml-sections-core.js";
 
@@ -33,12 +34,15 @@ function nameKey(name: string): string {
 export function suggestEntityName(
   componentId: string,
   componentTitle: string,
-  existingNames: ReadonlySet<string>
+  yaml: string
 ): string | null {
   if (!isPlatformComponentId(componentId)) return null;
   const title = componentTitle.trim();
   if (!title) return null;
 
+  // Names collide per platform (unlike globally-unique ids), so the
+  // pool is scoped to the component's own top-level section.
+  const existingNames = collectExistingNames(yaml, parseCatalogId(componentId).domain);
   const taken = new Set<string>();
   for (const name of existingNames) {
     const key = nameKey(name);

--- a/src/util/default-entity-name.ts
+++ b/src/util/default-entity-name.ts
@@ -1,5 +1,5 @@
-import { isFeaturedId } from "./featured-id.js";
-import { readInstanceScalar } from "./yaml-sections-core.js";
+import { isPlatformComponentId } from "./featured-id.js";
+import { collectInstanceScalars } from "./yaml-sections-core.js";
 
 /**
  * Collision key mirroring esphome's str_sanitize(str_snake_case(name)),
@@ -35,8 +35,7 @@ export function suggestEntityName(
   componentTitle: string,
   existingNames: ReadonlySet<string>
 ): string | null {
-  const looksPlatform = isFeaturedId(componentId) ? false : componentId.includes(".");
-  if (!looksPlatform) return null;
+  if (!isPlatformComponentId(componentId)) return null;
   const title = componentTitle.trim();
   if (!title) return null;
 
@@ -56,19 +55,15 @@ export function suggestEntityName(
 }
 
 /**
- * Scan the YAML for every 'name:' line and return the set of values.
- * Deliberately over-collects (the device name under 'esphome:',
- * automation names, every platform's entities); esphome scopes the
- * duplicate check per platform, so the only cost of a false hit is an
- * unneeded numeric suffix, never a missed collision.
+ * Scan the YAML for every 'name:' line under the *domain* top-level
+ * section, matching the scope of esphome's per-platform duplicate
+ * check. Still over-collects within the section (nested sub-entity
+ * names, sub-device duplicates esphome would allow); the cost of a
+ * false hit is an unneeded numeric suffix. The scan is line-based: a
+ * name behind a block scalar or inside a packages/!include file is
+ * invisible and can still collide; the user can still edit the seeded
+ * value before submitting.
  */
-export function collectExistingNames(yaml: string): Set<string> {
-  const names = new Set<string>();
-  if (!yaml) return names;
-  for (const line of yaml.split("\n")) {
-    if (!/^\s/.test(line)) continue;
-    const name = readInstanceScalar(line, "name");
-    if (name !== null) names.add(name);
-  }
-  return names;
+export function collectExistingNames(yaml: string, domain: string): Set<string> {
+  return collectInstanceScalars(yaml, "name", domain);
 }

--- a/src/util/default-entity-name.ts
+++ b/src/util/default-entity-name.ts
@@ -1,0 +1,74 @@
+import { isFeaturedId } from "./featured-id.js";
+import { readInstanceScalar } from "./yaml-sections-core.js";
+
+/**
+ * Collision key mirroring esphome's str_sanitize(str_snake_case(name)),
+ * the exact normalization its duplicate-entity-name validator compares
+ * with (core/entity_helpers.py): spaces to underscores, lowercase, then
+ * every char outside [a-z0-9-_] to underscore.
+ */
+function nameKey(name: string): string {
+  return name
+    .replace(/ /g, "_")
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, "_");
+}
+
+/**
+ * Suggest a default 'name:' for a component being added via the
+ * catalog: the catalog title, suffixed with a counter when the title
+ * already names an entity in the YAML. Used by
+ * 'esphome-add-component-form' to seed the name field; the user can
+ * edit it (or clear it) before submitting.
+ *
+ * Only platform entries (id contains '.', e.g. 'switch.gpio') are
+ * seeded: they are entity platforms, where 'name' becomes the Home
+ * Assistant entity name and an unnamed entity stays internal. On the
+ * few undotted components with a top-level 'name' field (esphome,
+ * esp32_ble, sprinkler, ...) the key means something else, so they
+ * return null. Featured wraps also return null: their name presets
+ * arrive through seedDefaults, and their display title is a poor
+ * entity name.
+ */
+export function suggestEntityName(
+  componentId: string,
+  componentTitle: string,
+  existingNames: ReadonlySet<string>
+): string | null {
+  const looksPlatform = isFeaturedId(componentId) ? false : componentId.includes(".");
+  if (!looksPlatform) return null;
+  const title = componentTitle.trim();
+  if (!title) return null;
+
+  const taken = new Set<string>();
+  for (const name of existingNames) {
+    const key = nameKey(name);
+    if (key) taken.add(key);
+  }
+  if (!taken.has(nameKey(title))) return title;
+  let n = 2;
+  let candidate = `${title} ${n}`;
+  while (taken.has(nameKey(candidate))) {
+    n++;
+    candidate = `${title} ${n}`;
+  }
+  return candidate;
+}
+
+/**
+ * Scan the YAML for every 'name:' line and return the set of values.
+ * Deliberately over-collects (the device name under 'esphome:',
+ * automation names, every platform's entities); esphome scopes the
+ * duplicate check per platform, so the only cost of a false hit is an
+ * unneeded numeric suffix, never a missed collision.
+ */
+export function collectExistingNames(yaml: string): Set<string> {
+  const names = new Set<string>();
+  if (!yaml) return names;
+  for (const line of yaml.split("\n")) {
+    if (!/^\s/.test(line)) continue;
+    const name = readInstanceScalar(line, "name");
+    if (name !== null) names.add(name);
+  }
+  return names;
+}

--- a/src/util/featured-id.ts
+++ b/src/util/featured-id.ts
@@ -20,6 +20,16 @@ export function isFeaturedId(id: string): boolean {
 }
 
 /**
+ * True for platform-shaped catalog ids ('switch.gpio'). A featured id
+ * carries dots but wraps one underlying component, so it never reads
+ * as a platform entry. Shared by the id and name seeds so both judge
+ * platform-ness identically.
+ */
+export function isPlatformComponentId(id: string): boolean {
+  return isFeaturedId(id) ? false : id.includes(".");
+}
+
+/**
  * The featured entry a YAML instance materializes, or null.
 
  * Matches by section (``component_id``) plus the instance's emitted

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -403,7 +403,7 @@ export function collectInstanceScalars(
   let inSection = section === undefined;
   for (const line of yaml.split("\n")) {
     if (!/^\s/.test(line)) {
-      const top = line.match(/^([A-Za-z0-9_]+):/);
+      const top = line.match(TOP_LEVEL_KEY_RE);
       if (section !== undefined && top) inSection = top[1] === section;
       continue;
     }

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -386,6 +386,35 @@ export function readInstanceScalar(line: string, key: string): string | null {
 }
 
 /**
+ * Every value of an indented '<key>: value' line in *yaml*, as a set.
+ * Best-effort line scan via readInstanceScalar, deliberately simple
+ * (callers need a uniqueness pool, not a full parse). A real component
+ * field is always indented under a block, so column-0 lines are never
+ * collected. With *section* set, only lines under that top-level key
+ * are collected; blank and comment lines don't end a section.
+ */
+export function collectInstanceScalars(
+  yaml: string,
+  key: string,
+  section?: string
+): Set<string> {
+  const values = new Set<string>();
+  if (!yaml) return values;
+  let inSection = section === undefined;
+  for (const line of yaml.split("\n")) {
+    if (!/^\s/.test(line)) {
+      const top = line.match(/^([A-Za-z0-9_]+):/);
+      if (section !== undefined && top) inSection = top[1] === section;
+      continue;
+    }
+    if (!inSection) continue;
+    const value = readInstanceScalar(line, key);
+    if (value !== null) values.add(value);
+  }
+  return values;
+}
+
+/**
  * 1-indexed YAML line of the instance-relative field *relPath* within
  * *section*, or ``null`` so callers fall back to the whole-section range.
  * Descends both mapping keys (``["pin","number"]`` → the nested

--- a/test/components/device/add-component-form-seed-fns.test.ts
+++ b/test/components/device/add-component-form-seed-fns.test.ts
@@ -566,11 +566,20 @@ describe("buildInitialValues", () => {
     expect(values.name).toBe("A02YYUW Waterproof Ultrasonic Sensor");
   });
 
-  it("suffixes the seeded name against a name already in the YAML, case-insensitively", () => {
+  it("suffixes the seeded name against a same-platform name in the YAML, case-insensitively", () => {
     const yaml =
       "sensor:\n  - platform: a02yyuw\n    name: a02yyuw waterproof ultrasonic sensor\n";
     const values = seedWith(nameSeedComponent(), { yaml });
     expect(values.name).toBe("A02YYUW Waterproof Ultrasonic Sensor 2");
+  });
+
+  it("does not suffix against a same-named entity on another platform", () => {
+    // esphome's duplicate check is per platform; a switch may share a
+    // sensor's name.
+    const yaml =
+      "switch:\n  - platform: template\n    name: A02YYUW Waterproof Ultrasonic Sensor\n";
+    const values = seedWith(nameSeedComponent(), { yaml });
+    expect(values.name).toBe("A02YYUW Waterproof Ultrasonic Sensor");
   });
 
   it("does not seed a name for an undotted component with a name entry", () => {

--- a/test/components/device/add-component-form-seed-fns.test.ts
+++ b/test/components/device/add-component-form-seed-fns.test.ts
@@ -532,4 +532,91 @@ describe("buildInitialValues", () => {
     expect(values.scl).toBe(9);
     expect(values.sda).toBe(8);
   });
+
+  const nameSeedComponent = (over: Partial<ComponentCatalogEntry> = {}) =>
+    makeComponent({
+      id: "sensor.a02yyuw",
+      name: "A02YYUW Waterproof Ultrasonic Sensor",
+      config_entries: [
+        makeConfigEntry({ key: "id", type: ConfigEntryType.ID }),
+        makeConfigEntry({ key: "name", type: ConfigEntryType.STRING }),
+      ],
+      ...over,
+    });
+
+  const seedWith = (
+    component: ComponentCatalogEntry,
+    over: Partial<Parameters<typeof buildInitialValues>[0]> = {}
+  ) =>
+    buildInitialValues({
+      entries: component.config_entries,
+      component,
+      board: null,
+      yaml: "",
+      prefillReference: null,
+      prefillFields: null,
+      restoredValues: null,
+      localize,
+      ...over,
+    });
+
+  it("seeds the entity name from the catalog title for a platform component", () => {
+    const values = seedWith(nameSeedComponent());
+    expect(values.id).toBe("sensor_a02yyuw_1");
+    expect(values.name).toBe("A02YYUW Waterproof Ultrasonic Sensor");
+  });
+
+  it("suffixes the seeded name against a name already in the YAML, case-insensitively", () => {
+    const yaml =
+      "sensor:\n  - platform: a02yyuw\n    name: a02yyuw waterproof ultrasonic sensor\n";
+    const values = seedWith(nameSeedComponent(), { yaml });
+    expect(values.name).toBe("A02YYUW Waterproof Ultrasonic Sensor 2");
+  });
+
+  it("does not seed a name for an undotted component with a name entry", () => {
+    // Undotted name-carriers (esphome, esp32_ble, sprinkler, ...) use the
+    // key for something other than an entity name.
+    const values = seedWith(
+      nameSeedComponent({ id: "sprinkler", name: "Sprinkler Controller" })
+    );
+    expect(values.name).toBeUndefined();
+  });
+
+  it("does not seed a name when the schema has no top-level name entry", () => {
+    const values = seedWith(
+      nameSeedComponent({
+        config_entries: [makeConfigEntry({ key: "id", type: ConfigEntryType.ID })],
+      })
+    );
+    expect(values.name).toBeUndefined();
+  });
+
+  it("does not overwrite a name seeded from a default_value", () => {
+    const values = seedWith(
+      nameSeedComponent({
+        config_entries: [
+          makeConfigEntry({
+            key: "name",
+            type: ConfigEntryType.STRING,
+            required: true,
+            default_value: "Preset Name",
+          }),
+        ],
+      })
+    );
+    expect(values.name).toBe("Preset Name");
+  });
+
+  it("lets restoredValues override the seeded name", () => {
+    // A deliberately cleared name survives the detour round-trip.
+    const values = seedWith(nameSeedComponent(), { restoredValues: { name: "" } });
+    expect(values.name).toBe("");
+  });
+
+  it("lets prefillFields win over the seeded name", () => {
+    const values = seedWith(nameSeedComponent(), {
+      prefillFields: { name: "Constraint Name" },
+    });
+    expect(values.name).toBe("Constraint Name");
+  });
 });

--- a/test/util/default-entity-name.test.ts
+++ b/test/util/default-entity-name.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectExistingNames,
+  suggestEntityName,
+} from "../../src/util/default-entity-name.js";
+
+describe("suggestEntityName", () => {
+  it("seeds the catalog title verbatim for a platform-shaped id", () => {
+    expect(
+      suggestEntityName(
+        "sensor.a02yyuw",
+        "A02YYUW Waterproof Ultrasonic Sensor",
+        new Set()
+      )
+    ).toBe("A02YYUW Waterproof Ultrasonic Sensor");
+    expect(suggestEntityName("switch.gpio", "GPIO Switch", new Set())).toBe(
+      "GPIO Switch"
+    );
+  });
+
+  it("returns null for undotted top-level ids", () => {
+    // On the few undotted components with a top-level name field the key
+    // means something else (the esphome device hostname, the BLE
+    // advertised name, ...), never an entity name.
+    expect(suggestEntityName("esphome", "ESPHome Core", new Set())).toBe(null);
+    expect(suggestEntityName("sprinkler", "Sprinkler Controller", new Set())).toBe(null);
+  });
+
+  it("returns null for a featured wrap id", () => {
+    expect(
+      suggestEntityName(
+        "featured.esp32-poe-iso.onboard_ethernet",
+        "Ethernet (Onboard)",
+        new Set()
+      )
+    ).toBe(null);
+  });
+
+  it("returns null for an empty or blank title and trims whitespace", () => {
+    expect(suggestEntityName("switch.gpio", "", new Set())).toBe(null);
+    expect(suggestEntityName("switch.gpio", "   ", new Set())).toBe(null);
+    expect(suggestEntityName("switch.gpio", "  GPIO Switch ", new Set())).toBe(
+      "GPIO Switch"
+    );
+  });
+
+  it("suffixes with 2 on a collision and walks the counter", () => {
+    expect(
+      suggestEntityName("switch.gpio", "GPIO Switch", new Set(["GPIO Switch"]))
+    ).toBe("GPIO Switch 2");
+    expect(
+      suggestEntityName(
+        "switch.gpio",
+        "GPIO Switch",
+        new Set(["GPIO Switch", "GPIO Switch 2"])
+      )
+    ).toBe("GPIO Switch 3");
+  });
+
+  it("collides case-insensitively", () => {
+    expect(
+      suggestEntityName("switch.gpio", "GPIO Switch", new Set(["gpio switch"]))
+    ).toBe("GPIO Switch 2");
+  });
+
+  it("collides on esphome's sanitize key but not across a hyphen", () => {
+    // esphome compares sanitize(snake_case(name)): '?' keys like '_',
+    // while '-' survives sanitization as itself.
+    expect(
+      suggestEntityName("switch.gpio", "GPIO Switch", new Set(["GPIO?Switch"]))
+    ).toBe("GPIO Switch 2");
+    expect(
+      suggestEntityName("switch.gpio", "GPIO Switch", new Set(["GPIO-Switch"]))
+    ).toBe("GPIO Switch");
+  });
+});
+
+describe("collectExistingNames", () => {
+  it("returns an empty set for empty input", () => {
+    expect(collectExistingNames("")).toEqual(new Set());
+  });
+
+  it("picks up multi-word names on indented and list-item lines, peeling quotes", () => {
+    const yaml = [
+      "switch:",
+      "  - platform: gpio",
+      '    name: "Living Room Light"',
+      "sensor:",
+      "  - platform: dht",
+      "    temperature:",
+      "      name: Living Room Temp  # inline note",
+      "",
+    ].join("\n");
+    expect(collectExistingNames(yaml)).toEqual(
+      new Set(["Living Room Light", "Living Room Temp"])
+    );
+  });
+
+  it("ignores a column-0 name key", () => {
+    expect(collectExistingNames("name: Not A Component\n")).toEqual(new Set());
+  });
+
+  it("includes the esphome device name (accepted over-collection)", () => {
+    const yaml = "esphome:\n  name: my-device\n";
+    expect(collectExistingNames(yaml)).toEqual(new Set(["my-device"]));
+  });
+});

--- a/test/util/default-entity-name.test.ts
+++ b/test/util/default-entity-name.test.ts
@@ -77,31 +77,44 @@ describe("suggestEntityName", () => {
 
 describe("collectExistingNames", () => {
   it("returns an empty set for empty input", () => {
-    expect(collectExistingNames("")).toEqual(new Set());
+    expect(collectExistingNames("", "switch")).toEqual(new Set());
   });
 
   it("picks up multi-word names on indented and list-item lines, peeling quotes", () => {
     const yaml = [
+      "sensor:",
+      '  - name: "Porch Distance"',
+      "  - platform: dht",
+      "",
+      "    temperature:",
+      "      name: Living Room Temp  # inline note",
+      "",
+    ].join("\n");
+    expect(collectExistingNames(yaml, "sensor")).toEqual(
+      new Set(["Porch Distance", "Living Room Temp"])
+    );
+  });
+
+  it("scopes collection to the domain's top-level section", () => {
+    // Names collide per platform in esphome, so a switch named like a
+    // sensor must not force a suffix on the sensor seed.
+    const yaml = [
+      "esphome:",
+      "  name: my-device",
       "switch:",
       "  - platform: gpio",
       '    name: "Living Room Light"',
       "sensor:",
       "  - platform: dht",
-      "    temperature:",
-      "      name: Living Room Temp  # inline note",
+      "    name: Distance",
       "",
     ].join("\n");
-    expect(collectExistingNames(yaml)).toEqual(
-      new Set(["Living Room Light", "Living Room Temp"])
-    );
+    expect(collectExistingNames(yaml, "sensor")).toEqual(new Set(["Distance"]));
+    expect(collectExistingNames(yaml, "switch")).toEqual(new Set(["Living Room Light"]));
+    expect(collectExistingNames(yaml, "light")).toEqual(new Set());
   });
 
   it("ignores a column-0 name key", () => {
-    expect(collectExistingNames("name: Not A Component\n")).toEqual(new Set());
-  });
-
-  it("includes the esphome device name (accepted over-collection)", () => {
-    const yaml = "esphome:\n  name: my-device\n";
-    expect(collectExistingNames(yaml)).toEqual(new Set(["my-device"]));
+    expect(collectExistingNames("name: Not A Component\n", "name")).toEqual(new Set());
   });
 });

--- a/test/util/default-entity-name.test.ts
+++ b/test/util/default-entity-name.test.ts
@@ -4,26 +4,23 @@ import {
   suggestEntityName,
 } from "../../src/util/default-entity-name.js";
 
+const switchYaml = (...names: string[]): string =>
+  ["switch:", ...names.map((n) => `  - name: ${n}`), ""].join("\n");
+
 describe("suggestEntityName", () => {
   it("seeds the catalog title verbatim for a platform-shaped id", () => {
     expect(
-      suggestEntityName(
-        "sensor.a02yyuw",
-        "A02YYUW Waterproof Ultrasonic Sensor",
-        new Set()
-      )
+      suggestEntityName("sensor.a02yyuw", "A02YYUW Waterproof Ultrasonic Sensor", "")
     ).toBe("A02YYUW Waterproof Ultrasonic Sensor");
-    expect(suggestEntityName("switch.gpio", "GPIO Switch", new Set())).toBe(
-      "GPIO Switch"
-    );
+    expect(suggestEntityName("switch.gpio", "GPIO Switch", "")).toBe("GPIO Switch");
   });
 
   it("returns null for undotted top-level ids", () => {
     // On the few undotted components with a top-level name field the key
     // means something else (the esphome device hostname, the BLE
     // advertised name, ...), never an entity name.
-    expect(suggestEntityName("esphome", "ESPHome Core", new Set())).toBe(null);
-    expect(suggestEntityName("sprinkler", "Sprinkler Controller", new Set())).toBe(null);
+    expect(suggestEntityName("esphome", "ESPHome Core", "")).toBe(null);
+    expect(suggestEntityName("sprinkler", "Sprinkler Controller", "")).toBe(null);
   });
 
   it("returns null for a featured wrap id", () => {
@@ -31,35 +28,33 @@ describe("suggestEntityName", () => {
       suggestEntityName(
         "featured.esp32-poe-iso.onboard_ethernet",
         "Ethernet (Onboard)",
-        new Set()
+        ""
       )
     ).toBe(null);
   });
 
   it("returns null for an empty or blank title and trims whitespace", () => {
-    expect(suggestEntityName("switch.gpio", "", new Set())).toBe(null);
-    expect(suggestEntityName("switch.gpio", "   ", new Set())).toBe(null);
-    expect(suggestEntityName("switch.gpio", "  GPIO Switch ", new Set())).toBe(
-      "GPIO Switch"
-    );
+    expect(suggestEntityName("switch.gpio", "", "")).toBe(null);
+    expect(suggestEntityName("switch.gpio", "   ", "")).toBe(null);
+    expect(suggestEntityName("switch.gpio", "  GPIO Switch ", "")).toBe("GPIO Switch");
   });
 
   it("suffixes with 2 on a collision and walks the counter", () => {
     expect(
-      suggestEntityName("switch.gpio", "GPIO Switch", new Set(["GPIO Switch"]))
+      suggestEntityName("switch.gpio", "GPIO Switch", switchYaml("GPIO Switch"))
     ).toBe("GPIO Switch 2");
     expect(
       suggestEntityName(
         "switch.gpio",
         "GPIO Switch",
-        new Set(["GPIO Switch", "GPIO Switch 2"])
+        switchYaml("GPIO Switch", "GPIO Switch 2")
       )
     ).toBe("GPIO Switch 3");
   });
 
   it("collides case-insensitively", () => {
     expect(
-      suggestEntityName("switch.gpio", "GPIO Switch", new Set(["gpio switch"]))
+      suggestEntityName("switch.gpio", "GPIO Switch", switchYaml("gpio switch"))
     ).toBe("GPIO Switch 2");
   });
 
@@ -67,10 +62,16 @@ describe("suggestEntityName", () => {
     // esphome compares sanitize(snake_case(name)): '?' keys like '_',
     // while '-' survives sanitization as itself.
     expect(
-      suggestEntityName("switch.gpio", "GPIO Switch", new Set(["GPIO?Switch"]))
+      suggestEntityName("switch.gpio", "GPIO Switch", switchYaml("GPIO?Switch"))
     ).toBe("GPIO Switch 2");
     expect(
-      suggestEntityName("switch.gpio", "GPIO Switch", new Set(["GPIO-Switch"]))
+      suggestEntityName("switch.gpio", "GPIO Switch", switchYaml("GPIO-Switch"))
+    ).toBe("GPIO Switch");
+  });
+
+  it("scopes the collision pool to the component's own platform section", () => {
+    expect(
+      suggestEntityName("sensor.template", "GPIO Switch", switchYaml("GPIO Switch"))
     ).toBe("GPIO Switch");
   });
 });
@@ -107,9 +108,14 @@ describe("collectExistingNames", () => {
       "sensor:",
       "  - platform: dht",
       "    name: Distance",
+      "# ---- more sensors ----",
+      "  - platform: adc",
+      "    name: Voltage",
       "",
     ].join("\n");
-    expect(collectExistingNames(yaml, "sensor")).toEqual(new Set(["Distance"]));
+    expect(collectExistingNames(yaml, "sensor")).toEqual(
+      new Set(["Distance", "Voltage"])
+    );
     expect(collectExistingNames(yaml, "switch")).toEqual(new Set(["Living Room Light"]));
     expect(collectExistingNames(yaml, "light")).toEqual(new Set());
   });


### PR DESCRIPTION
# What does this implement/fix?

Adding an entity platform through the add-component dialog left the Name field empty; the user had to invent one, and an untouched Add produced an id-only entity that ESPHome treats as internal (never exposed to Home Assistant).

The form now seeds the Name field from the component's catalog title ("GPIO Switch", "A02YYUW Waterproof Ultrasonic Sensor"), editable and clearable like the auto-generated id. The suggestion is deduped against the `name:` values already in the component's own top-level section: ESPHome hard-fails on duplicate entity names, comparing `sanitize(snake_case(name))` per device/platform (`core/entity_helpers.py`), so the new `suggestEntityName` helper mirrors that exact key and walks a numeric suffix ("GPIO Switch 2") on collision, while a same-named entity on another platform doesn't force a suffix. The line scan still over-collects within the section (nested sub-entity names, sub-device duplicates ESPHome would allow), costing at most an unneeded suffix; a name behind a block scalar or in a `packages:`/`!include` file is invisible to it and can still collide, and the user sees the seeded value before pressing Add.

Scope of the seed: platform-shaped ids only (id contains `.`), mirroring `generateDefaultComponentId`'s judgment. A full-catalog survey shows top-level `name` string entries split into 290 dotted entity platforms (all entity domains) and 6 undotted components (`esphome`, `esp32_ble`, `ble_client`, `esp32_camera`, `serial_proxy`, `sprinkler`) where `name` means something else (device hostname, BLE advertised name, ...), so undotted ids never seed. Featured wraps are also excluded: their name presets already arrive through `seedDefaults`, and their display title can be the "SPI Bus (lcd_spi)" fallback shape.

Behavior notes:

- The seed sits beside the id seed in `buildInitialValues`, so detour-restored values, `prefillReference`, and `prefillFields` all still override it, and a `default_value`/preset name wins via the `undefined` guard.
- The dialog's skip-the-form fast path cannot flip: `name` is in `ALWAYS_SHOWN_KEYS`, so any component this seeds already painted an unlocked field.
- Clearing the field before Add still writes id-only YAML (`coerceFields` drops an empty string on a non-required field), preserving the internal-entity opt-out.
- No backend/catalog change needed; the title comes from `ComponentCatalogEntry.name`, which the dialog already holds.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2450

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
