### PR TITLE
Extract the WS liveness subsystem into a LivenessMonitor

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -10,6 +10,7 @@ import { clearStoredToken, getStoredToken, setStoredToken } from "../util/auth-t
 import { BASE_PATH } from "../util/base-path.js";
 import { hydrateBoard, hydratePagedBoardsResponse } from "../util/board-hydrate.js";
 import { APIError, CommandTimeoutError } from "./api-error.js";
+import { LivenessMonitor } from "./liveness.js";
 import type {
   AutomationAction,
   AutomationCatalogBody,
@@ -148,18 +149,6 @@ type PendingRequest = {
   reject: (error: Error) => void;
 };
 
-// Liveness probe: after HEARTBEAT_INTERVAL_MS of receive silence send
-// a 'ping'; no reply within HEARTBEAT_TIMEOUT_MS force-closes the
-// socket. Protocol-level server pings are invisible to page JS, so a
-// dead link otherwise stays OPEN forever. The tick runs faster than
-// the silence threshold so detection lags the threshold by at most
-// one tick; the in-flight guard keeps pings non-overlapping. The
-// timeout is generous because a backend busy compiling can take over
-// 10s to answer (the HA frontend uses 15s for the same reason).
-const HEARTBEAT_INTERVAL_MS = 15000;
-const HEARTBEAT_TIMEOUT_MS = 15000;
-const HEARTBEAT_TICK_MS = 5000;
-
 // A handshake against a dead peer stalls in CONNECTING with no
 // error/close event; time it out so the backoff loop keeps going.
 // Generous so a slow link never loses a handshake that would have
@@ -190,10 +179,13 @@ export class ESPHomeAPI {
   private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private _reconnectDelay = 1000;
   private _intentionalDisconnect = false;
-  private _heartbeatTimer: ReturnType<typeof setInterval> | null = null;
-  private _heartbeatInFlight = false;
-  private _lastMessageAt = 0;
   private _connectTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly _liveness = new LivenessMonitor({
+    getSocket: () => this._ws,
+    ping: (timeoutMs) => this.ping(timeoutMs),
+    onDead: (ws) => this._forceClose(ws),
+    onOnline: () => this._onNetworkOnline(),
+  });
   private _connectPromise: {
     resolve: (info: ServerInfoMessage) => void;
     reject: (error: Error) => void;
@@ -282,7 +274,7 @@ export class ESPHomeAPI {
     return new Promise((resolve, reject) => {
       this._connectPromise = { resolve, reject };
       this._intentionalDisconnect = false;
-      this._registerNetworkListeners();
+      this._liveness.registerNetworkListeners();
 
       const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
       const wsUrl = `${protocol}//${window.location.host}${BASE_PATH}ws`;
@@ -337,7 +329,7 @@ export class ESPHomeAPI {
       clearTimeout(this._reconnectTimer);
       this._reconnectTimer = null;
     }
-    this._unregisterNetworkListeners();
+    this._liveness.unregisterNetworkListeners();
     // Run the close cleanup (reject pending work, notify streams) now:
     // the per-socket identity guard keeps the socket's own async close
     // event from re-running it, so waiting on the event would leave
@@ -348,36 +340,8 @@ export class ESPHomeAPI {
 
   // ─── Liveness ─────────────────────────────────────────────
 
-  // Stable handler references make the add/remove pairs idempotent, so
-  // no registration flag is needed across reconnects. The existence
-  // guards keep teardown order-independent under test.
-  private _registerNetworkListeners(): void {
-    if (typeof window !== "undefined") {
-      window.addEventListener("offline", this._onWindowOffline);
-      window.addEventListener("online", this._onWindowOnline);
-    }
-    if (typeof document !== "undefined") {
-      document.addEventListener("visibilitychange", this._onVisibilityChange);
-    }
-  }
-
-  private _unregisterNetworkListeners(): void {
-    if (typeof window !== "undefined") {
-      window.removeEventListener("offline", this._onWindowOffline);
-      window.removeEventListener("online", this._onWindowOnline);
-    }
-    if (typeof document !== "undefined") {
-      document.removeEventListener("visibilitychange", this._onVisibilityChange);
-    }
-  }
-
-  private readonly _onWindowOffline = (): void => {
-    // An idle socket doesn't error when the interface drops; surface
-    // the disconnect now instead of after the heartbeat window.
-    if (this._ws) this._forceClose(this._ws);
-  };
-
-  private readonly _onWindowOnline = (): void => {
+  /** The LivenessMonitor's online hook: reconnect policy. */
+  private _onNetworkOnline(): void {
     if (this._intentionalDisconnect || this._connected) return;
     // An attempt stalled in CONNECTING was made against the interface
     // that just came back; abandon it rather than waiting out its
@@ -398,26 +362,6 @@ export class ESPHomeAPI {
         // _onClose schedules the next retry.
       });
     }
-  };
-
-  private readonly _onVisibilityChange = (): void => {
-    // The tick skips while hidden; catch up the moment the tab returns.
-    if (document.visibilityState === "visible") this._heartbeatTick();
-  };
-
-  private _startHeartbeat(): void {
-    this._stopHeartbeat();
-    this._lastMessageAt = Date.now();
-    this._heartbeatTimer = setInterval(() => {
-      this._heartbeatTick();
-    }, HEARTBEAT_TICK_MS);
-  }
-
-  private _stopHeartbeat(): void {
-    if (this._heartbeatTimer) {
-      clearInterval(this._heartbeatTimer);
-      this._heartbeatTimer = null;
-    }
   }
 
   private _clearConnectTimeout(): void {
@@ -425,35 +369,6 @@ export class ESPHomeAPI {
       clearTimeout(this._connectTimeoutTimer);
       this._connectTimeoutTimer = null;
     }
-  }
-
-  private _heartbeatTick(): void {
-    // A hidden tab has no one to show the disconnect to; the
-    // visibilitychange listener ticks immediately on return.
-    if (globalThis.document?.visibilityState === "hidden") return;
-    if (this._heartbeatInFlight) return;
-    if (Date.now() - this._lastMessageAt < HEARTBEAT_INTERVAL_MS) return;
-    const ws = this._ws;
-    // Probe only an OPEN socket: a visibility-edge tick during an
-    // in-flight connect would otherwise force-close the new attempt.
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    this._heartbeatInFlight = true;
-    this.ping(HEARTBEAT_TIMEOUT_MS)
-      .catch((err: unknown) => {
-        // An APIError reply proves the link is alive (e.g. the pre-auth
-        // gate); only silence or a failed send means a dead socket.
-        if (err instanceof APIError) return;
-        console.debug("[WS] Heartbeat got no reply; closing socket", err);
-        if (this._ws === ws) this._forceClose(ws);
-      })
-      .catch((err: unknown) => {
-        // A throw from the disconnect fan-out must not become an
-        // unhandled rejection, but it must not vanish either.
-        console.error("[WS] Heartbeat close path threw", err);
-      })
-      .finally(() => {
-        this._heartbeatInFlight = false;
-      });
   }
 
   /**
@@ -470,8 +385,7 @@ export class ESPHomeAPI {
   }
 
   private _onMessage(event: MessageEvent): void {
-    // Any frame proves the link is alive, parseable or not.
-    this._lastMessageAt = Date.now();
+    this._liveness.noteMessage();
     let data: Record<string, unknown>;
     try {
       data = JSON.parse(event.data);
@@ -492,7 +406,7 @@ export class ESPHomeAPI {
       this._connectionGeneration += 1;
       this._reconnectDelay = 1000;
       this._clearConnectTimeout();
-      this._startHeartbeat();
+      this._liveness.startHeartbeat();
       if (this._connectPromise) {
         this._connectPromise.resolve(this._serverInfo);
         this._connectPromise = null;
@@ -611,7 +525,7 @@ export class ESPHomeAPI {
     const wasConnected = this._connected;
     this._connected = false;
     this._ws = null;
-    this._stopHeartbeat();
+    this._liveness.stopHeartbeat();
     this._clearConnectTimeout();
 
     // A force-closed handshake fires no error event, so a pending

--- a/src/api/liveness.ts
+++ b/src/api/liveness.ts
@@ -1,0 +1,127 @@
+/**
+ * Client-side WS liveness: heartbeat probe + network/visibility events.
+ *
+ * Owns the timers and listeners; policy (what "dead" and "online" mean
+ * for reconnecting) stays with the API client via the hooks.
+ */
+import { APIError } from "./api-error.js";
+
+// Liveness probe: after HEARTBEAT_INTERVAL_MS of receive silence send
+// a 'ping'; no reply within HEARTBEAT_TIMEOUT_MS force-closes the
+// socket. Protocol-level server pings are invisible to page JS, so a
+// dead link otherwise stays OPEN forever. The tick runs faster than
+// the silence threshold so detection lags the threshold by at most
+// one tick; the in-flight guard keeps pings non-overlapping. The
+// timeout is generous because a backend busy compiling can take over
+// 10s to answer (the HA frontend uses 15s for the same reason).
+const HEARTBEAT_INTERVAL_MS = 15000;
+const HEARTBEAT_TIMEOUT_MS = 15000;
+const HEARTBEAT_TICK_MS = 5000;
+
+export interface LivenessMonitorHooks {
+  /** Current socket, or null while disconnected. */
+  getSocket(): WebSocket | null;
+  /** Send the liveness probe; any reply (even an error) resolves it. */
+  ping(timeoutMs: number): Promise<unknown>;
+  /** The socket is dead: close it and run the disconnect path. */
+  onDead(ws: WebSocket): void;
+  /** The OS reports connectivity returned; reconnect if warranted. */
+  onOnline(): void;
+}
+
+export class LivenessMonitor {
+  private _timer: ReturnType<typeof setInterval> | null = null;
+  private _inFlight = false;
+  private _lastMessageAt = 0;
+
+  constructor(private readonly _hooks: LivenessMonitorHooks) {}
+
+  // Stable handler references make the add/remove pairs idempotent, so
+  // no registration flag is needed across reconnects. The existence
+  // guards keep teardown order-independent under test.
+  registerNetworkListeners(): void {
+    if (typeof window !== "undefined") {
+      window.addEventListener("offline", this._onWindowOffline);
+      window.addEventListener("online", this._onWindowOnline);
+    }
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", this._onVisibilityChange);
+    }
+  }
+
+  unregisterNetworkListeners(): void {
+    if (typeof window !== "undefined") {
+      window.removeEventListener("offline", this._onWindowOffline);
+      window.removeEventListener("online", this._onWindowOnline);
+    }
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", this._onVisibilityChange);
+    }
+  }
+
+  /** Stamp receive-side liveness; any frame counts, parseable or not. */
+  noteMessage(): void {
+    this._lastMessageAt = Date.now();
+  }
+
+  startHeartbeat(): void {
+    this.stopHeartbeat();
+    this._lastMessageAt = Date.now();
+    this._timer = setInterval(() => {
+      this._tick();
+    }, HEARTBEAT_TICK_MS);
+  }
+
+  stopHeartbeat(): void {
+    if (this._timer) {
+      clearInterval(this._timer);
+      this._timer = null;
+    }
+  }
+
+  private readonly _onWindowOffline = (): void => {
+    // An idle socket doesn't error when the interface drops; surface
+    // the disconnect now instead of after the heartbeat window.
+    const ws = this._hooks.getSocket();
+    if (ws) this._hooks.onDead(ws);
+  };
+
+  private readonly _onWindowOnline = (): void => {
+    this._hooks.onOnline();
+  };
+
+  private readonly _onVisibilityChange = (): void => {
+    // The tick skips while hidden; catch up the moment the tab returns.
+    if (document.visibilityState === "visible") this._tick();
+  };
+
+  private _tick(): void {
+    // A hidden tab has no one to show the disconnect to; the
+    // visibilitychange listener ticks immediately on return.
+    if (globalThis.document?.visibilityState === "hidden") return;
+    if (this._inFlight) return;
+    if (Date.now() - this._lastMessageAt < HEARTBEAT_INTERVAL_MS) return;
+    const ws = this._hooks.getSocket();
+    // Probe only an OPEN socket: a visibility-edge tick during an
+    // in-flight connect would otherwise force-close the new attempt.
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    this._inFlight = true;
+    this._hooks
+      .ping(HEARTBEAT_TIMEOUT_MS)
+      .catch((err: unknown) => {
+        // An APIError reply proves the link is alive (e.g. the pre-auth
+        // gate); only silence or a failed send means a dead socket.
+        if (err instanceof APIError) return;
+        console.debug("[WS] Heartbeat got no reply; closing socket", err);
+        if (this._hooks.getSocket() === ws) this._hooks.onDead(ws);
+      })
+      .catch((err: unknown) => {
+        // A throw from the disconnect fan-out must not become an
+        // unhandled rejection, but it must not vanish either.
+        console.error("[WS] Heartbeat close path threw", err);
+      })
+      .finally(() => {
+        this._inFlight = false;
+      });
+  }
+}

--- a/test/api/liveness.test.ts
+++ b/test/api/liveness.test.ts
@@ -69,6 +69,18 @@ describe("LivenessMonitor", () => {
     monitor.stopHeartbeat();
   });
 
+  it("stops ticking after stopHeartbeat", async () => {
+    const { monitor, hooks } = makeMonitor({
+      ping: vi.fn<(timeoutMs: number) => Promise<unknown>>(() => Promise.resolve()),
+    });
+    monitor.startHeartbeat();
+    await vi.advanceTimersByTimeAsync(15000);
+    expect(hooks.ping).toHaveBeenCalledTimes(1);
+    monitor.stopHeartbeat();
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(hooks.ping).toHaveBeenCalledTimes(1);
+  });
+
   it("calls onDead on a ping rejection that is not an APIError", async () => {
     const { monitor, hooks, socket } = makeMonitor({
       ping: vi.fn(() => Promise.reject(new Error("timed out"))),
@@ -102,6 +114,10 @@ describe("LivenessMonitor", () => {
     rejectPing(new Error("timed out"));
     await vi.advanceTimersByTimeAsync(0);
     expect(hooks.onDead).not.toHaveBeenCalled();
+    // The positive control: the catch handler ran and re-read the
+    // socket, so the missing onDead is the guard, not an undrained
+    // rejection.
+    expect(hooks.getSocket).toHaveBeenCalledTimes(2);
     monitor.stopHeartbeat();
   });
 

--- a/test/api/liveness.test.ts
+++ b/test/api/liveness.test.ts
@@ -5,9 +5,9 @@ import {
   MockWebSocket,
   fireDocumentEvent,
   fireWindowEvent,
-  installMockDocument,
-  installMockWindow,
+  installMockWebSocket,
   setDocumentVisibility,
+  uninstallMockWebSocket,
 } from "./mock-websocket.js";
 
 type Hooks = {
@@ -31,14 +31,14 @@ function makeMonitor(overrides: Partial<Hooks> = {}) {
 
 describe("LivenessMonitor", () => {
   beforeEach(() => {
-    installMockWindow();
-    installMockDocument();
+    // Installs the WebSocket global too: the monitor's tick reads
+    // WebSocket.OPEN, which bare node runs may not define.
+    installMockWebSocket();
     vi.useFakeTimers();
   });
   afterEach(() => {
     vi.useRealTimers();
-    delete (globalThis as unknown as { window?: unknown }).window;
-    delete (globalThis as unknown as { document?: unknown }).document;
+    uninstallMockWebSocket();
   });
 
   it("pings only after the silence threshold", async () => {

--- a/test/api/liveness.test.ts
+++ b/test/api/liveness.test.ts
@@ -1,0 +1,164 @@
+import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { APIError } from "../../src/api/api-error.js";
+import { LivenessMonitor } from "../../src/api/liveness.js";
+import {
+  MockWebSocket,
+  fireDocumentEvent,
+  fireWindowEvent,
+  installMockDocument,
+  installMockWindow,
+  setDocumentVisibility,
+} from "./mock-websocket.js";
+
+type Hooks = {
+  getSocket: Mock<() => WebSocket | null>;
+  ping: Mock<(timeoutMs: number) => Promise<unknown>>;
+  onDead: Mock<(ws: WebSocket) => void>;
+  onOnline: Mock<() => void>;
+};
+
+function makeMonitor(overrides: Partial<Hooks> = {}) {
+  const socket = { readyState: MockWebSocket.OPEN } as unknown as WebSocket;
+  const hooks: Hooks = {
+    getSocket: vi.fn<() => WebSocket | null>(() => socket),
+    ping: vi.fn<(timeoutMs: number) => Promise<unknown>>(() => new Promise(() => {})),
+    onDead: vi.fn<(ws: WebSocket) => void>(),
+    onOnline: vi.fn<() => void>(),
+    ...overrides,
+  };
+  return { monitor: new LivenessMonitor(hooks), hooks, socket };
+}
+
+describe("LivenessMonitor", () => {
+  beforeEach(() => {
+    installMockWindow();
+    installMockDocument();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (globalThis as unknown as { window?: unknown }).window;
+    delete (globalThis as unknown as { document?: unknown }).document;
+  });
+
+  it("pings only after the silence threshold", async () => {
+    const { monitor, hooks } = makeMonitor();
+    monitor.startHeartbeat();
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(hooks.ping).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(hooks.ping).toHaveBeenCalledTimes(1);
+    monitor.stopHeartbeat();
+  });
+
+  it("noteMessage resets the silence clock", async () => {
+    const { monitor, hooks } = makeMonitor();
+    monitor.startHeartbeat();
+    await vi.advanceTimersByTimeAsync(10000);
+    monitor.noteMessage();
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(hooks.ping).not.toHaveBeenCalled();
+    monitor.stopHeartbeat();
+  });
+
+  it("keeps pings non-overlapping while one is in flight", async () => {
+    const { monitor, hooks } = makeMonitor();
+    monitor.startHeartbeat();
+    await vi.advanceTimersByTimeAsync(30000);
+    expect(hooks.ping).toHaveBeenCalledTimes(1);
+    monitor.stopHeartbeat();
+  });
+
+  it("calls onDead on a ping rejection that is not an APIError", async () => {
+    const { monitor, hooks, socket } = makeMonitor({
+      ping: vi.fn(() => Promise.reject(new Error("timed out"))),
+    });
+    monitor.startHeartbeat();
+    await vi.advanceTimersByTimeAsync(15000);
+    expect(hooks.onDead).toHaveBeenCalledWith(socket);
+    monitor.stopHeartbeat();
+  });
+
+  it("treats an APIError reply as proof of liveness", async () => {
+    const { monitor, hooks } = makeMonitor({
+      ping: vi.fn(() => Promise.reject(new APIError("not_authenticated", "nope"))),
+    });
+    monitor.startHeartbeat();
+    await vi.advanceTimersByTimeAsync(15000);
+    expect(hooks.onDead).not.toHaveBeenCalled();
+    monitor.stopHeartbeat();
+  });
+
+  it("skips onDead when the socket was already replaced", async () => {
+    let rejectPing!: (err: Error) => void;
+    const { monitor, hooks } = makeMonitor({
+      ping: vi.fn(() => new Promise((_, reject) => (rejectPing = reject))),
+    });
+    monitor.startHeartbeat();
+    await vi.advanceTimersByTimeAsync(15000);
+    hooks.getSocket.mockReturnValue({
+      readyState: MockWebSocket.OPEN,
+    } as unknown as WebSocket);
+    rejectPing(new Error("timed out"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(hooks.onDead).not.toHaveBeenCalled();
+    monitor.stopHeartbeat();
+  });
+
+  it("does not probe a socket that is not OPEN", async () => {
+    const { monitor, hooks } = makeMonitor({
+      getSocket: vi.fn(
+        () => ({ readyState: MockWebSocket.CONNECTING }) as unknown as WebSocket
+      ),
+    });
+    monitor.startHeartbeat();
+    await vi.advanceTimersByTimeAsync(30000);
+    expect(hooks.ping).not.toHaveBeenCalled();
+    monitor.stopHeartbeat();
+  });
+
+  it("skips ticks while the tab is hidden and catches up on the visibility edge", async () => {
+    const { monitor, hooks } = makeMonitor();
+    monitor.registerNetworkListeners();
+    monitor.startHeartbeat();
+    setDocumentVisibility("hidden");
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(hooks.ping).not.toHaveBeenCalled();
+    setDocumentVisibility("visible");
+    fireDocumentEvent("visibilitychange");
+    expect(hooks.ping).toHaveBeenCalledTimes(1);
+    monitor.stopHeartbeat();
+    monitor.unregisterNetworkListeners();
+  });
+
+  it("routes the offline event to onDead with the current socket", () => {
+    const { monitor, hooks, socket } = makeMonitor();
+    monitor.registerNetworkListeners();
+    fireWindowEvent("offline");
+    expect(hooks.onDead).toHaveBeenCalledWith(socket);
+    monitor.unregisterNetworkListeners();
+  });
+
+  it("ignores the offline event with no socket", () => {
+    const { monitor, hooks } = makeMonitor({ getSocket: vi.fn(() => null) });
+    monitor.registerNetworkListeners();
+    fireWindowEvent("offline");
+    expect(hooks.onDead).not.toHaveBeenCalled();
+    monitor.unregisterNetworkListeners();
+  });
+
+  it("routes the online event to onOnline", () => {
+    const { monitor, hooks } = makeMonitor();
+    monitor.registerNetworkListeners();
+    fireWindowEvent("online");
+    expect(hooks.onOnline).toHaveBeenCalledTimes(1);
+    monitor.unregisterNetworkListeners();
+  });
+
+  it("stops dispatch after unregisterNetworkListeners", () => {
+    const { monitor } = makeMonitor();
+    monitor.registerNetworkListeners();
+    monitor.unregisterNetworkListeners();
+    expect(() => fireWindowEvent("offline")).toThrow(/no window listeners/);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Behavior-free extraction agreed in #1566 (raised by both review bots on #1562): the WS liveness subsystem moves out of the 2483-line `esphome-api.ts` into its own `src/api/liveness.ts` (127 lines).

`LivenessMonitor` owns the mechanism (the heartbeat timer with its hidden-tab / in-flight / silence-threshold / OPEN-socket guards, the offline/online/visibilitychange listeners, the receive-side liveness stamp) and is constructed with hooks; policy stays on the client: `getSocket`, `ping`, `onDead` (routes to the existing `_forceClose`), and `onOnline` (the reconnect-policy body, now a private `_onNetworkOnline()` since it manipulates the backoff state and `connect()`). The per-attempt connect timeout and `_forceClose` stay in the client, shared with `disconnect()`.

The moved code is unchanged apart from `this._x` becoming hook calls. The existing liveness suite in `test/api/esphome-api.test.ts` passes without modification, which is the behavior-free proof; a new `test/api/liveness.test.ts` adds 12 direct unit tests over stub hooks (tick threshold, non-overlap, APIError-means-alive, replaced-socket guard, hidden-tab skip plus visibility catch-up, offline/online routing, unregister), the unit-testability the issue names as the point.

This is the seam #1564 will consume when the command/install dialogs adopt the connection-loss signal.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1566

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
