### PR TITLE
Prefill the name for non-platform components that carry a label

### DIFF
--- a/src/util/default-entity-name.ts
+++ b/src/util/default-entity-name.ts
@@ -1,5 +1,5 @@
 import { parseCatalogId } from "./config-entry-yaml-scan.js";
-import { isFeaturedId, isPlatformComponentId } from "./featured-id.js";
+import { isFeaturedId } from "./featured-id.js";
 import { collectInstanceScalars } from "./yaml-instance-scalars.js";
 
 /**
@@ -18,9 +18,10 @@ function nameKey(name: string): string {
 /**
  * Undotted components whose top-level 'name' is an identity the firmware
  * derives elsewhere, not a label to seed: the node hostname, and the
- * advertised BLE name (which defaults to that hostname). Every other
- * undotted 'name' in the catalog is a display label — ble_client,
- * esp32_camera (an entity), serial_proxy, sprinkler.
+ * advertised BLE name (which defaults to that hostname). The other undotted
+ * name-carriers in the esphome 2026.7.3 catalog are display labels —
+ * ble_client, esp32_camera (an entity), serial_proxy, sprinkler — so a
+ * later upstream identity field needs adding here.
  */
 const IDENTITY_NAME_COMPONENTS: ReadonlySet<string> = new Set(["esphome", "esp32_ble"]);
 
@@ -44,8 +45,7 @@ export function suggestEntityName(
   yaml: string
 ): string | null {
   if (isFeaturedId(componentId)) return null;
-  if (!isPlatformComponentId(componentId) && IDENTITY_NAME_COMPONENTS.has(componentId))
-    return null;
+  if (IDENTITY_NAME_COMPONENTS.has(componentId)) return null;
   const title = componentTitle.trim();
   if (!title) return null;
 
@@ -69,10 +69,12 @@ export function suggestEntityName(
 
 /**
  * Scan the YAML for every 'name:' line under the *domain* top-level
- * section, matching the scope of esphome's per-platform duplicate
- * check. Still over-collects within the section (nested sub-entity
- * names, sub-device duplicates esphome would allow); the cost of a
- * false hit is an unneeded numeric suffix. The scan is line-based: a
+ * section — esphome's per-platform duplicate scope for a dotted id, the
+ * component's own section for an undotted one, whose entities may well be
+ * named under a different domain. Still over-collects within the section
+ * (nested sub-entity names, sub-device duplicates esphome would allow);
+ * the cost of a false hit is an unneeded numeric suffix, of a miss a
+ * duplicate the user renames. The scan is line-based: a
  * name behind a block scalar or inside a packages/!include file is
  * invisible and can still collide; the user can still edit the seeded
  * value before submitting.

--- a/src/util/default-entity-name.ts
+++ b/src/util/default-entity-name.ts
@@ -1,5 +1,5 @@
 import { parseCatalogId } from "./config-entry-yaml-scan.js";
-import { isPlatformComponentId } from "./featured-id.js";
+import { isFeaturedId, isPlatformComponentId } from "./featured-id.js";
 import { collectInstanceScalars } from "./yaml-instance-scalars.js";
 
 /**
@@ -16,27 +16,36 @@ function nameKey(name: string): string {
 }
 
 /**
+ * Undotted components whose top-level 'name' is an identity the firmware
+ * derives elsewhere, not a label to seed: the node hostname, and the
+ * advertised BLE name (which defaults to that hostname). Every other
+ * undotted 'name' in the catalog is a display label — ble_client,
+ * esp32_camera (an entity), serial_proxy, sprinkler.
+ */
+const IDENTITY_NAME_COMPONENTS: ReadonlySet<string> = new Set(["esphome", "esp32_ble"]);
+
+/**
  * Suggest a default 'name:' for a component being added via the
  * catalog: the catalog title, suffixed with a counter when the title
  * already names an entity in the YAML. Used by
  * 'esphome-add-component-form' to seed the name field; the user can
  * edit it (or clear it) before submitting.
  *
- * Only platform entries (id contains '.', e.g. 'switch.gpio') are
- * seeded: they are entity platforms, where 'name' becomes the Home
- * Assistant entity name and an unnamed entity stays internal. On the
- * few undotted components with a top-level 'name' field (esphome,
- * esp32_ble, sprinkler, ...) the key means something else, so they
- * return null. Featured wraps also return null: their name presets
- * arrive through seedDefaults, and their display title is a poor
- * entity name.
+ * Platform entries (id contains '.', e.g. 'switch.gpio') are entity
+ * platforms, where 'name' becomes the Home Assistant entity name and an
+ * unnamed entity stays internal. Undotted components are seeded too,
+ * minus 'IDENTITY_NAME_COMPONENTS'. Featured wraps return null: their
+ * name presets arrive through seedDefaults, and their display title is a
+ * poor entity name.
  */
 export function suggestEntityName(
   componentId: string,
   componentTitle: string,
   yaml: string
 ): string | null {
-  if (!isPlatformComponentId(componentId)) return null;
+  if (isFeaturedId(componentId)) return null;
+  if (!isPlatformComponentId(componentId) && IDENTITY_NAME_COMPONENTS.has(componentId))
+    return null;
   const title = componentTitle.trim();
   if (!title) return null;
 

--- a/src/util/featured-id.ts
+++ b/src/util/featured-id.ts
@@ -22,8 +22,7 @@ export function isFeaturedId(id: string): boolean {
 /**
  * True for platform-shaped catalog ids ('switch.gpio'). A featured id
  * carries dots but wraps one underlying component, so it never reads
- * as a platform entry. Shared by the id and name seeds so both judge
- * platform-ness identically.
+ * as a platform entry.
  */
 export function isPlatformComponentId(id: string): boolean {
   return isFeaturedId(id) ? false : id.includes(".");

--- a/test/components/device/add-component-form-seed-fns.test.ts
+++ b/test/components/device/add-component-form-seed-fns.test.ts
@@ -602,12 +602,14 @@ describe("buildInitialValues", () => {
     expect(values.name).toBe("A02YYUW Waterproof Ultrasonic Sensor");
   });
 
-  it("does not seed a name for an undotted component with a name entry", () => {
-    // Undotted name-carriers (esphome, esp32_ble, sprinkler, ...) use the
-    // key for something other than an entity name.
-    const values = seedWith(
-      nameSeedComponent({ id: "sprinkler", name: "Sprinkler Controller" })
-    );
+  it("seeds a name for an undotted component whose name is a label", () => {
+    const values = seedWith(nameSeedComponent({ id: "ble_client", name: "BLE Client" }));
+    expect(values.name).toBe("BLE Client");
+  });
+
+  it("does not seed a name the firmware derives elsewhere", () => {
+    // esp32_ble's name is the advertised BLE name, defaulted from the node.
+    const values = seedWith(nameSeedComponent({ id: "esp32_ble", name: "ESP32 BLE" }));
     expect(values.name).toBeUndefined();
   });
 

--- a/test/util/default-entity-name.test.ts
+++ b/test/util/default-entity-name.test.ts
@@ -15,12 +15,25 @@ describe("suggestEntityName", () => {
     expect(suggestEntityName("switch.gpio", "GPIO Switch", "")).toBe("GPIO Switch");
   });
 
-  it("returns null for undotted top-level ids", () => {
-    // On the few undotted components with a top-level name field the key
-    // means something else (the esphome device hostname, the BLE
-    // advertised name, ...), never an entity name.
+  it("seeds undotted components whose name is a display label", () => {
+    expect(suggestEntityName("ble_client", "BLE Client", "")).toBe("BLE Client");
+    expect(suggestEntityName("esp32_camera", "ESP32 Camera", "")).toBe("ESP32 Camera");
+    expect(suggestEntityName("sprinkler", "Sprinkler Controller", "")).toBe(
+      "Sprinkler Controller"
+    );
+    expect(suggestEntityName("serial_proxy", "Serial Proxy", "")).toBe("Serial Proxy");
+  });
+
+  it("returns null for an undotted name the firmware derives elsewhere", () => {
+    // The node hostname and the advertised BLE name (which defaults to it)
+    // are identities, not labels.
     expect(suggestEntityName("esphome", "ESPHome Core", "")).toBe(null);
-    expect(suggestEntityName("sprinkler", "Sprinkler Controller", "")).toBe(null);
+    expect(suggestEntityName("esp32_ble", "ESP32 BLE", "")).toBe(null);
+  });
+
+  it("scopes an undotted collision to its own section", () => {
+    const yaml = ["ble_client:", "  - name: BLE Client", ""].join("\n");
+    expect(suggestEntityName("ble_client", "BLE Client", yaml)).toBe("BLE Client 2");
   });
 
   it("returns null for a featured wrap id", () => {


### PR DESCRIPTION
# What does this implement/fix?

Adding a BLE Client left the Name field empty. The catalog-title seed from #1552 only ran for platform-shaped ids (`switch.gpio`), and bailed on every undotted component because on some of those `name` means something other than a label.

I went through the catalog: exactly six undotted components have a top-level string `name`. Two are identities the firmware derives elsewhere, `esphome` (the node hostname) and `esp32_ble` (the advertised BLE name, which defaults to that hostname); those still return null. The other four are labels and now get seeded: `ble_client`, `esp32_camera` (whose schema extends `ENTITY_BASE_SCHEMA`, so it is a real Home Assistant entity name), `serial_proxy` and `sprinkler`. The collision suffix works the same way, scoped to the component's own top-level section.

**Related issue or feature (if applicable):**

- follow-up to #1552

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
