### PR TITLE
Prefill a unique id for nested-list rows that require one

### DIFF
--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -52,24 +52,32 @@ function arrayItemHandlers(
 
 // New nested-list rows whose schema requires a declaring id start with a
 // unique one prefilled (#2452) — the user shouldn't have to invent it.
-// Uniqueness spans the document plus current rows: in the add dialog the
-// form values aren't in the YAML yet, and in the section editor a
-// just-added sibling may not have flushed through the draft debounce.
-function makeNewNestedItem(
-  entry: ConfigEntry,
-  path: string[],
-  ctx: RenderCtx
-): Record<string, unknown> {
+// Uniqueness spans the document plus the whole form-values tree: in the
+// add dialog the form values aren't in the YAML yet, in the section
+// editor a just-added row may not have flushed through the draft
+// debounce, and a same-key sibling list under a *different* parent row
+// (esp32_ble_server's ``services[].characteristics[]``) isn't visible
+// through this list's own rows at all.
+function makeNewNestedItem(entry: ConfigEntry, ctx: RenderCtx): Record<string, unknown> {
   const idChild = (entry.config_entries ?? []).find(
     (c) => c.type === ConfigEntryType.ID && !c.references_component && c.required
   );
   if (!idChild) return {};
   const existing = collectExistingIds(ctx.yaml);
-  for (const item of asMappingList(ctx.getAt(path))) {
-    const value = item[idChild.key];
-    if (typeof value === "string" && value) existing.add(value);
-  }
+  collectValuesAtKey(ctx.getAt([]), idChild.key, existing);
   return { [idChild.key]: generateNestedItemId(entry.key, existing) };
+}
+
+// Walk the form-values tree and collect every string at *key*.
+function collectValuesAtKey(node: unknown, key: string, out: Set<string>): void {
+  if (Array.isArray(node)) {
+    for (const item of node) collectValuesAtKey(item, key, out);
+  } else if (node && typeof node === "object" && !(node instanceof YamlRawValue)) {
+    for (const [k, v] of Object.entries(node)) {
+      if (k === key && typeof v === "string" && v) out.add(v);
+      collectValuesAtKey(v, key, out);
+    }
+  }
 }
 
 export function renderListEmptyHint(items: readonly unknown[], ctx: RenderCtx) {
@@ -385,7 +393,7 @@ export function renderNestedListField(
   const items = asMappingList(raw);
   const disabled = effectiveDisabled(entry, ctx);
   const { addItem, removeAt } = arrayItemHandlers(ctx, path, () =>
-    makeNewNestedItem(entry, path, ctx)
+    makeNewNestedItem(entry, ctx)
   );
   const itemTitle = labelFor(entry, ctx);
   const childrenSchema = entry.config_entries ?? [];

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -50,14 +50,12 @@ function arrayItemHandlers(
   return { addItem, removeAt };
 }
 
-// New nested-list rows whose schema requires a declaring id start with a
-// unique one prefilled (#2452) — the user shouldn't have to invent it.
-// Uniqueness spans the document plus the whole form-values tree: in the
-// add dialog the form values aren't in the YAML yet, in the section
-// editor a just-added row may not have flushed through the draft
-// debounce, and a same-key sibling list under a *different* parent row
-// (esp32_ble_server's ``services[].characteristics[]``) isn't visible
-// through this list's own rows at all.
+// A new row whose schema requires a declaring id arrives with a unique one
+// prefilled (#2452). Uniqueness spans the document *and* the whole
+// form-values tree: the add dialog's values aren't in the YAML yet, a
+// just-added row may not have flushed through the draft debounce, and a
+// same-key sibling list under another parent row (esp32_ble_server's
+// ``services[].characteristics[]``) is invisible from this list's rows.
 function makeNewNestedItem(entry: ConfigEntry, ctx: RenderCtx): Record<string, unknown> {
   const idChild = (entry.config_entries ?? []).find(
     (c) => c.type === ConfigEntryType.ID && !c.references_component && c.required
@@ -68,15 +66,13 @@ function makeNewNestedItem(entry: ConfigEntry, ctx: RenderCtx): Record<string, u
   return { [idChild.key]: generateNestedItemId(entry.key, existing) };
 }
 
-// Walk the form-values tree and collect every string at *key*.
+// Walk the form-values tree and collect every string at *key*. Arrays fall
+// through the same branch — their numeric keys can't match a field name.
 function collectValuesAtKey(node: unknown, key: string, out: Set<string>): void {
-  if (Array.isArray(node)) {
-    for (const item of node) collectValuesAtKey(item, key, out);
-  } else if (node && typeof node === "object" && !(node instanceof YamlRawValue)) {
-    for (const [k, v] of Object.entries(node)) {
-      if (k === key && typeof v === "string" && v) out.add(v);
-      collectValuesAtKey(v, key, out);
-    }
+  if (!node || typeof node !== "object" || node instanceof YamlRawValue) return;
+  for (const [k, v] of Object.entries(node)) {
+    if (k === key && typeof v === "string" && v) out.add(v);
+    collectValuesAtKey(v, key, out);
   }
 }
 

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -2,6 +2,10 @@ import { html, nothing } from "lit";
 import { isLambdaValue } from "../../../api/types/automations.js";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../../api/types/config-entries.js";
+import {
+  collectExistingIds,
+  generateNestedItemId,
+} from "../../../util/default-component-id.js";
 import { asMappingList, isPrimitiveOrNullish } from "../../../util/nested-values.js";
 import { escapeForInput, unescapeForInput } from "../../../util/yaml-escape.js";
 import { YamlRawValue } from "../../../util/yaml-serialize.js";
@@ -44,6 +48,28 @@ function arrayItemHandlers(
   };
   const addItem = () => ctx.emitChange(path, [...readArrayAt(ctx, path), makeNewItem()]);
   return { addItem, removeAt };
+}
+
+// New nested-list rows whose schema requires a declaring id start with a
+// unique one prefilled (#2452) — the user shouldn't have to invent it.
+// Uniqueness spans the document plus current rows: in the add dialog the
+// form values aren't in the YAML yet, and in the section editor a
+// just-added sibling may not have flushed through the draft debounce.
+function makeNewNestedItem(
+  entry: ConfigEntry,
+  path: string[],
+  ctx: RenderCtx
+): Record<string, unknown> {
+  const idChild = (entry.config_entries ?? []).find(
+    (c) => c.type === ConfigEntryType.ID && !c.references_component && c.required
+  );
+  if (!idChild) return {};
+  const existing = collectExistingIds(ctx.yaml);
+  for (const item of asMappingList(ctx.getAt(path))) {
+    const value = item[idChild.key];
+    if (typeof value === "string" && value) existing.add(value);
+  }
+  return { [idChild.key]: generateNestedItemId(entry.key, existing) };
 }
 
 export function renderListEmptyHint(items: readonly unknown[], ctx: RenderCtx) {
@@ -358,7 +384,9 @@ export function renderNestedListField(
 
   const items = asMappingList(raw);
   const disabled = effectiveDisabled(entry, ctx);
-  const { addItem, removeAt } = arrayItemHandlers(ctx, path, () => ({}));
+  const { addItem, removeAt } = arrayItemHandlers(ctx, path, () =>
+    makeNewNestedItem(entry, path, ctx)
+  );
   const itemTitle = labelFor(entry, ctx);
   const childrenSchema = entry.config_entries ?? [];
 

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -3,7 +3,8 @@ import { isLambdaValue } from "../../../api/types/automations.js";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../../api/types/config-entries.js";
 import {
-  collectExistingIds,
+  addTakenIdsFromValues,
+  collectTakenIds,
   generateNestedItemId,
 } from "../../../util/default-component-id.js";
 import { asMappingList, isPrimitiveOrNullish } from "../../../util/nested-values.js";
@@ -51,29 +52,19 @@ function arrayItemHandlers(
 }
 
 // A new row whose schema requires a declaring id arrives with a unique one
-// prefilled (#2452). Uniqueness spans the document *and* the whole
-// form-values tree: the add dialog's values aren't in the YAML yet, a
-// just-added row may not have flushed through the draft debounce, and a
-// same-key sibling list under another parent row (esp32_ble_server's
-// ``services[].characteristics[]``) is invisible from this list's rows.
+// prefilled (#2452). The pool spans the document *and* the whole form-values
+// tree: the add dialog's values aren't in the YAML yet, a just-added row may
+// not have flushed through the draft debounce, and a same-key sibling list
+// under another parent row (esp32_ble_server's ``services[].characteristics[]``)
+// is invisible from this list's rows.
 function makeNewNestedItem(entry: ConfigEntry, ctx: RenderCtx): Record<string, unknown> {
   const idChild = (entry.config_entries ?? []).find(
     (c) => c.type === ConfigEntryType.ID && !c.references_component && c.required
   );
   if (!idChild) return {};
-  const existing = collectExistingIds(ctx.yaml);
-  collectValuesAtKey(ctx.getAt([]), idChild.key, existing);
-  return { [idChild.key]: generateNestedItemId(entry.key, existing) };
-}
-
-// Walk the form-values tree and collect every string at *key*. Arrays fall
-// through the same branch — their numeric keys can't match a field name.
-function collectValuesAtKey(node: unknown, key: string, out: Set<string>): void {
-  if (!node || typeof node !== "object" || node instanceof YamlRawValue) return;
-  for (const [k, v] of Object.entries(node)) {
-    if (k === key && typeof v === "string" && v) out.add(v);
-    collectValuesAtKey(v, key, out);
-  }
+  const taken = collectTakenIds(ctx.yaml);
+  addTakenIdsFromValues(ctx.getAt([]), taken);
+  return { [idChild.key]: generateNestedItemId(entry.key, taken) };
 }
 
 export function renderListEmptyHint(items: readonly unknown[], ctx: RenderCtx) {

--- a/src/util/default-component-id.ts
+++ b/src/util/default-component-id.ts
@@ -1,3 +1,4 @@
+import { normalizeEspHomeId } from "./esphome-id.js";
 import { isPlatformComponentId } from "./featured-id.js";
 import { collectInstanceScalars } from "./yaml-instance-scalars.js";
 
@@ -58,8 +59,9 @@ export function collectExistingIds(yaml: string): Set<string> {
 
 // Normalise to a valid ESPHome id ([a-zA-Z_][a-zA-Z0-9_]*): a featured
 // board id carries dashes (`esp32-poe-iso`) which dots-only wouldn't strip.
+// Generated ids are lowercased by convention before the shared reshape.
 function slugifyId(raw: string): string {
-  return raw.toLowerCase().replace(/[^a-z0-9_]+/g, "_");
+  return normalizeEspHomeId(raw.toLowerCase());
 }
 
 function uniquifyId(slug: string, existing: ReadonlySet<string>): string {

--- a/src/util/default-component-id.ts
+++ b/src/util/default-component-id.ts
@@ -59,9 +59,12 @@ export function collectExistingIds(yaml: string): Set<string> {
 
 // Normalise to a valid ESPHome id ([a-zA-Z_][a-zA-Z0-9_]*): a featured
 // board id carries dashes (`esp32-poe-iso`) which dots-only wouldn't strip.
-// Generated ids are lowercased by convention before the shared reshape.
+// Generated ids are lowercased by convention before the shared reshape, and
+// a digit-leading slug gets an underscore prefix — unlike user-typed input,
+// a generated id has no mid-typing UX to preserve.
 function slugifyId(raw: string): string {
-  return normalizeEspHomeId(raw.toLowerCase());
+  const slug = normalizeEspHomeId(raw.toLowerCase());
+  return /^[a-z_]/.test(slug) ? slug : `_${slug}`;
 }
 
 function uniquifyId(slug: string, existing: ReadonlySet<string>): string {

--- a/src/util/default-component-id.ts
+++ b/src/util/default-component-id.ts
@@ -37,7 +37,7 @@ export function generateDefaultComponentId(
   const isSingleton = !multiConf && !isPlatformComponentId(componentId);
   if (isSingleton) return null;
 
-  return uniquifyId(slugifyId(componentId), existing);
+  return generateUniqueId(componentId, existing);
 }
 
 /**
@@ -49,7 +49,7 @@ export function generateNestedItemId(
   listKey: string,
   existing: ReadonlySet<string>
 ): string {
-  return uniquifyId(slugifyId(listKey), existing);
+  return generateUniqueId(listKey, existing);
 }
 
 /** Scan the YAML for every `id:` line and return the set of values. */
@@ -57,22 +57,14 @@ export function collectExistingIds(yaml: string): Set<string> {
   return collectInstanceScalars(yaml, "id");
 }
 
-// Normalise to a valid ESPHome id ([a-zA-Z_][a-zA-Z0-9_]*): a featured
-// board id carries dashes (`esp32-poe-iso`) which dots-only wouldn't strip.
-// Generated ids are lowercased by convention before the shared reshape, and
-// a digit-leading slug gets an underscore prefix — unlike user-typed input,
-// a generated id has no mid-typing UX to preserve.
-function slugifyId(raw: string): string {
+// Slug *raw* into a valid ESPHome id ([a-zA-Z_][a-zA-Z0-9_]*), then walk a
+// numeric suffix until it clears *existing*. Unlike user-typed input, a
+// generated id has no mid-typing UX to preserve, so a digit-leading slug
+// takes an underscore prefix rather than being left invalid.
+function generateUniqueId(raw: string, existing: ReadonlySet<string>): string {
   const slug = normalizeEspHomeId(raw.toLowerCase());
-  return /^[a-z_]/.test(slug) ? slug : `_${slug}`;
-}
-
-function uniquifyId(slug: string, existing: ReadonlySet<string>): string {
+  const base = /^[a-z_]/.test(slug) ? slug : `_${slug}`;
   let n = 1;
-  let candidate = `${slug}_${n}`;
-  while (existing.has(candidate)) {
-    n++;
-    candidate = `${slug}_${n}`;
-  }
-  return candidate;
+  while (existing.has(`${base}_${n}`)) n++;
+  return `${base}_${n}`;
 }

--- a/src/util/default-component-id.ts
+++ b/src/util/default-component-id.ts
@@ -1,6 +1,12 @@
 import { normalizeEspHomeId } from "./esphome-id.js";
 import { isPlatformComponentId } from "./featured-id.js";
-import { collectInstanceScalars } from "./yaml-instance-scalars.js";
+import { collectInstanceScalars, readInstanceScalar } from "./yaml-instance-scalars.js";
+import { YamlRawValue } from "./yaml-serialize.js";
+
+// Keys that name an ESPHome id: `id` itself, or an `<prefix>_id` field. The
+// underscore keeps lookalikes (`valid`, `uuid`) out.
+const ID_NAMING_KEY_RE = /^(?:[a-z0-9_]+_)?id$/;
+const ID_NAMING_LINE_RE = /^\s+(?:-\s+)?((?:[a-z0-9_]+_)?id):/;
 
 /**
  * Auto-generate a default `id:` value for a component being added
@@ -55,6 +61,35 @@ export function generateNestedItemId(
 /** Scan the YAML for every `id:` line and return the set of values. */
 export function collectExistingIds(yaml: string): Set<string> {
   return collectInstanceScalars(yaml, "id");
+}
+
+/**
+ * Every value under an id-naming key (`id`, `*_id`) in *yaml*.
+ *
+ * Wider than `collectExistingIds` because a generated id must clear ids
+ * declared under another key too: tca9548a's `channels[].bus_id` mints from
+ * the same base slug as usb_uart's `channels[].id`. References land in the
+ * pool as well, which only ever bumps the numeric suffix.
+ */
+export function collectTakenIds(yaml: string): Set<string> {
+  const taken = new Set<string>();
+  for (const line of yaml.split("\n")) {
+    const key = line.match(ID_NAMING_LINE_RE)?.[1];
+    if (key === undefined) continue;
+    const value = readInstanceScalar(line, key);
+    if (value !== null) taken.add(value);
+  }
+  return taken;
+}
+
+/** Add every id-naming scalar in the form-values tree *node* to *out*. */
+export function addTakenIdsFromValues(node: unknown, out: Set<string>): void {
+  // Arrays fall through the same branch — their numeric keys can't name an id.
+  if (!node || typeof node !== "object" || node instanceof YamlRawValue) return;
+  for (const [key, value] of Object.entries(node)) {
+    if (typeof value === "string" && value && ID_NAMING_KEY_RE.test(key)) out.add(value);
+    addTakenIdsFromValues(value, out);
+  }
 }
 
 // Slug *raw* into a valid ESPHome id ([a-zA-Z_][a-zA-Z0-9_]*), then walk a

--- a/src/util/default-component-id.ts
+++ b/src/util/default-component-id.ts
@@ -36,9 +36,33 @@ export function generateDefaultComponentId(
   const isSingleton = !multiConf && !isPlatformComponentId(componentId);
   if (isSingleton) return null;
 
-  // Normalise to a valid ESPHome id ([a-zA-Z_][a-zA-Z0-9_]*): a featured
-  // board id carries dashes (`esp32-poe-iso`) which dots-only wouldn't strip.
-  const slug = componentId.toLowerCase().replace(/[^a-z0-9_]+/g, "_");
+  return uniquifyId(slugifyId(componentId), existing);
+}
+
+/**
+ * Auto-generate an `id:` value for a new nested-list row whose schema
+ * requires one (e.g. `voice_assistant.microphone` items): the list key
+ * plus a numeric suffix, unique against *existing*.
+ */
+export function generateNestedItemId(
+  listKey: string,
+  existing: ReadonlySet<string>
+): string {
+  return uniquifyId(slugifyId(listKey), existing);
+}
+
+/** Scan the YAML for every `id:` line and return the set of values. */
+export function collectExistingIds(yaml: string): Set<string> {
+  return collectInstanceScalars(yaml, "id");
+}
+
+// Normalise to a valid ESPHome id ([a-zA-Z_][a-zA-Z0-9_]*): a featured
+// board id carries dashes (`esp32-poe-iso`) which dots-only wouldn't strip.
+function slugifyId(raw: string): string {
+  return raw.toLowerCase().replace(/[^a-z0-9_]+/g, "_");
+}
+
+function uniquifyId(slug: string, existing: ReadonlySet<string>): string {
   let n = 1;
   let candidate = `${slug}_${n}`;
   while (existing.has(candidate)) {
@@ -46,9 +70,4 @@ export function generateDefaultComponentId(
     candidate = `${slug}_${n}`;
   }
   return candidate;
-}
-
-/** Scan the YAML for every `id:` line and return the set of values. */
-export function collectExistingIds(yaml: string): Set<string> {
-  return collectInstanceScalars(yaml, "id");
 }

--- a/src/util/default-component-id.ts
+++ b/src/util/default-component-id.ts
@@ -1,4 +1,4 @@
-import { normalizeEspHomeId } from "./esphome-id.js";
+import { isValidEspHomeId, normalizeEspHomeId } from "./esphome-id.js";
 import { isPlatformComponentId } from "./featured-id.js";
 import { collectInstanceScalars, readInstanceScalar } from "./yaml-instance-scalars.js";
 import { YamlRawValue } from "./yaml-serialize.js";
@@ -92,13 +92,13 @@ export function addTakenIdsFromValues(node: unknown, out: Set<string>): void {
   }
 }
 
-// Slug *raw* into a valid ESPHome id ([a-zA-Z_][a-zA-Z0-9_]*), then walk a
-// numeric suffix until it clears *existing*. Unlike user-typed input, a
-// generated id has no mid-typing UX to preserve, so a digit-leading slug
+// Slug *raw* into a valid ESPHome id, then walk a numeric suffix until it
+// clears *existing*. A normalised slug can only be invalid by leading with a
+// digit; unlike user-typed input it has no mid-typing UX to preserve, so it
 // takes an underscore prefix rather than being left invalid.
 function generateUniqueId(raw: string, existing: ReadonlySet<string>): string {
   const slug = normalizeEspHomeId(raw.toLowerCase());
-  const base = /^[a-z_]/.test(slug) ? slug : `_${slug}`;
+  const base = isValidEspHomeId(slug) ? slug : `_${slug}`;
   let n = 1;
   while (existing.has(`${base}_${n}`)) n++;
   return `${base}_${n}`;

--- a/test/components/device/render-nested-list-field.test.ts
+++ b/test/components/device/render-nested-list-field.test.ts
@@ -169,6 +169,29 @@ describe("renderNestedListField", () => {
     );
   });
 
+  it("seeded id clears ids declared under another key", () => {
+    // tca9548a declares through ``channels[].bus_id`` and usb_uart through
+    // ``channels[].id``, so both mint from base ``channels`` — the pool has
+    // to span every id-naming key or the two collide.
+    const entry = makeConfigEntry({
+      key: "channels",
+      type: ConfigEntryType.NESTED,
+      multi_value: true,
+      config_entries: [
+        makeConfigEntry({ key: "id", type: ConfigEntryType.ID, required: true }),
+      ],
+    });
+    const { ctx, emitChange } = makeCtx(
+      { channels: [] },
+      {
+        yaml: "tca9548a:\n  - id: mux\n    channels:\n      - bus_id: channels_1\n",
+      }
+    );
+    const tpl = renderNestedListField(entry, ["channels"], ctx);
+    collectHandlers(tpl.values).pop()!();
+    expect(emitChange).toHaveBeenCalledWith(["channels"], [{ id: "channels_2" }]);
+  });
+
   it("addItem appends a bare {} when no child requires a declaring id", () => {
     const entry = makeConfigEntry({
       key: "devices",

--- a/test/components/device/render-nested-list-field.test.ts
+++ b/test/components/device/render-nested-list-field.test.ts
@@ -151,6 +151,32 @@ describe("renderNestedListField", () => {
     );
   });
 
+  it("seeded id sees a same-key sibling list under a different parent row", () => {
+    // esp32_ble_server: every services[] row has its own characteristics[]
+    // list; an id minted in one must not collide with an unflushed id in
+    // the other.
+    const entry = makeConfigEntry({
+      key: "characteristics",
+      type: ConfigEntryType.NESTED,
+      multi_value: true,
+      config_entries: [
+        makeConfigEntry({ key: "id", type: ConfigEntryType.ID, required: true }),
+      ],
+    });
+    const { ctx, emitChange } = makeCtx({
+      services: [
+        { characteristics: [{ id: "characteristics_1" }] },
+        { characteristics: [] },
+      ],
+    });
+    const tpl = renderNestedListField(entry, ["services", "1", "characteristics"], ctx);
+    collectHandlers(tpl.values).pop()!();
+    expect(emitChange).toHaveBeenCalledWith(
+      ["services", "1", "characteristics"],
+      [{ id: "characteristics_2" }]
+    );
+  });
+
   it("addItem appends a bare {} when no child requires a declaring id", () => {
     const entry = makeConfigEntry({
       key: "devices",

--- a/test/components/device/render-nested-list-field.test.ts
+++ b/test/components/device/render-nested-list-field.test.ts
@@ -110,7 +110,7 @@ describe("renderNestedListField", () => {
     expect(json).toContain("device.multi_value_empty");
   });
 
-  it("addItem appends a fresh empty object at the field's path", () => {
+  it("addItem seeds a unique id when the row schema requires one (#2452)", () => {
     const entry = makeListEntry();
     const { ctx, emitChange } = makeCtx({
       devices: [{ id: "kitchen" }],
@@ -120,7 +120,58 @@ describe("renderNestedListField", () => {
     // Last handler in render order is the add button (rendered after
     // the items + their per-item remove buttons).
     handlers[handlers.length - 1]();
-    expect(emitChange).toHaveBeenCalledWith(["devices"], [{ id: "kitchen" }, {}]);
+    expect(emitChange).toHaveBeenCalledWith(
+      ["devices"],
+      [{ id: "kitchen" }, { id: "devices_1" }]
+    );
+  });
+
+  it("seeded id increments past document ids and unflushed sibling rows", () => {
+    const entry = makeListEntry();
+    const renderEntry = vi.fn(() => "<rendered>");
+    const emitChange = vi.fn();
+    const filterRenderable = vi.fn((entries: ConfigEntry[]) => entries);
+    const ctx = makeRenderCtx(
+      { devices: [{ id: "devices_2" }] },
+      {
+        board: null,
+        overrides: {
+          emitChange,
+          renderEntry,
+          filterRenderable,
+          yaml: "esphome:\n  devices:\n    - id: devices_1\n",
+        },
+      }
+    );
+    const tpl = renderNestedListField(entry, ["devices"], ctx);
+    collectHandlers(tpl.values).pop()!();
+    expect(emitChange).toHaveBeenCalledWith(
+      ["devices"],
+      [{ id: "devices_2" }, { id: "devices_3" }]
+    );
+  });
+
+  it("addItem appends a bare {} when no child requires a declaring id", () => {
+    const entry = makeConfigEntry({
+      key: "devices",
+      type: ConfigEntryType.NESTED,
+      multi_value: true,
+      config_entries: [
+        makeConfigEntry({ key: "id", type: ConfigEntryType.ID }),
+        makeConfigEntry({
+          key: "uart_id",
+          type: ConfigEntryType.ID,
+          required: true,
+          references_component: "uart",
+        }),
+      ],
+    });
+    const { ctx, emitChange } = makeCtx({ devices: [] });
+    const tpl = renderNestedListField(entry, ["devices"], ctx);
+    collectHandlers(tpl.values).pop()!();
+    // The optional id stays unseeded; the required reference is a picker,
+    // not a declaration.
+    expect(emitChange).toHaveBeenCalledWith(["devices"], [{}]);
   });
 
   it("removeAt drops the item at idx and emits the new array", () => {

--- a/test/components/device/render-nested-list-field.test.ts
+++ b/test/components/device/render-nested-list-field.test.ts
@@ -65,13 +65,16 @@ function collectHandlers(values: unknown[]): Array<(...args: unknown[]) => unkno
   return out;
 }
 
-function makeCtx(values: Record<string, unknown>): CtxStub {
+function makeCtx(
+  values: Record<string, unknown>,
+  extraOverrides: Partial<RenderCtx> = {}
+): CtxStub {
   const renderEntry = vi.fn(() => "<rendered>");
   const emitChange = vi.fn();
   const filterRenderable = vi.fn((entries: ConfigEntry[]) => entries);
   const ctx = makeRenderCtx(values, {
     board: null,
-    overrides: { emitChange, renderEntry, filterRenderable },
+    overrides: { emitChange, renderEntry, filterRenderable, ...extraOverrides },
   });
   return { ctx, renderEntry, emitChange, filterRenderable };
 }
@@ -128,20 +131,9 @@ describe("renderNestedListField", () => {
 
   it("seeded id increments past document ids and unflushed sibling rows", () => {
     const entry = makeListEntry();
-    const renderEntry = vi.fn(() => "<rendered>");
-    const emitChange = vi.fn();
-    const filterRenderable = vi.fn((entries: ConfigEntry[]) => entries);
-    const ctx = makeRenderCtx(
+    const { ctx, emitChange } = makeCtx(
       { devices: [{ id: "devices_2" }] },
-      {
-        board: null,
-        overrides: {
-          emitChange,
-          renderEntry,
-          filterRenderable,
-          yaml: "esphome:\n  devices:\n    - id: devices_1\n",
-        },
-      }
+      { yaml: "esphome:\n  devices:\n    - id: devices_1\n" }
     );
     const tpl = renderNestedListField(entry, ["devices"], ctx);
     collectHandlers(tpl.values).pop()!();

--- a/test/util/default-component-id.test.ts
+++ b/test/util/default-component-id.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   collectExistingIds,
   generateDefaultComponentId,
+  generateNestedItemId,
 } from "../../src/util/default-component-id.js";
 
 describe("generateDefaultComponentId", () => {
@@ -88,6 +89,22 @@ describe("generateDefaultComponentId", () => {
     expect(generateDefaultComponentId("Switch.GPIO", true, new Set())).toBe(
       "switch_gpio_1"
     );
+  });
+});
+
+describe("generateNestedItemId", () => {
+  it("suffixes the list key", () => {
+    expect(generateNestedItemId("microphone", new Set())).toBe("microphone_1");
+    expect(generateNestedItemId("devices", new Set())).toBe("devices_1");
+  });
+
+  it("increments past taken ids", () => {
+    const existing = new Set(["microphone_1", "microphone_2", "my_mic"]);
+    expect(generateNestedItemId("microphone", existing)).toBe("microphone_3");
+  });
+
+  it("slugs a key that isn't already id-shaped", () => {
+    expect(generateNestedItemId("On-Off", new Set())).toBe("on_off_1");
   });
 });
 

--- a/test/util/default-component-id.test.ts
+++ b/test/util/default-component-id.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  addTakenIdsFromValues,
   collectExistingIds,
+  collectTakenIds,
   generateDefaultComponentId,
   generateNestedItemId,
 } from "../../src/util/default-component-id.js";
@@ -109,6 +111,50 @@ describe("generateNestedItemId", () => {
 
   it("prefixes an underscore when the key starts with a digit", () => {
     expect(generateNestedItemId("1wire", new Set())).toBe("_1wire_1");
+  });
+});
+
+describe("collectTakenIds", () => {
+  it("collects plain and prefixed id keys", () => {
+    const yaml = `tca9548a:
+  - id: mux
+    channels:
+      - bus_id: channels_1
+sensor:
+  - platform: dht
+    uart_id: uart_1
+`;
+    expect(collectTakenIds(yaml)).toEqual(new Set(["mux", "channels_1", "uart_1"]));
+  });
+
+  it("ignores keys that merely end in the letters id", () => {
+    const yaml = `foo:\n  valid: yes\n  uuid: abc\n`;
+    expect(collectTakenIds(yaml)).toEqual(new Set());
+  });
+
+  it("ignores top-level keys", () => {
+    expect(collectTakenIds("id: something\n")).toEqual(new Set());
+  });
+});
+
+describe("addTakenIdsFromValues", () => {
+  it("walks nested lists and mappings for id-naming keys", () => {
+    const taken = new Set<string>();
+    addTakenIdsFromValues(
+      {
+        services: [
+          { characteristics: [{ id: "characteristics_1" }] },
+          { characteristics: [{ id: "characteristics_2" }] },
+        ],
+        channels: [{ bus_id: "channels_9" }],
+        name: "not an id",
+        empty: "",
+      },
+      taken
+    );
+    expect(taken).toEqual(
+      new Set(["characteristics_1", "characteristics_2", "channels_9"])
+    );
   });
 });
 

--- a/test/util/default-component-id.test.ts
+++ b/test/util/default-component-id.test.ts
@@ -106,6 +106,10 @@ describe("generateNestedItemId", () => {
   it("slugs a key that isn't already id-shaped", () => {
     expect(generateNestedItemId("On-Off", new Set())).toBe("on_off_1");
   });
+
+  it("prefixes an underscore when the key starts with a digit", () => {
+    expect(generateNestedItemId("1wire", new Set())).toBe("_1wire_1");
+  });
 });
 
 describe("collectExistingIds", () => {

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2038,8 +2038,10 @@ sensor:
   });
 
   it("round-trips a freshly-added empty item via the renderer's Add button", () => {
-    // ``renderNestedListField`` emits ``[..., {}]`` when the user
-    // clicks Add. The serializer should emit a bare dash
+    // ``renderNestedListField`` emits ``[..., {}]`` on Add for lists
+    // whose row schema has no required declaring id (rows requiring one
+    // arrive with it prefilled, #2452); bare rows also come from
+    // externally-authored YAML. The serializer should emit a bare dash
     // placeholder so the YAML stays valid even before the user
     // fills in a key.
     const yaml = `esphome:


### PR DESCRIPTION
# What does this implement/fix?

When a nested-list row's schema requires a declaring id (voice_assistant's `microphone` items, `esphome.devices[]`, usb_uart `channels[]`), the "+ Add" button now seeds a unique generated id (`microphone_1`, `devices_1`, ...) instead of leaving a blank required field the user has to invent a value for.

The seed reuses the same slug-plus-suffix convention the add-component dialog already mints for top-level ids, and uniqueness is checked against the document's ids plus the whole form-values tree, so an unflushed row, an add-dialog form (whose values aren't in the YAML yet), or a same-key sibling list under a different parent row (esp32_ble_server's per-service characteristics) can't collide. Lists without a required declaring id still add a bare row; optional ids and `references_component` pickers are never seeded.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2452

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

