### PR TITLE
Consolidate comment masking into scanner options

### DIFF
--- a/src/util/yaml-sensitive-redact.ts
+++ b/src/util/yaml-sensitive-redact.ts
@@ -75,22 +75,21 @@ export function maskSensitiveLines(
   sensitive: (key: string) => boolean = isSensitiveKey
 ): string[] {
   if (lines.length === 0) return [];
-  // CR-terminated lines match no anchored regex in the scanner and
-  // would fail open; mask the LF form and restore the CRs after.
-  const hadCr = lines.map((l) => l.endsWith("\r"));
-  const out = lines.map((l, i) => (hadCr[i] ? l.slice(0, -1) : l));
+  const out = lines.slice();
   const ranges = findSensitiveValueRanges(
     { lines: out.length, line: (n) => ({ text: out[n - 1] }) },
     { ...REDACT_SCAN_OPTIONS, sensitiveKeyPredicate: sensitive }
   );
   // Right-to-left so a line's earlier range offsets stay valid after a
-  // later range on the same line is replaced.
+  // later range on the same line is replaced. The scanner normalizes
+  // trailing CRs itself, and its columns are valid in the CR-bearing
+  // originals — the CR is line-final and past every range.
   for (let r = ranges.length - 1; r >= 0; r--) {
     const { line, valueFrom, valueTo } = ranges[r];
     const idx = line - 1;
     out[idx] = out[idx].slice(0, valueFrom) + placeholder + out[idx].slice(valueTo);
   }
-  return out.map((l, i) => (hadCr[i] ? `${l}\r` : l));
+  return out;
 }
 
 /** Whole-document masking for YAML leaving the app. */

--- a/src/util/yaml-sensitive-redact.ts
+++ b/src/util/yaml-sensitive-redact.ts
@@ -3,15 +3,13 @@
  * visually (``sensitiveValueMaskExtension``); these helpers rewrite
  * the text itself, for any surface that renders or transmits raw
  * YAML (search snippets, crash reports, bug submissions).
+ *
+ * Detection lives in ``findSensitiveValueRanges`` — this module only
+ * chooses the key predicate and the placeholder per surface, and
+ * applies the placeholder to the ranges the scanner emits.
  */
 
-import { RE_INLINE_COMMENT_BOUNDARY } from "./yaml-line-walker.js";
-import {
-  ALWAYS_SENSITIVE_KEYS,
-  BLOCK_SCALAR_HEADER,
-  findSensitiveValueRanges,
-  SECRET_TAG_VALUE,
-} from "./yaml-sensitive-scan.js";
+import { findSensitiveValueRanges } from "./yaml-sensitive-scan.js";
 
 // UI surfaces (search labels, snippets) show a full row of dots so a
 // masked value reads unmistakably as a mask.
@@ -20,18 +18,6 @@ const MASK_PLACEHOLDER = "••••••••";
 // Size-budgeted outputs (the crash report's prefilled issue URL) get a
 // single dot: every masked character costs 9 encoded chars there.
 const COMPACT_MASK_PLACEHOLDER = "•";
-
-// Key/value line with an optional comment prefix — ``# password: hunter2``
-// is just as much a leak as the live form; the captured prefix keeps the
-// comment marker in the masked output. A list dash may sit on either side
-// of the marker (``- # password:``, ``# - password:``). The key class
-// matches the scanner's ``KEY_LINE`` (hyphens and dots allowed) so
-// ``wifi-password:`` is seen.
-const KEY_VALUE_LINE =
-  /^(\s*(?:-\s+)?(?:#+\s*)?-?\s*)([a-zA-Z_][a-zA-Z0-9_.-]*)\s*:\s*(.+)$/;
-
-// A comment line, split into marker and content.
-const COMMENT_LINE = /^(\s*#+)\s*(.*)$/;
 
 // User-defined credential keys: any separator before the suffix.
 const SENSITIVE_KEY_SUFFIX = /[_.-](password|psk)$/i;
@@ -49,97 +35,39 @@ const CERT_MATERIAL_KEY =
 // swallow `remote_receiver`'s button codes.
 const REPORT_SENSITIVE_KEY_SUFFIX = /[_.-](pass|secret|token)$/i;
 
-/**
- * True when *key* names a credential whose value must not leave
- * the app in clear text. Combines two sources:
- *
- * - The shared ``ALWAYS_SENSITIVE_KEYS`` allowlist from the
- *   editor's mask scan (``password``/``ap_password`` etc).
- * - A ``*_password`` / ``*_psk`` suffix heuristic so
- *   user-defined substitution keys (``wifi_password:`` under a
- *   top-level ``substitutions:`` block, or any other place
- *   someone names their own credential field) are masked too.
- *
- * The heuristic is deliberately a touch wider than the scan's
- * allowlist. Over-masking is a cosmetic blemish; under-masking
- * leaks a credential.
- */
-function isSensitiveKey(key: string): boolean {
-  // Case-folded: reports include configs esphome would reject, so a
-  // mis-capitalized `Password:` must not slip past the allowlist.
-  if (ALWAYS_SENSITIVE_KEYS.has(key.toLowerCase())) return true;
-  return SENSITIVE_KEY_SUFFIX.test(key);
-}
-
-function isReportSensitiveKey(key: string): boolean {
-  return (
-    isSensitiveKey(key) ||
-    CERT_MATERIAL_KEY.test(key) ||
-    REPORT_SENSITIVE_KEY_SUFFIX.test(key)
-  );
-}
+// The scanner capabilities every text-masking surface opts into: the
+// editor's visual mask deliberately does not (comments stay visible
+// while editing; `${...}` values mask there).
+const REDACT_SCAN_OPTIONS = {
+  scanCommented: true,
+  emitCommentSpans: true,
+  skipSubstitutionRefs: true,
+} as const;
 
 /**
- * Strip the inline credential value from a single line of YAML.
+ * Strip credential values from a single line of YAML.
  *
- * ``line`` must be one line (the regex anchors to ``^`` / ``$``
- * and won't match across newlines; a multi-line input silently
- * no-ops rather than masks). ``!secret <name>`` and
- * ``${substitution}`` values are *not* masked — both carry only
- * the name of an indirection, not the credential itself.
- * Parent-scoped keys (``key:`` under ``encryption:``) aren't
- * matched here because a single line carries no parent context;
- * use ``maskSensitiveLines`` when the surrounding lines exist.
+ * The single-line window carries no parent context, so parent-scoped
+ * keys (``key:`` under ``encryption:``) aren't masked here; use
+ * ``maskSensitiveLines`` when the surrounding lines exist.
  */
 export function maskSensitiveLine(
   line: string,
   placeholder = MASK_PLACEHOLDER,
   sensitive: (key: string) => boolean = isSensitiveKey
 ): string {
-  // A line keeping its CR matches no anchored regex here or in the
-  // scanner, so CRLF input would fail open; strip and re-append.
-  if (line.endsWith("\r")) {
-    return `${maskSensitiveLine(line.slice(0, -1), placeholder, sensitive)}\r`;
-  }
-  const m = line.match(KEY_VALUE_LINE);
-  if (!m) return line;
-  const [, prefix, key, valueRaw] = m;
-  if (!sensitive(key)) return line;
-  const value = valueRaw.trim();
-  if (!value) return line;
-  // A comment-only value can still carry the credential
-  // (``password: # hunter2``); mask the comment body, keeping the marker.
-  if (value.startsWith("#")) return `${prefix}${key}: # ${placeholder}`;
-  // Preserve indirections (they carry only a name) and block-scalar
-  // headers (no credential of their own; rewriting breaks the YAML shape
-  // while the scanner masks the body lines) — but mask any trailing
-  // comment beside them.
-  if (
-    SECRET_TAG_VALUE.test(value) ||
-    value.startsWith("${") ||
-    BLOCK_SCALAR_HEADER.test(value)
-  ) {
-    const masked = maskCommentTail(value, placeholder);
-    return masked === value ? line : `${prefix}${key}: ${masked}`;
-  }
-  return `${prefix}${key}: ${placeholder}`;
+  return maskSensitiveLines([line], placeholder, sensitive)[0];
 }
 
 /**
- * Mask credential values across a contiguous block of YAML lines.
+ * Mask credential values across a contiguous block of YAML lines,
+ * including commented-out credentials and comment-carried credential
+ * text beside masked or preserved values.
  *
- * Runs the parent-aware ``findSensitiveValueRanges`` scanner over
- * the joined block (catching ``key:`` under ``encryption:`` and
- * block-scalar credentials), then falls back to the single-line
- * heuristic for credential text the scanner never sees: commented-out
- * lines (its ``KEY_LINE`` regex doesn't match leading ``#``) and
- * comment-carried credential text beside skipped values.
- *
- * Edge case for partial windows (search snippets): a ``key:``
- * line whose ``encryption:`` parent falls outside the block stays
- * unmasked (the scanner sees no parent on its stack). Whole
- * documents always carry their parents, so ``maskSensitiveYaml``
- * is unaffected.
+ * Edge case for partial windows (search snippets): a ``key:`` line
+ * whose ``encryption:`` parent falls outside the block stays unmasked
+ * (the scanner sees no parent on its stack). Whole documents always
+ * carry their parents, so ``maskSensitiveYaml`` is unaffected.
  */
 export function maskSensitiveLines(
   lines: readonly string[],
@@ -147,83 +75,22 @@ export function maskSensitiveLines(
   sensitive: (key: string) => boolean = isSensitiveKey
 ): string[] {
   if (lines.length === 0) return [];
-  // CR-terminated lines match no anchored regex here or in the scanner
-  // and would fail open; mask the LF form and restore the CRs after.
+  // CR-terminated lines match no anchored regex in the scanner and
+  // would fail open; mask the LF form and restore the CRs after.
   const hadCr = lines.map((l) => l.endsWith("\r"));
   const out = lines.map((l, i) => (hadCr[i] ? l.slice(0, -1) : l));
-  // The predicate hands the scanner this module's wider key heuristic, so
-  // heuristic-named keys get its parent-scope and block-scalar handling
-  // (a bare `wifi_password: |` body would otherwise stay clear text).
   const ranges = findSensitiveValueRanges(
     { lines: out.length, line: (n) => ({ text: out[n - 1] }) },
-    { sensitiveKeyPredicate: sensitive }
+    { ...REDACT_SCAN_OPTIONS, sensitiveKeyPredicate: sensitive }
   );
-  const scannerMaskedLines = new Set<number>();
-  for (const range of ranges) {
-    const idx = range.line - 1;
-    const line = out[idx];
-    // ``findSensitiveValueRanges`` skips ``!secret <name>`` (it only
-    // carries the indirection name, not the credential) but doesn't
-    // skip ``${substitution}`` references — they're the same shape
-    // of indirection and ``maskSensitiveLine`` already preserves
-    // them on single-line paths. Mirror that here so every masking
-    // path agrees on what stays visible.
-    const value = line.slice(range.valueFrom, range.valueTo).trim();
-    if (value.startsWith("${")) continue;
-    out[idx] =
-      line.slice(0, range.valueFrom) +
-      placeholder +
-      maskCommentTail(line.slice(range.valueTo), placeholder);
-    scannerMaskedLines.add(idx);
-  }
-  for (let i = 0; i < out.length; i++) {
-    if (scannerMaskedLines.has(i)) continue;
-    const line = out[i];
-    out[i] = maskSensitiveLine(line, placeholder, sensitive);
-    // A commented-out block scalar hides the credential on the following
-    // comment lines, which carry no key for the per-line fallback; mask
-    // the bodies indented past the header's key column, mirroring how the
-    // scanner terminates a real block scalar. Marker-adjacent content
-    // (``#hunter2``, no space) is always treated as body: its column is
-    // ambiguous, and skipping it would leak.
-    const headerColumn = commentedBlockHeaderColumn(line, sensitive);
-    if (headerColumn === -1) continue;
-    for (let j = i + 1; j < out.length; j++) {
-      const m = out[j].match(COMMENT_LINE);
-      if (!m) break;
-      if (!m[2]) continue;
-      const contentColumn = out[j].length - m[2].length;
-      if (contentColumn > m[1].length && contentColumn <= headerColumn) break;
-      out[j] = `${m[1]} ${placeholder}`;
-    }
+  // Right-to-left so a line's earlier range offsets stay valid after a
+  // later range on the same line is replaced.
+  for (let r = ranges.length - 1; r >= 0; r--) {
+    const { line, valueFrom, valueTo } = ranges[r];
+    const idx = line - 1;
+    out[idx] = out[idx].slice(0, valueFrom) + placeholder + out[idx].slice(valueTo);
   }
   return out.map((l, i) => (hadCr[i] ? `${l}\r` : l));
-}
-
-// The key's column within a commented sensitive block-scalar header
-// (dash-tolerant, via the same KEY_VALUE_LINE that recognizes it), or
-// -1 when the line isn't one.
-function commentedBlockHeaderColumn(
-  line: string,
-  sensitive: (key: string) => boolean
-): number {
-  const m = line.match(KEY_VALUE_LINE);
-  return m !== null &&
-    m[1].includes("#") &&
-    sensitive(m[2]) &&
-    BLOCK_SCALAR_HEADER.test(m[3].trim())
-    ? m[1].length
-    : -1;
-}
-
-// A trailing comment beside a masked or preserved value can carry the
-// credential itself; mask its body, keeping the marker and spacing.
-// Returns the input unchanged when it carries no comment.
-function maskCommentTail(tail: string, placeholder: string): string {
-  const boundary = tail.search(RE_INLINE_COMMENT_BOUNDARY);
-  if (boundary === -1) return tail;
-  const hash = tail.indexOf("#", boundary);
-  return `${tail.slice(0, hash)}# ${placeholder}`;
 }
 
 /** Whole-document masking for YAML leaving the app. */
@@ -233,4 +100,22 @@ export function maskSensitiveYaml(yaml: string): string {
     COMPACT_MASK_PLACEHOLDER,
     isReportSensitiveKey
   ).join("\n");
+}
+
+/**
+ * Additive key heuristic handed to the scanner, which already owns the
+ * allowlists, case folding, and parent scoping: user-defined
+ * ``*_password`` / ``*_psk`` substitution names. Over-masking is a
+ * cosmetic blemish; under-masking leaks a credential.
+ */
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEY_SUFFIX.test(key);
+}
+
+function isReportSensitiveKey(key: string): boolean {
+  return (
+    isSensitiveKey(key) ||
+    CERT_MATERIAL_KEY.test(key) ||
+    REPORT_SENSITIVE_KEY_SUFFIX.test(key)
+  );
 }

--- a/src/util/yaml-sensitive-scan.ts
+++ b/src/util/yaml-sensitive-scan.ts
@@ -39,6 +39,19 @@ export interface FindSensitiveValueRangesOptions {
    *  built-in allowlists), so wider heuristics (`*_password` suffixes)
    *  get the scanner's parent-scope and block-scalar handling. */
   sensitiveKeyPredicate?: (key: string) => boolean;
+  /** Also scan commented-out lines: a comment's shadow text runs
+   *  through the same key/value handling (allowlist + predicate only —
+   *  a commented key has no live parent scope), emitting ranges at the
+   *  real columns. A commented block-scalar header consumes the
+   *  following comment run. */
+  scanCommented?: boolean;
+  /** Beside a sensitive key, also emit the inline comment's content as
+   *  a range — a comment next to a credential routinely carries the
+   *  credential itself. */
+  emitCommentSpans?: boolean;
+  /** Skip `${...}` reference values like `!secret` refs: both carry
+   *  only the name of an indirection, never the credential. */
+  skipSubstitutionRefs?: boolean;
 }
 
 // Keys whose values are always credentials regardless of where they
@@ -93,6 +106,24 @@ export const BLOCK_SCALAR_HEADER = /^[|>][+-]?\d*\s*(#.*)?$/;
 // so a literal merely starting with "!secret" doesn't pass. Exported so
 // the text masker preserves exactly the values this scanner skips.
 export const SECRET_TAG_VALUE = /^!secret\b/;
+
+// A `${substitution}` reference value — the other indirection shape,
+// skipped only under `skipSubstitutionRefs`.
+const SUBSTITUTION_REF = /^\$\{/;
+
+// A commented-out line, split into the marker prefix (a list dash may
+// sit before the marker: `- # password:`) and the shadow text after it.
+const COMMENT_SHADOW = /^(\s*(?:-\s+)?#+)(.*)$/;
+
+// A comment line split into marker and content, for walking a commented
+// block-scalar's body run.
+const COMMENT_LINE = /^(\s*#+)\s*(.*)$/;
+
+// Leading whitespace, shared by the block-consumption rules.
+const LEADING_WHITESPACE = /^(\s*)/;
+
+// A single whitespace character.
+const WHITESPACE_CHAR = /\s/;
 
 /** Find the closing quote of a YAML scalar starting at `quoteStart`,
  *  honouring the (limited) escapes both quote styles allow:
@@ -152,7 +183,13 @@ export function findSensitiveValueRanges(
   yaml: string | LineSource,
   options: FindSensitiveValueRangesOptions = {}
 ): SensitiveValueRange[] {
-  const { maskAllValues = false, sensitiveKeyPredicate } = options;
+  const {
+    maskAllValues = false,
+    sensitiveKeyPredicate,
+    scanCommented = false,
+    emitCommentSpans = false,
+    skipSubstitutionRefs = false,
+  } = options;
   const ranges: SensitiveValueRange[] = [];
   let lines: string[];
   if (isLineSource(yaml)) {
@@ -172,11 +209,132 @@ export function findSensitiveValueRanges(
   // 0-indexed line cursor we advance manually so block-scalar bodies
   // (whose content can contain `:` and would otherwise be misparsed
   // as keys) are consumed by the block handler, not the outer loop.
+  // Inline-value handling shared by the live and commented paths: emit
+  // the value range (honouring the indirection skips) and, opted in,
+  // the comment-content span. Returns "block" when the value is a
+  // block-scalar header — the caller consumes the body with its own
+  // rule (real indent for live lines, the comment-run boundary for
+  // commented ones).
+  const emitInlineRanges = (
+    lineIdx: number,
+    valueStart: number,
+    trimmedRest: string
+  ): "block" | "done" => {
+    const line = lines[lineIdx];
+    const pushCommentSpan = (from: number) => {
+      if (!emitCommentSpans) return;
+      const hashIdx = findCommentIdx(line, from);
+      if (hashIdx === -1) return;
+      const span = commentContentSpan(line, hashIdx);
+      if (span)
+        ranges.push({ line: lineIdx + 1, valueFrom: span.from, valueTo: span.to });
+    };
+
+    // Comment-only value: the credential can hide in the comment body.
+    if (trimmedRest === "" || trimmedRest.startsWith("#")) {
+      pushCommentSpan(valueStart);
+      return "done";
+    }
+    // Indirections carry only a name — skip the value, mask any comment.
+    if (
+      SECRET_TAG_VALUE.test(trimmedRest) ||
+      (skipSubstitutionRefs && SUBSTITUTION_REF.test(trimmedRest))
+    ) {
+      pushCommentSpan(valueStart);
+      return "done";
+    }
+    if (BLOCK_SCALAR_HEADER.test(trimmedRest)) {
+      pushCommentSpan(valueStart);
+      return "block";
+    }
+
+    let valueEnd = line.length;
+    // For comment-stripping purposes, a `#` only starts a comment when
+    // preceded by whitespace AND outside any quoted scalar. So we
+    // skip past a leading quoted string before looking for the `#`.
+    let searchFrom = valueStart;
+    const firstChar = trimmedRest[0];
+    if (firstChar === '"' || firstChar === "'") {
+      const quoteStart = valueStart + (line.length - valueStart - trimmedRest.length);
+      const quoteEnd = findClosingQuote(line, quoteStart);
+      if (quoteEnd !== -1) searchFrom = quoteEnd + 1;
+      else searchFrom = line.length; // unterminated — treat rest as value
+    }
+    const commentIdx = findCommentIdx(line, searchFrom);
+    if (commentIdx !== -1) valueEnd = commentIdx;
+    while (valueEnd > valueStart && WHITESPACE_CHAR.test(line[valueEnd - 1])) {
+      valueEnd--;
+    }
+    if (valueEnd > valueStart) {
+      ranges.push({ line: lineIdx + 1, valueFrom: valueStart, valueTo: valueEnd });
+    }
+    if (commentIdx !== -1) pushCommentSpan(commentIdx);
+    return "done";
+  };
+
+  // A commented sensitive key line: shadow-parse it, emit its inline
+  // ranges, and consume a commented block-scalar's body run. Returns
+  // the next line index.
+  const scanCommentedLine = (lineIdx: number, markerLen: number): number => {
+    const line = lines[lineIdx];
+    const shadow = line.slice(markerLen);
+    const sm = shadow.match(KEY_LINE);
+    if (!sm) return lineIdx + 1;
+    const [, sLeading, sDash = "", sKey, sSep, sRest] = sm;
+    // No live parent scope inside a comment — allowlist and predicate only.
+    const sensitive =
+      maskAllValues ||
+      ALWAYS_SENSITIVE_KEYS.has(sKey.toLowerCase()) ||
+      sensitiveKeyPredicate?.(sKey) === true;
+    if (!sensitive) return lineIdx + 1;
+
+    const valueStart =
+      markerLen + sLeading.length + sDash.length + sKey.length + 1 + sSep.length;
+    if (emitInlineRanges(lineIdx, valueStart, sRest.trimStart()) !== "block") {
+      return lineIdx + 1;
+    }
+
+    // Commented block-scalar body run. Boundary: bodies mask while their
+    // content column exceeds the header's key column; marker-adjacent
+    // content (``#hunter2``) is always body — its column is ambiguous,
+    // and skipping it would leak; spaced content at or above the header
+    // column ends the run.
+    const headerColumn = markerLen + sLeading.length + sDash.length;
+    let next = lineIdx + 1;
+    while (next < lines.length) {
+      const cont = lines[next];
+      const cm = cont.match(COMMENT_LINE);
+      if (!cm) break;
+      if (!cm[2]) {
+        next++;
+        continue;
+      }
+      const contentColumn = cont.length - cm[2].length;
+      if (contentColumn > cm[1].length && contentColumn <= headerColumn) break;
+      let valEnd = cont.length;
+      while (valEnd > contentColumn && WHITESPACE_CHAR.test(cont[valEnd - 1])) {
+        valEnd--;
+      }
+      if (valEnd > contentColumn) {
+        ranges.push({ line: next + 1, valueFrom: contentColumn, valueTo: valEnd });
+      }
+      next++;
+    }
+    return next;
+  };
+
   let i = 0;
   while (i < lines.length) {
     const line = lines[i];
     const m = line.match(KEY_LINE);
     if (!m) {
+      if (scanCommented) {
+        const c = line.match(COMMENT_SHADOW);
+        if (c) {
+          i = scanCommentedLine(i, c[1].length);
+          continue;
+        }
+      }
       i++;
       continue;
     }
@@ -221,91 +379,68 @@ export function findSensitiveValueRanges(
       continue;
     }
 
-    const trimmedRest = rest.trimStart();
-
-    // Pure key (no inline value, no block scalar) or comment-only —
-    // nothing to mask on this line.
-    if (rest === "" || trimmedRest.startsWith("#")) {
-      i++;
-      continue;
-    }
-
-    // `!secret <name>` carries only the indirection name, not the
-    // credential itself. Leave it as-is so the user can still see
-    // which secret is being referenced.
-    if (SECRET_TAG_VALUE.test(trimmedRest)) {
+    const valueStart = leading.length + dash.length + key.length + 1 + sep.length;
+    if (emitInlineRanges(i, valueStart, rest.trimStart()) !== "block") {
       i++;
       continue;
     }
 
     // Block scalar (`|` / `>` with optional chomping/indent indicator):
     // the credential lives on the indented continuation lines, not on
-    // this header line. Consume the whole block in one shot — masking
+    // the header line. Consume the whole block in one shot — masking
     // each non-blank continuation line and skipping past it so the
     // outer loop doesn't try to reinterpret content like `secret: x`
-    // inside the block as YAML keys.
-    if (BLOCK_SCALAR_HEADER.test(trimmedRest)) {
-      // Use the *effective* indent (leading + dash) so a `- password: |`
-      // list item terminates the block at the next sibling key in the
-      // same item (which sits at `leading + dash` columns) instead of
-      // greedily eating it as block content.
-      const headerIndent = indent;
-      let next = i + 1;
-      while (next < lines.length) {
-        const cont = lines[next];
-        if (cont.trim() === "") {
-          next++;
-          continue;
-        }
-        // Deliberately whitespace-generic, NOT `indentOf` (spaces-only):
-        // `contIndent` doubles as the mask's start column, and the
-        // header indent it's compared against comes from KEY_LINE's
-        // `(\s*)` capture. Mid-edit input may be invalid YAML; a
-        // spaces-only count would end the block at a tab-led line and
-        // leave the credential on it unmasked.
-        const contIndent = (cont.match(/^(\s*)/)?.[1] ?? "").length;
-        if (contIndent <= headerIndent) break;
-        let valEnd = cont.length;
-        while (valEnd > contIndent && /\s/.test(cont[valEnd - 1])) valEnd--;
-        if (valEnd > contIndent) {
-          ranges.push({ line: next + 1, valueFrom: contIndent, valueTo: valEnd });
-        }
+    // inside the block as YAML keys. Use the *effective* indent
+    // (leading + dash) so a `- password: |` list item terminates the
+    // block at the next sibling key in the same item (which sits at
+    // `leading + dash` columns) instead of greedily eating it as block
+    // content.
+    const headerIndent = indent;
+    let next = i + 1;
+    while (next < lines.length) {
+      const cont = lines[next];
+      if (cont.trim() === "") {
         next++;
+        continue;
       }
-      i = next;
-      continue;
-    }
-
-    const valueStart = leading.length + dash.length + key.length + 1 + sep.length;
-    let valueEnd = line.length;
-
-    // For comment-stripping purposes, a `#` only starts a comment when
-    // preceded by whitespace AND outside any quoted scalar. So we
-    // skip past a leading quoted string before looking for the `#`.
-    let searchFrom = valueStart;
-    const firstChar = trimmedRest[0];
-    if (firstChar === '"' || firstChar === "'") {
-      const quoteStart = valueStart + (rest.length - trimmedRest.length);
-      const quoteEnd = findClosingQuote(line, quoteStart);
-      if (quoteEnd !== -1) searchFrom = quoteEnd + 1;
-      else searchFrom = line.length; // unterminated — treat rest as value
-    }
-
-    let commentIdx = -1;
-    for (let k = searchFrom; k < line.length; k++) {
-      if (line[k] === "#" && k > 0 && /\s/.test(line[k - 1])) {
-        commentIdx = k;
-        break;
+      // Deliberately whitespace-generic, NOT `indentOf` (spaces-only):
+      // `contIndent` doubles as the mask's start column, and the
+      // header indent it's compared against comes from KEY_LINE's
+      // `(\s*)` capture. Mid-edit input may be invalid YAML; a
+      // spaces-only count would end the block at a tab-led line and
+      // leave the credential on it unmasked.
+      const contIndent = (cont.match(LEADING_WHITESPACE)?.[1] ?? "").length;
+      if (contIndent <= headerIndent) break;
+      let valEnd = cont.length;
+      while (valEnd > contIndent && WHITESPACE_CHAR.test(cont[valEnd - 1])) valEnd--;
+      if (valEnd > contIndent) {
+        ranges.push({ line: next + 1, valueFrom: contIndent, valueTo: valEnd });
       }
+      next++;
     }
-    if (commentIdx !== -1) valueEnd = commentIdx;
-    while (valueEnd > valueStart && /\s/.test(line[valueEnd - 1])) valueEnd--;
-
-    if (valueEnd > valueStart) {
-      ranges.push({ line: i + 1, valueFrom: valueStart, valueTo: valueEnd });
-    }
-    i++;
+    i = next;
   }
 
   return ranges;
+}
+
+// First `#` at or after *from* that begins a comment (whitespace-preceded).
+function findCommentIdx(line: string, from: number): number {
+  for (let k = from; k < line.length; k++) {
+    if (line[k] === "#" && k > 0 && WHITESPACE_CHAR.test(line[k - 1])) return k;
+  }
+  return -1;
+}
+
+// The comment's content span (after the marker and its spacing, to the
+// trimmed end), or null when the comment is empty.
+function commentContentSpan(
+  line: string,
+  hashIdx: number
+): { from: number; to: number } | null {
+  let from = hashIdx + 1;
+  while (from < line.length && WHITESPACE_CHAR.test(line[from])) from++;
+  let to = line.length;
+  while (to > from && WHITESPACE_CHAR.test(line[to - 1])) to--;
+  return to > from ? { from, to } : null;
 }

--- a/src/util/yaml-sensitive-scan.ts
+++ b/src/util/yaml-sensitive-scan.ts
@@ -174,6 +174,11 @@ function isLineSource(value: string | LineSource): value is LineSource {
   return typeof value !== "string";
 }
 
+/**
+ * Ranges are returned in ascending ``(line, valueFrom)`` order; text
+ * maskers rely on this to apply replacements right-to-left without
+ * invalidating earlier offsets on the same line.
+ */
 export function findSensitiveValueRanges(
   yaml: string | LineSource,
   options: FindSensitiveValueRangesOptions = {}
@@ -292,10 +297,22 @@ export function findSensitiveValueRanges(
     const sm = shadow.match(KEY_LINE);
     if (!sm) return lineIdx + 1;
     const [, sLeading, sDash = "", sKey, sPreColon, sSep, sRest] = sm;
-    // No live parent scope inside a comment — allowlist and predicate only.
+    const sKeyFolded = sKey.toLowerCase();
+    // Parent scope comes from the live ancestor stack, read at the
+    // commented key's column: a `# key:` under a live `encryption:` is
+    // the same leak as its uncommented form. Commented keys never push
+    // onto the stack themselves.
+    const column = markerLen + sLeading.length + sDash.length;
+    let scoped = false;
+    for (let s = stack.length - 1; s >= 0 && !scoped; s--) {
+      if (stack[s].indent >= column) continue;
+      scoped = PARENT_SCOPED_SENSITIVE_KEYS.get(stack[s].key)?.has(sKeyFolded) === true;
+      break;
+    }
     const sensitive =
       maskAllValues ||
-      ALWAYS_SENSITIVE_KEYS.has(sKey.toLowerCase()) ||
+      scoped ||
+      ALWAYS_SENSITIVE_KEYS.has(sKeyFolded) ||
       sensitiveKeyPredicate?.(sKey) === true;
     if (!sensitive) return lineIdx + 1;
 
@@ -316,7 +333,7 @@ export function findSensitiveValueRanges(
     // content (``#hunter2``) is always body — its column is ambiguous,
     // and skipping it would leak; spaced content at or above the header
     // column ends the run.
-    const headerColumn = markerLen + sLeading.length + sDash.length;
+    const headerColumn = column;
     let next = lineIdx + 1;
     while (next < lines.length) {
       const cont = lines[next];

--- a/src/util/yaml-sensitive-scan.ts
+++ b/src/util/yaml-sensitive-scan.ts
@@ -89,7 +89,7 @@ const PARENT_SCOPED_SENSITIVE_KEYS = new Map<string, Set<string>>([
 // dashes as keys. Quoted keys (`"my key": …`) are still not
 // matched; they're rare enough in ESPHome configs and
 // `secrets.yaml` that we accept the limitation.
-const KEY_LINE = /^(\s*)(-\s+)?([a-zA-Z_][a-zA-Z0-9_.\-]*):(\s*)(.*)$/;
+const KEY_LINE = /^(\s*)(-\s+)?([a-zA-Z_][a-zA-Z0-9_.\-]*)(\s*):(\s*)(.*)$/;
 // Block-scalar header tail: `|`, `>`, optional chomping indicator (`+`/`-`),
 // optional explicit indentation digit, optional trailing comment.
 const BLOCK_SCALAR_HEADER = /^[|>][+-]?\d*\s*(#.*)?$/;
@@ -291,7 +291,7 @@ export function findSensitiveValueRanges(
     const shadow = line.slice(markerLen);
     const sm = shadow.match(KEY_LINE);
     if (!sm) return lineIdx + 1;
-    const [, sLeading, sDash = "", sKey, sSep, sRest] = sm;
+    const [, sLeading, sDash = "", sKey, sPreColon, sSep, sRest] = sm;
     // No live parent scope inside a comment — allowlist and predicate only.
     const sensitive =
       maskAllValues ||
@@ -300,7 +300,13 @@ export function findSensitiveValueRanges(
     if (!sensitive) return lineIdx + 1;
 
     const valueStart =
-      markerLen + sLeading.length + sDash.length + sKey.length + 1 + sSep.length;
+      markerLen +
+      sLeading.length +
+      sDash.length +
+      sKey.length +
+      sPreColon.length +
+      1 +
+      sSep.length;
     if (emitInlineRanges(lineIdx, valueStart, sRest.trimStart()) !== "block") {
       return lineIdx + 1;
     }
@@ -350,8 +356,9 @@ export function findSensitiveValueRanges(
     const leading = m[1];
     const dash = m[2] ?? "";
     const key = m[3];
-    const sep = m[4];
-    const rest = m[5];
+    const preColon = m[4];
+    const sep = m[5];
+    const rest = m[6];
     // Sensitivity checks and ancestor tracking case-fold the key: the
     // input may be YAML esphome would reject, and a mis-capitalized
     // `Encryption:` must still scope the `key:` under it.
@@ -387,7 +394,8 @@ export function findSensitiveValueRanges(
       continue;
     }
 
-    const valueStart = leading.length + dash.length + key.length + 1 + sep.length;
+    const valueStart =
+      leading.length + dash.length + key.length + preColon.length + 1 + sep.length;
     if (emitInlineRanges(i, valueStart, rest.trimStart()) !== "block") {
       i++;
       continue;

--- a/src/util/yaml-sensitive-scan.ts
+++ b/src/util/yaml-sensitive-scan.ts
@@ -186,10 +186,10 @@ export function findSensitiveValueRanges(
     skipSubstitutionRefs = false,
   } = options;
   const ranges: SensitiveValueRange[] = [];
-  // Trailing CRs are stripped at materialization: a line keeping its CR
-  // matches no anchored regex here (JS `.` and `$` treat `\r` as a line
-  // terminator), so CRLF input would silently fail open. Emitted columns
-  // stay valid in the caller's CR-bearing original — the CR is line-final.
+  // Trailing CRs are stripped at materialization: `.` excludes line
+  // terminators in JS, so a line keeping its CR cannot satisfy patterns
+  // ending `(.*)$` and would silently fail open. Emitted columns stay
+  // valid in the caller's CR-bearing original — the CR is line-final.
   let lines: string[];
   if (isLineSource(yaml)) {
     if (yaml.lines === 0) return ranges;
@@ -239,15 +239,26 @@ export function findSensitiveValueRanges(
   ): "block" | "done" => {
     const line = lines[lineIdx];
 
+    // A `#`-leading value IS the comment; its marker needs no
+    // whitespace guard (`password:#hunter2` is still a leak), so the
+    // span comes straight off the marker position.
+    if (trimmedRest.startsWith("#")) {
+      if (emitCommentSpans) {
+        const span = commentContentSpan(line, line.indexOf("#", valueStart));
+        if (span) {
+          ranges.push({ line: lineIdx + 1, valueFrom: span.from, valueTo: span.to });
+        }
+      }
+      return "done";
+    }
     // Value-less shapes share one action — mask only the comment, which
-    // can hide the credential: an empty or comment-only value, an
-    // indirection (it carries only a name), or a block-scalar header
-    // (its credential lives on the body lines).
+    // can hide the credential: an empty value, an indirection (it
+    // carries only a name), or a block-scalar header (its credential
+    // lives on the body lines).
     const isBlock = BLOCK_SCALAR_HEADER.test(trimmedRest);
     if (
       isBlock ||
       trimmedRest === "" ||
-      trimmedRest.startsWith("#") ||
       SECRET_TAG_VALUE.test(trimmedRest) ||
       (skipSubstitutionRefs && SUBSTITUTION_REF.test(trimmedRest))
     ) {

--- a/src/util/yaml-sensitive-scan.ts
+++ b/src/util/yaml-sensitive-scan.ts
@@ -58,14 +58,7 @@ export interface FindSensitiveValueRangesOptions {
 // appear in the document. These names are stable across the ESPHome
 // catalog (api/ota/mqtt/wifi/web_server/http_request all spell their
 // credential fields the same way).
-/**
- * Keys whose values are always credentials regardless of where
- * they appear in the document. Exported so single-line maskers
- * (``yaml-search-helpers.ts``) can share the same source of
- * truth — adding a key here lights it up in every consumer
- * automatically rather than drifting between copies.
- */
-export const ALWAYS_SENSITIVE_KEYS: ReadonlySet<string> = new Set([
+const ALWAYS_SENSITIVE_KEYS: ReadonlySet<string> = new Set([
   "password",
   "ap_password",
   "ota_password",
@@ -98,14 +91,12 @@ const PARENT_SCOPED_SENSITIVE_KEYS = new Map<string, Set<string>>([
 // `secrets.yaml` that we accept the limitation.
 const KEY_LINE = /^(\s*)(-\s+)?([a-zA-Z_][a-zA-Z0-9_.\-]*):(\s*)(.*)$/;
 // Block-scalar header tail: `|`, `>`, optional chomping indicator (`+`/`-`),
-// optional explicit indentation digit, optional trailing comment. Exported
-// so the text masker preserves headers whose bodies this scanner masks.
-export const BLOCK_SCALAR_HEADER = /^[|>][+-]?\d*\s*(#.*)?$/;
+// optional explicit indentation digit, optional trailing comment.
+const BLOCK_SCALAR_HEADER = /^[|>][+-]?\d*\s*(#.*)?$/;
 
 // A `!secret` tag value — carries only the indirection name. Word-bounded
-// so a literal merely starting with "!secret" doesn't pass. Exported so
-// the text masker preserves exactly the values this scanner skips.
-export const SECRET_TAG_VALUE = /^!secret\b/;
+// so a literal merely starting with "!secret" doesn't pass.
+const SECRET_TAG_VALUE = /^!secret\b/;
 
 // A `${substitution}` reference value — the other indirection shape,
 // skipped only under `skipSubstitutionRefs`.
@@ -191,14 +182,20 @@ export function findSensitiveValueRanges(
     skipSubstitutionRefs = false,
   } = options;
   const ranges: SensitiveValueRange[] = [];
+  // Trailing CRs are stripped at materialization: a line keeping its CR
+  // matches no anchored regex here (JS `.` and `$` treat `\r` as a line
+  // terminator), so CRLF input would silently fail open. Emitted columns
+  // stay valid in the caller's CR-bearing original — the CR is line-final.
   let lines: string[];
   if (isLineSource(yaml)) {
     if (yaml.lines === 0) return ranges;
     lines = new Array<string>(yaml.lines);
-    for (let n = 1; n <= yaml.lines; n++) lines[n - 1] = yaml.line(n).text;
+    for (let n = 1; n <= yaml.lines; n++) {
+      lines[n - 1] = stripTrailingCr(yaml.line(n).text);
+    }
   } else {
     if (!yaml) return ranges;
-    lines = yaml.split("\n");
+    lines = yaml.split("\n").map(stripTrailingCr);
   }
 
   // Stack of (indent, key) entries representing the current ancestor
@@ -206,9 +203,25 @@ export function findSensitiveValueRanges(
   // indent >= N is no longer an ancestor and is popped.
   const stack: Array<{ indent: number; key: string }> = [];
 
-  // 0-indexed line cursor we advance manually so block-scalar bodies
-  // (whose content can contain `:` and would otherwise be misparsed
-  // as keys) are consumed by the block handler, not the outer loop.
+  // Trim trailing whitespace off [from, to) and push the range when
+  // anything remains.
+  const pushTrimmedRange = (lineIdx: number, from: number, to: number) => {
+    const line = lines[lineIdx];
+    while (to > from && WHITESPACE_CHAR.test(line[to - 1])) to--;
+    if (to > from) ranges.push({ line: lineIdx + 1, valueFrom: from, valueTo: to });
+  };
+
+  // Under `emitCommentSpans`, push the content span of the first comment
+  // at or after *from*.
+  const pushCommentSpan = (lineIdx: number, from: number) => {
+    if (!emitCommentSpans) return;
+    const line = lines[lineIdx];
+    const hashIdx = findCommentIdx(line, from);
+    if (hashIdx === -1) return;
+    const span = commentContentSpan(line, hashIdx);
+    if (span) ranges.push({ line: lineIdx + 1, valueFrom: span.from, valueTo: span.to });
+  };
+
   // Inline-value handling shared by the live and commented paths: emit
   // the value range (honouring the indirection skips) and, opted in,
   // the comment-content span. Returns "block" when the value is a
@@ -221,34 +234,23 @@ export function findSensitiveValueRanges(
     trimmedRest: string
   ): "block" | "done" => {
     const line = lines[lineIdx];
-    const pushCommentSpan = (from: number) => {
-      if (!emitCommentSpans) return;
-      const hashIdx = findCommentIdx(line, from);
-      if (hashIdx === -1) return;
-      const span = commentContentSpan(line, hashIdx);
-      if (span)
-        ranges.push({ line: lineIdx + 1, valueFrom: span.from, valueTo: span.to });
-    };
 
-    // Comment-only value: the credential can hide in the comment body.
-    if (trimmedRest === "" || trimmedRest.startsWith("#")) {
-      pushCommentSpan(valueStart);
-      return "done";
-    }
-    // Indirections carry only a name — skip the value, mask any comment.
+    // Value-less shapes share one action — mask only the comment, which
+    // can hide the credential: an empty or comment-only value, an
+    // indirection (it carries only a name), or a block-scalar header
+    // (its credential lives on the body lines).
+    const isBlock = BLOCK_SCALAR_HEADER.test(trimmedRest);
     if (
+      isBlock ||
+      trimmedRest === "" ||
+      trimmedRest.startsWith("#") ||
       SECRET_TAG_VALUE.test(trimmedRest) ||
       (skipSubstitutionRefs && SUBSTITUTION_REF.test(trimmedRest))
     ) {
-      pushCommentSpan(valueStart);
-      return "done";
-    }
-    if (BLOCK_SCALAR_HEADER.test(trimmedRest)) {
-      pushCommentSpan(valueStart);
-      return "block";
+      pushCommentSpan(lineIdx, valueStart);
+      return isBlock ? "block" : "done";
     }
 
-    let valueEnd = line.length;
     // For comment-stripping purposes, a `#` only starts a comment when
     // preceded by whitespace AND outside any quoted scalar. So we
     // skip past a leading quoted string before looking for the `#`.
@@ -261,14 +263,8 @@ export function findSensitiveValueRanges(
       else searchFrom = line.length; // unterminated — treat rest as value
     }
     const commentIdx = findCommentIdx(line, searchFrom);
-    if (commentIdx !== -1) valueEnd = commentIdx;
-    while (valueEnd > valueStart && WHITESPACE_CHAR.test(line[valueEnd - 1])) {
-      valueEnd--;
-    }
-    if (valueEnd > valueStart) {
-      ranges.push({ line: lineIdx + 1, valueFrom: valueStart, valueTo: valueEnd });
-    }
-    if (commentIdx !== -1) pushCommentSpan(commentIdx);
+    pushTrimmedRange(lineIdx, valueStart, commentIdx !== -1 ? commentIdx : line.length);
+    if (commentIdx !== -1) pushCommentSpan(lineIdx, commentIdx);
     return "done";
   };
 
@@ -311,18 +307,15 @@ export function findSensitiveValueRanges(
       }
       const contentColumn = cont.length - cm[2].length;
       if (contentColumn > cm[1].length && contentColumn <= headerColumn) break;
-      let valEnd = cont.length;
-      while (valEnd > contentColumn && WHITESPACE_CHAR.test(cont[valEnd - 1])) {
-        valEnd--;
-      }
-      if (valEnd > contentColumn) {
-        ranges.push({ line: next + 1, valueFrom: contentColumn, valueTo: valEnd });
-      }
+      pushTrimmedRange(next, contentColumn, cont.length);
       next++;
     }
     return next;
   };
 
+  // 0-indexed line cursor we advance manually so block-scalar bodies
+  // (whose content can contain `:` and would otherwise be misparsed
+  // as keys) are consumed by the block handler, not the outer loop.
   let i = 0;
   while (i < lines.length) {
     const line = lines[i];
@@ -395,7 +388,6 @@ export function findSensitiveValueRanges(
     // block at the next sibling key in the same item (which sits at
     // `leading + dash` columns) instead of greedily eating it as block
     // content.
-    const headerIndent = indent;
     let next = i + 1;
     while (next < lines.length) {
       const cont = lines[next];
@@ -410,18 +402,18 @@ export function findSensitiveValueRanges(
       // spaces-only count would end the block at a tab-led line and
       // leave the credential on it unmasked.
       const contIndent = (cont.match(LEADING_WHITESPACE)?.[1] ?? "").length;
-      if (contIndent <= headerIndent) break;
-      let valEnd = cont.length;
-      while (valEnd > contIndent && WHITESPACE_CHAR.test(cont[valEnd - 1])) valEnd--;
-      if (valEnd > contIndent) {
-        ranges.push({ line: next + 1, valueFrom: contIndent, valueTo: valEnd });
-      }
+      if (contIndent <= indent) break;
+      pushTrimmedRange(next, contIndent, cont.length);
       next++;
     }
     i = next;
   }
 
   return ranges;
+}
+
+function stripTrailingCr(text: string): string {
+  return text.endsWith("\r") ? text.slice(0, -1) : text;
 }
 
 // First `#` at or after *from* that begins a comment (whitespace-preceded).

--- a/src/util/yaml-sensitive-scan.ts
+++ b/src/util/yaml-sensitive-scan.ts
@@ -95,11 +95,15 @@ const KEY_LINE = /^(\s*)(-\s+)?([a-zA-Z_][a-zA-Z0-9_.\-]*):(\s*)(.*)$/;
 const BLOCK_SCALAR_HEADER = /^[|>][+-]?\d*\s*(#.*)?$/;
 
 // A `!secret` tag value — carries only the indirection name. Word-bounded
-// so a literal merely starting with "!secret" doesn't pass.
+// so a literal merely starting with "!secret" doesn't pass. Deliberately
+// NOT secret-ref.ts's fully anchored SECRET_REF_RE: the scanner must
+// tolerate a trailing comment after the name (whose body it masks).
 const SECRET_TAG_VALUE = /^!secret\b/;
 
 // A `${substitution}` reference value — the other indirection shape,
-// skipped only under `skipSubstitutionRefs`.
+// skipped only under `skipSubstitutionRefs`. Deliberately NOT
+// substitutions.ts's contains-style matchers: a literal merely
+// containing `${...}` must still mask.
 const SUBSTITUTION_REF = /^\$\{/;
 
 // A commented-out line, split into the marker prefix (a list dash may

--- a/test/util/yaml-sensitive-redact.test.ts
+++ b/test/util/yaml-sensitive-redact.test.ts
@@ -179,6 +179,14 @@ describe("maskSensitiveYaml", () => {
     expect(masked).toContain("  password: # •");
   });
 
+  it("masks a value behind a space-before-colon key", () => {
+    const masked = maskSensitiveYaml(
+      "wifi:\n  password : hunter2\n  # ap_password : abcdef"
+    );
+    expect(masked).not.toContain("hunter2");
+    expect(masked).not.toContain("abcdef");
+  });
+
   it("masks a marker-adjacent comment-only value", () => {
     const masked = maskSensitiveYaml("wifi:\n  password:#hunter2");
     expect(masked).not.toContain("hunter2");

--- a/test/util/yaml-sensitive-redact.test.ts
+++ b/test/util/yaml-sensitive-redact.test.ts
@@ -179,6 +179,12 @@ describe("maskSensitiveYaml", () => {
     expect(masked).toContain("  password: # •");
   });
 
+  it("masks a marker-adjacent comment-only value", () => {
+    const masked = maskSensitiveYaml("wifi:\n  password:#hunter2");
+    expect(masked).not.toContain("hunter2");
+    expect(masked).toContain("  password:#•");
+  });
+
   it("masks user-named *_password / *_psk substitution keys", () => {
     const yaml = [
       "substitutions:",

--- a/test/util/yaml-sensitive-redact.test.ts
+++ b/test/util/yaml-sensitive-redact.test.ts
@@ -265,6 +265,15 @@ describe("maskSensitiveYaml", () => {
     expect(maskSensitiveLine("  wifi_pass: hunter2")).toBe("  wifi_pass: hunter2");
   });
 
+  it("masks and keeps a trailing comment on the label path", () => {
+    expect(maskSensitiveLine("  password: hunter2 # note secret")).toBe(
+      "  password: \u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022 # \u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022"
+    );
+    expect(maskSensitiveLine("  password: 'it''s # here' # c")).toBe(
+      "  password: \u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022 # \u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022"
+    );
+  });
+
   it("keeps public certificate material visible on UI paths", () => {
     // Only the outbound report widens to certificate blobs; search
     // labels and snippets keep the credential-only rules.

--- a/test/util/yaml-sensitive-scan.test.ts
+++ b/test/util/yaml-sensitive-scan.test.ts
@@ -119,6 +119,12 @@ wifi:
     ).toEqual(["body-one", "no-space-body"]);
   });
 
+  it("normalizes trailing CRs so CRLF input cannot fail open", () => {
+    const yaml = "wifi:\r\n  password: hunter2\r\nsensor:";
+    const ranges = findSensitiveValueRanges(yaml);
+    expect(ranges).toEqual([{ line: 2, valueFrom: 12, valueTo: 19 }]);
+  });
+
   it("masks plain `password:` values regardless of parent", () => {
     const yaml = `api:
   password: hunter2

--- a/test/util/yaml-sensitive-scan.test.ts
+++ b/test/util/yaml-sensitive-scan.test.ts
@@ -45,6 +45,80 @@ wifi:
     ]);
   });
 
+  it("keeps the options-off contract: no comments, no spans, ${} masked", () => {
+    const yaml = [
+      "wifi:",
+      "  # password: commented",
+      "  password: ${wifi_password}",
+      "  ap_password: hunter2 # note",
+    ].join("\n");
+    expect(valuesAt(yaml, findSensitiveValueRanges(yaml))).toEqual([
+      "${wifi_password}",
+      "hunter2",
+    ]);
+  });
+
+  it("skips ${...} values under skipSubstitutionRefs", () => {
+    const yaml = "wifi:\n  password: ${wifi_password}\n  ap_password: hunter2";
+    expect(
+      valuesAt(yaml, findSensitiveValueRanges(yaml, { skipSubstitutionRefs: true }))
+    ).toEqual(["hunter2"]);
+  });
+
+  it("emits comment spans beside sensitive keys under emitCommentSpans", () => {
+    const yaml = [
+      "wifi:",
+      "  password: hunter2 # old pass",
+      "  ap_password: # comment only",
+      "  psk: !secret the_psk # was abcdef",
+      "mqtt:",
+      "  password: | # block note",
+      "    body",
+      "esphome:",
+      "  name: fine # untouched",
+    ].join("\n");
+    expect(
+      valuesAt(yaml, findSensitiveValueRanges(yaml, { emitCommentSpans: true }))
+    ).toEqual([
+      "hunter2",
+      "old pass",
+      "comment only",
+      "was abcdef",
+      "block note",
+      "body",
+    ]);
+  });
+
+  it("scans commented keys under scanCommented, without parent scope", () => {
+    const yaml = [
+      "wifi:",
+      "  # password: hunter2",
+      "  - # ota_password: abcdef",
+      "  # - psk: qwerty",
+      "api:",
+      "  encryption:",
+      "    # key: scoped-needs-parent",
+      "  # note: not-sensitive",
+    ].join("\n");
+    expect(
+      valuesAt(yaml, findSensitiveValueRanges(yaml, { scanCommented: true }))
+    ).toEqual(["hunter2", "abcdef", "qwerty"]);
+  });
+
+  it("consumes a commented block scalar with the comment-run boundary", () => {
+    const yaml = [
+      "wifi:",
+      "  # password: |",
+      "  #   body-one",
+      "  #no-space-body",
+      "  # note: keep",
+      "sensor:",
+    ].join("\n");
+    expect(
+      valuesAt(yaml, findSensitiveValueRanges(yaml, { scanCommented: true }))
+    ).toEqual(["body-one", "no-space-body"]);
+  });
+
   it("masks plain `password:` values regardless of parent", () => {
     const yaml = `api:
   password: hunter2

--- a/test/util/yaml-sensitive-scan.test.ts
+++ b/test/util/yaml-sensitive-scan.test.ts
@@ -89,7 +89,7 @@ wifi:
     ]);
   });
 
-  it("scans commented keys under scanCommented, without parent scope", () => {
+  it("scans commented keys under scanCommented", () => {
     const yaml = [
       "wifi:",
       "  # password: hunter2",
@@ -97,12 +97,12 @@ wifi:
       "  # - psk: qwerty",
       "api:",
       "  encryption:",
-      "    # key: scoped-needs-parent",
+      "    # key: commented-scoped",
       "  # note: not-sensitive",
     ].join("\n");
     expect(
       valuesAt(yaml, findSensitiveValueRanges(yaml, { scanCommented: true }))
-    ).toEqual(["hunter2", "abcdef", "qwerty"]);
+    ).toEqual(["hunter2", "abcdef", "qwerty", "commented-scoped"]);
   });
 
   it("consumes a commented block scalar with the comment-run boundary", () => {
@@ -123,6 +123,28 @@ wifi:
     const yaml = "wifi:\r\n  password: hunter2\r\nsensor:";
     const ranges = findSensitiveValueRanges(yaml);
     expect(ranges).toEqual([{ line: 2, valueFrom: 12, valueTo: 19 }]);
+  });
+
+  it("emits ranges in ascending (line, valueFrom) order", () => {
+    const yaml = "wifi:\n  password: hunter2 # old pass\n  ap_password: abcdef";
+    const ranges = findSensitiveValueRanges(yaml, { emitCommentSpans: true });
+    const keys = ranges.map((r) => [r.line, r.valueFrom]);
+    const sorted = [...keys].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+    expect(keys).toEqual(sorted);
+    expect(ranges).toHaveLength(3);
+  });
+
+  it("scopes a commented key by the live ancestor stack", () => {
+    const yaml = [
+      "api:",
+      "  encryption:",
+      "    # key: commented-scoped",
+      "remote_receiver:",
+      "  # key: still-a-button-code",
+    ].join("\n");
+    expect(
+      valuesAt(yaml, findSensitiveValueRanges(yaml, { scanCommented: true }))
+    ).toEqual(["commented-scoped"]);
   });
 
   it("masks plain `password:` values regardless of parent", () => {


### PR DESCRIPTION
# What does this implement/fix?

The crash report work in #1591 left credential detection split across two engines; the scanner owned live lines while yaml-sensitive-redact grew its own approximations for commented lines, comment bodies, and substitution refs, kept in sync by comment contract only. This folds everything into the scanner behind three opt in options (scanCommented, emitCommentSpans, skipSubstitutionRefs), all defaulting off. The options off path is not byte identical to main; it is strictly wider, so the editor's visual mask and the secrets editor now also cover space before colon keys and CRLF documents, never narrower. The redact module shrinks to placeholder policy; it picks the predicate and placeholder per surface and applies the ranges the scanner emits, and the single line label path now runs the same engine.

Two deliberate behavior deltas, both alignments rather than regressions: masked output preserves the original spacing instead of normalizing it, and the search label path now masks and keeps trailing comments (and handles quoted values containing #) the way the snippet path already did. An A/B probe over the #1591 masking corpus matches apart from the spacing form, and the consolidation closes gaps the split engines could not: CRLF input masks in the scanner itself, space before colon keys mask everywhere, and a commented key under a live sensitive parent (# key: under encryption:) is scoped by the live ancestor stack.

**Related issue or feature (if applicable):**

- fixes #1593

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
