### PR TITLE
Share the widened id pool with top-level seeding

### DIFF
--- a/src/components/device/add-component-form-seed.ts
+++ b/src/components/device/add-component-form-seed.ts
@@ -10,7 +10,7 @@ import {
   resolveSoleCandidate,
 } from "../../util/config-entry-yaml-scan.js";
 import {
-  collectExistingIds,
+  collectTakenIds,
   generateDefaultComponentId,
 } from "../../util/default-component-id.js";
 import { suggestEntityName } from "../../util/default-entity-name.js";
@@ -194,7 +194,7 @@ export function buildInitialValues(ctx: SeedContext): Record<string, unknown> {
     const seeded = generateDefaultComponentId(
       component.id,
       component.multi_conf,
-      collectExistingIds(yaml)
+      collectTakenIds(yaml)
     );
     if (seeded !== null) next = { ...next, id: seeded };
   }

--- a/test/components/device/add-component-form-seed-fns.test.ts
+++ b/test/components/device/add-component-form-seed-fns.test.ts
@@ -351,6 +351,26 @@ describe("buildInitialValues", () => {
     expect(values.id).toBe("sensor_bme280_2");
   });
 
+  it("clears ids declared under another key", () => {
+    // Both minting paths share one pool, so a hand-typed ``bus_id`` counts.
+    const component = makeComponent({
+      id: "uart",
+      multi_conf: true,
+      config_entries: [makeConfigEntry({ key: "id", type: ConfigEntryType.ID })],
+    });
+    const values = buildInitialValues({
+      entries: component.config_entries,
+      component,
+      board: null,
+      yaml: "tca9548a:\n  - id: mux\n    channels:\n      - bus_id: uart_1\n",
+      prefillReference: null,
+      prefillFields: null,
+      restoredValues: null,
+      localize,
+    });
+    expect(values.id).toBe("uart_2");
+  });
+
   it("does not overwrite an id already seeded by a default_value", () => {
     const component = makeComponent({
       config_entries: [


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #1553, which widened the uniqueness pool for nested-list row ids from `id:` lines to every id-naming key (`id`, `*_id`) after a review turned up `tca9548a.channels[].bus_id` — a declaring id that mints from the same base slug as `usb_uart.channels[].id`. That widening only landed on the nested-row path; the top-level component seeding still scanned `id:` alone, so a hand-typed `bus_id: uart_1` could still collide with a freshly minted `uart_1` from the add dialog. Both minting paths now share `collectTakenIds`.

The review suggested repointing all three `collectExistingIds` call sites, but the other two are presence checks rather than minting: `_missingRequiredPrereqs` asks whether a featured prerequisite is already in the config, and the bundle-add loop skips members that are already present. For a minted id, over-inclusion is harmless since it only bumps the numeric suffix; for a presence check it would change behaviour, letting a mere reference (`uart_id: my_prereq`) read as the prerequisite being installed and suppress the warning or silently skip a bundle member. Those two keep the narrow scan.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
