### PR TITLE
Keep a stack of dependency detours in the add-component dialog

### DIFF
--- a/src/components/device/add-component-dialog-dep-nav.ts
+++ b/src/components/device/add-component-dialog-dep-nav.ts
@@ -7,16 +7,28 @@ import {
 } from "../../util/bus-constraint-prefill.js";
 import { fetchComponent } from "../../util/component-name-cache.js";
 
+/** One suspended level of a "+ Add <dep>" detour. */
+export interface DetourFrame {
+  component: ComponentCatalogEntry;
+  depDomain: string;
+  values: Record<string, unknown> | null;
+  prefill: BusPrefill | null;
+}
+
+/** Slice of ``ESPHomeAddComponentDialog`` state a suspended level restores into. */
+export interface DetourHost {
+  _selected: ComponentCatalogEntry | null;
+  _detourStack: DetourFrame[];
+  _returnValues: Record<string, unknown> | null;
+  _depPrefill: BusPrefill | null;
+}
+
 /** Slice of ``ESPHomeAddComponentDialog`` state ``navigateToDep`` reads / writes. */
-export interface DepNavHost {
+export interface DepNavHost extends DetourHost {
   readonly _api: ESPHomeAPI;
   platform: string;
   board: { id: string; featured_components?: FeaturedComponent[] } | null;
   _catalog: { filterByDomain(domain: string): void } | null;
-  _selected: ComponentCatalogEntry | null;
-  _returnTo: ComponentCatalogEntry | null;
-  _depDomain: string | null;
-  _depPrefill: BusPrefill | null;
   _submitError: string;
   _submitting: boolean;
   _depNavSeq: number;
@@ -29,12 +41,19 @@ export interface DepNavHost {
  * rank every sensor mentioning the bus name above the bus entry.
  * Domain-level deps (``output``, ``sensor``) fall back to the
  * category-filtered catalog where the user picks a variant.
+ *
+ * ``values`` is the requesting form's in-progress input, parked on the
+ * suspended level's frame until it is popped.
  */
-export async function navigateToDep(host: DepNavHost, domain: string): Promise<void> {
+export async function navigateToDep(
+  host: DepNavHost,
+  domain: string,
+  values: Record<string, unknown> | null = null
+): Promise<void> {
   if (host._submitting) return;
   // Snapshot, don't commit, until the lookup resolves: the original
   // form is still rendered + submit-enabled (request-add-component
-  // path), so a set _returnTo would mislead _onFormSubmit.
+  // path), so a pushed frame would mislead _onFormSubmit.
   const previousSelected = host._selected;
   host._submitError = "";
   const seq = ++host._depNavSeq;
@@ -51,8 +70,15 @@ export async function navigateToDep(host: DepNavHost, domain: string): Promise<v
   }
   if (seq !== host._depNavSeq) return;
   if (previousSelected) {
-    host._returnTo = previousSelected;
-    host._depDomain = domain;
+    host._detourStack = [
+      ...host._detourStack,
+      {
+        component: previousSelected,
+        depDomain: domain,
+        values,
+        prefill: host._depPrefill,
+      },
+    ];
   }
   if (direct) {
     // The requester's bus constraints become the new bus's starting
@@ -79,6 +105,17 @@ export async function navigateToDep(host: DepNavHost, domain: string): Promise<v
   await host.updateComplete;
   if (seq !== host._depNavSeq) return;
   host._catalog?.filterByDomain(domain);
+}
+
+/** Unwind one level, restoring its component, values and prefill; null when empty. */
+export function popDetour(host: DetourHost): DetourFrame | null {
+  const frame = host._detourStack[host._detourStack.length - 1];
+  if (!frame) return null;
+  host._detourStack = host._detourStack.slice(0, -1);
+  host._selected = frame.component;
+  host._returnValues = frame.values;
+  host._depPrefill = frame.prefill;
+  return frame;
 }
 
 /**

--- a/src/components/device/add-component-dialog-dep-nav.ts
+++ b/src/components/device/add-component-dialog-dep-nav.ts
@@ -80,6 +80,9 @@ export async function navigateToDep(
       },
     ];
   }
+  // The suspended level's prefill rides its frame from here; leaving it set
+  // would seed the catalog-fallback pick with the requester's bus values.
+  host._depPrefill = null;
   if (direct) {
     // The requester's bus constraints become the new bus's starting
     // values (ags10 caps i2c at 15kHz, most uart devices pin a baud).
@@ -114,7 +117,11 @@ export function popDetour(host: DetourHost): DetourFrame | null {
   host._detourStack = host._detourStack.slice(0, -1);
   host._selected = frame.component;
   host._returnValues = frame.values;
-  host._depPrefill = frame.prefill;
+  // `prefillFields` is merged after `restoredValues` in the seed, so a restored
+  // level keeps the prefill's required / option constraints but drops its
+  // values — the snapshot already carries them, edits included.
+  host._depPrefill =
+    frame.values && frame.prefill ? { ...frame.prefill, fields: {} } : frame.prefill;
   return frame;
 }
 

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -30,8 +30,11 @@ import { findMissingDependencies } from "./add-component-deps.js";
 import { chooseExcludeCategories } from "./add-component-dialog-categories.js";
 import {
   type DepNavHost,
+  type DetourFrame,
+  type DetourHost,
   matchesDepDomain,
   navigateToDep,
+  popDetour,
 } from "./add-component-dialog-dep-nav.js";
 import {
   hydrateForSelection,
@@ -120,19 +123,11 @@ export class ESPHomeAddComponentDialog extends LitElement {
   @query("esphome-add-component-form")
   private _form?: ESPHomeAddComponentForm;
 
-  /** Snapshot of the form's in-progress values, captured when a "+ Add <dep>"
-   *  detour starts and restored when the original form re-mounts, so a field
-   *  the user already filled survives the round-trip. */
+  /** Values to seed the next form mount with, handed back by a popped detour
+   *  frame. Null while a dep's own form is up, which must not inherit the
+   *  values (and id) of the component that asked for it. */
   @state()
   private _returnValues: Record<string, unknown> | null = null;
-
-  /** Restored values for the mounted form: only the *original* component on
-   *  return (`_returnTo` cleared) gets them; the dep's own form during the
-   *  detour (`_returnTo` set) must not, or the dep would inherit the original's
-   *  id and collide. */
-  private get _restoredValuesForMount(): Record<string, unknown> | null {
-    return this._returnTo ? null : this._returnValues;
-  }
 
   @state()
   private _selected: ComponentCatalogEntry | null = null;
@@ -144,19 +139,14 @@ export class ESPHomeAddComponentDialog extends LitElement {
   private _submitError = "";
 
   /**
-   * Component the user was originally adding when they clicked
-   * "+ Add <dep>" inside the form. After they finish adding the
-   * dependency, we restore this component so they don't have to
-   * re-navigate the catalog and re-fill what they had.
+   * Components suspended by a "+ Add <dep>" detour, innermost last. Each
+   * finished dependency pops one frame and restores that component, so the
+   * user doesn't re-navigate the catalog and re-fill what they had.
+   *
+   * Mutations replace the array; Lit compares by identity.
    */
   @state()
-  private _returnTo: ComponentCatalogEntry | null = null;
-
-  /** Domain the dep detour was started for (e.g. "output"). Used to
-   * locate the matching `references_component` field on the original
-   * form so we can pre-fill it with the just-created component's id. */
-  @state()
-  private _depDomain: string | null = null;
+  private _detourStack: DetourFrame[] = [];
 
   /** Pre-fill payload handed to the restored form on its next mount.
    *  Cleared after the form mounts so it doesn't apply to subsequent
@@ -242,15 +232,14 @@ export class ESPHomeAddComponentDialog extends LitElement {
    *  which abandons the detour but must NOT bump the selection seqs (its
    *  hydrate already validated against the current token). */
   private _clearDetourFields() {
-    this._returnTo = null;
-    this._depDomain = null;
+    this._detourStack = [];
     this._prefillReference = null;
     this._depPrefill = null;
     this._returnValues = null;
   }
 
-  private _resetDetourState() {
-    this._clearDetourFields();
+  /** Drop queued bundle work and invalidate in-flight lookups. */
+  private _cancelPendingWork() {
     this._bundleQueue = [];
     this._bundleProgress = null;
     this._depNavSeq++;
@@ -259,8 +248,14 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._selectionSeq++;
   }
 
+  private _resetDetourState() {
+    this._clearDetourFields();
+    this._cancelPendingWork();
+  }
+
   protected render() {
     const isForm = this._selected !== null;
+    const returnTo = this._detourStack[this._detourStack.length - 1]?.component ?? null;
     // The same dialog drives both the regular catalog flow and the
     // "Add core configuration" flow — a non-empty
     // `lockedCategories` flips the title text and tells the catalog
@@ -313,10 +308,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
             : nothing
         }
         ${
-          this._returnTo
+          returnTo
             ? html`<div class="return-banner">
                 ${this._localize("device.return_to_after_dep_prefix")}
-                <strong>${this._returnTo.name}</strong>
+                <strong>${returnTo.name}</strong>
                 ${this._localize("device.return_to_after_dep_suffix")}
               </div>`
             : nothing
@@ -349,7 +344,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
           .lockedCategories=${this.lockedCategories}
           .excludeCategories=${chooseExcludeCategories({
             isCoreLocked: isCore,
-            isInDepDetour: this._returnTo !== null,
+            isInDepDetour: returnTo !== null,
           })}
         ></esphome-component-catalog>
         ${
@@ -360,7 +355,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
                 .yaml=${this.yaml}
                 .prefillReference=${this._prefillReference}
                 .prefillFields=${this._depPrefill?.fields ?? null}
-                .restoredValues=${this._restoredValuesForMount}
+                .restoredValues=${this._returnValues}
                 .extraRequired=${this._depPrefill?.required ?? null}
                 .optionOverrides=${this._depPrefill?.optionOverrides ?? null}
                 .submitting=${this._submitting}
@@ -772,19 +767,12 @@ export class ESPHomeAddComponentDialog extends LitElement {
 
   private _onBack() {
     if (this._submitting) return;
-    // If the user is in the middle of a "go add a dependency" detour
-    // and they hit back, treat it as cancelling the detour: drop them
-    // back at the original component they were filling in, instead of
-    // sending them to the catalog and losing context.
-    if (this._returnTo) {
-      const restore = this._returnTo;
-      // Back out of the detour like a submit-return: keep the snapshot across
-      // the reset so the user's in-progress values survive on the original
-      // form (the binding reads `_returnValues` with `_returnTo` now null).
-      const snapshot = this._returnValues;
-      this._resetDetourState();
-      this._returnValues = snapshot;
-      this._selected = restore;
+    // Back inside a "go add a dependency" detour cancels that one level:
+    // drop the user at the component that asked for it, still filled in,
+    // instead of sending them to the catalog and losing context.
+    if (popDetour(this as unknown as DetourHost)) {
+      this._prefillReference = null;
+      this._cancelPendingWork();
       this._submitError = "";
       return;
     }
@@ -801,10 +789,11 @@ export class ESPHomeAddComponentDialog extends LitElement {
 
   private _onNavigateToDep(e: CustomEvent<{ domain: string }>) {
     e.stopPropagation();
-    // Snapshot what the user has filled before `navigateToDep` swaps
-    // `_selected` and unmounts the form, so it's restored on return.
-    this._returnValues = this._form?.currentValues ?? null;
-    return navigateToDep(this as unknown as DepNavHost, e.detail.domain);
+    // Read what the user has filled before `navigateToDep` swaps `_selected`
+    // and unmounts the form, so the suspended frame carries it.
+    const values = this._form?.currentValues ?? null;
+    this._returnValues = null;
+    return navigateToDep(this as unknown as DepNavHost, e.detail.domain, values);
   }
 
   private _onFormSubmit(e: CustomEvent<{ fields: Record<string, unknown> }>) {
@@ -860,19 +849,21 @@ export class ESPHomeAddComponentDialog extends LitElement {
       );
 
       // Surface the merged YAML as an unsaved draft. We dispatch this
-      // BEFORE deciding whether to close — when restoring `_returnTo`
+      // BEFORE deciding whether to close — when a detour frame pops
       // the dialog stays open, but the device still needs the new YAML
       // (so the dependency we just added shows up in the original
       // component's dropdown). `yaml-draft` advances only the working
       // buffer, leaving the dirty flag on so the user saves explicitly.
       this._dispatchDraft({ configuration, yaml, basedOn: baseYaml });
 
-      if (this._returnTo) {
-        // Just finished adding a dependency — restore the original
-        // component's form so the user can continue where they left
-        // off. The form re-mounts fresh and re-reads `this.yaml`,
-        // which now contains the dep, so the ID-reference dropdown
-        // will be populated.
+      // Read before the pop reassigns `_selected`.
+      const added = this._selected;
+      const frame = popDetour(this as unknown as DetourHost);
+      if (frame) {
+        // Just finished adding a dependency — restore the component that
+        // asked for it so the user can continue where they left off. The
+        // form re-mounts fresh and re-reads `this.yaml`, which now contains
+        // the dep, so the ID-reference dropdown will be populated.
         //
         // This branch wins over the bundle-advance branch below: if
         // the user is mid-bundle and detours to add a missing dep,
@@ -881,26 +872,16 @@ export class ESPHomeAddComponentDialog extends LitElement {
         // The bundle queue stays intact so the bundle step's own
         // submit (the next time around) will fall through to the
         // bundle-advance branch and continue.
-        const restore = this._returnTo;
-        const depDomain = this._depDomain;
+        //
         // Pre-fill the restored form's reference field with the new
         // id when the just-added component matches what the dep-nav
         // asked for (defends against the user picking off-domain in
         // the catalog fallback).
         const newId = fields["id"];
-        if (
-          depDomain &&
-          typeof newId === "string" &&
-          matchesDepDomain(this._selected, depDomain)
-        ) {
-          this._prefillReference = { domain: depDomain, id: newId };
-        } else {
-          this._prefillReference = null;
-        }
-        this._returnTo = null;
-        this._depDomain = null;
-        this._depPrefill = null;
-        this._selected = restore;
+        this._prefillReference =
+          typeof newId === "string" && matchesDepDomain(added, frame.depDomain)
+            ? { domain: frame.depDomain, id: newId }
+            : null;
       } else if (this._bundleQueue.length > 0 && this._bundleProgress) {
         // Bundle in flight — pop the next featured id and refresh the
         // form for it. The just-updated `this.yaml` (carried in via

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -480,7 +480,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
       this._submitError = result.message;
       return false;
     }
-    // Fresh sequence — abandon any in-flight dep-detour state.
+    // Fresh sequence — abandon any in-flight dep-detour state, which for a
+    // nested detour drops every suspended level, not just the innermost.
     this._clearDetourFields();
     this._bundleQueue = rest;
     this._bundleProgress = {

--- a/test/components/device/_add-component-dialog-host.ts
+++ b/test/components/device/_add-component-dialog-host.ts
@@ -37,3 +37,16 @@ export function makeAddComponentDialogHost<I>(
     getComponentBodies,
   };
 }
+
+/** Override the `@query` `_form` getter so a suite can drive `currentValues`. */
+export function setForm(
+  d: unknown,
+  form: { currentValues: Record<string, unknown> } | undefined
+) {
+  Object.defineProperty(d, "_form", { value: form, configurable: true });
+}
+
+/** Fire the form's "+ Add <dep>" event at the dialog. */
+export function navigateToDepEvent(domain: string): CustomEvent {
+  return new CustomEvent("navigate-to-dep", { detail: { domain } });
+}

--- a/test/components/device/add-component-dialog-dep-nav.test.ts
+++ b/test/components/device/add-component-dialog-dep-nav.test.ts
@@ -8,12 +8,16 @@ import {
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import {
   type DepNavHost,
+  type DetourFrame,
+  type DetourHost,
   matchesDepDomain,
   navigateToDep,
+  popDetour,
 } from "../../../src/components/device/add-component-dialog-dep-nav.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
 import { makeConfigEntry } from "../../util/_make-config-entry.js";
+import { makeDetourFrame } from "../../util/_make-detour-frame.js";
 
 function makeHost(
   getComponentBodies: (...args: unknown[]) => unknown,
@@ -25,8 +29,8 @@ function makeHost(
     board: { id: "apollo-esk-1" },
     _catalog: catalog,
     _selected: null,
-    _returnTo: null,
-    _depDomain: null,
+    _detourStack: [],
+    _returnValues: null,
     _depPrefill: null,
     _submitError: "",
     _submitting: false,
@@ -45,13 +49,14 @@ function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
 
 /** `fetchComponent` routes through `getComponentBodies` and returns
  *  the entry under the requested id (or null when absent). Tests
- *  pass the entry they want returned and this helper wraps it. */
-const respond = (entry: ComponentCatalogEntry | null) =>
-  vi
-    .fn()
-    .mockImplementation((ids: string[]) =>
-      Promise.resolve(entry ? { [ids[0]]: entry } : {})
-    );
+ *  pass the entries they want served, keyed by id. */
+const respond = (...entries: (ComponentCatalogEntry | null)[]) => {
+  const byId = new Map(entries.filter((e) => e !== null).map((e) => [e.id, e]));
+  return vi.fn().mockImplementation((ids: string[]) => {
+    const entry = byId.get(ids[0]);
+    return Promise.resolve(entry ? { [ids[0]]: entry } : {});
+  });
+};
 
 describe("navigateToDep", () => {
   const aht20 = makeComponentEntry("sensor.aht10");
@@ -70,8 +75,9 @@ describe("navigateToDep", () => {
 
     expect(getComponentBodies).toHaveBeenCalledWith(["i2c"], "esp32", "apollo-esk-1");
     expect(host._selected).toBe(i2c);
-    expect(host._returnTo).toBe(aht20);
-    expect(host._depDomain).toBe("i2c");
+    expect(host._detourStack).toHaveLength(1);
+    expect(host._detourStack[0].component).toBe(aht20);
+    expect(host._detourStack[0].depDomain).toBe("i2c");
     expect(filterByDomain).not.toHaveBeenCalled();
   });
 
@@ -85,8 +91,8 @@ describe("navigateToDep", () => {
 
     expect(getComponentBodies).toHaveBeenCalledWith(["output"], "esp32", "apollo-esk-1");
     expect(host._selected).toBeNull();
-    expect(host._returnTo).toBe(aht20);
-    expect(host._depDomain).toBe("output");
+    expect(host._detourStack[0].component).toBe(aht20);
+    expect(host._detourStack[0].depDomain).toBe("output");
     expect(filterByDomain).toHaveBeenCalledWith("output");
   });
 
@@ -115,10 +121,11 @@ describe("navigateToDep", () => {
     await navPromise;
 
     expect(host._selected).toBe(aht20);
+    expect(host._detourStack).toHaveLength(0);
     expect(filterByDomain).not.toHaveBeenCalled();
   });
 
-  test("_returnTo stays null while the exact-id lookup is in flight", async () => {
+  test("the frame is pushed only once the exact-id lookup resolves", async () => {
     // A submit during this window would otherwise be misclassified
     // as completing a dep detour by _onFormSubmit.
     const d = deferred<Record<string, ComponentCatalogEntry>>();
@@ -126,13 +133,52 @@ describe("navigateToDep", () => {
     host._selected = aht20;
 
     const navPromise = navigateToDep(host, "i2c");
-    expect(host._returnTo).toBeNull();
-    expect(host._depDomain).toBeNull();
+    expect(host._detourStack).toHaveLength(0);
 
     d.resolve({ i2c });
     await navPromise;
-    expect(host._returnTo).toBe(aht20);
-    expect(host._depDomain).toBe("i2c");
+    expect(host._detourStack[0].component).toBe(aht20);
+    expect(host._detourStack[0].depDomain).toBe("i2c");
+  });
+
+  test("the frame carries the level's in-progress values and prefill", async () => {
+    const host = makeHost(respond(i2c));
+    host._selected = aht20;
+    host._depPrefill = { fields: { frequency: "15kHz" }, required: [] };
+
+    await navigateToDep(host, "i2c", { name: "Cooker" });
+
+    expect(host._detourStack[0].values).toEqual({ name: "Cooker" });
+    expect(host._detourStack[0].prefill).toEqual({
+      fields: { frequency: "15kHz" },
+      required: [],
+    });
+  });
+
+  test("a dep of a dep pushes a second frame and keeps the first", async () => {
+    const bleClient = makeComponentEntry("ble_client");
+    const tracker = makeComponentEntry("esp32_ble_tracker");
+    const anova = makeComponentEntry("climate.anova");
+    const host = makeHost(respond(bleClient, tracker));
+    host._selected = anova;
+
+    await navigateToDep(host, "ble_client");
+    await navigateToDep(host, "esp32_ble_tracker");
+
+    expect(host._selected).toBe(tracker);
+    expect(host._detourStack.map((f) => f.component)).toEqual([anova, bleClient]);
+    expect(host._detourStack.map((f) => f.depDomain)).toEqual([
+      "ble_client",
+      "esp32_ble_tracker",
+    ]);
+  });
+
+  test("pushes nothing when the detour starts from the catalog", async () => {
+    const host = makeHost(respond(i2c));
+
+    await navigateToDep(host, "i2c");
+
+    expect(host._detourStack).toHaveLength(0);
   });
 
   test("a superseded navigation does not race against the latest one", async () => {
@@ -150,6 +196,8 @@ describe("navigateToDep", () => {
     await Promise.all([firstNav, secondNav]);
 
     expect(host._selected).toBe(uart);
+    expect(host._detourStack).toHaveLength(1);
+    expect(host._detourStack[0].depDomain).toBe("uart");
     expect(getComponentBodies).toHaveBeenCalledTimes(1);
   });
 
@@ -165,6 +213,54 @@ describe("navigateToDep", () => {
     expect(getComponentBodies).not.toHaveBeenCalled();
     expect(filterByDomain).not.toHaveBeenCalled();
     expect(host._selected).toBe(before);
+  });
+});
+
+describe("popDetour", () => {
+  const anova = makeComponentEntry("climate.anova");
+  const bleClient = makeComponentEntry("ble_client");
+  const prefill = { fields: { frequency: "15kHz" }, required: [] };
+  const detourHost = (stack: DetourFrame[]): DetourHost => ({
+    _selected: null,
+    _detourStack: stack,
+    _returnValues: null,
+    _depPrefill: null,
+  });
+
+  test("restores the top frame's component, values and prefill", () => {
+    const host = detourHost([
+      makeDetourFrame(anova, {
+        depDomain: "ble_client",
+        values: { name: "Cooker" },
+        prefill,
+      }),
+    ]);
+    host._selected = makeComponentEntry("esp32_ble_tracker");
+
+    const frame = popDetour(host);
+
+    expect(frame?.component).toBe(anova);
+    expect(host._selected).toBe(anova);
+    expect(host._returnValues).toEqual({ name: "Cooker" });
+    expect(host._depPrefill).toBe(prefill);
+    expect(host._detourStack).toHaveLength(0);
+  });
+
+  test("unwinds a nested chain one level per call", () => {
+    const host = detourHost([makeDetourFrame(anova), makeDetourFrame(bleClient)]);
+
+    expect(popDetour(host)?.component).toBe(bleClient);
+    expect(host._detourStack).toHaveLength(1);
+    expect(popDetour(host)?.component).toBe(anova);
+    expect(host._detourStack).toHaveLength(0);
+  });
+
+  test("returns null and changes nothing on an empty stack", () => {
+    const host = detourHost([]);
+    host._selected = bleClient;
+
+    expect(popDetour(host)).toBeNull();
+    expect(host._selected).toBe(bleClient);
   });
 });
 

--- a/test/components/device/add-component-dialog-dep-nav.test.ts
+++ b/test/components/device/add-component-dialog-dep-nav.test.ts
@@ -173,6 +173,22 @@ describe("navigateToDep", () => {
     ]);
   });
 
+  test("hands the requester's prefill to the frame, not to the catalog pick", async () => {
+    // The domain-level fallback leaves the user in the catalog; whatever they
+    // pick must not inherit the requester's bus values.
+    const host = makeHost(respond(null), { filterByDomain: vi.fn() });
+    host._selected = aht20;
+    host._depPrefill = { fields: { frequency: "15kHz" }, required: [] };
+
+    await navigateToDep(host, "output");
+
+    expect(host._depPrefill).toBeNull();
+    expect(host._detourStack[0].prefill).toEqual({
+      fields: { frequency: "15kHz" },
+      required: [],
+    });
+  });
+
   test("pushes nothing when the detour starts from the catalog", async () => {
     const host = makeHost(respond(i2c));
 
@@ -242,8 +258,27 @@ describe("popDetour", () => {
     expect(frame?.component).toBe(anova);
     expect(host._selected).toBe(anova);
     expect(host._returnValues).toEqual({ name: "Cooker" });
-    expect(host._depPrefill).toBe(prefill);
     expect(host._detourStack).toHaveLength(0);
+  });
+
+  test("keeps the frame's prefill constraints but not its values", () => {
+    // The snapshot already carries what the prefill seeded, edits included, and
+    // `prefillFields` is merged after `restoredValues` in the form seed.
+    const host = detourHost([
+      makeDetourFrame(anova, { values: { frequency: "20kHz" }, prefill }),
+    ]);
+
+    popDetour(host);
+
+    expect(host._depPrefill).toEqual({ fields: {}, required: [] });
+  });
+
+  test("keeps the frame's prefill whole when the level had no values", () => {
+    const host = detourHost([makeDetourFrame(anova, { prefill })]);
+
+    popDetour(host);
+
+    expect(host._depPrefill).toBe(prefill);
   });
 
   test("unwinds a nested chain one level per call", () => {

--- a/test/components/device/add-component-dialog-draft.test.ts
+++ b/test/components/device/add-component-dialog-draft.test.ts
@@ -13,18 +13,18 @@ vi.mock("../../../src/components/device/add-component-form.js", () => ({}));
 vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
 
 import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
+import { makeDetourFrame } from "../../util/_make-detour-frame.js";
 
 describe("add-component-dialog preserves the editor draft (#1146)", () => {
   it("merges into this.yaml and dispatches yaml-draft, not yaml-updated", async () => {
     const dialog = new ESPHomeAddComponentDialog();
     const addComponent = vi.fn().mockResolvedValue({ yaml: "MERGED" });
-    // `_returnTo` truthy drives the restore branch, which doesn't touch
+    // A pending detour frame drives the restore branch, which doesn't touch
     // the wa-dialog query — keeps this a pure logic test, no render.
     Object.assign(dialog as unknown as Record<string, unknown>, {
       _api: { addComponent },
       _selected: { id: "i2c" },
-      _returnTo: { id: "orig" },
-      _depDomain: null,
+      _detourStack: [makeDetourFrame({ id: "orig" }, { depDomain: "i2c" })],
     });
     dialog.configuration = "foo.yaml";
     dialog.yaml = "esphome:\n  name: foo\n";
@@ -57,8 +57,7 @@ describe("add-component-dialog preserves the editor draft (#1146)", () => {
     Object.assign(dialog as unknown as Record<string, unknown>, {
       _api: { addComponent },
       _selected: { id: "i2c" },
-      _returnTo: { id: "orig" },
-      _depDomain: null,
+      _detourStack: [makeDetourFrame({ id: "orig" }, { depDomain: "i2c" })],
     });
     dialog.configuration = "foo.yaml";
     dialog.yaml = ""; // still loading — must not become the merge base
@@ -78,7 +77,7 @@ describe("add-component-dialog preserves the editor draft (#1146)", () => {
   it("configless direct-add still merges the draft and closes the dialog", async () => {
     const dialog = new ESPHomeAddComponentDialog();
     const addComponent = vi.fn().mockResolvedValue({ yaml: "MERGED" });
-    // No `_returnTo` / bundle state → the navigate-and-close branch runs,
+    // No detour frame / bundle state → the navigate-and-close branch runs,
     // exercising the draft-merge of the direct-add path through
     // `_submitComponent`. `notify` defaults false so this stays a pure
     // logic test (the toast is covered in -configless.test.ts).

--- a/test/components/device/add-component-dialog-nested-detour.test.ts
+++ b/test/components/device/add-component-dialog-nested-detour.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * A dependency can itself be missing a dependency (climate.anova needs
+ * ble_client, which needs esp32_ble_tracker). Each level suspends onto the
+ * detour stack and is restored in turn, with its own in-progress values.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import "../../_mock-webawesome.js";
+
+vi.mock("../../../src/components/device/add-component-form.js", () => ({}));
+vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+
+import { identityLocalize, mount } from "../../_dom.js";
+import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
+import type { DetourFrame } from "../../../src/components/device/add-component-dialog-dep-nav.js";
+import type { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
+import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
+import { makeComponentEntry } from "../../util/_make-component-entry.js";
+import {
+  makeAddComponentDialogHost,
+  navigateToDepEvent,
+  setForm,
+} from "./_add-component-dialog-host.js";
+
+interface Internals {
+  _detourStack: DetourFrame[];
+  _returnValues: Record<string, unknown> | null;
+  _selected: unknown;
+  _prefillReference: { domain: string; id: string } | null;
+  _onBack: () => void;
+  _onNavigateToDep: (e: CustomEvent) => Promise<void>;
+  _submitComponent: (fields: Record<string, unknown>, notify?: boolean) => Promise<void>;
+}
+
+const anova = makeComponentEntry("climate.anova", { name: "Anova Cooker" });
+const bleClient = makeComponentEntry("ble_client", { name: "BLE Client" });
+const tracker = makeComponentEntry("esp32_ble_tracker", { name: "BLE Tracker Hub" });
+
+const bodies: Record<string, ComponentCatalogEntry> = {
+  ble_client: bleClient,
+  esp32_ble_tracker: tracker,
+};
+
+async function makeDialog() {
+  const host = makeAddComponentDialogHost<Internals>();
+  host.getComponentBodies.mockImplementation((ids: string[]) =>
+    Promise.resolve(bodies[ids[0]] ? { [ids[0]]: bodies[ids[0]] } : {})
+  );
+  await mount(host.dialog, { _localize: identityLocalize } as never);
+  return host;
+}
+
+const addDep = (d: Internals, domain: string) =>
+  d._onNavigateToDep(navigateToDepEvent(domain));
+
+/** Name in the "we'll bring you back to X" banner, or null when it's absent. */
+async function bannerName(dialog: ESPHomeAddComponentDialog): Promise<string | null> {
+  await dialog.updateComplete;
+  return dialog.shadowRoot?.querySelector(".return-banner strong")?.textContent ?? null;
+}
+
+afterEach(() => {
+  _clearComponentCache();
+  vi.clearAllMocks();
+});
+
+describe("nested dependency detours", () => {
+  it("suspends each level and returns through them in order", async () => {
+    const { dialog, d } = await makeDialog();
+    d._selected = anova;
+    setForm(d, { currentValues: { name: "Anova Cooker" } });
+
+    await addDep(d, "ble_client");
+    expect(d._selected).toBe(bleClient);
+    expect(await bannerName(dialog)).toBe("Anova Cooker");
+
+    setForm(d, { currentValues: { mac_address: "AA:BB:CC:DD:EE:FF" } });
+    await addDep(d, "esp32_ble_tracker");
+    expect(d._selected).toBe(tracker);
+    expect(d._detourStack.map((f) => f.component)).toEqual([anova, bleClient]);
+    expect(await bannerName(dialog)).toBe("BLE Client");
+
+    // Adding the hub returns to the ble_client form, with its own values and
+    // the hub's id ready for the reference field.
+    await d._submitComponent({ id: "tracker_1" });
+    expect(d._selected).toBe(bleClient);
+    expect(d._returnValues).toEqual({ mac_address: "AA:BB:CC:DD:EE:FF" });
+    expect(d._prefillReference).toEqual({ domain: "esp32_ble_tracker", id: "tracker_1" });
+    expect(await bannerName(dialog)).toBe("Anova Cooker");
+
+    // Adding the client returns to the cooker instead of closing the dialog.
+    await d._submitComponent({ id: "ble_client_1" });
+    expect(d._selected).toBe(anova);
+    expect(d._returnValues).toEqual({ name: "Anova Cooker" });
+    expect(d._prefillReference).toEqual({ domain: "ble_client", id: "ble_client_1" });
+    expect(d._detourStack).toHaveLength(0);
+    expect(await bannerName(dialog)).toBeNull();
+  });
+
+  it("backs out one level per click", async () => {
+    const { dialog, d } = await makeDialog();
+    d._selected = anova;
+    setForm(d, { currentValues: { name: "Anova Cooker" } });
+    await addDep(d, "ble_client");
+    setForm(d, { currentValues: { mac_address: "AA:BB:CC:DD:EE:FF" } });
+    await addDep(d, "esp32_ble_tracker");
+
+    d._onBack();
+    expect(d._selected).toBe(bleClient);
+    expect(await bannerName(dialog)).toBe("Anova Cooker");
+
+    d._onBack();
+    expect(d._selected).toBe(anova);
+    expect(d._returnValues).toEqual({ name: "Anova Cooker" });
+    expect(await bannerName(dialog)).toBeNull();
+
+    d._onBack();
+    expect(d._selected).toBeNull();
+  });
+});

--- a/test/components/device/add-component-dialog-restore-values.test.ts
+++ b/test/components/device/add-component-dialog-restore-values.test.ts
@@ -2,9 +2,10 @@
  * @vitest-environment happy-dom
  *
  * Full `_returnValues` (detour value snapshot) lifecycle. The snapshot is
- * captured when a "+ Add <dep>" detour starts, restored ONLY to the original
- * component on return, and cleared on every other detour exit so it can't
- * bleed onto an unrelated form (an id collision being the worst case).
+ * captured when a "+ Add <dep>" detour starts, parked on the detour frame while
+ * the dep's own form is up, handed back when that frame pops, and cleared on
+ * every other detour exit so it can't bleed onto an unrelated form (an id
+ * collision being the worst case).
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -15,18 +16,22 @@ vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
 vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
 
 import { ComponentCategory } from "../../../src/api/types/components.js";
+import type { DetourFrame } from "../../../src/components/device/add-component-dialog-dep-nav.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
-import { makeAddComponentDialogHost } from "./_add-component-dialog-host.js";
+import { makeDetourFrame } from "../../util/_make-detour-frame.js";
+import {
+  makeAddComponentDialogHost,
+  navigateToDepEvent,
+  setForm,
+} from "./_add-component-dialog-host.js";
 
 interface Internals {
-  _returnTo: unknown;
+  _detourStack: DetourFrame[];
   _returnValues: Record<string, unknown> | null;
   _selected: unknown;
-  _depDomain: string | null;
   _bundleQueue: string[];
   _bundleProgress: { current: number; total: number; bundleName: string } | null;
-  readonly _restoredValuesForMount: Record<string, unknown> | null;
   _onBack: () => void;
   _onNavigateToDep: (e: CustomEvent) => Promise<void>;
   _onBundleSelected: (e: CustomEvent) => Promise<void>;
@@ -36,90 +41,61 @@ interface Internals {
 
 const makeDialog = () => makeAddComponentDialogHost<Internals>();
 
-/** Override the `@query` `_form` getter for capture tests. */
-function setForm(
-  d: Internals,
-  form: { currentValues: Record<string, unknown> } | undefined
-) {
-  Object.defineProperty(d, "_form", { value: form, configurable: true });
-}
-
 afterEach(() => {
   _clearComponentCache();
   vi.clearAllMocks();
 });
 
-describe("_restoredValuesForMount gate", () => {
-  it("withholds values while a detour is in flight (dep form mounting)", () => {
-    const { d } = makeDialog();
-    d._returnValues = { cs_pin: "GPIO5" };
-    d._returnTo = { id: "sensor.atm90e32" };
-    expect(d._restoredValuesForMount).toBeNull();
-  });
-
-  it("restores values once the detour finished (original form re-mounts)", () => {
-    const { d } = makeDialog();
-    d._returnValues = { cs_pin: "GPIO5" };
-    d._returnTo = null;
-    expect(d._restoredValuesForMount).toEqual({ cs_pin: "GPIO5" });
-  });
-
-  it("is null on a fresh open with no snapshot", () => {
-    const { d } = makeDialog();
-    d._returnTo = null;
-    d._returnValues = null;
-    expect(d._restoredValuesForMount).toBeNull();
-  });
-});
-
 describe("_returnValues capture (_onNavigateToDep)", () => {
-  it("snapshots the form's in-progress values before the form unmounts", async () => {
+  it("parks the form's in-progress values on the frame, not the slot", async () => {
     const { d, getComponentBodies } = makeDialog();
     getComponentBodies.mockResolvedValue({ spi: makeComponentEntry("spi") });
+    d._selected = makeComponentEntry("sensor.atm90e32");
     setForm(d, { currentValues: { cs_pin: "GPIO5", line_frequency: "60HZ" } });
-    // Capture is synchronous, before `navigateToDep` swaps `_selected`.
-    const p = d._onNavigateToDep(
-      new CustomEvent("navigate-to-dep", { detail: { domain: "spi" } })
-    );
-    expect(d._returnValues).toEqual({ cs_pin: "GPIO5", line_frequency: "60HZ" });
-    await p;
+
+    await d._onNavigateToDep(navigateToDepEvent("spi"));
+
+    expect(d._detourStack[0].values).toEqual({
+      cs_pin: "GPIO5",
+      line_frequency: "60HZ",
+    });
+    // The dep's own form mounts empty.
+    expect(d._returnValues).toBeNull();
   });
 
-  it("snapshots null when no form is mounted", async () => {
+  it("parks null when no form is mounted", async () => {
     const { d, getComponentBodies } = makeDialog();
     getComponentBodies.mockResolvedValue({ spi: makeComponentEntry("spi") });
+    d._selected = makeComponentEntry("sensor.atm90e32");
     d._returnValues = { stale: 1 };
     setForm(d, undefined);
-    const p = d._onNavigateToDep(
-      new CustomEvent("navigate-to-dep", { detail: { domain: "spi" } })
-    );
+
+    await d._onNavigateToDep(navigateToDepEvent("spi"));
+
+    expect(d._detourStack[0].values).toBeNull();
     expect(d._returnValues).toBeNull();
-    await p;
   });
 });
 
 describe("_returnValues across detour exits", () => {
-  it("submit-return leaves the snapshot set so the restored form reads it", async () => {
+  it("submit-return hands the frame's snapshot to the restored form", async () => {
     const { d } = makeDialog();
     const original = makeComponentEntry("sensor.atm90e32", { name: "ATM90E32" });
     const dep = makeComponentEntry("spi", { category: ComponentCategory.BUS });
     d._selected = dep;
-    d._returnTo = original;
-    d._depDomain = "spi";
-    d._returnValues = { cs_pin: "GPIO5" };
+    d._detourStack = [makeDetourFrame(original, { values: { cs_pin: "GPIO5" } })];
 
     await d._submitComponent({ id: "spi_1" });
 
     expect(d._selected).toBe(original);
-    expect(d._returnTo).toBeNull();
+    expect(d._detourStack).toHaveLength(0);
     expect(d._returnValues).toEqual({ cs_pin: "GPIO5" });
   });
 
   it("back-out preserves the snapshot and restores the original form", () => {
     const { d } = makeDialog();
     const original = { id: "sensor.atm90e32" };
-    d._returnTo = original;
-    d._returnValues = { cs_pin: "GPIO5" };
+    d._detourStack = [makeDetourFrame(original, { values: { cs_pin: "GPIO5" } })];
 
     d._onBack();
 
@@ -149,7 +125,6 @@ describe("_returnValues across detour exits", () => {
     d._selected = makeComponentEntry("output.gpio", {
       category: ComponentCategory.OUTPUT,
     });
-    d._returnTo = null;
     d._bundleQueue = ["featured.bw15.b"];
     d._bundleProgress = { current: 1, total: 2, bundleName: "Bundle" };
     d._returnValues = { cs_pin: "GPIO5" };
@@ -160,10 +135,17 @@ describe("_returnValues across detour exits", () => {
     expect(d._returnValues).toBeNull();
   });
 
-  it("_resetDetourState clears the snapshot", () => {
+  it("_resetDetourState clears the snapshot and the whole stack", () => {
     const { d } = makeDialog();
+    d._detourStack = [
+      makeDetourFrame({ id: "climate.anova" }),
+      makeDetourFrame({ id: "ble_client" }),
+    ];
     d._returnValues = { cs_pin: "GPIO5" };
+
     d._resetDetourState();
+
     expect(d._returnValues).toBeNull();
+    expect(d._detourStack).toHaveLength(0);
   });
 });

--- a/test/components/device/add-dialog-target-snapshot.test.ts
+++ b/test/components/device/add-dialog-target-snapshot.test.ts
@@ -23,6 +23,7 @@ import { ESPHomeAddAutomationDialog } from "../../../src/components/device/add-a
 import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
 import { ESPHomeAddScriptDialog } from "../../../src/components/device/add-script-dialog.js";
 import type { YamlDraftDetail } from "../../../src/components/device/section-editor.js";
+import { makeDetourFrame } from "../../util/_make-detour-frame.js";
 
 function deferred<T>() {
   let resolve!: (v: T) => void;
@@ -98,13 +99,12 @@ describe("add dialogs snapshot their target before the await", () => {
   it("add-component keeps the pre-switch target", async () => {
     const dialog = new ESPHomeAddComponentDialog();
     const add = deferred<{ yaml: string }>();
-    // `_returnTo` truthy drives the restore branch, which doesn't
+    // A pending detour frame drives the restore branch, which doesn't
     // touch the wa-dialog query — pure logic, no render.
     Object.assign(dialog as unknown as Record<string, unknown>, {
       _api: { addComponent: vi.fn(() => add.promise) },
       _selected: { id: "i2c" },
-      _returnTo: { id: "orig" },
-      _depDomain: null,
+      _detourStack: [makeDetourFrame({ id: "orig" }, { depDomain: "i2c" })],
     });
     dialog.configuration = "device.yaml";
     dialog.yaml = "esphome:\n";

--- a/test/util/_make-detour-frame.ts
+++ b/test/util/_make-detour-frame.ts
@@ -1,0 +1,15 @@
+import type { DetourFrame } from "../../src/components/device/add-component-dialog-dep-nav.js";
+
+/** A suspended detour level; `component` is loose so seeds can pass a stub. */
+export function makeDetourFrame(
+  component: unknown,
+  overrides: Partial<DetourFrame> = {}
+): DetourFrame {
+  return {
+    component,
+    depDomain: "spi",
+    values: null,
+    prefill: null,
+    ...overrides,
+  } as DetourFrame;
+}


### PR DESCRIPTION
# What does this implement/fix?

A dependency can itself be missing a dependency; `climate.anova` needs `ble_client`, which needs `esp32_ble_tracker`. The detour return address was a single slot, so the second "+ Add <dep>" click overwrote the first. Adding the tracker returned to the BLE Client form with no return banner, and adding the client closed the dialog outright; the user never got back to the Anova Cooker form and the values they had typed there were gone.

`_returnTo` / `_depDomain` become a `_detourStack` of frames, each carrying the suspended component, the dep domain it was sent off to satisfy, its in-progress values and its prefill. `navigateToDep` pushes, the new `popDetour` restores one level, and both the submit return and Back unwind a single frame at a time. `_returnValues` turns into a strict hand off slot (push parks it on the frame, pop hands it back), which is why the `_restoredValuesForMount` gate is gone; the naive "any detour in flight" version withheld the inner level's own values once the stack was deeper than one.

No cycle guard or depth cap: each submit merges the component into the YAML and the form recomputes its missing dep banner, so a cycle stops offering the button, and every frame costs a deliberate click.

Verified in the browser as well as in tests: anova, then add BLE Client, then add ESP32 BLE Tracker Hub, and the chain returns through BLE Client to the Anova Cooker form with its name still filled in.

One pre existing quirk this preserves rather than fixes: Back during a detour drops an in flight bundle queue while the submit return keeps it.

**Related issue or feature (if applicable):**

- N/A, reported directly

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
