### PR TITLE
Move the instance-scalar primitives into their own module

### DIFF
--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -22,11 +22,11 @@ import { isPinFieldKey, parsePinGpio, scanPinGpios } from "./pin/gpio.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import { hasSubstitutionReference } from "./substitutions.js";
 import { indentOf } from "./yaml-line-walker.js";
+import { readInstanceScalar } from "./yaml-instance-scalars.js";
 import {
   collectIdsAtPath,
   findFieldLine,
   parseYamlTopLevelSections,
-  readInstanceScalar,
   type YamlSection,
 } from "./yaml-sections-core.js";
 

--- a/src/util/default-component-id.ts
+++ b/src/util/default-component-id.ts
@@ -1,5 +1,5 @@
 import { isPlatformComponentId } from "./featured-id.js";
-import { collectInstanceScalars } from "./yaml-sections-core.js";
+import { collectInstanceScalars } from "./yaml-instance-scalars.js";
 
 /**
  * Auto-generate a default `id:` value for a component being added

--- a/src/util/default-entity-name.ts
+++ b/src/util/default-entity-name.ts
@@ -1,6 +1,6 @@
 import { parseCatalogId } from "./config-entry-yaml-scan.js";
 import { isPlatformComponentId } from "./featured-id.js";
-import { collectInstanceScalars } from "./yaml-sections-core.js";
+import { collectInstanceScalars } from "./yaml-instance-scalars.js";
 
 /**
  * Collision key mirroring esphome's str_sanitize(str_snake_case(name)),

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -14,12 +14,12 @@ import {
   LIST_ITEM_START_RE,
 } from "./yaml-section-lexer.js";
 import { _blockScalarBodyEnd } from "./yaml-section-list.js";
+import { readInstanceScalar } from "./yaml-instance-scalars.js";
 import {
   instanceComponentId,
   lineIndent,
   listItemChildIndent,
   parseYamlTopLevelSections,
-  readInstanceScalar,
   smallestContainingSection,
   type YamlSection,
 } from "./yaml-sections-core.js";

--- a/src/util/yaml-board.ts
+++ b/src/util/yaml-board.ts
@@ -1,11 +1,8 @@
 import type { SlimBoard } from "../api/types/boards.js";
 import { chipNameToVariant } from "./chip-variant.js";
 import { canonicalComponentKey, TARGET_PLATFORM_KEYS } from "./component-presence.js";
-import {
-  lineIndent,
-  parseYamlTopLevelSections,
-  readInstanceScalar,
-} from "./yaml-sections-core.js";
+import { readInstanceScalar } from "./yaml-instance-scalars.js";
+import { lineIndent, parseYamlTopLevelSections } from "./yaml-sections-core.js";
 
 export interface YamlPlatformBoard {
   /** Canonical platform key (`rp2` folded to `rp2040`). */

--- a/src/util/yaml-instance-scalars.ts
+++ b/src/util/yaml-instance-scalars.ts
@@ -1,0 +1,63 @@
+import { splitInlineComment, stripQuotes } from "./yaml-scalar.js";
+import { TOP_LEVEL_KEY_RE } from "./yaml-section-lexer.js";
+
+const _INSTANCE_SCALAR_RE = new Map<string, RegExp>();
+
+/**
+ * Value of a ``<key>: value`` line (surrounding quotes peeled), or ``null``.
+ *
+ * Allows an optional leading ``- `` list dash; ``id`` / ``platform`` take a
+ * bare token, other keys (``name``) the rest of the line. A trailing inline
+ * comment is stripped quote-aware (YAML's whitespace-preceded ``#`` rule):
+ * ``name: a#b`` keeps ``a#b``, ``name: "Foo # b"`` keeps ``Foo # b``,
+ * ``name: Foo  # bar`` keeps ``Foo``, ``name: # c`` is ``null`` (comment
+ * only). Callers gate the line's indent.
+ */
+export function readInstanceScalar(line: string, key: string): string | null {
+  const bareToken = key === "id" || key === "platform";
+  let re = _INSTANCE_SCALAR_RE.get(key);
+  if (re === undefined) {
+    re = bareToken
+      ? new RegExp(`^\\s*(?:-\\s+)?${key}:\\s*["']?(\\S+?)["']?(?:\\s+#.*)?\\s*$`)
+      : new RegExp(`^\\s*(?:-\\s+)?${key}:\\s*(.*)$`);
+    _INSTANCE_SCALAR_RE.set(key, re);
+  }
+  const m = line.match(re);
+  if (!m) return null;
+  if (bareToken) return m[1];
+  const { value } = splitInlineComment(m[1]);
+  const trimmed = value.trim();
+  // Comment-only value (``name: # c``): the leading ``#`` isn't whitespace-
+  // preceded, so splitInlineComment keeps it. Quoted ``"#x"`` starts with the quote.
+  if (trimmed.startsWith("#")) return null;
+  return stripQuotes(trimmed).trim() || null;
+}
+
+/**
+ * Every value of an indented '<key>: value' line in *yaml*, as a set.
+ * Best-effort line scan via readInstanceScalar, deliberately simple
+ * (callers need a uniqueness pool, not a full parse). A real component
+ * field is always indented under a block, so column-0 lines are never
+ * collected. With *section* set, only lines under that top-level key
+ * are collected; blank and comment lines don't end a section.
+ */
+export function collectInstanceScalars(
+  yaml: string,
+  key: string,
+  section?: string
+): Set<string> {
+  const values = new Set<string>();
+  if (!yaml) return values;
+  let inSection = section === undefined;
+  for (const line of yaml.split("\n")) {
+    if (!/^\s/.test(line)) {
+      const top = line.match(TOP_LEVEL_KEY_RE);
+      if (section !== undefined && top) inSection = top[1] === section;
+      continue;
+    }
+    if (!inSection) continue;
+    const value = readInstanceScalar(line, key);
+    if (value !== null) values.add(value);
+  }
+  return values;
+}

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -14,7 +14,7 @@ import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import { isIndexSegment } from "./nested-values.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import { indentOf, RE_PAIR_LINE, stripComment } from "./yaml-line-walker.js";
-import { splitInlineComment, stripQuotes } from "./yaml-scalar.js";
+import { readInstanceScalar } from "./yaml-instance-scalars.js";
 import {
   _skipBlankAndCommentLines,
   endsBlockAtIndent,
@@ -351,67 +351,6 @@ export function listItemChildIndent(dashLine: string): number {
 /** Leading-space count of *line* (its indentation column). */
 export function lineIndent(line: string): number {
   return line.match(/^ */)?.[0].length ?? 0;
-}
-
-const _INSTANCE_SCALAR_RE = new Map<string, RegExp>();
-
-/**
- * Value of a ``<key>: value`` line (surrounding quotes peeled), or ``null``.
- *
- * Allows an optional leading ``- `` list dash; ``id`` / ``platform`` take a
- * bare token, other keys (``name``) the rest of the line. A trailing inline
- * comment is stripped quote-aware (YAML's whitespace-preceded ``#`` rule):
- * ``name: a#b`` keeps ``a#b``, ``name: "Foo # b"`` keeps ``Foo # b``,
- * ``name: Foo  # bar`` keeps ``Foo``, ``name: # c`` is ``null`` (comment
- * only). Callers gate the line's indent.
- */
-export function readInstanceScalar(line: string, key: string): string | null {
-  const bareToken = key === "id" || key === "platform";
-  let re = _INSTANCE_SCALAR_RE.get(key);
-  if (re === undefined) {
-    re = bareToken
-      ? new RegExp(`^\\s*(?:-\\s+)?${key}:\\s*["']?(\\S+?)["']?(?:\\s+#.*)?\\s*$`)
-      : new RegExp(`^\\s*(?:-\\s+)?${key}:\\s*(.*)$`);
-    _INSTANCE_SCALAR_RE.set(key, re);
-  }
-  const m = line.match(re);
-  if (!m) return null;
-  if (bareToken) return m[1];
-  const { value } = splitInlineComment(m[1]);
-  const trimmed = value.trim();
-  // Comment-only value (``name: # c``): the leading ``#`` isn't whitespace-
-  // preceded, so splitInlineComment keeps it. Quoted ``"#x"`` starts with the quote.
-  if (trimmed.startsWith("#")) return null;
-  return stripQuotes(trimmed).trim() || null;
-}
-
-/**
- * Every value of an indented '<key>: value' line in *yaml*, as a set.
- * Best-effort line scan via readInstanceScalar, deliberately simple
- * (callers need a uniqueness pool, not a full parse). A real component
- * field is always indented under a block, so column-0 lines are never
- * collected. With *section* set, only lines under that top-level key
- * are collected; blank and comment lines don't end a section.
- */
-export function collectInstanceScalars(
-  yaml: string,
-  key: string,
-  section?: string
-): Set<string> {
-  const values = new Set<string>();
-  if (!yaml) return values;
-  let inSection = section === undefined;
-  for (const line of yaml.split("\n")) {
-    if (!/^\s/.test(line)) {
-      const top = line.match(TOP_LEVEL_KEY_RE);
-      if (section !== undefined && top) inSection = top[1] === section;
-      continue;
-    }
-    if (!inSection) continue;
-    const value = readInstanceScalar(line, key);
-    if (value !== null) values.add(value);
-  }
-  return values;
 }
 
 /**

--- a/test/util/yaml-field-line.test.ts
+++ b/test/util/yaml-field-line.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { readInstanceScalar } from "../../src/util/yaml-instance-scalars.js";
 import {
   _clearYamlSectionsMemo,
   findFieldLine,
   parseYamlTopLevelSections,
-  readInstanceScalar,
   type YamlSection,
 } from "../../src/util/yaml-sections-core.js";
 


### PR DESCRIPTION
# What does this implement/fix?

Behavior-free follow-up to the file-size note on #1552: adding `collectInstanceScalars` pushed `yaml-sections-core.ts` from 591 to 620 lines, past the README's 500-600 hard cap.

This moves the two instance-scalar primitives (`readInstanceScalar`, `collectInstanceScalars`) into a new leaf module `src/util/yaml-instance-scalars.ts` and repoints the six importers directly (no re-export shim). `yaml-sections-core.ts` lands at 559 lines, back inside the band. The moved code is byte-identical; no logic changes.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
