### PR TITLE
Skip YAML-occupied pins when seeding board pin defaults

### DIFF
--- a/src/components/device/add-component-form-seed.ts
+++ b/src/components/device/add-component-form-seed.ts
@@ -206,7 +206,9 @@ export function buildInitialValues(ctx: SeedContext): Record<string, unknown> {
   // falls back to ESP32 GPIO22/21. Pins the YAML already wires stay
   // unseeded (a second uart would otherwise re-suggest the first
   // bus's pins, #1555); no exclude range — the new component isn't
-  // in the YAML yet.
+  // in the YAML yet. The scan's known imprecision is inherited: a
+  // token like "esp32-p4" registers GPIO4 as used (over-suppresses a
+  // default), and a substitution-wired pin is invisible to it.
   next = seedBoardPinDefaults(component.id, entries, board, next, findUsedPins(yaml));
 
   // Restore what the user typed before a "+ Add <dep>" detour, over the freshly

--- a/src/components/device/add-component-form-seed.ts
+++ b/src/components/device/add-component-form-seed.ts
@@ -6,6 +6,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { seedBoardPinDefaults } from "../../util/pin/board-defaults.js";
 import {
   findReferenceCandidates,
+  findUsedPins,
   resolveSoleCandidate,
 } from "../../util/config-entry-yaml-scan.js";
 import {
@@ -202,8 +203,11 @@ export function buildInitialValues(ctx: SeedContext): Record<string, unknown> {
   // ESP32-C3 (and other variants without an SCL/SDA alias) are
   // either invalid or wrong-numbered: i2c on C3 emits an
   // "Invalid pin number: 22" squiggle because the bus block
-  // falls back to ESP32 GPIO22/21.
-  next = seedBoardPinDefaults(component.id, entries, board, next);
+  // falls back to ESP32 GPIO22/21. Pins the YAML already wires stay
+  // unseeded (a second uart would otherwise re-suggest the first
+  // bus's pins, #1555); no exclude range — the new component isn't
+  // in the YAML yet.
+  next = seedBoardPinDefaults(component.id, entries, board, next, findUsedPins(yaml));
 
   // Restore what the user typed before a "+ Add <dep>" detour, over the freshly
   // seeded defaults, but before `prefillReference` so the just-added dep's id

--- a/src/util/pin/board-defaults.ts
+++ b/src/util/pin/board-defaults.ts
@@ -47,6 +47,10 @@ export function seedBoardPinDefaults(
   // feature tags that match the board manifest's pin-feature list.
   if (componentId.includes(".")) return values;
   let next = values;
+  // Pins this pass already seeded: two roles tagged on one GPIO must
+  // not both resolve to it, or the seeder manufactures the same
+  // duplicate-pin error the used-pin skip exists to remove.
+  const taken = new Set<number | string>();
   for (const entry of configEntries) {
     if (entry.type !== ConfigEntryType.PIN) continue;
     if (next[entry.key] !== undefined) continue;
@@ -61,9 +65,11 @@ export function seedBoardPinDefaults(
     // and a board with every tagged pin taken leaves the field for the
     // user instead of re-suggesting the first bus's pins (#1555).
     const matchingPin = board.pins.find(
-      (p) => p.features.includes(featureTag) && !usedPins.has(p.gpio)
+      (p) =>
+        p.features.includes(featureTag) && !usedPins.has(p.gpio) && !taken.has(p.gpio)
     );
     if (!matchingPin) continue;
+    taken.add(matchingPin.gpio);
     next = { ...next, [entry.key]: matchingPin.gpio };
   }
   return next;

--- a/src/util/pin/board-defaults.ts
+++ b/src/util/pin/board-defaults.ts
@@ -38,7 +38,8 @@ export function seedBoardPinDefaults(
   componentId: string,
   configEntries: ConfigEntry[],
   board: BoardCatalogEntry | null,
-  values: Record<string, unknown>
+  values: Record<string, unknown>,
+  usedPins: ReadonlyMap<number | string, string>
 ): Record<string, unknown> {
   if (!board?.pins?.length) return values;
   // Platform-qualified ids (``audio_adc.es7210``) → skip. Bus-like
@@ -55,7 +56,13 @@ export function seedBoardPinDefaults(
     // ``_pin_feature_from_name`` (device-builder#1012 / #1165).
     const role = entry.key.toLowerCase().replace(/_(pin|gpio)$/, "");
     const featureTag = `${componentId}_${role}`;
-    const matchingPin = board.pins.find((p) => p.features.includes(featureTag));
+    // First tagged pin the YAML doesn't wire yet: a second bus falls
+    // through to the next tagged pin (a wesp32 tags i2c_sda on three),
+    // and a board with every tagged pin taken leaves the field for the
+    // user instead of re-suggesting the first bus's pins (#1555).
+    const matchingPin = board.pins.find(
+      (p) => p.features.includes(featureTag) && !usedPins.has(p.gpio)
+    );
     if (!matchingPin) continue;
     next = { ...next, [entry.key]: matchingPin.gpio };
   }

--- a/test/components/device/add-component-form-seed.test.ts
+++ b/test/components/device/add-component-form-seed.test.ts
@@ -7,10 +7,12 @@
  */
 import { describe, expect, it } from "vitest";
 
+import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
 import type { ConfigEntry } from "../../../src/api/types/config-entries.js";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+import { buildInitialValues } from "../../../src/components/device/add-component-form-seed.js";
 import { identityLocalize } from "../../_dom.js";
 import { makeConfigEntry } from "../../util/_make-config-entry.js";
 
@@ -297,5 +299,48 @@ describe("add-component-form dep-add bus prefill (#1425)", () => {
     ]);
     // STRING entry keeps a string default, not a coerced number.
     expect(stop.default_value).toBe("1");
+  });
+});
+
+describe("board pin defaults skip YAML-occupied pins (#1555)", () => {
+  const uartBoard = {
+    id: "esp32-s3-devkitc-1",
+    esphome: { platform: "esp32", board: "esp32-s3-devkitc-1" },
+    pins: [
+      { gpio: 44, label: "GPIO44", features: ["uart_rx"] },
+      { gpio: 43, label: "GPIO43", features: ["uart_tx"] },
+    ],
+  } as unknown as BoardCatalogEntry;
+
+  function seedUart(yaml: string): Record<string, unknown> {
+    return buildInitialValues({
+      entries: [
+        makeConfigEntry({ key: "rx_pin", type: ConfigEntryType.PIN }),
+        makeConfigEntry({ key: "tx_pin", type: ConfigEntryType.PIN }),
+      ],
+      component: { id: "uart", config_entries: [] } as unknown as ComponentCatalogEntry,
+      board: uartBoard,
+      yaml,
+      prefillReference: null,
+      prefillFields: null,
+      restoredValues: null,
+      localize: identityLocalize,
+    });
+  }
+
+  it("leaves the pins unset when an existing bus already wires them", () => {
+    const yaml = [
+      "uart:",
+      "  - baud_rate: 9600",
+      "    rx_pin: 44",
+      "    tx_pin: 43",
+      "    id: uart_1",
+      "",
+    ].join("\n");
+    expect(seedUart(yaml)).toEqual({});
+  });
+
+  it("keeps seeding the first bus (pins not in the YAML yet)", () => {
+    expect(seedUart("")).toEqual({ rx_pin: 44, tx_pin: 43 });
   });
 });

--- a/test/util/pin/board-defaults.test.ts
+++ b/test/util/pin/board-defaults.test.ts
@@ -300,6 +300,28 @@ describe("seedBoardPinDefaults", () => {
     expect(result).toEqual({ rx_pin: 18, tx_pin: 17 });
   });
 
+  it("never seeds one GPIO for two roles in the same pass", () => {
+    // A pin tagged with both roles must not resolve for both entries —
+    // that would recreate the duplicate-pin error on submit. First
+    // entry wins by loop order; the second falls through or stays
+    // unset.
+    const board = makeBoard([
+      makePin({ gpio: 8, features: ["i2c_sda", "i2c_scl"] }),
+      makePin({ gpio: 9, features: ["i2c_scl"] }),
+    ]);
+    const result = seedBoardPinDefaults(
+      "i2c",
+      [
+        makeEntry({ key: "sda", default_value: "SDA" }),
+        makeEntry({ key: "scl", default_value: "SCL" }),
+      ],
+      board,
+      {},
+      NO_USED_PINS
+    );
+    expect(result).toEqual({ sda: 8, scl: 9 });
+  });
+
   it("falls through to the next free tagged pin (second i2c bus)", () => {
     // wesp32 shape: i2c_sda / i2c_scl tagged on several pins. A second
     // bus skips the pair the first bus wired and suggests the next

--- a/test/util/pin/board-defaults.test.ts
+++ b/test/util/pin/board-defaults.test.ts
@@ -51,6 +51,8 @@ function makeEntry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
   return makeConfigEntry({ type: ConfigEntryType.PIN, label: "", ...overrides });
 }
 
+const NO_USED_PINS = new Map<number | string, string>();
+
 describe("seedBoardPinDefaults", () => {
   // Original ESP32-C3 i2c repro shape: GPIO8 tagged i2c_sda, GPIO9
   // tagged i2c_scl. The bus's catalog entry has scl/sda PIN entries
@@ -71,9 +73,13 @@ describe("seedBoardPinDefaults", () => {
   ];
 
   it("seeds matching pins from board manifest features", () => {
-    const result = seedBoardPinDefaults("i2c", i2cEntries, makeBoard(c3Pins), {
-      id: "i2c_1",
-    });
+    const result = seedBoardPinDefaults(
+      "i2c",
+      i2cEntries,
+      makeBoard(c3Pins),
+      { id: "i2c_1" },
+      NO_USED_PINS
+    );
     // GPIO8 is tagged i2c_sda → sda entry gets 8.
     // GPIO9 is tagged i2c_scl → scl entry gets 9.
     expect(result).toEqual({ id: "i2c_1", scl: 9, sda: 8 });
@@ -85,23 +91,32 @@ describe("seedBoardPinDefaults", () => {
       i2cEntries,
       makeBoard(c3Pins),
       // User typed scl manually before clicking Add.
-      { id: "i2c_1", scl: 5 }
+      { id: "i2c_1", scl: 5 },
+      NO_USED_PINS
     );
     // sda still seeded; scl untouched.
     expect(result).toEqual({ id: "i2c_1", scl: 5, sda: 8 });
   });
 
   it("returns input unchanged when board is null", () => {
-    const result = seedBoardPinDefaults("i2c", i2cEntries, null, {
-      id: "i2c_1",
-    });
+    const result = seedBoardPinDefaults(
+      "i2c",
+      i2cEntries,
+      null,
+      { id: "i2c_1" },
+      NO_USED_PINS
+    );
     expect(result).toEqual({ id: "i2c_1" });
   });
 
   it("returns input unchanged when board has no pins", () => {
-    const result = seedBoardPinDefaults("i2c", i2cEntries, makeBoard([]), {
-      id: "i2c_1",
-    });
+    const result = seedBoardPinDefaults(
+      "i2c",
+      i2cEntries,
+      makeBoard([]),
+      { id: "i2c_1" },
+      NO_USED_PINS
+    );
     expect(result).toEqual({ id: "i2c_1" });
   });
 
@@ -111,9 +126,13 @@ describe("seedBoardPinDefaults", () => {
       makePin({ gpio: 0, features: ["adc"] }),
       makePin({ gpio: 1, features: ["adc"] }),
     ]);
-    const result = seedBoardPinDefaults("i2c", i2cEntries, board, {
-      id: "i2c_1",
-    });
+    const result = seedBoardPinDefaults(
+      "i2c",
+      i2cEntries,
+      board,
+      { id: "i2c_1" },
+      NO_USED_PINS
+    );
     // No seeding — user picks pins manually via the form.
     expect(result).toEqual({ id: "i2c_1" });
   });
@@ -127,7 +146,8 @@ describe("seedBoardPinDefaults", () => {
       "audio_adc.es7210",
       [makeEntry({ key: "din", default_value: "GPIO4" })],
       makeBoard([makePin({ gpio: 4, features: ["adc"] })]),
-      {}
+      {},
+      NO_USED_PINS
     );
     expect(result).toEqual({});
   });
@@ -144,7 +164,8 @@ describe("seedBoardPinDefaults", () => {
       "featured.athom-smart-plug-v3.relay",
       [makeEntry({ key: "pin", default_value: "GPIO12" })],
       makeBoard([makePin({ gpio: 8, features: ["i2c_sda"] })]),
-      { pin: "GPIO12" } // catalog preset already in values
+      { pin: "GPIO12" }, // catalog preset already in values
+      NO_USED_PINS
     );
     // No change — preset stays put.
     expect(result).toEqual({ pin: "GPIO12" });
@@ -164,7 +185,8 @@ describe("seedBoardPinDefaults", () => {
         }),
       ],
       board,
-      {}
+      {},
+      NO_USED_PINS
     );
     expect(result).toEqual({});
   });
@@ -185,7 +207,8 @@ describe("seedBoardPinDefaults", () => {
         makeEntry({ key: "tx_pin", default_value: "GPIO1" }),
       ],
       board,
-      {}
+      {},
+      NO_USED_PINS
     );
     expect(result).toEqual({ rx_pin: 20, tx_pin: 21 });
   });
@@ -204,9 +227,103 @@ describe("seedBoardPinDefaults", () => {
         makeEntry({ key: "tx_gpio", default_value: "GPIO1" }), // _gpio suffix
       ],
       board,
-      {}
+      {},
+      NO_USED_PINS
     );
     expect(result).toEqual({ rx: 20, tx_gpio: 21 });
+  });
+
+  it("leaves the field unset when every tagged pin is occupied (issue #1555)", () => {
+    // Second uart on a board with one uart_rx/uart_tx pair: the first
+    // bus already wires 20/21, and no other tagged pin exists, so
+    // seeding them again would just manufacture a "used in multiple
+    // places" error on submit.
+    const board = makeBoard([
+      makePin({ gpio: 20, features: ["uart_rx"] }),
+      makePin({ gpio: 21, features: ["uart_tx"] }),
+    ]);
+    const result = seedBoardPinDefaults(
+      "uart",
+      [
+        makeEntry({ key: "rx_pin", default_value: "GPIO3" }),
+        makeEntry({ key: "tx_pin", default_value: "GPIO1" }),
+      ],
+      board,
+      {},
+      new Map([
+        [20, "uart"],
+        [21, "uart"],
+      ])
+    );
+    // Left for the user to wire — no value at all, not a warned one.
+    expect(result).toEqual({});
+  });
+
+  it("seeds the free pin when only one of the pair is occupied", () => {
+    const board = makeBoard([
+      makePin({ gpio: 20, features: ["uart_rx"] }),
+      makePin({ gpio: 21, features: ["uart_tx"] }),
+    ]);
+    const result = seedBoardPinDefaults(
+      "uart",
+      [
+        makeEntry({ key: "rx_pin", default_value: "GPIO3" }),
+        makeEntry({ key: "tx_pin", default_value: "GPIO1" }),
+      ],
+      board,
+      {},
+      new Map([[20, "switch"]])
+    );
+    expect(result).toEqual({ tx_pin: 21 });
+  });
+
+  it("suggests the next workable uart pair when the board tags two", () => {
+    const board = makeBoard([
+      makePin({ gpio: 44, features: ["uart_rx"] }),
+      makePin({ gpio: 43, features: ["uart_tx"] }),
+      makePin({ gpio: 18, features: ["uart_rx"] }),
+      makePin({ gpio: 17, features: ["uart_tx"] }),
+    ]);
+    const result = seedBoardPinDefaults(
+      "uart",
+      [
+        makeEntry({ key: "rx_pin", default_value: "GPIO3" }),
+        makeEntry({ key: "tx_pin", default_value: "GPIO1" }),
+      ],
+      board,
+      {},
+      new Map([
+        [44, "uart"],
+        [43, "uart"],
+      ])
+    );
+    expect(result).toEqual({ rx_pin: 18, tx_pin: 17 });
+  });
+
+  it("falls through to the next free tagged pin (second i2c bus)", () => {
+    // wesp32 shape: i2c_sda / i2c_scl tagged on several pins. A second
+    // bus skips the pair the first bus wired and suggests the next
+    // workable pair by manifest order.
+    const board = makeBoard([
+      makePin({ gpio: 21, features: ["pwm", "i2c_sda"] }),
+      makePin({ gpio: 22, features: ["pwm", "i2c_scl"] }),
+      makePin({ gpio: 15, features: ["touch", "i2c_sda"] }),
+      makePin({ gpio: 4, features: ["adc", "i2c_scl"] }),
+    ]);
+    const result = seedBoardPinDefaults(
+      "i2c",
+      [
+        makeEntry({ key: "sda", default_value: "SDA" }),
+        makeEntry({ key: "scl", default_value: "SCL" }),
+      ],
+      board,
+      {},
+      new Map([
+        [21, "i2c"],
+        [22, "i2c"],
+      ])
+    );
+    expect(result).toEqual({ sda: 15, scl: 4 });
   });
 
   it("uses the FIRST matching pin when multiple are tagged", () => {
@@ -222,7 +339,8 @@ describe("seedBoardPinDefaults", () => {
       "i2c",
       [makeEntry({ key: "sda", default_value: "SDA" })],
       board,
-      {}
+      {},
+      NO_USED_PINS
     );
     expect(result).toEqual({ sda: 8 });
   });


### PR DESCRIPTION
# What does this implement/fix?

Adding a second `uart` (from the catalog, or via the #1554 missing dependency detour) pre filled the first bus's pins again: `seedBoardPinDefaults` seeded from the board manifest's `uart_rx` / `uart_tx` feature tags without looking at the YAML, so the pin picker warned about the very value the form suggested and submit produced "Pin 44 is used in multiple places".

`buildInitialValues` now threads `findUsedPins(yaml)` (the same canonical GPIO map the pin picker's conflict hints use) into the seeder, which picks the first tagged pin the YAML does not wire yet. A board tagging several pins per role (wesp32 tags `i2c_sda` on three) suggests the next workable pair for a second bus; when every tagged pin is taken the field is left empty for the user to wire. The first bus keeps today's behavior since its pins are not in the YAML yet, and one change covers the direct add, the fast path add, and the dep detour because all three enter through `buildInitialValues`.

**Related issue or feature (if applicable):**

- fixes #1555

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
