### PR TITLE
Reattach dialog job follows after a connection loss instead of failing

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -510,7 +510,7 @@ export class ESPHomeCommandDialog extends LitElement {
         <esphome-process-terminal
           .lines=${this._log.lines}
           ?light=${!this._darkMode}
-          ?streaming=${this._state === "running" && !showRunTimer(this)}
+          ?streaming=${this._state === "running" && !showRunTimer(this) && !wsDown}
           .state=${wsDown ? "error" : this._state}
           .statusMessage=${
             wsDown ? this._localize("layout.reconnecting") : this._statusMessage

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -22,6 +22,7 @@ import type { PairingSummary } from "../api/types/remote-build.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type { RemoteBuildJobState } from "../context/index.js";
 import {
+  apiConnectedContext,
   apiContext,
   buildOffloadJobsContext,
   buildOffloadPairingsContext,
@@ -104,6 +105,11 @@ export class ESPHomeCommandDialog extends LitElement {
   @consume({ context: darkModeContext, subscribe: true }) @state() _darkMode =
     initialDarkMode();
   @consume({ context: apiContext }) _api!: ESPHomeAPI;
+
+  /** WS liveness; drives the transient reconnecting banner over a run. */
+  @consume({ context: apiConnectedContext, subscribe: true })
+  @state()
+  _apiConnected = true;
 
   // Live firmware-job snapshot keyed by job_id. Drives the queued overlay so
   // we tell the user the dialog is waiting in line instead of sitting empty.
@@ -490,6 +496,10 @@ export class ESPHomeCommandDialog extends LitElement {
   };
 
   protected render() {
+    // Transient reconnecting banner over an active run only; idle and
+    // terminal states keep their own message, and the app-shell pill
+    // covers the global case.
+    const wsDown = !this._apiConnected && this._state === "running";
     return html`
       <esphome-base-dialog
         ?open=${this._open}
@@ -501,8 +511,10 @@ export class ESPHomeCommandDialog extends LitElement {
           .lines=${this._log.lines}
           ?light=${!this._darkMode}
           ?streaming=${this._state === "running" && !showRunTimer(this)}
-          .state=${this._state}
-          .statusMessage=${this._statusMessage}
+          .state=${wsDown ? "error" : this._state}
+          .statusMessage=${
+            wsDown ? this._localize("layout.reconnecting") : this._statusMessage
+          }
         >
           ${renderRemoteBuilderSubLine(this)} ${renderQueuedOverlay(this)}
           ${renderResetSuggestion(this)} ${renderOffloadHintSlot(this)}

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -496,9 +496,8 @@ export class ESPHomeCommandDialog extends LitElement {
   };
 
   protected render() {
-    // Transient reconnecting banner over an active run only; idle and
-    // terminal states keep their own message, and the app-shell pill
-    // covers the global case.
+    // Reconnecting banner only over an active run; terminal states
+    // keep their own message.
     const wsDown = !this._apiConnected && this._state === "running";
     return html`
       <esphome-base-dialog

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -181,8 +181,7 @@ export class ESPHomeCommandDialog extends LitElement {
   // missing — the build itself was fine, so the clean/reset hint is suppressed.
   @state() _compileMissingDependent = false;
 
-  // Flips true when a run ended because the connection was lost — not a
-  // build or YAML problem, so the failure hints are suppressed.
+  // Run ended on a lost connection; suppresses the failure hints.
   @state() _connectionInterrupted = false;
 
   // Locally-primed status / source so the queued overlay + remote-builder

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -181,6 +181,10 @@ export class ESPHomeCommandDialog extends LitElement {
   // missing — the build itself was fine, so the clean/reset hint is suppressed.
   @state() _compileMissingDependent = false;
 
+  // Flips true when a run ended because the connection was lost — not a
+  // build or YAML problem, so the failure hints are suppressed.
+  @state() _connectionInterrupted = false;
+
   // Locally-primed status / source so the queued overlay + remote-builder
   // sub-line paint on the first frame instead of waiting for the next jobs
   // context update.

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -120,6 +120,14 @@ export function startValidateStream(host: ESPHomeCommandDialog): void {
         host._state = "error";
         host._statusMessage = error;
       },
+      onConnectionLost: () => {
+        // The validate subprocess died with the connection; a re-run
+        // would be a fresh submission, so leave that to the user.
+        host._streamId = "";
+        host._log.flush();
+        host._state = "error";
+        host._statusMessage = host._localize("command.connection_interrupted");
+      },
     },
     { showSecrets: host._showSecrets }
   );
@@ -292,6 +300,20 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
       host._state = "error";
       host._statusMessage = error;
       host._jobId = "";
+    },
+    onConnectionLost: () => {
+      // The job keeps running server-side; keep _jobId and re-follow
+      // once the reconnect's auth lands. The follow replays the full
+      // history, so the log resets rather than duplicating it.
+      host._streamId = "";
+      void host._api.ready.then(() => {
+        // Skipped when the dialog closed, the user stopped, the chain
+        // moved to the dependent flash, or something already reattached.
+        if (host._jobId !== jobId || host._streamId !== "") return;
+        host._log.reset();
+        host._resetAnsiLogScroll();
+        followJob(host, jobId);
+      });
     },
   });
 }

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -306,11 +306,15 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
       // once the reconnect's auth lands. The follow replays the full
       // history, so the log resets rather than duplicating it.
       host._streamId = "";
+      const generation = host._api.connectionGeneration;
       void host._api.ready
         .then(() => {
+          // A refused send lands here synchronously with ready still
+          // resolved; only a genuinely new socket bumps the generation.
+          if (host._api.connectionGeneration === generation) return;
           // Skipped when the dialog closed, the user stopped, the chain
           // moved to the dependent flash, or something already reattached.
-          if (host._jobId !== jobId || host._streamId !== "") return;
+          if (!host._open || host._jobId !== jobId || host._streamId !== "") return;
           host._log.reset();
           host._resetAnsiLogScroll();
           followJob(host, jobId);

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -306,14 +306,18 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
       // once the reconnect's auth lands. The follow replays the full
       // history, so the log resets rather than duplicating it.
       host._streamId = "";
-      void host._api.ready.then(() => {
-        // Skipped when the dialog closed, the user stopped, the chain
-        // moved to the dependent flash, or something already reattached.
-        if (host._jobId !== jobId || host._streamId !== "") return;
-        host._log.reset();
-        host._resetAnsiLogScroll();
-        followJob(host, jobId);
-      });
+      void host._api.ready
+        .then(() => {
+          // Skipped when the dialog closed, the user stopped, the chain
+          // moved to the dependent flash, or something already reattached.
+          if (host._jobId !== jobId || host._streamId !== "") return;
+          host._log.reset();
+          host._resetAnsiLogScroll();
+          followJob(host, jobId);
+        })
+        .catch((err: unknown) => {
+          console.error("[command] Re-follow after reconnect failed", err);
+        });
     },
   });
 }

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -3,6 +3,7 @@ import { type FirmwareJob, JobStatus, JobType } from "../../api/types/firmware-j
 import { ErrorCode } from "../../api/types/protocol.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
 import { isNeverFlashed } from "../../util/never-flashed.js";
+import { resumeFollowOnReady } from "../../util/resume-follow.js";
 import { isValidationFailureLine } from "../../util/validation-log.js";
 import { classifyNoCompatiblePeerReason } from "../../util/version-mismatch.js";
 import type { CommandType, ESPHomeCommandDialog } from "../command-dialog.js";
@@ -77,6 +78,7 @@ export function resetRunState(host: ESPHomeCommandDialog): void {
   host._userStopped = false;
   host._failedDuringValidate = false;
   host._compileMissingDependent = false;
+  host._connectionInterrupted = false;
 }
 
 export async function startCommand(host: ESPHomeCommandDialog): Promise<void> {
@@ -127,6 +129,7 @@ export function startValidateStream(host: ESPHomeCommandDialog): void {
         host._log.flush();
         host._state = "error";
         host._statusMessage = host._localize("command.connection_interrupted");
+        host._connectionInterrupted = true;
       },
     },
     { showSecrets: host._showSecrets }
@@ -306,28 +309,33 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
       // once the reconnect's auth lands. The follow replays the full
       // history, so the log resets rather than duplicating it.
       host._streamId = "";
-      const generation = host._api.connectionGeneration;
-      void host._api.ready
-        .then(() => {
-          // A refused send lands here synchronously with ready still
-          // resolved; only a genuinely new socket bumps the generation.
-          if (host._api.connectionGeneration === generation) return;
-          // Skipped when the dialog closed, the user stopped, the chain
-          // moved to the dependent flash, or something already reattached.
-          if (!host._open || host._jobId !== jobId || host._streamId !== "") return;
+      resumeFollowOnReady(host._api, {
+        // Stale when the dialog closed, the user stopped, the chain
+        // moved to the dependent flash, or something already reattached.
+        isStale: () => !host._open || host._jobId !== jobId || host._streamId !== "",
+        resume: () => {
           host._log.reset();
           host._resetAnsiLogScroll();
           followJob(host, jobId);
-        })
-        .catch((err: unknown) => {
+        },
+        giveUp: (err) => {
           console.error("[command] Re-follow after reconnect failed", err);
-        });
+          host._log.flush();
+          host._state = "error";
+          host._statusMessage = host._localize("command.connection_interrupted");
+          host._connectionInterrupted = true;
+          host._jobId = "";
+        },
+      });
     },
   });
 }
 
 export function stopCommand(host: ESPHomeCommandDialog): void {
   if (host._state !== "running") return;
+  // The cancel can't reach the backend while disconnected; claiming
+  // "Stopped." would be a lie the job disproves by finishing.
+  if (!host._apiConnected) return;
   if (host._jobId) host._api.firmwareCancel(host._jobId).catch(() => {});
   host._state = "error";
   host._userStopped = true;

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -126,10 +126,7 @@ export function startValidateStream(host: ESPHomeCommandDialog): void {
         // The validate subprocess died with the connection; a re-run
         // would be a fresh submission, so leave that to the user.
         host._streamId = "";
-        host._log.flush();
-        host._state = "error";
-        host._statusMessage = host._localize("command.connection_interrupted");
-        host._connectionInterrupted = true;
+        markConnectionInterrupted(host);
       },
     },
     { showSecrets: host._showSecrets }
@@ -318,12 +315,8 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
           host._resetAnsiLogScroll();
           followJob(host, jobId);
         },
-        giveUp: (err) => {
-          console.error("[command] Re-follow after reconnect failed", err);
-          host._log.flush();
-          host._state = "error";
-          host._statusMessage = host._localize("command.connection_interrupted");
-          host._connectionInterrupted = true;
+        giveUp: () => {
+          markConnectionInterrupted(host);
           host._jobId = "";
         },
       });
@@ -331,10 +324,18 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
   });
 }
 
+// Terminal interruption state; the message and the hint-suppressing
+// flag travel together.
+function markConnectionInterrupted(host: ESPHomeCommandDialog): void {
+  host._log.flush();
+  host._state = "error";
+  host._statusMessage = host._localize("command.connection_interrupted");
+  host._connectionInterrupted = true;
+}
+
 export function stopCommand(host: ESPHomeCommandDialog): void {
   if (host._state !== "running") return;
-  // The cancel can't reach the backend while disconnected; claiming
-  // "Stopped." would be a lie the job disproves by finishing.
+  // The cancel can't reach the backend while disconnected.
   if (!host._apiConnected) return;
   if (host._jobId) host._api.firmwareCancel(host._jobId).catch(() => {});
   host._state = "error";

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -374,7 +374,6 @@ function renderActions(host: ESPHomeCommandDialog): TemplateResult | typeof noth
   });
   switch (host._state) {
     case "running":
-      // Disabled while disconnected: the cancel can't reach the backend.
       return renderTermButton({
         icon: "stop",
         label: host._localize("command.stop"),

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -136,6 +136,8 @@ export function renderResetSuggestion(
   // A compile that succeeded but found no dependent flash isn't a build
   // failure — clean/reset wouldn't help.
   if (host._compileMissingDependent) return nothing;
+  // A lost connection isn't a build or YAML problem either.
+  if (host._connectionInterrupted) return nothing;
   if (host._commandType === "validate" || host._failedDuringValidate) {
     return renderValidationFailureSuggestion(host);
   }
@@ -372,10 +374,12 @@ function renderActions(host: ESPHomeCommandDialog): TemplateResult | typeof noth
   });
   switch (host._state) {
     case "running":
+      // Disabled while disconnected: the cancel can't reach the backend.
       return renderTermButton({
         icon: "stop",
         label: host._localize("command.stop"),
         variant: "stop",
+        disabled: !host._apiConnected,
         onClick: host._stop,
       });
     case "error":

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -19,6 +19,7 @@ import type { PairingSummary } from "../api/types/remote-build.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
   activeJobsContext,
+  apiConnectedContext,
   apiContext,
   buildOffloadPairingsContext,
   darkModeContext,
@@ -97,6 +98,11 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   @consume({ context: darkModeContext, subscribe: true }) @state() _darkMode =
     initialDarkMode();
   @consume({ context: apiContext }) _api!: ESPHomeAPI;
+
+  /** WS liveness; drives the transient reconnecting banner over a build. */
+  @consume({ context: apiConnectedContext, subscribe: true })
+  @state()
+  _apiConnected = true;
 
   // Live job snapshot — the compile job's progress gauge is the second
   // compile-start signal beside the log scanner (covers raw ninja builds).

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -599,9 +599,7 @@ export function waitForRunningJob(
               host._log.reset();
               follow();
             },
-            giveUp: (err) => {
-              console.error("[install] Re-follow after reconnect failed", err);
-              host._streamId = "";
+            giveUp: () => {
               host._compileReject = null;
               host._fail(host._localize(failKey));
               resolve(false);
@@ -668,9 +666,7 @@ export function compileAndWait(
               host._log.reset();
               follow(jobId);
             },
-            giveUp: (err) => {
-              console.error("[install] Re-follow after reconnect failed", err);
-              host._streamId = "";
+            giveUp: () => {
               host._jobId = "";
               host._compileReject = null;
               reject(new Error(host._localize("command.connection_interrupted")));

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -570,25 +570,40 @@ export function waitForRunningJob(
 ): Promise<boolean> {
   return new Promise((resolve) => {
     host._compileReject = () => resolve(false);
-    host._streamId = host._api.firmwareFollowJob(jobId, {
-      onOutput: (line) => {
-        if (host._step === "queued") host._step = "compiling";
-        host._timer.noteLine(line);
-        host._log.enqueue(line);
-      },
-      onResult: () => {
-        host._streamId = "";
-        host._compileReject = null;
-        host._log.flush();
-        resolve(true);
-      },
-      onError: () => {
-        host._streamId = "";
-        host._compileReject = null;
-        host._fail(host._localize(failKey));
-        resolve(false);
-      },
-    });
+    const follow = (): void => {
+      host._streamId = host._api.firmwareFollowJob(jobId, {
+        onOutput: (line) => {
+          if (host._step === "queued") host._step = "compiling";
+          host._timer.noteLine(line);
+          host._log.enqueue(line);
+        },
+        onResult: () => {
+          host._streamId = "";
+          host._compileReject = null;
+          host._log.flush();
+          resolve(true);
+        },
+        onError: () => {
+          host._streamId = "";
+          host._compileReject = null;
+          host._fail(host._localize(failKey));
+          resolve(false);
+        },
+        onConnectionLost: () => {
+          // The job keeps running server-side; keep the wait pending and
+          // re-follow once the reconnect's auth lands. The follow replays
+          // the full history, so reset the log rather than duplicating it.
+          host._streamId = "";
+          void host._api.ready.then(() => {
+            // A dismissal settled the wait and nulled the reject hook.
+            if (host._compileReject === null || host._streamId !== "") return;
+            host._log.reset();
+            follow();
+          });
+        },
+      });
+    };
+    follow();
   });
 }
 
@@ -603,16 +618,8 @@ export function compileAndWait(
     host._compileReject = reject;
     // Not an async executor (no-misused-promises): an async function
     // where the constructor expects a void-returning one.
-    const start = async () => {
-      const job = await host._api.firmwareCompile(configuration);
-      host._jobId = job.job_id;
-      // Capture so a compile failure can pick the right hint variant:
-      // local jobs get the link-to-reset, remote jobs get the plain-text
-      // "ask the operator of <receiver>" instruction.
-      host._jobSource = job.source;
-      host._jobSourceLabel = job.source_label;
-      host._jobSourcePin = job.source_pin_sha256;
-      host._streamId = host._api.firmwareFollowJob(job.job_id, {
+    const follow = (jobId: string): void => {
+      host._streamId = host._api.firmwareFollowJob(jobId, {
         onOutput: (line) => {
           if (host._step === "queued") {
             host._step = "compiling";
@@ -646,7 +653,30 @@ export function compileAndWait(
           host._compileReject = null;
           reject(new Error(error));
         },
+        onConnectionLost: () => {
+          // The compile keeps running server-side; keep the promise
+          // pending (a dismissal still settles it via _compileReject)
+          // and re-follow once the reconnect's auth lands. The follow
+          // replays the full history, so reset the log first.
+          host._streamId = "";
+          void host._api.ready.then(() => {
+            if (host._jobId !== jobId || host._streamId !== "") return;
+            host._log.reset();
+            follow(jobId);
+          });
+        },
       });
+    };
+    const start = async () => {
+      const job = await host._api.firmwareCompile(configuration);
+      host._jobId = job.job_id;
+      // Capture so a compile failure can pick the right hint variant:
+      // local jobs get the link-to-reset, remote jobs get the plain-text
+      // "ask the operator of <receiver>" instruction.
+      host._jobSource = job.source;
+      host._jobSourceLabel = job.source_label;
+      host._jobSourcePin = job.source_pin_sha256;
+      follow(job.job_id);
     };
     start().catch((err: unknown) => {
       host._compileReject = null;

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -550,6 +550,33 @@ async function artifactsSettled(
 }
 
 /**
+ * Re-attach a job follow once the reconnect's auth lands.
+ *
+ * The job keeps running server-side across a WS drop; the follow
+ * replays the full history, so the log resets rather than duplicating.
+ */
+function resumeFollowOnReady(
+  host: ESPHomeFirmwareInstallDialog,
+  isStale: () => boolean,
+  follow: () => void
+): void {
+  host._streamId = "";
+  const generation = host._api.connectionGeneration;
+  void host._api.ready
+    .then(() => {
+      // A refused send lands here synchronously with ready still
+      // resolved; only a genuinely new socket bumps the generation.
+      if (host._api.connectionGeneration === generation) return;
+      if (isStale() || host._streamId !== "") return;
+      host._log.reset();
+      follow();
+    })
+    .catch((err: unknown) => {
+      console.error("[install] Re-follow after reconnect failed", err);
+    });
+}
+
+/**
  * Stream an already-running job into the dialog and wait for it to reach
  * a terminal state.
  *
@@ -563,29 +590,6 @@ async function artifactsSettled(
  * case fails the dialog with *failKey*; a retry re-reads the active-jobs
  * map.
  */
-/**
- * Re-attach a job follow once the reconnect's auth lands.
- *
- * The job keeps running server-side across a WS drop; the follow
- * replays the full history, so the log resets rather than duplicating.
- */
-function resumeFollowOnReady(
-  host: ESPHomeFirmwareInstallDialog,
-  isStale: () => boolean,
-  follow: () => void
-): void {
-  host._streamId = "";
-  void host._api.ready
-    .then(() => {
-      if (isStale() || host._streamId !== "") return;
-      host._log.reset();
-      follow();
-    })
-    .catch((err: unknown) => {
-      console.error("[install] Re-follow after reconnect failed", err);
-    });
-}
-
 export function waitForRunningJob(
   host: ESPHomeFirmwareInstallDialog,
   jobId: string,

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -8,6 +8,7 @@ import { chipNameToVariant, chipPlatformFamily } from "../../util/chip-variant.j
 import { triggerDownload } from "../../util/download-text.js";
 import { getErrorMessage } from "../../util/error-message.js";
 import { pairingDisplayNameForPin } from "../../util/pairing-display-name.js";
+import { resumeFollowOnReady } from "../../util/resume-follow.js";
 import { formatApiError } from "../../util/format-api-error.js";
 import { dispatchShowLogsAfterInstall } from "../../util/post-install-logs.js";
 import { openFlasher } from "../../util/usb-flasher.js";
@@ -550,33 +551,6 @@ async function artifactsSettled(
 }
 
 /**
- * Re-attach a job follow once the reconnect's auth lands.
- *
- * The job keeps running server-side across a WS drop; the follow
- * replays the full history, so the log resets rather than duplicating.
- */
-function resumeFollowOnReady(
-  host: ESPHomeFirmwareInstallDialog,
-  isStale: () => boolean,
-  follow: () => void
-): void {
-  host._streamId = "";
-  const generation = host._api.connectionGeneration;
-  void host._api.ready
-    .then(() => {
-      // A refused send lands here synchronously with ready still
-      // resolved; only a genuinely new socket bumps the generation.
-      if (host._api.connectionGeneration === generation) return;
-      if (isStale() || host._streamId !== "") return;
-      host._log.reset();
-      follow();
-    })
-    .catch((err: unknown) => {
-      console.error("[install] Re-follow after reconnect failed", err);
-    });
-}
-
-/**
  * Stream an already-running job into the dialog and wait for it to reach
  * a terminal state.
  *
@@ -616,9 +590,24 @@ export function waitForRunningJob(
           host._fail(host._localize(failKey));
           resolve(false);
         },
-        onConnectionLost: () =>
-          // A dismissal settled the wait and nulled the reject hook.
-          resumeFollowOnReady(host, () => host._compileReject === null, follow),
+        onConnectionLost: () => {
+          host._streamId = "";
+          resumeFollowOnReady(host._api, {
+            // A dismissal settled the wait and nulled the reject hook.
+            isStale: () => host._compileReject === null || host._streamId !== "",
+            resume: () => {
+              host._log.reset();
+              follow();
+            },
+            giveUp: (err) => {
+              console.error("[install] Re-follow after reconnect failed", err);
+              host._streamId = "";
+              host._compileReject = null;
+              host._fail(host._localize(failKey));
+              resolve(false);
+            },
+          });
+        },
       });
     };
     follow();
@@ -669,14 +658,25 @@ export function compileAndWait(
           host._compileReject = null;
           reject(new Error(error));
         },
-        onConnectionLost: () =>
-          // The submit gap (await firmwareCompile) means a retry can arm
-          // before its follow attaches; the job id pins ownership.
-          resumeFollowOnReady(
-            host,
-            () => host._jobId !== jobId,
-            () => follow(jobId)
-          ),
+        onConnectionLost: () => {
+          host._streamId = "";
+          resumeFollowOnReady(host._api, {
+            // The submit gap (await firmwareCompile) means a retry can
+            // arm before its follow attaches; the job id pins ownership.
+            isStale: () => host._jobId !== jobId || host._streamId !== "",
+            resume: () => {
+              host._log.reset();
+              follow(jobId);
+            },
+            giveUp: (err) => {
+              console.error("[install] Re-follow after reconnect failed", err);
+              host._streamId = "";
+              host._jobId = "";
+              host._compileReject = null;
+              reject(new Error(host._localize("command.connection_interrupted")));
+            },
+          });
+        },
       });
     };
     // Not an async executor (no-misused-promises): an async function

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -563,6 +563,29 @@ async function artifactsSettled(
  * case fails the dialog with *failKey*; a retry re-reads the active-jobs
  * map.
  */
+/**
+ * Re-attach a job follow once the reconnect's auth lands.
+ *
+ * The job keeps running server-side across a WS drop; the follow
+ * replays the full history, so the log resets rather than duplicating.
+ */
+function resumeFollowOnReady(
+  host: ESPHomeFirmwareInstallDialog,
+  isStale: () => boolean,
+  follow: () => void
+): void {
+  host._streamId = "";
+  void host._api.ready
+    .then(() => {
+      if (isStale() || host._streamId !== "") return;
+      host._log.reset();
+      follow();
+    })
+    .catch((err: unknown) => {
+      console.error("[install] Re-follow after reconnect failed", err);
+    });
+}
+
 export function waitForRunningJob(
   host: ESPHomeFirmwareInstallDialog,
   jobId: string,
@@ -589,18 +612,9 @@ export function waitForRunningJob(
           host._fail(host._localize(failKey));
           resolve(false);
         },
-        onConnectionLost: () => {
-          // The job keeps running server-side; keep the wait pending and
-          // re-follow once the reconnect's auth lands. The follow replays
-          // the full history, so reset the log rather than duplicating it.
-          host._streamId = "";
-          void host._api.ready.then(() => {
-            // A dismissal settled the wait and nulled the reject hook.
-            if (host._compileReject === null || host._streamId !== "") return;
-            host._log.reset();
-            follow();
-          });
-        },
+        onConnectionLost: () =>
+          // A dismissal settled the wait and nulled the reject hook.
+          resumeFollowOnReady(host, () => host._compileReject === null, follow),
       });
     };
     follow();
@@ -616,8 +630,6 @@ export function compileAndWait(
     // reopen) can settle this promise. followJob callbacks clear the hook to
     // null on fire so a normal completion doesn't double-reject on teardown.
     host._compileReject = reject;
-    // Not an async executor (no-misused-promises): an async function
-    // where the constructor expects a void-returning one.
     const follow = (jobId: string): void => {
       host._streamId = host._api.firmwareFollowJob(jobId, {
         onOutput: (line) => {
@@ -653,20 +665,18 @@ export function compileAndWait(
           host._compileReject = null;
           reject(new Error(error));
         },
-        onConnectionLost: () => {
-          // The compile keeps running server-side; keep the promise
-          // pending (a dismissal still settles it via _compileReject)
-          // and re-follow once the reconnect's auth lands. The follow
-          // replays the full history, so reset the log first.
-          host._streamId = "";
-          void host._api.ready.then(() => {
-            if (host._jobId !== jobId || host._streamId !== "") return;
-            host._log.reset();
-            follow(jobId);
-          });
-        },
+        onConnectionLost: () =>
+          // The submit gap (await firmwareCompile) means a retry can arm
+          // before its follow attaches; the job id pins ownership.
+          resumeFollowOnReady(
+            host,
+            () => host._jobId !== jobId,
+            () => follow(jobId)
+          ),
       });
     };
+    // Not an async executor (no-misused-promises): an async function
+    // where the constructor expects a void-returning one.
     const start = async () => {
       const job = await host._api.firmwareCompile(configuration);
       host._jobId = job.job_id;

--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -88,7 +88,14 @@ export function renderResetSuggestion(
 // download-ready screens have no status icon — their bespoke bodies render in
 // the status-extra slot below.
 
+// Transient reconnecting banner over the follow-backed phases only; the
+// job keeps running server-side and the flow re-attaches on reconnect.
+function wsDown(host: ESPHomeFirmwareInstallDialog): boolean {
+  return !host._apiConnected && (host._step === "queued" || host._step === "compiling");
+}
+
 export function cardState(host: ESPHomeFirmwareInstallDialog): ProcessTerminalState {
+  if (wsDown(host)) return "error";
   switch (host._step) {
     case "choose-binary":
       return null;
@@ -139,6 +146,7 @@ function downloadReadyDetail(host: ESPHomeFirmwareInstallDialog): string {
 }
 
 export function cardStatusMessage(host: ESPHomeFirmwareInstallDialog): string {
+  if (wsDown(host)) return host._localize("layout.reconnecting");
   if (host._step === "choose-binary") {
     return host._localize("firmware.choose_binary_title");
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -437,6 +437,7 @@
     "timer_offload_hint": "This compile took a while. Send builds to a faster machine on your network to speed it up.",
     "validate_success": "Configuration is valid!",
     "validate_failed": "Validation failed.",
+    "connection_interrupted": "Connection to the dashboard was lost. Run again to retry.",
     "show_secrets": "Show secrets",
     "hide_secrets": "Hide secrets",
     "show_secrets_tooltip": "Reveal resolved !secret values in the validate output",

--- a/src/util/resume-follow.ts
+++ b/src/util/resume-follow.ts
@@ -1,0 +1,36 @@
+/**
+ * Re-attach a job follow once the reconnect's auth lands.
+ *
+ * The job keeps running server-side across a WS drop. The generation
+ * capture separates a genuine reconnect from a refused send that lands
+ * with 'ready' still resolved; 'giveUp' runs on the paths that will
+ * never resume so the run reaches a terminal state instead of pinning
+ * as live. A stale run (dismissed, stopped, or already reattached)
+ * resolves silently.
+ */
+export function resumeFollowOnReady(
+  api: { ready: Promise<void>; connectionGeneration: number },
+  hooks: {
+    isStale: () => boolean;
+    resume: () => void;
+    giveUp: (err: unknown) => void;
+  }
+): void {
+  const generation = api.connectionGeneration;
+  let gaveUp = false;
+  const giveUp = (err: unknown): void => {
+    if (gaveUp) return;
+    gaveUp = true;
+    hooks.giveUp(err);
+  };
+  void api.ready
+    .then(() => {
+      if (hooks.isStale()) return;
+      if (api.connectionGeneration === generation) {
+        giveUp(new Error("send refused with no reconnect"));
+        return;
+      }
+      hooks.resume();
+    })
+    .catch(giveUp);
+}

--- a/src/util/resume-follow.ts
+++ b/src/util/resume-follow.ts
@@ -4,33 +4,33 @@
  * The job keeps running server-side across a WS drop. The generation
  * capture separates a genuine reconnect from a refused send that lands
  * with 'ready' still resolved; 'giveUp' runs on the paths that will
- * never resume so the run reaches a terminal state instead of pinning
- * as live. A stale run (dismissed, stopped, or already reattached)
- * resolves silently.
+ * never resume. A stale run (dismissed, stopped, or already
+ * reattached) resolves silently.
  */
 export function resumeFollowOnReady(
   api: { ready: Promise<void>; connectionGeneration: number },
   hooks: {
     isStale: () => boolean;
     resume: () => void;
-    giveUp: (err: unknown) => void;
+    giveUp: () => void;
   }
 ): void {
   const generation = api.connectionGeneration;
-  let gaveUp = false;
-  const giveUp = (err: unknown): void => {
-    if (gaveUp) return;
-    gaveUp = true;
-    hooks.giveUp(err);
+  const fail = (err: unknown): void => {
+    if (hooks.isStale()) return;
+    console.error("[WS] Re-follow after reconnect failed", err);
+    hooks.giveUp();
   };
-  void api.ready
-    .then(() => {
-      if (hooks.isStale()) return;
-      if (api.connectionGeneration === generation) {
-        giveUp(new Error("send refused with no reconnect"));
-        return;
-      }
+  void api.ready.then(() => {
+    if (hooks.isStale()) return;
+    if (api.connectionGeneration === generation) {
+      fail(new Error("send refused with no reconnect"));
+      return;
+    }
+    try {
       hooks.resume();
-    })
-    .catch(giveUp);
+    } catch (err) {
+      fail(err);
+    }
+  }, fail);
 }

--- a/test/components/_command-dialog-host.ts
+++ b/test/components/_command-dialog-host.ts
@@ -10,6 +10,7 @@ export interface StreamCbs {
   onOutput: (line: string) => void;
   onResult: (data: unknown) => void;
   onError: (error: string) => void;
+  onConnectionLost?: () => void;
 }
 
 export function makeCommandDialogHost(
@@ -26,6 +27,7 @@ export function makeCommandDialogHost(
         follows[jobId] = cbs;
         return `stream-${++streamSeq}`;
       },
+      ready: Promise.resolve(),
       ...apiExtra,
     },
     _jobs: jobs,
@@ -48,6 +50,7 @@ export function makeCommandDialogHost(
     _failedDuringValidate: false,
     _compileMissingDependent: false,
     _localize: (key: string) => key,
+    _resetAnsiLogScroll: () => {},
     _flipToLogs: () => {
       flipped = true;
     },

--- a/test/components/_command-dialog-host.ts
+++ b/test/components/_command-dialog-host.ts
@@ -29,13 +29,14 @@ export function makeCommandDialogHost(
         return `stream-${++streamSeq}`;
       },
       ready: Promise.resolve(),
-      // Bumps per read: ready is pre-resolved here, so model the
-      // reconnect as having happened by the time a resume rechecks.
+      // Static until the test's bumpGeneration models a reconnect; an
+      // unbumped resume is the refused-send give-up path.
       get connectionGeneration(): number {
-        return ++generation;
+        return generation;
       },
       ...apiExtra,
     },
+    _apiConnected: true,
     _jobs: jobs,
     _commandType: "install",
     _open: true,
@@ -70,5 +71,8 @@ export function makeCommandDialogHost(
     host: host as unknown as ESPHomeCommandDialog,
     follows,
     flipped: () => flipped,
+    bumpGeneration: () => {
+      generation += 1;
+    },
   };
 }

--- a/test/components/_command-dialog-host.ts
+++ b/test/components/_command-dialog-host.ts
@@ -21,6 +21,7 @@ export function makeCommandDialogHost(
   const follows: Record<string, StreamCbs> = {};
   let flipped = false;
   let streamSeq = 0;
+  let generation = 0;
   const host = {
     _api: {
       firmwareFollowJob: (jobId: string, cbs: StreamCbs): string => {
@@ -28,10 +29,16 @@ export function makeCommandDialogHost(
         return `stream-${++streamSeq}`;
       },
       ready: Promise.resolve(),
+      // Bumps per read: ready is pre-resolved here, so model the
+      // reconnect as having happened by the time a resume rechecks.
+      get connectionGeneration(): number {
+        return ++generation;
+      },
       ...apiExtra,
     },
     _jobs: jobs,
     _commandType: "install",
+    _open: true,
     _jobId: "",
     _timerJobId: "",
     _timer: { reset: () => {} },

--- a/test/components/_command-dialog-host.ts
+++ b/test/components/_command-dialog-host.ts
@@ -4,6 +4,7 @@ import type { ConfiguredDevice } from "../../src/api/types/devices.js";
 import type { FirmwareJob } from "../../src/api/types/firmware-jobs.js";
 import { JobStatus } from "../../src/api/types/firmware-jobs.js";
 import type { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
+import { flushMicrotasks } from "../_dom.js";
 import { fakeLogBuffer } from "../_fake-host.js";
 
 export interface StreamCbs {
@@ -13,6 +14,29 @@ export interface StreamCbs {
   onConnectionLost?: () => void;
 }
 
+/** Fake of the resumable-API surface resume-follow.ts consumes: ready
+ *  pre-resolved, generation static until bumpGeneration models the
+ *  reconnect (an unbumped resume is the refused-send give-up path). */
+export function makeReconnectApi(): {
+  ready: Promise<void>;
+  readonly connectionGeneration: number;
+  bumpGeneration: () => void;
+} {
+  let generation = 0;
+  return {
+    ready: Promise.resolve(),
+    get connectionGeneration(): number {
+      return generation;
+    },
+    bumpGeneration: () => {
+      generation += 1;
+    },
+  };
+}
+
+/** Drain the pre-resolved ready's .then chain. */
+export const flushResume = (): Promise<void> => flushMicrotasks(4);
+
 export function makeCommandDialogHost(
   jobs: Map<string, FirmwareJob>,
   apiExtra: Record<string, unknown> = {},
@@ -21,21 +45,17 @@ export function makeCommandDialogHost(
   const follows: Record<string, StreamCbs> = {};
   let flipped = false;
   let streamSeq = 0;
-  let generation = 0;
+  const reconnectApi = makeReconnectApi();
   const host = {
-    _api: {
+    // Assigned onto the reconnect fake so its generation getter survives
+    // (a spread would snapshot the getter's value).
+    _api: Object.assign(reconnectApi, {
       firmwareFollowJob: (jobId: string, cbs: StreamCbs): string => {
         follows[jobId] = cbs;
         return `stream-${++streamSeq}`;
       },
-      ready: Promise.resolve(),
-      // Static until the test's bumpGeneration models a reconnect; an
-      // unbumped resume is the refused-send give-up path.
-      get connectionGeneration(): number {
-        return generation;
-      },
       ...apiExtra,
-    },
+    }),
     _apiConnected: true,
     _jobs: jobs,
     _commandType: "install",
@@ -71,8 +91,6 @@ export function makeCommandDialogHost(
     host: host as unknown as ESPHomeCommandDialog,
     follows,
     flipped: () => flipped,
-    bumpGeneration: () => {
-      generation += 1;
-    },
+    bumpGeneration: reconnectApi.bumpGeneration,
   };
 }

--- a/test/components/command-dialog-connection-loss.test.ts
+++ b/test/components/command-dialog-connection-loss.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import "../_mock-webawesome.js";
+
+import type { FirmwareJob } from "../../src/api/types/firmware-jobs.js";
+import { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
+import {
+  followJob,
+  startValidateStream,
+} from "../../src/components/command-dialog/commands.js";
+import { makeFirmwareJob } from "../_make-firmware-job.js";
+import { type StreamCbs, makeCommandDialogHost } from "./_command-dialog-host.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const jobsOf = (...jobs: FirmwareJob[]) =>
+  new Map(jobs.map((j) => [j.job_id, j] as const));
+
+const flushResume = async () => {
+  // ready resolves immediately in the fake; drain its .then chain.
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe("command-dialog follow connection loss", () => {
+  it("keeps the job, stays running, and re-follows with a reset log", async () => {
+    const { host, follows } = makeCommandDialogHost(
+      jobsOf(makeFirmwareJob({ job_id: "j1" }))
+    );
+    (host as any)._jobId = "j1";
+    followJob(host, "j1");
+    (host as any)._log.append(["partial output"]);
+
+    follows["j1"].onConnectionLost!();
+    expect((host as any)._jobId).toBe("j1");
+    expect((host as any)._state).toBe("running");
+    expect((host as any)._streamId).toBe("");
+
+    await flushResume();
+    expect((host as any)._streamId).toBe("stream-2");
+    expect((host as any)._log.lines).toEqual([]);
+  });
+
+  it("does not re-follow when the user stopped during the outage", async () => {
+    const { host, follows } = makeCommandDialogHost(
+      jobsOf(makeFirmwareJob({ job_id: "j1" }))
+    );
+    (host as any)._jobId = "j1";
+    followJob(host, "j1");
+
+    follows["j1"].onConnectionLost!();
+    (host as any)._jobId = ""; // stopCommand / dialog close during the outage
+
+    await flushResume();
+    expect((host as any)._streamId).toBe("");
+  });
+
+  it("does not re-follow when something already reattached", async () => {
+    const { host, follows } = makeCommandDialogHost(
+      jobsOf(makeFirmwareJob({ job_id: "j1" }))
+    );
+    (host as any)._jobId = "j1";
+    followJob(host, "j1");
+
+    follows["j1"].onConnectionLost!();
+    followJob(host, "j1"); // a manual reattach (stream-2) wins
+
+    await flushResume();
+    expect((host as any)._streamId).toBe("stream-2");
+  });
+});
+
+describe("command-dialog reconnecting banner overlay", () => {
+  it("overrides the terminal only while a run is active", async () => {
+    const el = new ESPHomeCommandDialog();
+    (el as any)._api = { firmwareFollowJob: () => "s1", ready: Promise.resolve() };
+    document.body.appendChild(el);
+    (el as any)._open = true;
+    (el as any)._state = "running";
+    (el as any)._apiConnected = false;
+    await el.updateComplete;
+    const terminal = el.shadowRoot!.querySelector("esphome-process-terminal") as any;
+    expect(terminal.state).toBe("error");
+    expect(terminal.statusMessage).toBe("layout.reconnecting");
+
+    (el as any)._apiConnected = true;
+    await el.updateComplete;
+    expect(terminal.state).toBe("running");
+
+    (el as any)._state = "error";
+    (el as any)._statusMessage = "command.install_failed";
+    (el as any)._apiConnected = false;
+    await el.updateComplete;
+    expect(terminal.state).toBe("error");
+    expect(terminal.statusMessage).toBe("command.install_failed");
+  });
+});
+
+describe("command-dialog validate connection loss", () => {
+  it("shows the localized interruption message instead of raw prose", () => {
+    let cbs!: StreamCbs;
+    const validate = vi.fn((_c: string, callbacks: StreamCbs) => {
+      cbs = callbacks;
+      return "v1";
+    });
+    const { host } = makeCommandDialogHost(jobsOf(), { validate });
+    (host as any)._commandType = "validate";
+    (host as any)._showSecrets = false;
+    startValidateStream(host);
+
+    cbs.onConnectionLost!();
+    expect((host as any)._state).toBe("error");
+    expect((host as any)._statusMessage).toBe("command.connection_interrupted");
+    expect((host as any)._streamId).toBe("");
+  });
+});

--- a/test/components/command-dialog-connection-loss.test.ts
+++ b/test/components/command-dialog-connection-loss.test.ts
@@ -12,16 +12,16 @@ import {
   startValidateStream,
   stopCommand,
 } from "../../src/components/command-dialog/commands.js";
-import { flushMicrotasks } from "../_dom.js";
 import { makeFirmwareJob } from "../_make-firmware-job.js";
-import { type StreamCbs, makeCommandDialogHost } from "./_command-dialog-host.js";
+import {
+  type StreamCbs,
+  flushResume,
+  makeCommandDialogHost,
+} from "./_command-dialog-host.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const jobsOf = (...jobs: FirmwareJob[]) =>
   new Map(jobs.map((j) => [j.job_id, j] as const));
-
-// ready resolves immediately in the fake; drain its .then chain.
-const flushResume = () => flushMicrotasks(4);
 
 describe("command-dialog follow connection loss", () => {
   it("keeps the job, stays running, and re-follows with a reset log", async () => {

--- a/test/components/command-dialog-connection-loss.test.ts
+++ b/test/components/command-dialog-connection-loss.test.ts
@@ -49,10 +49,27 @@ describe("command-dialog follow connection loss", () => {
     followJob(host, "j1");
 
     follows["j1"].onConnectionLost!();
-    (host as any)._jobId = ""; // stopCommand / dialog close during the outage
+    (host as any)._jobId = ""; // stopCommand during the outage
 
     await flushResume();
     expect((host as any)._streamId).toBe("");
+  });
+
+  it("does not re-follow onto a dialog closed during the outage", async () => {
+    // close()/_onDialogHide flip _open without clearing _jobId, so the
+    // open check is the guard that covers dismissal.
+    const { host, follows } = makeCommandDialogHost(
+      jobsOf(makeFirmwareJob({ job_id: "j1" }))
+    );
+    (host as any)._jobId = "j1";
+    followJob(host, "j1");
+
+    follows["j1"].onConnectionLost!();
+    (host as any)._open = false;
+
+    await flushResume();
+    expect((host as any)._streamId).toBe("");
+    expect((host as any)._jobId).toBe("j1");
   });
 
   it("does not re-follow when something already reattached", async () => {

--- a/test/components/command-dialog-connection-loss.test.ts
+++ b/test/components/command-dialog-connection-loss.test.ts
@@ -11,6 +11,7 @@ import {
   followJob,
   startValidateStream,
 } from "../../src/components/command-dialog/commands.js";
+import { flushMicrotasks } from "../_dom.js";
 import { makeFirmwareJob } from "../_make-firmware-job.js";
 import { type StreamCbs, makeCommandDialogHost } from "./_command-dialog-host.js";
 
@@ -18,11 +19,8 @@ import { type StreamCbs, makeCommandDialogHost } from "./_command-dialog-host.js
 const jobsOf = (...jobs: FirmwareJob[]) =>
   new Map(jobs.map((j) => [j.job_id, j] as const));
 
-const flushResume = async () => {
-  // ready resolves immediately in the fake; drain its .then chain.
-  await Promise.resolve();
-  await Promise.resolve();
-};
+// ready resolves immediately in the fake; drain its .then chain.
+const flushResume = () => flushMicrotasks(4);
 
 describe("command-dialog follow connection loss", () => {
   it("keeps the job, stays running, and re-follows with a reset log", async () => {

--- a/test/components/command-dialog-connection-loss.test.ts
+++ b/test/components/command-dialog-connection-loss.test.ts
@@ -10,6 +10,7 @@ import { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
 import {
   followJob,
   startValidateStream,
+  stopCommand,
 } from "../../src/components/command-dialog/commands.js";
 import { flushMicrotasks } from "../_dom.js";
 import { makeFirmwareJob } from "../_make-firmware-job.js";
@@ -24,7 +25,7 @@ const flushResume = () => flushMicrotasks(4);
 
 describe("command-dialog follow connection loss", () => {
   it("keeps the job, stays running, and re-follows with a reset log", async () => {
-    const { host, follows } = makeCommandDialogHost(
+    const { host, follows, bumpGeneration } = makeCommandDialogHost(
       jobsOf(makeFirmwareJob({ job_id: "j1" }))
     );
     (host as any)._jobId = "j1";
@@ -36,12 +37,13 @@ describe("command-dialog follow connection loss", () => {
     expect((host as any)._state).toBe("running");
     expect((host as any)._streamId).toBe("");
 
+    bumpGeneration(); // the reconnect happened
     await flushResume();
     expect((host as any)._streamId).toBe("stream-2");
     expect((host as any)._log.lines).toEqual([]);
   });
 
-  it("does not re-follow when the user stopped during the outage", async () => {
+  it("gives up with a terminal state when the send was refused with no reconnect", async () => {
     const { host, follows } = makeCommandDialogHost(
       jobsOf(makeFirmwareJob({ job_id: "j1" }))
     );
@@ -49,7 +51,25 @@ describe("command-dialog follow connection loss", () => {
     followJob(host, "j1");
 
     follows["j1"].onConnectionLost!();
+    // No bumpGeneration: ready resolved without a new socket.
+    await flushResume();
+    expect((host as any)._streamId).toBe("");
+    expect((host as any)._state).toBe("error");
+    expect((host as any)._statusMessage).toBe("command.connection_interrupted");
+    expect((host as any)._connectionInterrupted).toBe(true);
+    expect((host as any)._jobId).toBe("");
+  });
+
+  it("does not re-follow when the user stopped during the outage", async () => {
+    const { host, follows, bumpGeneration } = makeCommandDialogHost(
+      jobsOf(makeFirmwareJob({ job_id: "j1" }))
+    );
+    (host as any)._jobId = "j1";
+    followJob(host, "j1");
+
+    follows["j1"].onConnectionLost!();
     (host as any)._jobId = ""; // stopCommand during the outage
+    bumpGeneration();
 
     await flushResume();
     expect((host as any)._streamId).toBe("");
@@ -58,7 +78,7 @@ describe("command-dialog follow connection loss", () => {
   it("does not re-follow onto a dialog closed during the outage", async () => {
     // close()/_onDialogHide flip _open without clearing _jobId, so the
     // open check is the guard that covers dismissal.
-    const { host, follows } = makeCommandDialogHost(
+    const { host, follows, bumpGeneration } = makeCommandDialogHost(
       jobsOf(makeFirmwareJob({ job_id: "j1" }))
     );
     (host as any)._jobId = "j1";
@@ -66,14 +86,28 @@ describe("command-dialog follow connection loss", () => {
 
     follows["j1"].onConnectionLost!();
     (host as any)._open = false;
+    bumpGeneration();
 
     await flushResume();
     expect((host as any)._streamId).toBe("");
     expect((host as any)._jobId).toBe("j1");
   });
 
+  it("Stop is a no-op while disconnected so it can't claim a false stop", () => {
+    const firmwareCancel = vi.fn();
+    const { host } = makeCommandDialogHost(jobsOf(makeFirmwareJob({ job_id: "j1" })), {
+      firmwareCancel,
+    });
+    (host as any)._jobId = "j1";
+    (host as any)._apiConnected = false;
+    stopCommand(host);
+    expect(firmwareCancel).not.toHaveBeenCalled();
+    expect((host as any)._state).toBe("running");
+    expect((host as any)._jobId).toBe("j1");
+  });
+
   it("does not re-follow when something already reattached", async () => {
-    const { host, follows } = makeCommandDialogHost(
+    const { host, follows, bumpGeneration } = makeCommandDialogHost(
       jobsOf(makeFirmwareJob({ job_id: "j1" }))
     );
     (host as any)._jobId = "j1";
@@ -81,6 +115,7 @@ describe("command-dialog follow connection loss", () => {
 
     follows["j1"].onConnectionLost!();
     followJob(host, "j1"); // a manual reattach (stream-2) wins
+    bumpGeneration();
 
     await flushResume();
     expect((host as any)._streamId).toBe("stream-2");

--- a/test/components/command-dialog-connection-loss.test.ts
+++ b/test/components/command-dialog-connection-loss.test.ts
@@ -84,6 +84,8 @@ describe("command-dialog reconnecting banner overlay", () => {
     const terminal = el.shadowRoot!.querySelector("esphome-process-terminal") as any;
     expect(terminal.state).toBe("error");
     expect(terminal.statusMessage).toBe("layout.reconnecting");
+    // The stream is paused, so the pulsing dot pauses with it.
+    expect(terminal.hasAttribute("streaming")).toBe(false);
 
     (el as any)._apiConnected = true;
     await el.updateComplete;

--- a/test/components/firmware-install-dialog/connection-loss.test.ts
+++ b/test/components/firmware-install-dialog/connection-loss.test.ts
@@ -18,6 +18,7 @@ import type { StreamCbs } from "../_command-dialog-host.js";
 
 function makeHost() {
   const follows: StreamCbs[] = [];
+  let generation = 0;
   const host = {
     _api: {
       firmwareCompile: vi.fn(async () => ({
@@ -31,6 +32,11 @@ function makeHost() {
         return `stream-${follows.length}`;
       }),
       ready: Promise.resolve(),
+      // Bumps per read: ready is pre-resolved here, so model the
+      // reconnect as having happened by the time a resume rechecks.
+      get connectionGeneration(): number {
+        return ++generation;
+      },
     },
     _jobId: "",
     _streamId: "",

--- a/test/components/firmware-install-dialog/connection-loss.test.ts
+++ b/test/components/firmware-install-dialog/connection-loss.test.ts
@@ -13,14 +13,8 @@ import {
   cardStatusMessage,
 } from "../../../src/components/firmware-install-dialog/renderers.js";
 import { fakeLogBuffer } from "../../_fake-host.js";
-import { identityLocalize } from "../../_dom.js";
-
-type StreamCbs = {
-  onOutput: (line: string) => void;
-  onResult: (data: unknown) => void;
-  onError: (error: string) => void;
-  onConnectionLost?: () => void;
-};
+import { flushMicrotasks, identityLocalize } from "../../_dom.js";
+import type { StreamCbs } from "../_command-dialog-host.js";
 
 function makeHost() {
   const follows: StreamCbs[] = [];
@@ -56,11 +50,7 @@ function makeHost() {
   return { host: host as unknown as ESPHomeFirmwareInstallDialog, follows, raw: host };
 }
 
-const flushResume = async () => {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
-};
+const flushResume = () => flushMicrotasks(4);
 
 describe("compileAndWait connection loss", () => {
   it("keeps the promise pending, re-follows, and the replayed result resolves", async () => {

--- a/test/components/firmware-install-dialog/connection-loss.test.ts
+++ b/test/components/firmware-install-dialog/connection-loss.test.ts
@@ -32,10 +32,10 @@ function makeHost() {
         return `stream-${follows.length}`;
       }),
       ready: Promise.resolve(),
-      // Bumps per read: ready is pre-resolved here, so model the
-      // reconnect as having happened by the time a resume rechecks.
+      // Static until the test's bumpGeneration models a reconnect; an
+      // unbumped resume is the refused-send give-up path.
       get connectionGeneration(): number {
-        return ++generation;
+        return generation;
       },
     },
     _jobId: "",
@@ -53,14 +53,21 @@ function makeHost() {
     _localize: identityLocalize,
     _fail: vi.fn(),
   };
-  return { host: host as unknown as ESPHomeFirmwareInstallDialog, follows, raw: host };
+  return {
+    host: host as unknown as ESPHomeFirmwareInstallDialog,
+    follows,
+    raw: host,
+    bumpGeneration: () => {
+      generation += 1;
+    },
+  };
 }
 
 const flushResume = () => flushMicrotasks(4);
 
 describe("compileAndWait connection loss", () => {
   it("keeps the promise pending, re-follows, and the replayed result resolves", async () => {
-    const { host, follows, raw } = makeHost();
+    const { host, follows, raw, bumpGeneration } = makeHost();
     const pending = compileAndWait(host, "x.yaml");
     await Promise.resolve(); // firmwareCompile resolves, first follow attaches
     expect(follows).toHaveLength(1);
@@ -70,6 +77,7 @@ describe("compileAndWait connection loss", () => {
     expect(raw._jobId).toBe("j1");
     expect(raw._fail).not.toHaveBeenCalled();
 
+    bumpGeneration(); // the reconnect happened
     await flushResume();
     expect(follows).toHaveLength(2);
     expect(raw._log.lines).toEqual([]);
@@ -79,8 +87,21 @@ describe("compileAndWait connection loss", () => {
     await expect(pending).resolves.toBeUndefined();
   });
 
-  it("does not re-follow after a dismissal settled the wait", async () => {
+  it("rejects with the interruption message when the send was refused with no reconnect", async () => {
     const { host, follows, raw } = makeHost();
+    const pending = compileAndWait(host, "x.yaml");
+    await Promise.resolve();
+
+    follows[0].onConnectionLost!();
+    // No bumpGeneration: ready resolved without a new socket.
+    await flushResume();
+    expect(follows).toHaveLength(1);
+    expect(raw._jobId).toBe("");
+    await expect(pending).rejects.toThrow("command.connection_interrupted");
+  });
+
+  it("does not re-follow after a dismissal settled the wait", async () => {
+    const { host, follows, raw, bumpGeneration } = makeHost();
     const pending = compileAndWait(host, "x.yaml");
     await Promise.resolve();
 
@@ -90,6 +111,7 @@ describe("compileAndWait connection loss", () => {
     raw._compileReject?.();
     raw._compileReject = null;
     raw._jobId = "";
+    bumpGeneration();
 
     await flushResume();
     expect(follows).toHaveLength(1);
@@ -99,11 +121,12 @@ describe("compileAndWait connection loss", () => {
 
 describe("waitForRunningJob connection loss", () => {
   it("re-follows and resolves from the replayed terminal result", async () => {
-    const { host, follows, raw } = makeHost();
+    const { host, follows, raw, bumpGeneration } = makeHost();
     const pending = waitForRunningJob(host, "j9");
 
     expect(follows).toHaveLength(1);
     follows[0].onConnectionLost!();
+    bumpGeneration();
     await flushResume();
     expect(follows).toHaveLength(2);
 
@@ -112,13 +135,26 @@ describe("waitForRunningJob connection loss", () => {
     expect(raw._fail).not.toHaveBeenCalled();
   });
 
-  it("does not re-follow after a dismissal", async () => {
+  it("fails the wait when the send was refused with no reconnect", async () => {
     const { host, follows, raw } = makeHost();
+    const pending = waitForRunningJob(host, "j9");
+
+    follows[0].onConnectionLost!();
+    // No bumpGeneration: ready resolved without a new socket.
+    await flushResume();
+    expect(follows).toHaveLength(1);
+    expect(raw._fail).toHaveBeenCalledWith("firmware.download_failed");
+    await expect(pending).resolves.toBe(false);
+  });
+
+  it("does not re-follow after a dismissal", async () => {
+    const { host, follows, raw, bumpGeneration } = makeHost();
     const pending = waitForRunningJob(host, "j9");
 
     follows[0].onConnectionLost!();
     raw._compileReject?.();
     raw._compileReject = null;
+    bumpGeneration();
 
     await flushResume();
     expect(follows).toHaveLength(1);

--- a/test/components/firmware-install-dialog/connection-loss.test.ts
+++ b/test/components/firmware-install-dialog/connection-loss.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, expect, it, vi } from "vitest";
+import { JobStatus } from "../../../src/api/types/firmware-jobs.js";
+import type { ESPHomeFirmwareInstallDialog } from "../../../src/components/firmware-install-dialog.js";
+import {
+  compileAndWait,
+  waitForRunningJob,
+} from "../../../src/components/firmware-install-dialog/install-flow.js";
+import {
+  cardState,
+  cardStatusMessage,
+} from "../../../src/components/firmware-install-dialog/renderers.js";
+import { fakeLogBuffer } from "../../_fake-host.js";
+import { identityLocalize } from "../../_dom.js";
+
+type StreamCbs = {
+  onOutput: (line: string) => void;
+  onResult: (data: unknown) => void;
+  onError: (error: string) => void;
+  onConnectionLost?: () => void;
+};
+
+function makeHost() {
+  const follows: StreamCbs[] = [];
+  const host = {
+    _api: {
+      firmwareCompile: vi.fn(async () => ({
+        job_id: "j1",
+        source: "local",
+        source_label: "",
+        source_pin_sha256: "",
+      })),
+      firmwareFollowJob: vi.fn((_jobId: string, cbs: StreamCbs): string => {
+        follows.push(cbs);
+        return `stream-${follows.length}`;
+      }),
+      ready: Promise.resolve(),
+    },
+    _jobId: "",
+    _streamId: "",
+    _compileReject: null as (() => void) | null,
+    _step: "queued",
+    _statusMessage: "",
+    _errorMessage: "",
+    _failureKind: null,
+    _jobSource: null,
+    _jobSourceLabel: "",
+    _jobSourcePin: "",
+    _timer: { noteLine: () => {} },
+    _log: fakeLogBuffer(),
+    _localize: identityLocalize,
+    _fail: vi.fn(),
+  };
+  return { host: host as unknown as ESPHomeFirmwareInstallDialog, follows, raw: host };
+}
+
+const flushResume = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe("compileAndWait connection loss", () => {
+  it("keeps the promise pending, re-follows, and the replayed result resolves", async () => {
+    const { host, follows, raw } = makeHost();
+    const pending = compileAndWait(host, "x.yaml");
+    await Promise.resolve(); // firmwareCompile resolves, first follow attaches
+    expect(follows).toHaveLength(1);
+    raw._log.append(["partial output"]);
+
+    follows[0].onConnectionLost!();
+    expect(raw._jobId).toBe("j1");
+    expect(raw._fail).not.toHaveBeenCalled();
+
+    await flushResume();
+    expect(follows).toHaveLength(2);
+    expect(raw._log.lines).toEqual([]);
+
+    follows[1].onOutput("replayed line");
+    follows[1].onResult({ status: JobStatus.COMPLETED });
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it("does not re-follow after a dismissal settled the wait", async () => {
+    const { host, follows, raw } = makeHost();
+    const pending = compileAndWait(host, "x.yaml");
+    await Promise.resolve();
+
+    follows[0].onConnectionLost!();
+    // _detachStream during the outage: settles the promise and clears
+    // the ownership fields.
+    raw._compileReject?.();
+    raw._compileReject = null;
+    raw._jobId = "";
+
+    await flushResume();
+    expect(follows).toHaveLength(1);
+    await expect(pending).rejects.toBeUndefined();
+  });
+});
+
+describe("waitForRunningJob connection loss", () => {
+  it("re-follows and resolves from the replayed terminal result", async () => {
+    const { host, follows, raw } = makeHost();
+    const pending = waitForRunningJob(host, "j9");
+
+    expect(follows).toHaveLength(1);
+    follows[0].onConnectionLost!();
+    await flushResume();
+    expect(follows).toHaveLength(2);
+
+    follows[1].onResult({ status: JobStatus.COMPLETED });
+    await expect(pending).resolves.toBe(true);
+    expect(raw._fail).not.toHaveBeenCalled();
+  });
+
+  it("does not re-follow after a dismissal", async () => {
+    const { host, follows, raw } = makeHost();
+    const pending = waitForRunningJob(host, "j9");
+
+    follows[0].onConnectionLost!();
+    raw._compileReject?.();
+    raw._compileReject = null;
+
+    await flushResume();
+    expect(follows).toHaveLength(1);
+    await expect(pending).resolves.toBe(false);
+  });
+});
+
+describe("reconnecting banner overlay", () => {
+  it("overrides the card only during the follow-backed steps", () => {
+    const base = { _localize: identityLocalize, _statusMessage: "Compiling…" };
+    const compiling = {
+      ...base,
+      _apiConnected: false,
+      _step: "compiling",
+    } as unknown as ESPHomeFirmwareInstallDialog;
+    expect(cardState(compiling)).toBe("error");
+    expect(cardStatusMessage(compiling)).toBe("layout.reconnecting");
+
+    const flashing = {
+      ...base,
+      _apiConnected: false,
+      _step: "flashing",
+    } as unknown as ESPHomeFirmwareInstallDialog;
+    expect(cardState(flashing)).toBe("running");
+    expect(cardStatusMessage(flashing)).toBe("Compiling…");
+
+    const connected = {
+      ...base,
+      _apiConnected: true,
+      _step: "compiling",
+    } as unknown as ESPHomeFirmwareInstallDialog;
+    expect(cardState(connected)).toBe("running");
+    expect(cardStatusMessage(connected)).toBe("Compiling…");
+  });
+});

--- a/test/components/firmware-install-dialog/connection-loss.test.ts
+++ b/test/components/firmware-install-dialog/connection-loss.test.ts
@@ -13,14 +13,20 @@ import {
   cardStatusMessage,
 } from "../../../src/components/firmware-install-dialog/renderers.js";
 import { fakeLogBuffer } from "../../_fake-host.js";
-import { flushMicrotasks, identityLocalize } from "../../_dom.js";
-import type { StreamCbs } from "../_command-dialog-host.js";
+import { identityLocalize } from "../../_dom.js";
+import {
+  type StreamCbs,
+  flushResume,
+  makeReconnectApi,
+} from "../_command-dialog-host.js";
 
 function makeHost() {
   const follows: StreamCbs[] = [];
-  let generation = 0;
+  const reconnectApi = makeReconnectApi();
   const host = {
-    _api: {
+    // Assigned onto the reconnect fake so its generation getter survives
+    // (a spread would snapshot the getter's value).
+    _api: Object.assign(reconnectApi, {
       firmwareCompile: vi.fn(async () => ({
         job_id: "j1",
         source: "local",
@@ -31,13 +37,7 @@ function makeHost() {
         follows.push(cbs);
         return `stream-${follows.length}`;
       }),
-      ready: Promise.resolve(),
-      // Static until the test's bumpGeneration models a reconnect; an
-      // unbumped resume is the refused-send give-up path.
-      get connectionGeneration(): number {
-        return generation;
-      },
-    },
+    }),
     _jobId: "",
     _streamId: "",
     _compileReject: null as (() => void) | null,
@@ -57,13 +57,9 @@ function makeHost() {
     host: host as unknown as ESPHomeFirmwareInstallDialog,
     follows,
     raw: host,
-    bumpGeneration: () => {
-      generation += 1;
-    },
+    bumpGeneration: reconnectApi.bumpGeneration,
   };
 }
-
-const flushResume = () => flushMicrotasks(4);
 
 describe("compileAndWait connection loss", () => {
   it("keeps the promise pending, re-follows, and the replayed result resolves", async () => {


### PR DESCRIPTION
# What does this implement/fix?

When the WS dropped mid-operation, the command dialog and firmware install dialog surfaced the API client's raw error prose and gave up: "WebSocket connection closed" landed verbatim in the command dialog's banner (validate and follow paths), and `compileAndWait` rejected with the raw string, which showed as the error detail under "Compilation failed." — even though the backend job keeps running across a WS drop and `firmware/follow_job` replays historical output on re-attach.

This adopts the typed `onConnectionLost` stream callback from #1562 in both dialogs:

- **Job follows re-attach instead of failing.** The command dialog's `followJob` and the install flow's `compileAndWait` / `waitForRunningJob` keep the job id and their pending promise on connection loss, then re-follow the same job once `api.ready` resolves after the reconnect's auth. The follow's history replay repaints the log (reset first, so nothing duplicates) and the replayed result frame converges the outcome — a job that finished during the outage completes normally, a failed one shows its real error. Stale-resume guards cover dialog close, user Stop, the chain moving to the dependent flash, and dismissal mid-outage (which still settles the promise via `_compileReject`). Nothing is ever re-submitted.
- **Validate shows a localized message.** Validate is a per-connection stream whose subprocess dies with the socket; re-running would be a fresh submission, so it ends with a new `command.connection_interrupted` string ("Connection to the dashboard was lost. Run again to retry.") instead of raw prose.
- **A transient reconnecting banner over active runs.** Both dialogs consume `apiConnectedContext`; while disconnected and a run is active (command dialog: `_state === "running"`, install dialog: the follow-backed queued/compiling steps) the process-terminal shows `layout.reconnecting` as an error banner, reverting on reconnect. Idle and terminal states keep their own message, and the WebSerial/USB flash phases are untouched (local, not job-backed).

Verified live on a rig: SIGSTOP the backend mid-ESP-IDF-compile — the banner appears over the terminal with the job and timer kept; SIGCONT — the dialog re-follows, the replay repaints the history, and the run converges to "Compilation complete!" with no user action.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1564

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
