### PR TITLE
Select a board-curated component after adding it

### DIFF
--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -14,7 +14,11 @@ import { exclusiveBusTarget } from "../../util/bus-availability.js";
 import type { BusPrefill } from "../../util/bus-constraint-prefill.js";
 import { collectExistingIds } from "../../util/default-component-id.js";
 import { DialogOpenController } from "../../util/dialog-open-controller.js";
-import { buildFeaturedId, isFeaturedId } from "../../util/featured-id.js";
+import {
+  buildFeaturedId,
+  isFeaturedId,
+  resolveFeaturedComponentId,
+} from "../../util/featured-id.js";
 import { fireEvent } from "../../util/fire-event.js";
 import { formatApiError } from "../../util/format-api-error.js";
 import { notifyError, notifySuccess } from "../../util/notify.js";
@@ -566,6 +570,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._depNavSeq++;
     let draft = this.yaml || undefined;
     let lastAdded: { domain: string; id: string } | null = null;
+    // The last member this run actually merged, for the closing select.
+    // A member skipped as already present isn't one the user just added,
+    // so it deliberately doesn't count.
+    let lastMerged: { componentId: string; instanceId?: string } | null = null;
     let addedAny = false;
     // Every exit that merged anything publishes the same draft; the
     // per-exit comments explain why each one publishes.
@@ -654,6 +662,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
         );
         draft = yaml;
         addedAny = true;
+        lastMerged = {
+          componentId: resolveFeaturedComponentId(fullIds[i], this.board),
+          instanceId: typeof memberId === "string" ? memberId : undefined,
+        };
         if (typeof memberId === "string") existingIds.add(memberId);
         // Keep `this.yaml` current so the next member's dep check + reference
         // dropdown see what this batch already added; the host draft is
@@ -662,6 +674,17 @@ export class ESPHomeAddComponentDialog extends LitElement {
         lastAdded = this._chainReference(entry, fields);
       }
       publishDraft();
+      // Land on the last member merged, so a bundle leaves the editor on
+      // what it added rather than wherever the user happened to be. Same
+      // guarded shape as the single add: no target, no navigation.
+      if (lastMerged) {
+        const target = findAddedSection(
+          this.yaml,
+          lastMerged.componentId,
+          lastMerged.instanceId
+        );
+        if (target) fireEvent(this, "section-select", target);
+      }
       this._dialog.open = false;
       this._selected = null;
       this._resetDetourState();
@@ -881,7 +904,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
         // Falls through silently if we can't find it — better to
         // leave the previous selection alone than navigate somewhere
         // wrong.
-        const componentId = this._selected.id;
+        // Resolved first: a board-curated entry's catalog id is the
+        // synthetic `featured.<board>.<local>`, which matches no section
+        // key, so the lookup found nothing and the editor stayed put.
+        const componentId = resolveFeaturedComponentId(this._selected.id, this.board);
         const componentName = this._selected.name;
         const newId = fields["id"];
         const target = findAddedSection(

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -724,7 +724,17 @@ export class ESPHomeAddComponentDialog extends LitElement {
         resolveFeaturedComponentId(added.componentId, board),
         added.instanceId
       );
-      if (target) fireEvent(this, "section-select", target);
+      if (target) {
+        const { sectionKey, fromLine, toLine } = target;
+        fireEvent(this, "section-select", { sectionKey, fromLine });
+        // Both events, as a navigator click sends: `section-select` moves
+        // the navigator and the form, and only `yaml-highlight` scrolls the
+        // YAML pane to the block.
+        fireEvent(this, "yaml-highlight", {
+          range: { fromLine, toLine },
+          scroll: true,
+        });
+      }
     }
     this._dialog.open = false;
     this._selected = null;

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -17,6 +17,7 @@ import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import {
   buildFeaturedId,
   featuredEntryForId,
+  isFeaturedId,
   resolveFeaturedComponentId,
 } from "../../util/featured-id.js";
 import { fireEvent } from "../../util/fire-event.js";
@@ -719,11 +720,16 @@ export class ESPHomeAddComponentDialog extends LitElement {
    */
   private _selectAndClose(added: AddedBlock | null, board: BoardCatalogEntry | null) {
     if (added) {
-      const target = findAddedSection(
-        added.yaml,
-        resolveFeaturedComponentId(added.componentId, board),
-        added.instanceId
-      );
+      const componentId = resolveFeaturedComponentId(added.componentId, board);
+      // A featured id the board can't resolve is a catalog bug in this same
+      // (lockstep) release: it can never match a section key, so the jump
+      // below is skipped with nothing else to show for it.
+      if (isFeaturedId(componentId)) {
+        console.warn(
+          `Board carries no featured entry for '${componentId}'; skipping the post-add jump.`
+        );
+      }
+      const target = findAddedSection(added.yaml, componentId, added.instanceId);
       if (target) {
         const { sectionKey, fromLine, toLine } = target;
         fireEvent(this, "section-select", { sectionKey, fromLine });

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -558,6 +558,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // slip the merged draft past the page's identity guard.
     const configuration = this.configuration;
     const baseYaml = this.yaml;
+    // Resolves each member's id below. A board that no longer matches the
+    // one these ids were built from simply won't match in the resolver, so
+    // a swap costs the navigation rather than aiming it somewhere wrong.
+    const board = this.board;
     const fullIds = bundle.component_ids.map((localId) =>
       buildFeaturedId(boardId, localId)
     );
@@ -663,7 +667,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
         draft = yaml;
         addedAny = true;
         lastMerged = {
-          componentId: resolveFeaturedComponentId(fullIds[i], this.board),
+          componentId: resolveFeaturedComponentId(fullIds[i], board),
           instanceId: typeof memberId === "string" ? memberId : undefined,
         };
         if (typeof memberId === "string") existingIds.add(memberId);
@@ -679,7 +683,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
       // guarded shape as the single add: no target, no navigation.
       if (lastMerged) {
         const target = findAddedSection(
-          this.yaml,
+          draft ?? this.yaml,
           lastMerged.componentId,
           lastMerged.instanceId
         );
@@ -794,9 +798,12 @@ export class ESPHomeAddComponentDialog extends LitElement {
    */
   private async _submitComponent(fields: Record<string, unknown>, notify = false) {
     if (!this._selected || !this.configuration || this._submitting) return;
-    // Same pre-await target and basis snapshot as the bundle flow.
+    // Same pre-await target and basis snapshot as the bundle flow. `board`
+    // rides along: it resolves the added id below and is a host-owned prop
+    // a device switch mid-round-trip would rebind.
     const configuration = this.configuration;
     const baseYaml = this.yaml;
+    const board = this.board;
     this._submitting = true;
     this._submitError = "";
     // Invalidate any in-flight dep-nav lookup — a late resolve must
@@ -907,7 +914,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
         // Resolved first: a board-curated entry's catalog id is the
         // synthetic `featured.<board>.<local>`, which matches no section
         // key, so the lookup found nothing and the editor stayed put.
-        const componentId = resolveFeaturedComponentId(this._selected.id, this.board);
+        const componentId = resolveFeaturedComponentId(this._selected.id, board);
         const componentName = this._selected.name;
         const newId = fields["id"];
         const target = findAddedSection(

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -16,7 +16,7 @@ import { collectExistingIds } from "../../util/default-component-id.js";
 import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import {
   buildFeaturedId,
-  isFeaturedId,
+  featuredEntryForId,
   resolveFeaturedComponentId,
 } from "../../util/featured-id.js";
 import { fireEvent } from "../../util/fire-event.js";
@@ -50,6 +50,17 @@ import "./add-component-form.js";
 import type { ESPHomeAddComponentForm } from "./add-component-form.js";
 import "./component-catalog.js";
 import type { ESPHomeComponentCatalog } from "./component-catalog.js";
+
+/** A block just merged into the YAML, for the post-add lookup. */
+interface AddedBlock {
+  /** The YAML the merge returned, pinned so a host re-binding `yaml` can't
+   *  reorder what the lookup reads. */
+  yaml: string;
+  /** Catalog id, still in its raw `featured.<board>.<local>` form when the
+   *  entry is board-curated; `_selectAndClose` resolves it. */
+  componentId: string;
+  instanceId?: string;
+}
 
 registerMdiIcons({
   close: mdiClose,
@@ -424,9 +435,9 @@ export class ESPHomeAddComponentDialog extends LitElement {
     entry: ComponentCatalogEntry
   ): { boardId: string; missing: string[]; unresolved: string[] } | null {
     const board = this.board;
-    if (!board || !isFeaturedId(entry.id)) return null;
+    if (!board) return null;
     const featured = board.featured_components ?? [];
-    const fc = featured.find((c) => buildFeaturedId(board.id, c.id) === entry.id);
+    const fc = featuredEntryForId(entry.id, board);
     if (!fc?.requires?.length) return null;
     const existingIds = collectExistingIds(this.yaml);
     const missing: string[] = [];
@@ -574,10 +585,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._depNavSeq++;
     let draft = this.yaml || undefined;
     let lastAdded: { domain: string; id: string } | null = null;
-    // The last member this run actually merged, for the closing select.
-    // A member skipped as already present isn't one the user just added,
-    // so it deliberately doesn't count.
-    let lastMerged: { componentId: string; instanceId?: string } | null = null;
+    // The last member this run actually merged, for the closing select. One
+    // skipped as already present isn't what the user just added, so it
+    // deliberately doesn't count.
+    let lastMerged: AddedBlock | null = null;
     let addedAny = false;
     // Every exit that merged anything publishes the same draft; the
     // per-exit comments explain why each one publishes.
@@ -654,8 +665,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
         // still be re-added — a rarer path, scoped out alongside the
         // create-wizard ``_applyFullSetup`` follow-up and backstopped by
         // ESPHome's global id uniqueness.
-        const memberId = fields["id"];
-        if (typeof memberId === "string" && existingIds.has(memberId)) {
+        const memberId = typeof fields["id"] === "string" ? fields["id"] : undefined;
+        if (memberId && existingIds.has(memberId)) {
           lastAdded = this._chainReference(entry, fields);
           continue;
         }
@@ -666,11 +677,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
         );
         draft = yaml;
         addedAny = true;
-        lastMerged = {
-          componentId: resolveFeaturedComponentId(fullIds[i], board),
-          instanceId: typeof memberId === "string" ? memberId : undefined,
-        };
-        if (typeof memberId === "string") existingIds.add(memberId);
+        lastMerged = { yaml, componentId: fullIds[i], instanceId: memberId };
+        if (memberId) existingIds.add(memberId);
         // Keep `this.yaml` current so the next member's dep check + reference
         // dropdown see what this batch already added; the host draft is
         // published once at the end rather than churning the editor per member.
@@ -678,20 +686,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
         lastAdded = this._chainReference(entry, fields);
       }
       publishDraft();
-      // Land on the last member merged, so a bundle leaves the editor on
-      // what it added rather than wherever the user happened to be. Same
-      // guarded shape as the single add: no target, no navigation.
-      if (lastMerged) {
-        const target = findAddedSection(
-          draft ?? this.yaml,
-          lastMerged.componentId,
-          lastMerged.instanceId
-        );
-        if (target) fireEvent(this, "section-select", target);
-      }
-      this._dialog.open = false;
-      this._selected = null;
-      this._resetDetourState();
+      // Land on the last member merged rather than wherever the user was.
+      this._selectAndClose(lastMerged, board);
       // Every member already present is a no-op; don't claim we "Added" it.
       const message = addedAny
         ? this._localize("device.bundle_added", { name: bundle.name })
@@ -711,6 +707,28 @@ export class ESPHomeAddComponentDialog extends LitElement {
     } finally {
       this._submitting = false;
     }
+  }
+
+  /**
+   * Land the editor on the block just added, then close. A board-curated
+   * entry's catalog id is the synthetic `featured.<board>.<local>`, which
+   * matches no section key, so it is resolved before the lookup. Selecting
+   * before the close keeps the event in the tree; an unlocatable block
+   * leaves the previous selection alone rather than navigating somewhere
+   * wrong.
+   */
+  private _selectAndClose(added: AddedBlock | null, board: BoardCatalogEntry | null) {
+    if (added) {
+      const target = findAddedSection(
+        added.yaml,
+        resolveFeaturedComponentId(added.componentId, board),
+        added.instanceId
+      );
+      if (target) fireEvent(this, "section-select", target);
+    }
+    this._dialog.open = false;
+    this._selected = null;
+    this._resetDetourState();
   }
 
   /** Surface the merged YAML as an unsaved editor draft (host saves explicitly). */
@@ -906,28 +924,16 @@ export class ESPHomeAddComponentDialog extends LitElement {
         this._returnValues = null;
         this._selected = nextComponent;
       } else {
-        // Auto-select the just-added component so the navigator
-        // highlights it and the section editor jumps to its block.
-        // Falls through silently if we can't find it — better to
-        // leave the previous selection alone than navigate somewhere
-        // wrong.
-        // Resolved first: a board-curated entry's catalog id is the
-        // synthetic `featured.<board>.<local>`, which matches no section
-        // key, so the lookup found nothing and the editor stayed put.
-        const componentId = resolveFeaturedComponentId(this._selected.id, board);
         const componentName = this._selected.name;
         const newId = fields["id"];
-        const target = findAddedSection(
-          yaml,
-          componentId,
-          typeof newId === "string" ? newId : undefined
+        this._selectAndClose(
+          {
+            yaml,
+            componentId: this._selected.id,
+            instanceId: typeof newId === "string" ? newId : undefined,
+          },
+          board
         );
-        if (target) {
-          fireEvent(this, "section-select", target);
-        }
-        this._dialog.open = false;
-        this._selected = null;
-        this._resetDetourState();
         // Configless add skipped the form, so the close is the only
         // signal the add happened — toast to confirm.
         if (notify) {

--- a/src/util/featured-id.ts
+++ b/src/util/featured-id.ts
@@ -64,8 +64,8 @@ export function featuredDisplayName(fc: FeaturedComponent, fallback: string): st
   return fallback;
 }
 
-/** The board's featured entry a catalog id names, or null when the id isn't
- *  featured or the board doesn't carry it. */
+/** The featured entry a catalog id refers to; null when the id isn't a
+ *  featured one, or the board doesn't carry it. */
 export function featuredEntryForId<T extends { id: string; component_id: string }>(
   id: string,
   board: { id: string; featured_components?: ReadonlyArray<T> } | null

--- a/src/util/featured-id.ts
+++ b/src/util/featured-id.ts
@@ -64,14 +64,24 @@ export function featuredDisplayName(fc: FeaturedComponent, fallback: string): st
   return fallback;
 }
 
+/** The board's featured entry a catalog id names, or null when the id isn't
+ *  featured or the board doesn't carry it. */
+export function featuredEntryForId<T extends { id: string; component_id: string }>(
+  id: string,
+  board: { id: string; featured_components?: ReadonlyArray<T> } | null
+): T | null {
+  if (!board || !isFeaturedId(id)) return null;
+  return (
+    (board.featured_components ?? []).find(
+      (c) => buildFeaturedId(board.id, c.id) === id
+    ) ?? null
+  );
+}
+
 /** Resolve a featured catalog id to the component it actually adds; non-featured or unknown ids pass through. */
 export function resolveFeaturedComponentId(
   id: string,
   board: FeaturedIdBoard | null
 ): string {
-  if (!board || !isFeaturedId(id)) return id;
-  const fc = (board.featured_components ?? []).find(
-    (c) => buildFeaturedId(board.id, c.id) === id
-  );
-  return fc?.component_id ?? id;
+  return featuredEntryForId(id, board)?.component_id ?? id;
 }

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -125,14 +125,15 @@ export function findAddedSection(
   yaml: string,
   componentId: string,
   newId: string | undefined
-): { sectionKey: string; fromLine: number } | null {
+): { sectionKey: string; fromLine: number; toLine: number } | null {
   const sections = parseYamlTopLevelSections(yaml);
 
   // Top-level (non-platform) component — match the bare key, e.g.
   // adding "wifi" navigates to the `wifi:` block.
   if (!componentId.includes(".")) {
     const match = _topLevelBlockByKey(sections, componentId);
-    if (match) return { sectionKey: match.key, fromLine: match.fromLine };
+    if (match)
+      return { sectionKey: match.key, fromLine: match.fromLine, toLine: match.toLine };
   }
 
   // Platform-based component — find the list item(s) under the parent
@@ -143,6 +144,7 @@ export function findAddedSection(
     return {
       sectionKey: sectionKeyOf(candidates[0]),
       fromLine: candidates[0].fromLine,
+      toLine: candidates[0].toLine,
     };
   }
 
@@ -156,7 +158,7 @@ export function findAddedSection(
     for (const s of candidates) {
       for (let i = s.fromLine - 1; i < s.toLine && i < lines.length; i++) {
         if (idRe.test(lines[i])) {
-          return { sectionKey: sectionKeyOf(s), fromLine: s.fromLine };
+          return { sectionKey: sectionKeyOf(s), fromLine: s.fromLine, toLine: s.toLine };
         }
       }
     }
@@ -165,7 +167,7 @@ export function findAddedSection(
   // Last resort: pick the candidate that appears latest in the file.
   // The backend typically appends, so the new one is at the bottom.
   const last = candidates[candidates.length - 1];
-  return { sectionKey: sectionKeyOf(last), fromLine: last.fromLine };
+  return { sectionKey: sectionKeyOf(last), fromLine: last.fromLine, toLine: last.toLine };
 }
 
 /**

--- a/test/components/device/_add-component-dialog-host.ts
+++ b/test/components/device/_add-component-dialog-host.ts
@@ -6,10 +6,10 @@ import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-co
 /**
  * A dialog wired to a stub API so the submit / bundle / detour paths run.
  *
- * Suites type the returned `d` with their own `Internals`, since which
- * privates each one reaches for legitimately differs. Every caller must
- * still `vi.mock` the form, the catalog and sonner-js at module scope —
- * those have to run before the import and so can't live here.
+ * Each suite supplies its own `Internals` type for `d`, because they
+ * legitimately reach for different privates. Callers must still `vi.mock`
+ * the form, the catalog and sonner-js at module scope: those run before
+ * the import, so they can't live here.
  */
 export function makeAddComponentDialogHost<I>(
   options: {

--- a/test/components/device/_add-component-dialog-host.ts
+++ b/test/components/device/_add-component-dialog-host.ts
@@ -17,7 +17,6 @@ export function makeAddComponentDialogHost<I>(
     /** What the stubbed `addComponent` resolves to. */
     mergedYaml?: string;
     board?: BoardCatalogEntry | null;
-    open?: boolean;
   } = {}
 ) {
   const addComponent = vi
@@ -31,9 +30,6 @@ export function makeAddComponentDialogHost<I>(
   dialog.configuration = "foo.yaml";
   dialog.yaml = options.yaml ?? "esphome:\n  name: foo\n";
   if (options.board !== undefined) dialog.board = options.board;
-  if (options.open) {
-    (dialog as unknown as { _dialog: { open: boolean } })._dialog.open = true;
-  }
   return {
     dialog,
     d: dialog as unknown as I,

--- a/test/components/device/_add-component-dialog-host.ts
+++ b/test/components/device/_add-component-dialog-host.ts
@@ -1,0 +1,43 @@
+import { vi } from "vitest";
+
+import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
+import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
+
+/**
+ * A dialog wired to a stub API so the submit / bundle / detour paths run.
+ *
+ * Suites type the returned `d` with their own `Internals`, since which
+ * privates each one reaches for legitimately differs. Every caller must
+ * still `vi.mock` the form, the catalog and sonner-js at module scope —
+ * those have to run before the import and so can't live here.
+ */
+export function makeAddComponentDialogHost<I>(
+  options: {
+    yaml?: string;
+    /** What the stubbed `addComponent` resolves to. */
+    mergedYaml?: string;
+    board?: BoardCatalogEntry | null;
+    open?: boolean;
+  } = {}
+) {
+  const addComponent = vi
+    .fn()
+    .mockResolvedValue({ yaml: options.mergedYaml ?? "MERGED" });
+  const getComponentBodies = vi.fn().mockResolvedValue({});
+  const dialog = new ESPHomeAddComponentDialog();
+  Object.assign(dialog as unknown as Record<string, unknown>, {
+    _api: { addComponent, getComponentBodies },
+  });
+  dialog.configuration = "foo.yaml";
+  dialog.yaml = options.yaml ?? "esphome:\n  name: foo\n";
+  if (options.board !== undefined) dialog.board = options.board;
+  if (options.open) {
+    (dialog as unknown as { _dialog: { open: boolean } })._dialog.open = true;
+  }
+  return {
+    dialog,
+    d: dialog as unknown as I,
+    addComponent,
+    getComponentBodies,
+  };
+}

--- a/test/components/device/add-component-dialog-bundle.test.ts
+++ b/test/components/device/add-component-dialog-bundle.test.ts
@@ -17,9 +17,9 @@ vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
 import toast from "sonner-js";
 
 import { ComponentCategory } from "../../../src/api/types/components.js";
-import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
+import { makeAddComponentDialogHost } from "./_add-component-dialog-host.js";
 
 interface Internals {
   _dialog: { open: boolean };
@@ -34,17 +34,7 @@ interface Internals {
   _onBundleSelected: (e: CustomEvent) => Promise<void>;
 }
 
-function makeDialog() {
-  const addComponent = vi.fn().mockResolvedValue({ yaml: "MERGED" });
-  const getComponentBodies = vi.fn().mockResolvedValue({});
-  const dialog = new ESPHomeAddComponentDialog();
-  Object.assign(dialog as unknown as Record<string, unknown>, {
-    _api: { addComponent, getComponentBodies },
-  });
-  dialog.configuration = "foo.yaml";
-  dialog.yaml = "esphome:\n  name: foo\n";
-  return { dialog, d: dialog as unknown as Internals, addComponent, getComponentBodies };
-}
+const makeDialog = () => makeAddComponentDialogHost<Internals>();
 
 function bundleEvent(componentIds: string[], boardId = "bd") {
   return new CustomEvent("add-bundle", {

--- a/test/components/device/add-component-dialog-restore-values.test.ts
+++ b/test/components/device/add-component-dialog-restore-values.test.ts
@@ -15,9 +15,9 @@ vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
 vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
 
 import { ComponentCategory } from "../../../src/api/types/components.js";
-import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
+import { makeAddComponentDialogHost } from "./_add-component-dialog-host.js";
 
 interface Internals {
   _returnTo: unknown;
@@ -34,18 +34,7 @@ interface Internals {
   _resetDetourState: () => void;
 }
 
-/** Dialog wired with a stub API so `_submitComponent`/detour paths run. */
-function makeDialog() {
-  const addComponent = vi.fn().mockResolvedValue({ yaml: "MERGED" });
-  const getComponentBodies = vi.fn().mockResolvedValue({});
-  const dialog = new ESPHomeAddComponentDialog();
-  Object.assign(dialog as unknown as Record<string, unknown>, {
-    _api: { addComponent, getComponentBodies },
-  });
-  dialog.configuration = "foo.yaml";
-  dialog.yaml = "esphome:\n  name: foo\n";
-  return { d: dialog as unknown as Internals, addComponent, getComponentBodies };
-}
+const makeDialog = () => makeAddComponentDialogHost<Internals>();
 
 /** Override the `@query` `_form` getter for capture tests. */
 function setForm(

--- a/test/components/device/add-component-dialog-select.test.ts
+++ b/test/components/device/add-component-dialog-select.test.ts
@@ -133,6 +133,44 @@ describe("add-component-dialog selects what it added", () => {
     expect(seen).toEqual([{ sectionKey: "binary_sensor.gpio", fromLine: 8 }]);
   });
 
+  it("warns when the board can't resolve a featured id", async () => {
+    // An unresolvable featured id can never match a section key, so the jump
+    // is skipped; without a warning that is indistinguishable in production
+    // from the bug this PR fixes.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { dialog, d } = makeDialog();
+    d._selected = makeComponentEntry("featured.apollo-esk-1.unknown", {
+      name: "Mystery",
+      category: ComponentCategory.BINARY_SENSOR,
+    });
+    const seen = capture(dialog);
+
+    await d._submitComponent({ id: "boot_button" }, true);
+
+    expect(seen).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("featured.apollo-esk-1.unknown")
+    );
+    warn.mockRestore();
+  });
+
+  it("stays quiet when a resolved id simply isn't in the YAML", async () => {
+    // Resolution worked; the section is genuinely absent. Nothing to report.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { dialog, d } = makeDialog();
+    d._selected = makeComponentEntry("featured.apollo-esk-1.led", {
+      name: "LED",
+      category: ComponentCategory.LIGHT,
+    });
+    const seen = capture(dialog);
+
+    await d._submitComponent({ id: "led" }, true);
+
+    expect(seen).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   // Better to stay put than navigate somewhere wrong. Two distinct ways to
   // miss: the id never resolves, and it resolves to a section the merged
   // YAML doesn't hold — only the second reaches the resolver.

--- a/test/components/device/add-component-dialog-select.test.ts
+++ b/test/components/device/add-component-dialog-select.test.ts
@@ -1,0 +1,189 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The add dialog selects what it just added, so the navigator and the
+ * section editor land on it instead of leaving the user wherever they
+ * were. A board-curated entry's catalog id is the synthetic
+ * `featured.<board>.<local>`, which matches no YAML section key, so it
+ * has to be resolved to the component it actually adds first.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import "../../_mock-webawesome.js";
+
+vi.mock("../../../src/components/device/add-component-form.js", () => ({}));
+vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+
+import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
+import { ComponentCategory } from "../../../src/api/types/components.js";
+import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
+import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
+import { makeComponentEntry } from "../../util/_make-component-entry.js";
+
+// A binary_sensor already in the device, so the added one has to be told
+// apart from it by id rather than just "the only gpio block".
+const YAML = [
+  "esphome:",
+  "  name: foo",
+  "binary_sensor:",
+  "  - platform: gpio",
+  "    name: Motion Module",
+  "    id: motion_module",
+  "    pin: 3",
+  "",
+].join("\n");
+
+const MERGED = `${YAML}  - platform: gpio\n    name: Boot Button\n    id: boot_button\n    pin: 9\n`;
+
+/** A board whose `boot_button` preset materializes a `binary_sensor.gpio`. */
+const BOARD = {
+  id: "apollo-esk-1",
+  featured_components: [
+    { id: "boot_button", component_id: "binary_sensor.gpio", fields: {} },
+    { id: "led", component_id: "light.binary", fields: {} },
+  ],
+} as unknown as BoardCatalogEntry;
+
+interface Internals {
+  _dialog: { open: boolean };
+  _selected: unknown;
+  _fastPathFields: (entry: unknown) => Record<string, unknown> | null;
+  _submitComponent: (fields: Record<string, unknown>, notify?: boolean) => Promise<void>;
+  _onBundleSelected: (e: CustomEvent) => Promise<void>;
+}
+
+function makeDialog(mergedYaml = MERGED) {
+  const addComponent = vi.fn().mockResolvedValue({ yaml: mergedYaml });
+  const getComponentBodies = vi.fn().mockResolvedValue({});
+  const dialog = new ESPHomeAddComponentDialog();
+  Object.assign(dialog as unknown as Record<string, unknown>, {
+    _api: { addComponent, getComponentBodies },
+  });
+  dialog.configuration = "foo.yaml";
+  dialog.yaml = YAML;
+  dialog.board = BOARD;
+  return {
+    dialog,
+    d: dialog as unknown as Internals,
+    addComponent,
+    getComponentBodies,
+  };
+}
+
+/** Every `section-select` the dialog dispatches. */
+const capture = (el: EventTarget) => {
+  const seen: { sectionKey: string; fromLine: number }[] = [];
+  el.addEventListener("section-select", (e) =>
+    seen.push((e as CustomEvent<{ sectionKey: string; fromLine: number }>).detail)
+  );
+  return seen;
+};
+
+afterEach(() => {
+  _clearComponentCache();
+  vi.clearAllMocks();
+});
+
+describe("add-component-dialog selects what it added", () => {
+  it("resolves a board-curated id to the section it actually adds", async () => {
+    // The reported bug: `featured.apollo-esk-1.boot_button` matched no
+    // section, so nothing was selected and the editor stayed on whatever
+    // was open — here, the other gpio binary_sensor.
+    const { dialog, d } = makeDialog();
+    d._selected = makeComponentEntry("featured.apollo-esk-1.boot_button", {
+      name: "Boot Button",
+      category: ComponentCategory.BINARY_SENSOR,
+    });
+    const seen = capture(dialog);
+
+    await d._submitComponent({ id: "boot_button" }, true);
+
+    expect(seen).toEqual([{ sectionKey: "binary_sensor.gpio", fromLine: 8 }]);
+  });
+
+  it("still selects a plain catalog component", async () => {
+    // Non-featured ids pass through the resolver untouched.
+    const { dialog, d } = makeDialog();
+    d._selected = makeComponentEntry("binary_sensor.gpio", {
+      name: "GPIO Binary Sensor",
+      category: ComponentCategory.BINARY_SENSOR,
+    });
+    const seen = capture(dialog);
+
+    await d._submitComponent({ id: "boot_button" }, true);
+
+    expect(seen).toEqual([{ sectionKey: "binary_sensor.gpio", fromLine: 8 }]);
+  });
+
+  it("leaves the selection alone when the added block can't be found", async () => {
+    // Better to stay put than navigate somewhere wrong.
+    const { dialog, d } = makeDialog();
+    d._selected = makeComponentEntry("featured.apollo-esk-1.unknown", {
+      name: "Mystery",
+      category: ComponentCategory.BINARY_SENSOR,
+    });
+    const seen = capture(dialog);
+
+    await d._submitComponent({ id: "boot_button" }, true);
+
+    expect(seen).toEqual([]);
+  });
+
+  it("lands on the last member a bundle merged", async () => {
+    const { dialog, d, addComponent, getComponentBodies } = makeDialog();
+    getComponentBodies.mockResolvedValue({
+      "featured.apollo-esk-1.led": makeComponentEntry("featured.apollo-esk-1.led", {
+        category: ComponentCategory.LIGHT,
+      }),
+      "featured.apollo-esk-1.boot_button": makeComponentEntry(
+        "featured.apollo-esk-1.boot_button",
+        { category: ComponentCategory.BINARY_SENSOR }
+      ),
+    });
+    addComponent
+      .mockResolvedValueOnce({ yaml: YAML })
+      .mockResolvedValueOnce({ yaml: MERGED });
+    d._fastPathFields = vi.fn().mockImplementation((entry: { id: string }) => ({
+      id: entry.id.endsWith("led") ? "led" : "boot_button",
+    }));
+    const seen = capture(dialog);
+
+    await d._onBundleSelected(
+      new CustomEvent("add-bundle", {
+        detail: {
+          bundle: { name: "Full setup", component_ids: ["led", "boot_button"] },
+          boardId: "apollo-esk-1",
+        },
+      })
+    );
+
+    // The headline member is the one added last, not the first.
+    expect(seen).toEqual([{ sectionKey: "binary_sensor.gpio", fromLine: 8 }]);
+  });
+
+  it("selects nothing when every bundle member was already present", async () => {
+    // Nothing was added, so there is nothing to land on.
+    const { dialog, d, getComponentBodies } = makeDialog();
+    getComponentBodies.mockResolvedValue({
+      "featured.apollo-esk-1.boot_button": makeComponentEntry(
+        "featured.apollo-esk-1.boot_button",
+        { category: ComponentCategory.BINARY_SENSOR }
+      ),
+    });
+    // `motion_module` is already in YAML, so the member is skipped.
+    d._fastPathFields = vi.fn().mockReturnValue({ id: "motion_module" });
+    const seen = capture(dialog);
+
+    await d._onBundleSelected(
+      new CustomEvent("add-bundle", {
+        detail: {
+          bundle: { name: "Full setup", component_ids: ["boot_button"] },
+          boardId: "apollo-esk-1",
+        },
+      })
+    );
+
+    expect(seen).toEqual([]);
+  });
+});

--- a/test/components/device/add-component-dialog-select.test.ts
+++ b/test/components/device/add-component-dialog-select.test.ts
@@ -117,17 +117,24 @@ describe("add-component-dialog selects what it added", () => {
   });
 
   it("leaves the selection alone when the added block can't be found", async () => {
-    // Better to stay put than navigate somewhere wrong.
-    const { dialog, d } = makeDialog();
-    d._selected = makeComponentEntry("featured.apollo-esk-1.unknown", {
-      name: "Mystery",
-      category: ComponentCategory.BINARY_SENSOR,
-    });
-    const seen = capture(dialog);
+    // Better to stay put than navigate somewhere wrong. Two distinct ways
+    // to miss: the id never resolves, and it resolves to a section the
+    // merged YAML doesn't hold. Only the second exercises the resolver.
+    for (const id of [
+      "featured.apollo-esk-1.unknown", // not on the board — passes through
+      "featured.apollo-esk-1.led", // resolves to light.binary, absent here
+    ]) {
+      const { dialog, d } = makeDialog();
+      d._selected = makeComponentEntry(id, {
+        name: "Mystery",
+        category: ComponentCategory.BINARY_SENSOR,
+      });
+      const seen = capture(dialog);
 
-    await d._submitComponent({ id: "boot_button" }, true);
+      await d._submitComponent({ id: "boot_button" }, true);
 
-    expect(seen).toEqual([]);
+      expect(seen).toEqual([]);
+    }
   });
 
   it("lands on the last member a bundle merged", async () => {

--- a/test/components/device/add-component-dialog-select.test.ts
+++ b/test/components/device/add-component-dialog-select.test.ts
@@ -17,9 +17,9 @@ vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
 
 import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
 import { ComponentCategory } from "../../../src/api/types/components.js";
-import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
+import { makeAddComponentDialogHost } from "./_add-component-dialog-host.js";
 
 // A binary_sensor already in the device, so the added one has to be told
 // apart from it by id rather than just "the only gpio block".
@@ -46,30 +46,14 @@ const BOARD = {
 } as unknown as BoardCatalogEntry;
 
 interface Internals {
-  _dialog: { open: boolean };
   _selected: unknown;
   _fastPathFields: (entry: unknown) => Record<string, unknown> | null;
   _submitComponent: (fields: Record<string, unknown>, notify?: boolean) => Promise<void>;
   _onBundleSelected: (e: CustomEvent) => Promise<void>;
 }
 
-function makeDialog(mergedYaml = MERGED) {
-  const addComponent = vi.fn().mockResolvedValue({ yaml: mergedYaml });
-  const getComponentBodies = vi.fn().mockResolvedValue({});
-  const dialog = new ESPHomeAddComponentDialog();
-  Object.assign(dialog as unknown as Record<string, unknown>, {
-    _api: { addComponent, getComponentBodies },
-  });
-  dialog.configuration = "foo.yaml";
-  dialog.yaml = YAML;
-  dialog.board = BOARD;
-  return {
-    dialog,
-    d: dialog as unknown as Internals,
-    addComponent,
-    getComponentBodies,
-  };
-}
+const makeDialog = () =>
+  makeAddComponentDialogHost<Internals>({ yaml: YAML, mergedYaml: MERGED, board: BOARD });
 
 /** Every `section-select` the dialog dispatches. */
 const capture = (el: EventTarget) => {
@@ -116,25 +100,23 @@ describe("add-component-dialog selects what it added", () => {
     expect(seen).toEqual([{ sectionKey: "binary_sensor.gpio", fromLine: 8 }]);
   });
 
-  it("leaves the selection alone when the added block can't be found", async () => {
-    // Better to stay put than navigate somewhere wrong. Two distinct ways
-    // to miss: the id never resolves, and it resolves to a section the
-    // merged YAML doesn't hold. Only the second exercises the resolver.
-    for (const id of [
-      "featured.apollo-esk-1.unknown", // not on the board — passes through
-      "featured.apollo-esk-1.led", // resolves to light.binary, absent here
-    ]) {
-      const { dialog, d } = makeDialog();
-      d._selected = makeComponentEntry(id, {
-        name: "Mystery",
-        category: ComponentCategory.BINARY_SENSOR,
-      });
-      const seen = capture(dialog);
+  // Better to stay put than navigate somewhere wrong. Two distinct ways to
+  // miss: the id never resolves, and it resolves to a section the merged
+  // YAML doesn't hold — only the second reaches the resolver.
+  it.each([
+    ["an id the board doesn't carry", "featured.apollo-esk-1.unknown"],
+    ["an id resolving to an absent section", "featured.apollo-esk-1.led"],
+  ])("leaves the selection alone for %s", async (_label, id) => {
+    const { dialog, d } = makeDialog();
+    d._selected = makeComponentEntry(id, {
+      name: "Mystery",
+      category: ComponentCategory.BINARY_SENSOR,
+    });
+    const seen = capture(dialog);
 
-      await d._submitComponent({ id: "boot_button" }, true);
+    await d._submitComponent({ id: "boot_button" }, true);
 
-      expect(seen).toEqual([]);
-    }
+    expect(seen).toEqual([]);
   });
 
   it("lands on the last member a bundle merged", async () => {

--- a/test/components/device/add-component-dialog-select.test.ts
+++ b/test/components/device/add-component-dialog-select.test.ts
@@ -64,6 +64,23 @@ const capture = (el: EventTarget) => {
   return seen;
 };
 
+/** Every `yaml-highlight` the dialog dispatches. */
+const captureHighlight = (el: EventTarget) => {
+  const seen: { range: { fromLine: number; toLine: number } | null; scroll: boolean }[] =
+    [];
+  el.addEventListener("yaml-highlight", (e) =>
+    seen.push(
+      (
+        e as CustomEvent<{
+          range: { fromLine: number; toLine: number } | null;
+          scroll: boolean;
+        }>
+      ).detail
+    )
+  );
+  return seen;
+};
+
 afterEach(() => {
   _clearComponentCache();
   vi.clearAllMocks();
@@ -84,6 +101,22 @@ describe("add-component-dialog selects what it added", () => {
     await d._submitComponent({ id: "boot_button" }, true);
 
     expect(seen).toEqual([{ sectionKey: "binary_sensor.gpio", fromLine: 8 }]);
+  });
+
+  it("scrolls the YAML pane to the block it added", async () => {
+    // `section-select` moves the navigator and the form only; the YAML pane
+    // is driven by `yaml-highlight`, so an add that fires just the first
+    // lands the editor on a block the user still has to scroll to.
+    const { dialog, d } = makeDialog();
+    d._selected = makeComponentEntry("featured.apollo-esk-1.boot_button", {
+      name: "Boot Button",
+      category: ComponentCategory.BINARY_SENSOR,
+    });
+    const highlights = captureHighlight(dialog);
+
+    await d._submitComponent({ id: "boot_button" }, true);
+
+    expect(highlights).toEqual([{ range: { fromLine: 8, toLine: 11 }, scroll: true }]);
   });
 
   it("still selects a plain catalog component", async () => {
@@ -148,6 +181,39 @@ describe("add-component-dialog selects what it added", () => {
     );
 
     // The headline member is the one added last, not the first.
+    expect(seen).toEqual([{ sectionKey: "binary_sensor.gpio", fromLine: 8 }]);
+  });
+
+  it("lands on the last member merged, not the last member listed", async () => {
+    // A member already present is skipped, so "last listed" and "last
+    // actually merged" diverge; the select must follow the merge.
+    const { dialog, d, addComponent, getComponentBodies } = makeDialog();
+    getComponentBodies.mockResolvedValue({
+      "featured.apollo-esk-1.boot_button": makeComponentEntry(
+        "featured.apollo-esk-1.boot_button",
+        { category: ComponentCategory.BINARY_SENSOR }
+      ),
+      "featured.apollo-esk-1.led": makeComponentEntry("featured.apollo-esk-1.led", {
+        category: ComponentCategory.LIGHT,
+      }),
+    });
+    addComponent.mockResolvedValueOnce({ yaml: MERGED });
+    d._fastPathFields = vi.fn().mockImplementation((entry: { id: string }) => ({
+      // The second member is already in YAML, so it is skipped.
+      id: entry.id.endsWith("boot_button") ? "boot_button" : "motion_module",
+    }));
+    const seen = capture(dialog);
+
+    await d._onBundleSelected(
+      new CustomEvent("add-bundle", {
+        detail: {
+          bundle: { name: "Full setup", component_ids: ["boot_button", "led"] },
+          boardId: "apollo-esk-1",
+        },
+      })
+    );
+
+    expect(addComponent).toHaveBeenCalledTimes(1);
     expect(seen).toEqual([{ sectionKey: "binary_sensor.gpio", fromLine: 8 }]);
   });
 

--- a/test/util/yaml-sections-find-added.test.ts
+++ b/test/util/yaml-sections-find-added.test.ts
@@ -43,6 +43,7 @@ describe("findAddedSection", () => {
     expect(findAddedSection(yaml, "wifi", undefined)).toEqual({
       sectionKey: "wifi",
       fromLine: 3,
+      toLine: 4,
     });
   });
 
@@ -51,6 +52,7 @@ describe("findAddedSection", () => {
     expect(findAddedSection(yaml, "sensor.dht", undefined)).toEqual({
       sectionKey: "sensor.dht",
       fromLine: 2,
+      toLine: 3,
     });
   });
 


### PR DESCRIPTION
# What does this implement/fix?

Adding a component from the Device navigator is supposed to select it, so the navigator highlights the new row and the middle pane opens its form. For board-curated ("featured") presets it didn't: with `GPIO Binary Sensor / Motion Module` open on a starter-kit device, adding **Boot Button** appended the block correctly but left both the navigator and the form pane on Motion Module.

The dialog does try to select what it added:

```ts
const componentId = this._selected.id;
const target = findAddedSection(yaml, componentId, newId);
if (target) fireEvent(this, "section-select", target);
```

but it looks the component up by its **catalog** id, and a board-curated entry's id is the synthetic `featured.<board>.<local>` that `buildFeaturedId` composes. `findAddedSection` matches against real YAML section keys, so `featured.apollo-esk-1.boot_button` matched nothing, the guard swallowed the miss, and the post-add re-parse went on faithfully preserving the previous selection; the one signal meant to override it never fired.

Resolving the id first through `resolveFeaturedComponentId` fixes it. That helper already exists for exactly this question and is what `add-component-form.ts` uses for its own `_sectionKey`; non-featured ids pass through untouched, so plain adds are unchanged, and the featured-prerequisite chain gets the fix for free since it funnels through the same function. The API call still sends the raw featured id, which is what the backend resolves.

Verified against the real app on the board from the report (`apollo-esk-1`), adding the same two components in the same order:

```
                 before                after
Motion Module    (nothing selected)    binary_sensor.gpio line 40
Boot Button      (nothing selected)    binary_sensor.gpio line 45
```

Two supporting changes: `findAddedSection` now also returns the block's `toLine`, because selecting moves the navigator and the form but the YAML pane is driven by a separate `yaml-highlight` event that needs a range — without it the editor landed on a block still scrolled off screen. And `featuredEntryForId` is split out of `resolveFeaturedComponentId` in `src/util/featured-id.ts`, since `_missingRequiredPrereqs` had an open-coded copy of the same scan; behaviour is unchanged, but it does widen that util's public surface.

**Second, independent gap in the same dialog:** adding a bundle ("full setup") never fired `section-select` at all, whatever the ids. It now lands on the last member it actually merged; members skipped as already present don't count, since they aren't what the user just added.

There was no `section-select` coverage for this dialog at all, which is why this shipped. The new tests fail on `main` for exactly the two cases that were broken and pass for the three guards.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

