### PR TITLE
Hoist the indexed line-to-path walk into a shared walker

### DIFF
--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -199,12 +199,10 @@ function _parseYamlAutomations(yaml: string): YamlSection[] {
   // inside a trigger or action body (``on_*`` / another ``*_action`` /
   // ``then``-family ancestor) is edited within that automation's tree
   // and excluded.
-  const actionMatches: Array<{
-    idx: number;
-    indent: number;
-    field: string;
-    host: YamlSection;
-  }> = [];
+  const actionMatchesByHost = new Map<
+    YamlSection,
+    Map<number, { indent: number; field: string }>
+  >();
   for (let i = 0; i < lines.length; i++) {
     const match = lines[i].match(_COMPONENT_ACTION_FIELD_RE);
     if (!match) continue;
@@ -213,30 +211,26 @@ function _parseYamlAutomations(yaml: string): YamlSection[] {
     if (match[2].startsWith("on_")) continue;
     const host = smallestContainingSection(sections, i + 1);
     if (!host) continue;
-    actionMatches.push({ idx: i, indent: match[1].length, field: match[2], host });
+    let byLine = actionMatchesByHost.get(host);
+    if (!byLine) actionMatchesByHost.set(host, (byLine = new Map()));
+    byLine.set(i, { indent: match[1].length, field: match[2] });
   }
-  // One walk per host: sections are disjoint and ascending, so consecutive
-  // grouping keeps the matches' global line order in the emitted rows.
-  for (let m = 0; m < actionMatches.length; ) {
-    const host = actionMatches[m].host;
-    const group: typeof actionMatches = [];
-    for (; m < actionMatches.length && actionMatches[m].host === host; m++) {
-      group.push(actionMatches[m]);
-    }
+  // One walk per host. Hosts arrive in first-match order and the walker
+  // visits ascending, so — sections being disjoint — the emitted rows
+  // keep the match lines' global order.
+  for (const [host, byLine] of actionMatchesByHost) {
     let componentId: string | null | undefined;
-    let g = 0;
+    let remaining = byLine.size;
     walkIndexedPaths(lines, host, (v) => {
-      // A match the walker refused to visit (block-scalar body, line
+      // A match the walker never visits (block-scalar body, line
       // shallower than the host's child column) emits nothing.
-      while (g < group.length && group[g].idx < v.lineIdx) g++;
-      if (g >= group.length) return false;
-      if (v.lineIdx !== group[g].idx) return;
-      const { idx, indent, field } = group[g];
-      g++;
+      const match = byLine.get(v.lineIdx);
+      if (!match) return;
+      const stop = --remaining === 0 ? false : undefined;
       // A field inside an automation body is edited within that
       // automation's tree, not addressed on the instance.
       for (const frame of v.frames) {
-        if (typeof frame.seg === "string" && isAutomationKey(frame.seg)) return;
+        if (typeof frame.seg === "string" && isAutomationKey(frame.seg)) return stop;
       }
       const segments: Array<string | number> = v.frames.map((frame) => frame.seg);
       // Refuse paths the dotted encoding can't carry: an index whose
@@ -249,23 +243,23 @@ function _parseYamlAutomations(yaml: string): YamlSection[] {
           (typeof seg === "number" && typeof segments[i - 1] !== "string") ||
           (typeof seg === "string" && seg.includes("."))
       );
-      if (unencodable) return;
+      if (unencodable) return stop;
       componentId ??= instanceComponentId(sections, host);
       if (!componentId) return false;
-      segments.push(field);
+      segments.push(match.field);
       const dotted = joinActionFieldPath(segments);
       const labelHead = host.name || componentId;
       automations.push({
         key: `automation:component_action:${componentId}:${dotted}`,
         displayLabel: `${labelHead} → ${dotted}`,
-        fromLine: idx + 1,
-        toLine: _findBlockEnd(lines, idx, indent),
+        fromLine: v.lineIdx + 1,
+        toLine: _findBlockEnd(lines, v.lineIdx, match.indent),
         id: componentId,
         name: host.name,
         parentKey: host.parentKey ?? host.key,
         actionField: dotted,
       });
-      return;
+      return stop;
     });
   }
 

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -8,14 +8,13 @@
 import { joinActionFieldPath } from "./action-field-path.js";
 import {
   BARE_MAPPING_KEY_RE,
-  BLOCK_SCALAR_RE,
   endsBlockAtIndent,
   isAutomationKey,
   isBlankOrCommentLine,
   LIST_ITEM_START_RE,
 } from "./yaml-section-lexer.js";
-import { _blockScalarBodyEnd } from "./yaml-section-list.js";
 import { readInstanceScalar } from "./yaml-instance-scalars.js";
+import { walkIndexedPaths } from "./yaml-indexed-path.js";
 import {
   instanceComponentId,
   lineIndent,
@@ -200,32 +199,73 @@ function _parseYamlAutomations(yaml: string): YamlSection[] {
   // inside a trigger or action body (``on_*`` / another ``*_action`` /
   // ``then``-family ancestor) is edited within that automation's tree
   // and excluded.
+  const actionMatches: Array<{
+    idx: number;
+    indent: number;
+    field: string;
+    host: YamlSection;
+  }> = [];
   for (let i = 0; i < lines.length; i++) {
     const match = lines[i].match(_COMPONENT_ACTION_FIELD_RE);
     if (!match) continue;
-    const indent = match[1].length;
-    const field = match[2];
     // An ``on_*`` key is a trigger, already emitted by the loop above;
     // skip it here so an ``on_…_action`` name can't be counted twice.
-    if (field.startsWith("on_")) continue;
-    const fromLine = i + 1;
-    const host = smallestContainingSection(sections, fromLine);
+    if (match[2].startsWith("on_")) continue;
+    const host = smallestContainingSection(sections, i + 1);
     if (!host) continue;
-    const segments = _actionFieldPath(lines, host, i, indent, field);
-    if (!segments) continue;
-    const componentId = instanceComponentId(sections, host);
-    if (!componentId) continue;
-    const dotted = joinActionFieldPath(segments);
-    const labelHead = host.name || componentId;
-    automations.push({
-      key: `automation:component_action:${componentId}:${dotted}`,
-      displayLabel: `${labelHead} → ${dotted}`,
-      fromLine,
-      toLine: _findBlockEnd(lines, i, indent),
-      id: componentId,
-      name: host.name,
-      parentKey: host.parentKey ?? host.key,
-      actionField: dotted,
+    actionMatches.push({ idx: i, indent: match[1].length, field: match[2], host });
+  }
+  // One walk per host: sections are disjoint and ascending, so consecutive
+  // grouping keeps the matches' global line order in the emitted rows.
+  for (let m = 0; m < actionMatches.length; ) {
+    const host = actionMatches[m].host;
+    const group: typeof actionMatches = [];
+    for (; m < actionMatches.length && actionMatches[m].host === host; m++) {
+      group.push(actionMatches[m]);
+    }
+    let componentId: string | null | undefined;
+    let g = 0;
+    walkIndexedPaths(lines, host, (v) => {
+      // A match the walker refused to visit (block-scalar body, line
+      // shallower than the host's child column) emits nothing.
+      while (g < group.length && group[g].idx < v.lineIdx) g++;
+      if (g >= group.length) return false;
+      if (v.lineIdx !== group[g].idx) return;
+      const { idx, indent, field } = group[g];
+      g++;
+      // A field inside an automation body is edited within that
+      // automation's tree, not addressed on the instance.
+      for (const frame of v.frames) {
+        if (typeof frame.seg === "string" && isAutomationKey(frame.seg)) return;
+      }
+      const segments: Array<string | number> = v.frames.map((frame) => frame.seg);
+      // Refuse paths the dotted encoding can't carry: an index whose
+      // container key the bare-key regex couldn't name (quoted,
+      // hyphenated — the frame dropped while its dashes still count),
+      // or a segment containing a dot, which the lossless-join
+      // invariant of ``action-field-path.ts`` forbids.
+      const unencodable = segments.some(
+        (seg, i) =>
+          (typeof seg === "number" && typeof segments[i - 1] !== "string") ||
+          (typeof seg === "string" && seg.includes("."))
+      );
+      if (unencodable) return;
+      componentId ??= instanceComponentId(sections, host);
+      if (!componentId) return false;
+      segments.push(field);
+      const dotted = joinActionFieldPath(segments);
+      const labelHead = host.name || componentId;
+      automations.push({
+        key: `automation:component_action:${componentId}:${dotted}`,
+        displayLabel: `${labelHead} → ${dotted}`,
+        fromLine: idx + 1,
+        toLine: _findBlockEnd(lines, idx, indent),
+        id: componentId,
+        name: host.name,
+        parentKey: host.parentKey ?? host.key,
+        actionField: dotted,
+      });
+      return;
     });
   }
 
@@ -311,112 +351,6 @@ function _parseYamlAutomations(yaml: string): YamlSection[] {
   }
 
   return automations;
-}
-
-/** A dash item's leader — the match length is the item's content column. */
-const _DASH_LEADER_RE = /^\s*-(\s+|$)/;
-
-/**
- * Concrete path segments from *host*'s body to the ``*_action`` key at
- * *targetIdx*, list items as 0-based indices — the backend's
- * ``component_action`` addressing. ``null`` when the field sits inside
- * an automation body (an ``isAutomationKey`` ancestor — edited within
- * that automation's tree) or the structure doesn't resolve. Best-effort
- * like the rest of this fallback: block scalars and flow collections
- * aren't modelled, so a key-shaped line inside one can misframe until
- * backend parse corrects it.
- */
-function _actionFieldPath(
-  lines: string[],
-  host: YamlSection,
-  targetIdx: number,
-  targetIndent: number,
-  field: string
-): Array<string | number> | null {
-  const hostLine = lines[host.fromLine - 1] ?? "";
-  const childIndent = listItemChildIndent(hostLine);
-  if (targetIndent < childIndent) return null;
-  // Walk the instance body accumulating the enclosing frames: block
-  // mapping keys by indent, list items as counted dash indices.
-  const stack: Array<{ indent: number; seg: string | number }> = [];
-  // A bare inline first key on the instance dash line (``- valves:``)
-  // opens a block the loop below never sees — seed its frame.
-  const hostDash = hostLine.match(_DASH_LEADER_RE);
-  const hostInlineKey = hostDash
-    ? hostLine.slice(hostDash[0].length).match(BARE_MAPPING_KEY_RE)
-    : null;
-  if (hostInlineKey) stack.push({ indent: childIndent, seg: hostInlineKey[1] });
-  // A block scalar opened inline on the dash line hides its body from
-  // the loop's opener check — refuse a target inside it, start past it.
-  let walkStart = host.fromLine;
-  if (
-    hostDash &&
-    !hostInlineKey &&
-    BLOCK_SCALAR_RE.test(hostLine.slice(hostDash[0].length))
-  ) {
-    const end = _blockScalarBodyEnd(lines, host.fromLine, childIndent);
-    if (targetIdx < end) return null;
-    walkStart = end;
-  }
-  for (let j = walkStart; j <= targetIdx; j++) {
-    const line = lines[j];
-    if (isBlankOrCommentLine(line)) continue;
-    let indent = lineIndent(line);
-    let rest = line.slice(indent);
-    const dash = line.match(_DASH_LEADER_RE);
-    while (stack.length) {
-      const top = stack[stack.length - 1];
-      if (top.indent < indent) break;
-      // A dash keeps its same-indent frames: the sibling index it
-      // increments, and — in the zero-indent sequence style — the
-      // parent key whose column the dashes share.
-      if (dash && top.indent === indent) break;
-      stack.pop();
-    }
-    if (dash) {
-      const top = stack[stack.length - 1];
-      if (top && top.indent === indent && typeof top.seg === "number") {
-        top.seg += 1;
-      } else {
-        stack.push({ indent, seg: 0 });
-      }
-      rest = line.slice(dash[0].length);
-      if (!rest.trim()) continue;
-      // An inline first key sits at the item's content column.
-      indent = dash[0].length;
-    }
-    if (j === targetIdx) {
-      for (const frame of stack) {
-        if (typeof frame.seg === "string" && isAutomationKey(frame.seg)) return null;
-      }
-      const segments: Array<string | number> = stack.map((frame) => frame.seg);
-      // Refuse paths the dotted encoding can't carry: an index whose
-      // container key the bare-key regex couldn't name (quoted,
-      // hyphenated — the frame dropped while its dashes still count),
-      // or a segment containing a dot, which the lossless-join
-      // invariant of ``action-field-path.ts`` forbids.
-      const unencodable = segments.some(
-        (seg, idx) =>
-          (typeof seg === "number" && typeof segments[idx - 1] !== "string") ||
-          (typeof seg === "string" && seg.includes("."))
-      );
-      if (unencodable) return null;
-      segments.push(field);
-      return segments;
-    }
-    // A block scalar's body is opaque text: a ``*_action``-looking line
-    // inside it is not a field, and its content must not misframe the
-    // walk — refuse a target inside it, skip past it otherwise.
-    if (BLOCK_SCALAR_RE.test(rest)) {
-      const end = _blockScalarBodyEnd(lines, j + 1, indent);
-      if (targetIdx < end) return null;
-      j = end - 1;
-      continue;
-    }
-    const blockKey = rest.match(BARE_MAPPING_KEY_RE);
-    if (blockKey) stack.push({ indent, seg: blockKey[1] });
-  }
-  return null;
 }
 
 /** Resolve a handler at ``indent`` to its target instance: the host for a

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -7,6 +7,7 @@
 
 import { joinActionFieldPath } from "./action-field-path.js";
 import {
+  BARE_MAPPING_KEY_RE,
   BLOCK_SCALAR_RE,
   endsBlockAtIndent,
   isAutomationKey,
@@ -41,8 +42,6 @@ const _COMPONENT_ACTION_FIELD_RE = /^(\s+)([a-z0-9_]+_action):/;
 export const API_ACTIONS_BLOCK_KEYS = ["actions", "services"] as const;
 /** An inline ``on_*:`` trigger handler: group 1 the indent, group 2 the key. */
 const _ON_HANDLER_RE = /^(\s+)(on_[a-zA-Z_]+):/;
-/** A bare mapping-key line (``temperature:``) — key, no value, optional comment. */
-const _BARE_MAPPING_KEY_RE = /^ *([A-Za-z_][\w.]*):\s*(#.*)?$/;
 /** A dash line with inline content — the match length is the item's
  *  content column. */
 const _DASH_CONTENT_RE = /^\s*-\s+(?=\S)/;
@@ -344,7 +343,7 @@ function _actionFieldPath(
   // opens a block the loop below never sees — seed its frame.
   const hostDash = hostLine.match(_DASH_LEADER_RE);
   const hostInlineKey = hostDash
-    ? hostLine.slice(hostDash[0].length).match(_BARE_MAPPING_KEY_RE)
+    ? hostLine.slice(hostDash[0].length).match(BARE_MAPPING_KEY_RE)
     : null;
   if (hostInlineKey) stack.push({ indent: childIndent, seg: hostInlineKey[1] });
   // A block scalar opened inline on the dash line hides its body from
@@ -414,7 +413,7 @@ function _actionFieldPath(
       j = end - 1;
       continue;
     }
-    const blockKey = rest.match(_BARE_MAPPING_KEY_RE);
+    const blockKey = rest.match(BARE_MAPPING_KEY_RE);
     if (blockKey) stack.push({ indent, seg: blockKey[1] });
   }
   return null;
@@ -468,7 +467,7 @@ function _subEntity(
     if (ind < childIndent) return null; // left the instance's children
     if (ind === childIndent) {
       // Must be a bare mapping key (``temperature:``), not a sibling scalar.
-      const header = lines[j].match(_BARE_MAPPING_KEY_RE);
+      const header = lines[j].match(BARE_MAPPING_KEY_RE);
       if (!header) return null;
       headerIdx = j;
       key = header[1];

--- a/src/util/yaml-indexed-path.ts
+++ b/src/util/yaml-indexed-path.ts
@@ -5,8 +5,9 @@
  * `listItemChildIndent` on the section's own line (a flat host falls
  * back to `indent + 2` rather than reading the first child), block
  * scalars and flow collections aren't modelled, and only bare `key:`
- * lines open frames — a quoted or hyphenated container drops its frame,
- * which consumers detect as an index with no named parent.
+ * lines open frames — a quoted, hyphenated, or digit-leading container
+ * drops its frame, surfacing as an index with no named parent or as a
+ * shortened path.
  */
 
 import {
@@ -119,6 +120,10 @@ export function walkIndexedPaths(
  * key on 1-indexed *line*, list items as 0-based numeric indices, or
  * null (keyless / blank / comment line, block-scalar body, line outside
  * the section or shallower than its child column).
+ *
+ * Consumed today by the round-trip contract tests beside
+ * `findFieldLine`'s; one-shot queries only — a per-line sweep should
+ * use `walkIndexedPaths` directly.
  */
 export function indexedPathAtLine(
   yaml: string,

--- a/src/util/yaml-indexed-path.ts
+++ b/src/util/yaml-indexed-path.ts
@@ -1,13 +1,12 @@
 /**
  * Line → indexed-path walk over a section's body: `findFieldLine`'s
- * inverse, in its own module only for `yaml-sections-core`'s file-size
- * cap. Frames follow the fallback parser's rules, not `findFieldLine`'s
- * descent: the child column comes from `listItemChildIndent` on the
- * section's own line (a flat host falls back to `indent + 2` rather
- * than reading the first child), block scalars and flow collections
- * aren't modelled, and only bare `key:` lines open frames — a quoted or
- * hyphenated container drops its frame, which consumers detect as an
- * index with no named parent.
+ * inverse. Frames follow the fallback parser's rules, not
+ * `findFieldLine`'s descent: the child column comes from
+ * `listItemChildIndent` on the section's own line (a flat host falls
+ * back to `indent + 2` rather than reading the first child), block
+ * scalars and flow collections aren't modelled, and only bare `key:`
+ * lines open frames — a quoted or hyphenated container drops its frame,
+ * which consumers detect as an index with no named parent.
  */
 
 import {
@@ -35,13 +34,8 @@ export interface IndexedPathFrame {
 export interface IndexedPathVisit {
   /** 0-based index of the visited line. */
   lineIdx: number;
-  /** The line's own key — bare (`pin:`), valued (`number: 33`), or
-   *  dash-inline (`- name: x`) — or null for a keyless line. */
-  key: string | null;
-  /** True when the line's bare key opens a frame (value-less `key:`). */
-  isBare: boolean;
-  /** Content column of the line's key (dash-adjusted for inline keys). */
-  keyIndent: number;
+  /** Line content from the key column (dash-stripped, comment kept). */
+  rest: string;
   /** Live enclosing-frame stack, outermost first, NOT including the
    *  line's own key. Mutated in place as the walk advances — copy what
    *  must outlive the callback. */
@@ -79,7 +73,8 @@ export function walkIndexedPaths(
   for (let j = walkStart; j <= last; j++) {
     const line = lines[j];
     if (isBlankOrCommentLine(line)) continue;
-    let indent = lineIndent(line);
+    const rawIndent = lineIndent(line);
+    let indent = rawIndent;
     let rest = line.slice(indent);
     const dash = line.match(LIST_ITEM_START_RE);
     while (stack.length) {
@@ -104,16 +99,9 @@ export function walkIndexedPaths(
       // An inline first key sits at the item's content column.
       indent = contentCol;
     }
-    if (lineIndent(line) >= childIndent) {
-      const bare = rest.match(BARE_MAPPING_KEY_RE);
-      const pair = bare ? null : stripComment(rest).match(RE_PAIR_LINE);
-      const stop = visit({
-        lineIdx: j,
-        key: bare?.[1] ?? pair?.[1] ?? null,
-        isBare: bare !== null,
-        keyIndent: indent,
-        frames: stack,
-      });
+    const bare = rest.match(BARE_MAPPING_KEY_RE);
+    if (rawIndent >= childIndent) {
+      const stop = visit({ lineIdx: j, rest, frames: stack });
       if (stop === false) return;
     }
     // A block scalar's body is opaque text: a key-shaped line inside it
@@ -122,8 +110,7 @@ export function walkIndexedPaths(
       j = _blockScalarBodyEnd(lines, j + 1, indent) - 1;
       continue;
     }
-    const blockKey = rest.match(BARE_MAPPING_KEY_RE);
-    if (blockKey) stack.push({ indent, seg: blockKey[1] });
+    if (bare) stack.push({ indent, seg: bare[1] });
   }
 }
 
@@ -142,8 +129,9 @@ export function indexedPathAtLine(
   let path: Array<string | number> | null = null;
   walkIndexedPaths(lines, section, (v) => {
     if (v.lineIdx < line - 1) return;
-    if (v.lineIdx === line - 1 && v.key !== null) {
-      path = [...v.frames.map((f) => f.seg), v.key];
+    if (v.lineIdx === line - 1) {
+      const key = stripComment(v.rest).match(RE_PAIR_LINE)?.[1];
+      if (key !== undefined) path = [...v.frames.map((f) => f.seg), key];
     }
     return false;
   });

--- a/src/util/yaml-indexed-path.ts
+++ b/src/util/yaml-indexed-path.ts
@@ -1,0 +1,151 @@
+/**
+ * Line → indexed-path walk over a section's body: `findFieldLine`'s
+ * inverse, in its own module only for `yaml-sections-core`'s file-size
+ * cap. Frames follow the fallback parser's rules, not `findFieldLine`'s
+ * descent: the child column comes from `listItemChildIndent` on the
+ * section's own line (a flat host falls back to `indent + 2` rather
+ * than reading the first child), block scalars and flow collections
+ * aren't modelled, and only bare `key:` lines open frames — a quoted or
+ * hyphenated container drops its frame, which consumers detect as an
+ * index with no named parent.
+ */
+
+import {
+  BARE_MAPPING_KEY_RE,
+  BLOCK_SCALAR_RE,
+  isBlankOrCommentLine,
+  LIST_ITEM_START_RE,
+} from "./yaml-section-lexer.js";
+import { _blockScalarBodyEnd } from "./yaml-section-list.js";
+import { RE_PAIR_LINE, stripComment } from "./yaml-line-walker.js";
+import {
+  lineIndent,
+  listItemChildIndent,
+  type YamlSection,
+} from "./yaml-sections-core.js";
+
+/** One enclosing container frame: a bare mapping key or a 0-based list
+ *  index, at the indent column that owns it. */
+export interface IndexedPathFrame {
+  indent: number;
+  seg: string | number;
+}
+
+/** A visited content line and the container frames enclosing it. */
+export interface IndexedPathVisit {
+  /** 0-based index of the visited line. */
+  lineIdx: number;
+  /** The line's own key — bare (`pin:`), valued (`number: 33`), or
+   *  dash-inline (`- name: x`) — or null for a keyless line. */
+  key: string | null;
+  /** True when the line's bare key opens a frame (value-less `key:`). */
+  isBare: boolean;
+  /** Content column of the line's key (dash-adjusted for inline keys). */
+  keyIndent: number;
+  /** Live enclosing-frame stack, outermost first, NOT including the
+   *  line's own key. Mutated in place as the walk advances — copy what
+   *  must outlive the callback. */
+  frames: readonly IndexedPathFrame[];
+}
+
+/**
+ * One forward pass over *section*'s body, firing *visit* for each
+ * addressable content line in line order. Return `false` to stop.
+ *
+ * Lines shallower than the section's child column, blank/comment lines,
+ * and block-scalar bodies still maintain frames but are never visited.
+ */
+export function walkIndexedPaths(
+  lines: string[],
+  section: YamlSection,
+  visit: (v: IndexedPathVisit) => void | false
+): void {
+  const hostLine = lines[section.fromLine - 1] ?? "";
+  const childIndent = listItemChildIndent(hostLine);
+  const stack: IndexedPathFrame[] = [];
+  // A bare inline first key on the instance dash line (``- valves:``)
+  // opens a block the loop below never sees — seed its frame.
+  const hostDash = hostLine.match(LIST_ITEM_START_RE);
+  const hostRest = hostDash ? hostLine.slice(childIndent) : "";
+  const hostInlineKey = hostDash ? hostRest.match(BARE_MAPPING_KEY_RE) : null;
+  if (hostInlineKey) stack.push({ indent: childIndent, seg: hostInlineKey[1] });
+  // A block scalar opened inline on the dash line hides its body from
+  // the loop's opener check — start past it, its body unvisited.
+  let walkStart = section.fromLine;
+  if (hostDash && !hostInlineKey && BLOCK_SCALAR_RE.test(hostRest)) {
+    walkStart = _blockScalarBodyEnd(lines, section.fromLine, childIndent);
+  }
+  const last = Math.min(section.toLine, lines.length) - 1;
+  for (let j = walkStart; j <= last; j++) {
+    const line = lines[j];
+    if (isBlankOrCommentLine(line)) continue;
+    let indent = lineIndent(line);
+    let rest = line.slice(indent);
+    const dash = line.match(LIST_ITEM_START_RE);
+    while (stack.length) {
+      const top = stack[stack.length - 1];
+      if (top.indent < indent) break;
+      // A dash keeps its same-indent frames: the sibling index it
+      // increments, and — in the zero-indent sequence style — the
+      // parent key whose column the dashes share.
+      if (dash && top.indent === indent) break;
+      stack.pop();
+    }
+    if (dash) {
+      const top = stack[stack.length - 1];
+      if (top && top.indent === indent && typeof top.seg === "number") {
+        top.seg += 1;
+      } else {
+        stack.push({ indent, seg: 0 });
+      }
+      const contentCol = listItemChildIndent(line);
+      rest = line.slice(contentCol);
+      if (!rest.trim()) continue;
+      // An inline first key sits at the item's content column.
+      indent = contentCol;
+    }
+    if (lineIndent(line) >= childIndent) {
+      const bare = rest.match(BARE_MAPPING_KEY_RE);
+      const pair = bare ? null : stripComment(rest).match(RE_PAIR_LINE);
+      const stop = visit({
+        lineIdx: j,
+        key: bare?.[1] ?? pair?.[1] ?? null,
+        isBare: bare !== null,
+        keyIndent: indent,
+        frames: stack,
+      });
+      if (stop === false) return;
+    }
+    // A block scalar's body is opaque text: a key-shaped line inside it
+    // is not a field, and its content must not misframe the walk.
+    if (BLOCK_SCALAR_RE.test(rest)) {
+      j = _blockScalarBodyEnd(lines, j + 1, indent) - 1;
+      continue;
+    }
+    const blockKey = rest.match(BARE_MAPPING_KEY_RE);
+    if (blockKey) stack.push({ indent, seg: blockKey[1] });
+  }
+}
+
+/**
+ * `findFieldLine`'s inverse: the indexed section-relative path of the
+ * key on 1-indexed *line*, list items as 0-based numeric indices, or
+ * null (keyless / blank / comment line, block-scalar body, line outside
+ * the section or shallower than its child column).
+ */
+export function indexedPathAtLine(
+  yaml: string,
+  section: YamlSection,
+  line: number
+): Array<string | number> | null {
+  const lines = yaml.split("\n");
+  let path: Array<string | number> | null = null;
+  walkIndexedPaths(lines, section, (v) => {
+    if (v.lineIdx < line - 1) return;
+    if (v.lineIdx === line - 1 && v.key !== null) {
+      path = [...v.frames.map((f) => f.seg), v.key];
+    }
+    return false;
+  });
+  return path;
+}

--- a/src/util/yaml-indexed-path.ts
+++ b/src/util/yaml-indexed-path.ts
@@ -126,6 +126,15 @@ export function indexedPathAtLine(
   line: number
 ): Array<string | number> | null {
   const lines = yaml.split("\n");
+  // The walk starts past the section's own line; a list-item header's
+  // inline key (``- platform: gpio``) still inverts.
+  if (line === section.fromLine) {
+    const hostLine = lines[line - 1] ?? "";
+    if (!LIST_ITEM_START_RE.test(hostLine)) return null;
+    const rest = hostLine.slice(listItemChildIndent(hostLine));
+    const key = stripComment(rest).match(RE_PAIR_LINE)?.[1];
+    return key === undefined ? null : [key];
+  }
   let path: Array<string | number> | null = null;
   walkIndexedPaths(lines, section, (v) => {
     if (v.lineIdx < line - 1) return;

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -62,6 +62,15 @@ export const TOP_LEVEL_KEY_RE = /^([a-zA-Z_][a-zA-Z0-9_]*):/;
 export const LIST_ITEM_INLINE_KEY_RE = new RegExp(`^\\s*-\\s+(${KEY_PATTERN}):\\s*(.*)$`);
 
 /**
+ * A bare mapping-key line (``temperature:``) — key, no value, optional
+ * comment. This is the frame-opening key shape structural walkers push:
+ * a valued ``key: value`` line has no children, and a quoted or
+ * hyphenated key deliberately doesn't match (its frame drops, which the
+ * indexed-path consumers detect as an unencodable path).
+ */
+export const BARE_MAPPING_KEY_RE = /^ *([A-Za-z_][\w.]*):\s*(#.*)?$/;
+
+/**
  * Detect a YAML list-item start. Accepts both the standard
  * `  - <content>` form and the bare `  -` (end-of-line) form
  * `updateSectionInYaml` emits when a list item's inline-keyed

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -63,10 +63,9 @@ export const LIST_ITEM_INLINE_KEY_RE = new RegExp(`^\\s*-\\s+(${KEY_PATTERN}):\\
 
 /**
  * A bare mapping-key line (``temperature:``) — key, no value, optional
- * comment. This is the frame-opening key shape structural walkers push:
- * a valued ``key: value`` line has no children, and a quoted or
- * hyphenated key deliberately doesn't match (its frame drops, which the
- * indexed-path consumers detect as an unencodable path).
+ * comment. The frame-opening key shape structural walkers push: a
+ * valued ``key: value`` line has no children, and a quoted or
+ * hyphenated key deliberately doesn't match.
  */
 export const BARE_MAPPING_KEY_RE = /^ *([A-Za-z_][\w.]*):\s*(#.*)?$/;
 

--- a/test/util/yaml-automations.test.ts
+++ b/test/util/yaml-automations.test.ts
@@ -263,3 +263,43 @@ describe("parseYamlAutomations — empty / no-automation input", () => {
     expect(parseYamlAutomations("")).toEqual([]);
   });
 });
+
+describe("parseYamlAutomations — many-instance sweep", () => {
+  it("emits every nested action leaf across a large multi-instance config", () => {
+    const instance = (n: number) => [
+      `  - id: lawn_${n}`,
+      `    main_switch: Lawn ${n}`,
+      "    repeat_number:",
+      `      id: repeat_${n}`,
+      "      set_action:",
+      "        - logger.log: repeat changed",
+      "    valves:",
+      "      - valve_switch: Front",
+      "        run_duration_number:",
+      `          id: front_${n}`,
+      "          set_action:",
+      "            - logger.log: front changed",
+      "      - valve_switch: Back",
+      "        run_duration_number:",
+      `          id: back_${n}`,
+      "          set_action:",
+      "            - logger.log: back changed",
+    ];
+    const yaml = [
+      "sprinkler:",
+      ...Array.from({ length: 25 }, (_, n) => instance(n)).flat(),
+      "",
+    ].join("\n");
+    const rows = parseYamlAutomations(yaml);
+    expect(rows).toHaveLength(75);
+    expect(rows[0].key).toBe(
+      "automation:component_action:lawn_0:repeat_number.set_action"
+    );
+    expect(rows[1].key).toBe(
+      "automation:component_action:lawn_0:valves.0.run_duration_number.set_action"
+    );
+    expect(rows[74].key).toBe(
+      "automation:component_action:lawn_24:valves.1.run_duration_number.set_action"
+    );
+  });
+});

--- a/test/util/yaml-automations.test.ts
+++ b/test/util/yaml-automations.test.ts
@@ -113,6 +113,39 @@ describe("parseYamlAutomations — component triggers", () => {
     expect(action?.actionField).toBe("open_action");
   });
 
+  it("keeps trigger rows before action rows, each in global line order", () => {
+    const yaml = [
+      "cover:",
+      "  - platform: template",
+      "    id: front_cover",
+      "    on_open:",
+      "      then:",
+      "        - logger.log: front open",
+      "    open_action:",
+      "      - switch.turn_on: relay_a",
+      "    close_action:",
+      "      - switch.turn_off: relay_a",
+      "  - platform: template",
+      "    id: back_cover",
+      "    on_open:",
+      "      then:",
+      "        - logger.log: back open",
+      "    open_action:",
+      "      - switch.turn_on: relay_b",
+      "    stop_action:",
+      "      - switch.turn_off: relay_b",
+      "",
+    ].join("\n");
+    expect(keys(yaml)).toEqual([
+      "automation:component_on:front_cover:on_open",
+      "automation:component_on:back_cover:on_open",
+      "automation:component_action:front_cover:open_action",
+      "automation:component_action:front_cover:close_action",
+      "automation:component_action:back_cover:open_action",
+      "automation:component_action:back_cover:stop_action",
+    ]);
+  });
+
   it("does not double-count an on_*_action key as both trigger and action", () => {
     const yaml = [
       "cover:",

--- a/test/util/yaml-field-line.test.ts
+++ b/test/util/yaml-field-line.test.ts
@@ -227,6 +227,27 @@ describe("indexedPathAtLine", () => {
     expect(indexedPathAtLine(yaml, section, 2)).toEqual(["0"]);
   });
 
+  it("returns null on a flat section's own header line", () => {
+    const yaml = ["wifi:", "  ssid: x", ""].join("\n");
+    const section = sectionAt(yaml, 1);
+    expect(indexedPathAtLine(yaml, section, 1)).toBeNull();
+  });
+
+  it("inverts a bare inline first key on the section's dash line", () => {
+    const yaml = ["sprinkler:", "  - valves:", "      - valve_switch: Front", ""].join(
+      "\n"
+    );
+    const section = sectionAt(yaml, 2);
+    expect(indexedPathAtLine(yaml, section, 2)).toEqual(["valves"]);
+    expect(findFieldLine(yaml, section, ["valves"])).toBe(2);
+  });
+
+  it("returns null for a keyless scalar list item line", () => {
+    const yaml = ["wifi:", "  networks:", "  - one", "  - two", ""].join("\n");
+    const section = sectionAt(yaml, 1);
+    expect(indexedPathAtLine(yaml, section, 3)).toBeNull();
+  });
+
   it("returns null for blank, comment, block-scalar-body, and out-of-section lines", () => {
     const yaml = [
       "sensor:",

--- a/test/util/yaml-field-line.test.ts
+++ b/test/util/yaml-field-line.test.ts
@@ -227,6 +227,15 @@ describe("indexedPathAtLine", () => {
     expect(indexedPathAtLine(yaml, section, 2)).toEqual(["0"]);
   });
 
+  it("drops a digit-leading container's frame (documented inversion gap)", () => {
+    // ``0:`` inverts as a leaf but never opens a frame, so a child's
+    // path comes back shortened and does not round-trip.
+    const yaml = ["substitutions:", "  0:", "    name: x", ""].join("\n");
+    const section = sectionAt(yaml, 1);
+    expect(indexedPathAtLine(yaml, section, 3)).toEqual(["name"]);
+    expect(findFieldLine(yaml, section, ["0", "name"])).toBe(3);
+  });
+
   it("returns null on a flat section's own header line", () => {
     const yaml = ["wifi:", "  ssid: x", ""].join("\n");
     const section = sectionAt(yaml, 1);

--- a/test/util/yaml-field-line.test.ts
+++ b/test/util/yaml-field-line.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { indexedPathAtLine } from "../../src/util/yaml-indexed-path.js";
 import { readInstanceScalar } from "../../src/util/yaml-instance-scalars.js";
 import {
   _clearYamlSectionsMemo,
@@ -174,5 +175,88 @@ describe("findFieldLine", () => {
     ].join("\n");
     const second = sectionAt(yaml, 4); // the second `- platform: gpio`
     expect(findFieldLine(yaml, second, ["name"])).toBe(5);
+  });
+});
+
+const AREAS_YAML = [
+  "esphome:",
+  "  name: x",
+  "  areas:",
+  "    - name: zombie",
+  "      id: ff",
+  "    - name: other",
+  "      id: gg",
+  "",
+].join("\n");
+
+describe("indexedPathAtLine", () => {
+  it("inverts a top-level and a nested field line", () => {
+    const section = sectionAt(LIST_YAML, 2);
+    expect(indexedPathAtLine(LIST_YAML, section, 3)).toEqual(["name"]);
+    expect(indexedPathAtLine(LIST_YAML, section, 5)).toEqual(["pin"]);
+    expect(indexedPathAtLine(LIST_YAML, section, 6)).toEqual(["pin", "number"]);
+    expect(indexedPathAtLine(LIST_YAML, section, 7)).toEqual(["pin", "mode"]);
+  });
+
+  it("counts list items as numeric indices", () => {
+    const section = sectionAt(AREAS_YAML, 1);
+    expect(indexedPathAtLine(AREAS_YAML, section, 4)).toEqual(["areas", 0, "name"]);
+    expect(indexedPathAtLine(AREAS_YAML, section, 5)).toEqual(["areas", 0, "id"]);
+    expect(indexedPathAtLine(AREAS_YAML, section, 6)).toEqual(["areas", 1, "name"]);
+    expect(indexedPathAtLine(AREAS_YAML, section, 7)).toEqual(["areas", 1, "id"]);
+  });
+
+  it("inverts a same-indent compact block-sequence line", () => {
+    const yaml = ["wifi:", "  group:", "    items:", "    - ssid: a", "    - ssid: b", ""].join(
+      "\n"
+    );
+    const section = sectionAt(yaml, 1);
+    expect(indexedPathAtLine(yaml, section, 4)).toEqual(["group", "items", 0, "ssid"]);
+    expect(indexedPathAtLine(yaml, section, 5)).toEqual(["group", "items", 1, "ssid"]);
+  });
+
+  it("reads a numeric mapping key as a string segment", () => {
+    const yaml = ["substitutions:", "  0: zero", "  name: x", ""].join("\n");
+    const section = sectionAt(yaml, 1);
+    expect(indexedPathAtLine(yaml, section, 2)).toEqual(["0"]);
+  });
+
+  it("returns null for blank, comment, block-scalar-body, and out-of-section lines", () => {
+    const yaml = [
+      "sensor:",
+      "  - platform: template",
+      "",
+      "    # a comment",
+      "    lambda: |-",
+      "      return id(x) + 1;",
+      "    update_interval: 60s",
+      "wifi:",
+      "  ssid: x",
+      "",
+    ].join("\n");
+    const section = sectionAt(yaml, 2);
+    expect(indexedPathAtLine(yaml, section, 3)).toBeNull(); // blank
+    expect(indexedPathAtLine(yaml, section, 4)).toBeNull(); // comment
+    expect(indexedPathAtLine(yaml, section, 6)).toBeNull(); // scalar body
+    expect(indexedPathAtLine(yaml, section, 7)).toEqual(["update_interval"]);
+    expect(indexedPathAtLine(yaml, section, 9)).toBeNull(); // outside the section
+  });
+
+  it("round-trips every keyed line through findFieldLine", () => {
+    for (const [yaml, fromLine] of [
+      [LIST_YAML, 2],
+      [AREAS_YAML, 1],
+    ] as const) {
+      const section = sectionAt(yaml, fromLine);
+      const lineCount = yaml.split("\n").length;
+      let inverted = 0;
+      for (let line = section.fromLine + 1; line <= Math.min(section.toLine, lineCount); line++) {
+        const path = indexedPathAtLine(yaml, section, line);
+        if (path === null) continue;
+        expect(findFieldLine(yaml, section, path.map(String))).toBe(line);
+        inverted++;
+      }
+      expect(inverted).toBeGreaterThan(3);
+    }
   });
 });

--- a/test/util/yaml-field-line.test.ts
+++ b/test/util/yaml-field-line.test.ts
@@ -192,6 +192,7 @@ const AREAS_YAML = [
 describe("indexedPathAtLine", () => {
   it("inverts a top-level and a nested field line", () => {
     const section = sectionAt(LIST_YAML, 2);
+    expect(indexedPathAtLine(LIST_YAML, section, 2)).toEqual(["platform"]);
     expect(indexedPathAtLine(LIST_YAML, section, 3)).toEqual(["name"]);
     expect(indexedPathAtLine(LIST_YAML, section, 5)).toEqual(["pin"]);
     expect(indexedPathAtLine(LIST_YAML, section, 6)).toEqual(["pin", "number"]);
@@ -207,9 +208,14 @@ describe("indexedPathAtLine", () => {
   });
 
   it("inverts a same-indent compact block-sequence line", () => {
-    const yaml = ["wifi:", "  group:", "    items:", "    - ssid: a", "    - ssid: b", ""].join(
-      "\n"
-    );
+    const yaml = [
+      "wifi:",
+      "  group:",
+      "    items:",
+      "    - ssid: a",
+      "    - ssid: b",
+      "",
+    ].join("\n");
     const section = sectionAt(yaml, 1);
     expect(indexedPathAtLine(yaml, section, 4)).toEqual(["group", "items", 0, "ssid"]);
     expect(indexedPathAtLine(yaml, section, 5)).toEqual(["group", "items", 1, "ssid"]);
@@ -250,7 +256,11 @@ describe("indexedPathAtLine", () => {
       const section = sectionAt(yaml, fromLine);
       const lineCount = yaml.split("\n").length;
       let inverted = 0;
-      for (let line = section.fromLine + 1; line <= Math.min(section.toLine, lineCount); line++) {
+      for (
+        let line = section.fromLine;
+        line <= Math.min(section.toLine, lineCount);
+        line++
+      ) {
         const path = indexedPathAtLine(yaml, section, line);
         if (path === null) continue;
         expect(findFieldLine(yaml, section, path.map(String))).toBe(line);


### PR DESCRIPTION
# What does this implement/fix?

`_actionFieldPath` in yaml-automations.ts was a second structural YAML interpreter beside yaml-sections-core's `findFieldLine`: two independent walks over the same text with their own rules, guaranteed to drift. It was also quadratic, since the component_action pass called it once per `*_action` match and every call rescanned from the instance's first line.

The walk now lives in a new `yaml-indexed-path.ts` as `findFieldLine`'s inverse: `walkIndexedPaths` makes one forward pass over a section's body maintaining the enclosing frames (mapping keys by indent, list items as counted dash indices, block scalars skipped), and `indexedPathAtLine` answers the single line to indexed path query on top of it. The automation pass is now a thin consumer: one walk per host instance, with the `isAutomationKey` ancestor filter and the dotted encoding guard applied in the visitor. The bare mapping key regex moved to the section lexer so both walkers share one definition.

The module sits beside yaml-sections-core rather than inside it because core is already at the file size band, and the names avoid colliding with yaml-cursor-paths' AST based `indexedKeyPathAt`, which is a different contract. A pre existing ordering pin test (added first, passing against the old code) locks the emitted row order, and an ad hoc differential run over real configs confirmed `parseYamlAutomations` output is byte identical before and after. Measured on a single instance sprinkler shape: 3.9 ms to 0.4 ms at 505 lines, 35 ms to 1.1 ms at 1505 lines.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1548

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
