### PR TITLE
Create the section block when enabling security on a package config

### DIFF
--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -153,7 +153,13 @@ export function applySectionValues(
  *  unsaved draft (the section has no local block, so the splice can't reach it). */
 function createSectionBlock(host: ESPHomeDeviceSectionConfig): void {
   revalidateFields(host);
-  emitYamlDraft(host, appendSectionToYaml(host.yaml, host.sectionKey, host._values));
+  emitYamlDraft(
+    host,
+    appendSectionToYaml(host.yaml, host.sectionKey, host._values, {
+      // Same serialization semantics as the splice in flushDraft.
+      keepEmptyStrings: KEEP_EMPTY_STRING_SECTIONS.has(host.sectionKey),
+    })
+  );
 }
 
 /**

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -118,23 +118,29 @@ export function applySectionValues(
     host._values = setIn(host._values, path, value);
   }
   host._setDirty(true);
+  // Cancel any pending debounced flush on both paths below — a keystroke
+  // inside the debounce window must not race the deliberate apply.
+  if (host._draftTimer !== null) {
+    clearTimeout(host._draftTimer);
+    host._draftTimer = null;
+  }
   // A map-singleton section supplied only by a `packages:` include (api /
   // web_server, reached via the ?section= deep-link) has no local block to
   // splice into, so the flush below would drop the write. Append a fresh
   // top-level block instead; it deep-merges with the package on compile.
-  // Restricted to map singletons: a dotted platform section (ota.esphome) or a
-  // list-bodied one (globals) needs a list shape / list-merge semantics we
-  // can't assume, so those fall through to the flush (unchanged).
+  // Restricted to map singletons: a dotted platform section (ota.esphome),
+  // a list-bodied one (globals), and a bare platform domain (`sensor:`, also
+  // list-bodied) need a list shape / list-merge semantics we can't assume,
+  // so those fall through to the flush (unchanged).
   const mapSingleton =
-    !isPlatformComponentId(host.sectionKey) && !LIST_SECTIONS.has(host.sectionKey);
+    !isPlatformComponentId(host.sectionKey) &&
+    !LIST_SECTIONS.has(host.sectionKey) &&
+    !host._isPlatformDomain;
   const absent =
     resolveCurrentFromLine(host.yaml, host.sectionKey, host.fromLine) === undefined;
   if (absent && mapSingleton) {
     createSectionBlock(host);
     return;
-  }
-  if (host._draftTimer !== null) {
-    clearTimeout(host._draftTimer);
   }
   flushDraft(host);
 }

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -8,6 +8,7 @@ import {
   resolveSectionEntries,
 } from "../../../util/section-entry-overrides.js";
 import {
+  appendSectionToYaml,
   removeSectionFromYaml,
   updateSectionInYaml,
 } from "../../../util/yaml-section-values.js";
@@ -110,10 +111,38 @@ export function applySectionValues(
     host._values = setIn(host._values, path, value);
   }
   host._setDirty(true);
+  // A map-singleton section supplied only by a `packages:` include (api /
+  // web_server, reached via the ?section= deep-link) has no local block to
+  // splice into, so the flush below would drop the write. Append a fresh
+  // top-level block instead; it deep-merges with the package on compile. A
+  // dotted platform section (ota.esphome) needs list-merge semantics we can't
+  // assume, so it falls through to the flush (unchanged).
+  const absent =
+    resolveCurrentFromLine(host.yaml, host.sectionKey, host.fromLine) === undefined;
+  if (absent && !host.sectionKey.includes(".")) {
+    createSectionBlock(host);
+    return;
+  }
   if (host._draftTimer !== null) {
     clearTimeout(host._draftTimer);
   }
   flushDraft(host);
+}
+
+/** Append a brand-new top-level block for the applied values, surfaced as an
+ *  unsaved draft (the section has no local block, so the splice can't reach it). */
+function createSectionBlock(host: ESPHomeDeviceSectionConfig): void {
+  const basedOn = host.yaml;
+  const newYaml = appendSectionToYaml(basedOn, host.sectionKey, host._values);
+  host._setDirty(false);
+  if (newYaml === basedOn) return;
+  host._lastSelfWrittenYaml = newYaml;
+  fireSectionEvent(host, "yaml-draft", {
+    configuration: host.configuration,
+    yaml: newYaml,
+    basedOn,
+    node: host,
+  });
 }
 
 /**

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -1,10 +1,12 @@
 import { clearPathErrors, validateEntries } from "../../../util/config-validation.js";
+import { isPlatformComponentId } from "../../../util/featured-id.js";
 import { fireEvent } from "../../../util/fire-event.js";
 import { formatApiError } from "../../../util/format-api-error.js";
 import { setIn } from "../../../util/nested-values.js";
 import { notifyError, notifySuccess } from "../../../util/notify.js";
 import {
   KEEP_EMPTY_STRING_SECTIONS,
+  LIST_SECTIONS,
   resolveSectionEntries,
 } from "../../../util/section-entry-overrides.js";
 import {
@@ -59,10 +61,15 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): string | null {
     { keepEmptyStrings: KEEP_EMPTY_STRING_SECTIONS.has(host.sectionKey) }
   );
 
+  return emitYamlDraft(host, newYaml);
+}
+
+/** Clear the dirty flag and, when *newYaml* differs from the live buffer,
+ *  publish it as this element's own `yaml-draft` (tagged via
+ *  `_lastSelfWrittenYaml` so the parent's loop-back is ignored). */
+function emitYamlDraft(host: ESPHomeDeviceSectionConfig, newYaml: string): string | null {
   host._setDirty(false);
-
   if (newYaml === host.yaml) return null;
-
   host._lastSelfWrittenYaml = newYaml;
   fireSectionEvent(host, "yaml-draft", {
     configuration: host.configuration,
@@ -114,12 +121,15 @@ export function applySectionValues(
   // A map-singleton section supplied only by a `packages:` include (api /
   // web_server, reached via the ?section= deep-link) has no local block to
   // splice into, so the flush below would drop the write. Append a fresh
-  // top-level block instead; it deep-merges with the package on compile. A
-  // dotted platform section (ota.esphome) needs list-merge semantics we can't
-  // assume, so it falls through to the flush (unchanged).
+  // top-level block instead; it deep-merges with the package on compile.
+  // Restricted to map singletons: a dotted platform section (ota.esphome) or a
+  // list-bodied one (globals) needs a list shape / list-merge semantics we
+  // can't assume, so those fall through to the flush (unchanged).
+  const mapSingleton =
+    !isPlatformComponentId(host.sectionKey) && !LIST_SECTIONS.has(host.sectionKey);
   const absent =
     resolveCurrentFromLine(host.yaml, host.sectionKey, host.fromLine) === undefined;
-  if (absent && !host.sectionKey.includes(".")) {
+  if (absent && mapSingleton) {
     createSectionBlock(host);
     return;
   }
@@ -132,17 +142,7 @@ export function applySectionValues(
 /** Append a brand-new top-level block for the applied values, surfaced as an
  *  unsaved draft (the section has no local block, so the splice can't reach it). */
 function createSectionBlock(host: ESPHomeDeviceSectionConfig): void {
-  const basedOn = host.yaml;
-  const newYaml = appendSectionToYaml(basedOn, host.sectionKey, host._values);
-  host._setDirty(false);
-  if (newYaml === basedOn) return;
-  host._lastSelfWrittenYaml = newYaml;
-  fireSectionEvent(host, "yaml-draft", {
-    configuration: host.configuration,
-    yaml: newYaml,
-    basedOn,
-    node: host,
-  });
+  emitYamlDraft(host, appendSectionToYaml(host.yaml, host.sectionKey, host._values));
 }
 
 /**

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -30,15 +30,7 @@ import { fireSectionEvent, prepareSectionEvent } from "../section-editor.js";
 export function flushDraft(host: ESPHomeDeviceSectionConfig): string | null {
   host._draftTimer = null;
   if (!host._config) return null;
-
-  const renderEntries = resolveSectionEntries(host.sectionKey, host._config.entries);
-  host._fieldErrors = validateEntries(
-    renderEntries,
-    host._values,
-    host._presentComponents,
-    host.board?.esphome.platform ?? null,
-    host.sectionKey
-  );
+  revalidateFields(host);
 
   const fromLine = resolveCurrentFromLine(host.yaml, host.sectionKey, host.fromLine);
   if (fromLine === undefined) {
@@ -62,6 +54,18 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): string | null {
   );
 
   return emitYamlDraft(host, newYaml);
+}
+
+/** Recompute the section's field errors against the render schema. */
+function revalidateFields(host: ESPHomeDeviceSectionConfig): void {
+  if (!host._config) return;
+  host._fieldErrors = validateEntries(
+    resolveSectionEntries(host.sectionKey, host._config.entries),
+    host._values,
+    host._presentComponents,
+    host.board?.esphome.platform ?? null,
+    host.sectionKey
+  );
 }
 
 /** Clear the dirty flag and, when *newYaml* differs from the live buffer,
@@ -148,6 +152,7 @@ export function applySectionValues(
 /** Append a brand-new top-level block for the applied values, surfaced as an
  *  unsaved draft (the section has no local block, so the splice can't reach it). */
 function createSectionBlock(host: ESPHomeDeviceSectionConfig): void {
+  revalidateFields(host);
   emitYamlDraft(host, appendSectionToYaml(host.yaml, host.sectionKey, host._values));
 }
 

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -316,26 +316,6 @@ function _isInlinableScalar(value: unknown): boolean {
  * avoid a stray `sensor:` that ESPHome rejects, and to keep the
  * resulting YAML tidy.
  */
-/**
- * Append a brand-new top-level *sectionKey* block built from *values*, for a
- * section with no local block to splice into (a component supplied only by a
- * ``packages:`` include). The appended block deep-merges with the package on
- * the next compile. Reuses the splice path's serializer, so a ``!secret ...``
- * value round-trips as an unquoted tag rather than a quoted literal.
- */
-export function appendSectionToYaml(
-  yaml: string,
-  sectionKey: string,
-  values: Record<string, unknown>,
-  options: SerializeYamlOptions = {}
-): string {
-  const block = serializeYamlValues({ [sectionKey]: values }, "", options);
-  if (block.length === 0) return yaml;
-  const base = yaml.replace(/\s+$/, "");
-  const body = block.join("\n");
-  return base ? `${base}\n\n${body}\n` : `${body}\n`;
-}
-
 export function removeSectionFromYaml(
   yaml: string,
   sectionKey: string,
@@ -375,4 +355,24 @@ export function removeSectionFromYaml(
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Append a brand-new top-level *sectionKey* block built from *values*, for a
+ * section with no local block to splice into (a component supplied only by a
+ * ``packages:`` include). The appended block deep-merges with the package on
+ * the next compile. Reuses the splice path's serializer, so a ``!secret ...``
+ * value round-trips as an unquoted tag rather than a quoted literal.
+ */
+export function appendSectionToYaml(
+  yaml: string,
+  sectionKey: string,
+  values: Record<string, unknown>,
+  options: SerializeYamlOptions = {}
+): string {
+  const block = serializeYamlValues({ [sectionKey]: values }, "", options);
+  if (block.length === 0) return yaml;
+  const base = yaml.trimEnd();
+  const body = block.join("\n");
+  return base ? `${base}\n\n${body}\n` : `${body}\n`;
 }

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -25,6 +25,14 @@ import {
   serializeYamlValues,
 } from "./yaml-serialize.js";
 
+/** Any non-whitespace character — a document with none counts as empty. */
+const NON_BLANK_RE = /\S/;
+
+/** Trailing newlines and whitespace-only lines at the document end. Leaves
+ *  trailing spaces on the last content line alone (a block scalar's final
+ *  line may carry meaningful ones). */
+const TRAILING_BLANK_LINES_RE = /(?:\n[ \t]*)+$/;
+
 /**
  * Find the 0-indexed line range [start, end) for a section.
  *
@@ -400,9 +408,7 @@ export function appendSectionToYaml(
     indentStep,
   });
   if (block.length === 0) return yaml;
-  // Trim only trailing newlines / blank lines: trailing spaces on the last
-  // content line survive, while a whitespace-only document counts as empty.
-  const base = /\S/.test(yaml) ? yaml.replace(/(?:\n[ \t]*)+$/, "") : "";
+  const base = NON_BLANK_RE.test(yaml) ? yaml.replace(TRAILING_BLANK_LINES_RE, "") : "";
   const body = block.join("\n");
   return base ? `${base}\n\n${body}\n` : `${body}\n`;
 }

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -316,6 +316,26 @@ function _isInlinableScalar(value: unknown): boolean {
  * avoid a stray `sensor:` that ESPHome rejects, and to keep the
  * resulting YAML tidy.
  */
+/**
+ * Append a brand-new top-level *sectionKey* block built from *values*, for a
+ * section with no local block to splice into (a component supplied only by a
+ * ``packages:`` include). The appended block deep-merges with the package on
+ * the next compile. Reuses the splice path's serializer, so a ``!secret ...``
+ * value round-trips as an unquoted tag rather than a quoted literal.
+ */
+export function appendSectionToYaml(
+  yaml: string,
+  sectionKey: string,
+  values: Record<string, unknown>,
+  options: SerializeYamlOptions = {}
+): string {
+  const block = serializeYamlValues({ [sectionKey]: values }, "", options);
+  if (block.length === 0) return yaml;
+  const base = yaml.replace(/\s+$/, "");
+  const body = block.join("\n");
+  return base ? `${base}\n\n${body}\n` : `${body}\n`;
+}
+
 export function removeSectionFromYaml(
   yaml: string,
   sectionKey: string,

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -357,12 +357,34 @@ export function removeSectionFromYaml(
   return lines.join("\n");
 }
 
+/** Indent of the first indented child line under any top-level key — the
+ *  document's own indent step, so an appended block matches a 4-space file.
+ *  Document-level on purpose: the per-section ``_detectSectionChildIndent``
+ *  can't tell its 2-space fallback from a detected 2-space. ``null`` when no
+ *  key has an indented child (empty doc, flat scalars). */
+function _detectDocumentIndentStep(lines: string[]): string | null {
+  let underKey = false;
+  for (const line of lines) {
+    if (TOP_LEVEL_KEY_START_RE.test(line)) {
+      underKey = true;
+      continue;
+    }
+    if (!underKey || line.trim() === "" || isCommentLine(line)) continue;
+    const indent = _leadingIndent(line);
+    if (indent) return indent;
+    underKey = false; // zero-indented body (column-0 dash); wait for the next key
+  }
+  return null;
+}
+
 /**
  * Append a brand-new top-level *sectionKey* block built from *values*, for a
  * section with no local block to splice into (a component supplied only by a
  * ``packages:`` include). The appended block deep-merges with the package on
  * the next compile. Reuses the splice path's serializer, so a ``!secret ...``
- * value round-trips as an unquoted tag rather than a quoted literal.
+ * value round-trips as an unquoted tag rather than a quoted literal; the
+ * indent step follows the document's own. Trailing blank lines collapse to
+ * one separator blank line.
  */
 export function appendSectionToYaml(
   yaml: string,
@@ -370,7 +392,12 @@ export function appendSectionToYaml(
   values: Record<string, unknown>,
   options: SerializeYamlOptions = {}
 ): string {
-  const block = serializeYamlValues({ [sectionKey]: values }, "", options);
+  const indentStep =
+    options.indentStep ?? _detectDocumentIndentStep(yaml.split("\n")) ?? undefined;
+  const block = serializeYamlValues({ [sectionKey]: values }, "", {
+    ...options,
+    indentStep,
+  });
   if (block.length === 0) return yaml;
   const base = yaml.trimEnd();
   const body = block.join("\n");

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -384,7 +384,8 @@ function _detectDocumentIndentStep(lines: string[]): string | null {
  * the next compile. Reuses the splice path's serializer, so a ``!secret ...``
  * value round-trips as an unquoted tag rather than a quoted literal; the
  * indent step follows the document's own. Trailing blank lines collapse to
- * one separator blank line.
+ * one separator blank line; trailing spaces on the last content line are
+ * kept (a block scalar's final line may carry meaningful ones).
  */
 export function appendSectionToYaml(
   yaml: string,
@@ -399,7 +400,9 @@ export function appendSectionToYaml(
     indentStep,
   });
   if (block.length === 0) return yaml;
-  const base = yaml.trimEnd();
+  // Trim only trailing newlines / blank lines: trailing spaces on the last
+  // content line survive, while a whitespace-only document counts as empty.
+  const base = /\S/.test(yaml) ? yaml.replace(/(?:\n[ \t]*)+$/, "") : "";
   const body = block.join("\n");
   return base ? `${base}\n\n${body}\n` : `${body}\n`;
 }

--- a/test/components/device/section-config-apply-values.test.ts
+++ b/test/components/device/section-config-apply-values.test.ts
@@ -110,4 +110,13 @@ describe("applySectionValues — package-provided section has no local block", (
     // No local ota block to splice and no map-singleton append path → dropped.
     expect(drafts).toHaveLength(0);
   });
+
+  it("leaves a list-bodied section (globals) to the flush (wrong shape to append)", () => {
+    const { c, drafts } = host("globals", PACKAGE_YAML, undefined, {});
+
+    applySectionValues(c, [{ path: ["id"], value: "x" }]);
+    // globals is a YAML list, not a map singleton — appending a map block would
+    // be malformed, so it is not created here.
+    expect(drafts).toHaveLength(0);
+  });
 });

--- a/test/components/device/section-config-apply-values.test.ts
+++ b/test/components/device/section-config-apply-values.test.ts
@@ -14,12 +14,18 @@ import { ESPHomeDeviceSectionConfig } from "../../../src/components/device/devic
 import { applySectionValues } from "../../../src/components/device/device-section-config/draft-and-delete.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-function host(sectionKey: string, yaml: string, fromLine: number, values: object) {
+function host(
+  sectionKey: string,
+  yaml: string,
+  fromLine: number | undefined,
+  values: object
+) {
   const c = new ESPHomeDeviceSectionConfig();
   const inner = c as any;
   inner.yaml = yaml;
   inner.sectionKey = sectionKey;
   inner.fromLine = fromLine;
+  inner.configuration = "dev.yaml";
   inner._config = { entries: [] };
   inner._presentComponents = new Set<string>();
   inner._values = values;
@@ -60,5 +66,48 @@ describe("applySectionValues — ethernet clk_mode migration", () => {
     // Untouched siblings survive the splice.
     expect(drafts[0]).toContain("mdc_pin: GPIO23");
     expect(drafts[0]).toContain("phy_addr: 0");
+  });
+});
+
+describe("applySectionValues — package-provided section has no local block", () => {
+  // api from a `packages:` include: no local `api:` key, so the splice can't
+  // reach it. Enabling encryption must append a fresh block so it merges with
+  // the package instead of silently dropping the write.
+  const PACKAGE_YAML = "packages:\n  x: github://a/b\nwifi:\n  ssid: !secret s\n";
+
+  it("appends a new top-level block with an unquoted !secret tag", () => {
+    const { c, drafts } = host("api", PACKAGE_YAML, undefined, {});
+
+    applySectionValues(c, [{ path: ["encryption", "key"], value: "!secret k" }]);
+
+    expect(drafts).toHaveLength(1);
+    // Prior content is preserved, and the block is appended (not spliced).
+    expect(drafts[0]).toContain("packages:");
+    expect(drafts[0]).toContain("api:");
+    expect(drafts[0]).toContain("encryption:");
+    // The secret round-trips as a real tag, not a quoted literal string.
+    expect(drafts[0]).toContain("key: !secret k");
+    expect(drafts[0]).not.toContain('"!secret k"');
+  });
+
+  it("splices into an existing local block (no new top-level key)", () => {
+    const yaml = "api:\n  reboot_timeout: 0s\n";
+    const { c, drafts } = host("api", yaml, 1, { reboot_timeout: "0s" });
+
+    applySectionValues(c, [{ path: ["encryption", "key"], value: "!secret k" }]);
+
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0]).toContain("key: !secret k");
+    expect(drafts[0]).toContain("reboot_timeout: 0s");
+    // Spliced into the one api block, not a second appended api:.
+    expect(drafts[0].match(/^api:/gm) ?? []).toHaveLength(1);
+  });
+
+  it("leaves a dotted platform section (ota.esphome) to the flush (no block appended)", () => {
+    const { c, drafts } = host("ota.esphome", PACKAGE_YAML, undefined, {});
+
+    applySectionValues(c, [{ path: ["password"], value: "!secret p" }]);
+    // No local ota block to splice and no map-singleton append path → dropped.
+    expect(drafts).toHaveLength(0);
   });
 });

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -3549,4 +3549,12 @@ describe("appendSectionToYaml", () => {
       "api:\n  reboot_timeout: 0s\n"
     );
   });
+
+  it("keeps trailing spaces on the last content line (block-scalar tail)", () => {
+    const yaml = "esphome:\n  comment: |\n    line with trailing spaces  \n";
+    const after = appendSectionToYaml(yaml, "api", { reboot_timeout: "0s" });
+    expect(after).toBe(
+      "esphome:\n  comment: |\n    line with trailing spaces  \n\napi:\n  reboot_timeout: 0s\n"
+    );
+  });
 });

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -6,6 +6,7 @@ import {
   parseYamlSectionValues,
 } from "../../src/util/yaml-section-reader.js";
 import {
+  appendSectionToYaml,
   removeSectionFromYaml,
   updateSectionInYaml,
 } from "../../src/util/yaml-section-values.js";
@@ -3512,5 +3513,40 @@ describe("updateSectionInYaml — nested flow lists keep style and comment (#138
     expect(after).toContain("glyphs: [x, y] # icons");
     expect(after).toContain("file: c.ttf");
     expect(after).toContain("glyphs: [z]");
+  });
+});
+
+describe("appendSectionToYaml", () => {
+  it("appends a full block after one separator blank line (exact layout)", () => {
+    const yaml = "wifi:\n  ssid: !secret wifi_ssid\n\n\n";
+    const after = appendSectionToYaml(yaml, "api", {
+      encryption: { key: "!secret my_key" },
+    });
+    // Trailing blank lines collapse to the single separator; the !secret
+    // tag emits unquoted.
+    expect(after).toBe(
+      "wifi:\n  ssid: !secret wifi_ssid\n\napi:\n  encryption:\n    key: !secret my_key\n"
+    );
+  });
+
+  it("matches the document's 4-space indent step", () => {
+    const yaml = "wifi:\n    ssid: home\n";
+    const after = appendSectionToYaml(yaml, "api", {
+      encryption: { key: "!secret my_key" },
+    });
+    expect(after).toBe(
+      "wifi:\n    ssid: home\n\napi:\n    encryption:\n        key: !secret my_key\n"
+    );
+  });
+
+  it("returns the input unchanged when every value serializes empty", () => {
+    const yaml = "wifi:\n  ssid: home\n";
+    expect(appendSectionToYaml(yaml, "api", { encryption: { key: "" } })).toBe(yaml);
+  });
+
+  it("emits just the block for an empty document", () => {
+    expect(appendSectionToYaml("", "api", { reboot_timeout: "0s" })).toBe(
+      "api:\n  reboot_timeout: 0s\n"
+    );
   });
 });

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -3557,4 +3557,18 @@ describe("appendSectionToYaml", () => {
       "esphome:\n  comment: |\n    line with trailing spaces  \n\napi:\n  reboot_timeout: 0s\n"
     );
   });
+
+  it("skips a column-0 dash body when detecting the indent step", () => {
+    // The dash item's 2-space child must not be read as the document step;
+    // the next key's real child indent (4-space) wins.
+    const yaml = "sensor:\n- platform: dht\n  pin: D1\nwifi:\n    ssid: y\n";
+    const after = appendSectionToYaml(yaml, "api", { reboot_timeout: "0s" });
+    expect(after).toBe(`${yaml}\napi:\n    reboot_timeout: 0s\n`);
+  });
+
+  it("falls back to the canonical step when only column-0 dash bodies exist", () => {
+    const yaml = "sensor:\n- platform: dht\n  pin: D1\n";
+    const after = appendSectionToYaml(yaml, "api", { reboot_timeout: "0s" });
+    expect(after).toBe(`${yaml}\napi:\n  reboot_timeout: 0s\n`);
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Enabling a security setting whose component is supplied **only by a `packages:` include** did nothing. For a config like Athom's, where `api:` comes from a github package and there is no local `api:` block, clicking the editor's "Enable encryption" CTA wrote the Noise key to `secrets.yaml` but the `api: encryption: key:` never landed in the device YAML. Configs with a local `api:` block worked.

Root cause: the security notice fires `apply-section-values` → `applySectionValues`, which sets the value into the section's draft then flushes. The flush resolves the section's line in the **local** YAML; for a package-provided section that resolves to nothing, so both `flushDraft` and `updateSectionInYaml` no-op and the write is silently dropped. There was no "create a new top-level block" path.

Fix: when the applied section is a map-singleton (`api`, `web_server`) with no local block, append a fresh top-level block for the applied values instead of dropping it. It deep-merges with the package on the next compile. The block is built with the same serializer the splice path already uses, so a `!secret …` value round-trips as an unquoted YAML tag rather than a quoted literal string (a quoted `"!secret …"` would not resolve the secret). A new `appendSectionToYaml` helper in `yaml-section-values.ts` owns the append.

Scope: this is the explicit notice-apply path only. A dotted platform section (`ota.esphome`) needs list-merge semantics that aren't safe to assume for a package config, so it is left to the existing flush (unchanged). Per-keystroke edits of a package section are also out of scope (the debounced flush can't tell create-intent from the section-removed-mid-edit race it guards against).

In practice this state is reached via the section deep-link (a package-only section isn't listed by the navigator, which reads local top-level keys), so this pairs with the "Not encrypted" pill deep-link work.

Verified end-to-end on a live Athom package config: the deep-link opens the api section, "Enable encryption" appends

```yaml
api:
  encryption:
    key: !secret athom_co2_sensor_6061a4__encryption_key
```

(unquoted tag), preserving the package and other sections. Unit tests pin the append (unquoted `!secret`, content preserved), the local-block splice (no regression, no duplicate `api:`), and the dotted-section drop.

Note: the backend `devices/add_component` path quotes `!secret` values (`key: "!secret …"`), which is why this fix serializes on the frontend rather than routing through it; that backend quoting is a separate bug addressed in its own PR.

**Related issue or feature (if applicable):**

- No GitHub issue; found while testing the encryption deep-link.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
