### PR TITLE
Detect a dead dashboard connection and surface it in the logs dialog

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -288,7 +288,17 @@ export class ESPHomeAPI {
       const wsUrl = `${protocol}//${window.location.host}${BASE_PATH}ws`;
 
       // Listeners ignore events from a socket a reconnect replaced.
-      const ws = new WebSocket(wsUrl);
+      let ws: WebSocket;
+      try {
+        ws = new WebSocket(wsUrl);
+      } catch (err) {
+        // A synchronous constructor throw (CSP, malformed host) fires
+        // no close event; route it through the normal close path so
+        // the failure is logged and the backoff loop keeps going.
+        console.error("[WS] Failed to open a socket", err);
+        this._onClose();
+        return;
+      }
       this._ws = ws;
 
       ws.addEventListener("message", (event) => {
@@ -369,6 +379,14 @@ export class ESPHomeAPI {
 
   private readonly _onWindowOnline = (): void => {
     if (this._intentionalDisconnect || this._connected) return;
+    // An attempt stalled in CONNECTING was made against the interface
+    // that just came back; abandon it rather than waiting out its
+    // connect timeout. Before clearing the retry timer, since the
+    // forced close re-arms one.
+    const stalled = this._ws;
+    if (stalled && stalled.readyState === WebSocket.CONNECTING) {
+      this._forceClose(stalled);
+    }
     this._reconnectDelay = 1000;
     if (this._reconnectTimer) {
       clearTimeout(this._reconnectTimer);
@@ -428,9 +446,10 @@ export class ESPHomeAPI {
         console.debug("[WS] Heartbeat got no reply; closing socket", err);
         if (this._ws === ws) this._forceClose(ws);
       })
-      .catch(() => {
+      .catch((err: unknown) => {
         // A throw from the disconnect fan-out must not become an
-        // unhandled rejection.
+        // unhandled rejection, but it must not vanish either.
+        console.error("[WS] Heartbeat close path threw", err);
       })
       .finally(() => {
         this._heartbeatInFlight = false;
@@ -614,10 +633,16 @@ export class ESPHomeAPI {
     }
     this._pendingRequests.clear();
 
-    // Notify stream handlers
+    // Notify stream handlers. Each callback is isolated so one
+    // consumer throwing can't abort the fan-out or the reconnect
+    // scheduling below.
     for (const [, stream] of this._streamHandlers) {
-      if (stream.onConnectionLost) stream.onConnectionLost();
-      else stream.onError?.("WebSocket connection closed");
+      try {
+        if (stream.onConnectionLost) stream.onConnectionLost();
+        else stream.onError?.("WebSocket connection closed");
+      } catch (err) {
+        console.error("[WS] Stream close handler threw", err);
+      }
     }
     this._streamHandlers.clear();
 
@@ -625,7 +650,11 @@ export class ESPHomeAPI {
     this._eventSubscriptions.clear();
 
     if (wasConnected) {
-      this.onDisconnected?.();
+      try {
+        this.onDisconnected?.();
+      } catch (err) {
+        console.error("[WS] onDisconnected handler threw", err);
+      }
     }
 
     // Auto-reconnect unless intentionally disconnected. While the
@@ -704,6 +733,7 @@ export class ESPHomeAPI {
     callbacks: StreamCallbacks<TResult>
   ): string {
     if (!this._ws || this._ws.readyState !== WebSocket.OPEN) {
+      console.debug(`[WS] Stream send refused (not connected): ${command}`);
       if (callbacks.onConnectionLost) callbacks.onConnectionLost();
       else callbacks.onError?.("WebSocket not connected");
       return "";

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -148,6 +148,16 @@ type PendingRequest = {
   reject: (error: Error) => void;
 };
 
+// Client-side liveness probe. The server's protocol-level pings are
+// answered by the browser invisibly, so a dead TCP connection (wifi
+// off, backend frozen, NAT/proxy drop) keeps readyState OPEN forever
+// with no signal to JS. After HEARTBEAT_INTERVAL_MS of receive
+// silence the client sends a 'ping' command; a reply that doesn't
+// arrive within HEARTBEAT_TIMEOUT_MS force-closes the socket so the
+// normal close/reconnect path runs.
+const HEARTBEAT_INTERVAL_MS = 15000;
+const HEARTBEAT_TIMEOUT_MS = 5000;
+
 // Type-erased bucket for in-flight streams; each command's real result
 // shape is bound at its sendStreamCommand call site.
 type StreamHandler = StreamCallbacks<unknown>;
@@ -170,6 +180,10 @@ export class ESPHomeAPI {
   private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private _reconnectDelay = 1000;
   private _intentionalDisconnect = false;
+  private _heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private _heartbeatInFlight = false;
+  private _lastMessageAt = 0;
+  private _networkListenersRegistered = false;
   private _connectPromise: {
     resolve: (info: ServerInfoMessage) => void;
     reject: (error: Error) => void;
@@ -258,24 +272,33 @@ export class ESPHomeAPI {
     return new Promise((resolve, reject) => {
       this._connectPromise = { resolve, reject };
       this._intentionalDisconnect = false;
+      this._registerNetworkListeners();
 
       const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
       const wsUrl = `${protocol}//${window.location.host}${BASE_PATH}ws`;
 
-      this._ws = new WebSocket(wsUrl);
+      // Every listener checks it still belongs to the current socket:
+      // a force-closed socket (heartbeat timeout, offline event) can
+      // fire its close/error long after a reconnect replaced it, and
+      // acting on the stale event would tear down the new connection.
+      const ws = new WebSocket(wsUrl);
+      this._ws = ws;
 
-      this._ws.addEventListener("message", (event) => {
+      ws.addEventListener("message", (event) => {
+        if (this._ws !== ws) return;
         this._onMessage(event);
       });
 
-      this._ws.addEventListener("error", () => {
+      ws.addEventListener("error", () => {
+        if (this._ws !== ws) return;
         if (this._connectPromise) {
           this._connectPromise.reject(new Error("WebSocket connection failed"));
           this._connectPromise = null;
         }
       });
 
-      this._ws.addEventListener("close", () => {
+      ws.addEventListener("close", () => {
+        if (this._ws !== ws) return;
         this._onClose();
       });
     });
@@ -288,12 +311,104 @@ export class ESPHomeAPI {
       clearTimeout(this._reconnectTimer);
       this._reconnectTimer = null;
     }
+    this._stopHeartbeat();
+    this._unregisterNetworkListeners();
     this._ws?.close();
     this._ws = null;
     this._connected = false;
   }
 
+  // ─── Liveness ─────────────────────────────────────────────
+
+  private _registerNetworkListeners(): void {
+    if (this._networkListenersRegistered) return;
+    this._networkListenersRegistered = true;
+    window.addEventListener("offline", this._onWindowOffline);
+    window.addEventListener("online", this._onWindowOnline);
+  }
+
+  private _unregisterNetworkListeners(): void {
+    if (!this._networkListenersRegistered) return;
+    this._networkListenersRegistered = false;
+    window.removeEventListener("offline", this._onWindowOffline);
+    window.removeEventListener("online", this._onWindowOnline);
+  }
+
+  private readonly _onWindowOffline = (): void => {
+    // The kernel won't error an idle socket when the interface goes
+    // away; close it proactively so the disconnect surfaces now
+    // instead of after the heartbeat window.
+    this._forceClose(this._ws);
+  };
+
+  private readonly _onWindowOnline = (): void => {
+    if (this._intentionalDisconnect || this._connected) return;
+    this._reconnectDelay = 1000;
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+    // A non-null socket means a connect attempt is already in flight.
+    if (!this._ws) {
+      this.connect().catch(() => {
+        // _onClose schedules the next retry.
+      });
+    }
+  };
+
+  private _startHeartbeat(): void {
+    this._stopHeartbeat();
+    this._lastMessageAt = Date.now();
+    this._heartbeatTimer = setInterval(() => {
+      this._heartbeatTick();
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  private _stopHeartbeat(): void {
+    if (this._heartbeatTimer) {
+      clearInterval(this._heartbeatTimer);
+      this._heartbeatTimer = null;
+    }
+  }
+
+  private _heartbeatTick(): void {
+    if (this._heartbeatInFlight) return;
+    if (Date.now() - this._lastMessageAt < HEARTBEAT_INTERVAL_MS) return;
+    const ws = this._ws;
+    if (!ws) return;
+    this._heartbeatInFlight = true;
+    this.sendCommand("ping", undefined, HEARTBEAT_TIMEOUT_MS)
+      .catch((err: unknown) => {
+        // An APIError reply (e.g. the pre-auth gate rejecting 'ping'
+        // while the login form is up) proves the link is alive; only
+        // a timeout or a failed send means the socket is dead even
+        // though the browser still reports it OPEN.
+        if (err instanceof APIError) return;
+        if (this._ws === ws) this._forceClose(ws);
+      })
+      .finally(() => {
+        this._heartbeatInFlight = false;
+      });
+  }
+
+  /**
+   * Close a socket known dead and run the disconnect path now.
+   *
+   * close() alone only *starts* the closing handshake; against an
+   * unresponsive peer the socket hangs in CLOSING and the close
+   * event never fires, so the disconnect would never surface.
+   */
+  private _forceClose(ws: WebSocket | null): void {
+    if (!ws) return;
+    ws.close();
+    // Skipped when close() dispatched the close event synchronously
+    // (test mocks do); the close listener already ran _onClose.
+    if (this._ws === ws) this._onClose();
+  }
+
   private _onMessage(event: MessageEvent): void {
+    // Any frame proves the link is alive, parseable or not.
+    this._lastMessageAt = Date.now();
     let data: Record<string, unknown>;
     try {
       data = JSON.parse(event.data);
@@ -313,6 +428,7 @@ export class ESPHomeAPI {
       // value rather than the previous one.
       this._connectionGeneration += 1;
       this._reconnectDelay = 1000;
+      this._startHeartbeat();
       if (this._connectPromise) {
         this._connectPromise.resolve(this._serverInfo);
         this._connectPromise = null;
@@ -431,6 +547,7 @@ export class ESPHomeAPI {
     const wasConnected = this._connected;
     this._connected = false;
     this._ws = null;
+    this._stopHeartbeat();
 
     // Park ``ready`` until the next successful connect+auth. Without
     // this, anyone awaiting it during the reconnect-backoff window

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -324,11 +324,12 @@ export class ESPHomeAPI {
       clearTimeout(this._reconnectTimer);
       this._reconnectTimer = null;
     }
-    this._stopHeartbeat();
-    this._clearConnectTimeout();
     this._unregisterNetworkListeners();
-    this._ws?.close();
-    this._ws = null;
+    // Run the close cleanup (reject pending work, notify streams) now:
+    // the per-socket identity guard keeps the socket's own async close
+    // event from re-running it, so waiting on the event would leave
+    // everything hanging.
+    if (this._ws) this._forceClose(this._ws);
     this._connected = false;
   }
 

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -378,7 +378,9 @@ export class ESPHomeAPI {
     if (globalThis.document?.visibilityState === "hidden") return;
     if (Date.now() - this._lastMessageAt < HEARTBEAT_INTERVAL_MS) return;
     const ws = this._ws;
-    if (!ws) return;
+    // Probe only an OPEN socket: a visibility-edge tick during an
+    // in-flight connect would otherwise force-close the new attempt.
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
     this.ping(HEARTBEAT_TIMEOUT_MS).catch((err: unknown) => {
       // An APIError reply proves the link is alive (e.g. the pre-auth
       // gate); only silence or a failed send means a dead socket.

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -151,10 +151,18 @@ type PendingRequest = {
 // Liveness probe: after HEARTBEAT_INTERVAL_MS of receive silence send
 // a 'ping'; no reply within HEARTBEAT_TIMEOUT_MS force-closes the
 // socket. Protocol-level server pings are invisible to page JS, so a
-// dead link otherwise stays OPEN forever. TIMEOUT < INTERVAL keeps
-// pings non-overlapping.
+// dead link otherwise stays OPEN forever. The tick runs faster than
+// the silence threshold so detection lags the threshold by at most
+// one tick; the in-flight guard keeps pings non-overlapping.
 const HEARTBEAT_INTERVAL_MS = 15000;
 const HEARTBEAT_TIMEOUT_MS = 5000;
+const HEARTBEAT_TICK_MS = 5000;
+
+// A handshake against a dead peer stalls in CONNECTING with no
+// error/close event; time it out so the backoff loop keeps going.
+const CONNECT_TIMEOUT_MS = 10000;
+
+const RECONNECT_MAX_DELAY_MS = 30000;
 
 // Type-erased bucket for in-flight streams; each command's real result
 // shape is bound at its sendStreamCommand call site.
@@ -179,7 +187,9 @@ export class ESPHomeAPI {
   private _reconnectDelay = 1000;
   private _intentionalDisconnect = false;
   private _heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private _heartbeatInFlight = false;
   private _lastMessageAt = 0;
+  private _connectTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
   private _connectPromise: {
     resolve: (info: ServerInfoMessage) => void;
     reject: (error: Error) => void;
@@ -294,6 +304,12 @@ export class ESPHomeAPI {
         if (this._ws !== ws) return;
         this._onClose();
       });
+
+      this._clearConnectTimeout();
+      this._connectTimeoutTimer = setTimeout(() => {
+        this._connectTimeoutTimer = null;
+        if (this._ws === ws && !this._connected) this._forceClose(ws);
+      }, CONNECT_TIMEOUT_MS);
     });
   }
 
@@ -305,6 +321,7 @@ export class ESPHomeAPI {
       this._reconnectTimer = null;
     }
     this._stopHeartbeat();
+    this._clearConnectTimeout();
     this._unregisterNetworkListeners();
     this._ws?.close();
     this._ws = null;
@@ -362,7 +379,7 @@ export class ESPHomeAPI {
     this._lastMessageAt = Date.now();
     this._heartbeatTimer = setInterval(() => {
       this._heartbeatTick();
-    }, HEARTBEAT_INTERVAL_MS);
+    }, HEARTBEAT_TICK_MS);
   }
 
   private _stopHeartbeat(): void {
@@ -372,21 +389,34 @@ export class ESPHomeAPI {
     }
   }
 
+  private _clearConnectTimeout(): void {
+    if (this._connectTimeoutTimer) {
+      clearTimeout(this._connectTimeoutTimer);
+      this._connectTimeoutTimer = null;
+    }
+  }
+
   private _heartbeatTick(): void {
     // A hidden tab has no one to show the disconnect to; the
     // visibilitychange listener ticks immediately on return.
     if (globalThis.document?.visibilityState === "hidden") return;
+    if (this._heartbeatInFlight) return;
     if (Date.now() - this._lastMessageAt < HEARTBEAT_INTERVAL_MS) return;
     const ws = this._ws;
     // Probe only an OPEN socket: a visibility-edge tick during an
     // in-flight connect would otherwise force-close the new attempt.
     if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    this.ping(HEARTBEAT_TIMEOUT_MS).catch((err: unknown) => {
-      // An APIError reply proves the link is alive (e.g. the pre-auth
-      // gate); only silence or a failed send means a dead socket.
-      if (err instanceof APIError) return;
-      if (this._ws === ws) this._forceClose(ws);
-    });
+    this._heartbeatInFlight = true;
+    this.ping(HEARTBEAT_TIMEOUT_MS)
+      .catch((err: unknown) => {
+        // An APIError reply proves the link is alive (e.g. the pre-auth
+        // gate); only silence or a failed send means a dead socket.
+        if (err instanceof APIError) return;
+        if (this._ws === ws) this._forceClose(ws);
+      })
+      .finally(() => {
+        this._heartbeatInFlight = false;
+      });
   }
 
   /**
@@ -424,6 +454,7 @@ export class ESPHomeAPI {
       // value rather than the previous one.
       this._connectionGeneration += 1;
       this._reconnectDelay = 1000;
+      this._clearConnectTimeout();
       this._startHeartbeat();
       if (this._connectPromise) {
         this._connectPromise.resolve(this._serverInfo);
@@ -544,6 +575,14 @@ export class ESPHomeAPI {
     this._connected = false;
     this._ws = null;
     this._stopHeartbeat();
+    this._clearConnectTimeout();
+
+    // A force-closed handshake fires no error event, so a pending
+    // connect() would otherwise hang forever.
+    if (this._connectPromise) {
+      this._connectPromise.reject(new Error("WebSocket connection closed"));
+      this._connectPromise = null;
+    }
 
     // Park ``ready`` until the next successful connect+auth. Without
     // this, anyone awaiting it during the reconnect-backoff window
@@ -572,11 +611,16 @@ export class ESPHomeAPI {
     }
 
     // Auto-reconnect unless intentionally disconnected. While the
-    // browser reports offline every retry is doomed; the online
-    // listener restarts the loop the moment connectivity returns.
-    if (!this._intentionalDisconnect && globalThis.navigator?.onLine !== false) {
-      const delay = this._reconnectDelay;
-      this._reconnectDelay = Math.min(this._reconnectDelay * 2, 30000);
+    // browser reports offline every retry is doomed, so hold at the
+    // backoff ceiling; the online listener preempts for instant
+    // recovery, and the slow retries cover a false-negative onLine
+    // (embedded webviews are known to misreport it).
+    if (!this._intentionalDisconnect) {
+      const offline = globalThis.navigator?.onLine === false;
+      const delay = offline ? RECONNECT_MAX_DELAY_MS : this._reconnectDelay;
+      if (!offline) {
+        this._reconnectDelay = Math.min(this._reconnectDelay * 2, RECONNECT_MAX_DELAY_MS);
+      }
       console.debug(`[WS] Reconnecting in ${delay}ms...`);
       this._reconnectTimer = setTimeout(() => {
         this._reconnectTimer = null;

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -312,7 +312,10 @@ export class ESPHomeAPI {
       this._clearConnectTimeout();
       this._connectTimeoutTimer = setTimeout(() => {
         this._connectTimeoutTimer = null;
-        if (this._ws === ws && !this._connected) this._forceClose(ws);
+        if (this._ws === ws && !this._connected) {
+          console.debug(`[WS] Handshake stalled for ${CONNECT_TIMEOUT_MS}ms; closing`);
+          this._forceClose(ws);
+        }
       }, CONNECT_TIMEOUT_MS);
     });
   }
@@ -336,18 +339,23 @@ export class ESPHomeAPI {
   // ─── Liveness ─────────────────────────────────────────────
 
   // Stable handler references make the add/remove pairs idempotent, so
-  // no registration flag is needed across reconnects.
+  // no registration flag is needed across reconnects. The existence
+  // guards keep teardown order-independent under test.
   private _registerNetworkListeners(): void {
-    window.addEventListener("offline", this._onWindowOffline);
-    window.addEventListener("online", this._onWindowOnline);
+    if (typeof window !== "undefined") {
+      window.addEventListener("offline", this._onWindowOffline);
+      window.addEventListener("online", this._onWindowOnline);
+    }
     if (typeof document !== "undefined") {
       document.addEventListener("visibilitychange", this._onVisibilityChange);
     }
   }
 
   private _unregisterNetworkListeners(): void {
-    window.removeEventListener("offline", this._onWindowOffline);
-    window.removeEventListener("online", this._onWindowOnline);
+    if (typeof window !== "undefined") {
+      window.removeEventListener("offline", this._onWindowOffline);
+      window.removeEventListener("online", this._onWindowOnline);
+    }
     if (typeof document !== "undefined") {
       document.removeEventListener("visibilitychange", this._onVisibilityChange);
     }
@@ -417,7 +425,12 @@ export class ESPHomeAPI {
         // An APIError reply proves the link is alive (e.g. the pre-auth
         // gate); only silence or a failed send means a dead socket.
         if (err instanceof APIError) return;
+        console.debug("[WS] Heartbeat got no reply; closing socket", err);
         if (this._ws === ws) this._forceClose(ws);
+      })
+      .catch(() => {
+        // A throw from the disconnect fan-out must not become an
+        // unhandled rejection.
       })
       .finally(() => {
         this._heartbeatInFlight = false;

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -153,14 +153,18 @@ type PendingRequest = {
 // socket. Protocol-level server pings are invisible to page JS, so a
 // dead link otherwise stays OPEN forever. The tick runs faster than
 // the silence threshold so detection lags the threshold by at most
-// one tick; the in-flight guard keeps pings non-overlapping.
+// one tick; the in-flight guard keeps pings non-overlapping. The
+// timeout is generous because a backend busy compiling can take over
+// 10s to answer (the HA frontend uses 15s for the same reason).
 const HEARTBEAT_INTERVAL_MS = 15000;
-const HEARTBEAT_TIMEOUT_MS = 5000;
+const HEARTBEAT_TIMEOUT_MS = 15000;
 const HEARTBEAT_TICK_MS = 5000;
 
 // A handshake against a dead peer stalls in CONNECTING with no
 // error/close event; time it out so the backoff loop keeps going.
-const CONNECT_TIMEOUT_MS = 10000;
+// Generous so a slow link never loses a handshake that would have
+// completed; the browser's own stall timeout is minutes.
+const CONNECT_TIMEOUT_MS = 30000;
 
 const RECONNECT_MAX_DELAY_MS = 30000;
 

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -148,13 +148,11 @@ type PendingRequest = {
   reject: (error: Error) => void;
 };
 
-// Client-side liveness probe. The server's protocol-level pings are
-// answered by the browser invisibly, so a dead TCP connection (wifi
-// off, backend frozen, NAT/proxy drop) keeps readyState OPEN forever
-// with no signal to JS. After HEARTBEAT_INTERVAL_MS of receive
-// silence the client sends a 'ping' command; a reply that doesn't
-// arrive within HEARTBEAT_TIMEOUT_MS force-closes the socket so the
-// normal close/reconnect path runs.
+// Liveness probe: after HEARTBEAT_INTERVAL_MS of receive silence send
+// a 'ping'; no reply within HEARTBEAT_TIMEOUT_MS force-closes the
+// socket. Protocol-level server pings are invisible to page JS, so a
+// dead link otherwise stays OPEN forever. TIMEOUT < INTERVAL keeps
+// pings non-overlapping.
 const HEARTBEAT_INTERVAL_MS = 15000;
 const HEARTBEAT_TIMEOUT_MS = 5000;
 
@@ -181,9 +179,7 @@ export class ESPHomeAPI {
   private _reconnectDelay = 1000;
   private _intentionalDisconnect = false;
   private _heartbeatTimer: ReturnType<typeof setInterval> | null = null;
-  private _heartbeatInFlight = false;
   private _lastMessageAt = 0;
-  private _networkListenersRegistered = false;
   private _connectPromise: {
     resolve: (info: ServerInfoMessage) => void;
     reject: (error: Error) => void;
@@ -277,10 +273,7 @@ export class ESPHomeAPI {
       const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
       const wsUrl = `${protocol}//${window.location.host}${BASE_PATH}ws`;
 
-      // Every listener checks it still belongs to the current socket:
-      // a force-closed socket (heartbeat timeout, offline event) can
-      // fire its close/error long after a reconnect replaced it, and
-      // acting on the stale event would tear down the new connection.
+      // Listeners ignore events from a socket a reconnect replaced.
       const ws = new WebSocket(wsUrl);
       this._ws = ws;
 
@@ -320,25 +313,28 @@ export class ESPHomeAPI {
 
   // ─── Liveness ─────────────────────────────────────────────
 
+  // Stable handler references make the add/remove pairs idempotent, so
+  // no registration flag is needed across reconnects.
   private _registerNetworkListeners(): void {
-    if (this._networkListenersRegistered) return;
-    this._networkListenersRegistered = true;
     window.addEventListener("offline", this._onWindowOffline);
     window.addEventListener("online", this._onWindowOnline);
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", this._onVisibilityChange);
+    }
   }
 
   private _unregisterNetworkListeners(): void {
-    if (!this._networkListenersRegistered) return;
-    this._networkListenersRegistered = false;
     window.removeEventListener("offline", this._onWindowOffline);
     window.removeEventListener("online", this._onWindowOnline);
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", this._onVisibilityChange);
+    }
   }
 
   private readonly _onWindowOffline = (): void => {
-    // The kernel won't error an idle socket when the interface goes
-    // away; close it proactively so the disconnect surfaces now
-    // instead of after the heartbeat window.
-    this._forceClose(this._ws);
+    // An idle socket doesn't error when the interface drops; surface
+    // the disconnect now instead of after the heartbeat window.
+    if (this._ws) this._forceClose(this._ws);
   };
 
   private readonly _onWindowOnline = (): void => {
@@ -354,6 +350,11 @@ export class ESPHomeAPI {
         // _onClose schedules the next retry.
       });
     }
+  };
+
+  private readonly _onVisibilityChange = (): void => {
+    // The tick skips while hidden; catch up the moment the tab returns.
+    if (document.visibilityState === "visible") this._heartbeatTick();
   };
 
   private _startHeartbeat(): void {
@@ -372,34 +373,27 @@ export class ESPHomeAPI {
   }
 
   private _heartbeatTick(): void {
-    if (this._heartbeatInFlight) return;
+    // A hidden tab has no one to show the disconnect to; the
+    // visibilitychange listener ticks immediately on return.
+    if (globalThis.document?.visibilityState === "hidden") return;
     if (Date.now() - this._lastMessageAt < HEARTBEAT_INTERVAL_MS) return;
     const ws = this._ws;
     if (!ws) return;
-    this._heartbeatInFlight = true;
-    this.sendCommand("ping", undefined, HEARTBEAT_TIMEOUT_MS)
-      .catch((err: unknown) => {
-        // An APIError reply (e.g. the pre-auth gate rejecting 'ping'
-        // while the login form is up) proves the link is alive; only
-        // a timeout or a failed send means the socket is dead even
-        // though the browser still reports it OPEN.
-        if (err instanceof APIError) return;
-        if (this._ws === ws) this._forceClose(ws);
-      })
-      .finally(() => {
-        this._heartbeatInFlight = false;
-      });
+    this.ping(HEARTBEAT_TIMEOUT_MS).catch((err: unknown) => {
+      // An APIError reply proves the link is alive (e.g. the pre-auth
+      // gate); only silence or a failed send means a dead socket.
+      if (err instanceof APIError) return;
+      if (this._ws === ws) this._forceClose(ws);
+    });
   }
 
   /**
    * Close a socket known dead and run the disconnect path now.
    *
-   * close() alone only *starts* the closing handshake; against an
-   * unresponsive peer the socket hangs in CLOSING and the close
-   * event never fires, so the disconnect would never surface.
+   * close() only starts the closing handshake; against a dead peer
+   * the close event never fires.
    */
-  private _forceClose(ws: WebSocket | null): void {
-    if (!ws) return;
+  private _forceClose(ws: WebSocket): void {
     ws.close();
     // Skipped when close() dispatched the close event synchronously
     // (test mocks do); the close listener already ran _onClose.
@@ -563,7 +557,8 @@ export class ESPHomeAPI {
 
     // Notify stream handlers
     for (const [, stream] of this._streamHandlers) {
-      stream.onError?.("WebSocket connection closed");
+      if (stream.onConnectionLost) stream.onConnectionLost();
+      else stream.onError?.("WebSocket connection closed");
     }
     this._streamHandlers.clear();
 
@@ -574,8 +569,10 @@ export class ESPHomeAPI {
       this.onDisconnected?.();
     }
 
-    // Auto-reconnect unless intentionally disconnected
-    if (!this._intentionalDisconnect) {
+    // Auto-reconnect unless intentionally disconnected. While the
+    // browser reports offline every retry is doomed; the online
+    // listener restarts the loop the moment connectivity returns.
+    if (!this._intentionalDisconnect && globalThis.navigator?.onLine !== false) {
       const delay = this._reconnectDelay;
       this._reconnectDelay = Math.min(this._reconnectDelay * 2, 30000);
       console.debug(`[WS] Reconnecting in ${delay}ms...`);
@@ -643,7 +640,8 @@ export class ESPHomeAPI {
     callbacks: StreamCallbacks<TResult>
   ): string {
     if (!this._ws || this._ws.readyState !== WebSocket.OPEN) {
-      callbacks.onError?.("WebSocket not connected");
+      if (callbacks.onConnectionLost) callbacks.onConnectionLost();
+      else callbacks.onError?.("WebSocket not connected");
       return "";
     }
 
@@ -2397,8 +2395,8 @@ export class ESPHomeAPI {
   }
 
   /** Ping the server. */
-  async ping(): Promise<{ pong: boolean }> {
-    return this.sendCommand("ping");
+  async ping(timeout?: number): Promise<{ pong: boolean }> {
+    return this.sendCommand("ping", undefined, timeout);
   }
 
   // ─── Editor (live YAML validation) ────────────────────────

--- a/src/api/types/streaming.ts
+++ b/src/api/types/streaming.ts
@@ -12,4 +12,8 @@ export interface StreamCallbacks<TResult = { success: boolean; code: number }> {
   onOutput?: (line: string) => void;
   onResult?: (data: TResult) => void;
   onError?: (error: string) => void;
+  /** The WS itself dropped (or the send was refused). Fired instead of
+   *  onError when provided, so consumers can tell a connection-level
+   *  stop from a command error without parsing the message. */
+  onConnectionLost?: () => void;
 }

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -650,12 +650,6 @@ export class ESPHomeApp extends LitElement {
     if (changed.has("_onboardingShouldShow") && this._onboardingShouldShow) {
       this._onboardingWizard?.open();
     }
-    if (changed.has("_showReconnectPill") && this._showReconnectPill) {
-      // Promote the pill into the top layer so it paints above open
-      // modals; hiding is implicit when the render drops the element.
-      const pill = this.renderRoot.querySelector<HTMLElement>(".reconnect-pill");
-      if (pill && !pill.matches(":popover-open")) pill.showPopover();
-    }
   }
 }
 

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -650,6 +650,12 @@ export class ESPHomeApp extends LitElement {
     if (changed.has("_onboardingShouldShow") && this._onboardingShouldShow) {
       this._onboardingWizard?.open();
     }
+    if (changed.has("_showReconnectPill") && this._showReconnectPill) {
+      // Promote the pill into the top layer so it paints above open
+      // modals; hiding is implicit when the render drops the element.
+      const pill = this.renderRoot.querySelector<HTMLElement>(".reconnect-pill");
+      if (pill && !pill.matches(":popover-open")) pill.showPopover();
+    }
   }
 }
 

--- a/src/components/app-shell/connection-overlays.ts
+++ b/src/components/app-shell/connection-overlays.ts
@@ -42,6 +42,12 @@ export const connectionOverlayStyles = css`
 
   .reconnect-pill {
     position: fixed;
+    /* Reset the UA popover centering (inset: 0 + margin: auto) so the
+       fixed bottom-center placement below wins. */
+    inset: auto;
+    margin: 0;
+    border: none;
+    overflow: visible;
     bottom: var(--wa-space-l);
     left: 50%;
     transform: translateX(-50%);
@@ -71,8 +77,14 @@ export function renderRouteLoadingBar(): TemplateResult {
   return html`<div class="route-loading-bar" aria-hidden="true"></div>`;
 }
 
+/**
+ * A manual popover, not a plain fixed div: wa-dialog opens with the
+ * native showModal(), whose top layer paints above any z-index, so a
+ * fixed pill is invisible while a modal is open. The caller must
+ * showPopover() after render (removal from the DOM auto-hides it).
+ */
 export function renderReconnectPill(localize: LocalizeFunc): TemplateResult {
-  return html`<div class="reconnect-pill" role="status">
+  return html`<div class="reconnect-pill" popover="manual" role="status">
     ${localize("layout.reconnecting")}
   </div>`;
 }

--- a/src/components/app-shell/connection-overlays.ts
+++ b/src/components/app-shell/connection-overlays.ts
@@ -1,4 +1,5 @@
 import { css, html, type TemplateResult } from "lit";
+import { ref } from "lit/directives/ref.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 
 /**
@@ -77,14 +78,29 @@ export function renderRouteLoadingBar(): TemplateResult {
   return html`<div class="route-loading-bar" aria-hidden="true"></div>`;
 }
 
+// Module-level so the ref callback keeps one identity across renders;
+// an inline arrow would re-fire on every host render. The microtask
+// defers past the commit: ref fires before Lit inserts the fragment,
+// and showPopover() throws on a disconnected element.
+function showPillOnAttach(el?: Element): void {
+  if (!(el instanceof HTMLElement) || typeof el.showPopover !== "function") return;
+  queueMicrotask(() => {
+    if (el.isConnected && !el.matches(":popover-open")) el.showPopover();
+  });
+}
+
 /**
- * A manual popover, not a plain fixed div: wa-dialog opens with the
- * native showModal(), whose top layer paints above any z-index, so a
- * fixed pill is invisible while a modal is open. The caller must
- * showPopover() after render (removal from the DOM auto-hides it).
+ * A manual popover, not a plain fixed div: modal dialogs sit in the
+ * browser top layer above any z-index. Shows itself on attach; DOM
+ * removal hides it.
  */
 export function renderReconnectPill(localize: LocalizeFunc): TemplateResult {
-  return html`<div class="reconnect-pill" popover="manual" role="status">
+  return html`<div
+    class="reconnect-pill"
+    popover="manual"
+    role="status"
+    ${ref(showPillOnAttach)}
+  >
     ${localize("layout.reconnecting")}
   </div>`;
 }

--- a/src/components/app-shell/connection-overlays.ts
+++ b/src/components/app-shell/connection-overlays.ts
@@ -83,9 +83,17 @@ export function renderRouteLoadingBar(): TemplateResult {
 // defers past the commit: ref fires before Lit inserts the fragment,
 // and showPopover() throws on a disconnected element.
 function showPillOnAttach(el?: Element): void {
-  if (!(el instanceof HTMLElement) || typeof el.showPopover !== "function") return;
+  if (!(el instanceof HTMLElement)) return;
   queueMicrotask(() => {
-    if (el.isConnected && !el.matches(":popover-open")) el.showPopover();
+    if (!el.isConnected) return;
+    try {
+      if (!el.matches(":popover-open")) el.showPopover();
+    } catch {
+      // No popover support: degrade to the plain fixed pill (visible
+      // everywhere except under a modal's top layer) rather than
+      // staying display:none forever.
+      el.removeAttribute("popover");
+    }
   });
 }
 

--- a/src/components/app-shell/connection-overlays.ts
+++ b/src/components/app-shell/connection-overlays.ts
@@ -85,13 +85,12 @@ export function renderRouteLoadingBar(): TemplateResult {
 function showPillOnAttach(el?: Element): void {
   if (!(el instanceof HTMLElement)) return;
   queueMicrotask(() => {
-    if (!el.isConnected) return;
     try {
       if (!el.matches(":popover-open")) el.showPopover();
     } catch {
-      // No popover support: degrade to the plain fixed pill (visible
-      // everywhere except under a modal's top layer) rather than
-      // staying display:none forever.
+      // No popover support or a detached element: degrade to the plain
+      // fixed pill (visible everywhere except under a modal's top
+      // layer) rather than staying display:none forever.
       el.removeAttribute("popover");
     }
   });

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -234,8 +234,11 @@ export class ESPHomeLogsDialog extends LitElement {
       if (watching) this._quietSerial.ensureArmed();
       else this._quietSerial.disarm();
     }
-    if (changedProperties.has("_apiConnected") && this._apiConnected) {
-      resumeAfterReconnect(this);
+    if (changedProperties.has("_apiConnected")) {
+      // The banner toggling resizes the log area on both edges;
+      // re-pin the scroll so the tail stays visible.
+      this._resetAnsiLogScroll();
+      if (this._apiConnected) resumeAfterReconnect(this);
     }
   }
 

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -15,7 +15,12 @@ import { LitElement, html } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { LocalizeFunc } from "../common/localize.js";
-import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
+import {
+  apiConnectedContext,
+  apiContext,
+  darkModeContext,
+  localizeContext,
+} from "../context/index.js";
 import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -41,6 +46,7 @@ import {
   onStop,
   openOta,
   openPassive,
+  resumeAfterReconnect,
   setSerialOpenFailed,
   setSerialStream,
   switchToOtaLogs,
@@ -108,6 +114,12 @@ export class ESPHomeLogsDialog extends LitElement {
   @consume({ context: apiContext })
   _api!: ESPHomeAPI;
 
+  /** WS liveness; false shows the connection-lost banner, the
+   *  false→true edge resumes a stream the drop stopped. */
+  @consume({ context: apiConnectedContext, subscribe: true })
+  @state()
+  _apiConnected = true;
+
   @property()
   configuration = "";
 
@@ -142,6 +154,11 @@ export class ESPHomeLogsDialog extends LitElement {
   // Reconnect hook for a Web Serial session whose reader is gone (a reopen
   // failed -> `dead`); the "click Start to reconnect" recovery (#636).
   _reconnect: (() => Promise<void>) | null = null;
+
+  // Set when the OTA stream was stopped by a lost WS connection rather
+  // than by the user; the reconnect edge in willUpdate resumes it. A
+  // manual Stop/Start clears it so a user-stopped stream stays stopped.
+  _stoppedByConnectionLoss = false;
 
   // Watchdog for a Web Serial session that shows nothing (uart: repurposed
   // the console pins, wrong baud). Armed/disarmed off the session state in
@@ -221,6 +238,9 @@ export class ESPHomeLogsDialog extends LitElement {
       const watching = this._open && s.kind === "serial" && !s.paused;
       if (watching) this._quietSerial.ensureArmed();
       else this._quietSerial.disarm();
+    }
+    if (changedProperties.has("_apiConnected") && this._apiConnected) {
+      resumeAfterReconnect(this);
     }
   }
 
@@ -312,6 +332,10 @@ export class ESPHomeLogsDialog extends LitElement {
           placeholder=${this._localize("dashboard.logs_placeholder")}
           ?light=${!this._darkMode}
           ?streaming=${streaming}
+          .state=${this._apiConnected ? null : "error"}
+          .statusMessage=${
+            this._apiConnected ? "" : this._localize("dashboard.logs_connection_lost")
+          }
         >
           ${
             this._backToInstall

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -155,11 +155,6 @@ export class ESPHomeLogsDialog extends LitElement {
   // failed -> `dead`); the "click Start to reconnect" recovery (#636).
   _reconnect: (() => Promise<void>) | null = null;
 
-  // Set when the OTA stream was stopped by a lost WS connection rather
-  // than by the user; the reconnect edge in willUpdate resumes it. A
-  // manual Stop/Start clears it so a user-stopped stream stays stopped.
-  _stoppedByConnectionLoss = false;
-
   // Watchdog for a Web Serial session that shows nothing (uart: repurposed
   // the console pins, wrong baud). Armed/disarmed off the session state in
   // willUpdate; fed displayed lines via _noteSerialActivity. When it goes

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -234,7 +234,9 @@ export class ESPHomeLogsDialog extends LitElement {
       if (watching) this._quietSerial.ensureArmed();
       else this._quietSerial.disarm();
     }
-    if (changedProperties.has("_apiConnected")) {
+    // A Web Serial session reads USB, not the dashboard WS; the
+    // connection banner and its scroll re-pin are ota-only.
+    if (changedProperties.has("_apiConnected") && this._session.kind === "ota") {
       // The banner toggling resizes the log area on both edges;
       // re-pin the scroll so the tail stays visible.
       this._resetAnsiLogScroll();
@@ -314,6 +316,9 @@ export class ESPHomeLogsDialog extends LitElement {
     const expandLabel = this._localize(
       this._expanded ? "dashboard.logs_collapse" : "dashboard.logs_expand"
     );
+    // Only the ota source rides the dashboard WS; a Web Serial stream
+    // is healthy regardless, so no false error banner there.
+    const wsDown = s.kind === "ota" && !this._apiConnected;
 
     return html`
       <esphome-base-dialog
@@ -330,10 +335,8 @@ export class ESPHomeLogsDialog extends LitElement {
           placeholder=${this._localize("dashboard.logs_placeholder")}
           ?light=${!this._darkMode}
           ?streaming=${streaming}
-          .state=${this._apiConnected ? null : "error"}
-          .statusMessage=${
-            this._apiConnected ? "" : this._localize("dashboard.logs_connection_lost")
-          }
+          .state=${wsDown ? "error" : null}
+          .statusMessage=${wsDown ? this._localize("dashboard.logs_connection_lost") : ""}
         >
           ${
             this._backToInstall

--- a/src/components/logs-dialog/session.ts
+++ b/src/components/logs-dialog/session.ts
@@ -52,7 +52,6 @@ function beginSession(host: ESPHomeLogsDialog, onBackToInstall?: () => void): vo
   host._clearLogs();
   host._expanded = false;
   host._showStates = true;
-  host._stoppedByConnectionLoss = false;
   host._backToInstallHandler = onBackToInstall ?? null;
   host._backToInstall = host._backToInstallHandler !== null;
 }
@@ -170,7 +169,6 @@ function stopBackendStream(host: ESPHomeLogsDialog, streamId: string): Promise<v
 export function onStart(host: ESPHomeLogsDialog): void {
   const s = host._session;
   if (isStreaming(s)) return;
-  host._stoppedByConnectionLoss = false;
   switch (s.kind) {
     case "ota":
       startOtaStream(host);
@@ -190,7 +188,6 @@ export function onStart(host: ESPHomeLogsDialog): void {
 // without a close/reopen that reboots the device (#526).
 export function onStop(host: ESPHomeLogsDialog): void {
   const s = host._session;
-  host._stoppedByConnectionLoss = false;
   switch (s.kind) {
     case "ota":
       if (s.streamId !== null) {
@@ -204,14 +201,6 @@ export function onStop(host: ESPHomeLogsDialog): void {
       break;
   }
 }
-
-// The API client's own failure strings: the '_onClose' fan-out when the
-// socket dies mid-stream, and 'sendStreamCommand' refusing a send on a
-// closed socket. Anything else is a real backend error worth showing.
-const CONNECTION_LOSS_ERRORS = new Set([
-  "WebSocket connection closed",
-  "WebSocket not connected",
-]);
 
 export function startOtaStream(host: ESPHomeLogsDialog): void {
   const s = host._session;
@@ -233,30 +222,25 @@ export function startOtaStream(host: ESPHomeLogsDialog): void {
       },
       onResult: () => markOtaStopped(host, streamId),
       onError: (error: string) => {
-        // The synchronous send-refused call lands while streamId is
-        // still ""; the empty-id check after the call handles it.
-        if (streamId === "") return;
         const wasCurrent =
           host._session.kind === "ota" && host._session.streamId === streamId;
         markOtaStopped(host, streamId);
-        if (!wasCurrent) return;
-        if (CONNECTION_LOSS_ERRORS.has(error)) {
-          // The banner driven by _apiConnected explains the stop; the
-          // reconnect edge resumes the stream.
-          host._stoppedByConnectionLoss = true;
-        } else {
-          host._log.append([error]);
-        }
+        if (wasCurrent) host._log.append([error]);
+      },
+      onConnectionLost: () => {
+        // Fires synchronously on a refused send (streamId still "",
+        // session already stopped) or later when the socket dies; a
+        // stale stream's late signal must not flag the replacement.
+        const cur = host._session;
+        const current = cur.kind === "ota" && cur.streamId === streamId;
+        if (streamId !== "" && !current) return;
+        host._session = { kind: "ota", port: s.port, streamId: null, interrupted: true };
       },
     },
     { noStates: !host._showStates }
   );
-  if (streamId === "") {
-    // sendStreamCommand refused the send: the socket is already known
-    // dead. Stay stopped and let the reconnect edge respawn.
-    host._stoppedByConnectionLoss = true;
-    return;
-  }
+  // A refused send already stopped the session via onConnectionLost.
+  if (streamId === "") return;
   host._session = { kind: "ota", port: s.port, streamId };
 }
 
@@ -267,10 +251,9 @@ export function startOtaStream(host: ESPHomeLogsDialog): void {
  * reconnect's auth dance instead of racing it.
  */
 export function resumeAfterReconnect(host: ESPHomeLogsDialog): void {
-  if (!host._open || !host._stoppedByConnectionLoss) return;
   const s = host._session;
-  if (s.kind !== "ota" || s.streamId !== null) return;
-  host._stoppedByConnectionLoss = false;
+  if (!host._open || s.kind !== "ota" || s.streamId !== null || !s.interrupted) return;
+  host._session = { kind: "ota", port: s.port, streamId: null };
   host._log.append([host._localize("dashboard.logs_reconnected")]);
   void host._api.ready.then(() => startOtaStream(host));
 }

--- a/src/components/logs-dialog/session.ts
+++ b/src/components/logs-dialog/session.ts
@@ -261,7 +261,16 @@ export function resumeAfterReconnect(host: ESPHomeLogsDialog): void {
   host._session = { kind: "ota", port: s.port, streamId: null };
   host._log.flush();
   host._log.append([host._localize("dashboard.logs_reconnected")]);
-  void host._api.ready.then(() => startOtaStream(host));
+  void host._api.ready
+    .then(() => startOtaStream(host))
+    .catch(() => {
+      // Restore the flag so the next reconnect edge retries instead of
+      // stranding the user on a resume line that never resumed.
+      const cur = host._session;
+      if (cur.kind === "ota" && cur.streamId === null) {
+        host._session = { ...cur, interrupted: true };
+      }
+    });
 }
 
 function markOtaStopped(host: ESPHomeLogsDialog, streamId: string): void {

--- a/src/components/logs-dialog/session.ts
+++ b/src/components/logs-dialog/session.ts
@@ -263,9 +263,10 @@ export function resumeAfterReconnect(host: ESPHomeLogsDialog): void {
   host._log.append([host._localize("dashboard.logs_reconnected")]);
   void host._api.ready
     .then(() => startOtaStream(host))
-    .catch(() => {
+    .catch((err: unknown) => {
       // Restore the flag so the next reconnect edge retries instead of
       // stranding the user on a resume line that never resumed.
+      console.error("[logs] Resume after reconnect failed", err);
       const cur = host._session;
       if (cur.kind === "ota" && cur.streamId === null) {
         host._session = { ...cur, interrupted: true };

--- a/src/components/logs-dialog/session.ts
+++ b/src/components/logs-dialog/session.ts
@@ -52,6 +52,7 @@ function beginSession(host: ESPHomeLogsDialog, onBackToInstall?: () => void): vo
   host._clearLogs();
   host._expanded = false;
   host._showStates = true;
+  host._stoppedByConnectionLoss = false;
   host._backToInstallHandler = onBackToInstall ?? null;
   host._backToInstall = host._backToInstallHandler !== null;
 }
@@ -169,6 +170,7 @@ function stopBackendStream(host: ESPHomeLogsDialog, streamId: string): Promise<v
 export function onStart(host: ESPHomeLogsDialog): void {
   const s = host._session;
   if (isStreaming(s)) return;
+  host._stoppedByConnectionLoss = false;
   switch (s.kind) {
     case "ota":
       startOtaStream(host);
@@ -188,6 +190,7 @@ export function onStart(host: ESPHomeLogsDialog): void {
 // without a close/reopen that reboots the device (#526).
 export function onStop(host: ESPHomeLogsDialog): void {
   const s = host._session;
+  host._stoppedByConnectionLoss = false;
   switch (s.kind) {
     case "ota":
       if (s.streamId !== null) {
@@ -201,6 +204,14 @@ export function onStop(host: ESPHomeLogsDialog): void {
       break;
   }
 }
+
+// The API client's own failure strings: the '_onClose' fan-out when the
+// socket dies mid-stream, and 'sendStreamCommand' refusing a send on a
+// closed socket. Anything else is a real backend error worth showing.
+const CONNECTION_LOSS_ERRORS = new Set([
+  "WebSocket connection closed",
+  "WebSocket not connected",
+]);
 
 export function startOtaStream(host: ESPHomeLogsDialog): void {
   const s = host._session;
@@ -221,11 +232,47 @@ export function startOtaStream(host: ESPHomeLogsDialog): void {
         host._enqueueLine(line);
       },
       onResult: () => markOtaStopped(host, streamId),
-      onError: () => markOtaStopped(host, streamId),
+      onError: (error: string) => {
+        // The synchronous send-refused call lands while streamId is
+        // still ""; the empty-id check after the call handles it.
+        if (streamId === "") return;
+        const wasCurrent =
+          host._session.kind === "ota" && host._session.streamId === streamId;
+        markOtaStopped(host, streamId);
+        if (!wasCurrent) return;
+        if (CONNECTION_LOSS_ERRORS.has(error)) {
+          // The banner driven by _apiConnected explains the stop; the
+          // reconnect edge resumes the stream.
+          host._stoppedByConnectionLoss = true;
+        } else {
+          host._log.append([error]);
+        }
+      },
     },
     { noStates: !host._showStates }
   );
+  if (streamId === "") {
+    // sendStreamCommand refused the send: the socket is already known
+    // dead. Stay stopped and let the reconnect edge respawn.
+    host._stoppedByConnectionLoss = true;
+    return;
+  }
   host._session = { kind: "ota", port: s.port, streamId };
+}
+
+/**
+ * Resume an OTA stream the connection drop stopped, once the WS is back.
+ *
+ * Waits on 'api.ready' so the respawned command lands after the
+ * reconnect's auth dance instead of racing it.
+ */
+export function resumeAfterReconnect(host: ESPHomeLogsDialog): void {
+  if (!host._open || !host._stoppedByConnectionLoss) return;
+  const s = host._session;
+  if (s.kind !== "ota" || s.streamId !== null) return;
+  host._stoppedByConnectionLoss = false;
+  host._log.append([host._localize("dashboard.logs_reconnected")]);
+  void host._api.ready.then(() => startOtaStream(host));
 }
 
 function markOtaStopped(host: ESPHomeLogsDialog, streamId: string): void {

--- a/src/components/logs-dialog/session.ts
+++ b/src/components/logs-dialog/session.ts
@@ -225,7 +225,12 @@ export function startOtaStream(host: ESPHomeLogsDialog): void {
         const wasCurrent =
           host._session.kind === "ota" && host._session.streamId === streamId;
         markOtaStopped(host, streamId);
-        if (wasCurrent) host._log.append([error]);
+        if (wasCurrent) {
+          // Drain batched output first so the error lands after the
+          // lines that preceded it.
+          host._log.flush();
+          host._log.append([error]);
+        }
       },
       onConnectionLost: () => {
         // Fires synchronously on a refused send (streamId still "",
@@ -254,6 +259,7 @@ export function resumeAfterReconnect(host: ESPHomeLogsDialog): void {
   const s = host._session;
   if (!host._open || s.kind !== "ota" || s.streamId !== null || !s.interrupted) return;
   host._session = { kind: "ota", port: s.port, streamId: null };
+  host._log.flush();
   host._log.append([host._localize("dashboard.logs_reconnected")]);
   void host._api.ready.then(() => startOtaStream(host));
 }

--- a/src/components/logs-session.ts
+++ b/src/components/logs-session.ts
@@ -27,7 +27,15 @@
  */
 export type LogsSession =
   | { readonly kind: "idle" }
-  | { readonly kind: "ota"; readonly port: string; readonly streamId: string | null }
+  | {
+      readonly kind: "ota";
+      readonly port: string;
+      readonly streamId: string | null;
+      /** Stopped by a lost dashboard connection (not the user); the
+       *  reconnect edge resumes it. Any other transition rebuilds the
+       *  session without it, so a user stop never auto-resumes. */
+      readonly interrupted?: boolean;
+    }
   | { readonly kind: "reconnecting"; readonly paused: boolean }
   | {
       readonly kind: "serial";

--- a/src/components/process-terminal/process-terminal.ts
+++ b/src/components/process-terminal/process-terminal.ts
@@ -84,7 +84,10 @@ export class ESPHomeProcessTerminal extends LitElement {
     if (this.state !== "success" && this.state !== "error") return nothing;
     const isSuccess = this.state === "success";
     return html`
-      <div class="status-banner status-banner--${isSuccess ? "success" : "error"}">
+      <div
+        class="status-banner status-banner--${isSuccess ? "success" : "error"}"
+        role="status"
+      >
         <wa-icon
           library="mdi"
           name=${isSuccess ? "check-circle" : "alert-circle"}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -97,6 +97,8 @@
     "logs_serial_unavailable": "Serial isn't available. {network_action}",
     "logs_switch_to_network": "Stream network logs instead",
     "logs_switched_to_network": "Switched to network logs; waiting for the device to come online…",
+    "logs_connection_lost": "Connection to the dashboard lost. Reconnecting…",
+    "logs_reconnected": "Reconnected to the dashboard; resuming logs…",
     "select_all": "Select all",
     "deselect_all": "Deselect all",
     "selected_count": "{count} selected",

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -584,6 +584,31 @@ describe("ESPHomeAPI — streaming commands", () => {
     expect(onError).toHaveBeenCalledWith("WebSocket connection closed");
   });
 
+  it("prefers onConnectionLost over onError when the socket drops", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const onError = vi.fn();
+    const onConnectionLost = vi.fn();
+    api.sendStreamCommand(
+      "devices/logs",
+      { configuration: "foo.yaml" },
+      { onError, onConnectionLost }
+    );
+    ws.close();
+    expect(onConnectionLost).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("prefers onConnectionLost over onError on a refused send", () => {
+    const api = new ESPHomeAPI();
+    const onError = vi.fn();
+    const onConnectionLost = vi.fn();
+    const id = api.sendStreamCommand("x", {}, { onError, onConnectionLost });
+    expect(id).toBe("");
+    expect(onConnectionLost).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("stopStream sends devices/stop_stream with the stream id", async () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
@@ -2452,6 +2477,7 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
   });
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllGlobals();
     uninstallMockWebSocket();
   });
 
@@ -2498,7 +2524,7 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
   });
 
   it("keeps the socket open when the ping is rejected by the auth gate", async () => {
-    // An error frame is still a reply — the link is alive; only
+    // An error frame is still a reply; the link is alive, and only
     // silence may force-close the socket.
     const api = new ESPHomeAPI();
     const ws = await connect(api);
@@ -2540,5 +2566,19 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
     api.disconnect();
     fireWindowEvent("online");
     expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("suspends reconnect attempts while the browser reports offline", async () => {
+    vi.stubGlobal("navigator", { onLine: false });
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    fireWindowEvent("offline");
+    expect(ws.readyState).toBe(MockWebSocket.CLOSED);
+    // No doomed retries while offline; the online event restarts the loop.
+    await vi.advanceTimersByTimeAsync(120000);
+    expect(MockWebSocket.instances).toHaveLength(1);
+    vi.stubGlobal("navigator", { onLine: true });
+    fireWindowEvent("online");
+    expect(MockWebSocket.instances).toHaveLength(2);
   });
 });

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -2609,6 +2609,20 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
     expect(MockWebSocket.instances).toHaveLength(1);
   });
 
+  it("online abandons a connect attempt stalled in CONNECTING", async () => {
+    const api = makeApi();
+    const ws = await connect(api);
+    ws.close();
+    await vi.advanceTimersByTimeAsync(1000);
+    // The retry fired and its handshake is stalling.
+    expect(MockWebSocket.instances).toHaveLength(2);
+    const stalled = MockWebSocket.latest();
+    expect(stalled.readyState).toBe(MockWebSocket.CONNECTING);
+    fireWindowEvent("online");
+    expect(stalled.readyState).toBe(MockWebSocket.CLOSED);
+    expect(MockWebSocket.instances).toHaveLength(3);
+  });
+
   it("holds retries at the backoff ceiling while the browser reports offline", async () => {
     vi.stubGlobal("navigator", { onLine: false });
     const api = makeApi();

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -112,6 +112,22 @@ describe("ESPHomeAPI — connection", () => {
     expect(onDisconnected).toHaveBeenCalledTimes(1);
     expect(api.connected).toBe(false);
   });
+
+  it("disconnect() runs the close cleanup for pending work", async () => {
+    // The socket's own close event is async in real browsers and the
+    // identity guard ignores it once _ws moved on, so disconnect()
+    // must reject and notify everything itself.
+    const api = new ESPHomeAPI();
+    await connect(api);
+    const pending = api.sendCommand("ping");
+    const onConnectionLost = vi.fn();
+    api.sendStreamCommand("devices/logs", {}, { onConnectionLost });
+    api.disconnect();
+    await expect(pending).rejects.toThrow(/WebSocket connection closed/);
+    expect(onConnectionLost).toHaveBeenCalledTimes(1);
+    expect(api.connected).toBe(false);
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
 });
 
 describe("ESPHomeAPI — sendCommand", () => {

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -2508,7 +2508,7 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
     const ws = await connect(api);
     await vi.advanceTimersByTimeAsync(15000);
     expect(ws.sentAs<{ command: string }>(0).command).toBe("ping");
-    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(15000);
     expect(ws.readyState).toBe(MockWebSocket.CLOSED);
     expect(api.connected).toBe(false);
     expect(onDisconnected).toHaveBeenCalledTimes(1);
@@ -2602,7 +2602,7 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
     const ws = MockWebSocket.latest();
     // No open/ServerInfo ever arrives; the connect timeout force-closes
     // the attempt so the backoff loop keeps going.
-    await vi.advanceTimersByTimeAsync(10000);
+    await vi.advanceTimersByTimeAsync(30000);
     expect(ws.readyState).toBe(MockWebSocket.CLOSED);
     await vi.advanceTimersByTimeAsync(1000);
     expect(MockWebSocket.instances).toHaveLength(2);

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -28,6 +28,22 @@ const serverInfoAuthRequired = {
 const stubLocalStorage = (initial?: Record<string, string>) =>
   stubStorage("localStorage", initial);
 
+// Every instance is tracked and disconnected after each test; a leaked
+// heartbeat interval otherwise ticks into the gap where the mock
+// WebSocket global is already gone.
+const liveApis: ESPHomeAPI[] = [];
+
+function makeApi(): ESPHomeAPI {
+  const api = new ESPHomeAPI();
+  liveApis.push(api);
+  return api;
+}
+
+afterEach(() => {
+  for (const api of liveApis) api.disconnect();
+  liveApis.length = 0;
+});
+
 async function connect(api: ESPHomeAPI): Promise<MockWebSocket> {
   const pending = api.connect();
   const ws = MockWebSocket.latest();
@@ -46,7 +62,7 @@ describe("ESPHomeAPI — connection", () => {
   });
 
   it("opens a ws:// URL from the page location", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const pending = api.connect();
     const ws = MockWebSocket.latest();
     ws.open();
@@ -57,7 +73,7 @@ describe("ESPHomeAPI — connection", () => {
 
   it("upgrades to wss:// when the page is https", async () => {
     installMockWindow({ protocol: "https:", host: "example.test" });
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const pending = api.connect();
     const ws = MockWebSocket.latest();
     ws.open();
@@ -67,7 +83,7 @@ describe("ESPHomeAPI — connection", () => {
   });
 
   it("resolves with server info and fires onConnected", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const onConnected = vi.fn();
     api.onConnected = onConnected;
     const ws = await connect(api);
@@ -78,21 +94,21 @@ describe("ESPHomeAPI — connection", () => {
   });
 
   it("returns the existing server info when already connected", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     await connect(api);
     const second = await api.connect();
     expect(second).toEqual(serverInfo);
   });
 
   it("rejects connect() on transport error", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const pending = api.connect();
     MockWebSocket.latest().triggerError();
     await expect(pending).rejects.toThrow(/WebSocket connection failed/);
   });
 
   it("does not fire onDisconnected if connect never succeeded", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const onDisconnected = vi.fn();
     api.onDisconnected = onDisconnected;
     const pending = api.connect();
@@ -104,7 +120,7 @@ describe("ESPHomeAPI — connection", () => {
   });
 
   it("fires onDisconnected when an established connection closes", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const onDisconnected = vi.fn();
     api.onDisconnected = onDisconnected;
     const ws = await connect(api);
@@ -117,7 +133,7 @@ describe("ESPHomeAPI — connection", () => {
     // The socket's own close event is async in real browsers and the
     // identity guard ignores it once _ws moved on, so disconnect()
     // must reject and notify everything itself.
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     await connect(api);
     const pending = api.sendCommand("ping");
     const onConnectionLost = vi.fn();
@@ -140,7 +156,7 @@ describe("ESPHomeAPI — sendCommand", () => {
   });
 
   it("sends a command with a message_id and resolves the result", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.sendCommand<{ ok: boolean }>("ping", { foo: "bar" });
@@ -154,15 +170,15 @@ describe("ESPHomeAPI — sendCommand", () => {
   });
 
   it("omits args when none are given", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
-    void api.sendCommand("ping");
+    void api.sendCommand("ping").catch(() => {});
     const sent = ws.sentAs<{ args?: unknown }>(0);
     expect(sent.args).toBeUndefined();
   });
 
   it("rejects with an APIError carrying error_code + details", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.sendCommand("boom");
     const { message_id } = ws.sentAs<{ message_id: string }>(0);
@@ -187,7 +203,7 @@ describe("ESPHomeAPI — sendCommand", () => {
 
   it("rejects when no response arrives before the timeout", async () => {
     vi.useFakeTimers();
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const pending = api.connect();
     const ws = MockWebSocket.latest();
     ws.open();
@@ -205,22 +221,22 @@ describe("ESPHomeAPI — sendCommand", () => {
   });
 
   it("throws when the socket is not open", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     await expect(api.sendCommand("ping")).rejects.toThrow(/not connected/);
   });
 
   it("assigns sequential message_ids", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
-    void api.sendCommand("a");
-    void api.sendCommand("b");
+    void api.sendCommand("a").catch(() => {});
+    void api.sendCommand("b").catch(() => {});
     const id0 = ws.sentAs<{ message_id: string }>(0).message_id;
     const id1 = ws.sentAs<{ message_id: string }>(1).message_id;
     expect(Number(id1)).toBe(Number(id0) + 1);
   });
 
   it("rejects all pending requests when the socket closes", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.sendCommand("ping");
     ws.close();
@@ -245,7 +261,7 @@ describe("ESPHomeAPI — getAvailableAutomations", () => {
   };
 
   it("omits the yaml arg when the draft is empty so the backend reads disk (#1348)", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.getAvailableAutomations("device.yaml", "");
     const sent = ws.sentAs<{ command: string; message_id: string; args: unknown }>(0);
@@ -256,7 +272,7 @@ describe("ESPHomeAPI — getAvailableAutomations", () => {
   });
 
   it("forwards a non-empty draft so the backend scopes off it (#1348)", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const draft = "esphome:\n  name: d\n";
     const pending = api.getAvailableAutomations("device.yaml", draft);
@@ -276,7 +292,7 @@ describe("ESPHomeAPI — cloneDevice", () => {
   });
 
   it("sends ``devices/clone`` with snake_case args and returns the new configuration", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.cloneDevice(
@@ -307,10 +323,10 @@ describe("ESPHomeAPI — cloneDevice", () => {
     // ``friendly_name:`` line untouched, producing two list
     // entries with the same label. Pin that the helper omits the
     // key entirely on ``undefined`` so the default kicks in.
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
-    void api.cloneDevice("kitchen.yaml", "bedroom-bulb");
+    void api.cloneDevice("kitchen.yaml", "bedroom-bulb").catch(() => {});
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
 
     expect(sent.args).toEqual({
@@ -327,10 +343,10 @@ describe("ESPHomeAPI — cloneDevice", () => {
     // ``new_friendly_name: ""`` on the wire so the backend's
     // ``if new_friendly_name:`` short-circuit fires and the
     // rewrite is skipped.
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
-    void api.cloneDevice("kitchen.yaml", "bedroom-bulb", "");
+    void api.cloneDevice("kitchen.yaml", "bedroom-bulb", "").catch(() => {});
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
 
     expect(sent.args).toEqual({
@@ -359,7 +375,7 @@ describe("ESPHomeAPI — getAvailableAutomations", () => {
     // boundary so every caller is safe by construction (avoids
     // duplicating the backfill in ``loadAndHydrateAvailable``,
     // ``api-action-editor``, ``script-editor``, etc.).
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.getAvailableAutomations("device.yaml");
@@ -383,7 +399,7 @@ describe("ESPHomeAPI — getAvailableAutomations", () => {
   });
 
   it("preserves config_entries when the wire payload already carries them", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.getAvailableAutomations("device.yaml");
@@ -419,7 +435,7 @@ describe("ESPHomeAPI — editFriendlyName", () => {
   });
 
   it("sends ``devices/edit_friendly_name`` with snake_case args", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.editFriendlyName("kitchen.yaml", "Reading Lamp");
@@ -447,7 +463,7 @@ describe("ESPHomeAPI — editFriendlyName", () => {
     // ``rewritten: false`` so the caller knows to skip the
     // follow-up install. Pin that the helper passes the flag
     // through unchanged so the dashboard handler can branch on it.
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.editFriendlyName("kitchen.yaml", "Kitchen");
@@ -471,7 +487,7 @@ describe("ESPHomeAPI — updateConfig", () => {
   });
 
   it("sends ``allow_wipe: true`` when allowWipe is set", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.updateConfig("secrets.yaml", "", { allowWipe: true });
@@ -492,7 +508,7 @@ describe("ESPHomeAPI — updateConfig", () => {
   });
 
   it("omits ``allow_wipe`` when opts is unset", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.updateConfig("kitchen.yaml", "esphome:\n  name: kitchen\n");
@@ -512,7 +528,7 @@ describe("ESPHomeAPI — updateConfig", () => {
   });
 
   it("omits ``allow_wipe`` when allowWipe is false", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.updateConfig("secrets.yaml", "wifi_ssid: home\n", {
@@ -539,7 +555,7 @@ describe("ESPHomeAPI — streaming commands", () => {
   });
 
   it("delivers output events to onOutput", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const onOutput = vi.fn();
     const onResult = vi.fn();
@@ -556,7 +572,7 @@ describe("ESPHomeAPI — streaming commands", () => {
   });
 
   it("delivers result events and stops listening afterwards", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const onOutput = vi.fn();
     const onResult = vi.fn();
@@ -577,7 +593,7 @@ describe("ESPHomeAPI — streaming commands", () => {
   });
 
   it("routes ErrorMessage to the stream's onError", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const onError = vi.fn();
     const messageId = api.sendStreamCommand(
@@ -594,7 +610,7 @@ describe("ESPHomeAPI — streaming commands", () => {
   });
 
   it("calls onError with connection-closed when the socket drops", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const onError = vi.fn();
     api.sendStreamCommand("devices/logs", { configuration: "foo.yaml" }, { onError });
@@ -603,7 +619,7 @@ describe("ESPHomeAPI — streaming commands", () => {
   });
 
   it("prefers onConnectionLost over onError when the socket drops", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const onError = vi.fn();
     const onConnectionLost = vi.fn();
@@ -618,7 +634,7 @@ describe("ESPHomeAPI — streaming commands", () => {
   });
 
   it("prefers onConnectionLost over onError on a refused send", () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const onError = vi.fn();
     const onConnectionLost = vi.fn();
     const id = api.sendStreamCommand("x", {}, { onError, onConnectionLost });
@@ -628,7 +644,7 @@ describe("ESPHomeAPI — streaming commands", () => {
   });
 
   it("stopStream sends devices/stop_stream with the stream id", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     // Start a streaming command so we have a message_id worth cancelling.
@@ -652,7 +668,7 @@ describe("ESPHomeAPI — streaming commands", () => {
   });
 
   it("stopStream drops the local handler so further output events are ignored", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const onOutput = vi.fn();
     const onResult = vi.fn();
@@ -667,7 +683,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     ws.receive({ message_id: streamId, event: "output", data: "before-stop" });
     expect(onOutput).toHaveBeenCalledWith("before-stop");
 
-    void api.stopStream(streamId);
+    void api.stopStream(streamId).catch(() => {});
 
     // Anything that arrives after stop — whether genuinely racing or a
     // misbehaving backend that keeps sending — must not reach the caller.
@@ -683,7 +699,7 @@ describe("ESPHomeAPI — streaming commands", () => {
   });
 
   it("signals an error via onError if send is attempted while disconnected", () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const onError = vi.fn();
     const id = api.sendStreamCommand("x", {}, { onError });
     expect(id).toBe("");
@@ -700,7 +716,7 @@ describe("ESPHomeAPI — event subscriptions", () => {
   });
 
   it("confirms the subscription via a result and then forwards events", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const received: Array<{ event: string; data: unknown }> = [];
     const subscribed = api.subscribeEvents((event, data) =>
@@ -730,7 +746,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("listDevices sends devices/list and unwraps the result", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const payload = { configured: [], importable: [] };
     const pending = api.listDevices();
@@ -742,7 +758,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("desktopCheckUpdate sends desktop/check_update and unwraps the result", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const payload = {
       any_available: true,
@@ -764,7 +780,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("desktopInstallUpdate sends desktop/update and unwraps the result", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.desktopInstallUpdate();
     const sent = ws.sentAs<{ command: string; message_id: string; args?: unknown }>(0);
@@ -775,7 +791,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("addComponent merges configuration into args", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.addComponent("foo.yaml", {
       component_id: "dht",
@@ -797,7 +813,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("addComponent forwards the draft yaml when given", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.addComponent(
       "foo.yaml",
@@ -819,9 +835,9 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("firmwareInstall defaults port to OTA, force_local and bootloader to false", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
-    void api.firmwareInstall("foo.yaml");
+    void api.firmwareInstall("foo.yaml").catch(() => {});
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
     expect(sent.args).toEqual({
       configuration: "foo.yaml",
@@ -832,9 +848,9 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("firmwareInstall threads force_local through to the backend", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
-    void api.firmwareInstall("foo.yaml", "OTA", true);
+    void api.firmwareInstall("foo.yaml", "OTA", true).catch(() => {});
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
     expect(sent.args).toEqual({
       configuration: "foo.yaml",
@@ -845,9 +861,9 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("firmwareInstall threads bootloader through to the backend", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
-    void api.firmwareInstall("foo.yaml", "OTA", false, true);
+    void api.firmwareInstall("foo.yaml", "OTA", false, true).catch(() => {});
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
     expect(sent.args).toEqual({
       configuration: "foo.yaml",
@@ -858,7 +874,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("validate sends devices/validate through the stream API", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const id = api.validate("foo.yaml", { onOutput: () => {} });
     expect(id).toBeTruthy();
@@ -868,7 +884,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("logs sends devices/logs without no_states by default", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const id = api.logs("foo.yaml", "OTA", { onOutput: () => {} });
     expect(id).toBeTruthy();
@@ -878,7 +894,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("logs forwards no_states=true when noStates is set", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     api.logs("foo.yaml", "OTA", { onOutput: () => {} }, { noStates: true });
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
@@ -890,7 +906,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("logs omits no_states when noStates is false", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     api.logs("foo.yaml", "OTA", { onOutput: () => {} }, { noStates: false });
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
@@ -898,16 +914,16 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("updatePreferences passes the partial prefs as args", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
-    void api.updatePreferences({ theme: "dark" as never });
+    void api.updatePreferences({ theme: "dark" as never }).catch(() => {});
     const sent = ws.sentAs<{ command: string; args: Record<string, unknown> }>(0);
     expect(sent.command).toBe("config/set_preferences");
     expect(sent.args).toEqual({ theme: "dark" });
   });
 
   it("detectChip sends config/detect_chip with the port arg and unwraps the chip info", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const payload = {
       chip_family: "ESP32-C3",
@@ -928,7 +944,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("detectChip surfaces a backend error message to the caller", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.detectChip("/dev/cu.usbserial-10");
     const sent = ws.sentAs<{ message_id: string }>(0);
@@ -943,7 +959,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("getRemoteBuildSettings sends remote_build/get_settings and unwraps the result", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const payload = { enabled: true, peers: [] };
     const pending = api.getRemoteBuildSettings();
@@ -955,7 +971,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("setRemoteBuildSettings sends remote_build/set_settings with the args and returns the result", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.setRemoteBuildSettings({ enabled: true });
     const sent = ws.sentAs<{
@@ -976,7 +992,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     // flag and the pairings list off the same round-trip; live
     // updates flow through the OFFLOADER_REMOTE_BUILDS_TOGGLED
     // / OFFLOADER_PAIRING_ENABLED_CHANGED events on subscribe.
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.getOffloaderRemoteBuildSettings();
     const sent = ws.sentAs<{ command: string; message_id: string; args?: unknown }>(0);
@@ -993,7 +1009,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     // build" switch. The backend round-trip carries strict
     // boolean validation (rejects truthy non-booleans); the
     // API helper passes the value through unchanged.
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.setOffloaderRemoteBuildSettings({
       remote_builds_enabled: false,
@@ -1016,7 +1032,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     // from ``(host, port)`` to pin so receiver hostname
     // changes don't break the row identity); the API helper
     // matches.
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.setOffloaderPairingEnabled({
       pin_sha256: "a".repeat(64),
@@ -1053,7 +1069,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("setOffloaderRemoteBuildSettings forwards version_match_policy", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.setOffloaderRemoteBuildSettings({
       version_match_policy: "exact_required",
@@ -1078,7 +1094,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     // The advanced "include this machine in the build pool" toggle
     // flips this field alone; the helper must accept it without
     // requiring the other two settings.
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.setOffloaderRemoteBuildSettings({
       include_local_in_pool: true,
@@ -1110,7 +1126,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   // the ``listRemoteBuildPeers`` deletion in #248.
 
   it("approveRemoteBuildPeer sends remote_build/approve_peer with dashboard_id", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.approveRemoteBuildPeer({ dashboard_id: "green" });
     const sent = ws.sentAs<{
@@ -1126,7 +1142,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("removeRemoteBuildPeer sends remote_build/remove_peer with dashboard_id", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.removeRemoteBuildPeer({ dashboard_id: "green" });
     const sent = ws.sentAs<{
@@ -1142,7 +1158,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("setRemoteBuildPairingWindow sends remote_build/set_pairing_window with open flag", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.setRemoteBuildPairingWindow({ open: true });
     const sent = ws.sentAs<{
@@ -1158,7 +1174,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("previewRemoteBuildPair sends remote_build/preview_pair and unwraps the pin", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.previewRemoteBuildPair({
       hostname: "build.local",
@@ -1177,7 +1193,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("requestRemoteBuildPair sends host + pin + both labels (TOCTOU + dual label)", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const args = {
       hostname: "build.local",
@@ -1211,7 +1227,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("remoteBuildResetPeerBuildEnv sends remote_build/reset_peer_build_env and returns the mirror job", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.remoteBuildResetPeerBuildEnv({
       pin_sha256: "a".repeat(64),
@@ -1229,7 +1245,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("unpairRemoteBuild sends remote_build/unpair with pin_sha256", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.unpairRemoteBuild({
       pin_sha256: "a".repeat(64),
@@ -1247,7 +1263,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("editRemoteBuildPairingEndpoint sends remote_build/edit_pairing_endpoint with pin + new coords", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const pending = api.editRemoteBuildPairingEndpoint({
       pin_sha256: "a".repeat(64),
@@ -1286,7 +1302,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("getRemoteBuildIdentity sends remote_build/get_identity and unwraps the result", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const payload = {
       dashboard_id: "abc123",
@@ -1304,7 +1320,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
   });
 
   it("rotateRemoteBuildIdentity sends remote_build/rotate_identity and unwraps the result", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const payload = {
       dashboard_id: "abc123",
@@ -1333,7 +1349,7 @@ describe("ESPHomeAPI — auth", () => {
   });
 
   it("ready resolves immediately when requires_auth is false", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const pending = api.connect();
     const ws = MockWebSocket.latest();
     ws.open();
@@ -1344,7 +1360,7 @@ describe("ESPHomeAPI — auth", () => {
   });
 
   it("fires onAuthRequired when requires_auth is true and no token is stored", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const onAuthRequired = vi.fn();
     api.onAuthRequired = onAuthRequired;
     const pending = api.connect();
@@ -1362,7 +1378,7 @@ describe("ESPHomeAPI — auth", () => {
         expires_at: 1_700_000_000,
       }),
     });
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const onAuthRequired = vi.fn();
     api.onAuthRequired = onAuthRequired;
 
@@ -1402,7 +1418,7 @@ describe("ESPHomeAPI — auth", () => {
         expires_at: 1_700_000_000,
       }),
     });
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const onAuthRequired = vi.fn();
     api.onAuthRequired = onAuthRequired;
 
@@ -1427,7 +1443,7 @@ describe("ESPHomeAPI — auth", () => {
   });
 
   it("login(credentials) sends username/password and persists the token", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const pending = api.connect();
     const ws = MockWebSocket.latest();
     ws.open();
@@ -1459,7 +1475,7 @@ describe("ESPHomeAPI — auth", () => {
   });
 
   it("login surfaces APIError with not_authenticated for bad credentials", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const pending = api.connect();
     const ws = MockWebSocket.latest();
     ws.open();
@@ -1485,7 +1501,7 @@ describe("ESPHomeAPI — auth", () => {
   });
 
   it("login surfaces APIError with rate_limited including the details string", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const pending = api.connect();
     const ws = MockWebSocket.latest();
     ws.open();
@@ -1517,7 +1533,7 @@ describe("ESPHomeAPI — auth", () => {
         expires_at: 1_700_000_000,
       }),
     });
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const pending = api.connect();
     const ws = MockWebSocket.latest();
     ws.open();
@@ -1557,7 +1573,7 @@ describe("ESPHomeAPI — auth", () => {
       clear: () => {},
     });
 
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const onAuthRequired = vi.fn();
     api.onAuthRequired = onAuthRequired;
 
@@ -1606,7 +1622,7 @@ describe("ESPHomeAPI — auth", () => {
     // Without this contract, any caller that awaits ``api.ready``
     // during the reconnect-backoff window resumes against the closed
     // socket and immediately hits "WebSocket not connected".
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const pending = api.connect();
     const ws = MockWebSocket.latest();
     ws.open();
@@ -1649,7 +1665,7 @@ describe("ESPHomeAPI — auth", () => {
         expires_at: 1_700_000_000,
       }),
     });
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const pending = api.connect();
     const ws = MockWebSocket.latest();
     ws.open();
@@ -1687,7 +1703,7 @@ describe("ESPHomeAPI — automations catalog", () => {
   });
 
   it("sends ``automations/get_triggers`` and returns the list as-is", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.getAutomationTriggers();
@@ -1725,10 +1741,10 @@ describe("ESPHomeAPI — automations catalog", () => {
     // them as snake_case ``board_id`` on the wire — TypeScript camel
     // case at the call site, Python snake_case across the
     // protocol.
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
-    void api.getAutomationTriggers("esp32", "esp32-s3-devkitc-1");
+    void api.getAutomationTriggers("esp32", "esp32-s3-devkitc-1").catch(() => {});
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
     expect(sent.args).toEqual({
       platform: "esp32",
@@ -1737,7 +1753,7 @@ describe("ESPHomeAPI — automations catalog", () => {
   });
 
   it("sends ``automations/get_actions`` and returns the list", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.getAutomationActions("esp32");
@@ -1753,7 +1769,7 @@ describe("ESPHomeAPI — automations catalog", () => {
   });
 
   it("sends ``automations/get_conditions`` and returns the list", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.getAutomationConditions();
@@ -1768,7 +1784,7 @@ describe("ESPHomeAPI — automations catalog", () => {
   });
 
   it("sends ``automations/get_light_effects`` and returns the list", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.getLightEffects();
@@ -1783,7 +1799,7 @@ describe("ESPHomeAPI — automations catalog", () => {
   });
 
   it("sends ``automations/get_available`` with the YAML path and returns the context payload", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.getAvailableAutomations("kitchen.yaml");
@@ -1818,7 +1834,7 @@ describe("ESPHomeAPI — getComponentBodies", () => {
   });
 
   it("sends ``components/get_component_bodies`` with the requested ids", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.getComponentBodies(["wifi", "api"]);
@@ -1839,10 +1855,10 @@ describe("ESPHomeAPI — getComponentBodies", () => {
   });
 
   it("forwards platform / board_id as snake_case when provided", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
-    void api.getComponentBodies(["wifi"], "esp32", "esp32-s3-devkitc-1");
+    void api.getComponentBodies(["wifi"], "esp32", "esp32-s3-devkitc-1").catch(() => {});
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
     expect(sent.args).toEqual({
       component_ids: ["wifi"],
@@ -1852,10 +1868,10 @@ describe("ESPHomeAPI — getComponentBodies", () => {
   });
 
   it("omits platform / board_id when not provided so the backend's default path runs", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
-    void api.getComponentBodies(["wifi"]);
+    void api.getComponentBodies(["wifi"]).catch(() => {});
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
     expect(sent.args).toEqual({ component_ids: ["wifi"] });
     expect("platform" in sent.args).toBe(false);
@@ -1863,7 +1879,7 @@ describe("ESPHomeAPI — getComponentBodies", () => {
   });
 
   it("short-circuits on an empty id list without touching the socket", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const result = await api.getComponentBodies([]);
@@ -1881,7 +1897,7 @@ describe("ESPHomeAPI — getCompatibleBoards", () => {
   });
 
   it("sends ``boards/get_compatible_boards`` with board_id and hydrates the slim results", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.getCompatibleBoards("generic-esp32c3");
@@ -1947,7 +1963,7 @@ describe("ESPHomeAPI — getCompatibleBoards", () => {
   });
 
   it("returns an empty list when the backend has no siblings", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.getCompatibleBoards("m5stack-cores3");
@@ -1970,7 +1986,7 @@ describe("ESPHomeAPI — automations parse / upsert / delete", () => {
   });
 
   it("sends ``automations/parse`` and returns the structured ParsedAutomation list", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.parseDeviceAutomations("kitchen.yaml");
@@ -2006,7 +2022,7 @@ describe("ESPHomeAPI — automations parse / upsert / delete", () => {
     // YAML range. Pin that the helper preserves the tree's shape
     // verbatim (no key-mangling) so the structured editor's
     // representation lines up with the backend dataclass.
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const automation = {
@@ -2050,7 +2066,7 @@ describe("ESPHomeAPI — automations parse / upsert / delete", () => {
   });
 
   it("sends ``automations/delete`` with the location locator", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const location = { kind: "script" as const, id: "morning_alarm" };
@@ -2070,7 +2086,7 @@ describe("ESPHomeAPI — automations parse / upsert / delete", () => {
   });
 
   it("sends ``editor/migrate_config`` with the draft content", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.migrateConfig("api:\n  services: []\n");
@@ -2092,7 +2108,7 @@ describe("ESPHomeAPI — automations parse / upsert / delete", () => {
     // has a non-catalog action — edit raw YAML" rather than
     // best-effort-rebuild. Pin that the typed APIError shape
     // round-trips.
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.parseDeviceAutomations("broken.yaml");
@@ -2119,7 +2135,7 @@ describe("ESPHomeAPI — setDeviceLabelsBulk", () => {
     // and spreads ``updates`` straight through would break the
     // backend contract silently because the dialog-side tests
     // only exercise ``computeUpdates()``'s in-memory shape.
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.setDeviceLabelsBulk([
@@ -2150,7 +2166,7 @@ describe("ESPHomeAPI — setDeviceLabelsBulk", () => {
   });
 
   it("forwards per-entry failures from the backend response", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.setDeviceLabelsBulk([
@@ -2181,7 +2197,7 @@ describe("ESPHomeAPI — firmware download (HTTP)", () => {
 
   it("mints a download token over the WebSocket", async () => {
     installMockWebSocket();
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.firmwareDownloadToken("kitchen.yaml", "firmware.elf");
@@ -2200,7 +2216,7 @@ describe("ESPHomeAPI — firmware download (HTTP)", () => {
   });
 
   it("builds a base-path-aware, token-encoded URL and passes the filename through", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     vi.spyOn(api, "firmwareDownloadToken").mockResolvedValue({
       token: "a b/c+d",
       filename: "kitchen-firmware.elf",
@@ -2219,7 +2235,7 @@ describe("ESPHomeAPI — firmware download (HTTP)", () => {
   });
 
   it("fetches the bytes for Web Serial flashing", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     vi.spyOn(api, "firmwareDownloadUrl").mockResolvedValue({
       url: "/api/firmware/download?token=t",
       filename: "kitchen-firmware.factory.bin",
@@ -2238,7 +2254,7 @@ describe("ESPHomeAPI — firmware download (HTTP)", () => {
   });
 
   it("throws when the byte fetch responds non-ok", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     vi.spyOn(api, "firmwareDownloadUrl").mockResolvedValue({
       url: "/api/firmware/download?token=t",
       filename: "kitchen-missing.bin",
@@ -2287,7 +2303,7 @@ describe("ESPHomeAPI — import bundle upload (HTTP)", () => {
 
   it("mints a token over the WS then POSTs the file (detect pass)", async () => {
     installMockWebSocket();
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const fetchFn = vi.fn(async () => ({ ok: true, json: async () => IMPORTED }));
     vi.stubGlobal("fetch", fetchFn);
@@ -2305,7 +2321,7 @@ describe("ESPHomeAPI — import bundle upload (HTTP)", () => {
 
   it("adds mode=resolve and a repeated overwrite param per path", async () => {
     installMockWebSocket();
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const fetchFn = vi.fn(async () => ({ ok: true, json: async () => IMPORTED }));
     vi.stubGlobal("fetch", fetchFn);
@@ -2321,7 +2337,7 @@ describe("ESPHomeAPI — import bundle upload (HTTP)", () => {
 
   it("emits mode=resolve with no overwrite params for an empty resolve (keep all)", async () => {
     installMockWebSocket();
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     const fetchFn = vi.fn(async () => ({ ok: true, json: async () => IMPORTED }));
     vi.stubGlobal("fetch", fetchFn);
@@ -2337,7 +2353,7 @@ describe("ESPHomeAPI — import bundle upload (HTTP)", () => {
 
   it("surfaces the server's {error_code, details} on a non-OK JSON response", async () => {
     installMockWebSocket();
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     vi.stubGlobal(
       "fetch",
@@ -2358,7 +2374,7 @@ describe("ESPHomeAPI — import bundle upload (HTTP)", () => {
 
   it("falls back to status + statusText when the error body isn't JSON (e.g. a 413)", async () => {
     installMockWebSocket();
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     vi.stubGlobal(
       "fetch",
@@ -2393,7 +2409,7 @@ describe("ESPHomeAPI — console-debug redaction", () => {
 
   it("redacts the password in a logged auth/login frame", async () => {
     const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.login({ username: "admin", password: "hunter2" });
@@ -2411,7 +2427,7 @@ describe("ESPHomeAPI — console-debug redaction", () => {
 
   it("redacts the fresh token in a received auth/login result", async () => {
     const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.login({ token: "old-token" });
@@ -2431,7 +2447,7 @@ describe("ESPHomeAPI — console-debug redaction", () => {
 
   it("leaves non-auth command traffic untouched", async () => {
     const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.sendCommand("ping", { foo: "bar" });
@@ -2446,7 +2462,7 @@ describe("ESPHomeAPI — console-debug redaction", () => {
 
   it("redacts the value of a config/set_secret frame (but sends it on the wire)", async () => {
     const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.setSecret("api_key", "topsecretvalue", false);
@@ -2464,7 +2480,7 @@ describe("ESPHomeAPI — console-debug redaction", () => {
 
   it("redacts the pairing_key of a request_pair frame (but sends it on the wire)", async () => {
     const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
 
     const pending = api.requestRemoteBuildPair({
@@ -2500,7 +2516,7 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
   });
 
   it("sends a ping after an idle interval", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     await vi.advanceTimersByTimeAsync(15000);
     const sent = ws.sentAs<{ command: string }>(0);
@@ -2508,7 +2524,7 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
   });
 
   it("suppresses the ping when a frame arrived within the interval", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     await vi.advanceTimersByTimeAsync(10000);
     // Any received frame counts as liveness, even an unroutable one.
@@ -2518,7 +2534,7 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
   });
 
   it("closes the socket and disconnects when the ping gets no reply", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const onDisconnected = vi.fn();
     api.onDisconnected = onDisconnected;
     const ws = await connect(api);
@@ -2531,7 +2547,7 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
   });
 
   it("keeps the socket open when the ping is answered", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     await vi.advanceTimersByTimeAsync(15000);
     const sent = ws.sentAs<{ command: string; message_id: string }>(0);
@@ -2544,7 +2560,7 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
   it("keeps the socket open when the ping is rejected by the auth gate", async () => {
     // An error frame is still a reply; the link is alive, and only
     // silence may force-close the socket.
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     await vi.advanceTimersByTimeAsync(15000);
     const sent = ws.sentAs<{ message_id: string }>(0);
@@ -2559,7 +2575,7 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
   });
 
   it("closes the socket on the window offline event", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const onDisconnected = vi.fn();
     api.onDisconnected = onDisconnected;
     const ws = await connect(api);
@@ -2569,7 +2585,7 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
   });
 
   it("reconnects immediately on the window online event", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     ws.close();
     // The backoff timer is pending; online preempts it.
@@ -2579,16 +2595,23 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
   });
 
   it("removes the network listeners on intentional disconnect", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     await connect(api);
     api.disconnect();
+    expect(() => fireWindowEvent("online")).toThrow(/no window listeners/);
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("ignores the online event while already connected", async () => {
+    const api = makeApi();
+    await connect(api);
     fireWindowEvent("online");
     expect(MockWebSocket.instances).toHaveLength(1);
   });
 
   it("holds retries at the backoff ceiling while the browser reports offline", async () => {
     vi.stubGlobal("navigator", { onLine: false });
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     fireWindowEvent("offline");
     expect(ws.readyState).toBe(MockWebSocket.CLOSED);
@@ -2601,7 +2624,7 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
   });
 
   it("skips the heartbeat while the tab is hidden and catches up on the visibility edge", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     const ws = await connect(api);
     setDocumentVisibility("hidden");
     await vi.advanceTimersByTimeAsync(60000);
@@ -2612,7 +2635,7 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
   });
 
   it("times out a handshake that stalls in CONNECTING", async () => {
-    const api = new ESPHomeAPI();
+    const api = makeApi();
     void api.connect().catch(() => {});
     expect(MockWebSocket.instances).toHaveLength(1);
     const ws = MockWebSocket.latest();

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -3,7 +3,9 @@ import { APIError, CommandTimeoutError } from "../../src/api/api-error.js";
 import { ESPHomeAPI } from "../../src/api/esphome-api.js";
 import {
   MockWebSocket,
+  fireWindowEvent,
   installMockWebSocket,
+  installMockWindow,
   uninstallMockWebSocket,
 } from "./mock-websocket.js";
 import { stubStorage } from "../_storage.js";
@@ -52,11 +54,7 @@ describe("ESPHomeAPI — connection", () => {
   });
 
   it("upgrades to wss:// when the page is https", async () => {
-    (
-      globalThis as unknown as {
-        window: { location: { protocol: string; host: string } };
-      }
-    ).window = { location: { protocol: "https:", host: "example.test" } };
+    installMockWindow({ protocol: "https:", host: "example.test" });
     const api = new ESPHomeAPI();
     const pending = api.connect();
     const ws = MockWebSocket.latest();
@@ -2444,5 +2442,103 @@ describe("ESPHomeAPI — console-debug redaction", () => {
     const text = debugText(debugSpy);
     expect(text).not.toContain("ABCD-EFGH-JKMN-PQRS");
     expect(text).toContain("<redacted>");
+  });
+});
+
+describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
+  beforeEach(() => {
+    installMockWebSocket();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    uninstallMockWebSocket();
+  });
+
+  it("sends a ping after an idle interval", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    await vi.advanceTimersByTimeAsync(15000);
+    const sent = ws.sentAs<{ command: string }>(0);
+    expect(sent.command).toBe("ping");
+  });
+
+  it("suppresses the ping when a frame arrived within the interval", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    await vi.advanceTimersByTimeAsync(10000);
+    // Any received frame counts as liveness, even an unroutable one.
+    ws.receive({ message_id: "nope", event: "output", data: "x" });
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(ws.sent).toHaveLength(0);
+  });
+
+  it("closes the socket and disconnects when the ping gets no reply", async () => {
+    const api = new ESPHomeAPI();
+    const onDisconnected = vi.fn();
+    api.onDisconnected = onDisconnected;
+    const ws = await connect(api);
+    await vi.advanceTimersByTimeAsync(15000);
+    expect(ws.sentAs<{ command: string }>(0).command).toBe("ping");
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(ws.readyState).toBe(MockWebSocket.CLOSED);
+    expect(api.connected).toBe(false);
+    expect(onDisconnected).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the socket open when the ping is answered", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    await vi.advanceTimersByTimeAsync(15000);
+    const sent = ws.sentAs<{ command: string; message_id: string }>(0);
+    ws.receive({ message_id: sent.message_id, result: { pong: true } });
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(ws.readyState).toBe(MockWebSocket.OPEN);
+    expect(api.connected).toBe(true);
+  });
+
+  it("keeps the socket open when the ping is rejected by the auth gate", async () => {
+    // An error frame is still a reply — the link is alive; only
+    // silence may force-close the socket.
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    await vi.advanceTimersByTimeAsync(15000);
+    const sent = ws.sentAs<{ message_id: string }>(0);
+    ws.receive({
+      message_id: sent.message_id,
+      error_code: "not_authenticated",
+      details: "auth required",
+    });
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(ws.readyState).toBe(MockWebSocket.OPEN);
+    expect(api.connected).toBe(true);
+  });
+
+  it("closes the socket on the window offline event", async () => {
+    const api = new ESPHomeAPI();
+    const onDisconnected = vi.fn();
+    api.onDisconnected = onDisconnected;
+    const ws = await connect(api);
+    fireWindowEvent("offline");
+    expect(ws.readyState).toBe(MockWebSocket.CLOSED);
+    expect(onDisconnected).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconnects immediately on the window online event", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    ws.close();
+    // The backoff timer is pending; online preempts it.
+    expect(MockWebSocket.instances).toHaveLength(1);
+    fireWindowEvent("online");
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it("ignores the online event after an intentional disconnect", async () => {
+    const api = new ESPHomeAPI();
+    await connect(api);
+    api.disconnect();
+    fireWindowEvent("online");
+    expect(MockWebSocket.instances).toHaveLength(1);
   });
 });

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -3,9 +3,11 @@ import { APIError, CommandTimeoutError } from "../../src/api/api-error.js";
 import { ESPHomeAPI } from "../../src/api/esphome-api.js";
 import {
   MockWebSocket,
+  fireDocumentEvent,
   fireWindowEvent,
   installMockWebSocket,
   installMockWindow,
+  setDocumentVisibility,
   uninstallMockWebSocket,
 } from "./mock-websocket.js";
 import { stubStorage } from "../_storage.js";
@@ -2560,7 +2562,7 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
     expect(MockWebSocket.instances).toHaveLength(2);
   });
 
-  it("ignores the online event after an intentional disconnect", async () => {
+  it("removes the network listeners on intentional disconnect", async () => {
     const api = new ESPHomeAPI();
     await connect(api);
     api.disconnect();
@@ -2568,17 +2570,41 @@ describe("ESPHomeAPI — liveness (heartbeat + network events)", () => {
     expect(MockWebSocket.instances).toHaveLength(1);
   });
 
-  it("suspends reconnect attempts while the browser reports offline", async () => {
+  it("holds retries at the backoff ceiling while the browser reports offline", async () => {
     vi.stubGlobal("navigator", { onLine: false });
     const api = new ESPHomeAPI();
     const ws = await connect(api);
     fireWindowEvent("offline");
     expect(ws.readyState).toBe(MockWebSocket.CLOSED);
-    // No doomed retries while offline; the online event restarts the loop.
-    await vi.advanceTimersByTimeAsync(120000);
+    // No 1s retry storm, but no full suspension either: a
+    // false-negative onLine costs one slow cycle, not the loop.
+    await vi.advanceTimersByTimeAsync(29000);
     expect(MockWebSocket.instances).toHaveLength(1);
-    vi.stubGlobal("navigator", { onLine: true });
-    fireWindowEvent("online");
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it("skips the heartbeat while the tab is hidden and catches up on the visibility edge", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    setDocumentVisibility("hidden");
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(ws.sent).toHaveLength(0);
+    setDocumentVisibility("visible");
+    fireDocumentEvent("visibilitychange");
+    expect(ws.sentAs<{ command: string }>(0).command).toBe("ping");
+  });
+
+  it("times out a handshake that stalls in CONNECTING", async () => {
+    const api = new ESPHomeAPI();
+    void api.connect().catch(() => {});
+    expect(MockWebSocket.instances).toHaveLength(1);
+    const ws = MockWebSocket.latest();
+    // No open/ServerInfo ever arrives; the connect timeout force-closes
+    // the attempt so the backoff loop keeps going.
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(ws.readyState).toBe(MockWebSocket.CLOSED);
+    await vi.advanceTimersByTimeAsync(1000);
     expect(MockWebSocket.instances).toHaveLength(2);
   });
 });

--- a/test/api/mock-websocket.ts
+++ b/test/api/mock-websocket.ts
@@ -71,12 +71,41 @@ export class MockWebSocket {
   }
 }
 
+type WindowListener = (event: unknown) => void;
+
+/** Minimal window stand-in: location for URL building plus the event
+ *  surface the API client's offline/online listeners need. */
+export function installMockWindow(
+  location: { protocol: string; host: string } = {
+    protocol: "http:",
+    host: "localhost:8000",
+  }
+): void {
+  const listeners = new Map<string, Set<WindowListener>>();
+  (globalThis as unknown as { window: unknown }).window = {
+    location,
+    addEventListener(type: string, listener: WindowListener): void {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type)!.add(listener);
+    },
+    removeEventListener(type: string, listener: WindowListener): void {
+      listeners.get(type)?.delete(listener);
+    },
+    _fire(type: string): void {
+      listeners.get(type)?.forEach((l) => l({}));
+    },
+  };
+}
+
+/** Fire a window event (e.g. 'offline' / 'online') on the mock window. */
+export function fireWindowEvent(type: string): void {
+  (globalThis as unknown as { window: { _fire(type: string): void } }).window._fire(type);
+}
+
 export function installMockWebSocket(): void {
   MockWebSocket.reset();
   (globalThis as unknown as { WebSocket: unknown }).WebSocket = MockWebSocket;
-  (globalThis as unknown as { window: unknown }).window = {
-    location: { protocol: "http:", host: "localhost:8000" },
-  };
+  installMockWindow();
 }
 
 export function uninstallMockWebSocket(): void {

--- a/test/api/mock-websocket.ts
+++ b/test/api/mock-websocket.ts
@@ -73,6 +73,8 @@ export class MockWebSocket {
 
 type WindowListener = (event: unknown) => void;
 
+let windowListeners = new Map<string, Set<WindowListener>>();
+
 /** Minimal window stand-in: location for URL building plus the event
  *  surface the API client's offline/online listeners need. */
 export function installMockWindow(
@@ -82,6 +84,7 @@ export function installMockWindow(
   }
 ): void {
   const listeners = new Map<string, Set<WindowListener>>();
+  windowListeners = listeners;
   (globalThis as unknown as { window: unknown }).window = {
     location,
     addEventListener(type: string, listener: WindowListener): void {
@@ -91,15 +94,12 @@ export function installMockWindow(
     removeEventListener(type: string, listener: WindowListener): void {
       listeners.get(type)?.delete(listener);
     },
-    _fire(type: string): void {
-      listeners.get(type)?.forEach((l) => l({}));
-    },
   };
 }
 
 /** Fire a window event (e.g. 'offline' / 'online') on the mock window. */
 export function fireWindowEvent(type: string): void {
-  (globalThis as unknown as { window: { _fire(type: string): void } }).window._fire(type);
+  windowListeners.get(type)?.forEach((l) => l({}));
 }
 
 export function installMockWebSocket(): void {

--- a/test/api/mock-websocket.ts
+++ b/test/api/mock-websocket.ts
@@ -102,14 +102,48 @@ export function fireWindowEvent(type: string): void {
   windowListeners.get(type)?.forEach((l) => l({}));
 }
 
+let documentListeners = new Map<string, Set<WindowListener>>();
+let documentVisibility: "visible" | "hidden" = "visible";
+
+/** Minimal document stand-in: the visibility surface the API client's
+ *  heartbeat needs (the node test env has no document at all). */
+export function installMockDocument(): void {
+  const listeners = new Map<string, Set<WindowListener>>();
+  documentListeners = listeners;
+  documentVisibility = "visible";
+  (globalThis as unknown as { document: unknown }).document = {
+    get visibilityState() {
+      return documentVisibility;
+    },
+    addEventListener(type: string, listener: WindowListener): void {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type)!.add(listener);
+    },
+    removeEventListener(type: string, listener: WindowListener): void {
+      listeners.get(type)?.delete(listener);
+    },
+  };
+}
+
+export function setDocumentVisibility(state: "visible" | "hidden"): void {
+  documentVisibility = state;
+}
+
+/** Fire a document event (e.g. 'visibilitychange') on the mock document. */
+export function fireDocumentEvent(type: string): void {
+  documentListeners.get(type)?.forEach((l) => l({}));
+}
+
 export function installMockWebSocket(): void {
   MockWebSocket.reset();
   (globalThis as unknown as { WebSocket: unknown }).WebSocket = MockWebSocket;
   installMockWindow();
+  installMockDocument();
 }
 
 export function uninstallMockWebSocket(): void {
   MockWebSocket.reset();
   delete (globalThis as unknown as { WebSocket?: unknown }).WebSocket;
   delete (globalThis as unknown as { window?: unknown }).window;
+  delete (globalThis as unknown as { document?: unknown }).document;
 }

--- a/test/api/mock-websocket.ts
+++ b/test/api/mock-websocket.ts
@@ -97,9 +97,13 @@ export function installMockWindow(
   };
 }
 
-/** Fire a window event (e.g. 'offline' / 'online') on the mock window. */
+/** Fire a window event (e.g. 'offline' / 'online') on the mock window.
+ *  Throws when nothing listens, so an unregistered-listener state is
+ *  assertable and never mistaken for a dispatch that ran. */
 export function fireWindowEvent(type: string): void {
-  windowListeners.get(type)?.forEach((l) => l({}));
+  const listeners = windowListeners.get(type);
+  if (!listeners?.size) throw new Error(`no window listeners for ${type}`);
+  listeners.forEach((l) => l({}));
 }
 
 let documentListeners = new Map<string, Set<WindowListener>>();
@@ -129,9 +133,12 @@ export function setDocumentVisibility(state: "visible" | "hidden"): void {
   documentVisibility = state;
 }
 
-/** Fire a document event (e.g. 'visibilitychange') on the mock document. */
+/** Fire a document event (e.g. 'visibilitychange') on the mock document.
+ *  Throws when nothing listens, same contract as fireWindowEvent. */
 export function fireDocumentEvent(type: string): void {
-  documentListeners.get(type)?.forEach((l) => l({}));
+  const listeners = documentListeners.get(type);
+  if (!listeners?.size) throw new Error(`no document listeners for ${type}`);
+  listeners.forEach((l) => l({}));
 }
 
 export function installMockWebSocket(): void {

--- a/test/components/app-shell/connection-overlays.test.ts
+++ b/test/components/app-shell/connection-overlays.test.ts
@@ -30,6 +30,13 @@ describe("connection overlays", () => {
     expect(pill!.getAttribute("role")).toBe("status");
     expect(pill!.textContent).toContain("layout.reconnecting");
   });
+
+  it("renders the pill as a manual popover so it paints above modal top layers", () => {
+    const pill = renderInto(
+      renderReconnectPill(identityLocalize as LocalizeFunc)
+    ).querySelector(".reconnect-pill");
+    expect(pill!.getAttribute("popover")).toBe("manual");
+  });
 });
 
 describe("ReconnectPillGate", () => {

--- a/test/components/logs-dialog-connection-loss.test.ts
+++ b/test/components/logs-dialog-connection-loss.test.ts
@@ -13,7 +13,11 @@ import type { LogsSession } from "../../src/components/logs-session.js";
 const session = (el: ESPHomeLogsDialog): LogsSession => (el as any)._session;
 const call = (el: ESPHomeLogsDialog, method: string) => (el as any)[method]();
 
-type StreamCallbacks = { onOutput: (l: string) => void; onError: (e: string) => void };
+type StreamCallbacks = {
+  onOutput: (l: string) => void;
+  onError: (e: string) => void;
+  onConnectionLost: () => void;
+};
 
 describe("logs-dialog OTA connection loss", () => {
   let el: ESPHomeLogsDialog;
@@ -37,11 +41,14 @@ describe("logs-dialog OTA connection loss", () => {
     document.body.appendChild(el);
   });
 
-  it("flags a connection-loss stop instead of appending the error", () => {
+  it("marks the session interrupted on connection loss without appending a line", () => {
     el.open("OTA");
-    handlers[0].onError("WebSocket connection closed");
-    expect(session(el)).toMatchObject({ kind: "ota", streamId: null });
-    expect((el as any)._stoppedByConnectionLoss).toBe(true);
+    handlers[0].onConnectionLost();
+    expect(session(el)).toMatchObject({
+      kind: "ota",
+      streamId: null,
+      interrupted: true,
+    });
     expect((el as any)._log.lines).toEqual([]);
   });
 
@@ -49,20 +56,31 @@ describe("logs-dialog OTA connection loss", () => {
     el.open("OTA");
     handlers[0].onError("configuration not found");
     expect(session(el)).toMatchObject({ kind: "ota", streamId: null });
-    expect((el as any)._stoppedByConnectionLoss).toBe(false);
+    expect(session(el)).not.toHaveProperty("interrupted", true);
     expect((el as any)._log.lines).toEqual(["configuration not found"]);
   });
 
-  it("stays stopped and flagged when the send is refused outright", () => {
-    // sendStreamCommand returns "" (and fires onError synchronously)
-    // when the socket is already known dead.
+  it("ignores a stale stream's late connection-loss signal", () => {
+    el.open("OTA"); // stream-1
+    call(el, "_onStop");
+    call(el, "_onStart"); // stream-2
+    handlers[0].onConnectionLost(); // stale
+    expect(session(el)).toMatchObject({ kind: "ota", streamId: "stream-2" });
+  });
+
+  it("stays stopped and interrupted when the send is refused outright", () => {
+    // sendStreamCommand fires onConnectionLost synchronously and
+    // returns "" when the socket is already known dead.
     logs.mockImplementation((_c: string, _p: string, cb: StreamCallbacks) => {
-      cb.onError("WebSocket not connected");
+      cb.onConnectionLost();
       return "";
     });
     el.open("OTA");
-    expect(session(el)).toMatchObject({ kind: "ota", streamId: null });
-    expect((el as any)._stoppedByConnectionLoss).toBe(true);
+    expect(session(el)).toMatchObject({
+      kind: "ota",
+      streamId: null,
+      interrupted: true,
+    });
   });
 
   it("resumes the stream on the reconnect edge with a reconnected line", async () => {
@@ -70,23 +88,21 @@ describe("logs-dialog OTA connection loss", () => {
     await el.updateComplete;
     (el as any)._apiConnected = false;
     await el.updateComplete;
-    handlers[0].onError("WebSocket connection closed");
+    handlers[0].onConnectionLost();
 
     (el as any)._apiConnected = true;
     await el.updateComplete;
     await vi.waitFor(() => expect(logs).toHaveBeenCalledTimes(2));
     expect((el as any)._log.lines).toEqual(["dashboard.logs_reconnected"]);
     expect(session(el)).toMatchObject({ kind: "ota", streamId: "stream-2" });
-    expect((el as any)._stoppedByConnectionLoss).toBe(false);
   });
 
-  it("does not resume a stream the user stopped", async () => {
+  it("does not resume a stream the user stopped before the drop", async () => {
     el.open("OTA");
     await el.updateComplete;
+    call(el, "_onStop");
     (el as any)._apiConnected = false;
     await el.updateComplete;
-    handlers[0].onError("WebSocket connection closed");
-    call(el, "_onStop");
 
     (el as any)._apiConnected = true;
     await el.updateComplete;

--- a/test/components/logs-dialog-connection-loss.test.ts
+++ b/test/components/logs-dialog-connection-loss.test.ts
@@ -123,4 +123,15 @@ describe("logs-dialog OTA connection loss", () => {
     expect(terminal.state).toBeNull();
     expect(terminal.statusMessage).toBe("");
   });
+
+  it("shows no banner for a Web Serial session when the WS drops", async () => {
+    // The serial bytes come off USB; the dashboard connection is
+    // irrelevant to that stream.
+    el.openPassive({ onReconnect: () => Promise.resolve() });
+    (el as any)._apiConnected = false;
+    await el.updateComplete;
+    const terminal = el.shadowRoot!.querySelector("esphome-process-terminal") as any;
+    expect(terminal.state).toBeNull();
+    expect(terminal.statusMessage).toBe("");
+  });
 });

--- a/test/components/logs-dialog-connection-loss.test.ts
+++ b/test/components/logs-dialog-connection-loss.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
+import type { LogsSession } from "../../src/components/logs-session.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const session = (el: ESPHomeLogsDialog): LogsSession => (el as any)._session;
+const call = (el: ESPHomeLogsDialog, method: string) => (el as any)[method]();
+
+type StreamCallbacks = { onOutput: (l: string) => void; onError: (e: string) => void };
+
+describe("logs-dialog OTA connection loss", () => {
+  let el: ESPHomeLogsDialog;
+  let logs: ReturnType<typeof vi.fn>;
+  let handlers: StreamCallbacks[];
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = new ESPHomeLogsDialog();
+    handlers = [];
+    let n = 0;
+    logs = vi.fn((_c: string, _p: string, cb: StreamCallbacks) => {
+      handlers.push(cb);
+      return `stream-${++n}`;
+    });
+    (el as any)._api = {
+      logs,
+      stopStream: vi.fn(() => Promise.resolve()),
+      ready: Promise.resolve(),
+    };
+    document.body.appendChild(el);
+  });
+
+  it("flags a connection-loss stop instead of appending the error", () => {
+    el.open("OTA");
+    handlers[0].onError("WebSocket connection closed");
+    expect(session(el)).toMatchObject({ kind: "ota", streamId: null });
+    expect((el as any)._stoppedByConnectionLoss).toBe(true);
+    expect((el as any)._log.lines).toEqual([]);
+  });
+
+  it("appends a real backend error to the log pane", () => {
+    el.open("OTA");
+    handlers[0].onError("configuration not found");
+    expect(session(el)).toMatchObject({ kind: "ota", streamId: null });
+    expect((el as any)._stoppedByConnectionLoss).toBe(false);
+    expect((el as any)._log.lines).toEqual(["configuration not found"]);
+  });
+
+  it("stays stopped and flagged when the send is refused outright", () => {
+    // sendStreamCommand returns "" (and fires onError synchronously)
+    // when the socket is already known dead.
+    logs.mockImplementation((_c: string, _p: string, cb: StreamCallbacks) => {
+      cb.onError("WebSocket not connected");
+      return "";
+    });
+    el.open("OTA");
+    expect(session(el)).toMatchObject({ kind: "ota", streamId: null });
+    expect((el as any)._stoppedByConnectionLoss).toBe(true);
+  });
+
+  it("resumes the stream on the reconnect edge with a reconnected line", async () => {
+    el.open("OTA");
+    await el.updateComplete;
+    (el as any)._apiConnected = false;
+    await el.updateComplete;
+    handlers[0].onError("WebSocket connection closed");
+
+    (el as any)._apiConnected = true;
+    await el.updateComplete;
+    await vi.waitFor(() => expect(logs).toHaveBeenCalledTimes(2));
+    expect((el as any)._log.lines).toEqual(["dashboard.logs_reconnected"]);
+    expect(session(el)).toMatchObject({ kind: "ota", streamId: "stream-2" });
+    expect((el as any)._stoppedByConnectionLoss).toBe(false);
+  });
+
+  it("does not resume a stream the user stopped", async () => {
+    el.open("OTA");
+    await el.updateComplete;
+    (el as any)._apiConnected = false;
+    await el.updateComplete;
+    handlers[0].onError("WebSocket connection closed");
+    call(el, "_onStop");
+
+    (el as any)._apiConnected = true;
+    await el.updateComplete;
+    await (el as any)._api.ready;
+    expect(logs).toHaveBeenCalledTimes(1);
+    expect(session(el)).toMatchObject({ kind: "ota", streamId: null });
+  });
+
+  it("shows the connection-lost banner on the terminal while disconnected", async () => {
+    el.open("OTA");
+    (el as any)._apiConnected = false;
+    await el.updateComplete;
+    const terminal = el.shadowRoot!.querySelector("esphome-process-terminal") as any;
+    expect(terminal.state).toBe("error");
+    expect(terminal.statusMessage).toBe("dashboard.logs_connection_lost");
+
+    (el as any)._apiConnected = true;
+    await el.updateComplete;
+    expect(terminal.state).toBeNull();
+    expect(terminal.statusMessage).toBe("");
+  });
+});

--- a/test/components/logs-dialog-connection-loss.test.ts
+++ b/test/components/logs-dialog-connection-loss.test.ts
@@ -3,8 +3,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+import "../_mock-webawesome.js";
 
 import { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
 import type { LogsSession } from "../../src/components/logs-session.js";


### PR DESCRIPTION
# What does this implement/fix?

With the dashboard running remotely (HA add-on or another host), turning off the browser machine's wifi and opening Logs shows "Waiting for logs…" forever with the streaming dot green and no hint anything is wrong.

Three gaps compound into that:

1. **The browser never learns the socket is dead.** There is no client-side liveness check; the backend's protocol-level pings are answered by the browser invisibly, so an idle dead TCP link keeps `readyState OPEN` indefinitely. This adds a heartbeat to the API client: after 15s of receive silence it sends the existing `ping` command (5s tick, in-flight guard, paused in hidden tabs with a catch-up tick on the visibility edge); no reply within 15s force-closes the socket into the normal reconnect path. The ping timeout matches the HA frontend's value and rationale (a busy backend can take over 10s to answer). `window` `offline`/`online` listeners give instant detection when the OS knows; while `navigator.onLine` reports offline, retries hold at the 30s backoff ceiling (not fully suspended, since embedded webviews misreport `onLine`) and the online event preempts for instant recovery. Two live-verified subtleties: `close()` only starts the closing handshake and against a dead peer the close event never fires, so the force path runs `_onClose` directly with per-socket identity guards; and a handshake against a dead peer stalls in CONNECTING the same way, so `connect()` arms a 30s timeout (the HA frontend ships none; ours only needs to beat the browser's multi-minute stall). `disconnect()` runs the same cleanup directly since the identity guard ignores the socket's own late close event.
2. **The existing reconnect pill is invisible under modals.** `wa-dialog` uses native `showModal()`, whose top layer paints above any z-index. The pill is now a `popover="manual"` that shows itself on attach, so it renders in the top layer above open dialogs.
3. **The logs dialog itself gave no feedback.** Streams now get a typed `onConnectionLost` callback (fired instead of `onError` for the WS-drop and refused-send cases, so consumers stop string-matching the client's error prose). The logs dialog consumes `apiConnectedContext`: while disconnected it shows an error banner ("Connection to the dashboard lost. Reconnecting…") on the terminal and re-pins the scroll on both banner edges, the interruption is recorded on the session (`interrupted` on the `ota` variant, cleared structurally by every other transition), and the reconnect edge auto-resumes the stream with a "Reconnected to the dashboard; resuming logs…" line. Real backend stream errors now land in the log pane (behind a `flush()` so ordering is preserved) instead of vanishing. A user-stopped stream never auto-resumes.

Verified end to end against a live rig by freezing the backend with `SIGSTOP` (TCP stays open, nothing answers, exactly the dead-socket shape): within the heartbeat window the pill appears above the open logs modal and the banner shows with the stream stopped; on `SIGCONT` the client reconnects and the logs resume automatically.

Out of scope, filed separately: #1563 (quiet-watchdog when the *device*, not the dashboard, is unreachable), #1564 (adopt `onConnectionLost` in the command/install dialogs), #1565 (shared logs-dialog test scaffold).

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
