### PR TITLE
Hoist the shared logs-dialog test scaffold into _logs-dialog-env

### DIFF
--- a/test/components/_logs-dialog-env.ts
+++ b/test/components/_logs-dialog-env.ts
@@ -7,6 +7,10 @@ import { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
 import { type LogsSession, isStreaming } from "../../src/components/logs-session.js";
 
 export { toastError } from "./_logs-dialog-mocks.js";
+// The one path to the component for the family: a direct value import
+// in a test file would evaluate before this module registers the
+// mocks whenever it sorts first.
+export { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const session = (el: ESPHomeLogsDialog): LogsSession => (el as any)._session;

--- a/test/components/_logs-dialog-env.ts
+++ b/test/components/_logs-dialog-env.ts
@@ -1,0 +1,34 @@
+// Shared scaffold for the logs-dialog test family. The mocks import
+// comes first so the component tree below evaluates with them
+// registered; test files import only this module.
+import "./_logs-dialog-mocks.js";
+
+import { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
+import { type LogsSession, isStreaming } from "../../src/components/logs-session.js";
+
+export { toastError } from "./_logs-dialog-mocks.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export const session = (el: ESPHomeLogsDialog): LogsSession => (el as any)._session;
+export const streaming = (el: ESPHomeLogsDialog): boolean => isStreaming(session(el));
+export const paused = (el: ESPHomeLogsDialog): boolean => (el as any)._serialPaused;
+export const call = (el: ESPHomeLogsDialog, method: string) => (el as any)[method]();
+export const append = (el: ESPHomeLogsDialog, lines: string[]) =>
+  (el as any)._log.append(lines);
+
+/** Construct a dialog with a stubbed API (merged over the minimal
+ *  default) and mount it unless the test drives it detached. */
+export function makeLogsDialog(
+  api: Record<string, unknown> = {},
+  { mount = true }: { mount?: boolean } = {}
+): ESPHomeLogsDialog {
+  const el = new ESPHomeLogsDialog();
+  (el as any)._api = {
+    logs: () => "s1",
+    stopStream: () => Promise.resolve(),
+    ...api,
+  };
+  if (mount) document.body.appendChild(el);
+  return el;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/test/components/_logs-dialog-mocks.ts
+++ b/test/components/_logs-dialog-mocks.ts
@@ -6,7 +6,7 @@ import { vi } from "vitest";
 import "../_mock-webawesome.js";
 
 /** Captures dashboard error toasts for assertion. */
-export const toastError = vi.fn();
+const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
 
 vi.mock("sonner-js", () => ({
   default: {
@@ -15,3 +15,5 @@ vi.mock("sonner-js", () => ({
     info: vi.fn(),
   },
 }));
+
+export { toastError };

--- a/test/components/_logs-dialog-mocks.ts
+++ b/test/components/_logs-dialog-mocks.ts
@@ -1,0 +1,17 @@
+// Mocks for the logs-dialog test family. The vi.mock calls run when
+// this module is evaluated, so it must be imported (directly or via
+// _logs-dialog-env.js) before anything that pulls in the component
+// tree.
+import { vi } from "vitest";
+import "../_mock-webawesome.js";
+
+/** Captures dashboard error toasts for assertion. */
+export const toastError = vi.fn();
+
+vi.mock("sonner-js", () => ({
+  default: {
+    error: (...args: unknown[]) => toastError(...args),
+    success: vi.fn(),
+    info: vi.fn(),
+  },
+}));

--- a/test/components/logs-dialog-connection-loss.test.ts
+++ b/test/components/logs-dialog-connection-loss.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { call, makeLogsDialog, session } from "./_logs-dialog-env.js";
 
-import type { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
+import type { ESPHomeLogsDialog } from "./_logs-dialog-env.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 type StreamCallbacks = {

--- a/test/components/logs-dialog-connection-loss.test.ts
+++ b/test/components/logs-dialog-connection-loss.test.ts
@@ -3,15 +3,11 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import "../_mock-webawesome.js";
+import { call, makeLogsDialog, session } from "./_logs-dialog-env.js";
 
-import { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
-import type { LogsSession } from "../../src/components/logs-session.js";
+import type { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const session = (el: ESPHomeLogsDialog): LogsSession => (el as any)._session;
-const call = (el: ESPHomeLogsDialog, method: string) => (el as any)[method]();
-
 type StreamCallbacks = {
   onOutput: (l: string) => void;
   onError: (e: string) => void;
@@ -24,20 +20,17 @@ describe("logs-dialog OTA connection loss", () => {
   let handlers: StreamCallbacks[];
 
   beforeEach(() => {
-    document.body.innerHTML = "";
-    el = new ESPHomeLogsDialog();
     handlers = [];
     let n = 0;
     logs = vi.fn((_c: string, _p: string, cb: StreamCallbacks) => {
       handlers.push(cb);
       return `stream-${++n}`;
     });
-    (el as any)._api = {
+    el = makeLogsDialog({
       logs,
       stopStream: vi.fn(() => Promise.resolve()),
       ready: Promise.resolve(),
-    };
-    document.body.appendChild(el);
+    });
   });
 
   it("marks the session interrupted on connection loss without appending a line", () => {

--- a/test/components/logs-dialog-crash.test.ts
+++ b/test/components/logs-dialog-crash.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { append, makeLogsDialog } from "./_logs-dialog-env.js";
 
-import type { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
+import type { ESPHomeLogsDialog } from "./_logs-dialog-env.js";
 import { CRASH_BANNER_LINE as CRASH_LINE } from "../_crash-lines.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/test/components/logs-dialog-crash.test.ts
+++ b/test/components/logs-dialog-crash.test.ts
@@ -3,22 +3,17 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+import { append, makeLogsDialog } from "./_logs-dialog-env.js";
 
-import { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
+import type { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
 import { CRASH_BANNER_LINE as CRASH_LINE } from "../_crash-lines.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const append = (el: ESPHomeLogsDialog, lines: string[]) => (el as any)._log.append(lines);
-
 describe("logs-dialog crash callout", () => {
   let el: ESPHomeLogsDialog;
 
   beforeEach(() => {
-    el = new ESPHomeLogsDialog();
-    (el as any)._api = { logs: () => "s1", stopStream: () => Promise.resolve() };
-    document.body.appendChild(el);
+    el = makeLogsDialog();
   });
 
   const callout = () => el.shadowRoot!.querySelector(".crash-callout");

--- a/test/components/logs-dialog-decode.test.ts
+++ b/test/components/logs-dialog-decode.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { append, makeLogsDialog } from "./_logs-dialog-env.js";
 
-import type { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
+import type { ESPHomeLogsDialog } from "./_logs-dialog-env.js";
 import { STALE_BUILD_LOG_LINE } from "../../src/util/crash-decode.js";
 import { stripAnsi } from "../../src/util/ansi-escapes.js";
 

--- a/test/components/logs-dialog-decode.test.ts
+++ b/test/components/logs-dialog-decode.test.ts
@@ -3,15 +3,13 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+import { append, makeLogsDialog } from "./_logs-dialog-env.js";
 
-import { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
+import type { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
 import { STALE_BUILD_LOG_LINE } from "../../src/util/crash-decode.js";
 import { stripAnsi } from "../../src/util/ansi-escapes.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const append = (el: ESPHomeLogsDialog, lines: string[]) => (el as any)._log.append(lines);
 const lines = (el: ESPHomeLogsDialog): string[] => (el as any)._log.lines;
 
 // A Web Serial crash: no decoder attached, so no Decoded lines arrive.
@@ -35,19 +33,13 @@ describe("logs-dialog inline backtrace decode", () => {
   let decodeBacktrace: ReturnType<typeof vi.fn<DecodeMock>>;
 
   beforeEach(() => {
-    el = new ESPHomeLogsDialog();
     decodeBacktrace = vi.fn<DecodeMock>(async () => ({
       decoded: [{ index: 2, text: "Decoded 0x400d1a2c: loop() at main.cpp:42" }],
       stale_build: false,
       unavailable_reason: "",
     }));
-    (el as any)._api = {
-      logs: () => "s1",
-      stopStream: () => Promise.resolve(),
-      decodeBacktrace,
-    };
+    el = makeLogsDialog({ decodeBacktrace });
     el.configuration = "ol.yaml";
-    document.body.appendChild(el);
     el.open("OTA");
   });
 

--- a/test/components/logs-dialog-quiet-serial.test.ts
+++ b/test/components/logs-dialog-quiet-serial.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { call, makeLogsDialog, session } from "./_logs-dialog-env.js";
 
-import type { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
+import type { ESPHomeLogsDialog } from "./_logs-dialog-env.js";
 import { switchToOtaLogs } from "../../src/components/logs-dialog/session.js";
 import { OTA_PORT } from "../../src/components/logs-session.js";
 

--- a/test/components/logs-dialog-quiet-serial.test.ts
+++ b/test/components/logs-dialog-quiet-serial.test.ts
@@ -6,19 +6,13 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-vi.mock("sonner-js", () => ({
-  default: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
-}));
+import { call, makeLogsDialog, session } from "./_logs-dialog-env.js";
 
-import { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
+import type { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
 import { switchToOtaLogs } from "../../src/components/logs-dialog/session.js";
-import { OTA_PORT, type LogsSession } from "../../src/components/logs-session.js";
+import { OTA_PORT } from "../../src/components/logs-session.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const session = (el: ESPHomeLogsDialog): LogsSession => (el as any)._session;
-const call = (el: ESPHomeLogsDialog, method: string) => (el as any)[method]();
 const banner = (el: ESPHomeLogsDialog): Element | null =>
   el.shadowRoot!.querySelector(".reset-suggestion");
 
@@ -30,11 +24,9 @@ describe("logs-dialog quiet-serial banner", () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
-    el = new ESPHomeLogsDialog();
     logs = vi.fn(() => "stream-1");
-    (el as any)._api = { logs, stopStream: vi.fn(() => Promise.resolve()) };
+    el = makeLogsDialog({ logs, stopStream: vi.fn(() => Promise.resolve()) });
     cancel = vi.fn();
-    document.body.appendChild(el);
   });
 
   afterEach(() => {
@@ -157,9 +149,11 @@ describe("switchToOtaLogs", () => {
   const port = { close: vi.fn(), setSignals: vi.fn() } as unknown as SerialPort;
 
   beforeEach(() => {
-    el = new ESPHomeLogsDialog();
     logs = vi.fn(() => "stream-1");
-    (el as any)._api = { logs, stopStream: vi.fn(() => Promise.resolve()) };
+    el = makeLogsDialog(
+      { logs, stopStream: vi.fn(() => Promise.resolve()) },
+      { mount: false }
+    );
     (el as any)._open = true;
   });
 

--- a/test/components/logs-dialog.test.ts
+++ b/test/components/logs-dialog.test.ts
@@ -3,34 +3,21 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
-
-const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
-vi.mock("sonner-js", () => ({
-  default: {
-    error: (...args: unknown[]) => toastError(...args),
-    success: vi.fn(),
-    info: vi.fn(),
-  },
-}));
+import {
+  call,
+  makeLogsDialog,
+  paused,
+  session,
+  streaming,
+  toastError,
+} from "./_logs-dialog-env.js";
 
 import { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
 import { crashCalloutStyles } from "../../src/components/process-terminal/crash-callout.js";
 import { startOtaStream } from "../../src/components/logs-dialog/session.js";
-import {
-  hasSerialPort,
-  isStreaming,
-  type LogsSession,
-} from "../../src/components/logs-session.js";
+import { hasSerialPort } from "../../src/components/logs-session.js";
 
-// Read the dialog's private session/getters without sprinkling casts inline.
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const session = (el: ESPHomeLogsDialog): LogsSession => (el as any)._session;
-const streaming = (el: ESPHomeLogsDialog): boolean => isStreaming(session(el));
-const paused = (el: ESPHomeLogsDialog): boolean => (el as any)._serialPaused;
-const call = (el: ESPHomeLogsDialog, method: string) => (el as any)[method]();
-
 interface DeferredStop {
   promise: Promise<void>;
   resolve: () => void;
@@ -51,12 +38,11 @@ describe("logs-dialog states-toggle restart", () => {
   let stopStream: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    el = new ESPHomeLogsDialog();
     stop = deferred();
     let n = 0;
     logs = vi.fn(() => `stream-${++n}`);
     stopStream = vi.fn(() => stop.promise);
-    (el as any)._api = { logs, stopStream };
+    el = makeLogsDialog({ logs, stopStream }, { mount: false });
   });
 
   it("does not respawn a stream when the dialog is closed mid-restart", async () => {
@@ -97,16 +83,17 @@ describe("logs-dialog states-toggle restart", () => {
 
 describe("logs-dialog OTA stale-callback guard", () => {
   it("ignores onResult from a torn-down stream so it can't stop its replacement", () => {
-    const el = new ESPHomeLogsDialog();
     const handlers: { onResult: () => void }[] = [];
     let n = 0;
-    (el as any)._api = {
-      logs: (_c: string, _p: string, cb: { onResult: () => void }) => {
-        handlers.push(cb);
-        return `stream-${++n}`;
+    const el = makeLogsDialog(
+      {
+        logs: (_c: string, _p: string, cb: { onResult: () => void }) => {
+          handlers.push(cb);
+          return `stream-${++n}`;
+        },
       },
-      stopStream: () => Promise.resolve(),
-    };
+      { mount: false }
+    );
 
     el.open("OTA"); // stream-1
     call(el, "_onStop"); // stop stream-1
@@ -122,12 +109,7 @@ describe("logs-dialog OTA stale-callback guard", () => {
 });
 
 describe("logs-dialog header source chip", () => {
-  function mount(): ESPHomeLogsDialog {
-    const el = new ESPHomeLogsDialog();
-    (el as any)._api = { logs: () => "s1", stopStream: () => Promise.resolve() };
-    document.body.appendChild(el);
-    return el;
-  }
+  const mount = (): ESPHomeLogsDialog => makeLogsDialog();
 
   function chipText(el: ESPHomeLogsDialog): string {
     return el.shadowRoot!.querySelector(".source-chip")?.textContent?.trim() ?? "";
@@ -157,12 +139,7 @@ describe("logs-dialog header source chip", () => {
 });
 
 describe("logs-dialog States toggle gate (#539)", () => {
-  function mount(): ESPHomeLogsDialog {
-    const el = new ESPHomeLogsDialog();
-    (el as any)._api = { logs: () => "s1", stopStream: () => Promise.resolve() };
-    document.body.appendChild(el);
-    return el;
-  }
+  const mount = (): ESPHomeLogsDialog => makeLogsDialog();
 
   // The States toggle is the only toolbar control with aria-pressed.
   const hasStatesToggle = (el: ESPHomeLogsDialog): boolean =>
@@ -198,9 +175,11 @@ describe("logs-dialog passive Web Serial session (#526)", () => {
 
   beforeEach(() => {
     toastError.mockClear();
-    el = new ESPHomeLogsDialog();
     logs = vi.fn(() => "stream-1");
-    (el as any)._api = { logs, stopStream: vi.fn(() => Promise.resolve()) };
+    el = makeLogsDialog(
+      { logs, stopStream: vi.fn(() => Promise.resolve()) },
+      { mount: false }
+    );
     port = {
       close: vi.fn(() => Promise.resolve()),
       setSignals: vi.fn(() => Promise.resolve()),

--- a/test/components/logs-dialog.test.ts
+++ b/test/components/logs-dialog.test.ts
@@ -4,6 +4,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  ESPHomeLogsDialog,
   call,
   makeLogsDialog,
   paused,
@@ -12,7 +13,6 @@ import {
   toastError,
 } from "./_logs-dialog-env.js";
 
-import { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
 import { crashCalloutStyles } from "../../src/components/process-terminal/crash-callout.js";
 import { startOtaStream } from "../../src/components/logs-dialog/session.js";
 import { hasSerialPort } from "../../src/components/logs-session.js";


### PR DESCRIPTION
# What does this implement/fix?

Test-only refactor from #1565: the logs-dialog test family (six files) copied the same scaffold with drift — the webawesome `vi.mock` pair in four spellings, the sonner/toast mock twice, the `session` / `call` any-cast accessors three times, and the minimal `_api` host wiring in five places.

One import surface now, following the `_install-method-dialog-env.ts` / `_command-dialog-host.ts` precedent, split in two files because a single module cannot both register `vi.mock`s and import the component (its own component import would evaluate before the registrations in its body):

- `test/components/_logs-dialog-mocks.ts` — side-effect mocks only (`../_mock-webawesome.js` plus the sonner mock with an exported `toastError` spy); imports nothing from `src/`.
- `test/components/_logs-dialog-env.ts` — imports the mocks first, then the component; exports the accessors (`session` / `streaming` / `paused` / `call` / `append`), re-exports `toastError`, and a `makeLogsDialog(api?, { mount })` factory carrying the default `{ logs, stopStream }` stub.

Five test files are repointed (their per-file custom stream-capture shapes become factory arguments); `logs-dialog-batching.test.ts` is untouched — it has its own rAF harness and no scaffold. Net: the five files shed 89 scaffold lines for 42, and all 83 tests in the family pass unchanged in what they assert.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1565

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
