### PR TITLE
Deep-link the "Not encrypted" indicator to the api section

### DIFF
--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -25,10 +25,13 @@ export function editDevice(device: ConfiguredDevice) {
 }
 
 /** Open the editor deep-linked to a component section (e.g. ``api`` for the
- *  encryption affordance); the section is read from ``?section=`` on load. */
+ *  encryption affordance); the section is read from ``?section=`` on load.
+ *  ``reveal=1`` is the one-shot intent to show the visual pane even in a
+ *  YAML-only or mobile layout — consumed and stripped on arrival, so a
+ *  reload keeps the user's saved layout. */
 export function editDeviceSection(device: ConfiguredDevice, section: string) {
   const path = `/device/${encodeURIComponent(device.configuration)}`;
-  void navigate(`${path}?section=${encodeURIComponent(section)}`);
+  void navigate(`${path}?section=${encodeURIComponent(section)}&reveal=1`);
 }
 
 /**

--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -24,6 +24,13 @@ export function editDevice(device: ConfiguredDevice) {
   void navigate(`/device/${encodeURIComponent(device.configuration)}`);
 }
 
+/** Open the editor deep-linked to a component section (e.g. ``api`` for the
+ *  encryption affordance); the section is read from ``?section=`` on load. */
+export function editDeviceSection(device: ConfiguredDevice, section: string) {
+  const path = `/device/${encodeURIComponent(device.configuration)}`;
+  void navigate(`${path}?section=${encodeURIComponent(section)}`);
+}
+
 /**
  * Soft-delete: backend moves YAML to ``<config_dir>/archive/`` and
  * wipes the per-device build dir. Reversible via ``unarchiveDevice``.

--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -26,12 +26,17 @@ export function editDevice(device: ConfiguredDevice) {
 
 /** Open the editor deep-linked to a component section (e.g. ``api`` for the
  *  encryption affordance); the section is read from ``?section=`` on load.
- *  ``reveal=1`` is the one-shot intent to show the visual pane even in a
- *  YAML-only or mobile layout — consumed and stripped on arrival, so a
- *  reload keeps the user's saved layout. */
-export function editDeviceSection(device: ConfiguredDevice, section: string) {
+ *  ``reveal`` opts into the one-shot ``reveal=1`` intent: show the visual
+ *  pane even in a YAML-only or mobile layout — consumed and stripped on
+ *  arrival, so a reload keeps the user's saved layout. */
+export function editDeviceSection(
+  device: ConfiguredDevice,
+  section: string,
+  opts: { reveal?: boolean } = {}
+) {
   const path = `/device/${encodeURIComponent(device.configuration)}`;
-  void navigate(`${path}?section=${encodeURIComponent(section)}&reveal=1`);
+  const reveal = opts.reveal ? "&reveal=1" : "";
+  void navigate(`${path}?section=${encodeURIComponent(section)}${reveal}`);
 }
 
 /**

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -192,7 +192,7 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
                     </span>`
                   : nothing
               }
-              ${apiEnabled ? renderEncryptionBadge(this._localize, encState) : nothing}
+              ${apiEnabled ? renderEncryptionBadge(this, d, encState) : nothing}
             </div>`
           : nothing
       }

--- a/src/components/dashboard/device-drawer-content/render-sections.ts
+++ b/src/components/dashboard/device-drawer-content/render-sections.ts
@@ -59,14 +59,14 @@ export function renderEncryptionBadge(
   const v = getEncryptionVisual(state);
   if (!v) return nothing;
   const localize = host._localize;
-  // Plaintext is the only state with a one-click fix: a button that deep-links
-  // to the api section's Enable-encryption affordance. Keep the "Not encrypted"
-  // text as the accessible name and add the action as the hover hint.
-  if (state === "plaintext") {
+  // Plaintext is the only actionable state: a button that deep-links to the
+  // api section's Enable-encryption affordance. The warning tooltip stays so
+  // the "anyone on the LAN can access this device" notice isn't lost.
+  if (v.actionable) {
     return html`<button
       type="button"
       class="status-badge ${v.badgeClass}"
-      title=${localize("dashboard.encryption_add_action")}
+      title=${localize(v.tooltipKey)}
       @click=${() => fireEvent(host, "open-encryption-settings", d)}
     >
       <wa-icon library="mdi" name=${v.iconName}></wa-icon>

--- a/src/components/dashboard/device-drawer-content/render-sections.ts
+++ b/src/components/dashboard/device-drawer-content/render-sections.ts
@@ -52,11 +52,27 @@ function emptyMdnsText(d: ConfiguredDevice, localize: LocalizeFunc): string {
 }
 
 export function renderEncryptionBadge(
-  localize: LocalizeFunc,
+  host: ESPHomeDeviceDrawerContent,
+  d: ConfiguredDevice,
   state: EncryptionState
 ): TemplateResult | typeof nothing {
   const v = getEncryptionVisual(state);
   if (!v) return nothing;
+  const localize = host._localize;
+  // Plaintext is the only state with a one-click fix: a button that deep-links
+  // to the api section's Enable-encryption affordance. Keep the "Not encrypted"
+  // text as the accessible name and add the action as the hover hint.
+  if (state === "plaintext") {
+    return html`<button
+      type="button"
+      class="status-badge ${v.badgeClass}"
+      title=${localize("dashboard.encryption_add_action")}
+      @click=${() => fireEvent(host, "open-encryption-settings", d)}
+    >
+      <wa-icon library="mdi" name=${v.iconName}></wa-icon>
+      ${localize(v.labelKey)}
+    </button>`;
+  }
   return html`<span class="status-badge ${v.badgeClass}" title=${localize(v.tooltipKey)}>
     <wa-icon library="mdi" name=${v.iconName}></wa-icon>
     ${localize(v.labelKey)}

--- a/src/components/dashboard/device-drawer-content/styles.ts
+++ b/src/components/dashboard/device-drawer-content/styles.ts
@@ -293,6 +293,18 @@ export const deviceDrawerContentStyles = css`
     font-size: 13px;
   }
 
+  /* The plaintext badge is a button deep-linking to the Enable-encryption
+     affordance; reset the native chrome so it matches the passive badge. */
+  button.status-badge {
+    border: none;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  button.status-badge:focus-visible {
+    outline: 2px solid var(--esphome-primary);
+    outline-offset: 2px;
+  }
+
   .status-badge--modified {
     background: color-mix(in srgb, var(--esphome-warning, #f59e0b), transparent 85%);
     color: var(--esphome-warning, #d97706);

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -149,7 +149,7 @@ export function renderCardGrid(
             ?select-mode=${host._selectMode}
             ?selected=${host._selectedDevices.has(device.configuration)}
             @edit-device=${() => editDevice(device)}
-            @open-encryption-settings=${() => editDeviceSection(device, "api")}
+            @open-encryption-settings=${() => editDeviceSection(device, "api", { reveal: true })}
             @install-device=${() => host._openInstallMethod(device)}
             @update-device=${() => host._openCommand(device, "install")}
             @open-logs=${() => host._openLogs(device)}
@@ -202,7 +202,7 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
       @deselect-all=${(e: CustomEvent<string[]>) => host._removeFromSelection(e.detail)}
       @edit-device=${(e: CustomEvent<ConfiguredDevice>) => editDevice(e.detail)}
       @open-encryption-settings=${(e: CustomEvent<ConfiguredDevice>) =>
-        editDeviceSection(e.detail, "api")}
+        editDeviceSection(e.detail, "api", { reveal: true })}
       @update-device=${(e: CustomEvent<ConfiguredDevice>) =>
         host._openCommand(e.detail, "install")}
       @open-logs=${(e: CustomEvent<ConfiguredDevice>) => host._openLogs(e.detail)}
@@ -271,7 +271,7 @@ export function renderDrawer(host: ESPHomePageDashboard): TemplateResult {
       }}
       @open-encryption-settings=${(e: CustomEvent<ConfiguredDevice>) => {
         host._drawerOpen = false;
-        editDeviceSection(e.detail, "api");
+        editDeviceSection(e.detail, "api", { reveal: true });
       }}
       @update-device=${(e: CustomEvent<ConfiguredDevice>) => {
         host._drawerOpen = false;

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -11,7 +11,7 @@ import { showPendingChanges, showUpdateAvailable } from "../../util/device-sync.
 import { buildWebUiUrl } from "../../util/web-ui-url.js";
 import { tourAnchor } from "../guided-tour/tour-anchor.js";
 import { getActiveTourConfiguration } from "../guided-tour/tour-session.js";
-import { downloadYaml, editDevice } from "./actions.js";
+import { downloadYaml, editDevice, editDeviceSection } from "./actions.js";
 import { renderFacets } from "./render-facets.js";
 import {
   renderAddDeviceCard,
@@ -149,6 +149,7 @@ export function renderCardGrid(
             ?select-mode=${host._selectMode}
             ?selected=${host._selectedDevices.has(device.configuration)}
             @edit-device=${() => editDevice(device)}
+            @open-encryption-settings=${() => editDeviceSection(device, "api")}
             @install-device=${() => host._openInstallMethod(device)}
             @update-device=${() => host._openCommand(device, "install")}
             @open-logs=${() => host._openLogs(device)}
@@ -200,6 +201,8 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
       @select-all=${(e: CustomEvent<string[]>) => host._addToSelection(e.detail)}
       @deselect-all=${(e: CustomEvent<string[]>) => host._removeFromSelection(e.detail)}
       @edit-device=${(e: CustomEvent<ConfiguredDevice>) => editDevice(e.detail)}
+      @open-encryption-settings=${(e: CustomEvent<ConfiguredDevice>) =>
+        editDeviceSection(e.detail, "api")}
       @update-device=${(e: CustomEvent<ConfiguredDevice>) =>
         host._openCommand(e.detail, "install")}
       @open-logs=${(e: CustomEvent<ConfiguredDevice>) => host._openLogs(e.detail)}
@@ -265,6 +268,10 @@ export function renderDrawer(host: ESPHomePageDashboard): TemplateResult {
       @edit-device=${(e: CustomEvent) => {
         host._drawerOpen = false;
         editDevice(e.detail);
+      }}
+      @open-encryption-settings=${(e: CustomEvent<ConfiguredDevice>) => {
+        host._drawerOpen = false;
+        editDeviceSection(e.detail, "api");
       }}
       @update-device=${(e: CustomEvent<ConfiguredDevice>) => {
         host._drawerOpen = false;

--- a/src/components/dashboard/table-cell-styles.ts
+++ b/src/components/dashboard/table-cell-styles.ts
@@ -79,6 +79,25 @@ export const tableCellStyles = css`
   .cell-encryption.mismatch {
     color: var(--esphome-error);
   }
+  /* Plaintext deep-links to the Enable-encryption affordance; reset the
+     native button chrome and reuse the busy cell's hover halo. */
+  button.cell-encryption {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px;
+    margin: -2px;
+    border: none;
+    background: none;
+    color: inherit;
+    cursor: pointer;
+    border-radius: var(--wa-border-radius-s);
+    transition: background 0.12s;
+  }
+  button.cell-encryption:hover,
+  button.cell-encryption:focus-visible {
+    background: var(--esphome-tint);
+    outline: none;
+  }
 
   .status-recent wa-icon {
     font-size: 16px;

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -6,7 +6,10 @@ import type { FirmwareJob } from "../../api/types/firmware-jobs.js";
 import { JobStatus } from "../../api/types/firmware-jobs.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../util/device-sort.js";
-import { getCompactEncryptionVisual } from "../../util/encryption-state.js";
+import {
+  getCompactEncryptionVisual,
+  getEncryptionState,
+} from "../../util/encryption-state.js";
 import { fireEvent } from "../../util/fire-event.js";
 import { formatFileSize } from "../../util/format-file-size.js";
 import { renderLabelChips } from "../../util/label-chip-template.js";
@@ -153,7 +156,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
         const row = info.row.original;
         // Compact view: no lock for encrypted devices, only the
         // attention states (plaintext / pending / mismatch) get an icon.
-        const encVisual = getCompactEncryptionVisual({
+        const encInputs = {
           api_enabled: row.api_enabled,
           api_encrypted: row.api_encrypted,
           api_encryption_active: row.api_encryption_active,
@@ -161,7 +164,11 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
           // "pending" state is about a local YAML edit not yet flashed, so it
           // must match the drawer's raw-flag badge (mDNS freshness is irrelevant).
           has_pending_changes: row.hasPendingChanges,
-        });
+        };
+        const encVisual = getCompactEncryptionVisual(encInputs);
+        // Plaintext is the only state with a one-click fix — deep-link to the
+        // api section's Enable-encryption affordance; the rest stay passive.
+        const encActionable = getEncryptionState(encInputs) === "plaintext";
         return html`<span class="cell-name-wrap">
           <span class="cell-name">${row.friendly_name || row.name}</span>
           ${
@@ -191,14 +198,25 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
               : nothing
           }
           ${
-            encVisual
-              ? html`<wa-icon
-                  class="cell-encryption ${encVisual.cssClass}"
-                  library="mdi"
-                  name=${encVisual.iconName}
-                  title=${localize(encVisual.tooltipKey)}
-                ></wa-icon>`
-              : nothing
+            !encVisual
+              ? nothing
+              : encActionable
+                ? html`<button
+                    type="button"
+                    class="cell-encryption ${encVisual.cssClass}"
+                    title=${localize("dashboard.encryption_add_action")}
+                    aria-label=${localize("dashboard.encryption_add_action")}
+                    @click=${(e: Event) =>
+                      dispatchRowEvent(e, "open-encryption-settings", row._device)}
+                  >
+                    <wa-icon library="mdi" name=${encVisual.iconName}></wa-icon>
+                  </button>`
+                : html`<wa-icon
+                    class="cell-encryption ${encVisual.cssClass}"
+                    library="mdi"
+                    name=${encVisual.iconName}
+                    title=${localize(encVisual.tooltipKey)}
+                  ></wa-icon>`
           }
         </span>`;
       },

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -162,11 +162,12 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
           // must match the drawer's raw-flag badge (mDNS freshness is irrelevant).
           has_pending_changes: row.hasPendingChanges,
         });
-        const encTooltip = encVisual ? localize(encVisual.tooltipKey) : "";
         // The button's name carries the warning plus the action; the passive
         // icon keeps the plain warning.
-        const encActionTooltip = encVisual
-          ? localize(encVisual.actionTooltipKey ?? encVisual.tooltipKey)
+        const encTitle = encVisual
+          ? localize(
+              encVisual.actionable ? encVisual.actionTooltipKey : encVisual.tooltipKey
+            )
           : "";
         return html`<span class="cell-name-wrap">
           <span class="cell-name">${row.friendly_name || row.name}</span>
@@ -203,8 +204,8 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
                 ? html`<button
                     type="button"
                     class="cell-encryption ${encVisual.cssClass}"
-                    title=${encActionTooltip}
-                    aria-label=${encActionTooltip}
+                    title=${encTitle}
+                    aria-label=${encTitle}
                     @click=${(e: Event) =>
                       dispatchRowEvent(e, "open-encryption-settings", row._device)}
                   >
@@ -214,7 +215,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
                     class="cell-encryption ${encVisual.cssClass}"
                     library="mdi"
                     name=${encVisual.iconName}
-                    title=${encTooltip}
+                    title=${encTitle}
                   ></wa-icon>`
           }
         </span>`;

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -6,10 +6,7 @@ import type { FirmwareJob } from "../../api/types/firmware-jobs.js";
 import { JobStatus } from "../../api/types/firmware-jobs.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../util/device-sort.js";
-import {
-  getCompactEncryptionVisual,
-  getEncryptionState,
-} from "../../util/encryption-state.js";
+import { getCompactEncryptionVisual } from "../../util/encryption-state.js";
 import { fireEvent } from "../../util/fire-event.js";
 import { formatFileSize } from "../../util/format-file-size.js";
 import { renderLabelChips } from "../../util/label-chip-template.js";
@@ -166,9 +163,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
           has_pending_changes: row.hasPendingChanges,
         };
         const encVisual = getCompactEncryptionVisual(encInputs);
-        // Plaintext is the only state with a one-click fix — deep-link to the
-        // api section's Enable-encryption affordance; the rest stay passive.
-        const encActionable = getEncryptionState(encInputs) === "plaintext";
+        const encTooltip = encVisual ? localize(encVisual.tooltipKey) : "";
         return html`<span class="cell-name-wrap">
           <span class="cell-name">${row.friendly_name || row.name}</span>
           ${
@@ -200,12 +195,12 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
           ${
             !encVisual
               ? nothing
-              : encActionable
+              : encVisual.actionable
                 ? html`<button
                     type="button"
                     class="cell-encryption ${encVisual.cssClass}"
-                    title=${localize("dashboard.encryption_add_action")}
-                    aria-label=${localize("dashboard.encryption_add_action")}
+                    title=${encTooltip}
+                    aria-label=${encTooltip}
                     @click=${(e: Event) =>
                       dispatchRowEvent(e, "open-encryption-settings", row._device)}
                   >
@@ -215,7 +210,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
                     class="cell-encryption ${encVisual.cssClass}"
                     library="mdi"
                     name=${encVisual.iconName}
-                    title=${localize(encVisual.tooltipKey)}
+                    title=${encTooltip}
                   ></wa-icon>`
           }
         </span>`;

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -153,7 +153,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
         const row = info.row.original;
         // Compact view: no lock for encrypted devices, only the
         // attention states (plaintext / pending / mismatch) get an icon.
-        const encInputs = {
+        const encVisual = getCompactEncryptionVisual({
           api_enabled: row.api_enabled,
           api_encrypted: row.api_encrypted,
           api_encryption_active: row.api_encryption_active,
@@ -161,9 +161,13 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
           // "pending" state is about a local YAML edit not yet flashed, so it
           // must match the drawer's raw-flag badge (mDNS freshness is irrelevant).
           has_pending_changes: row.hasPendingChanges,
-        };
-        const encVisual = getCompactEncryptionVisual(encInputs);
+        });
         const encTooltip = encVisual ? localize(encVisual.tooltipKey) : "";
+        // The button's name carries the warning plus the action; the passive
+        // icon keeps the plain warning.
+        const encActionTooltip = encVisual
+          ? localize(encVisual.actionTooltipKey ?? encVisual.tooltipKey)
+          : "";
         return html`<span class="cell-name-wrap">
           <span class="cell-name">${row.friendly_name || row.name}</span>
           ${
@@ -199,8 +203,8 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
                 ? html`<button
                     type="button"
                     class="cell-encryption ${encVisual.cssClass}"
-                    title=${encTooltip}
-                    aria-label=${encTooltip}
+                    title=${encActionTooltip}
+                    aria-label=${encActionTooltip}
                     @click=${(e: Event) =>
                       dispatchRowEvent(e, "open-encryption-settings", row._device)}
                   >

--- a/src/components/device-card/render-bits.ts
+++ b/src/components/device-card/render-bits.ts
@@ -63,7 +63,6 @@ export function renderEncryptionIcon(
         id="ind-encryption"
         type="button"
         class="encryption-icon ${visual.cssClass}"
-        title=${label}
         aria-label=${label}
         @click=${(e: Event) => {
           e.stopPropagation();

--- a/src/components/device-card/render-bits.ts
+++ b/src/components/device-card/render-bits.ts
@@ -45,20 +45,19 @@ export function renderLabels(card: ESPHomeDeviceCard): TemplateResult | typeof n
 export function renderEncryptionIcon(
   card: ESPHomeDeviceCard
 ): TemplateResult | typeof nothing {
-  const inputs = {
+  const visual = getCompactEncryptionVisual({
     api_enabled: card.apiEnabled,
     api_encrypted: card.apiEncrypted,
     api_encryption_active: card.apiEncryptionActive,
     has_pending_changes: card.hasPendingChanges,
-  };
-  const visual = getCompactEncryptionVisual(inputs);
+  });
   if (!visual) return nothing;
-  const label = card._localize(visual.tooltipKey);
   // Plaintext is the only actionable state: render the warning as a button
-  // that deep-links to the api section's Enable-encryption affordance. Keep
-  // the warning as the button's label so the "anyone on the LAN can access
-  // this device" notice isn't lost.
-  if (visual.actionable) {
+  // that deep-links to the api section's Enable-encryption affordance, named
+  // with the warning plus the action so neither is lost. Passive while
+  // selecting — in select mode the whole card is one toggle target.
+  if (visual.actionable && !card.selectMode) {
+    const label = card._localize(visual.actionTooltipKey ?? visual.tooltipKey);
     return html`<button
         id="ind-encryption"
         type="button"
@@ -73,6 +72,7 @@ export function renderEncryptionIcon(
       </button>
       <wa-tooltip for="ind-encryption">${label}</wa-tooltip>`;
   }
+  const tooltip = card._localize(visual.tooltipKey);
   return html`<wa-icon
       id="ind-encryption"
       class="encryption-icon ${visual.cssClass}"
@@ -80,9 +80,9 @@ export function renderEncryptionIcon(
       name=${visual.iconName}
       tabindex="0"
       role="img"
-      aria-label=${label}
+      aria-label=${tooltip}
     ></wa-icon>
-    <wa-tooltip for="ind-encryption">${label}</wa-tooltip>`;
+    <wa-tooltip for="ind-encryption">${tooltip}</wa-tooltip>`;
 }
 
 export function renderStatusBadge(card: ESPHomeDeviceCard): TemplateResult {

--- a/src/components/device-card/render-bits.ts
+++ b/src/components/device-card/render-bits.ts
@@ -1,10 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { DeviceState } from "../../api/types/devices.js";
 import { JobStatus, JobType } from "../../api/types/firmware-jobs.js";
-import {
-  getCompactEncryptionVisual,
-  getEncryptionState,
-} from "../../util/encryption-state.js";
+import { getCompactEncryptionVisual } from "../../util/encryption-state.js";
 import { fireEvent } from "../../util/fire-event.js";
 import { renderLabelChips, resolveLabelIds } from "../../util/label-chip-template.js";
 import type { ESPHomeDeviceCard } from "../device-card.js";
@@ -56,11 +53,12 @@ export function renderEncryptionIcon(
   };
   const visual = getCompactEncryptionVisual(inputs);
   if (!visual) return nothing;
-  // Plaintext is the only state with a one-click fix: deep-link to the api
-  // section's Enable-encryption affordance. The others already have
-  // encryption configured, so they stay passive indicators.
-  if (getEncryptionState(inputs) === "plaintext") {
-    const label = card._localize("dashboard.encryption_add_action");
+  const label = card._localize(visual.tooltipKey);
+  // Plaintext is the only actionable state: render the warning as a button
+  // that deep-links to the api section's Enable-encryption affordance. Keep
+  // the warning as the button's label so the "anyone on the LAN can access
+  // this device" notice isn't lost.
+  if (visual.actionable) {
     return html`<button
         id="ind-encryption"
         type="button"
@@ -83,9 +81,9 @@ export function renderEncryptionIcon(
       name=${visual.iconName}
       tabindex="0"
       role="img"
-      aria-label=${card._localize(visual.tooltipKey)}
+      aria-label=${label}
     ></wa-icon>
-    <wa-tooltip for="ind-encryption">${card._localize(visual.tooltipKey)}</wa-tooltip>`;
+    <wa-tooltip for="ind-encryption">${label}</wa-tooltip>`;
 }
 
 export function renderStatusBadge(card: ESPHomeDeviceCard): TemplateResult {

--- a/src/components/device-card/render-bits.ts
+++ b/src/components/device-card/render-bits.ts
@@ -1,7 +1,10 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { DeviceState } from "../../api/types/devices.js";
 import { JobStatus, JobType } from "../../api/types/firmware-jobs.js";
-import { getCompactEncryptionVisual } from "../../util/encryption-state.js";
+import {
+  getCompactEncryptionVisual,
+  getEncryptionState,
+} from "../../util/encryption-state.js";
 import { fireEvent } from "../../util/fire-event.js";
 import { renderLabelChips, resolveLabelIds } from "../../util/label-chip-template.js";
 import type { ESPHomeDeviceCard } from "../device-card.js";
@@ -45,13 +48,34 @@ export function renderLabels(card: ESPHomeDeviceCard): TemplateResult | typeof n
 export function renderEncryptionIcon(
   card: ESPHomeDeviceCard
 ): TemplateResult | typeof nothing {
-  const visual = getCompactEncryptionVisual({
+  const inputs = {
     api_enabled: card.apiEnabled,
     api_encrypted: card.apiEncrypted,
     api_encryption_active: card.apiEncryptionActive,
     has_pending_changes: card.hasPendingChanges,
-  });
+  };
+  const visual = getCompactEncryptionVisual(inputs);
   if (!visual) return nothing;
+  // Plaintext is the only state with a one-click fix: deep-link to the api
+  // section's Enable-encryption affordance. The others already have
+  // encryption configured, so they stay passive indicators.
+  if (getEncryptionState(inputs) === "plaintext") {
+    const label = card._localize("dashboard.encryption_add_action");
+    return html`<button
+        id="ind-encryption"
+        type="button"
+        class="encryption-icon ${visual.cssClass}"
+        title=${label}
+        aria-label=${label}
+        @click=${(e: Event) => {
+          e.stopPropagation();
+          fireEvent(card, "open-encryption-settings");
+        }}
+      >
+        <wa-icon library="mdi" name=${visual.iconName}></wa-icon>
+      </button>
+      <wa-tooltip for="ind-encryption">${label}</wa-tooltip>`;
+  }
   return html`<wa-icon
       id="ind-encryption"
       class="encryption-icon ${visual.cssClass}"

--- a/src/components/device-card/render-bits.ts
+++ b/src/components/device-card/render-bits.ts
@@ -57,7 +57,7 @@ export function renderEncryptionIcon(
   // with the warning plus the action so neither is lost. Passive while
   // selecting — in select mode the whole card is one toggle target.
   if (visual.actionable && !card.selectMode) {
-    const label = card._localize(visual.actionTooltipKey ?? visual.tooltipKey);
+    const label = card._localize(visual.actionTooltipKey);
     return html`<button
         id="ind-encryption"
         type="button"

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -144,6 +144,22 @@ export const deviceCardStyles = [
       font-size: 14px;
       flex-shrink: 0;
     }
+    /* Plaintext is a button that deep-links to the Enable-encryption
+       affordance; reset the native chrome so it matches the passive icon. */
+    button.encryption-icon {
+      display: inline-flex;
+      align-items: center;
+      padding: 0;
+      border: none;
+      background: none;
+      color: inherit;
+      cursor: pointer;
+    }
+    button.encryption-icon:focus-visible {
+      outline: 2px solid var(--esphome-primary);
+      outline-offset: 2px;
+      border-radius: var(--wa-border-radius-s);
+    }
     .encryption-icon.secure {
       color: var(--esphome-success);
       opacity: 0.85;

--- a/src/pages/device-url-state.ts
+++ b/src/pages/device-url-state.ts
@@ -66,6 +66,11 @@ export function buildDeviceUrl(
 ): string {
   const params = new URLSearchParams(search);
 
+  // `reveal` is a one-shot navigation intent (the "Not encrypted"
+  // deep-link's pane reveal); it must never survive into a rebuilt URL
+  // or a reload would re-fire it.
+  params.delete("reveal");
+
   // Selected section + line
   if (state.selectedSection) {
     params.set("section", state.selectedSection);

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -750,6 +750,14 @@ export class ESPHomePageDevice extends LitElement {
       // diagnosable.
       console.warn("Failed to load device preferences:", err);
     }
+
+    // A ?section= deep-link (e.g. the "Not encrypted" pill → api section)
+    // targets the visual pane, so YAML-only would hide it. Reveal the split
+    // view for this open only — an in-memory set, not _cacheLayout, so the
+    // user's saved YAML-only preference returns on the next open.
+    if (this._layout === "right" && this._readUrlParam("section", null) !== null) {
+      this._layout = "both";
+    }
   }
 
   private async _loadBoard(boardId: string) {

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -27,6 +27,7 @@ import type {
   YamlDraftDetail,
   YamlUpdatedDetail,
 } from "../components/device/section-editor.js";
+import { layoutRevealingAnchor } from "../components/device/tour-reveal-layout.js";
 import type { ESPHomeFirmwareInstallDialog } from "../components/firmware-install-dialog.js";
 import { tourAnchor } from "../components/guided-tour/tour-anchor.js";
 import { TourLayoutController } from "../components/guided-tour/tour-layout-controller.js";
@@ -759,16 +760,15 @@ export class ESPHomePageDevice extends LitElement {
 
     if (this._pendingReveal) {
       this._pendingReveal = false;
-      // In-memory only, so the saved layout returns on the next open. On
-      // mobile the split view collapses to YAML, so reveal the visual pane
-      // alone there; on desktop only a YAML-only layout needs the split.
-      if (this._isMobile) {
-        this._layout = "left";
-      } else if (this._layout === "right") {
-        this._layout = "both";
-      }
-      // Strip the intent from the URL so a reload doesn't re-fire it.
-      this._updateUrl();
+      // In-memory only, so the saved layout returns on the next open. The
+      // tour's reveal helper owns the mobile-collapse rule (visual-only on
+      // mobile, split on a YAML-only desktop layout).
+      const reveal = layoutRevealingAnchor("central", this._layout, this._isMobile);
+      if (reveal) this._layout = reveal;
+      // Strip the intent from the URL so a reload doesn't re-fire it. Not
+      // from a page unmounted during the preferences fetch — a detached
+      // replaceState would rewrite whatever route the user is on now.
+      if (this.isConnected) this._updateUrl();
     }
   }
 

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -222,6 +222,12 @@ export class ESPHomePageDevice extends LitElement {
    *  re-derive focus on every later load (board swap). */
   private _pendingUrlLine?: number = this._readUrlLine();
 
+  /** One-shot ``?reveal=`` deep-link intent (the "Not encrypted"
+   *  indicator): show the visual pane this open even in a YAML-only or
+   *  mobile layout. Consumed in ``_loadPreferences``; ``buildDeviceUrl``
+   *  strips the param so a reload keeps the saved layout. */
+  private _pendingReveal = this._readUrlParam("reveal", null) !== null;
+
   /** Instance-relative field path the YAML cursor is on, for the form to
    *  scroll into view; empty on a section header / non-field line. */
   @state()
@@ -749,6 +755,20 @@ export class ESPHomePageDevice extends LitElement {
       // user silently dropped into the non-YAML first-open layout is
       // diagnosable.
       console.warn("Failed to load device preferences:", err);
+    }
+
+    if (this._pendingReveal) {
+      this._pendingReveal = false;
+      // In-memory only, so the saved layout returns on the next open. On
+      // mobile the split view collapses to YAML, so reveal the visual pane
+      // alone there; on desktop only a YAML-only layout needs the split.
+      if (this._isMobile) {
+        this._layout = "left";
+      } else if (this._layout === "right") {
+        this._layout = "both";
+      }
+      // Strip the intent from the URL so a reload doesn't re-fire it.
+      this._updateUrl();
     }
   }
 

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -750,14 +750,6 @@ export class ESPHomePageDevice extends LitElement {
       // diagnosable.
       console.warn("Failed to load device preferences:", err);
     }
-
-    // A ?section= deep-link (e.g. the "Not encrypted" pill → api section)
-    // targets the visual pane, so YAML-only would hide it. Reveal the split
-    // view for this open only — an in-memory set, not _cacheLayout, so the
-    // user's saved YAML-only preference returns on the next open.
-    if (this._layout === "right" && this._readUrlParam("section", null) !== null) {
-      this._layout = "both";
-    }
   }
 
   private async _loadBoard(boardId: string) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -250,6 +250,7 @@
     "table_status_unencrypted_tooltip": "API traffic is unencrypted — anyone on the LAN can access this device",
     "table_status_encryption_pending_tooltip": "Encryption is configured in the YAML but the device is still running plaintext — install the firmware to apply",
     "table_status_encryption_mismatch_tooltip": "YAML enables encryption but the device is broadcasting plaintext — reinstall the firmware to apply",
+    "encryption_add_action": "Add encryption",
     "table_no_results": "No results found.",
     "pagination_total": "{count, plural, one {# row total} other {# rows total}}",
     "pagination_rows_per_page": "Rows per page",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -248,6 +248,7 @@
     "table_status_encryption_mismatch": "Encryption mismatch",
     "table_status_encrypted_tooltip": "API traffic is encrypted",
     "table_status_unencrypted_tooltip": "API traffic is unencrypted — anyone on the LAN can access this device",
+    "table_status_unencrypted_action_tooltip": "API traffic is unencrypted — anyone on the LAN can access this device. Click to add encryption",
     "table_status_encryption_pending_tooltip": "Encryption is configured in the YAML but the device is still running plaintext — install the firmware to apply",
     "table_status_encryption_mismatch_tooltip": "YAML enables encryption but the device is broadcasting plaintext — reinstall the firmware to apply",
     "table_no_results": "No results found.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -250,7 +250,6 @@
     "table_status_unencrypted_tooltip": "API traffic is unencrypted — anyone on the LAN can access this device",
     "table_status_encryption_pending_tooltip": "Encryption is configured in the YAML but the device is still running plaintext — install the firmware to apply",
     "table_status_encryption_mismatch_tooltip": "YAML enables encryption but the device is broadcasting plaintext — reinstall the firmware to apply",
-    "encryption_add_action": "Add encryption",
     "table_no_results": "No results found.",
     "pagination_total": "{count, plural, one {# row total} other {# rows total}}",
     "pagination_rows_per_page": "Rows per page",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -248,7 +248,7 @@
     "table_status_encryption_mismatch": "Encryption mismatch",
     "table_status_encrypted_tooltip": "API traffic is encrypted",
     "table_status_unencrypted_tooltip": "API traffic is unencrypted — anyone on the LAN can access this device",
-    "table_status_unencrypted_action_tooltip": "API traffic is unencrypted — anyone on the LAN can access this device. Click to add encryption",
+    "table_status_unencrypted_action_tooltip": "API traffic is unencrypted — anyone on the LAN can access this device. Open the API settings to enable encryption",
     "table_status_encryption_pending_tooltip": "Encryption is configured in the YAML but the device is still running plaintext — install the firmware to apply",
     "table_status_encryption_mismatch_tooltip": "YAML enables encryption but the device is broadcasting plaintext — reinstall the firmware to apply",
     "table_no_results": "No results found.",

--- a/src/util/encryption-state.ts
+++ b/src/util/encryption-state.ts
@@ -109,6 +109,10 @@ export interface EncryptionVisual {
    *  table / drawer render the indicator as a button that deep-links to the
    *  api section's Enable-encryption affordance. */
   actionable?: boolean;
+  /** Tooltip / accessible-name key for the icon-only actionable surfaces
+   *  (card, table): the warning plus what clicking does. The drawer keeps
+   *  ``tooltipKey`` — its visible label already states the problem. */
+  actionTooltipKey?: string;
 }
 
 const VISUALS: Record<Exclude<EncryptionState, "none">, EncryptionVisual> = {
@@ -128,6 +132,7 @@ const VISUALS: Record<Exclude<EncryptionState, "none">, EncryptionVisual> = {
     labelKey: "dashboard.table_status_unencrypted",
     tooltipKey: "dashboard.table_status_unencrypted_tooltip",
     actionable: true,
+    actionTooltipKey: "dashboard.table_status_unencrypted_action_tooltip",
   },
   pending: {
     iconName: "lock-clock",

--- a/src/util/encryption-state.ts
+++ b/src/util/encryption-state.ts
@@ -87,7 +87,7 @@ export function getEncryptionState(d: EncryptionInputs): EncryptionState {
   return observed == null ? "active" : "mismatch";
 }
 
-export interface EncryptionVisual {
+interface EncryptionVisualBase {
   iconName: string;
   iconPath: string;
   /** CSS class on the lock icon — controls the colour treatment.
@@ -105,15 +105,17 @@ export interface EncryptionVisual {
   labelKey: string;
   /** Localize key for the title / aria-label. */
   tooltipKey: string;
-  /** True for the one state with a one-click fix (plaintext): the card /
-   *  table / drawer render the indicator as a button that deep-links to the
-   *  api section's Enable-encryption affordance. */
-  actionable?: boolean;
-  /** Tooltip / accessible-name key for the icon-only actionable surfaces
-   *  (card, table): the warning plus what clicking does. The drawer keeps
-   *  ``tooltipKey`` — its visible label already states the problem. */
-  actionTooltipKey?: string;
 }
+
+/** ``actionable: true`` marks the one state with a one-click fix (plaintext):
+ *  the card / table / drawer render the indicator as a button that deep-links
+ *  to the api section's Enable-encryption affordance, and it must carry
+ *  ``actionTooltipKey`` — the icon-only surfaces' accessible name (warning
+ *  plus action). The drawer keeps ``tooltipKey``; its visible label already
+ *  states the problem. */
+export type EncryptionVisual =
+  | (EncryptionVisualBase & { actionable?: false; actionTooltipKey?: never })
+  | (EncryptionVisualBase & { actionable: true; actionTooltipKey: string });
 
 const VISUALS: Record<Exclude<EncryptionState, "none">, EncryptionVisual> = {
   active: {

--- a/src/util/encryption-state.ts
+++ b/src/util/encryption-state.ts
@@ -105,6 +105,10 @@ export interface EncryptionVisual {
   labelKey: string;
   /** Localize key for the title / aria-label. */
   tooltipKey: string;
+  /** True for the one state with a one-click fix (plaintext): the card /
+   *  table / drawer render the indicator as a button that deep-links to the
+   *  api section's Enable-encryption affordance. */
+  actionable?: boolean;
 }
 
 const VISUALS: Record<Exclude<EncryptionState, "none">, EncryptionVisual> = {
@@ -123,6 +127,7 @@ const VISUALS: Record<Exclude<EncryptionState, "none">, EncryptionVisual> = {
     badgeClass: "status-badge--unencrypted",
     labelKey: "dashboard.table_status_unencrypted",
     tooltipKey: "dashboard.table_status_unencrypted_tooltip",
+    actionable: true,
   },
   pending: {
     iconName: "lock-clock",

--- a/test/components/dashboard/_host.ts
+++ b/test/components/dashboard/_host.ts
@@ -1,4 +1,5 @@
 import { identityLocalize } from "../../_dom.js";
+import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
 import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
 
 /**
@@ -16,4 +17,38 @@ export function makeDashboardHost(
     _search: "",
     ...overrides,
   } as unknown as ESPHomePageDashboard;
+}
+
+/**
+ * ``makeDashboardHost`` plus the inert baseline ``renderTable`` requires
+ * (table prefs, selection, facet stubs). Pass devices and test-specific
+ * state through ``overrides``.
+ */
+export function makeTableHost(
+  overrides: Record<string, unknown> = {}
+): ESPHomePageDashboard {
+  return makeDashboardHost({
+    _devices: [],
+    _sortedDevices: [],
+    _applyFacetFilters: (list: ConfiguredDevice[]) => list,
+    _activeJobs: new Map(),
+    _recentJobs: new Map(),
+    _tablePageSize: 25,
+    _tableSorting: [],
+    _tableColumnVisibility: {},
+    _selectMode: false,
+    _visibleImportableDevices: [],
+    _selectedDevices: new Set<string>(),
+    _recentlyAdopted: null,
+    _expertMode: false,
+    _selectedLabels: [],
+    _selectedAreas: [],
+    _selectedPlatforms: [],
+    _selectedStates: [],
+    _selectedUpdateStatus: [],
+    _activeFacetCount: 0,
+    _computeLabelUsage: () => new Map(),
+    _allVisibleSelected: false,
+    ...overrides,
+  });
 }

--- a/test/components/dashboard/actions-edit-section.test.ts
+++ b/test/components/dashboard/actions-edit-section.test.ts
@@ -10,13 +10,13 @@ import { editDeviceSection } from "../../../src/components/dashboard/actions.js"
 import { navigate } from "../../../src/util/navigation.js";
 
 describe("editDeviceSection", () => {
-  it("deep-links to the editor with the section query param", () => {
+  it("deep-links to the editor with the section and one-shot reveal params", () => {
     editDeviceSection({ configuration: "kitchen.yaml" } as ConfiguredDevice, "api");
-    expect(navigate).toHaveBeenCalledWith("/device/kitchen.yaml?section=api");
+    expect(navigate).toHaveBeenCalledWith("/device/kitchen.yaml?section=api&reveal=1");
   });
 
   it("URI-encodes the configuration and the section", () => {
     editDeviceSection({ configuration: "foo (1).yaml" } as ConfiguredDevice, "api");
-    expect(navigate).toHaveBeenCalledWith("/device/foo%20(1).yaml?section=api");
+    expect(navigate).toHaveBeenCalledWith("/device/foo%20(1).yaml?section=api&reveal=1");
   });
 });

--- a/test/components/dashboard/actions-edit-section.test.ts
+++ b/test/components/dashboard/actions-edit-section.test.ts
@@ -10,13 +10,20 @@ import { editDeviceSection } from "../../../src/components/dashboard/actions.js"
 import { navigate } from "../../../src/util/navigation.js";
 
 describe("editDeviceSection", () => {
-  it("deep-links to the editor with the section and one-shot reveal params", () => {
+  it("deep-links to the editor with the section query param", () => {
     editDeviceSection({ configuration: "kitchen.yaml" } as ConfiguredDevice, "api");
+    expect(navigate).toHaveBeenCalledWith("/device/kitchen.yaml?section=api");
+  });
+
+  it("adds the one-shot reveal intent only when opted in", () => {
+    editDeviceSection({ configuration: "kitchen.yaml" } as ConfiguredDevice, "api", {
+      reveal: true,
+    });
     expect(navigate).toHaveBeenCalledWith("/device/kitchen.yaml?section=api&reveal=1");
   });
 
   it("URI-encodes the configuration and the section", () => {
     editDeviceSection({ configuration: "foo (1).yaml" } as ConfiguredDevice, "api");
-    expect(navigate).toHaveBeenCalledWith("/device/foo%20(1).yaml?section=api&reveal=1");
+    expect(navigate).toHaveBeenCalledWith("/device/foo%20(1).yaml?section=api");
   });
 });

--- a/test/components/dashboard/actions-edit-section.test.ts
+++ b/test/components/dashboard/actions-edit-section.test.ts
@@ -1,0 +1,22 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/util/navigation.js", () => ({ navigate: vi.fn() }));
+
+import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
+import { editDeviceSection } from "../../../src/components/dashboard/actions.js";
+import { navigate } from "../../../src/util/navigation.js";
+
+describe("editDeviceSection", () => {
+  it("deep-links to the editor with the section query param", () => {
+    editDeviceSection({ configuration: "kitchen.yaml" } as ConfiguredDevice, "api");
+    expect(navigate).toHaveBeenCalledWith("/device/kitchen.yaml?section=api");
+  });
+
+  it("URI-encodes the configuration and the section", () => {
+    editDeviceSection({ configuration: "foo (1).yaml" } as ConfiguredDevice, "api");
+    expect(navigate).toHaveBeenCalledWith("/device/foo%20(1).yaml?section=api");
+  });
+});

--- a/test/components/dashboard/device-drawer-content-encryption.test.ts
+++ b/test/components/dashboard/device-drawer-content-encryption.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The drawer's plaintext badge is a button deep-linking to the api section's
+ * Enable-encryption affordance; the other states render passive spans.
+ */
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+
+import { identityLocalize } from "../../_dom.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+import type { ESPHomeDeviceDrawerContent } from "../../../src/components/dashboard/device-drawer-content.js";
+import { renderEncryptionBadge } from "../../../src/components/dashboard/device-drawer-content/render-sections.js";
+
+function hostEl(): HTMLElement {
+  const el = document.createElement("div");
+  (el as unknown as { _localize: (k: string) => string })._localize = identityLocalize;
+  document.body.appendChild(el);
+  return el;
+}
+
+describe("drawer encryption badge deep-link", () => {
+  it("plaintext renders a button that emits open-encryption-settings with the device", () => {
+    const host = hostEl();
+    const device = makeConfiguredDevice({ name: "kitchen" });
+    render(
+      renderEncryptionBadge(
+        host as unknown as ESPHomeDeviceDrawerContent,
+        device,
+        "plaintext"
+      ),
+      host
+    );
+    const btn = host.querySelector<HTMLButtonElement>("button.status-badge");
+    expect(btn).not.toBeNull();
+    let detail: unknown;
+    host.addEventListener("open-encryption-settings", (e) => {
+      detail = (e as CustomEvent).detail;
+    });
+    btn!.click();
+    expect(detail).toBe(device);
+  });
+
+  it("active state stays a passive span", () => {
+    const host = hostEl();
+    render(
+      renderEncryptionBadge(
+        host as unknown as ESPHomeDeviceDrawerContent,
+        makeConfiguredDevice({ name: "kitchen" }),
+        "active"
+      ),
+      host
+    );
+    expect(host.querySelector("button.status-badge")).toBeNull();
+    expect(host.querySelector("span.status-badge")).not.toBeNull();
+  });
+});

--- a/test/components/dashboard/device-drawer-content-encryption.test.ts
+++ b/test/components/dashboard/device-drawer-content-encryption.test.ts
@@ -33,6 +33,8 @@ describe("drawer encryption badge deep-link", () => {
     );
     const btn = host.querySelector<HTMLButtonElement>("button.status-badge");
     expect(btn).not.toBeNull();
+    // The warning notice stays as the tooltip even though it's now a button.
+    expect(btn!.title).toBe("dashboard.table_status_unencrypted_tooltip");
     let detail: unknown;
     host.addEventListener("open-encryption-settings", (e) => {
       detail = (e as CustomEvent).detail;

--- a/test/components/dashboard/render-content-encryption-wiring.test.ts
+++ b/test/components/dashboard/render-content-encryption-wiring.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the open-encryption-settings → editDeviceSection wiring on all
+ * three dashboard surfaces (card grid, table, drawer), reveal opt-in
+ * included.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("../../../src/util/navigation.js", () => ({ navigate: vi.fn() }));
+
+import { renderInto } from "../../_dom.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
+import {
+  renderCardGrid,
+  renderDrawer,
+  renderTable,
+} from "../../../src/components/dashboard/render-content.js";
+import { navigate } from "../../../src/util/navigation.js";
+import { makeDashboardHost } from "./_host.js";
+
+const DEEP_LINK = "/device/kitchen.yaml?section=api&reveal=1";
+
+afterEach(() => {
+  vi.mocked(navigate).mockClear();
+});
+
+function dispatchOpen(el: Element, detail?: ConfiguredDevice) {
+  el.dispatchEvent(new CustomEvent("open-encryption-settings", { detail }));
+}
+
+describe("open-encryption-settings wiring", () => {
+  it("card grid deep-links to the api section with the reveal intent", () => {
+    const device = makeConfiguredDevice();
+    const host = makeDashboardHost({
+      _devices: [device],
+      _activeJobs: new Map(),
+      _recentJobs: new Map(),
+      _recentlyAdopted: null,
+      _selectMode: false,
+      _selectedDevices: new Set<string>(),
+    });
+    const container = renderInto(renderCardGrid(host, [device]));
+    const card = container.querySelector("esphome-device-card");
+    expect(card).not.toBeNull();
+
+    dispatchOpen(card!);
+    expect(navigate).toHaveBeenCalledWith(DEEP_LINK);
+  });
+
+  it("table deep-links the event's device to the api section", () => {
+    const device = makeConfiguredDevice();
+    const host = makeDashboardHost({
+      _devices: [device],
+      _sortedDevices: [device],
+      _applyFacetFilters: (list: ConfiguredDevice[]) => list,
+      _activeJobs: new Map(),
+      _recentJobs: new Map(),
+      _tablePageSize: 25,
+      _tableSorting: [],
+      _tableColumnVisibility: {},
+      _selectMode: false,
+      _visibleImportableDevices: [],
+      _selectedDevices: new Set<string>(),
+      _recentlyAdopted: null,
+      _expertMode: false,
+      _selectedLabels: [],
+      _selectedAreas: [],
+      _selectedPlatforms: [],
+      _selectedStates: [],
+      _selectedUpdateStatus: [],
+      _activeFacetCount: 0,
+      _computeLabelUsage: () => new Map(),
+      _allVisibleSelected: false,
+    });
+    const container = renderInto(renderTable(host));
+    const table = container.querySelector("esphome-device-table");
+    expect(table).not.toBeNull();
+
+    dispatchOpen(table!, device);
+    expect(navigate).toHaveBeenCalledWith(DEEP_LINK);
+  });
+
+  it("drawer closes and deep-links the event's device to the api section", () => {
+    const device = makeConfiguredDevice();
+    const host = makeDashboardHost({
+      _drawerOpen: true,
+      _drawerDevice: device,
+      _activeJobs: new Map(),
+    });
+    const container = renderInto(renderDrawer(host));
+    const drawer = container.querySelector("esphome-device-drawer");
+    expect(drawer).not.toBeNull();
+
+    dispatchOpen(drawer!, device);
+    expect(navigate).toHaveBeenCalledWith(DEEP_LINK);
+    expect(host._drawerOpen).toBe(false);
+  });
+});

--- a/test/components/dashboard/render-content-encryption-wiring.test.ts
+++ b/test/components/dashboard/render-content-encryption-wiring.test.ts
@@ -20,7 +20,7 @@ import {
   renderTable,
 } from "../../../src/components/dashboard/render-content.js";
 import { navigate } from "../../../src/util/navigation.js";
-import { makeDashboardHost } from "./_host.js";
+import { makeDashboardHost, makeTableHost } from "./_host.js";
 
 const DEEP_LINK = "/device/kitchen.yaml?section=api&reveal=1";
 
@@ -53,29 +53,7 @@ describe("open-encryption-settings wiring", () => {
 
   it("table deep-links the event's device to the api section", () => {
     const device = makeConfiguredDevice();
-    const host = makeDashboardHost({
-      _devices: [device],
-      _sortedDevices: [device],
-      _applyFacetFilters: (list: ConfiguredDevice[]) => list,
-      _activeJobs: new Map(),
-      _recentJobs: new Map(),
-      _tablePageSize: 25,
-      _tableSorting: [],
-      _tableColumnVisibility: {},
-      _selectMode: false,
-      _visibleImportableDevices: [],
-      _selectedDevices: new Set<string>(),
-      _recentlyAdopted: null,
-      _expertMode: false,
-      _selectedLabels: [],
-      _selectedAreas: [],
-      _selectedPlatforms: [],
-      _selectedStates: [],
-      _selectedUpdateStatus: [],
-      _activeFacetCount: 0,
-      _computeLabelUsage: () => new Map(),
-      _allVisibleSelected: false,
-    });
+    const host = makeTableHost({ _devices: [device], _sortedDevices: [device] });
     const container = renderInto(renderTable(host));
     const table = container.querySelector("esphome-device-table");
     expect(table).not.toBeNull();

--- a/test/components/dashboard/render-table-default-order.test.ts
+++ b/test/components/dashboard/render-table-default-order.test.ts
@@ -15,7 +15,7 @@ import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
 import { DashboardView } from "../../../src/api/types/system.js";
 import { renderTable } from "../../../src/components/dashboard/render-content.js";
 import { sortDevices } from "../../../src/util/device-sort.js";
-import { makeDashboardHost } from "./_host.js";
+import { makeTableHost } from "./_host.js";
 
 // Backend snapshot order: lexicographic by YAML path, capitals first.
 const BACKEND_ORDER = ["Garland", "ecu Boiler", "plg Servion"].map((name) =>
@@ -27,29 +27,10 @@ const BACKEND_ORDER = ["Garland", "ecu Boiler", "plg Servion"].map((name) =>
 );
 
 function makeHost(devices: ConfiguredDevice[]) {
-  return makeDashboardHost({
+  return makeTableHost({
     _devices: devices,
     _sortedDevices: sortDevices(devices),
-    _applyFacetFilters: (list: ConfiguredDevice[]) => list,
-    _activeJobs: new Map(),
-    _recentJobs: new Map(),
-    _tablePageSize: 25,
-    _tableSorting: [],
-    _tableColumnVisibility: {},
-    _selectMode: false,
-    _visibleImportableDevices: [],
-    _selectedDevices: new Set<string>(),
-    _recentlyAdopted: null,
     _view: DashboardView.TABLE,
-    _expertMode: false,
-    _selectedLabels: [],
-    _selectedAreas: [],
-    _selectedPlatforms: [],
-    _selectedStates: [],
-    _selectedUpdateStatus: [],
-    _activeFacetCount: 0,
-    _computeLabelUsage: () => new Map(),
-    _allVisibleSelected: false,
   });
 }
 

--- a/test/components/dashboard/table-columns.test.ts
+++ b/test/components/dashboard/table-columns.test.ts
@@ -9,7 +9,7 @@
 import type { CellContext } from "@tanstack/lit-table";
 import { type TemplateResult } from "lit";
 import { describe, expect, it } from "vitest";
-import { identityLocalize, renderInto } from "../../_dom.js";
+import { clickCollect, identityLocalize, renderInto } from "../../_dom.js";
 import {
   createDeviceColumns,
   type DeviceRow,
@@ -205,5 +205,43 @@ describe("name-cell encryption indicator uses the raw pending flag", () => {
     );
     expect(container.querySelector(".cell-encryption")).not.toBeNull();
     expect(container.querySelector(".cell-indicator--modified")).toBeNull();
+  });
+});
+
+describe("name-cell encryption deep-link", () => {
+  it("plaintext renders a button that deep-links and stops the row click", () => {
+    const device = { configuration: "kitchen.yaml" } as unknown as DeviceRow["_device"];
+    const container = renderInto(
+      renderNameCell({
+        api_enabled: true,
+        api_encrypted: false,
+        api_encryption_active: null,
+        _device: device,
+      })
+    );
+    const btn = container.querySelector<HTMLButtonElement>("button.cell-encryption");
+    expect(btn).not.toBeNull();
+    let detail: unknown;
+    container.addEventListener("open-encryption-settings", (e) => {
+      detail = (e as CustomEvent).detail;
+    });
+    // stopPropagation keeps the row's own click (row-click → drawer) from firing.
+    expect(clickCollect(container, btn!, ["open-encryption-settings", "click"])).toEqual([
+      "open-encryption-settings",
+    ]);
+    expect(detail).toBe(device);
+  });
+
+  it("pending stays a passive icon (encryption already configured)", () => {
+    const container = renderInto(
+      renderNameCell({
+        api_enabled: true,
+        api_encrypted: true,
+        api_encryption_active: null,
+        hasPendingChanges: true,
+      })
+    );
+    expect(container.querySelector("button.cell-encryption")).toBeNull();
+    expect(container.querySelector("wa-icon.cell-encryption")).not.toBeNull();
   });
 });

--- a/test/components/dashboard/table-columns.test.ts
+++ b/test/components/dashboard/table-columns.test.ts
@@ -221,6 +221,10 @@ describe("name-cell encryption deep-link", () => {
     );
     const btn = container.querySelector<HTMLButtonElement>("button.cell-encryption");
     expect(btn).not.toBeNull();
+    // The accessible name carries the warning plus the action.
+    expect(btn!.getAttribute("aria-label")).toBe(
+      "dashboard.table_status_unencrypted_action_tooltip"
+    );
     let detail: unknown;
     container.addEventListener("open-encryption-settings", (e) => {
       detail = (e as CustomEvent).detail;

--- a/test/components/device-card-encryption-action.test.ts
+++ b/test/components/device-card-encryption-action.test.ts
@@ -23,6 +23,11 @@ describe("device-card encryption deep-link", () => {
     });
     const btn = el.shadowRoot!.querySelector<HTMLButtonElement>("button.encryption-icon");
     expect(btn).not.toBeNull();
+    // The accessible name carries the warning plus the action, not the
+    // plain warning tooltip.
+    expect(btn!.getAttribute("aria-label")).toBe(
+      "dashboard.table_status_unencrypted_action_tooltip"
+    );
     // stopPropagation keeps the card's own click (card-click → drawer) from firing.
     expect(clickCollect(el, btn!, ["open-encryption-settings", "card-click"])).toEqual([
       "open-encryption-settings",

--- a/test/components/device-card-encryption-action.test.ts
+++ b/test/components/device-card-encryption-action.test.ts
@@ -29,6 +29,17 @@ describe("device-card encryption deep-link", () => {
     ]);
   });
 
+  it("stays passive in select mode so the whole card remains one toggle target", async () => {
+    const el = await mount({
+      apiEnabled: true,
+      apiEncrypted: false,
+      apiEncryptionActive: null,
+      selectMode: true,
+    });
+    expect(el.shadowRoot!.querySelector("button.encryption-icon")).toBeNull();
+    expect(el.shadowRoot!.querySelector("wa-icon.encryption-icon")).not.toBeNull();
+  });
+
   it("encrypted device shows no lock at all", async () => {
     const el = await mount({
       apiEnabled: true,

--- a/test/components/device-card-encryption-action.test.ts
+++ b/test/components/device-card-encryption-action.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The plaintext lock is the only encryption state that deep-links to the api
+ * section's Enable-encryption affordance; encrypted shows nothing and the
+ * other attention states stay passive icons.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
+
+import { clickCollect } from "../_dom.js";
+import { mountDeviceCard as mount } from "./_device-card.js";
+
+describe("device-card encryption deep-link", () => {
+  it("plaintext lock is a button that deep-links and does not open the drawer", async () => {
+    const el = await mount({
+      apiEnabled: true,
+      apiEncrypted: false,
+      apiEncryptionActive: null,
+    });
+    const btn = el.shadowRoot!.querySelector<HTMLButtonElement>("button.encryption-icon");
+    expect(btn).not.toBeNull();
+    // stopPropagation keeps the card's own click (card-click → drawer) from firing.
+    expect(clickCollect(el, btn!, ["open-encryption-settings", "card-click"])).toEqual([
+      "open-encryption-settings",
+    ]);
+  });
+
+  it("encrypted device shows no lock at all", async () => {
+    const el = await mount({
+      apiEnabled: true,
+      apiEncrypted: true,
+      apiEncryptionActive: "Noise_NNpsk0_25519_ChaChaPoly_SHA256",
+    });
+    expect(el.shadowRoot!.querySelector(".encryption-icon")).toBeNull();
+  });
+
+  it("mismatch stays a passive icon (encryption already configured)", async () => {
+    const el = await mount({
+      apiEnabled: true,
+      apiEncrypted: true,
+      apiEncryptionActive: "",
+    });
+    expect(el.shadowRoot!.querySelector("button.encryption-icon")).toBeNull();
+    expect(el.shadowRoot!.querySelector("wa-icon.encryption-icon")).not.toBeNull();
+  });
+});

--- a/test/pages/device-url-state.test.ts
+++ b/test/pages/device-url-state.test.ts
@@ -104,6 +104,15 @@ describe("buildDeviceUrl", () => {
     expect(url).toBe("/device");
   });
 
+  it("always drops the one-shot reveal intent", () => {
+    const url = buildDeviceUrl("?section=api&reveal=1", base, {
+      selectedSection: "api",
+      selectedFromLine: undefined,
+      openSections: [],
+    });
+    expect(url).toBe("/device?section=api");
+  });
+
   it("serializes open sections as a comma-separated list", () => {
     const url = buildDeviceUrl("", base, {
       selectedSection: null,

--- a/test/pages/device.test.ts
+++ b/test/pages/device.test.ts
@@ -91,6 +91,47 @@ describe("esphome-page-device layout persistence", () => {
   });
 });
 
+describe("esphome-page-device section deep-link reveal", () => {
+  const prefs = (layout: string) =>
+    vi.fn(() =>
+      Promise.resolve({ navigator_visible: true, device_editor_layout: layout })
+    );
+
+  beforeEach(() => localStorage.clear());
+  afterEach(() => {
+    localStorage.clear();
+    window.history.replaceState({}, "", "/");
+  });
+
+  test("a ?section deep-link reveals the split view for a YAML-only user without persisting", async () => {
+    window.history.replaceState({}, "", "/device/kitchen.yaml?section=api");
+    localStorage.setItem("esphome-editor-layout", "right");
+    const page = makePage();
+    page._api = { getPreferences: prefs("yaml") } as unknown as ESPHomeAPI;
+    await page._loadPreferences();
+    expect(page._layout).toBe("both");
+    // In-memory only — the saved YAML-only preference returns on the next open.
+    expect(localStorage.getItem("esphome-editor-layout")).toBe("right");
+  });
+
+  test("without a ?section param a YAML-only user stays in YAML-only", async () => {
+    window.history.replaceState({}, "", "/device/kitchen.yaml");
+    localStorage.setItem("esphome-editor-layout", "right");
+    const page = makePage();
+    page._api = { getPreferences: prefs("yaml") } as unknown as ESPHomeAPI;
+    await page._loadPreferences();
+    expect(page._layout).toBe("right");
+  });
+
+  test("a ?section deep-link leaves a split-view user in split view", async () => {
+    window.history.replaceState({}, "", "/device/kitchen.yaml?section=api");
+    const page = makePage();
+    page._api = { getPreferences: prefs("both") } as unknown as ESPHomeAPI;
+    await page._loadPreferences();
+    expect(page._layout).toBe("both");
+  });
+});
+
 interface SaveView {
   _api: ESPHomeAPI;
   id: string;

--- a/test/pages/device.test.ts
+++ b/test/pages/device.test.ts
@@ -91,47 +91,6 @@ describe("esphome-page-device layout persistence", () => {
   });
 });
 
-describe("esphome-page-device section deep-link reveal", () => {
-  const prefs = (layout: string) =>
-    vi.fn(() =>
-      Promise.resolve({ navigator_visible: true, device_editor_layout: layout })
-    );
-
-  beforeEach(() => localStorage.clear());
-  afterEach(() => {
-    localStorage.clear();
-    window.history.replaceState({}, "", "/");
-  });
-
-  test("a ?section deep-link reveals the split view for a YAML-only user without persisting", async () => {
-    window.history.replaceState({}, "", "/device/kitchen.yaml?section=api");
-    localStorage.setItem("esphome-editor-layout", "right");
-    const page = makePage();
-    page._api = { getPreferences: prefs("yaml") } as unknown as ESPHomeAPI;
-    await page._loadPreferences();
-    expect(page._layout).toBe("both");
-    // In-memory only — the saved YAML-only preference returns on the next open.
-    expect(localStorage.getItem("esphome-editor-layout")).toBe("right");
-  });
-
-  test("without a ?section param a YAML-only user stays in YAML-only", async () => {
-    window.history.replaceState({}, "", "/device/kitchen.yaml");
-    localStorage.setItem("esphome-editor-layout", "right");
-    const page = makePage();
-    page._api = { getPreferences: prefs("yaml") } as unknown as ESPHomeAPI;
-    await page._loadPreferences();
-    expect(page._layout).toBe("right");
-  });
-
-  test("a ?section deep-link leaves a split-view user in split view", async () => {
-    window.history.replaceState({}, "", "/device/kitchen.yaml?section=api");
-    const page = makePage();
-    page._api = { getPreferences: prefs("both") } as unknown as ESPHomeAPI;
-    await page._loadPreferences();
-    expect(page._layout).toBe("both");
-  });
-});
-
 interface SaveView {
   _api: ESPHomeAPI;
   id: string;

--- a/test/pages/device.test.ts
+++ b/test/pages/device.test.ts
@@ -106,6 +106,8 @@ describe("esphome-page-device one-shot reveal deep-link", () => {
     window.history.replaceState({}, "", "/device/kitchen.yaml?section=api&reveal=1");
     localStorage.setItem("esphome-editor-layout", "right");
     const page = makePage();
+    // The URL strip only runs on a still-mounted page.
+    Object.defineProperty(page, "isConnected", { value: true });
     page._api = { getPreferences: prefs } as unknown as ESPHomeAPI;
     await page._loadPreferences();
     expect(page._layout).toBe("both");
@@ -114,6 +116,18 @@ describe("esphome-page-device one-shot reveal deep-link", () => {
     // The one-shot intent is stripped so a reload keeps the saved layout.
     expect(window.location.search).not.toContain("reveal");
     expect(window.location.search).toContain("section=api");
+  });
+
+  test("a page unmounted during the fetch never rewrites the current route", async () => {
+    window.history.replaceState({}, "", "/device/kitchen.yaml?section=api&reveal=1");
+    const page = makePage(); // never attached: isConnected is false
+    page._api = { getPreferences: prefs } as unknown as ESPHomeAPI;
+    // Simulate the user navigating away while getPreferences was in flight.
+    window.history.replaceState({}, "", "/device/other.yaml");
+    await page._loadPreferences();
+    // No replaceState from the dead page; the current route is untouched.
+    expect(window.location.pathname).toBe("/device/other.yaml");
+    expect(window.location.search).toBe("");
   });
 
   test("a reload with only ?section keeps the YAML-only layout", async () => {

--- a/test/pages/device.test.ts
+++ b/test/pages/device.test.ts
@@ -91,6 +91,50 @@ describe("esphome-page-device layout persistence", () => {
   });
 });
 
+describe("esphome-page-device one-shot reveal deep-link", () => {
+  const prefs = vi.fn(() =>
+    Promise.resolve({ navigator_visible: true, device_editor_layout: "yaml" })
+  );
+
+  beforeEach(() => localStorage.clear());
+  afterEach(() => {
+    localStorage.clear();
+    window.history.replaceState({}, "", "/");
+  });
+
+  test("reveal=1 shows the split view for a YAML-only user, then strips itself", async () => {
+    window.history.replaceState({}, "", "/device/kitchen.yaml?section=api&reveal=1");
+    localStorage.setItem("esphome-editor-layout", "right");
+    const page = makePage();
+    page._api = { getPreferences: prefs } as unknown as ESPHomeAPI;
+    await page._loadPreferences();
+    expect(page._layout).toBe("both");
+    // In-memory only: the saved preference survives for the next open.
+    expect(localStorage.getItem("esphome-editor-layout")).toBe("right");
+    // The one-shot intent is stripped so a reload keeps the saved layout.
+    expect(window.location.search).not.toContain("reveal");
+    expect(window.location.search).toContain("section=api");
+  });
+
+  test("a reload with only ?section keeps the YAML-only layout", async () => {
+    window.history.replaceState({}, "", "/device/kitchen.yaml?section=api");
+    localStorage.setItem("esphome-editor-layout", "right");
+    const page = makePage();
+    page._api = { getPreferences: prefs } as unknown as ESPHomeAPI;
+    await page._loadPreferences();
+    expect(page._layout).toBe("right");
+  });
+
+  test("reveal=1 on mobile shows the visual pane alone", async () => {
+    window.history.replaceState({}, "", "/device/kitchen.yaml?section=api&reveal=1");
+    const page = makePage();
+    (page as unknown as { _isMobile: boolean })._isMobile = true;
+    page._api = { getPreferences: prefs } as unknown as ESPHomeAPI;
+    await page._loadPreferences();
+    expect(page._layout).toBe("left");
+  });
+});
+
 interface SaveView {
   _api: ESPHomeAPI;
   id: string;

--- a/test/util/encryption-state.test.ts
+++ b/test/util/encryption-state.test.ts
@@ -207,4 +207,19 @@ describe("getCompactEncryptionVisual", () => {
   it("returns null when the API is disabled (no indicator at all)", () => {
     expect(getCompactEncryptionVisual(inputs({ api_enabled: false }))).toBeNull();
   });
+
+  it("marks only plaintext actionable (the one state with a one-click fix)", () => {
+    const plaintext = getCompactEncryptionVisual(
+      inputs({ api_encrypted: false, api_encryption_active: null })
+    );
+    expect(plaintext?.actionable).toBe(true);
+
+    const pending = getCompactEncryptionVisual(
+      inputs({ api_encryption_active: "", has_pending_changes: true })
+    );
+    expect(pending?.actionable).toBeUndefined();
+
+    const mismatch = getCompactEncryptionVisual(inputs({ api_encryption_active: "" }));
+    expect(mismatch?.actionable).toBeUndefined();
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Users see a "Not encrypted" warning on their devices but have no path from it to the fix. A recent Discord support thread ("if something I created with esphome has this 'Not encrypted' warning... is there a simple way to fix it?") was answered by pointing at the docs; the dashboard itself offered nothing.

This makes the plaintext encryption indicator a clickable affordance that opens the editor at the **api** section, where the "Enable encryption" CTA (`esphome-security-notice`) already renders automatically when the `encryption:` block is absent. Nothing new is built on the destination side; the indicator just deep-links there.

Covered on all three surfaces the indicator appears on, gated to the plaintext state only (pending / mismatch already have `encryption:` configured, so they stay passive):

- **Device card** lock icon becomes a button that fires `open-encryption-settings` (with `stopPropagation` so it doesn't also open the drawer). In bulk-select mode it stays a passive icon so the whole card remains one toggle target.
- **Table** encryption cell becomes a button dispatching the same row event.
- **Drawer** detail pill (the element in the Discord screenshot) becomes a button; the "Not encrypted" text stays as the accessible name with the warning as the hover hint.

All three route to a new `editDeviceSection(device, "api")` in `dashboard/actions.ts`, which navigates to `/device/<config>?section=api` (the `?section=` param is already parsed into the editor's selected section).

The "is this state actionable" decision lives once on the encryption visual (`actionable` on the plaintext entry in `util/encryption-state.ts`), as does the copy: the icon-only surfaces (card, table) name both the problem and the action ("API traffic is unencrypted — anyone on the LAN can access this device. Open the API settings to enable encryption", `table_status_unencrypted_action_tooltip`), so the LAN-exposure warning is preserved everywhere while the affordance is discoverable, pointer-neutral, and uses the destination CTA's verb.

The deep-link carries a **one-shot `reveal=1` intent** (mirroring the existing `?line=` pattern): on arrival the editor shows the visual pane even for a YAML-only layout (split view on desktop, visual-only on mobile where the split collapses), then consumes the intent and strips the param from the URL. In-memory only, so a reload or the next open keeps the user's saved layout — this addresses the earlier review finding without the re-fires-on-every-reload behavior that got the first reveal removed.

**Recorded decision:**

- **Table lock stays clickable in bulk-select mode** (asymmetric with the card, which falls back to a passive icon there). The table's busy status cell already intercepts row clicks the same way, and `createDeviceColumns` is built from `localize` alone, so threading `selectMode` through the column factory is a structural change out of proportion to the edge; the table follows its existing precedent.

**Related issue or feature (if applicable):**

- No GitHub issue; reported in Discord #general-support (2026-07-30).

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
