### PR TITLE
Drop "Save and" from the security-applied toast

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1003,7 +1003,7 @@
     "load_config_error": "Failed to load section config",
     "yaml_only_section": "This section doesn't have a structured editor — edit it directly in the YAML pane on the right.",
     "security_generate": "Generate",
-    "security_applied": "Save and install the device to apply the new credentials.",
+    "security_applied": "Install the device to apply the new credentials.",
     "api_encryption_notice": "API is enabled without encryption. Anyone on your network can read or control this device.",
     "api_encryption_enable": "Enable encryption",
     "api_encryption_dialog_title": "Enable API encryption",


### PR DESCRIPTION
# What does this implement/fix?

The Enable-encryption success toast said "Save and install the device to apply the new credentials." Install already runs a save first, so telling the user to save as a separate step is misleading. The toast now reads "Install the device to apply the new credentials."

**Related issue or feature (if applicable):**

- No issue; user-reported while testing the encryption flow.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
