### PR TITLE
Guard installs on chip disagreement and resume after a board pick

### DIFF
--- a/src/api/types/boards.ts
+++ b/src/api/types/boards.ts
@@ -13,7 +13,9 @@ export interface BoardEsphomeConfig {
   board: string;
   variant: string | null;
   framework: string | null;
-  // rp2-only chip series ('rp2040' / 'rp2350'); null on other platforms.
+  // Chip series for platforms that lump several chips under one key
+  // ('rp2040' / 'rp2350', LibreTiny 'bk7231' etc.); null where variant
+  // carries the chip or the platform is single-chip.
   mcu: string | null;
 }
 

--- a/src/components/device/board-reselect-dialog.ts
+++ b/src/components/device/board-reselect-dialog.ts
@@ -6,9 +6,8 @@ import type { ESPHomeAPI } from "../../api/index.js";
 import type { SlimBoard } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
-import { applyBoardChange } from "../../util/board-change.js";
+import { applyBoardChange, matchCatalogBoard } from "../../util/board-change.js";
 import { chipNameToVariant } from "../../util/chip-variant.js";
-import { canonicalComponentKey } from "../../util/component-presence.js";
 import { debounce } from "../../util/debounce.js";
 import { notifyError } from "../../util/notify.js";
 import { PagedListController } from "../../util/paged-list-controller.js";
@@ -24,6 +23,8 @@ export interface BoardReselectOpenOptions {
   configuration: string;
   /** Saved YAML when the caller already holds it; fetched otherwise. */
   yaml?: string;
+  /** Runs after a pick is applied; carries the caller's pending action. */
+  onApplied?: () => void;
 }
 
 /**
@@ -62,6 +63,8 @@ export class ESPHomeBoardReselectDialog extends LitElement {
 
   private _configuration = "";
 
+  private _onApplied?: () => void;
+
   /** Variant of the paged listing; the search re-query needs it. */
   private _variant: string | null = null;
 
@@ -88,6 +91,7 @@ export class ESPHomeBoardReselectDialog extends LitElement {
         return false;
       }
       this._configuration = opts.configuration;
+      this._onApplied = opts.onApplied;
       this._description = this._localize("device.board_reselect_desc", { board: label });
       await this.updateComplete;
       this._dialog.open();
@@ -133,16 +137,7 @@ export class ESPHomeBoardReselectDialog extends LitElement {
   /** Resolve candidates; true when any exist (state is then populated). */
   private async _loadCandidates(parsed: YamlPlatformBoard | null): Promise<boolean> {
     if (parsed?.board) {
-      const board = parsed.board.toLowerCase();
-      const { boards } = await this._api.getBoards({
-        query: parsed.board,
-        limit: 100,
-      });
-      const match = boards.find(
-        (b) =>
-          b.esphome.board.toLowerCase() === board &&
-          canonicalComponentKey(b.esphome.platform) === parsed.platform
-      );
+      const match = await matchCatalogBoard(this._api, parsed.board, parsed.platform);
       if (match) {
         // The compatible-boards command returns the complete same-target
         // set in one page — the query search alone would cap the list. An
@@ -217,6 +212,7 @@ export class ESPHomeBoardReselectDialog extends LitElement {
           composed: true,
         })
       );
+      this._onApplied?.();
     }
   };
 }

--- a/src/components/device/board-reselect-dialog.ts
+++ b/src/components/device/board-reselect-dialog.ts
@@ -212,7 +212,15 @@ export class ESPHomeBoardReselectDialog extends LitElement {
           composed: true,
         })
       );
-      this._onApplied?.();
+      // One-shot, guarded: a throw must not reject this handler, and a
+      // cleared callback can't fire twice or outlive its open.
+      const onApplied = this._onApplied;
+      this._onApplied = undefined;
+      try {
+        onApplied?.();
+      } catch (err) {
+        console.error("Board reselect completion failed:", err);
+      }
     }
   };
 }

--- a/src/components/device/board-reselect-dialog.ts
+++ b/src/components/device/board-reselect-dialog.ts
@@ -12,6 +12,7 @@ import { debounce } from "../../util/debounce.js";
 import { notifyError } from "../../util/notify.js";
 import { PagedListController } from "../../util/paged-list-controller.js";
 import { readPlatformBoard, type YamlPlatformBoard } from "../../util/yaml-board.js";
+import { WIZARD_BOARD_PLATFORMS } from "../wizard/wizard-step-board-platforms.js";
 import type { ESPHomeChangeBoardDialog } from "./change-board-dialog.js";
 import { navItemMatches } from "./navigator-search-match.js";
 
@@ -65,8 +66,10 @@ export class ESPHomeBoardReselectDialog extends LitElement {
 
   private _onApplied?: () => void;
 
-  /** Variant of the paged listing; the search re-query needs it. */
-  private _variant: string | null = null;
+  /** Platform and chip facet of the paged listing; the search re-query needs them. */
+  private _platform = "esp32";
+
+  private _chipFacet: { variant?: string; mcu?: string } = {};
 
   /** Latest raw input value, committed to `_search` by the debounce. */
   private _pendingSearch = "";
@@ -149,11 +152,19 @@ export class ESPHomeBoardReselectDialog extends LitElement {
         }
       }
     }
-    // A variant-only YAML (`esp32.variant:` with no `board:`, or a board
-    // string the catalog doesn't carry) still pins the chip — every board
-    // of that variant is compatible. Anything broader is not offered.
-    if (parsed?.platform === "esp32" && parsed.variant) {
-      this._variant = chipNameToVariant(parsed.variant);
+    // A variant-only YAML (a `variant:` with no `board:`, or a board
+    // string the catalog doesn't carry) still pins the chip — every
+    // board of that chip on the YAML's platform is compatible.
+    // Anything broader is not offered. The catalog facets esp32 by
+    // `variant` and the multi-chip platforms by `mcu`; the wizard's
+    // platform table already records which is which.
+    if (parsed?.variant) {
+      this._platform = parsed.platform;
+      const chip = chipNameToVariant(parsed.variant);
+      const usesMcu = WIZARD_BOARD_PLATFORMS.some(
+        (p) => p.platform === parsed.platform && p.mcu
+      );
+      this._chipFacet = usesMcu ? { mcu: chip } : { variant: chip };
       // Probe page 0 up front so the none-found case toasts instead of
       // opening an empty dialog; the reset serves it without a refetch
       // (offset 0 is only ever the reset's own first fetch).
@@ -170,8 +181,8 @@ export class ESPHomeBoardReselectDialog extends LitElement {
 
   private _fetchVariantPage = async (offset: number, limit: number) => {
     const page = await this._api.getBoards({
-      platform: "esp32",
-      variant: this._variant ?? undefined,
+      platform: this._platform,
+      ...this._chipFacet,
       ...(this._search ? { query: this._search } : {}),
       offset,
       limit,

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -988,14 +988,14 @@ export class ESPHomePageDashboard extends LitElement {
 
   _openCommand = (device: ConfiguredDevice, type: CommandType, port?: string) => {
     if (type === "install") {
-      void this._guardBoardThen(device, () => openCommand(this, device, type, port));
+      void this._guardBoardThen(device, (d) => openCommand(this, d, type, port));
       return;
     }
     openCommand(this, device, type, port);
   };
   _showJobProgress = (device: ConfiguredDevice) => showJobProgress(this, device);
   _openInstallMethod = (device: ConfiguredDevice) => {
-    void this._guardBoardThen(device, () => openInstallMethod(this, device));
+    void this._guardBoardThen(device, (d) => openInstallMethod(this, d));
   };
 
   /** Hard block: force the board fix before a single-device install
@@ -1007,7 +1007,7 @@ export class ESPHomePageDashboard extends LitElement {
    *  install with only a toast. */
   _guardBoardThen = async (
     device: ConfiguredDevice,
-    proceed: () => void | Promise<void>
+    proceed: (device: ConfiguredDevice) => void | Promise<void>
   ) => {
     // Every path guarded: the void call sites (and the pick callback)
     // would otherwise turn a throw into a silent unhandled rejection.
@@ -1019,6 +1019,10 @@ export class ESPHomePageDashboard extends LitElement {
         notifyError(this._localize("device.install_start_failed"));
       }
     };
+    // The resume re-resolves the live device: the pick just rewrote
+    // board_id, and the clicked snapshot must not race the relink.
+    const live = () =>
+      this._devices.find((d) => d.configuration === device.configuration) ?? device;
     await run(async () => {
       if (showJobProgress(this, device)) return;
       const yaml = await findBoardDisagreement(this._api, this._localize, device);
@@ -1027,12 +1031,12 @@ export class ESPHomePageDashboard extends LitElement {
         (await openBoardReselect(this._boardReselectDialog, {
           configuration: device.configuration,
           yaml,
-          onApplied: () => void run(proceed),
+          onApplied: () => void run(() => proceed(live())),
         }))
       ) {
         return;
       }
-      await proceed();
+      await proceed(device);
     });
   };
   _onInstallMethodSelect = (e: CustomEvent<{ method: string; port?: string }>) =>

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -1009,17 +1009,17 @@ export class ESPHomePageDashboard extends LitElement {
     device: ConfiguredDevice,
     proceed: () => void | Promise<void>
   ) => {
-    // Each stage guarded: the void call sites (and the pick callback)
-    // would otherwise turn any throw into a silent unhandled rejection.
-    const start = async () => {
+    // Every path guarded: the void call sites (and the pick callback)
+    // would otherwise turn a throw into a silent unhandled rejection.
+    const run = async (fn: () => void | Promise<void>) => {
       try {
-        await proceed();
+        await fn();
       } catch (err) {
         console.error("Install entry failed:", err);
         notifyError(this._localize("device.install_start_failed"));
       }
     };
-    try {
+    await run(async () => {
       if (showJobProgress(this, device)) return;
       const yaml = await findBoardDisagreement(this._api, this._localize, device);
       if (
@@ -1027,17 +1027,13 @@ export class ESPHomePageDashboard extends LitElement {
         (await openBoardReselect(this._boardReselectDialog, {
           configuration: device.configuration,
           yaml,
-          onApplied: () => void start(),
+          onApplied: () => void run(proceed),
         }))
       ) {
         return;
       }
-    } catch (err) {
-      console.error("Install entry failed:", err);
-      notifyError(this._localize("device.install_start_failed"));
-      return;
-    }
-    await start();
+      await proceed();
+    });
   };
   _onInstallMethodSelect = (e: CustomEvent<{ method: string; port?: string }>) =>
     onInstallMethodSelect(this, e);

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -999,17 +999,26 @@ export class ESPHomePageDashboard extends LitElement {
   };
 
   /** Hard block: force the board fix before a single-device install
-   *  opens. Re-attaching to a running job starts no install, so it
-   *  skips the guard's fetches; bulk update stays ungated (OTA only,
-   *  N pickers can't stack). A picker with nothing to offer falls
-   *  through — the chip check downstream stays the guard, and
-   *  blocking would strand the install with only a toast. */
+   *  opens; a pick resumes the pending install. Re-attaching to a
+   *  running job starts no install, so it skips the guard's fetches;
+   *  bulk update stays ungated (OTA only, N pickers can't stack). A
+   *  picker with nothing to offer falls through — the chip check
+   *  downstream stays the guard, and blocking would strand the
+   *  install with only a toast. */
   _guardBoardThen = async (
     device: ConfiguredDevice,
     proceed: () => void | Promise<void>
   ) => {
-    // Whole body guarded: the void call sites would otherwise turn any
-    // throw into a silent unhandled rejection.
+    // Each stage guarded: the void call sites (and the pick callback)
+    // would otherwise turn any throw into a silent unhandled rejection.
+    const start = async () => {
+      try {
+        await proceed();
+      } catch (err) {
+        console.error("Install entry failed:", err);
+        notifyError(this._localize("device.install_start_failed"));
+      }
+    };
     try {
       if (showJobProgress(this, device)) return;
       const yaml = await findBoardDisagreement(this._api, this._localize, device);
@@ -1018,15 +1027,17 @@ export class ESPHomePageDashboard extends LitElement {
         (await openBoardReselect(this._boardReselectDialog, {
           configuration: device.configuration,
           yaml,
+          onApplied: () => void start(),
         }))
       ) {
         return;
       }
-      await proceed();
     } catch (err) {
       console.error("Install entry failed:", err);
       notifyError(this._localize("device.install_start_failed"));
+      return;
     }
+    await start();
   };
   _onInstallMethodSelect = (e: CustomEvent<{ method: string; port?: string }>) =>
     onInstallMethodSelect(this, e);

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -54,7 +54,11 @@ import {
   resolveBackendErrors,
 } from "../util/backend-field-errors.js";
 import { fetchBoard } from "../util/board-body-cache.js";
-import { applyBoardChange, openBoardReselect } from "../util/board-change.js";
+import {
+  applyBoardChange,
+  chipDisagrees,
+  openBoardReselect,
+} from "../util/board-change.js";
 import { ConfigLoadController } from "../util/config-load-controller.js";
 import { showPendingChanges, showUpdateAvailable } from "../util/device-sync.js";
 import { deviceLayoutToPref, prefToDeviceLayout } from "../util/editor-layout.js";
@@ -1024,18 +1028,26 @@ export class ESPHomePageDevice extends LitElement {
     return saved;
   };
 
-  /** The parsed YAML platform block when it names a different chip than
-   *  the selected board, else null. */
+  /** The parsed YAML platform block when it names a different board than
+   *  the selected one, else null. */
   private _boardDisagreement() {
     if (!this._board) return null;
     const parsed = readPlatformBoard(this._yaml);
     return parsed && boardDisagreesWithYaml(parsed, this._board) ? parsed : null;
   }
 
-  private _openBoardReselect(): Promise<boolean> {
+  /** Whether the buffer pins a different chip than the selected board. */
+  private async _installChipDisagreement(): Promise<boolean> {
+    if (!this._board) return false;
+    const parsed = readPlatformBoard(this._yaml);
+    return parsed !== null && (await chipDisagrees(this._api, parsed, this._board));
+  }
+
+  private _openBoardReselect(opts: { onApplied?: () => void } = {}): Promise<boolean> {
     return openBoardReselect(this._boardReselectDialog, {
       configuration: this.id,
       yaml: this._yaml,
+      ...opts,
     });
   }
 
@@ -1154,23 +1166,28 @@ export class ESPHomePageDevice extends LitElement {
       this._suppressBoardPrompt = false;
     }
     if (!saved) return;
-    // Hard block: an unresolved YAML/board disagreement dead-ends the
-    // install chip check, so force the fix before offering install
-    // methods. Dismissing the picker keeps install blocked; the next
-    // click re-prompts. When the picker has nothing to offer (no
-    // catalog candidates, or a transient failure) fall through — the
-    // chip check downstream stays the guard, and blocking here would
-    // strand the install with only a toast.
-    if (this._boardDisagreement() && (await this._openBoardReselect())) {
+    const start = async () => {
+      try {
+        await run();
+      } catch (err) {
+        // Surfaced rather than lost as an unhandled rejection.
+        console.error("Install entry failed:", err);
+        notifyError(this._localize("device.install_start_failed"));
+      }
+    };
+    // Hard block: an unresolved chip disagreement dead-ends the install
+    // chip check, so force the fix before offering install methods; a
+    // pick resumes the install. When the picker has nothing to offer
+    // (no catalog candidates, or a transient failure) fall through —
+    // the chip check downstream stays the guard, and blocking here
+    // would strand the install with only a toast.
+    if (
+      (await this._installChipDisagreement()) &&
+      (await this._openBoardReselect({ onApplied: () => void start() }))
+    ) {
       return;
     }
-    try {
-      await run();
-    } catch (err) {
-      // Surfaced rather than lost as an unhandled rejection.
-      console.error("Install entry failed:", err);
-      notifyError(this._localize("device.install_start_failed"));
-    }
+    await start();
   };
   private _saveThenInstall = () => this._installAfterSave(this._installCtrl.onInstall);
   private _saveThenUpdate = () => this._installAfterSave(this._installCtrl.onUpdate);

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -65,7 +65,7 @@ import { deviceLayoutToPref, prefToDeviceLayout } from "../util/editor-layout.js
 import { followActiveJob } from "../util/firmware-job-display.js";
 import { consumeJustCreated } from "../util/just-created.js";
 import { goBackOrHome, navigate, PopLeaveGuardController } from "../util/navigation.js";
-import { notifyError, notifyInfo, notifySuccess } from "../util/notify.js";
+import { notifyError, notifyInfo, notifySuccess, notifyWarning } from "../util/notify.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { renderAsyncState } from "../util/render-async-state.js";
@@ -1036,11 +1036,18 @@ export class ESPHomePageDevice extends LitElement {
     return parsed && boardDisagreesWithYaml(parsed, this._board) ? parsed : null;
   }
 
-  /** Whether the buffer pins a different chip than the selected board. */
+  /** Whether the buffer pins a different chip than the selected board; fails open. */
   private async _installChipDisagreement(): Promise<boolean> {
     if (!this._board) return false;
     const parsed = readPlatformBoard(this._yaml);
-    return parsed !== null && (await chipDisagrees(this._api, parsed, this._board));
+    if (parsed === null) return false;
+    try {
+      return await chipDisagrees(this._api, parsed, this._board);
+    } catch (err) {
+      console.warn("Board disagreement check failed:", err);
+      notifyWarning(this._localize("device.board_check_failed"));
+      return false;
+    }
   }
 
   private _openBoardReselect(opts: { onApplied?: () => void } = {}): Promise<boolean> {

--- a/src/util/board-change.ts
+++ b/src/util/board-change.ts
@@ -49,7 +49,7 @@ export function matchCatalogBoard(
   }
   const target = board.toLowerCase();
   return cache.fetch(`${platform}\n${target}`, async () => {
-    const { boards } = await api.getBoards({ query: board, limit: 100 });
+    const { boards } = await api.getBoards({ query: board, platform, limit: 100 });
     return boards.find(
       (b) =>
         b.esphome.board.toLowerCase() === target &&

--- a/src/util/board-change.ts
+++ b/src/util/board-change.ts
@@ -11,6 +11,7 @@ import { canonicalComponentKey } from "./component-presence.js";
 import { KeyedPromiseCache } from "./keyed-promise-cache.js";
 import { notifyError, notifySuccess, notifyWarning } from "./notify.js";
 import {
+  boardChipToken,
   platformDisagrees,
   readPlatformBoard,
   variantDisagrees,
@@ -101,11 +102,14 @@ export async function chipDisagrees(
 ): Promise<boolean> {
   if (platformDisagrees(parsed.platform, stored)) return true;
   if (parsed.board?.toLowerCase() === stored.esphome.board.toLowerCase()) return false;
-  if (!stored.esphome.variant) return false;
+  if (!boardChipToken(stored)) return false;
   const resolved = parsed.board
     ? await matchCatalogBoard(api, parsed.board, parsed.platform)
     : undefined;
-  return variantDisagrees(resolved?.esphome.variant ?? parsed.variant, stored);
+  const yamlChip = resolved
+    ? (boardChipToken(resolved) ?? parsed.variant)
+    : parsed.variant;
+  return variantDisagrees(yamlChip, stored);
 }
 
 /** Write a device's sidecar `board_id` and toast the outcome; true on success. */

--- a/src/util/board-change.ts
+++ b/src/util/board-change.ts
@@ -32,8 +32,8 @@ export function openBoardReselect(
 }
 
 // The catalog is immutable per session, so misses memoise too. Keyed
-// on the api instance so a reconnect (or a test's fresh mock) starts
-// with an empty cache.
+// on the api instance (one per app-shell lifetime) so a test's fresh
+// mock starts with an empty cache.
 const _matchCaches = new WeakMap<ESPHomeAPI, KeyedPromiseCache<SlimBoard | undefined>>();
 
 /** The catalog board whose PlatformIO string and platform match, memoised per session. */

--- a/src/util/board-change.ts
+++ b/src/util/board-change.ts
@@ -1,4 +1,5 @@
 import type { ESPHomeAPI } from "../api/index.js";
+import type { SlimBoard } from "../api/types/boards.js";
 import type { ConfiguredDevice } from "../api/types/devices.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type {
@@ -6,8 +7,10 @@ import type {
   ESPHomeBoardReselectDialog,
 } from "../components/device/board-reselect-dialog.js";
 import { fetchBoard } from "./board-body-cache.js";
+import { chipNameToVariant } from "./chip-variant.js";
+import { canonicalComponentKey } from "./component-presence.js";
 import { notifyError, notifySuccess, notifyWarning } from "./notify.js";
-import { boardDisagreesWithYaml, readPlatformBoard } from "./yaml-board.js";
+import { readPlatformBoard, type YamlPlatformBoard } from "./yaml-board.js";
 
 /** Open the reselect picker; a missing dialog is a bug, not "nothing to
  *  offer" — log it loudly and fail open. */
@@ -20,6 +23,23 @@ export function openBoardReselect(
     return Promise.resolve(false);
   }
   return dialog.open(opts);
+}
+
+/** The catalog board whose PlatformIO string and platform match, else null. */
+export async function matchCatalogBoard(
+  api: ESPHomeAPI,
+  board: string,
+  platform: string
+): Promise<SlimBoard | null> {
+  const target = board.toLowerCase();
+  const { boards } = await api.getBoards({ query: board, limit: 100 });
+  return (
+    boards.find(
+      (b) =>
+        b.esphome.board.toLowerCase() === target &&
+        canonicalComponentKey(b.esphome.platform) === platform
+    ) ?? null
+  );
 }
 
 /**
@@ -44,12 +64,42 @@ export async function findBoardDisagreement(
     ]);
     if (!board) return null;
     const parsed = readPlatformBoard(yaml);
-    return parsed !== null && boardDisagreesWithYaml(parsed, board) ? yaml : null;
+    if (parsed === null) return null;
+    return (await chipDisagrees(api, parsed, board)) ? yaml : null;
   } catch (err) {
     console.warn("Board disagreement check failed:", err);
     notifyWarning(localize("device.board_check_failed"));
     return null;
   }
+}
+
+/**
+ * Whether the YAML pins a different chip than the stored board.
+ *
+ * Chip-level only: a board-string mismatch alone never flags. The
+ * reselect picker resolves string mismatches by variant, so a string
+ * the catalog doesn't carry could otherwise re-block every install
+ * with a picker no pick can satisfy.
+ */
+async function chipDisagrees(
+  api: ESPHomeAPI,
+  parsed: YamlPlatformBoard,
+  stored: SlimBoard
+): Promise<boolean> {
+  if (parsed.platform !== canonicalComponentKey(stored.esphome.platform)) return true;
+  let yamlVariant = parsed.variant;
+  if (parsed.board) {
+    // The board string pins the hardware; equality settles it, and a
+    // resolved string beats an explicit variant beside it.
+    if (parsed.board.toLowerCase() === stored.esphome.board.toLowerCase()) return false;
+    const resolved = await matchCatalogBoard(api, parsed.board, parsed.platform);
+    if (resolved) yamlVariant = resolved.esphome.variant ?? yamlVariant;
+  }
+  return Boolean(
+    yamlVariant &&
+    stored.esphome.variant &&
+    chipNameToVariant(yamlVariant) !== chipNameToVariant(stored.esphome.variant)
+  );
 }
 
 /** Write a device's sidecar `board_id` and toast the outcome; true on success. */

--- a/src/util/board-change.ts
+++ b/src/util/board-change.ts
@@ -7,10 +7,15 @@ import type {
   ESPHomeBoardReselectDialog,
 } from "../components/device/board-reselect-dialog.js";
 import { fetchBoard } from "./board-body-cache.js";
-import { chipNameToVariant } from "./chip-variant.js";
 import { canonicalComponentKey } from "./component-presence.js";
+import { KeyedPromiseCache } from "./keyed-promise-cache.js";
 import { notifyError, notifySuccess, notifyWarning } from "./notify.js";
-import { readPlatformBoard, type YamlPlatformBoard } from "./yaml-board.js";
+import {
+  platformDisagrees,
+  readPlatformBoard,
+  variantDisagrees,
+  type YamlPlatformBoard,
+} from "./yaml-board.js";
 
 /** Open the reselect picker; a missing dialog is a bug, not "nothing to
  *  offer" — log it loudly and fail open. */
@@ -25,21 +30,31 @@ export function openBoardReselect(
   return dialog.open(opts);
 }
 
-/** The catalog board whose PlatformIO string and platform match, else null. */
-export async function matchCatalogBoard(
+// The catalog is immutable per session, so misses memoise too. Keyed
+// on the api instance so a reconnect (or a test's fresh mock) starts
+// with an empty cache.
+const _matchCaches = new WeakMap<ESPHomeAPI, KeyedPromiseCache<SlimBoard | undefined>>();
+
+/** The catalog board whose PlatformIO string and platform match, memoised per session. */
+export function matchCatalogBoard(
   api: ESPHomeAPI,
   board: string,
   platform: string
-): Promise<SlimBoard | null> {
+): Promise<SlimBoard | undefined> {
+  let cache = _matchCaches.get(api);
+  if (!cache) {
+    cache = new KeyedPromiseCache();
+    _matchCaches.set(api, cache);
+  }
   const target = board.toLowerCase();
-  const { boards } = await api.getBoards({ query: board, limit: 100 });
-  return (
-    boards.find(
+  return cache.fetch(`${platform}\n${target}`, async () => {
+    const { boards } = await api.getBoards({ query: board, limit: 100 });
+    return boards.find(
       (b) =>
         b.esphome.board.toLowerCase() === target &&
         canonicalComponentKey(b.esphome.platform) === platform
-    ) ?? null
-  );
+    );
+  });
 }
 
 /**
@@ -76,30 +91,21 @@ export async function findBoardDisagreement(
 /**
  * Whether the YAML pins a different chip than the stored board.
  *
- * Chip-level only: a board-string mismatch alone never flags. The
- * reselect picker resolves string mismatches by variant, so a string
- * the catalog doesn't carry could otherwise re-block every install
- * with a picker no pick can satisfy.
+ * The install-gating rule: a board-string mismatch alone never flags,
+ * and a resolved board string beats an explicit variant beside it.
  */
-async function chipDisagrees(
+export async function chipDisagrees(
   api: ESPHomeAPI,
   parsed: YamlPlatformBoard,
   stored: SlimBoard
 ): Promise<boolean> {
-  if (parsed.platform !== canonicalComponentKey(stored.esphome.platform)) return true;
-  let yamlVariant = parsed.variant;
-  if (parsed.board) {
-    // The board string pins the hardware; equality settles it, and a
-    // resolved string beats an explicit variant beside it.
-    if (parsed.board.toLowerCase() === stored.esphome.board.toLowerCase()) return false;
-    const resolved = await matchCatalogBoard(api, parsed.board, parsed.platform);
-    if (resolved) yamlVariant = resolved.esphome.variant ?? yamlVariant;
-  }
-  return Boolean(
-    yamlVariant &&
-    stored.esphome.variant &&
-    chipNameToVariant(yamlVariant) !== chipNameToVariant(stored.esphome.variant)
-  );
+  if (platformDisagrees(parsed.platform, stored)) return true;
+  if (parsed.board?.toLowerCase() === stored.esphome.board.toLowerCase()) return false;
+  if (!stored.esphome.variant) return false;
+  const resolved = parsed.board
+    ? await matchCatalogBoard(api, parsed.board, parsed.platform)
+    : undefined;
+  return variantDisagrees(resolved?.esphome.variant ?? parsed.variant, stored);
 }
 
 /** Write a device's sidecar `board_id` and toast the outcome; true on success. */

--- a/src/util/yaml-board.ts
+++ b/src/util/yaml-board.ts
@@ -47,7 +47,7 @@ export function platformDisagrees(platform: string, board: SlimBoard): boolean {
 
 /** The board's chip identity: esp32-family variant, else the mcu series. */
 export function boardChipToken(board: SlimBoard): string | null {
-  return board.esphome.variant ?? board.esphome.mcu ?? null;
+  return board.esphome.variant || board.esphome.mcu || null;
 }
 
 /** Whether the YAML-side chip token pins a different chip than *board*; unknown sides agree. */

--- a/src/util/yaml-board.ts
+++ b/src/util/yaml-board.ts
@@ -40,23 +40,34 @@ export function readPlatformBoard(yaml: string): YamlPlatformBoard | null {
   return { platform: canonicalComponentKey(section.key), board, variant };
 }
 
+/** Whether *platform* names a different target platform than *board*. */
+export function platformDisagrees(platform: string, board: SlimBoard): boolean {
+  return platform !== canonicalComponentKey(board.esphome.platform);
+}
+
+/** Whether *variant* pins a different chip than *board*; unknown sides agree. */
+export function variantDisagrees(variant: string | null, board: SlimBoard): boolean {
+  return Boolean(
+    variant &&
+    board.esphome.variant &&
+    chipNameToVariant(variant) !== chipNameToVariant(board.esphome.variant)
+  );
+}
+
 /**
- * Whether the YAML names a different chip than the selected catalog board.
+ * Whether the YAML names a different board than the selected catalog board.
  *
- * Curated-vs-generic picks sharing one PlatformIO board string compare
- * equal on every axis and never flag.
+ * String-level, suiting the save-time reselect offer; install gating uses
+ * the chip-level rule in board-change.ts. Curated-vs-generic picks sharing
+ * one PlatformIO board string compare equal on every axis and never flag.
  */
 export function boardDisagreesWithYaml(
   parsed: YamlPlatformBoard,
   board: SlimBoard
 ): boolean {
-  if (parsed.platform !== canonicalComponentKey(board.esphome.platform)) return true;
+  if (platformDisagrees(parsed.platform, board)) return true;
   if (parsed.board && parsed.board.toLowerCase() !== board.esphome.board.toLowerCase()) {
     return true;
   }
-  return Boolean(
-    parsed.variant &&
-    board.esphome.variant &&
-    chipNameToVariant(parsed.variant) !== chipNameToVariant(board.esphome.variant)
-  );
+  return variantDisagrees(parsed.variant, board);
 }

--- a/src/util/yaml-board.ts
+++ b/src/util/yaml-board.ts
@@ -45,12 +45,16 @@ export function platformDisagrees(platform: string, board: SlimBoard): boolean {
   return platform !== canonicalComponentKey(board.esphome.platform);
 }
 
-/** Whether *variant* pins a different chip than *board*; unknown sides agree. */
+/** The board's chip identity: esp32-family variant, else the mcu series. */
+export function boardChipToken(board: SlimBoard): string | null {
+  return board.esphome.variant ?? board.esphome.mcu ?? null;
+}
+
+/** Whether the YAML-side chip token pins a different chip than *board*; unknown sides agree. */
 export function variantDisagrees(variant: string | null, board: SlimBoard): boolean {
+  const chip = boardChipToken(board);
   return Boolean(
-    variant &&
-    board.esphome.variant &&
-    chipNameToVariant(variant) !== chipNameToVariant(board.esphome.variant)
+    variant && chip && chipNameToVariant(variant) !== chipNameToVariant(chip)
   );
 }
 

--- a/test/components/device/board-reselect-dialog.test.ts
+++ b/test/components/device/board-reselect-dialog.test.ts
@@ -74,7 +74,11 @@ describe("board-reselect-dialog", () => {
     });
     await el.updateComplete;
     expect(opened).toBe(true);
-    expect(getBoards).toHaveBeenCalledWith({ query: "esp32-c3-devkitm-1", limit: 100 });
+    expect(getBoards).toHaveBeenCalledWith({
+      query: "esp32-c3-devkitm-1",
+      platform: "esp32",
+      limit: 100,
+    });
     expect(getCompatibleBoards).toHaveBeenCalledWith("c3-curated");
     expect(inner().boards).toEqual([C3_CURATED, C3_GENERIC]);
     expect((inner() as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(
@@ -358,6 +362,7 @@ describe("board-reselect-dialog", () => {
     expect(api.getConfig).toHaveBeenCalledWith("dev.yaml");
     expect(api.getBoards).toHaveBeenCalledWith({
       query: "esp32-c3-devkitm-1",
+      platform: "esp32",
       limit: 100,
     });
   });

--- a/test/components/device/board-reselect-dialog.test.ts
+++ b/test/components/device/board-reselect-dialog.test.ts
@@ -280,6 +280,53 @@ describe("board-reselect-dialog", () => {
     });
   });
 
+  it("runs onApplied after a successful pick", async () => {
+    const api = {
+      getBoards: vi.fn().mockResolvedValue({ boards: [C3_CURATED] }),
+      getCompatibleBoards: vi.fn().mockResolvedValue([C3_CURATED]),
+      updateDevice: vi.fn().mockResolvedValue({}),
+    };
+    const { el, inner } = await makeDialog(api as unknown as ESPHomeAPI);
+    const onApplied = vi.fn();
+    await el.open({
+      configuration: "dev.yaml",
+      yaml: "esp32:\n  board: esp32-c3-devkitm-1\n",
+      onApplied,
+    });
+    inner().dispatchEvent(
+      new CustomEvent("select-board", {
+        detail: { boardId: "c3-curated" },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await vi.waitFor(() => expect(onApplied).toHaveBeenCalledTimes(1));
+  });
+
+  it("skips onApplied when the pick fails to apply", async () => {
+    const api = {
+      getBoards: vi.fn().mockResolvedValue({ boards: [C3_CURATED] }),
+      getCompatibleBoards: vi.fn().mockResolvedValue([C3_CURATED]),
+      updateDevice: vi.fn().mockRejectedValue(new Error("boom")),
+    };
+    const { el, inner } = await makeDialog(api as unknown as ESPHomeAPI);
+    const onApplied = vi.fn();
+    await el.open({
+      configuration: "dev.yaml",
+      yaml: "esp32:\n  board: esp32-c3-devkitm-1\n",
+      onApplied,
+    });
+    inner().dispatchEvent(
+      new CustomEvent("select-board", {
+        detail: { boardId: "c3-curated" },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await vi.waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(onApplied).not.toHaveBeenCalled();
+  });
+
   it("toasts an error and emits nothing when the update fails", async () => {
     const api = {
       getBoards: vi.fn().mockResolvedValue({ boards: [C3_CURATED] }),

--- a/test/components/device/board-reselect-dialog.test.ts
+++ b/test/components/device/board-reselect-dialog.test.ts
@@ -287,6 +287,27 @@ describe("board-reselect-dialog", () => {
     expect(onApplied).toHaveBeenCalledTimes(1);
   });
 
+  it("survives a throwing onApplied without losing the pick", async () => {
+    const api = {
+      getBoards: vi.fn().mockResolvedValue({ boards: [C3_CURATED] }),
+      getCompatibleBoards: vi.fn().mockResolvedValue([C3_CURATED]),
+      updateDevice: vi.fn().mockResolvedValue({}),
+    };
+    const { el, inner } = await makeDialog(api as unknown as ESPHomeAPI);
+    const onChanged = vi.fn();
+    el.addEventListener("board-changed", onChanged as EventListener);
+    await el.open({
+      configuration: "dev.yaml",
+      yaml: "esp32:\n  board: esp32-c3-devkitm-1\n",
+      onApplied: () => {
+        throw new Error("boom");
+      },
+    });
+    pickBoard(inner, "c3-curated");
+    await vi.waitFor(() => expect(onChanged).toHaveBeenCalledTimes(1));
+    expect(toast.success).toHaveBeenCalled();
+  });
+
   it("toasts an error and runs no completions when the update fails", async () => {
     const api = {
       getBoards: vi.fn().mockResolvedValue({ boards: [C3_CURATED] }),

--- a/test/components/device/board-reselect-dialog.test.ts
+++ b/test/components/device/board-reselect-dialog.test.ts
@@ -103,6 +103,24 @@ describe("board-reselect-dialog", () => {
     expect(inner().hasMore).toBe(false);
   });
 
+  it("lists the YAML's own platform by mcu for an rp2 variant", async () => {
+    // The rp2 catalog facets its chips by mcu, not variant.
+    const pico = makeSlimBoard("rpi-pico", { platform: "rp2", mcu: "rp2040" });
+    const getBoards = vi.fn().mockResolvedValue({ boards: [pico], total: 1 });
+    const { el, inner } = await makeDialog({ getBoards } as unknown as ESPHomeAPI);
+    await el.open({
+      configuration: "dev.yaml",
+      yaml: "rp2:\n  variant: RP2040\n",
+    });
+    expect(getBoards).toHaveBeenCalledWith({
+      platform: "rp2",
+      mcu: "rp2040",
+      offset: 0,
+      limit: 50,
+    });
+    await vi.waitFor(() => expect(inner().boards).toEqual([pico]));
+  });
+
   it("falls back to same-variant boards when the catalog lacks the board string", async () => {
     const getBoards = vi
       .fn()

--- a/test/components/device/board-reselect-dialog.test.ts
+++ b/test/components/device/board-reselect-dialog.test.ts
@@ -42,6 +42,16 @@ async function makeDialog(api: Partial<ESPHomeAPI>) {
   return { el, inner };
 }
 
+function pickBoard(inner: () => ESPHomeChangeBoardDialog, boardId: string) {
+  inner().dispatchEvent(
+    new CustomEvent("select-board", {
+      detail: { boardId },
+      bubbles: true,
+      composed: true,
+    })
+  );
+}
+
 describe("board-reselect-dialog", () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -248,7 +258,7 @@ describe("board-reselect-dialog", () => {
     await vi.waitFor(() => expect(inner().boards).toEqual([C3_CURATED, C3_GENERIC]));
   });
 
-  it("applies the pick via devices/update and emits board-changed", async () => {
+  it("applies the pick via devices/update, emits board-changed, runs onApplied", async () => {
     const api = {
       getBoards: vi.fn().mockResolvedValue({ boards: [C3_CURATED] }),
       getCompatibleBoards: vi.fn().mockResolvedValue([C3_CURATED]),
@@ -256,18 +266,14 @@ describe("board-reselect-dialog", () => {
     };
     const { el, inner } = await makeDialog(api as unknown as ESPHomeAPI);
     const onChanged = vi.fn();
+    const onApplied = vi.fn();
     el.addEventListener("board-changed", onChanged as EventListener);
     await el.open({
       configuration: "dev.yaml",
       yaml: "esp32:\n  board: esp32-c3-devkitm-1\n",
+      onApplied,
     });
-    inner().dispatchEvent(
-      new CustomEvent("select-board", {
-        detail: { boardId: "c3-curated" },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    pickBoard(inner, "c3-curated");
     await vi.waitFor(() => expect(onChanged).toHaveBeenCalledTimes(1));
     expect(api.updateDevice).toHaveBeenCalledWith({
       configuration: "dev.yaml",
@@ -278,56 +284,10 @@ describe("board-reselect-dialog", () => {
       configuration: "dev.yaml",
       boardId: "c3-curated",
     });
+    expect(onApplied).toHaveBeenCalledTimes(1);
   });
 
-  it("runs onApplied after a successful pick", async () => {
-    const api = {
-      getBoards: vi.fn().mockResolvedValue({ boards: [C3_CURATED] }),
-      getCompatibleBoards: vi.fn().mockResolvedValue([C3_CURATED]),
-      updateDevice: vi.fn().mockResolvedValue({}),
-    };
-    const { el, inner } = await makeDialog(api as unknown as ESPHomeAPI);
-    const onApplied = vi.fn();
-    await el.open({
-      configuration: "dev.yaml",
-      yaml: "esp32:\n  board: esp32-c3-devkitm-1\n",
-      onApplied,
-    });
-    inner().dispatchEvent(
-      new CustomEvent("select-board", {
-        detail: { boardId: "c3-curated" },
-        bubbles: true,
-        composed: true,
-      })
-    );
-    await vi.waitFor(() => expect(onApplied).toHaveBeenCalledTimes(1));
-  });
-
-  it("skips onApplied when the pick fails to apply", async () => {
-    const api = {
-      getBoards: vi.fn().mockResolvedValue({ boards: [C3_CURATED] }),
-      getCompatibleBoards: vi.fn().mockResolvedValue([C3_CURATED]),
-      updateDevice: vi.fn().mockRejectedValue(new Error("boom")),
-    };
-    const { el, inner } = await makeDialog(api as unknown as ESPHomeAPI);
-    const onApplied = vi.fn();
-    await el.open({
-      configuration: "dev.yaml",
-      yaml: "esp32:\n  board: esp32-c3-devkitm-1\n",
-      onApplied,
-    });
-    inner().dispatchEvent(
-      new CustomEvent("select-board", {
-        detail: { boardId: "c3-curated" },
-        bubbles: true,
-        composed: true,
-      })
-    );
-    await vi.waitFor(() => expect(toast.error).toHaveBeenCalled());
-    expect(onApplied).not.toHaveBeenCalled();
-  });
-
-  it("toasts an error and emits nothing when the update fails", async () => {
+  it("toasts an error and runs no completions when the update fails", async () => {
     const api = {
       getBoards: vi.fn().mockResolvedValue({ boards: [C3_CURATED] }),
       getCompatibleBoards: vi.fn().mockResolvedValue([C3_CURATED]),
@@ -335,20 +295,17 @@ describe("board-reselect-dialog", () => {
     };
     const { el, inner } = await makeDialog(api as unknown as ESPHomeAPI);
     const onChanged = vi.fn();
+    const onApplied = vi.fn();
     el.addEventListener("board-changed", onChanged as EventListener);
     await el.open({
       configuration: "dev.yaml",
       yaml: "esp32:\n  board: esp32-c3-devkitm-1\n",
+      onApplied,
     });
-    inner().dispatchEvent(
-      new CustomEvent("select-board", {
-        detail: { boardId: "c3-curated" },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    pickBoard(inner, "c3-curated");
     await vi.waitFor(() => expect(toast.error).toHaveBeenCalled());
     expect(onChanged).not.toHaveBeenCalled();
+    expect(onApplied).not.toHaveBeenCalled();
   });
 
   it("fetches the YAML when the caller passes none", async () => {

--- a/test/pages/dashboard-board-guard.test.ts
+++ b/test/pages/dashboard-board-guard.test.ts
@@ -46,8 +46,20 @@ describe("dashboard install hard block", () => {
     expect(openReselect).toHaveBeenCalledWith({
       configuration: "stale.yaml",
       yaml: "esp32:\n  variant: esp32s3\n",
+      onApplied: expect.any(Function),
     });
     expect(page._installMethodOpen).toBe(false);
+  });
+
+  it("resumes the blocked install once a pick is applied", async () => {
+    vi.mocked(findBoardDisagreement).mockResolvedValue("esp32:\n  variant: esp32s3\n");
+    const { page, openReselect } = makePage();
+    page._openInstallMethod(DEVICE);
+    await vi.waitFor(() => expect(openReselect).toHaveBeenCalledTimes(1));
+    expect(page._installMethodOpen).toBe(false);
+    const { onApplied } = openReselect.mock.calls[0][0] as { onApplied: () => void };
+    onApplied();
+    await vi.waitFor(() => expect(page._installMethodOpen).toBe(true));
   });
 
   it("blocks the direct update install the same way", async () => {

--- a/test/pages/dashboard-board-guard.test.ts
+++ b/test/pages/dashboard-board-guard.test.ts
@@ -38,7 +38,7 @@ function makePage() {
 }
 
 describe("dashboard install hard block", () => {
-  it("blocks the install-method picker and opens the reselect dialog", async () => {
+  it("blocks the install-method picker, then a pick resumes it", async () => {
     vi.mocked(findBoardDisagreement).mockResolvedValue("esp32:\n  variant: esp32s3\n");
     const { page, openReselect } = makePage();
     page._openInstallMethod(DEVICE);
@@ -48,14 +48,6 @@ describe("dashboard install hard block", () => {
       yaml: "esp32:\n  variant: esp32s3\n",
       onApplied: expect.any(Function),
     });
-    expect(page._installMethodOpen).toBe(false);
-  });
-
-  it("resumes the blocked install once a pick is applied", async () => {
-    vi.mocked(findBoardDisagreement).mockResolvedValue("esp32:\n  variant: esp32s3\n");
-    const { page, openReselect } = makePage();
-    page._openInstallMethod(DEVICE);
-    await vi.waitFor(() => expect(openReselect).toHaveBeenCalledTimes(1));
     expect(page._installMethodOpen).toBe(false);
     const { onApplied } = openReselect.mock.calls[0][0] as { onApplied: () => void };
     onApplied();

--- a/test/pages/device-board-prompt.test.ts
+++ b/test/pages/device-board-prompt.test.ts
@@ -110,24 +110,54 @@ describe("post-save board reselect prompt", () => {
   });
 });
 
-describe("install hard block on board disagreement", () => {
+describe("install hard block on chip disagreement", () => {
+  const C3_CATALOG = {
+    esphome: { platform: "esp32", board: "esp32-c3-devkitm-1", variant: "esp32c3" },
+  };
+
   function makeInstallPage(overrides: Partial<PageView> = {}) {
     const made = makePage({
       _showActiveJobProgress: () => false,
       _saveYaml: async () => true,
+      _api: {
+        getBoards: vi.fn().mockResolvedValue({ boards: [C3_CATALOG] }),
+      } as unknown as ESPHomeAPI,
       ...overrides,
     });
     return { ...made, run: vi.fn() };
   }
 
-  it("blocks install and opens the picker while the YAML disagrees", async () => {
+  it("blocks install and opens the picker while the chips disagree", async () => {
     const { page, openReselect, run } = makeInstallPage();
     await page._installAfterSave(run);
     expect(run).not.toHaveBeenCalled();
     expect(openReselect).toHaveBeenCalledWith({
       configuration: "dev.yaml",
       yaml: C3_YAML,
+      onApplied: expect.any(Function),
     });
+  });
+
+  it("resumes the blocked install once a pick is applied", async () => {
+    const { page, openReselect, run } = makeInstallPage();
+    await page._installAfterSave(run);
+    expect(run).not.toHaveBeenCalled();
+    const { onApplied } = openReselect.mock.calls[0][0] as { onApplied: () => void };
+    onApplied();
+    await vi.waitFor(() => expect(run).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not block a same-chip board-string mismatch", async () => {
+    // An uncatalogued string on the right chip has no better pick to offer.
+    const { page, openReselect, run } = makeInstallPage({
+      _yaml: "esp32:\n  board: vendor-s3\n  variant: esp32s3\n",
+      _api: {
+        getBoards: vi.fn().mockResolvedValue({ boards: [] }),
+      } as unknown as ESPHomeAPI,
+    });
+    await page._installAfterSave(run);
+    expect(openReselect).not.toHaveBeenCalled();
+    expect(run).toHaveBeenCalledTimes(1);
   });
 
   it("re-prompts on every blocked install click", async () => {

--- a/test/pages/device-board-prompt.test.ts
+++ b/test/pages/device-board-prompt.test.ts
@@ -147,6 +147,17 @@ describe("install hard block on chip disagreement", () => {
     await vi.waitFor(() => expect(run).toHaveBeenCalledTimes(1));
   });
 
+  it("fails open to the install when the chip check rejects", async () => {
+    const { page, openReselect, run } = makeInstallPage({
+      _api: {
+        getBoards: vi.fn().mockRejectedValue(new Error("boom")),
+      } as unknown as ESPHomeAPI,
+    });
+    await page._installAfterSave(run);
+    expect(openReselect).not.toHaveBeenCalled();
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
   it("does not block a same-chip board-string mismatch", async () => {
     // An uncatalogued string on the right chip has no better pick to offer.
     const { page, openReselect, run } = makeInstallPage({

--- a/test/util/board-change.test.ts
+++ b/test/util/board-change.test.ts
@@ -153,6 +153,63 @@ describe("findBoardDisagreement", () => {
     ).toBe(yaml);
   });
 
+  it("flags a resolved LibreTiny board on a different mcu series", async () => {
+    // LibreTiny YAMLs carry no variant; the chip rides the board string
+    // and the catalog records it as the mcu series.
+    const bk7231 = makeSlimBoard("cb2s", {
+      platform: "bk72xx",
+      board: "cb2s",
+      mcu: "bk7231",
+    }) as BoardCatalogEntry;
+    const bk7238 = makeSlimBoard("cb3s-38", {
+      platform: "bk72xx",
+      board: "cb3s_38",
+      mcu: "bk7238",
+    });
+    vi.mocked(fetchBoard).mockResolvedValue(bk7231);
+    const yaml = "bk72xx:\n  board: cb3s_38\n";
+    expect(
+      await findBoardDisagreement(makeApi(yaml, [bk7238]), identityLocalize, {
+        configuration: "dev.yaml",
+        board_id: "cb2s",
+      })
+    ).toBe(yaml);
+  });
+
+  it("is null for an uncatalogued LibreTiny board string", async () => {
+    const bk7231 = makeSlimBoard("cb2s", {
+      platform: "bk72xx",
+      board: "cb2s",
+      mcu: "bk7231",
+    }) as BoardCatalogEntry;
+    vi.mocked(fetchBoard).mockResolvedValue(bk7231);
+    const yaml = "bk72xx:\n  board: vendor-bk\n";
+    expect(
+      await findBoardDisagreement(makeApi(yaml), identityLocalize, {
+        configuration: "dev.yaml",
+        board_id: "cb2s",
+      })
+    ).toBeNull();
+  });
+
+  it("flags an rp2 variant against a different stored mcu series", async () => {
+    const pico = makeSlimBoard("rpi-pico", {
+      platform: "rp2",
+      board: "rpipico",
+      mcu: "rp2040",
+    }) as BoardCatalogEntry;
+    vi.mocked(fetchBoard).mockResolvedValue(pico);
+    const yaml = "rp2:\n  variant: RP2350\n";
+    const api = makeApi(yaml);
+    expect(
+      await findBoardDisagreement(api, identityLocalize, {
+        configuration: "dev.yaml",
+        board_id: "rpi-pico",
+      })
+    ).toBe(yaml);
+    expect(api.getBoards).not.toHaveBeenCalled();
+  });
+
   it("fails open with a warning toast on a fetch failure", async () => {
     // Fail open so install is never blocked on a backend blip, but keep
     // a persistent failure distinguishable from a genuine "agrees".

--- a/test/util/board-change.test.ts
+++ b/test/util/board-change.test.ts
@@ -8,7 +8,7 @@ vi.mock("../../src/util/board-body-cache.js", () => ({ fetchBoard: vi.fn() }));
 import toast from "sonner-js";
 import { makeSlimBoard } from "../_make-slim-board.js";
 import type { ESPHomeAPI } from "../../src/api/index.js";
-import type { BoardCatalogEntry } from "../../src/api/types/boards.js";
+import type { BoardCatalogEntry, SlimBoard } from "../../src/api/types/boards.js";
 import { fetchBoard } from "../../src/util/board-body-cache.js";
 import { findBoardDisagreement } from "../../src/util/board-change.js";
 
@@ -30,6 +30,16 @@ const C3_SIBLING = makeSlimBoard("lolin-c3-mini", {
 });
 
 const DEVICE = { configuration: "dev.yaml", board_id: "generic-esp32s3" };
+const C3_DEVICE = { configuration: "dev.yaml", board_id: "generic-esp32c3" };
+
+const makeApi = (yaml: string | Error, boards: SlimBoard[] = []) =>
+  ({
+    getConfig:
+      yaml instanceof Error
+        ? vi.fn().mockRejectedValue(yaml)
+        : vi.fn().mockResolvedValue(yaml),
+    getBoards: vi.fn().mockResolvedValue({ boards }),
+  }) as unknown as ESPHomeAPI;
 
 describe("findBoardDisagreement", () => {
   afterEach(() => {
@@ -37,7 +47,7 @@ describe("findBoardDisagreement", () => {
   });
 
   it("is false without a stored board id", async () => {
-    const api = { getConfig: vi.fn() } as unknown as ESPHomeAPI;
+    const api = makeApi("");
     expect(
       await findBoardDisagreement(api, identityLocalize, {
         configuration: "dev.yaml",
@@ -50,115 +60,96 @@ describe("findBoardDisagreement", () => {
   it("returns the fetched YAML when it names a different chip", async () => {
     // Callers hand this to the reselect picker to spare a refetch.
     vi.mocked(fetchBoard).mockResolvedValue(S3_BOARD);
-    const api = {
-      getConfig: vi.fn().mockResolvedValue("esp32:\n  variant: esp32c3\n"),
-    } as unknown as ESPHomeAPI;
-    expect(await findBoardDisagreement(api, identityLocalize, DEVICE)).toBe(
-      "esp32:\n  variant: esp32c3\n"
+    const yaml = "esp32:\n  variant: esp32c3\n";
+    expect(await findBoardDisagreement(makeApi(yaml), identityLocalize, DEVICE)).toBe(
+      yaml
     );
   });
 
   it("is null when the YAML agrees", async () => {
     vi.mocked(fetchBoard).mockResolvedValue(S3_BOARD);
-    const api = {
-      getConfig: vi.fn().mockResolvedValue("esp32:\n  board: esp32-s3-devkitc-1\n"),
-    } as unknown as ESPHomeAPI;
-    expect(await findBoardDisagreement(api, identityLocalize, DEVICE)).toBeNull();
+    const yaml = "esp32:\n  board: esp32-s3-devkitc-1\n";
+    expect(
+      await findBoardDisagreement(makeApi(yaml), identityLocalize, DEVICE)
+    ).toBeNull();
   });
 
   it("flags a platform mismatch without a catalog lookup", async () => {
     vi.mocked(fetchBoard).mockResolvedValue(S3_BOARD);
-    const api = {
-      getConfig: vi.fn().mockResolvedValue("esp8266:\n  board: esp01_1m\n"),
-      getBoards: vi.fn(),
-    } as unknown as ESPHomeAPI;
-    expect(await findBoardDisagreement(api, identityLocalize, DEVICE)).toBe(
-      "esp8266:\n  board: esp01_1m\n"
-    );
+    const yaml = "esp8266:\n  board: esp01_1m\n";
+    const api = makeApi(yaml);
+    expect(await findBoardDisagreement(api, identityLocalize, DEVICE)).toBe(yaml);
     expect(api.getBoards).not.toHaveBeenCalled();
   });
 
   it("is null for an uncatalogued board string on the same chip", async () => {
-    // No pick could ever satisfy a string test here — a flag would
-    // re-open the picker on every install, permanently blocking it.
+    // No pick could satisfy a string test here.
     vi.mocked(fetchBoard).mockResolvedValue(C3_BOARD);
-    const api = {
-      getConfig: vi
-        .fn()
-        .mockResolvedValue("esp32:\n  board: vendor-c3\n  variant: esp32c3\n"),
-      getBoards: vi.fn().mockResolvedValue({ boards: [] }),
-    } as unknown as ESPHomeAPI;
+    const yaml = "esp32:\n  board: vendor-c3\n  variant: esp32c3\n";
     expect(
-      await findBoardDisagreement(api, identityLocalize, {
-        configuration: "dev.yaml",
-        board_id: "generic-esp32c3",
-      })
+      await findBoardDisagreement(makeApi(yaml), identityLocalize, C3_DEVICE)
     ).toBeNull();
   });
 
   it("is null for an uncatalogued board string with no variant", async () => {
     vi.mocked(fetchBoard).mockResolvedValue(C3_BOARD);
-    const api = {
-      getConfig: vi.fn().mockResolvedValue("esp32:\n  board: vendor-mystery\n"),
-      getBoards: vi.fn().mockResolvedValue({ boards: [] }),
-    } as unknown as ESPHomeAPI;
+    const yaml = "esp32:\n  board: vendor-mystery\n";
     expect(
-      await findBoardDisagreement(api, identityLocalize, {
-        configuration: "dev.yaml",
-        board_id: "generic-esp32c3",
-      })
+      await findBoardDisagreement(makeApi(yaml), identityLocalize, C3_DEVICE)
     ).toBeNull();
   });
 
   it("flags an uncatalogued board string beside a differing variant", async () => {
     vi.mocked(fetchBoard).mockResolvedValue(S3_BOARD);
-    const api = {
-      getConfig: vi
-        .fn()
-        .mockResolvedValue("esp32:\n  board: vendor-c3\n  variant: esp32c3\n"),
-      getBoards: vi.fn().mockResolvedValue({ boards: [] }),
-    } as unknown as ESPHomeAPI;
-    expect(await findBoardDisagreement(api, identityLocalize, DEVICE)).toBe(
-      "esp32:\n  board: vendor-c3\n  variant: esp32c3\n"
+    const yaml = "esp32:\n  board: vendor-c3\n  variant: esp32c3\n";
+    expect(await findBoardDisagreement(makeApi(yaml), identityLocalize, DEVICE)).toBe(
+      yaml
     );
+  });
+
+  it("is null without a catalog lookup when the stored board has no variant", async () => {
+    vi.mocked(fetchBoard).mockResolvedValue(
+      makeSlimBoard("no-variant-board") as BoardCatalogEntry
+    );
+    const yaml = "esp32:\n  board: vendor-x\n  variant: esp32c3\n";
+    const api = makeApi(yaml);
+    expect(
+      await findBoardDisagreement(api, identityLocalize, {
+        configuration: "dev.yaml",
+        board_id: "no-variant-board",
+      })
+    ).toBeNull();
+    expect(api.getBoards).not.toHaveBeenCalled();
   });
 
   it("is null when a resolved board string names the stored chip", async () => {
     vi.mocked(fetchBoard).mockResolvedValue(C3_BOARD);
-    const api = {
-      getConfig: vi.fn().mockResolvedValue("esp32:\n  board: lolin_c3_mini\n"),
-      getBoards: vi.fn().mockResolvedValue({ boards: [C3_SIBLING] }),
-    } as unknown as ESPHomeAPI;
+    const yaml = "esp32:\n  board: lolin_c3_mini\n";
     expect(
-      await findBoardDisagreement(api, identityLocalize, {
-        configuration: "dev.yaml",
-        board_id: "generic-esp32c3",
-      })
+      await findBoardDisagreement(
+        makeApi(yaml, [C3_SIBLING]),
+        identityLocalize,
+        C3_DEVICE
+      )
     ).toBeNull();
   });
 
   it("flags a resolved board string naming a different chip", async () => {
     // The resolved string beats a stale explicit variant beside it.
     vi.mocked(fetchBoard).mockResolvedValue(S3_BOARD);
-    const api = {
-      getConfig: vi
-        .fn()
-        .mockResolvedValue("esp32:\n  board: lolin_c3_mini\n  variant: esp32s3\n"),
-      getBoards: vi.fn().mockResolvedValue({ boards: [C3_SIBLING] }),
-    } as unknown as ESPHomeAPI;
-    expect(await findBoardDisagreement(api, identityLocalize, DEVICE)).toBe(
-      "esp32:\n  board: lolin_c3_mini\n  variant: esp32s3\n"
-    );
+    const yaml = "esp32:\n  board: lolin_c3_mini\n  variant: esp32s3\n";
+    expect(
+      await findBoardDisagreement(makeApi(yaml, [C3_SIBLING]), identityLocalize, DEVICE)
+    ).toBe(yaml);
   });
 
   it("fails open with a warning toast on a fetch failure", async () => {
     // Fail open so install is never blocked on a backend blip, but keep
     // a persistent failure distinguishable from a genuine "agrees".
     vi.mocked(fetchBoard).mockResolvedValue(S3_BOARD);
-    const api = {
-      getConfig: vi.fn().mockRejectedValue(new Error("boom")),
-    } as unknown as ESPHomeAPI;
-    expect(await findBoardDisagreement(api, identityLocalize, DEVICE)).toBeNull();
+    expect(
+      await findBoardDisagreement(makeApi(new Error("boom")), identityLocalize, DEVICE)
+    ).toBeNull();
     expect(toast.warning).toHaveBeenCalled();
   });
 });

--- a/test/util/board-change.test.ts
+++ b/test/util/board-change.test.ts
@@ -20,6 +20,14 @@ const S3_BOARD = makeSlimBoard("generic-esp32s3", {
   board: "esp32-s3-devkitc-1",
   variant: "esp32s3",
 }) as BoardCatalogEntry;
+const C3_BOARD = makeSlimBoard("generic-esp32c3", {
+  board: "esp32-c3-devkitm-1",
+  variant: "esp32c3",
+}) as BoardCatalogEntry;
+const C3_SIBLING = makeSlimBoard("lolin-c3-mini", {
+  board: "lolin_c3_mini",
+  variant: "esp32c3",
+});
 
 const DEVICE = { configuration: "dev.yaml", board_id: "generic-esp32s3" };
 
@@ -56,6 +64,91 @@ describe("findBoardDisagreement", () => {
       getConfig: vi.fn().mockResolvedValue("esp32:\n  board: esp32-s3-devkitc-1\n"),
     } as unknown as ESPHomeAPI;
     expect(await findBoardDisagreement(api, identityLocalize, DEVICE)).toBeNull();
+  });
+
+  it("flags a platform mismatch without a catalog lookup", async () => {
+    vi.mocked(fetchBoard).mockResolvedValue(S3_BOARD);
+    const api = {
+      getConfig: vi.fn().mockResolvedValue("esp8266:\n  board: esp01_1m\n"),
+      getBoards: vi.fn(),
+    } as unknown as ESPHomeAPI;
+    expect(await findBoardDisagreement(api, identityLocalize, DEVICE)).toBe(
+      "esp8266:\n  board: esp01_1m\n"
+    );
+    expect(api.getBoards).not.toHaveBeenCalled();
+  });
+
+  it("is null for an uncatalogued board string on the same chip", async () => {
+    // No pick could ever satisfy a string test here — a flag would
+    // re-open the picker on every install, permanently blocking it.
+    vi.mocked(fetchBoard).mockResolvedValue(C3_BOARD);
+    const api = {
+      getConfig: vi
+        .fn()
+        .mockResolvedValue("esp32:\n  board: vendor-c3\n  variant: esp32c3\n"),
+      getBoards: vi.fn().mockResolvedValue({ boards: [] }),
+    } as unknown as ESPHomeAPI;
+    expect(
+      await findBoardDisagreement(api, identityLocalize, {
+        configuration: "dev.yaml",
+        board_id: "generic-esp32c3",
+      })
+    ).toBeNull();
+  });
+
+  it("is null for an uncatalogued board string with no variant", async () => {
+    vi.mocked(fetchBoard).mockResolvedValue(C3_BOARD);
+    const api = {
+      getConfig: vi.fn().mockResolvedValue("esp32:\n  board: vendor-mystery\n"),
+      getBoards: vi.fn().mockResolvedValue({ boards: [] }),
+    } as unknown as ESPHomeAPI;
+    expect(
+      await findBoardDisagreement(api, identityLocalize, {
+        configuration: "dev.yaml",
+        board_id: "generic-esp32c3",
+      })
+    ).toBeNull();
+  });
+
+  it("flags an uncatalogued board string beside a differing variant", async () => {
+    vi.mocked(fetchBoard).mockResolvedValue(S3_BOARD);
+    const api = {
+      getConfig: vi
+        .fn()
+        .mockResolvedValue("esp32:\n  board: vendor-c3\n  variant: esp32c3\n"),
+      getBoards: vi.fn().mockResolvedValue({ boards: [] }),
+    } as unknown as ESPHomeAPI;
+    expect(await findBoardDisagreement(api, identityLocalize, DEVICE)).toBe(
+      "esp32:\n  board: vendor-c3\n  variant: esp32c3\n"
+    );
+  });
+
+  it("is null when a resolved board string names the stored chip", async () => {
+    vi.mocked(fetchBoard).mockResolvedValue(C3_BOARD);
+    const api = {
+      getConfig: vi.fn().mockResolvedValue("esp32:\n  board: lolin_c3_mini\n"),
+      getBoards: vi.fn().mockResolvedValue({ boards: [C3_SIBLING] }),
+    } as unknown as ESPHomeAPI;
+    expect(
+      await findBoardDisagreement(api, identityLocalize, {
+        configuration: "dev.yaml",
+        board_id: "generic-esp32c3",
+      })
+    ).toBeNull();
+  });
+
+  it("flags a resolved board string naming a different chip", async () => {
+    // The resolved string beats a stale explicit variant beside it.
+    vi.mocked(fetchBoard).mockResolvedValue(S3_BOARD);
+    const api = {
+      getConfig: vi
+        .fn()
+        .mockResolvedValue("esp32:\n  board: lolin_c3_mini\n  variant: esp32s3\n"),
+      getBoards: vi.fn().mockResolvedValue({ boards: [C3_SIBLING] }),
+    } as unknown as ESPHomeAPI;
+    expect(await findBoardDisagreement(api, identityLocalize, DEVICE)).toBe(
+      "esp32:\n  board: lolin_c3_mini\n  variant: esp32s3\n"
+    );
   });
 
   it("fails open with a warning toast on a fetch failure", async () => {

--- a/test/util/board-change.test.ts
+++ b/test/util/board-change.test.ts
@@ -74,6 +74,16 @@ describe("findBoardDisagreement", () => {
     ).toBeNull();
   });
 
+  it("is null when the board string matches despite a contradicting variant", async () => {
+    // Every same-string pick shares the chip, so flagging would loop;
+    // the compile surfaces the YAML's own contradiction.
+    vi.mocked(fetchBoard).mockResolvedValue(S3_BOARD);
+    const yaml = "esp32:\n  board: esp32-s3-devkitc-1\n  variant: esp32c3\n";
+    const api = makeApi(yaml);
+    expect(await findBoardDisagreement(api, identityLocalize, DEVICE)).toBeNull();
+    expect(api.getBoards).not.toHaveBeenCalled();
+  });
+
   it("flags a platform mismatch without a catalog lookup", async () => {
     vi.mocked(fetchBoard).mockResolvedValue(S3_BOARD);
     const yaml = "esp8266:\n  board: esp01_1m\n";

--- a/test/util/yaml-board.test.ts
+++ b/test/util/yaml-board.test.ts
@@ -109,4 +109,14 @@ describe("boardDisagreesWithYaml", () => {
       boardDisagreesWithYaml(parsed, slimBoard({ board: "esp32dev", variant: "esp32" }))
     ).toBe(false);
   });
+
+  it("compares an rp2 variant against the board's mcu series", () => {
+    // Boards on mcu-faceted platforms carry variant null; the chip
+    // token falls back to the mcu.
+    const parsed = readPlatformBoard("rp2:\n  variant: RP2350\n")!;
+    const pico = slimBoard({ platform: "rp2", board: "rpipico", mcu: "rp2040" });
+    expect(boardDisagreesWithYaml(parsed, pico)).toBe(true);
+    const parsed2040 = readPlatformBoard("rp2:\n  variant: RP2040\n")!;
+    expect(boardDisagreesWithYaml(parsed2040, pico)).toBe(false);
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Clicking Update on some devices opened the "Select the board matching your configuration" picker, and picking a board appeared to do nothing; on affected configs the picker came back on every Update click, permanently blocking installs.

Two defects in the board-disagreement install guard, fixed on both install surfaces (dashboard and device editor):

1. **The guards flagged raw board-string mismatches no pick could resolve.** The backend derives a `board_id` for devices whose YAML names a `board:` string the catalog doesn't carry, using a platform/variant fallback, so the derived board's PlatformIO string differs from the YAML's by construction. Both install guards compared strings, flagged the mismatch, and opened the reselect picker; but the picker's candidates are catalog boards, none of which can ever equal the YAML's uncatalogued string, so the pick never satisfied the guard and the next Update click re-blocked. The guards now check at chip level: platform first, then the chip, resolving the YAML's board string through the catalog when possible (a resolved string beats a stale explicit `variant:` beside it; an equal string settles agreement outright, since every same-string pick shares the chip). A string the catalog doesn't carry falls back to the YAML's own `variant:`, so a same-chip derivation no longer blocks anything. The Web Serial chip check downstream still guards genuine wrong-chip flashes.

2. **A successful pick dropped the pending install.** The guards opened the picker and returned; picking a board wrote the sidecar and toasted, but the update the user asked for never started, and nothing suggested clicking Update again. The reselect dialog now takes a guarded, one-shot `onApplied` callback and both guards pass their pending install, so fixing the board flows straight into the install dialog. The dashboard resume re-resolves the live device by configuration so the pick's sidecar write can't race the device_updated relink.

Supporting changes:

- The platform and chip comparison clauses live once, as `platformDisagrees` / `variantDisagrees` kernels in `yaml-board.ts`, shared by the string-level save-time advisory (`boardDisagreesWithYaml`) and the new chip-level install rule (`chipDisagrees` in `board-change.ts`). The chip-token change deliberately widens the save-time advisory too: an rp2/LibreTiny mcu mismatch (`rp2: variant: RP2350` beside a stored rp2040 board) previously compared vacuously against `variant: null` and never prompted; it now does.
- A board's chip identity is `variant ?? mcu` (`boardChipToken`), so the comparison also works for platforms that record their chip as an mcu series: rp2 (RP2040/RP2350) and the LibreTiny family (bk7231/bk7238/..., whose YAML carries no `variant:` at all and whose chip rides the resolved board string).
- The reselect picker's chip listing is no longer hardcoded to esp32: it lists the YAML's own platform, faceted by `variant` or `mcu` per the wizard's existing platform table, so an rp2 (or future) chip mismatch gets a real picker instead of a dead-end "No boards in the catalog match" toast.
- The catalog resolution (`matchCatalogBoard`) is shared by the guard and the picker and memoised per API instance, so the guard and the picker provably agree on what "resolvable" means and a flagged install doesn't pay the lookup twice.
- Both guards fail open with a warning toast on a backend blip, so a transient `getBoards`/config fetch failure can never silently block an install.

Verified live against a dev backend: a config with `esp32: board: <uncatalogued>` plus `variant: esp32c3` reproduces the permanent picker loop on current main and goes straight to the install dialog with this fix; an `rp2: variant: RP2040` config no longer produces the dead-end toast; a genuinely wrong stored board still opens the picker, and the pick now resumes the install without a second Update click.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2479

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
