### PR TITLE
Fix unreadable warning text in dark mode

### DIFF
--- a/src/components/device/config-entry-renderers/constraint-cluster.styles.ts
+++ b/src/components/device/config-entry-renderers/constraint-cluster.styles.ts
@@ -29,7 +29,7 @@ export const constraintClusterStyles = css`
     color: var(--wa-color-text-quiet);
   }
   .constraint-cluster-header.unsatisfied {
-    color: var(--wa-color-warning-text-quiet, currentColor);
+    color: var(--wa-color-warning-on-quiet, currentColor);
   }
   .constraint-cluster-header wa-icon {
     flex-shrink: 0;

--- a/src/components/update-all-dialog.ts
+++ b/src/components/update-all-dialog.ts
@@ -118,7 +118,7 @@ export class ESPHomeUpdateAllDialog extends LitElement {
 
       .summary-note {
         margin-top: var(--wa-space-2xs);
-        color: var(--wa-color-warning-text-quiet);
+        color: var(--wa-color-warning-on-quiet);
       }
     `,
   ];

--- a/src/styles/banners.ts
+++ b/src/styles/banners.ts
@@ -36,7 +36,7 @@ export const warningBannerStyles = css`
     padding: var(--wa-space-s) var(--wa-space-m);
     border-radius: var(--wa-border-radius-s);
     background: var(--wa-color-warning-fill-quiet, #fff7e0);
-    color: var(--wa-color-warning-text-quiet, #6b4f00);
+    color: var(--wa-color-warning-on-quiet, #6b4f00);
     border-left: 3px solid var(--wa-color-warning-border-loud, #f0b400);
     font-size: var(--wa-font-size-s);
   }

--- a/test/styles/wa-color-tokens.test.ts
+++ b/test/styles/wa-color-tokens.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Every `--wa-color-*` token referenced under src/ must exist in the
+ * WebAwesome styles tree. A phantom token is invisible to tsc and falls
+ * back silently (or to a hard-coded color that ignores the theme); this
+ * pins the vocabulary so the next typo fails a test instead of shipping.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const WA_STYLES_DIR = "node_modules/@home-assistant/webawesome/dist/styles";
+const TOKEN_RE = /--wa-color-[a-z0-9-]+/g;
+
+// Known phantoms awaiting the follow-up sweep; do not add to this list —
+// fix the token instead.
+const KNOWN_PHANTOMS = new Set([
+  "--wa-color-border",
+  "--wa-color-brand-text-quiet",
+  "--wa-color-danger-border",
+  "--wa-color-danger-text-normal",
+  "--wa-color-neutral-500",
+  "--wa-color-success-quiet",
+  "--wa-color-surface-subtle",
+  "--wa-color-text",
+  "--wa-color-text-subtle",
+  "--wa-color-warning-quiet",
+]);
+
+function walk(dir: string, suffix: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) walk(path, suffix, out);
+    else if (path.endsWith(suffix)) out.push(path);
+  }
+  return out;
+}
+
+function tokensIn(paths: string[]): Set<string> {
+  const tokens = new Set<string>();
+  for (const path of paths) {
+    for (const match of readFileSync(path, "utf8").matchAll(TOKEN_RE)) {
+      tokens.add(match[0]);
+    }
+  }
+  return tokens;
+}
+
+describe("wa color tokens", () => {
+  it("references only tokens the WebAwesome styles define", () => {
+    const defined = tokensIn(walk(WA_STYLES_DIR, ".css"));
+    const referenced = tokensIn(walk("src", ".ts"));
+    const phantoms = [...referenced].filter(
+      (token) => !defined.has(token) && !KNOWN_PHANTOMS.has(token)
+    );
+    expect(phantoms).toEqual([]);
+  });
+
+  it("keeps the phantom allowlist honest", () => {
+    const defined = tokensIn(walk(WA_STYLES_DIR, ".css"));
+    const referenced = tokensIn(walk("src", ".ts"));
+    for (const token of KNOWN_PHANTOMS) {
+      expect(defined.has(token)).toBe(false);
+      expect(referenced.has(token)).toBe(true);
+    }
+  });
+});

--- a/test/styles/wa-color-tokens.test.ts
+++ b/test/styles/wa-color-tokens.test.ts
@@ -24,14 +24,13 @@ const KNOWN_PHANTOMS = new Set([
   "--wa-color-warning-quiet",
 ]);
 
-// Dynamic node imports: tsconfig's `types` pin excludes the node
-// ambients, so the static form fails tsc (same shape as
-// test/build-scripts/gen-language-manifest.test.ts).
 async function collectTokens(): Promise<{
   defined: Set<string>;
   referenced: Set<string>;
 }> {
+  // @ts-expect-error — node-only module (see gen-language-manifest.test.ts)
   const { readdirSync, readFileSync, statSync } = await import("node:fs");
+  // @ts-expect-error — node-only module
   const { join } = await import("node:path");
 
   const walk = (dir: string, suffix: string, out: string[] = []): string[] => {

--- a/test/styles/wa-color-tokens.test.ts
+++ b/test/styles/wa-color-tokens.test.ts
@@ -4,8 +4,6 @@
  * back silently (or to a hard-coded color that ignores the theme); this
  * pins the vocabulary so the next typo fails a test instead of shipping.
  */
-import { readdirSync, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const WA_STYLES_DIR = "node_modules/@home-assistant/webawesome/dist/styles";
@@ -26,38 +24,52 @@ const KNOWN_PHANTOMS = new Set([
   "--wa-color-warning-quiet",
 ]);
 
-function walk(dir: string, suffix: string, out: string[] = []): string[] {
-  for (const entry of readdirSync(dir)) {
-    const path = join(dir, entry);
-    if (statSync(path).isDirectory()) walk(path, suffix, out);
-    else if (path.endsWith(suffix)) out.push(path);
-  }
-  return out;
-}
+// Dynamic node imports: tsconfig's `types` pin excludes the node
+// ambients, so the static form fails tsc (same shape as
+// test/build-scripts/gen-language-manifest.test.ts).
+async function collectTokens(): Promise<{
+  defined: Set<string>;
+  referenced: Set<string>;
+}> {
+  const { readdirSync, readFileSync, statSync } = await import("node:fs");
+  const { join } = await import("node:path");
 
-function tokensIn(paths: string[]): Set<string> {
-  const tokens = new Set<string>();
-  for (const path of paths) {
-    for (const match of readFileSync(path, "utf8").matchAll(TOKEN_RE)) {
-      tokens.add(match[0]);
+  const walk = (dir: string, suffix: string, out: string[] = []): string[] => {
+    for (const entry of readdirSync(dir)) {
+      const path = join(dir, entry);
+      if (statSync(path).isDirectory()) walk(path, suffix, out);
+      else if (path.endsWith(suffix)) out.push(path);
     }
-  }
-  return tokens;
+    return out;
+  };
+
+  const tokensIn = (paths: string[]): Set<string> => {
+    const tokens = new Set<string>();
+    for (const path of paths) {
+      for (const match of readFileSync(path, "utf8").matchAll(TOKEN_RE)) {
+        tokens.add(match[0]);
+      }
+    }
+    return tokens;
+  };
+
+  return {
+    defined: tokensIn(walk(WA_STYLES_DIR, ".css")),
+    referenced: tokensIn(walk("src", ".ts")),
+  };
 }
 
 describe("wa color tokens", () => {
-  it("references only tokens the WebAwesome styles define", () => {
-    const defined = tokensIn(walk(WA_STYLES_DIR, ".css"));
-    const referenced = tokensIn(walk("src", ".ts"));
+  it("references only tokens the WebAwesome styles define", async () => {
+    const { defined, referenced } = await collectTokens();
     const phantoms = [...referenced].filter(
       (token) => !defined.has(token) && !KNOWN_PHANTOMS.has(token)
     );
     expect(phantoms).toEqual([]);
   });
 
-  it("keeps the phantom allowlist honest", () => {
-    const defined = tokensIn(walk(WA_STYLES_DIR, ".css"));
-    const referenced = tokensIn(walk("src", ".ts"));
+  it("keeps the phantom allowlist honest", async () => {
+    const { defined, referenced } = await collectTokens();
     for (const token of KNOWN_PHANTOMS) {
       expect(defined.has(token)).toBe(false);
       expect(referenced.has(token)).toBe(true);


### PR DESCRIPTION
# What does this implement/fix?

Warning text was unreadable in dark mode: dark brown text on the near-black dark-theme warning fill. The cause is a phantom token; `--wa-color-warning-text-quiet` does not exist in the WebAwesome theme (the text-on-fill tokens are named `--wa-color-warning-on-quiet` / `-on-normal` / `-on-loud`), so the color always fell through to the hard-coded light-mode fallback while the background token resolved per theme.

Replaces the phantom token with `--wa-color-warning-on-quiet` at its three call sites: the shared `warningBannerStyles`, the update-all dialog's summary note, and the constraint-cluster header. In light mode the shared banner keeps the tone its fallback approximated; the other two sites had no working fallback, so they gain a proper warning tone in light mode too (verified visually, both look right). Dark mode gets the theme's readable warning tone.

Also adds a guard test asserting every `--wa-color-*` token referenced under src/ exists in the WebAwesome styles tree, so the next phantom fails CI instead of shipping silently. The guard surfaced the full extent of this class: ten more phantom tokens (`danger-text-normal`, `brand-text-quiet`, `border`, `danger-border`, `neutral-500`, `success-quiet`, `surface-subtle`, `text`, `text-subtle`, `warning-quiet`) are allowlisted in the test with a note pointing at the follow-up sweep; those degrade to inherited colors rather than becoming unreadable, so they stay out of this fix.

**Related issue or feature (if applicable):**

- noticed while reviewing esphome/device-builder-frontend#1597

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).

