### PR TITLE
Seed the identity field a sub-entity's schema actually offers

### DIFF
--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -2,11 +2,6 @@ import { html, nothing } from "lit";
 import { isLambdaValue } from "../../../api/types/automations.js";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../../api/types/config-entries.js";
-import {
-  addTakenIdsFromValues,
-  collectTakenIds,
-  generateNestedItemId,
-} from "../../../util/default-component-id.js";
 import { asMappingList, isPrimitiveOrNullish } from "../../../util/nested-values.js";
 import { escapeForInput, unescapeForInput } from "../../../util/yaml-escape.js";
 import { YamlRawValue } from "../../../util/yaml-serialize.js";
@@ -21,6 +16,7 @@ import {
   renderYamlOnlyField,
   type RenderCtx,
 } from "../config-entry-renderers-shared.js";
+import { seedIdFor } from "./seed-identity.js";
 
 // Returns an empty array (not undefined) when nothing's there or the value
 // isn't an array — list mutations always round-trip through this so the new
@@ -52,19 +48,10 @@ function arrayItemHandlers(
 }
 
 // A new row whose schema requires a declaring id arrives with a unique one
-// prefilled (#2452). The pool spans the document *and* the whole form-values
-// tree: the add dialog's values aren't in the YAML yet, a just-added row may
-// not have flushed through the draft debounce, and a same-key sibling list
-// under another parent row (esp32_ble_server's ``services[].characteristics[]``)
-// is invisible from this list's rows.
+// prefilled (#2452); a row without one exists fine as a bare item.
 function makeNewNestedItem(entry: ConfigEntry, ctx: RenderCtx): Record<string, unknown> {
-  const idChild = (entry.config_entries ?? []).find(
-    (c) => c.type === ConfigEntryType.ID && !c.references_component && c.required
-  );
-  if (!idChild) return {};
-  const taken = collectTakenIds(ctx.yaml);
-  addTakenIdsFromValues(ctx.getAt([]), taken);
-  return { [idChild.key]: generateNestedItemId(entry.key, taken) };
+  const seed = seedIdFor(entry, ctx, { requiredOnly: true });
+  return seed ? { [seed.key]: seed.id } : {};
 }
 
 export function renderListEmptyHint(items: readonly unknown[], ctx: RenderCtx) {

--- a/src/components/device/config-entry-renderers/nested.ts
+++ b/src/components/device/config-entry-renderers/nested.ts
@@ -13,6 +13,7 @@ import {
   renderLabel,
   type RenderCtx,
 } from "../config-entry-renderers-shared.js";
+import { hasNameChild, seedIdFor } from "./seed-identity.js";
 
 // Stash of the values a sub-reading held when its enable switch was
 // turned off, keyed by the form's ``stashOwner`` (the host element,
@@ -85,6 +86,7 @@ export function renderNestedField(entry: ConfigEntry, path: string[], ctx: Rende
                 title=${enableLabel}
                 @change=${(e: Event) =>
                   onEnableToggle(
+                    entry,
                     path,
                     key,
                     isOpen,
@@ -127,12 +129,14 @@ export function renderNestedField(entry: ConfigEntry, path: string[], ctx: Rende
 
 // Enabling restores the values stashed by the last disable (so an
 // accidental off/on round-trip keeps the user's settings); with no
-// stash it seeds the entity's name (its label, editable) so the group
-// becomes non-empty and serializes. Either way it expands for editing.
-// Disabling stashes the current group, then clears it — the serializer
-// prunes the empty object so the block leaves the YAML — and collapses.
-// Exported for direct unit testing (the render path only wires it up).
+// stash it seeds whichever identity field the group's schema offers, so
+// the group becomes non-empty and serializes. Either way it expands for
+// editing. Disabling stashes the current group, then clears it — the
+// serializer prunes the empty object so the block leaves the YAML — and
+// collapses. Exported for direct unit testing (the render path only
+// wires it up).
 export function onEnableToggle(
+  entry: ConfigEntry,
   path: string[],
   key: string,
   isOpen: boolean,
@@ -146,13 +150,21 @@ export function onEnableToggle(
     if (restored && hasSerializableValue(restored)) {
       stash.delete(key);
       ctx.emitChange(path, restored);
-    } else {
+    } else if (hasNameChild(entry)) {
       // Seed the *localized* label the user is looking at, so the
       // name they get matches the switch they clicked (WYSIWYG) and
       // reads natively in their dashboard locale. It's a plain
       // editable value, not locale-pinned state — don't "fix" this
       // to the entry key.
       ctx.emitChange([...path, "name"], label);
+    } else {
+      // A nameless group (pipsolar's output sub-entities, opentherm's)
+      // rejects ``name:`` outright, so seed its id instead — required or
+      // not, it's the only identity the group has to serialize on. A
+      // group with neither (a light's ``initial_state``) seeds nothing
+      // and persists once the user sets one of its fields.
+      const seed = seedIdFor(entry, ctx);
+      if (seed) ctx.emitChange([...path, seed.key], seed.id);
     }
     if (!isOpen) ctx.toggleNested(key);
   } else {

--- a/src/components/device/config-entry-renderers/nested.ts
+++ b/src/components/device/config-entry-renderers/nested.ts
@@ -85,15 +85,15 @@ export function renderNestedField(entry: ConfigEntry, path: string[], ctx: Rende
                 aria-label=${enableLabel}
                 title=${enableLabel}
                 @change=${(e: Event) =>
-                  onEnableToggle(
+                  onEnableToggle({
                     entry,
                     path,
                     key,
                     isOpen,
-                    (e.target as unknown as { checked: boolean }).checked,
+                    checked: (e.target as unknown as { checked: boolean }).checked,
                     label,
-                    ctx
-                  )}
+                    ctx,
+                  })}
               ></wa-switch>`
             : nothing
         }
@@ -135,15 +135,16 @@ export function renderNestedField(entry: ConfigEntry, path: string[], ctx: Rende
 // serializer prunes the empty object so the block leaves the YAML — and
 // collapses. Exported for direct unit testing (the render path only
 // wires it up).
-export function onEnableToggle(
-  entry: ConfigEntry,
-  path: string[],
-  key: string,
-  isOpen: boolean,
-  checked: boolean,
-  label: string,
-  ctx: RenderCtx
-): void {
+export function onEnableToggle(opts: {
+  entry: ConfigEntry;
+  path: string[];
+  key: string;
+  isOpen: boolean;
+  checked: boolean;
+  label: string;
+  ctx: RenderCtx;
+}): void {
+  const { entry, path, key, isOpen, checked, label, ctx } = opts;
   const stash = _enableStash(ctx);
   if (checked) {
     const restored = stash.get(key);
@@ -160,11 +161,14 @@ export function onEnableToggle(
     } else {
       // A nameless group (pipsolar's output sub-entities, opentherm's)
       // rejects ``name:`` outright, so seed its id instead — required or
-      // not, it's the only identity the group has to serialize on. A
-      // group with neither (a light's ``initial_state``) seeds nothing
-      // and persists once the user sets one of its fields.
+      // not, it's the only identity the group has to serialize on.
       const seed = seedIdFor(entry, ctx);
+      // With neither (a light's ``initial_state``) there's nothing valid to
+      // write, so re-emit the still-absent group: the switch the user just
+      // clicked has no backing value, and only a re-render walks it back to
+      // off. The group persists once they set one of its own fields.
       if (seed) ctx.emitChange([...path, seed.key], seed.id);
+      else ctx.emitChange(path, undefined);
     }
     if (!isOpen) ctx.toggleNested(key);
   } else {

--- a/src/components/device/config-entry-renderers/nested.ts
+++ b/src/components/device/config-entry-renderers/nested.ts
@@ -166,7 +166,10 @@ export function onEnableToggle(opts: {
       // With neither (a light's ``initial_state``) there's nothing valid to
       // write, so re-emit the still-absent group: the switch the user just
       // clicked has no backing value, and only a re-render walks it back to
-      // off. The group persists once they set one of its own fields.
+      // off. The group persists once they set one of its own fields. This
+      // leans on the host handing itself a fresh values object for every
+      // ``value-change``, no-op included (``setIn`` spreads unconditionally) —
+      // an identity-preserving fast path there would strand the switch on.
       if (seed) ctx.emitChange([...path, seed.key], seed.id);
       else ctx.emitChange(path, undefined);
     }

--- a/src/components/device/config-entry-renderers/seed-identity.ts
+++ b/src/components/device/config-entry-renderers/seed-identity.ts
@@ -15,9 +15,11 @@ import {
 } from "../../../util/default-component-id.js";
 import type { RenderCtx } from "../config-entry-renderers-shared.js";
 
-/** Whether *entry*'s schema carries a `name` field. */
+/** Whether *entry*'s schema carries a `name` field to seed a label into. */
 export function hasNameChild(entry: ConfigEntry): boolean {
-  return (entry.config_entries ?? []).some((c) => c.key === "name");
+  return (entry.config_entries ?? []).some(
+    (c) => c.key === "name" && c.type === ConfigEntryType.STRING
+  );
 }
 
 /**
@@ -25,27 +27,38 @@ export function hasNameChild(entry: ConfigEntry): boolean {
  * schema declares no id to seed.
  *
  * With *requiredOnly* the id has to be required — a list row exists without
- * one, so seeding an optional id there would be noise; a nested group needs
- * a value to serialize, so its optional id is the identity of last resort.
- * The pool spans the document *and* the whole form-values tree: the add
- * dialog's values aren't in the YAML yet, a just-added row may not have
- * flushed through the draft debounce, and a same-key sibling list under
- * another parent row (esp32_ble_server's ``services[].characteristics[]``)
- * is invisible from this list's rows.
+ * one, so seeding an optional id there would be noise; a nested group needs a
+ * value to serialize, so its optional id is the identity of last resort. The
+ * pool spans the document *and* the whole form-values tree: the add dialog's
+ * values aren't in the YAML yet, a just-added row may not have flushed
+ * through the draft debounce, and a same-key sibling list under another
+ * parent row (esp32_ble_server's ``services[].characteristics[]``) is
+ * invisible from this list's rows.
  */
 export function seedIdFor(
   entry: ConfigEntry,
   ctx: RenderCtx,
   { requiredOnly = false }: { requiredOnly?: boolean } = {}
 ): { key: string; id: string } | null {
-  const idChild = (entry.config_entries ?? []).find(
-    (c) =>
-      c.type === ConfigEntryType.ID &&
-      !c.references_component &&
-      (c.required || !requiredOnly)
-  );
+  const idChild = declaringIdChild(entry, requiredOnly);
   if (!idChild) return null;
   const taken = collectTakenIds(ctx.yaml);
   addTakenIdsFromValues(ctx.getAt([]), taken);
   return { key: idChild.key, id: generateNestedItemId(entry.key, taken) };
+}
+
+// A declaring id, never a `references_component` pointer. A *required* one
+// counts under any key (tca9548a declares through ``bus_id``); an optional one
+// only when literally ``id``, so a catalog entry missing its
+// `references_component` flag can't take a generated id into a pointer field.
+function declaringIdChild(
+  entry: ConfigEntry,
+  requiredOnly: boolean
+): ConfigEntry | undefined {
+  return (entry.config_entries ?? []).find(
+    (c) =>
+      c.type === ConfigEntryType.ID &&
+      !c.references_component &&
+      (c.required || (!requiredOnly && c.key === "id"))
+  );
 }

--- a/src/components/device/config-entry-renderers/seed-identity.ts
+++ b/src/components/device/config-entry-renderers/seed-identity.ts
@@ -1,8 +1,9 @@
 /**
  * Identity seeding for a subtree the user just materialized — a new
- * nested-list row, or a sub-entity switched on. Both need something in the
- * group for it to serialize at all, and neither should make the user invent
- * an id (device-builder#2452, #2459).
+ * nested-list row, or a sub-entity switched on. Neither should make the user
+ * invent an id (device-builder#2452, #2459). A row serializes as a bare item
+ * regardless, so only a required declaring id is prefilled there; a
+ * switched-on sub-entity needs an identity field to persist at all.
  */
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../../api/types/config-entries.js";

--- a/src/components/device/config-entry-renderers/seed-identity.ts
+++ b/src/components/device/config-entry-renderers/seed-identity.ts
@@ -1,0 +1,49 @@
+/**
+ * Identity seeding for a subtree the user just materialized — a new
+ * nested-list row, or a sub-entity switched on. Both need something in the
+ * group for it to serialize at all, and neither should make the user invent
+ * an id (device-builder#2452, #2459).
+ */
+import type { ConfigEntry } from "../../../api/types/config-entries.js";
+import { ConfigEntryType } from "../../../api/types/config-entries.js";
+import {
+  addTakenIdsFromValues,
+  collectTakenIds,
+  generateNestedItemId,
+} from "../../../util/default-component-id.js";
+import type { RenderCtx } from "../config-entry-renderers-shared.js";
+
+/** Whether *entry*'s schema carries a `name` field. */
+export function hasNameChild(entry: ConfigEntry): boolean {
+  return (entry.config_entries ?? []).some((c) => c.key === "name");
+}
+
+/**
+ * A unique id for a subtree materializing under *entry*, or null when its
+ * schema declares no id to seed.
+ *
+ * With *requiredOnly* the id has to be required — a list row exists without
+ * one, so seeding an optional id there would be noise; a nested group needs
+ * a value to serialize, so its optional id is the identity of last resort.
+ * The pool spans the document *and* the whole form-values tree: the add
+ * dialog's values aren't in the YAML yet, a just-added row may not have
+ * flushed through the draft debounce, and a same-key sibling list under
+ * another parent row (esp32_ble_server's ``services[].characteristics[]``)
+ * is invisible from this list's rows.
+ */
+export function seedIdFor(
+  entry: ConfigEntry,
+  ctx: RenderCtx,
+  { requiredOnly = false }: { requiredOnly?: boolean } = {}
+): { key: string; id: string } | null {
+  const idChild = (entry.config_entries ?? []).find(
+    (c) =>
+      c.type === ConfigEntryType.ID &&
+      !c.references_component &&
+      (c.required || !requiredOnly)
+  );
+  if (!idChild) return null;
+  const taken = collectTakenIds(ctx.yaml);
+  addTakenIdsFromValues(ctx.getAt([]), taken);
+  return { key: idChild.key, id: generateNestedItemId(entry.key, taken) };
+}

--- a/src/components/device/config-entry-renderers/seed-identity.ts
+++ b/src/components/device/config-entry-renderers/seed-identity.ts
@@ -2,8 +2,9 @@
  * Identity seeding for a subtree the user just materialized — a new
  * nested-list row, or a sub-entity switched on. Neither should make the user
  * invent an id (device-builder#2452, #2459). A row serializes as a bare item
- * regardless, so only a required declaring id is prefilled there; a
- * switched-on sub-entity needs an identity field to persist at all.
+ * regardless, so only a required declaring id is prefilled there; a group
+ * serializes only once it holds a value, so it seeds whichever identity
+ * field its schema offers, if any.
  */
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../../api/types/config-entries.js";

--- a/test/components/device/render-nested-field-enable-toggle.test.ts
+++ b/test/components/device/render-nested-field-enable-toggle.test.ts
@@ -31,6 +31,23 @@ function makeSensorEntry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
   });
 }
 
+// A light's initial_state: no name, no declaring id — nothing to seed.
+function makeInitialStateEntry(): ConfigEntry {
+  return makeConfigEntry({
+    key: "initial_state",
+    type: ConfigEntryType.NESTED,
+    platform_type: "light",
+    config_entries: [
+      makeConfigEntry({ key: "brightness", type: ConfigEntryType.FLOAT }),
+      makeConfigEntry({
+        key: "power_supply",
+        type: ConfigEntryType.ID,
+        references_component: "power_supply",
+      }),
+    ],
+  });
+}
+
 const switchesOf = (tpl: unknown) => findElementBindings(tpl, "wa-switch");
 
 describe("renderNestedField enable switch", () => {
@@ -80,44 +97,44 @@ describe("renderNestedField enable switch", () => {
 describe("onEnableToggle", () => {
   it("enabling with no stash seeds the name with the entity label and expands", () => {
     const ctx = makeRenderCtx({});
-    onEnableToggle(
-      makeSensorEntry(),
-      ["min_free"],
-      "min_free",
-      false,
-      true,
-      "Min Free",
-      ctx
-    );
+    onEnableToggle({
+      entry: makeSensorEntry(),
+      path: ["min_free"],
+      key: "min_free",
+      isOpen: false,
+      checked: true,
+      label: "Min Free",
+      ctx,
+    });
     expect(ctx.emitChange).toHaveBeenCalledWith(["min_free", "name"], "Min Free");
     expect(ctx.toggleNested).toHaveBeenCalledWith("min_free");
   });
 
   it("does not re-expand an already-open group on enable", () => {
     const ctx = makeRenderCtx({});
-    onEnableToggle(
-      makeSensorEntry(),
-      ["min_free"],
-      "min_free",
-      true,
-      true,
-      "Min Free",
-      ctx
-    );
+    onEnableToggle({
+      entry: makeSensorEntry(),
+      path: ["min_free"],
+      key: "min_free",
+      isOpen: true,
+      checked: true,
+      label: "Min Free",
+      ctx,
+    });
     expect(ctx.toggleNested).not.toHaveBeenCalled();
   });
 
   it("disabling clears the whole group and collapses it", () => {
     const ctx = makeRenderCtx({ min_free: { name: "Min Free" } });
-    onEnableToggle(
-      makeSensorEntry(),
-      ["min_free"],
-      "min_free",
-      true,
-      false,
-      "Min Free",
-      ctx
-    );
+    onEnableToggle({
+      entry: makeSensorEntry(),
+      path: ["min_free"],
+      key: "min_free",
+      isOpen: true,
+      checked: false,
+      label: "Min Free",
+      ctx,
+    });
     expect(ctx.emitChange).toHaveBeenCalledWith(["min_free"], undefined);
     expect(ctx.toggleNested).toHaveBeenCalledWith("min_free");
   });
@@ -140,26 +157,26 @@ describe("onEnableToggle", () => {
       }
     );
 
-    onEnableToggle(
-      makeSensorEntry(),
-      ["min_free"],
-      "min_free",
-      true,
-      false,
-      "Min Free",
-      ctx
-    );
+    onEnableToggle({
+      entry: makeSensorEntry(),
+      path: ["min_free"],
+      key: "min_free",
+      isOpen: true,
+      checked: false,
+      label: "Min Free",
+      ctx,
+    });
     expect(getIn(values, ["min_free"])).toBeUndefined();
 
-    onEnableToggle(
-      makeSensorEntry(),
-      ["min_free"],
-      "min_free",
-      false,
-      true,
-      "Min Free",
-      ctx
-    );
+    onEnableToggle({
+      entry: makeSensorEntry(),
+      path: ["min_free"],
+      key: "min_free",
+      isOpen: false,
+      checked: true,
+      label: "Min Free",
+      ctx,
+    });
     expect(ctx.emitChange).toHaveBeenLastCalledWith(["min_free"], configured);
   });
 
@@ -182,15 +199,15 @@ describe("onEnableToggle", () => {
         },
       }
     );
-    onEnableToggle(
-      entry,
-      ["battery_float_voltage"],
-      "battery_float_voltage",
-      false,
-      true,
-      "Battery Float Voltage",
-      ctx
-    );
+    onEnableToggle({
+      entry: entry,
+      path: ["battery_float_voltage"],
+      key: "battery_float_voltage",
+      isOpen: false,
+      checked: true,
+      label: "Battery Float Voltage",
+      ctx,
+    });
     expect(ctx.emitChange).toHaveBeenCalledWith(
       ["battery_float_voltage", "id"],
       "battery_float_voltage_2"
@@ -214,37 +231,70 @@ describe("onEnableToggle", () => {
       ],
     });
     const ctx = makeRenderCtx({});
-    onEnableToggle(entry, ["t_set"], "t_set", false, true, "T Set", ctx);
+    onEnableToggle({
+      entry: entry,
+      path: ["t_set"],
+      key: "t_set",
+      isOpen: false,
+      checked: true,
+      label: "T Set",
+      ctx,
+    });
     expect(ctx.emitChange).toHaveBeenCalledWith(["t_set", "id"], "t_set_1");
   });
 
-  it("seeds nothing when the schema offers neither a name nor an id", () => {
+  it("writes no field when the schema offers neither a name nor an id", () => {
     // A light's ``initial_state`` has only colour/brightness fields; it
     // persists once the user sets one, and must not get an invalid ``name:``.
-    const entry = makeConfigEntry({
+    const ctx = makeRenderCtx({});
+    onEnableToggle({
+      entry: makeInitialStateEntry(),
+      path: ["initial_state"],
       key: "initial_state",
-      type: ConfigEntryType.NESTED,
-      platform_type: "light",
+      isOpen: false,
+      checked: true,
+      label: "Initial",
+      ctx,
+    });
+    expect(ctx.emitChange).toHaveBeenCalledWith(["initial_state"], undefined);
+    expect(ctx.toggleNested).toHaveBeenCalledWith("initial_state");
+  });
+
+  it("re-emits an already-open identity-less group so the switch walks back", () => {
+    // Nothing valid to write and no expand to trigger a re-render, so the
+    // switch would otherwise read "on" over an absent group indefinitely.
+    const ctx = makeRenderCtx({});
+    onEnableToggle({
+      entry: makeInitialStateEntry(),
+      path: ["initial_state"],
+      key: "initial_state",
+      isOpen: true,
+      checked: true,
+      label: "Initial",
+      ctx,
+    });
+    expect(ctx.emitChange).toHaveBeenCalledWith(["initial_state"], undefined);
+    expect(ctx.toggleNested).not.toHaveBeenCalled();
+  });
+
+  it("prefers the name over a declaring id when the schema has both", () => {
+    const entry = makeSensorEntry({
       config_entries: [
-        makeConfigEntry({ key: "brightness", type: ConfigEntryType.FLOAT }),
-        makeConfigEntry({
-          key: "power_supply",
-          type: ConfigEntryType.ID,
-          references_component: "power_supply",
-        }),
+        makeConfigEntry({ key: "name", type: ConfigEntryType.STRING }),
+        makeConfigEntry({ key: "id", type: ConfigEntryType.ID }),
       ],
     });
     const ctx = makeRenderCtx({});
-    onEnableToggle(
+    onEnableToggle({
       entry,
-      ["initial_state"],
-      "initial_state",
-      false,
-      true,
-      "Initial",
-      ctx
-    );
-    expect(ctx.emitChange).not.toHaveBeenCalled();
-    expect(ctx.toggleNested).toHaveBeenCalledWith("initial_state");
+      path: ["min_free"],
+      key: "min_free",
+      isOpen: false,
+      checked: true,
+      label: "Min Free",
+      ctx,
+    });
+    expect(ctx.emitChange).toHaveBeenCalledWith(["min_free", "name"], "Min Free");
+    expect(ctx.emitChange).not.toHaveBeenCalledWith(["min_free", "id"], "min_free_1");
   });
 });

--- a/test/components/device/render-nested-field-enable-toggle.test.ts
+++ b/test/components/device/render-nested-field-enable-toggle.test.ts
@@ -5,10 +5,10 @@
  * sensors, a DHT's temperature/humidity) only land in YAML once
  * their group holds a value, so an untouched one is silently "off".
  * ``renderNestedField`` gives those a ``wa-switch``; ``onEnableToggle``
- * is the change handler: on restores the stashed config (or seeds the
- * name) and expands, off stashes then clears the group so the block
- * leaves the YAML. Switch state derives from the current values
- * (loaded from YAML), so it round-trips.
+ * is the change handler: on restores the stashed config (or seeds
+ * whichever identity field the schema offers) and expands, off stashes
+ * then clears the group so the block leaves the YAML. Switch state
+ * derives from the current values (loaded from YAML), so it round-trips.
  */
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -80,20 +80,44 @@ describe("renderNestedField enable switch", () => {
 describe("onEnableToggle", () => {
   it("enabling with no stash seeds the name with the entity label and expands", () => {
     const ctx = makeRenderCtx({});
-    onEnableToggle(["min_free"], "min_free", false, true, "Min Free", ctx);
+    onEnableToggle(
+      makeSensorEntry(),
+      ["min_free"],
+      "min_free",
+      false,
+      true,
+      "Min Free",
+      ctx
+    );
     expect(ctx.emitChange).toHaveBeenCalledWith(["min_free", "name"], "Min Free");
     expect(ctx.toggleNested).toHaveBeenCalledWith("min_free");
   });
 
   it("does not re-expand an already-open group on enable", () => {
     const ctx = makeRenderCtx({});
-    onEnableToggle(["min_free"], "min_free", true, true, "Min Free", ctx);
+    onEnableToggle(
+      makeSensorEntry(),
+      ["min_free"],
+      "min_free",
+      true,
+      true,
+      "Min Free",
+      ctx
+    );
     expect(ctx.toggleNested).not.toHaveBeenCalled();
   });
 
   it("disabling clears the whole group and collapses it", () => {
     const ctx = makeRenderCtx({ min_free: { name: "Min Free" } });
-    onEnableToggle(["min_free"], "min_free", true, false, "Min Free", ctx);
+    onEnableToggle(
+      makeSensorEntry(),
+      ["min_free"],
+      "min_free",
+      true,
+      false,
+      "Min Free",
+      ctx
+    );
     expect(ctx.emitChange).toHaveBeenCalledWith(["min_free"], undefined);
     expect(ctx.toggleNested).toHaveBeenCalledWith("min_free");
   });
@@ -116,10 +140,111 @@ describe("onEnableToggle", () => {
       }
     );
 
-    onEnableToggle(["min_free"], "min_free", true, false, "Min Free", ctx);
+    onEnableToggle(
+      makeSensorEntry(),
+      ["min_free"],
+      "min_free",
+      true,
+      false,
+      "Min Free",
+      ctx
+    );
     expect(getIn(values, ["min_free"])).toBeUndefined();
 
-    onEnableToggle(["min_free"], "min_free", false, true, "Min Free", ctx);
+    onEnableToggle(
+      makeSensorEntry(),
+      ["min_free"],
+      "min_free",
+      false,
+      true,
+      "Min Free",
+      ctx
+    );
     expect(ctx.emitChange).toHaveBeenLastCalledWith(["min_free"], configured);
+  });
+
+  it("seeds a unique id when the group has no name field (#2459)", () => {
+    // pipsolar's output sub-entities reject ``name:`` and require an id.
+    const entry = makeConfigEntry({
+      key: "battery_float_voltage",
+      type: ConfigEntryType.NESTED,
+      platform_type: "output",
+      config_entries: [
+        makeConfigEntry({ key: "id", type: ConfigEntryType.ID, required: true }),
+        makeConfigEntry({ key: "inverted", type: ConfigEntryType.BOOLEAN }),
+      ],
+    });
+    const ctx = makeRenderCtx(
+      {},
+      {
+        overrides: {
+          yaml: "output:\n  - platform: pipsolar\n    id: battery_float_voltage_1\n",
+        },
+      }
+    );
+    onEnableToggle(
+      entry,
+      ["battery_float_voltage"],
+      "battery_float_voltage",
+      false,
+      true,
+      "Battery Float Voltage",
+      ctx
+    );
+    expect(ctx.emitChange).toHaveBeenCalledWith(
+      ["battery_float_voltage", "id"],
+      "battery_float_voltage_2"
+    );
+    expect(ctx.toggleNested).toHaveBeenCalledWith("battery_float_voltage");
+  });
+
+  it("seeds an optional declaring id — it is the group's only identity", () => {
+    // opentherm's output sub-entities: no name, id present but not required.
+    const entry = makeConfigEntry({
+      key: "t_set",
+      type: ConfigEntryType.NESTED,
+      platform_type: "output",
+      config_entries: [
+        makeConfigEntry({ key: "id", type: ConfigEntryType.ID }),
+        makeConfigEntry({
+          key: "power_supply",
+          type: ConfigEntryType.ID,
+          references_component: "power_supply",
+        }),
+      ],
+    });
+    const ctx = makeRenderCtx({});
+    onEnableToggle(entry, ["t_set"], "t_set", false, true, "T Set", ctx);
+    expect(ctx.emitChange).toHaveBeenCalledWith(["t_set", "id"], "t_set_1");
+  });
+
+  it("seeds nothing when the schema offers neither a name nor an id", () => {
+    // A light's ``initial_state`` has only colour/brightness fields; it
+    // persists once the user sets one, and must not get an invalid ``name:``.
+    const entry = makeConfigEntry({
+      key: "initial_state",
+      type: ConfigEntryType.NESTED,
+      platform_type: "light",
+      config_entries: [
+        makeConfigEntry({ key: "brightness", type: ConfigEntryType.FLOAT }),
+        makeConfigEntry({
+          key: "power_supply",
+          type: ConfigEntryType.ID,
+          references_component: "power_supply",
+        }),
+      ],
+    });
+    const ctx = makeRenderCtx({});
+    onEnableToggle(
+      entry,
+      ["initial_state"],
+      "initial_state",
+      false,
+      true,
+      "Initial",
+      ctx
+    );
+    expect(ctx.emitChange).not.toHaveBeenCalled();
+    expect(ctx.toggleNested).toHaveBeenCalledWith("initial_state");
   });
 });

--- a/test/components/device/render-nested-field-enable-toggle.test.ts
+++ b/test/components/device/render-nested-field-enable-toggle.test.ts
@@ -263,9 +263,26 @@ describe("onEnableToggle", () => {
   it("re-emits an already-open identity-less group so the switch walks back", () => {
     // Nothing valid to write and no expand to trigger a re-render, so the
     // switch would otherwise read "on" over an absent group indefinitely.
-    const ctx = makeRenderCtx({});
+    // The no-op emit has to hand the host a *new* values object or nothing
+    // invalidates — pin that, not just the call, so a future
+    // identity-preserving fast path in setIn fails here instead of silently
+    // stranding the switch on.
+    let values: Record<string, unknown> = {};
+    const entry = makeInitialStateEntry();
+    const ctx = makeRenderCtx(
+      {},
+      {
+        overrides: {
+          emitChange: vi.fn((path: string[], value: unknown) => {
+            values = setIn(values, path, value);
+          }),
+          getAt: (path: string[]) => getIn(values, path),
+        },
+      }
+    );
+    const before = values;
     onEnableToggle({
-      entry: makeInitialStateEntry(),
+      entry,
       path: ["initial_state"],
       key: "initial_state",
       isOpen: true,
@@ -274,7 +291,11 @@ describe("onEnableToggle", () => {
       ctx,
     });
     expect(ctx.emitChange).toHaveBeenCalledWith(["initial_state"], undefined);
+    expect(values).not.toBe(before);
     expect(ctx.toggleNested).not.toHaveBeenCalled();
+    // Nothing landed, so the re-render paints the switch off.
+    const [sw] = switchesOf(renderNestedField(entry, ["initial_state"], ctx));
+    expect(sw[".checked"]).toBe(false);
   });
 
   it("prefers the name over a declaring id when the schema has both", () => {


### PR DESCRIPTION
# What does this implement/fix?

Turning on an optional sub-entity seeded `name:` unconditionally, which is right for the 1622 groups that have a `name` field and wrong for the 44 that don't. Those 44 got a key their schema rejects, so the toggle produced a config that won't compile:

```
light.binary: initial_state:
  [name] is an invalid option for [initial_state]. Please check the indentation.
```

The seed now follows what the schema actually offers. A group with `name` is unchanged. A nameless group with a declaring id gets a unique generated one instead, which validates clean (verified against `esphome config` with a pipsolar output). A group with neither, only `light.*.initial_state`, seeds nothing and persists as soon as the user sets one of its fields.

Catalog counts across the 1666 toggle sites: 1622 have `name`, 20 are nameless with a declaring id (pipsolar requires it, opentherm's is optional), 24 are `initial_state`.

The id fallback deliberately accepts an optional declaring id, unlike the nested-list rows added in #1553 where only a required one is seeded. A list row exists as an item without an id, so seeding an optional one there is noise; a nested group needs a value to serialize at all, so its id is the identity of last resort. That difference is the one flag on the shared helper, `seed-identity.ts`, which both callers now share instead of each hand-picking a field.

One residual worth knowing: for the 24 `initial_state` groups the switch springs back to off until the user sets a field, since nothing is written. That is the honest reading of "the group is empty", and it replaces a switch that stuck by writing YAML that fails to compile. Suppressing the switch for identity-less groups would be the follow-up if it grates.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2459

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
