### PR TITLE
Route device status reports through the picker with observed state

### DIFF
--- a/src/components/dashboard/device-drawer-content/reachability.ts
+++ b/src/components/dashboard/device-drawer-content/reachability.ts
@@ -6,7 +6,7 @@ import type {
   ReachabilityStateEvent,
 } from "../../../api/types/reachability.js";
 import { activeLocale, type LocalizeFunc } from "../../../common/localize.js";
-import { mdnsExpiryRemaining } from "../../../util/mdns-expiry.js";
+import { mdnsExpiryPhase, type MdnsExpiryPhase } from "../../../util/mdns-expiry.js";
 import {
   ageOf,
   formatSecondsAgo,
@@ -25,7 +25,7 @@ interface ReachabilityRowSpec {
   labelKey: string;
   age: number | null;
   rttMs?: number | null;
-  ttlRemaining?: number | null;
+  ttlPhase?: MdnsExpiryPhase;
   ttlLifetime?: number | null;
   txtRecords?: Record<string, string> | null;
 }
@@ -58,7 +58,7 @@ export function renderReachabilitySection(
       icon: "access-point-network",
       labelKey: "dashboard.drawer_source_mdns",
       age: mdnsAge,
-      ttlRemaining: mdnsExpiryRemaining(
+      ttlPhase: mdnsExpiryPhase(
         mdnsAge,
         r.mdns_ptr_ttl_seconds,
         deviceOffline,
@@ -141,13 +141,8 @@ function renderReachabilityRow(
           }
         </div>
         ${
-          row.source === "mdns"
-            ? renderMdnsExpiry(
-                row.ttlRemaining ?? null,
-                row.ttlLifetime ?? null,
-                localize,
-                lang
-              )
+          row.source === "mdns" && row.ttlPhase
+            ? renderMdnsExpiry(row.ttlPhase, row.ttlLifetime ?? null, localize, lang)
             : nothing
         }
         ${renderMdnsTxtRecords(row.txtRecords, localize)}

--- a/src/components/dashboard/device-drawer-content/reachability.ts
+++ b/src/components/dashboard/device-drawer-content/reachability.ts
@@ -58,7 +58,12 @@ export function renderReachabilitySection(
       icon: "access-point-network",
       labelKey: "dashboard.drawer_source_mdns",
       age: mdnsAge,
-      ttlRemaining: mdnsExpiryRemaining(mdnsAge, r.mdns_ptr_ttl_seconds, deviceOffline),
+      ttlRemaining: mdnsExpiryRemaining(
+        mdnsAge,
+        r.mdns_ptr_ttl_seconds,
+        deviceOffline,
+        r.active_source
+      ),
       ttlLifetime: r.mdns_ptr_ttl_seconds,
       txtRecords: r.mdns_txt_records ?? null,
     },
@@ -136,7 +141,7 @@ function renderReachabilityRow(
           }
         </div>
         ${
-          row.source === "mdns" && isActive
+          row.source === "mdns"
             ? renderMdnsExpiry(
                 row.ttlRemaining ?? null,
                 row.ttlLifetime ?? null,

--- a/src/components/dashboard/device-drawer-content/reachability.ts
+++ b/src/components/dashboard/device-drawer-content/reachability.ts
@@ -6,6 +6,7 @@ import type {
   ReachabilityStateEvent,
 } from "../../../api/types/reachability.js";
 import { activeLocale, type LocalizeFunc } from "../../../common/localize.js";
+import { mdnsExpiryRemaining } from "../../../util/mdns-expiry.js";
 import {
   ageOf,
   formatSecondsAgo,
@@ -28,12 +29,6 @@ interface ReachabilityRowSpec {
   ttlLifetime?: number | null;
   txtRecords?: Record<string, string> | null;
 }
-
-// Only surface the "Expires in" hint once the device has been quiet for
-// longer than this, so a freshly-heard healthy device shows no shrinking
-// timer (which would read as a false alarm). A UI threshold, not tied to
-// any record's TTL.
-const SHOW_EXPIRES_HINT_AFTER_SECONDS = 120;
 
 export function renderReachabilitySection(
   host: ESPHomeDeviceDrawerContent
@@ -63,13 +58,7 @@ export function renderReachabilitySection(
       icon: "access-point-network",
       labelKey: "dashboard.drawer_source_mdns",
       age: mdnsAge,
-      ttlRemaining:
-        deviceOffline ||
-        r.mdns_ptr_ttl_seconds === null ||
-        mdnsAge === null ||
-        mdnsAge <= SHOW_EXPIRES_HINT_AFTER_SECONDS
-          ? null
-          : Math.max(0, r.mdns_ptr_ttl_seconds - mdnsAge),
+      ttlRemaining: mdnsExpiryRemaining(mdnsAge, r.mdns_ptr_ttl_seconds, deviceOffline),
       ttlLifetime: r.mdns_ptr_ttl_seconds,
       txtRecords: r.mdns_txt_records ?? null,
     },

--- a/src/components/dashboard/device-drawer-content/reachability.ts
+++ b/src/components/dashboard/device-drawer-content/reachability.ts
@@ -26,7 +26,6 @@ interface ReachabilityRowSpec {
   age: number | null;
   rttMs?: number | null;
   ttlPhase?: MdnsExpiryPhase;
-  ttlLifetime?: number | null;
   txtRecords?: Record<string, string> | null;
 }
 
@@ -45,11 +44,12 @@ export function renderReachabilitySection(
   // re-anchors in lockstep with "last seen" (both move off mdnsAge)
   // rather than the PTR's remaining TTL, which the browser refreshes
   // erratically and would drift against the actively-probed A record.
-  // Held back until the device has been quiet a while (see the
-  // threshold) so a healthy device shows no shrinking timer, and never
-  // shown once the device is OFFLINE — by then it has already expired,
-  // and the reachability snapshot can be stale (no push fires on the
-  // mDNS Removed that took it offline), so trust the live device state.
+  // Held back until the device has been quiet a while (the quiet
+  // threshold lives in mdnsExpiryPhase, which owns every gate) so a
+  // healthy device shows no shrinking timer, and never shown once the
+  // device is OFFLINE — by then it has already expired, and the
+  // reachability snapshot can be stale (no push fires on the mDNS
+  // Removed that took it offline), so trust the live device state.
   const mdnsAge = ageOf(r.mdns_last_seen_seconds_ago, anchor, now);
   const deviceOffline = host.device?.runtime_state.state === DeviceState.OFFLINE;
   const rows: ReachabilityRowSpec[] = [
@@ -64,7 +64,6 @@ export function renderReachabilitySection(
         deviceOffline,
         r.active_source
       ),
-      ttlLifetime: r.mdns_ptr_ttl_seconds,
       txtRecords: r.mdns_txt_records ?? null,
     },
     {
@@ -142,7 +141,7 @@ function renderReachabilityRow(
         </div>
         ${
           row.source === "mdns" && row.ttlPhase
-            ? renderMdnsExpiry(row.ttlPhase, row.ttlLifetime ?? null, localize, lang)
+            ? renderMdnsExpiry(row.ttlPhase, localize, lang)
             : nothing
         }
         ${renderMdnsTxtRecords(row.txtRecords, localize)}

--- a/src/components/dashboard/device-drawer-render.ts
+++ b/src/components/dashboard/device-drawer-render.ts
@@ -108,22 +108,19 @@ export function renderMdnsTxtRecords(
  * that record to expire rather than actively re-querying every
  * device, which would load them.
  *
- * Same ``<details>`` chevron idiom as ``renderMdnsTxtRecords``.
- * *lifetimeSeconds* is the device's own announced record lifetime,
- * named in the explainer so it states the real duration rather than
- * a generic figure. Every gate lives in ``mdnsExpiryPhase``; this
- * renders ``nothing`` for any phase but ``soon`` / ``countdown``, and
- * when the lifetime is ``null`` (no PTR record cached), so the row
- * collapses to zero markup.
+ * Same ``<details>`` chevron idiom as ``renderMdnsTxtRecords``. The
+ * phase's ``ttl`` is the device's own announced record lifetime, named
+ * in the explainer so it states the real duration rather than a
+ * generic figure. Every gate lives in ``mdnsExpiryPhase``; this
+ * renders ``nothing`` for any phase but ``soon`` / ``countdown``, so
+ * the row collapses to zero markup.
  */
 export function renderMdnsExpiry(
   phase: MdnsExpiryPhase,
-  lifetimeSeconds: number | null,
   localize: LocalizeFunc,
   language: string | undefined
 ) {
   if (phase.kind !== "soon" && phase.kind !== "countdown") return nothing;
-  if (lifetimeSeconds === null) return nothing;
   const summary =
     phase.kind === "soon"
       ? localize("dashboard.drawer_mdns_expires_soon")
@@ -135,7 +132,7 @@ export function renderMdnsExpiry(
       <summary>${summary}</summary>
       <div class="mdns-expiry-body">
         ${localize("dashboard.drawer_mdns_expires_explainer", {
-          lifetime: formatCountdown(lifetimeSeconds, language),
+          lifetime: formatCountdown(phase.ttl, language),
         })}
       </div>
     </details>

--- a/src/components/dashboard/device-drawer-render.ts
+++ b/src/components/dashboard/device-drawer-render.ts
@@ -12,7 +12,7 @@ import { html, nothing } from "lit";
 import { DeviceState } from "../../api/types/devices.js";
 import type { ReachabilityStateEvent } from "../../api/types/reachability.js";
 import type { LocalizeFunc } from "../../common/localize.js";
-import { mdnsExpiresSoon } from "../../util/mdns-expiry.js";
+import type { MdnsExpiryPhase } from "../../util/mdns-expiry.js";
 import { formatCountdown } from "../../util/relative-time.js";
 import { renderVisitWebUiLink } from "../../util/visit-web-ui-link.js";
 
@@ -117,17 +117,19 @@ export function renderMdnsTxtRecords(
  * then does PTR expiry mean the device goes offline.
  */
 export function renderMdnsExpiry(
-  remainingSeconds: number | null,
+  phase: MdnsExpiryPhase,
   lifetimeSeconds: number | null,
   localize: LocalizeFunc,
   language: string | undefined
 ) {
-  if (remainingSeconds === null || lifetimeSeconds === null) return nothing;
-  const summary = mdnsExpiresSoon(remainingSeconds)
-    ? localize("dashboard.drawer_mdns_expires_soon")
-    : localize("dashboard.drawer_mdns_expires_in", {
-        t: formatCountdown(remainingSeconds, language),
-      });
+  if (phase.kind !== "soon" && phase.kind !== "countdown") return nothing;
+  if (lifetimeSeconds === null) return nothing;
+  const summary =
+    phase.kind === "soon"
+      ? localize("dashboard.drawer_mdns_expires_soon")
+      : localize("dashboard.drawer_mdns_expires_in", {
+          t: formatCountdown(phase.remaining, language),
+        });
   return html`
     <details class="mdns-expiry-details">
       <summary>${summary}</summary>

--- a/src/components/dashboard/device-drawer-render.ts
+++ b/src/components/dashboard/device-drawer-render.ts
@@ -111,10 +111,10 @@ export function renderMdnsTxtRecords(
  * Same ``<details>`` chevron idiom as ``renderMdnsTxtRecords``.
  * *lifetimeSeconds* is the device's own announced record lifetime,
  * named in the explainer so it states the real duration rather than
- * a generic figure. Returns ``nothing`` when either value is ``null``
- * (no PTR record cached) so the row collapses to zero markup. The
- * caller also gates this on mDNS being the active source, since only
- * then does PTR expiry mean the device goes offline.
+ * a generic figure. Every gate lives in ``mdnsExpiryPhase``; this
+ * renders ``nothing`` for any phase but ``soon`` / ``countdown``, and
+ * when the lifetime is ``null`` (no PTR record cached), so the row
+ * collapses to zero markup.
  */
 export function renderMdnsExpiry(
   phase: MdnsExpiryPhase,

--- a/src/components/dashboard/device-drawer-render.ts
+++ b/src/components/dashboard/device-drawer-render.ts
@@ -12,6 +12,7 @@ import { html, nothing } from "lit";
 import { DeviceState } from "../../api/types/devices.js";
 import type { ReachabilityStateEvent } from "../../api/types/reachability.js";
 import type { LocalizeFunc } from "../../common/localize.js";
+import { mdnsExpiresSoon } from "../../util/mdns-expiry.js";
 import { formatCountdown } from "../../util/relative-time.js";
 import { renderVisitWebUiLink } from "../../util/visit-web-ui-link.js";
 
@@ -122,15 +123,11 @@ export function renderMdnsExpiry(
   language: string | undefined
 ) {
   if (remainingSeconds === null || lifetimeSeconds === null) return nothing;
-  // Below 1s the countdown would read "0s", but the record isn't gone yet —
-  // zeroconf evicts on a periodic (~10s) sweep — so say "soon" instead of
-  // showing a stuck 0.
-  const summary =
-    remainingSeconds < 1
-      ? localize("dashboard.drawer_mdns_expires_soon")
-      : localize("dashboard.drawer_mdns_expires_in", {
-          t: formatCountdown(remainingSeconds, language),
-        });
+  const summary = mdnsExpiresSoon(remainingSeconds)
+    ? localize("dashboard.drawer_mdns_expires_soon")
+    : localize("dashboard.drawer_mdns_expires_in", {
+        t: formatCountdown(remainingSeconds, language),
+      });
   return html`
     <details class="mdns-expiry-details">
       <summary>${summary}</summary>

--- a/src/components/feedback-device-picker.ts
+++ b/src/components/feedback-device-picker.ts
@@ -3,7 +3,7 @@ import { mdiBugOutline, mdiChip, mdiClipboardTextOutline, mdiOpenInNew } from "@
 import { css, html, LitElement, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
-import type { ConfiguredDevice } from "../api/types/devices.js";
+import { type ConfiguredDevice, DeviceState } from "../api/types/devices.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
   apiContext,
@@ -27,7 +27,9 @@ import { matchesDeviceName } from "../util/device-search.js";
 import { deviceSortKey, sortDevices } from "../util/device-sort.js";
 import { detectInstallation } from "../util/installation.js";
 import { captureMaskedConfig } from "../util/masked-config-capture.js";
+import { mdnsExpirySummary } from "../util/mdns-expiry.js";
 import { notifyError } from "../util/notify.js";
+import { captureReachabilitySnapshot } from "../util/reachability-snapshot.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { feedbackLinkStyles } from "./feedback-link.styles.js";
 
@@ -285,7 +287,15 @@ export class ESPHomeFeedbackDevicePicker extends LitElement {
     this._capturing = device.configuration;
     const abandoned = () =>
       session !== this._session || !this.isConnected || !this.active;
-    const masked = await captureMaskedConfig(this._api, device.configuration, abandoned);
+    // The status form also wants the drawer's mDNS-row answer; fetch the
+    // reachability snapshot alongside the config so neither serializes
+    // the other, and let it degrade to null on a hiccup.
+    const [masked, reachability] = await Promise.all([
+      captureMaskedConfig(this._api, device.configuration, abandoned),
+      this.target === "status"
+        ? captureReachabilitySnapshot(this._api, device.name)
+        : Promise.resolve(null),
+    ]);
     if (abandoned()) return;
     this._capturing = "";
     if (masked === null) return;
@@ -297,7 +307,16 @@ export class ESPHomeFeedbackDevicePicker extends LitElement {
       this.target,
       device,
       masked,
-      this._prefillContext()
+      this._prefillContext(),
+      this.target === "status"
+        ? {
+            "mdns-expiry": mdnsExpirySummary(
+              reachability?.mdns_last_seen_seconds_ago ?? null,
+              reachability?.mdns_ptr_ttl_seconds ?? null,
+              device.runtime_state.state === DeviceState.OFFLINE
+            ),
+          }
+        : undefined
     );
     const url = built.toString();
     // The capture can outlive the click's transient activation, so the

--- a/src/components/feedback-device-picker.ts
+++ b/src/components/feedback-device-picker.ts
@@ -188,7 +188,12 @@ export class ESPHomeFeedbackDevicePicker extends LitElement {
     return html`
       <p class="summary-heading">${this._localize("feedback.device_includes_heading")}</p>
       <ul class="summary">
-        ${["feedback.device_includes_config", "feedback.device_includes_facts"].map(
+        ${[
+          "feedback.device_includes_config",
+          this.target === "status"
+            ? "feedback.device_includes_facts_status"
+            : "feedback.device_includes_facts",
+        ].map(
           (key) => html`
             <li>
               <wa-icon library="mdi" name="clipboard-text-outline"></wa-icon>

--- a/src/components/feedback-device-picker.ts
+++ b/src/components/feedback-device-picker.ts
@@ -3,7 +3,7 @@ import { mdiBugOutline, mdiChip, mdiClipboardTextOutline, mdiOpenInNew } from "@
 import { css, html, LitElement, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
-import { type ConfiguredDevice, DeviceState } from "../api/types/devices.js";
+import type { ConfiguredDevice } from "../api/types/devices.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
   apiContext,
@@ -27,7 +27,6 @@ import { matchesDeviceName } from "../util/device-search.js";
 import { deviceSortKey, sortDevices } from "../util/device-sort.js";
 import { detectInstallation } from "../util/installation.js";
 import { captureMaskedConfig } from "../util/masked-config-capture.js";
-import { mdnsExpirySummary } from "../util/mdns-expiry.js";
 import { notifyError } from "../util/notify.js";
 import { captureReachabilitySnapshot } from "../util/reachability-snapshot.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -308,15 +307,7 @@ export class ESPHomeFeedbackDevicePicker extends LitElement {
       device,
       masked,
       this._prefillContext(),
-      this.target === "status"
-        ? {
-            "mdns-expiry": mdnsExpirySummary(
-              reachability?.mdns_last_seen_seconds_ago ?? null,
-              reachability?.mdns_ptr_ttl_seconds ?? null,
-              device.runtime_state.state === DeviceState.OFFLINE
-            ),
-          }
-        : undefined
+      reachability
     );
     const url = built.toString();
     // The capture can outlive the click's transient activation, so the

--- a/src/components/feedback-dialog.ts
+++ b/src/components/feedback-dialog.ts
@@ -93,8 +93,8 @@ const BUG_LINKS: ReadonlyArray<FeedbackLink> = [
     icon: "access-point-network",
     labelKey: "feedback.bug_status",
     descKey: "feedback.bug_status_desc",
-    href: "https://github.com/esphome/device-builder/issues/new?template=device_status.yml",
-    versionSource: "dashboard",
+    drillTo: "device",
+    deviceTarget: "status",
   },
   {
     icon: "server-network",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1287,6 +1287,7 @@
     "device_includes_heading": "Picking a device pre-fills the GitHub report with:",
     "device_includes_config": "Its YAML config, known credentials masked",
     "device_includes_facts": "Device details: name, board, platform, versions, installation",
+    "device_includes_facts_status": "Device details: name, board, platform, versions, installation, online state, reachability source, IP network prefix",
     "device_hint": "Nothing is filed until you review and submit the form.",
     "device_skip": "No specific device",
     "device_filter": "Filter devices",

--- a/src/util/bug-report-prefill.ts
+++ b/src/util/bug-report-prefill.ts
@@ -9,16 +9,18 @@ import { deviceSortKey } from "./device-sort.js";
  * DOM-free so the shapes are unit-testable.
  */
 
-/** The two bug paths that carry a device config. */
-export type DeviceTarget = "builder" | "esphome";
+/** The bug paths that carry a device config. */
+export type DeviceTarget = "builder" | "esphome" | "status";
 
-// Field ids come from each repo's `.github/ISSUE_TEMPLATE/bug_report.yml`:
-// esphome/esphome's form has `config` + `additional`; the builder form has
-// `config` + `extra` (config added in esphome/device-builder#2482). GitHub
-// silently drops unknown params, so these must track the templates.
+// Field ids come from each repo's issue templates: esphome/esphome's
+// bug form has `config` + `additional`; the builder bug form has
+// `config` + `extra` (config added in esphome/device-builder#2482); the
+// device-status form has `config` + `observed` + `mdns-expiry`
+// (esphome/device-builder#2487). GitHub silently drops unknown params,
+// so these must track the templates.
 const DEVICE_TARGETS: Record<
   DeviceTarget,
-  { href: string; factsParam: "additional" | "extra" }
+  { href: string; factsParam: "additional" | "extra" | "observed" }
 > = {
   builder: {
     href: "https://github.com/esphome/device-builder/issues/new?template=bug_report.yml",
@@ -27,6 +29,10 @@ const DEVICE_TARGETS: Record<
   esphome: {
     href: ESPHOME_BUG_FORM_URL,
     factsParam: "additional",
+  },
+  status: {
+    href: "https://github.com/esphome/device-builder/issues/new?template=device_status.yml",
+    factsParam: "observed",
   },
 };
 
@@ -48,22 +54,29 @@ export function buildDeviceIssueUrl(
   device: ConfiguredDevice,
   /** Masked YAML; "" opens the form without a config. */
   maskedConfig: string,
-  ctx: PrefillContext
+  ctx: PrefillContext,
+  /** Target-specific fields (the status form's `mdns-expiry`), set
+   *  before the config fit so they count against the URL budget. */
+  extraParams?: Record<string, string>
 ): { url: URL; truncated: boolean } {
   const url = deviceTargetUrl(target, ctx, device);
   url.searchParams.set(
     DEVICE_TARGETS[target].factsParam,
     deviceFacts(device, target, ctx)
   );
+  for (const [key, value] of Object.entries(extraParams ?? {})) {
+    url.searchParams.set(key, value);
+  }
   const truncated = maskedConfig ? setFittedConfigParam(url, maskedConfig) : false;
   return { url, truncated };
 }
 
-/** Today's URL for the no-specific-device row; the builder path fills
- *  its required config field with the template's own sentence. */
+/** Today's URL for the no-specific-device row; the builder and status
+ *  paths fill their required config field with the template's own
+ *  sentence. */
 export function skipDeviceUrl(target: DeviceTarget, ctx: PrefillContext): URL {
   const url = deviceTargetUrl(target, ctx);
-  if (target === "builder") url.searchParams.set("config", NOT_DEVICE_SPECIFIC);
+  if (target !== "esphome") url.searchParams.set("config", NOT_DEVICE_SPECIFIC);
   return url;
 }
 
@@ -83,17 +96,30 @@ export function deviceFacts(
     platform && `Platform: ${platform}`,
     device.runtime_state.deployed_version &&
       `ESPHome running: ${device.runtime_state.deployed_version}`,
-    target === "builder" && ctx.esphomeVersion && `ESPHome: ${ctx.esphomeVersion}`,
+    target !== "esphome" && ctx.esphomeVersion && `ESPHome: ${ctx.esphomeVersion}`,
     ctx.installation && `Installation: ${ctx.installation}`,
+    ...(target === "status"
+      ? [
+          `State: ${device.runtime_state.state}`,
+          `Reachability source: ${device.runtime_state.active_source}`,
+          ipLine(device),
+        ]
+      : []),
   ]
     .filter(Boolean)
     .map((fact) => `- ${fact}`)
     .join("\n");
 }
 
+const ipLine = (device: ConfiguredDevice): string => {
+  const addresses = device.runtime_state.ip_addresses ?? [];
+  const ips = addresses.length ? addresses.join(", ") : device.ip;
+  return ips ? `IP: ${ips}` : "";
+};
+
 // Base form URL for *target* with the version param set: the builder
-// form takes the dashboard version, esphome's the device's compiled
-// version falling back to the installed core version.
+// and status forms take the dashboard version, esphome's the device's
+// compiled version falling back to the installed core version.
 function deviceTargetUrl(
   target: DeviceTarget,
   ctx: PrefillContext,

--- a/src/util/bug-report-prefill.ts
+++ b/src/util/bug-report-prefill.ts
@@ -64,7 +64,7 @@ export function buildDeviceIssueUrl(
   const url = deviceTargetUrl(target, ctx, device);
   url.searchParams.set(
     DEVICE_TARGETS[target].factsParam,
-    deviceFacts(device, target, ctx)
+    deviceFacts(device, target, ctx, reachability)
   );
   if (target === "status") {
     // Set before the config fit so it counts against the URL budget.
@@ -90,7 +90,10 @@ export function skipDeviceUrl(target: DeviceTarget, ctx: PrefillContext): URL {
 export function deviceFacts(
   device: ConfiguredDevice,
   target: DeviceTarget,
-  ctx: PrefillContext
+  ctx: PrefillContext,
+  /** Status-target snapshot; when present its state and source win, so
+   *  the observed lines agree with the mdns-expiry answer. */
+  reachability?: ReachabilityStateEvent | null
 ): string {
   const platform = issuePlatform(devicePlatform(device));
   return [
@@ -103,8 +106,10 @@ export function deviceFacts(
     ctx.installation && `Installation: ${ctx.installation}`,
     ...(target === "status"
       ? [
-          `State: ${device.runtime_state.state}`,
-          `Reachability source: ${device.runtime_state.active_source}`,
+          `State: ${reachability?.state ?? device.runtime_state.state}`,
+          `Reachability source: ${
+            reachability?.active_source ?? device.runtime_state.active_source
+          }`,
           ipLine(device),
         ]
       : []),
@@ -144,15 +149,17 @@ function mdnsExpirySummary(
   const age = reachability.mdns_last_seen_seconds_ago;
   if (age === null) return "no mDNS row";
   const offline = device.runtime_state.state === DeviceState.OFFLINE;
-  // Mirror the drawer's gate: it renders the countdown only while mDNS
-  // is the active source.
-  const mdnsActive = reachability.active_source === "mdns";
-  const remaining = mdnsActive
-    ? mdnsExpiryRemaining(age, reachability.mdns_ptr_ttl_seconds, offline)
-    : null;
+  const remaining = mdnsExpiryRemaining(
+    age,
+    reachability.mdns_ptr_ttl_seconds,
+    offline,
+    reachability.active_source
+  );
   if (remaining === null) {
     if (offline) return "no expiry countdown (device offline)";
-    if (!mdnsActive) return "no expiry countdown (mDNS not the active source)";
+    if (reachability.active_source !== "mdns") {
+      return "no expiry countdown (mDNS not the active source)";
+    }
     if (reachability.mdns_ptr_ttl_seconds === null) {
       return "no expiry countdown (no PTR TTL)";
     }

--- a/src/util/bug-report-prefill.ts
+++ b/src/util/bug-report-prefill.ts
@@ -114,10 +114,21 @@ export function deviceFacts(
     .join("\n");
 }
 
+const IPV4_LITERAL = /^\d{1,3}(\.\d{1,3}){3}$/;
+
+// Blunt each address for the public issue: enough prefix to tell LAN
+// from Docker-bridge from link-local, never the full host address.
+const maskIp = (address: string): string => {
+  if (address.includes(":")) return `${address.split(":")[0]}::x`;
+  if (!IPV4_LITERAL.test(address)) return address;
+  const [a, b] = address.split(".");
+  return `${a}.${b}.x.x`;
+};
+
 const ipLine = (device: ConfiguredDevice): string => {
   const addresses = device.runtime_state.ip_addresses;
-  const ips = addresses.length ? addresses.join(", ") : device.ip;
-  return ips ? `IP: ${ips}` : "";
+  const ips = (addresses.length ? addresses : device.ip ? [device.ip] : []).map(maskIp);
+  return ips.length ? `IP: ${ips.join(", ")}` : "";
 };
 
 /**

--- a/src/util/bug-report-prefill.ts
+++ b/src/util/bug-report-prefill.ts
@@ -3,7 +3,7 @@ import type { ReachabilityStateEvent } from "../api/types/reachability.js";
 import { setFittedConfigParam } from "./crash-report-budget.js";
 import { devicePlatform, ESPHOME_BUG_FORM_URL, issuePlatform } from "./crash-report.js";
 import { deviceSortKey } from "./device-sort.js";
-import { mdnsExpiresSoon, mdnsExpiryRemaining } from "./mdns-expiry.js";
+import { mdnsExpiryPhase } from "./mdns-expiry.js";
 import { formatCountdown } from "./relative-time.js";
 
 /**
@@ -149,28 +149,28 @@ function mdnsExpirySummary(
   device: ConfiguredDevice
 ): string {
   if (reachability === null) return "reachability read failed";
-  const age = reachability.mdns_last_seen_seconds_ago;
-  if (age === null) return "no mDNS row";
-  const offline = device.runtime_state.state === DeviceState.OFFLINE;
-  const remaining = mdnsExpiryRemaining(
-    age,
+  const phase = mdnsExpiryPhase(
+    reachability.mdns_last_seen_seconds_ago,
     reachability.mdns_ptr_ttl_seconds,
-    offline,
+    device.runtime_state.state === DeviceState.OFFLINE,
     reachability.active_source
   );
-  if (remaining === null) {
-    if (offline) return "no expiry countdown (device offline)";
-    if (reachability.active_source !== "mdns") {
+  switch (phase.kind) {
+    case "no-signal":
+      return "no mDNS row";
+    case "offline":
+      return "no expiry countdown (device offline)";
+    case "inactive-source":
       return "no expiry countdown (mDNS not the active source)";
-    }
-    if (reachability.mdns_ptr_ttl_seconds === null) {
+    case "no-ttl":
       return "no expiry countdown (no PTR TTL)";
-    }
-    return "no expiry countdown (heard recently)";
+    case "fresh":
+      return "no expiry countdown (heard recently)";
+    case "soon":
+      return "Expires soon";
+    case "countdown":
+      return `Expires in ${formatCountdown(phase.remaining, "en")}`;
   }
-  return mdnsExpiresSoon(remaining)
-    ? "Expires soon"
-    : `Expires in ${formatCountdown(remaining, "en")}`;
 }
 
 // Base form URL for *target* with the version param set: the builder

--- a/src/util/bug-report-prefill.ts
+++ b/src/util/bug-report-prefill.ts
@@ -140,14 +140,22 @@ function mdnsExpirySummary(
   reachability: ReachabilityStateEvent | null,
   device: ConfiguredDevice
 ): string {
-  const age = reachability?.mdns_last_seen_seconds_ago ?? null;
+  if (reachability === null) return "reachability read failed";
+  const age = reachability.mdns_last_seen_seconds_ago;
   if (age === null) return "no mDNS row";
-  const ttl = reachability?.mdns_ptr_ttl_seconds ?? null;
   const offline = device.runtime_state.state === DeviceState.OFFLINE;
-  const remaining = mdnsExpiryRemaining(age, ttl, offline);
+  // Mirror the drawer's gate: it renders the countdown only while mDNS
+  // is the active source.
+  const mdnsActive = reachability.active_source === "mdns";
+  const remaining = mdnsActive
+    ? mdnsExpiryRemaining(age, reachability.mdns_ptr_ttl_seconds, offline)
+    : null;
   if (remaining === null) {
     if (offline) return "no expiry countdown (device offline)";
-    if (ttl === null) return "no expiry countdown (no PTR TTL)";
+    if (!mdnsActive) return "no expiry countdown (mDNS not the active source)";
+    if (reachability.mdns_ptr_ttl_seconds === null) {
+      return "no expiry countdown (no PTR TTL)";
+    }
     return "no expiry countdown (heard recently)";
   }
   return mdnsExpiresSoon(remaining)

--- a/src/util/bug-report-prefill.ts
+++ b/src/util/bug-report-prefill.ts
@@ -125,12 +125,18 @@ const IPV4_LITERAL = /^\d{1,3}(\.\d{1,3}){3}$/;
 
 // Blunt each address for the public issue: enough prefix to tell LAN
 // from Docker-bridge from link-local, never the full host address.
-// Fails closed — anything not a recognised IP literal masks entirely.
+// Fails closed — anything not a recognised IP literal masks entirely,
+// including dotted colon shapes (a ported IPv4, a mapped IPv6) whose
+// leading group would carry a full address.
 const maskIp = (address: string): string => {
-  if (address.includes(":")) return `${address.split(":")[0]}::x`;
-  if (!IPV4_LITERAL.test(address)) return "x";
-  const [a, b] = address.split(".");
-  return `${a}.${b}.x.x`;
+  if (IPV4_LITERAL.test(address)) {
+    const [a, b] = address.split(".");
+    return `${a}.${b}.x.x`;
+  }
+  if (address.includes(":") && !address.includes(".")) {
+    return `${address.split(":")[0]}::x`;
+  }
+  return "x";
 };
 
 const ipLine = (device: ConfiguredDevice): string => {

--- a/src/util/bug-report-prefill.ts
+++ b/src/util/bug-report-prefill.ts
@@ -75,11 +75,11 @@ export function buildDeviceIssueUrl(
 }
 
 /** Today's URL for the no-specific-device row; the builder and status
- *  paths fill their required config field with the template's own
- *  sentence. */
+ *  paths fill their required fields with the template's own sentence. */
 export function skipDeviceUrl(target: DeviceTarget, ctx: PrefillContext): URL {
   const url = deviceTargetUrl(target, ctx);
   if (target !== "esphome") url.searchParams.set("config", NOT_DEVICE_SPECIFIC);
+  if (target === "status") url.searchParams.set("mdns-expiry", NOT_DEVICE_SPECIFIC);
   return url;
 }
 
@@ -91,8 +91,10 @@ export function deviceFacts(
   device: ConfiguredDevice,
   target: DeviceTarget,
   ctx: PrefillContext,
-  /** Status-target snapshot; when present its state and source win, so
-   *  the observed lines agree with the mdns-expiry answer. */
+  /** Status-target snapshot; when present its active source wins so the
+   *  observed line agrees with the mdns-expiry answer. State stays on
+   *  the live device — the snapshot can be stale on the OFFLINE
+   *  transition. */
   reachability?: ReachabilityStateEvent | null
 ): string {
   const platform = issuePlatform(devicePlatform(device));
@@ -106,7 +108,7 @@ export function deviceFacts(
     ctx.installation && `Installation: ${ctx.installation}`,
     ...(target === "status"
       ? [
-          `State: ${reachability?.state ?? device.runtime_state.state}`,
+          `State: ${device.runtime_state.state}`,
           `Reachability source: ${
             reachability?.active_source ?? device.runtime_state.active_source
           }`,
@@ -123,9 +125,10 @@ const IPV4_LITERAL = /^\d{1,3}(\.\d{1,3}){3}$/;
 
 // Blunt each address for the public issue: enough prefix to tell LAN
 // from Docker-bridge from link-local, never the full host address.
+// Fails closed — anything not a recognised IP literal masks entirely.
 const maskIp = (address: string): string => {
   if (address.includes(":")) return `${address.split(":")[0]}::x`;
-  if (!IPV4_LITERAL.test(address)) return address;
+  if (!IPV4_LITERAL.test(address)) return "x";
   const [a, b] = address.split(".");
   return `${a}.${b}.x.x`;
 };
@@ -133,7 +136,7 @@ const maskIp = (address: string): string => {
 const ipLine = (device: ConfiguredDevice): string => {
   const addresses = device.runtime_state.ip_addresses;
   const ips = (addresses.length ? addresses : device.ip ? [device.ip] : []).map(maskIp);
-  return ips.length ? `IP: ${ips.join(", ")}` : "";
+  return `IP: ${ips.length ? ips.join(", ") : "none resolved"}`;
 };
 
 /**

--- a/src/util/bug-report-prefill.ts
+++ b/src/util/bug-report-prefill.ts
@@ -1,7 +1,10 @@
-import type { ConfiguredDevice } from "../api/types/devices.js";
+import { type ConfiguredDevice, DeviceState } from "../api/types/devices.js";
+import type { ReachabilityStateEvent } from "../api/types/reachability.js";
 import { setFittedConfigParam } from "./crash-report-budget.js";
 import { devicePlatform, ESPHOME_BUG_FORM_URL, issuePlatform } from "./crash-report.js";
 import { deviceSortKey } from "./device-sort.js";
+import { mdnsExpiresSoon, mdnsExpiryRemaining } from "./mdns-expiry.js";
+import { formatCountdown } from "./relative-time.js";
 
 /**
  * Prefill assembly for the report-a-bug device picker: which GitHub
@@ -36,8 +39,8 @@ const DEVICE_TARGETS: Record<
   },
 };
 
-// The builder template's `config` field is required; its own description
-// tells reporters to write this when no device applies.
+// The builder and status templates' `config` fields are required; their
+// own descriptions tell reporters to write this when no device applies.
 const NOT_DEVICE_SPECIFIC = "not device specific";
 
 export interface PrefillContext {
@@ -55,17 +58,17 @@ export function buildDeviceIssueUrl(
   /** Masked YAML; "" opens the form without a config. */
   maskedConfig: string,
   ctx: PrefillContext,
-  /** Target-specific fields (the status form's `mdns-expiry`), set
-   *  before the config fit so they count against the URL budget. */
-  extraParams?: Record<string, string>
+  /** Status-target reachability snapshot; null when the read stalled. */
+  reachability?: ReachabilityStateEvent | null
 ): { url: URL; truncated: boolean } {
   const url = deviceTargetUrl(target, ctx, device);
   url.searchParams.set(
     DEVICE_TARGETS[target].factsParam,
     deviceFacts(device, target, ctx)
   );
-  for (const [key, value] of Object.entries(extraParams ?? {})) {
-    url.searchParams.set(key, value);
+  if (target === "status") {
+    // Set before the config fit so it counts against the URL budget.
+    url.searchParams.set("mdns-expiry", mdnsExpirySummary(reachability ?? null, device));
   }
   const truncated = maskedConfig ? setFittedConfigParam(url, maskedConfig) : false;
   return { url, truncated };
@@ -112,10 +115,34 @@ export function deviceFacts(
 }
 
 const ipLine = (device: ConfiguredDevice): string => {
-  const addresses = device.runtime_state.ip_addresses ?? [];
+  const addresses = device.runtime_state.ip_addresses;
   const ips = addresses.length ? addresses.join(", ") : device.ip;
   return ips ? `IP: ${ips}` : "";
 };
+
+/**
+ * The status form's `mdns-expiry` answer, in English (the form is
+ * English-only): the countdown the drawer would show, else why there
+ * isn't one.
+ */
+function mdnsExpirySummary(
+  reachability: ReachabilityStateEvent | null,
+  device: ConfiguredDevice
+): string {
+  const age = reachability?.mdns_last_seen_seconds_ago ?? null;
+  if (age === null) return "no mDNS row";
+  const ttl = reachability?.mdns_ptr_ttl_seconds ?? null;
+  const offline = device.runtime_state.state === DeviceState.OFFLINE;
+  const remaining = mdnsExpiryRemaining(age, ttl, offline);
+  if (remaining === null) {
+    if (offline) return "no expiry countdown (device offline)";
+    if (ttl === null) return "no expiry countdown (no PTR TTL)";
+    return "no expiry countdown (heard recently)";
+  }
+  return mdnsExpiresSoon(remaining)
+    ? "Expires soon"
+    : `Expires in ${formatCountdown(remaining, "en")}`;
+}
 
 // Base form URL for *target* with the version param set: the builder
 // and status forms take the dashboard version, esphome's the device's

--- a/src/util/mdns-expiry.ts
+++ b/src/util/mdns-expiry.ts
@@ -1,3 +1,5 @@
+import type { ReachabilitySource } from "../api/types/reachability.js";
+
 /**
  * The mDNS "Expires in" decisions shared by the device drawer and the
  * status-report prefill, so the report's mDNS line always matches what
@@ -12,16 +14,18 @@ const SHOW_EXPIRES_HINT_AFTER_SECONDS = 120;
 
 /**
  * Remaining seconds for the countdown, or null when no hint should
- * show: no mDNS signal, no PTR TTL, heard too recently, or the device
- * is already OFFLINE (by then the record has expired and the snapshot
- * can be stale).
+ * show: mDNS isn't the active source, no mDNS signal, no PTR TTL,
+ * heard too recently, or the device is already OFFLINE (by then the
+ * record has expired and the snapshot can be stale).
  */
 export function mdnsExpiryRemaining(
   ageSeconds: number | null,
   ptrTtlSeconds: number | null,
-  deviceOffline: boolean
+  deviceOffline: boolean,
+  activeSource: ReachabilitySource
 ): number | null {
   if (
+    activeSource !== "mdns" ||
     deviceOffline ||
     ptrTtlSeconds === null ||
     ageSeconds === null ||

--- a/src/util/mdns-expiry.ts
+++ b/src/util/mdns-expiry.ts
@@ -1,0 +1,59 @@
+import { formatCountdown } from "./relative-time.js";
+
+/**
+ * The mDNS "Expires in" decision shared by the device drawer and the
+ * status-report prefill, so the report's mDNS line always matches what
+ * the drawer shows.
+ */
+
+// Only surface the "Expires in" hint once the device has been quiet for
+// longer than this, so a freshly-heard healthy device shows no shrinking
+// timer (which would read as a false alarm). A UI threshold, not tied to
+// any record's TTL.
+export const SHOW_EXPIRES_HINT_AFTER_SECONDS = 120;
+
+/**
+ * Remaining seconds for the countdown, or null when no hint should
+ * show: no mDNS signal, no PTR TTL, heard too recently, or the device
+ * is already OFFLINE (by then the record has expired and the snapshot
+ * can be stale).
+ */
+export function mdnsExpiryRemaining(
+  ageSeconds: number | null,
+  ptrTtlSeconds: number | null,
+  deviceOffline: boolean
+): number | null {
+  if (
+    deviceOffline ||
+    ptrTtlSeconds === null ||
+    ageSeconds === null ||
+    ageSeconds <= SHOW_EXPIRES_HINT_AFTER_SECONDS
+  ) {
+    return null;
+  }
+  return Math.max(0, ptrTtlSeconds - ageSeconds);
+}
+
+/**
+ * The mDNS-row answer for the status report's prefill, in English (the
+ * form is English-only): the countdown when the drawer would show one,
+ * else why there isn't one.
+ */
+export function mdnsExpirySummary(
+  ageSeconds: number | null,
+  ptrTtlSeconds: number | null,
+  deviceOffline: boolean
+): string {
+  if (ageSeconds === null) return "no mDNS row";
+  const remaining = mdnsExpiryRemaining(ageSeconds, ptrTtlSeconds, deviceOffline);
+  if (remaining === null) {
+    return deviceOffline
+      ? "no expiry countdown (device offline)"
+      : "no expiry countdown (heard recently)";
+  }
+  // Below 1s the countdown would read "0s", but the record isn't gone
+  // yet — zeroconf evicts on a periodic sweep — so say "soon".
+  return remaining < 1
+    ? "Expires soon"
+    : `Expires in ${formatCountdown(remaining, "en")}`;
+}

--- a/src/util/mdns-expiry.ts
+++ b/src/util/mdns-expiry.ts
@@ -1,7 +1,5 @@
-import { formatCountdown } from "./relative-time.js";
-
 /**
- * The mDNS "Expires in" decision shared by the device drawer and the
+ * The mDNS "Expires in" decisions shared by the device drawer and the
  * status-report prefill, so the report's mDNS line always matches what
  * the drawer shows.
  */
@@ -10,7 +8,7 @@ import { formatCountdown } from "./relative-time.js";
 // longer than this, so a freshly-heard healthy device shows no shrinking
 // timer (which would read as a false alarm). A UI threshold, not tied to
 // any record's TTL.
-export const SHOW_EXPIRES_HINT_AFTER_SECONDS = 120;
+const SHOW_EXPIRES_HINT_AFTER_SECONDS = 120;
 
 /**
  * Remaining seconds for the countdown, or null when no hint should
@@ -35,25 +33,10 @@ export function mdnsExpiryRemaining(
 }
 
 /**
- * The mDNS-row answer for the status report's prefill, in English (the
- * form is English-only): the countdown when the drawer would show one,
- * else why there isn't one.
+ * Whether the countdown should read "soon" instead of a number. Below
+ * 1s it would read "0s", but the record isn't gone yet — zeroconf
+ * evicts on a periodic (~10s) sweep.
  */
-export function mdnsExpirySummary(
-  ageSeconds: number | null,
-  ptrTtlSeconds: number | null,
-  deviceOffline: boolean
-): string {
-  if (ageSeconds === null) return "no mDNS row";
-  const remaining = mdnsExpiryRemaining(ageSeconds, ptrTtlSeconds, deviceOffline);
-  if (remaining === null) {
-    return deviceOffline
-      ? "no expiry countdown (device offline)"
-      : "no expiry countdown (heard recently)";
-  }
-  // Below 1s the countdown would read "0s", but the record isn't gone
-  // yet — zeroconf evicts on a periodic sweep — so say "soon".
-  return remaining < 1
-    ? "Expires soon"
-    : `Expires in ${formatCountdown(remaining, "en")}`;
+export function mdnsExpiresSoon(remainingSeconds: number): boolean {
+  return remainingSeconds < 1;
 }

--- a/src/util/mdns-expiry.ts
+++ b/src/util/mdns-expiry.ts
@@ -19,8 +19,8 @@ export type MdnsExpiryPhase =
   | { kind: "inactive-source" }
   | { kind: "no-ttl" }
   | { kind: "fresh" }
-  | { kind: "soon" }
-  | { kind: "countdown"; remaining: number };
+  | { kind: "soon"; ttl: number }
+  | { kind: "countdown"; remaining: number; ttl: number };
 
 /**
  * Classify the countdown decision. Only ``soon`` and ``countdown``
@@ -43,5 +43,7 @@ export function mdnsExpiryPhase(
   const remaining = Math.max(0, ptrTtlSeconds - ageSeconds);
   // Below 1s the countdown would read "0s", but the record isn't gone
   // yet — zeroconf evicts on a periodic (~10s) sweep.
-  return remaining < 1 ? { kind: "soon" } : { kind: "countdown", remaining };
+  return remaining < 1
+    ? { kind: "soon", ttl: ptrTtlSeconds }
+    : { kind: "countdown", remaining, ttl: ptrTtlSeconds };
 }

--- a/src/util/mdns-expiry.ts
+++ b/src/util/mdns-expiry.ts
@@ -1,9 +1,10 @@
 import type { ReachabilitySource } from "../api/types/reachability.js";
 
 /**
- * The mDNS "Expires in" decisions shared by the device drawer and the
- * status-report prefill, so the report's mDNS line always matches what
- * the drawer shows.
+ * The mDNS "Expires in" decision shared by the device drawer and the
+ * status-report prefill. The classifier owns every gate and threshold;
+ * consumers only translate phases into their surface's wording, so the
+ * report's mDNS line can never diverge from what the drawer shows.
  */
 
 // Only surface the "Expires in" hint once the device has been quiet for
@@ -12,35 +13,35 @@ import type { ReachabilitySource } from "../api/types/reachability.js";
 // any record's TTL.
 const SHOW_EXPIRES_HINT_AFTER_SECONDS = 120;
 
+export type MdnsExpiryPhase =
+  | { kind: "no-signal" }
+  | { kind: "offline" }
+  | { kind: "inactive-source" }
+  | { kind: "no-ttl" }
+  | { kind: "fresh" }
+  | { kind: "soon" }
+  | { kind: "countdown"; remaining: number };
+
 /**
- * Remaining seconds for the countdown, or null when no hint should
- * show: mDNS isn't the active source, no mDNS signal, no PTR TTL,
- * heard too recently, or the device is already OFFLINE (by then the
- * record has expired and the snapshot can be stale).
+ * Classify the countdown decision. Only ``soon`` and ``countdown``
+ * surface a hint; the other phases name why there isn't one, in
+ * priority order: never heard, device already OFFLINE (by then the
+ * record has expired and the snapshot can be stale), mDNS not the
+ * active source, no PTR TTL, heard too recently.
  */
-export function mdnsExpiryRemaining(
+export function mdnsExpiryPhase(
   ageSeconds: number | null,
   ptrTtlSeconds: number | null,
   deviceOffline: boolean,
   activeSource: ReachabilitySource
-): number | null {
-  if (
-    activeSource !== "mdns" ||
-    deviceOffline ||
-    ptrTtlSeconds === null ||
-    ageSeconds === null ||
-    ageSeconds <= SHOW_EXPIRES_HINT_AFTER_SECONDS
-  ) {
-    return null;
-  }
-  return Math.max(0, ptrTtlSeconds - ageSeconds);
-}
-
-/**
- * Whether the countdown should read "soon" instead of a number. Below
- * 1s it would read "0s", but the record isn't gone yet — zeroconf
- * evicts on a periodic (~10s) sweep.
- */
-export function mdnsExpiresSoon(remainingSeconds: number): boolean {
-  return remainingSeconds < 1;
+): MdnsExpiryPhase {
+  if (ageSeconds === null) return { kind: "no-signal" };
+  if (deviceOffline) return { kind: "offline" };
+  if (activeSource !== "mdns") return { kind: "inactive-source" };
+  if (ptrTtlSeconds === null) return { kind: "no-ttl" };
+  if (ageSeconds <= SHOW_EXPIRES_HINT_AFTER_SECONDS) return { kind: "fresh" };
+  const remaining = Math.max(0, ptrTtlSeconds - ageSeconds);
+  // Below 1s the countdown would read "0s", but the record isn't gone
+  // yet — zeroconf evicts on a periodic (~10s) sweep.
+  return remaining < 1 ? { kind: "soon" } : { kind: "countdown", remaining };
 }

--- a/src/util/reachability-snapshot.ts
+++ b/src/util/reachability-snapshot.ts
@@ -25,7 +25,10 @@ export async function captureReachabilitySnapshot(
       firstEvent,
       subscribed.then(() => firstEvent),
       new Promise<null>((resolve) => {
-        timer = setTimeout(resolve, timeoutMs, null);
+        timer = setTimeout(() => {
+          console.warn("Reachability snapshot timed out");
+          resolve(null);
+        }, timeoutMs);
       }),
     ]);
   } catch (err) {

--- a/src/util/reachability-snapshot.ts
+++ b/src/util/reachability-snapshot.ts
@@ -1,8 +1,5 @@
 import type { ESPHomeAPI } from "../api/index.js";
-import type {
-  ReachabilityStateEvent,
-  ReachabilitySubscription,
-} from "../api/types/reachability.js";
+import type { ReachabilityStateEvent } from "../api/types/reachability.js";
 
 /**
  * One-shot reachability snapshot: the per-device subscription pushes its
@@ -10,29 +7,31 @@ import type {
  * unsubscribe. Bounded by *timeoutMs* and resolves null on timeout or
  * error — a report prefill must not stall on a reachability hiccup.
  */
-export function captureReachabilitySnapshot(
+export async function captureReachabilitySnapshot(
   api: ESPHomeAPI,
   deviceName: string,
   timeoutMs = 3000
 ): Promise<ReachabilityStateEvent | null> {
-  return new Promise((resolve) => {
-    let subscription: ReachabilitySubscription | null = null;
-    let done = false;
-    const finish = (state: ReachabilityStateEvent | null) => {
-      if (done) return;
-      done = true;
-      clearTimeout(timer);
-      void subscription?.unsubscribe().catch(() => undefined);
-      resolve(state);
-    };
-    const timer = setTimeout(() => finish(null), timeoutMs);
-    api
-      .subscribeDeviceReachability(deviceName, (state) => finish(state))
-      .then((sub) => {
-        subscription = sub;
-        // The snapshot may have landed before the subscribe call resolved.
-        if (done) void sub.unsubscribe().catch(() => undefined);
-      })
-      .catch(() => finish(null));
+  let first!: (state: ReachabilityStateEvent) => void;
+  const firstEvent = new Promise<ReachabilityStateEvent>((resolve) => {
+    first = resolve;
   });
+  const subscribed = api.subscribeDeviceReachability(deviceName, (state) => first(state));
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      // The event can land before the subscribe call resolves; racing
+      // the chained copy as well surfaces a subscribe rejection.
+      firstEvent,
+      subscribed.then(() => firstEvent),
+      new Promise<null>((resolve) => {
+        timer = setTimeout(resolve, timeoutMs, null);
+      }),
+    ]);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+    void subscribed.then((sub) => sub.unsubscribe()).catch(() => undefined);
+  }
 }

--- a/src/util/reachability-snapshot.ts
+++ b/src/util/reachability-snapshot.ts
@@ -28,7 +28,8 @@ export async function captureReachabilitySnapshot(
         timer = setTimeout(resolve, timeoutMs, null);
       }),
     ]);
-  } catch {
+  } catch (err) {
+    console.warn("Reading reachability failed", err);
     return null;
   } finally {
     clearTimeout(timer);

--- a/src/util/reachability-snapshot.ts
+++ b/src/util/reachability-snapshot.ts
@@ -1,0 +1,38 @@
+import type { ESPHomeAPI } from "../api/index.js";
+import type {
+  ReachabilityStateEvent,
+  ReachabilitySubscription,
+} from "../api/types/reachability.js";
+
+/**
+ * One-shot reachability snapshot: the per-device subscription pushes its
+ * initial state immediately, so subscribe, take the first event, and
+ * unsubscribe. Bounded by *timeoutMs* and resolves null on timeout or
+ * error — a report prefill must not stall on a reachability hiccup.
+ */
+export function captureReachabilitySnapshot(
+  api: ESPHomeAPI,
+  deviceName: string,
+  timeoutMs = 3000
+): Promise<ReachabilityStateEvent | null> {
+  return new Promise((resolve) => {
+    let subscription: ReachabilitySubscription | null = null;
+    let done = false;
+    const finish = (state: ReachabilityStateEvent | null) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      void subscription?.unsubscribe().catch(() => undefined);
+      resolve(state);
+    };
+    const timer = setTimeout(() => finish(null), timeoutMs);
+    api
+      .subscribeDeviceReachability(deviceName, (state) => finish(state))
+      .then((sub) => {
+        subscription = sub;
+        // The snapshot may have landed before the subscribe call resolved.
+        if (done) void sub.unsubscribe().catch(() => undefined);
+      })
+      .catch(() => finish(null));
+  });
+}

--- a/test/components/dashboard/render-mdns-expiry.test.ts
+++ b/test/components/dashboard/render-mdns-expiry.test.ts
@@ -15,11 +15,11 @@ import { findTemplatesByAnchor, isTemplateResult } from "../../_lit-template-wal
 import { renderMdnsExpiry } from "../../../src/components/dashboard/device-drawer-render.js";
 import type { MdnsExpiryPhase } from "../../../src/util/mdns-expiry.js";
 
-const COUNTDOWN: MdnsExpiryPhase = { kind: "countdown", remaining: 4321 };
+const COUNTDOWN: MdnsExpiryPhase = { kind: "countdown", remaining: 4321, ttl: 4500 };
 
 describe("renderMdnsExpiry", () => {
   it("renders a details fold-down for a countdown phase", () => {
-    const result = renderMdnsExpiry(COUNTDOWN, 4500, identityLocalize, "en");
+    const result = renderMdnsExpiry(COUNTDOWN, identityLocalize, "en");
     expect(isTemplateResult(result)).toBe(true);
     expect(findTemplatesByAnchor(result, "<details").length).toBe(1);
   });
@@ -33,19 +33,14 @@ describe("renderMdnsExpiry", () => {
       { kind: "fresh" },
     ];
     for (const phase of phases) {
-      expect(renderMdnsExpiry(phase, 4500, identityLocalize, "en")).toBe(nothing);
+      expect(renderMdnsExpiry(phase, identityLocalize, "en")).toBe(nothing);
     }
-  });
-
-  it("renders nothing when the lifetime is null (no PTR cached)", () => {
-    expect(renderMdnsExpiry(COUNTDOWN, null, identityLocalize, "en")).toBe(nothing);
   });
 
   it("says 'expires soon' instead of a stuck 0s at the eviction edge", () => {
     const keys: string[] = [];
     renderMdnsExpiry(
-      { kind: "soon" },
-      4500,
+      { kind: "soon", ttl: 4500 },
       (key) => {
         keys.push(key);
         return key;
@@ -60,7 +55,6 @@ describe("renderMdnsExpiry", () => {
     const keys: string[] = [];
     renderMdnsExpiry(
       COUNTDOWN,
-      4500,
       (key) => {
         keys.push(key);
         return key;
@@ -74,8 +68,7 @@ describe("renderMdnsExpiry", () => {
   it("passes the countdown to the summary and the lifetime to the explainer", () => {
     const calls: Array<[string, Record<string, unknown> | undefined]> = [];
     renderMdnsExpiry(
-      { kind: "countdown", remaining: 3600 + 14 * 60 },
-      4500,
+      { kind: "countdown", remaining: 3600 + 14 * 60, ttl: 4500 },
       (key, args) => {
         calls.push([key, args]);
         return key;

--- a/test/components/dashboard/render-mdns-expiry.test.ts
+++ b/test/components/dashboard/render-mdns-expiry.test.ts
@@ -5,35 +5,46 @@
  * section mounts under the mDNS row showing "Expires in <countdown>"
  * (the device's record lifetime minus time since last heard) and
  * folding open to explain the passive-mDNS mechanism, naming the
- * device's actual record lifetime. The caller gates it on mDNS being
- * the active source; here we pin the null render and the localize
- * keys / args.
+ * device's actual record lifetime. The phase classifier owns every
+ * gate; here we pin the null render and the localize keys / args.
  */
 import { nothing } from "lit";
 import { describe, expect, it } from "vitest";
 import { identityLocalize } from "../../_dom.js";
 import { findTemplatesByAnchor, isTemplateResult } from "../../_lit-template-walker.js";
 import { renderMdnsExpiry } from "../../../src/components/dashboard/device-drawer-render.js";
+import type { MdnsExpiryPhase } from "../../../src/util/mdns-expiry.js";
+
+const COUNTDOWN: MdnsExpiryPhase = { kind: "countdown", remaining: 4321 };
 
 describe("renderMdnsExpiry", () => {
-  it("renders a details fold-down when remaining + lifetime are present", () => {
-    const result = renderMdnsExpiry(4321, 4500, identityLocalize, "en");
+  it("renders a details fold-down for a countdown phase", () => {
+    const result = renderMdnsExpiry(COUNTDOWN, 4500, identityLocalize, "en");
     expect(isTemplateResult(result)).toBe(true);
     expect(findTemplatesByAnchor(result, "<details").length).toBe(1);
   });
 
-  it("renders nothing when remaining is null (no PTR cached)", () => {
-    expect(renderMdnsExpiry(null, 4500, identityLocalize, "en")).toBe(nothing);
+  it("renders nothing for every no-hint phase", () => {
+    const phases: MdnsExpiryPhase[] = [
+      { kind: "no-signal" },
+      { kind: "offline" },
+      { kind: "inactive-source" },
+      { kind: "no-ttl" },
+      { kind: "fresh" },
+    ];
+    for (const phase of phases) {
+      expect(renderMdnsExpiry(phase, 4500, identityLocalize, "en")).toBe(nothing);
+    }
   });
 
   it("renders nothing when the lifetime is null (no PTR cached)", () => {
-    expect(renderMdnsExpiry(4321, null, identityLocalize, "en")).toBe(nothing);
+    expect(renderMdnsExpiry(COUNTDOWN, null, identityLocalize, "en")).toBe(nothing);
   });
 
-  it("says 'expires soon' instead of a stuck 0s once the countdown hits zero", () => {
+  it("says 'expires soon' instead of a stuck 0s at the eviction edge", () => {
     const keys: string[] = [];
     renderMdnsExpiry(
-      0,
+      { kind: "soon" },
       4500,
       (key) => {
         keys.push(key);
@@ -48,7 +59,7 @@ describe("renderMdnsExpiry", () => {
   it("uses the summary and explainer localize keys", () => {
     const keys: string[] = [];
     renderMdnsExpiry(
-      4321,
+      COUNTDOWN,
       4500,
       (key) => {
         keys.push(key);
@@ -63,7 +74,7 @@ describe("renderMdnsExpiry", () => {
   it("passes the countdown to the summary and the lifetime to the explainer", () => {
     const calls: Array<[string, Record<string, unknown> | undefined]> = [];
     renderMdnsExpiry(
-      3600 + 14 * 60,
+      { kind: "countdown", remaining: 3600 + 14 * 60 },
       4500,
       (key, args) => {
         calls.push([key, args]);

--- a/test/components/dashboard/render-reachability-section.test.ts
+++ b/test/components/dashboard/render-reachability-section.test.ts
@@ -3,11 +3,11 @@
  *
  * ``renderMdnsExpiry`` / ``formatCountdown`` are unit-tested with
  * pre-computed values; this pins the glue in ``renderReachabilitySection``
- * that a real bug would hide in: the ``lifetime - age`` subtraction, the
- * ``mdns_ptr_ttl_seconds === null`` gate, and the render-site gate that
- * only shows the countdown when mDNS is the active source. Asserted via a
- * capturing localize so the countdown / lifetime args are observable
- * without walking the template.
+ * that a real bug would hide in: the section's inputs reaching
+ * ``mdnsExpiryPhase`` (which owns every gate — TTL, active source,
+ * offline, quiet threshold) and the phase reaching the render. Asserted
+ * via a capturing localize so the countdown / lifetime args are
+ * observable without walking the template.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DeviceState } from "../../../src/api/types/devices.js";

--- a/test/components/feedback-device-picker.test.ts
+++ b/test/components/feedback-device-picker.test.ts
@@ -33,7 +33,12 @@ describe("feedback-device-picker", () => {
     target_platform: "ESP32S3",
     board_id: "esp32dev",
     loaded_integrations: ["esp32", "wifi"],
-    runtime_state: { deployed_version: "2026.7.0" },
+    runtime_state: {
+      deployed_version: "2026.7.0",
+      state: "online",
+      active_source: "mdns",
+      ip_addresses: ["192.168.1.5"],
+    },
   };
 
   let el: ESPHomeFeedbackDevicePicker;
@@ -63,6 +68,10 @@ describe("feedback-device-picker", () => {
               reads.push({ resolve, reject });
             })
         ),
+        subscribeDeviceReachability: vi.fn((_name: string, cb: (s: unknown) => void) => {
+          cb({ mdns_last_seen_seconds_ago: 300, mdns_ptr_ttl_seconds: 4500 });
+          return Promise.resolve({ unsubscribe: () => Promise.resolve() });
+        }),
       },
     });
     await el.updateComplete;
@@ -187,6 +196,40 @@ describe("feedback-device-picker", () => {
     await el.updateComplete;
     const status = el.shadowRoot!.querySelector('[role="status"]');
     expect(status!.textContent).toContain("feedback.device_none");
+  });
+
+  it("prefills the status form with the drawer's mDNS answer", async () => {
+    el.target = "status";
+    await el.updateComplete;
+    await pick();
+    const url = new URL(openedUrls[0]);
+    expect(url.searchParams.get("template")).toBe("device_status.yml");
+    expect(url.searchParams.get("mdns-expiry")).toBe("Expires in 1h 10m");
+    expect(url.searchParams.get("observed")).toContain("State:");
+    expect(url.searchParams.get("config")).toContain("password: \u2022");
+  });
+
+  it("opens the status form with an mDNS fallback when reachability stalls", async () => {
+    (
+      el as unknown as {
+        _api: { subscribeDeviceReachability: unknown };
+      }
+    )._api.subscribeDeviceReachability = vi.fn(() => new Promise(() => undefined));
+    el.target = "status";
+    await el.updateComplete;
+    vi.useFakeTimers();
+    try {
+      deviceRow().click();
+      await vi.advanceTimersByTimeAsync(0);
+      reads[0].resolve(RAW_YAML);
+      // The 3s snapshot timeout elapses; the form must still open.
+      await vi.advanceTimersByTimeAsync(3000);
+    } finally {
+      vi.useRealTimers();
+    }
+    await settle(() => openedUrls.length > 0);
+    const url = new URL(openedUrls[0]);
+    expect(url.searchParams.get("mdns-expiry")).toBe("no mDNS row");
   });
 
   it("drops a capture that resolves after the picker unmounted", async () => {

--- a/test/components/feedback-device-picker.test.ts
+++ b/test/components/feedback-device-picker.test.ts
@@ -69,7 +69,11 @@ describe("feedback-device-picker", () => {
             })
         ),
         subscribeDeviceReachability: vi.fn((_name: string, cb: (s: unknown) => void) => {
-          cb({ mdns_last_seen_seconds_ago: 300, mdns_ptr_ttl_seconds: 4500 });
+          cb({
+            active_source: "mdns",
+            mdns_last_seen_seconds_ago: 300,
+            mdns_ptr_ttl_seconds: 4500,
+          });
           return Promise.resolve({ unsubscribe: () => Promise.resolve() });
         }),
       },
@@ -229,7 +233,7 @@ describe("feedback-device-picker", () => {
     }
     await settle(() => openedUrls.length > 0);
     const url = new URL(openedUrls[0]);
-    expect(url.searchParams.get("mdns-expiry")).toBe("no mDNS row");
+    expect(url.searchParams.get("mdns-expiry")).toBe("reachability read failed");
   });
 
   it("drops a capture that resolves after the picker unmounted", async () => {

--- a/test/util/bug-report-prefill.test.ts
+++ b/test/util/bug-report-prefill.test.ts
@@ -165,6 +165,16 @@ describe("buildDeviceIssueUrl", () => {
     ).toBe("Expires soon");
   });
 
+  it("lets the snapshot's state and source win the observed lines", () => {
+    const observed = buildDeviceIssueUrl("status", DEVICE, "", CTX, {
+      active_source: "ping",
+      state: "online",
+      mdns_last_seen_seconds_ago: 300,
+      mdns_ptr_ttl_seconds: 4500,
+    } as ReachabilityStateEvent).url.searchParams.get("observed")!;
+    expect(observed).toContain("Reachability source: ping");
+  });
+
   it("blunts every address family in the observed IP line", () => {
     const facts = (runtime: object) =>
       deviceFacts(

--- a/test/util/bug-report-prefill.test.ts
+++ b/test/util/bug-report-prefill.test.ts
@@ -99,7 +99,8 @@ describe("buildDeviceIssueUrl", () => {
     const observed = built.url.searchParams.get("observed")!;
     expect(observed).toContain("State: online");
     expect(observed).toContain("Reachability source: mdns");
-    expect(observed).toContain("IP: 192.168.1.5");
+    expect(observed).toContain("IP: 192.168.x.x");
+    expect(observed).not.toContain("192.168.1.5");
     expect(observed).toContain("ESPHome: 2026.7.2");
   });
 
@@ -132,6 +133,27 @@ describe("buildDeviceIssueUrl", () => {
     expect(expiry({ mdns_last_seen_seconds_ago: 4500, mdns_ptr_ttl_seconds: 4500 })).toBe(
       "Expires soon"
     );
+  });
+
+  it("blunts every address family in the observed IP line", () => {
+    const facts = (runtime: object) =>
+      deviceFacts(
+        {
+          ...DEVICE,
+          runtime_state: { ...DEVICE.runtime_state, ...runtime },
+        } as unknown as ConfiguredDevice,
+        "status",
+        CTX
+      );
+    expect(facts({ ip_addresses: ["10.0.42.7", "fe80::abcd:12ff:fe34:5678"] })).toContain(
+      "IP: 10.0.x.x, fe80::x"
+    );
+    const hostnameFallback = {
+      ...DEVICE,
+      ip: "garage.local",
+      runtime_state: { ...DEVICE.runtime_state, ip_addresses: [] },
+    } as unknown as ConfiguredDevice;
+    expect(deviceFacts(hostnameFallback, "status", CTX)).toContain("IP: garage.local");
   });
 
   it("status skip satisfies the required config field", () => {

--- a/test/util/bug-report-prefill.test.ts
+++ b/test/util/bug-report-prefill.test.ts
@@ -165,14 +165,19 @@ describe("buildDeviceIssueUrl", () => {
     ).toBe("Expires soon");
   });
 
-  it("lets the snapshot's state and source win the observed lines", () => {
-    const observed = buildDeviceIssueUrl("status", DEVICE, "", CTX, {
+  it("takes the source from the snapshot but keeps the state live", () => {
+    const offlineDevice = {
+      ...DEVICE,
+      runtime_state: { ...DEVICE.runtime_state, state: "offline" },
+    } as unknown as ConfiguredDevice;
+    const observed = buildDeviceIssueUrl("status", offlineDevice, "", CTX, {
       active_source: "ping",
       state: "online",
       mdns_last_seen_seconds_ago: 300,
       mdns_ptr_ttl_seconds: 4500,
     } as ReachabilityStateEvent).url.searchParams.get("observed")!;
     expect(observed).toContain("Reachability source: ping");
+    expect(observed).toContain("State: offline");
   });
 
   it("blunts every address family in the observed IP line", () => {
@@ -188,17 +193,24 @@ describe("buildDeviceIssueUrl", () => {
     expect(facts({ ip_addresses: ["10.0.42.7", "fe80::abcd:12ff:fe34:5678"] })).toContain(
       "IP: 10.0.x.x, fe80::x"
     );
-    const hostnameFallback = {
+    const unrecognised = {
       ...DEVICE,
       ip: "garage.local",
       runtime_state: { ...DEVICE.runtime_state, ip_addresses: [] },
     } as unknown as ConfiguredDevice;
-    expect(deviceFacts(hostnameFallback, "status", CTX)).toContain("IP: garage.local");
+    expect(deviceFacts(unrecognised, "status", CTX)).toContain("IP: x");
+    const addressless = {
+      ...DEVICE,
+      ip: "",
+      runtime_state: { ...DEVICE.runtime_state, ip_addresses: [] },
+    } as unknown as ConfiguredDevice;
+    expect(deviceFacts(addressless, "status", CTX)).toContain("IP: none resolved");
   });
 
-  it("status skip satisfies the required config field", () => {
+  it("status skip satisfies both required fields", () => {
     const url = skipDeviceUrl("status", CTX);
     expect(url.searchParams.get("config")).toBe("not device specific");
+    expect(url.searchParams.get("mdns-expiry")).toBe("not device specific");
     expect(url.searchParams.get("version")).toBe("1.8.0");
   });
 

--- a/test/util/bug-report-prefill.test.ts
+++ b/test/util/bug-report-prefill.test.ts
@@ -87,6 +87,7 @@ describe("buildDeviceIssueUrl", () => {
 
   it("prefills the status form with observed facts and the mDNS answer", () => {
     const built = buildDeviceIssueUrl("status", DEVICE, "wifi:\n  ssid: x", CTX, {
+      active_source: "mdns",
       mdns_last_seen_seconds_ago: 300,
       mdns_ptr_ttl_seconds: 4500,
     } as ReachabilityStateEvent);
@@ -116,23 +117,52 @@ describe("buildDeviceIssueUrl", () => {
         CTX,
         reachability as ReachabilityStateEvent | null
       ).url.searchParams.get("mdns-expiry");
-    expect(expiry(null)).toBe("no mDNS row");
-    expect(expiry({ mdns_last_seen_seconds_ago: 60, mdns_ptr_ttl_seconds: 4500 })).toBe(
-      "no expiry countdown (heard recently)"
+    expect(expiry(null)).toBe("reachability read failed");
+    expect(expiry({ active_source: "ping", mdns_last_seen_seconds_ago: null })).toBe(
+      "no mDNS row"
     );
-    expect(expiry({ mdns_last_seen_seconds_ago: 300, mdns_ptr_ttl_seconds: null })).toBe(
-      "no expiry countdown (no PTR TTL)"
-    );
+    expect(
+      expiry({
+        active_source: "mdns",
+        mdns_last_seen_seconds_ago: 60,
+        mdns_ptr_ttl_seconds: 4500,
+      })
+    ).toBe("no expiry countdown (heard recently)");
+    expect(
+      expiry({
+        active_source: "ping",
+        mdns_last_seen_seconds_ago: 300,
+        mdns_ptr_ttl_seconds: 4500,
+      })
+    ).toBe("no expiry countdown (mDNS not the active source)");
+    expect(
+      expiry({
+        active_source: "mdns",
+        mdns_last_seen_seconds_ago: 300,
+        mdns_ptr_ttl_seconds: null,
+      })
+    ).toBe("no expiry countdown (no PTR TTL)");
     const offline = {
       ...DEVICE,
       runtime_state: { ...DEVICE.runtime_state, state: "offline" },
     } as unknown as ConfiguredDevice;
     expect(
-      expiry({ mdns_last_seen_seconds_ago: 300, mdns_ptr_ttl_seconds: 4500 }, offline)
+      expiry(
+        {
+          active_source: "mdns",
+          mdns_last_seen_seconds_ago: 300,
+          mdns_ptr_ttl_seconds: 4500,
+        },
+        offline
+      )
     ).toBe("no expiry countdown (device offline)");
-    expect(expiry({ mdns_last_seen_seconds_ago: 4500, mdns_ptr_ttl_seconds: 4500 })).toBe(
-      "Expires soon"
-    );
+    expect(
+      expiry({
+        active_source: "mdns",
+        mdns_last_seen_seconds_ago: 4500,
+        mdns_ptr_ttl_seconds: 4500,
+      })
+    ).toBe("Expires soon");
   });
 
   it("blunts every address family in the observed IP line", () => {

--- a/test/util/bug-report-prefill.test.ts
+++ b/test/util/bug-report-prefill.test.ts
@@ -20,7 +20,12 @@ const DEVICE = {
   target_platform: "ESP32S3",
   board_id: "esp32dev",
   loaded_integrations: ["esp32", "wifi"],
-  runtime_state: { deployed_version: "2026.7.0" },
+  runtime_state: {
+    deployed_version: "2026.7.0",
+    state: "online",
+    active_source: "mdns",
+    ip_addresses: ["192.168.1.5"],
+  },
 } as unknown as ConfiguredDevice;
 
 describe("deviceFacts", () => {
@@ -77,6 +82,29 @@ describe("buildDeviceIssueUrl", () => {
     expect(esphome.url.searchParams.get("additional")).toContain("Garage Door");
     expect(esphome.url.searchParams.get("config")).toBeNull();
     expect(esphome.url.searchParams.get("version")).toBe("2026.7.1");
+  });
+
+  it("prefills the status form with observed facts and extra params", () => {
+    const built = buildDeviceIssueUrl("status", DEVICE, "wifi:\n  ssid: x", CTX, {
+      "mdns-expiry": "Expires in 1h 10m",
+    });
+    expect(built.url.origin + built.url.pathname).toBe(
+      "https://github.com/esphome/device-builder/issues/new"
+    );
+    expect(built.url.searchParams.get("template")).toBe("device_status.yml");
+    expect(built.url.searchParams.get("version")).toBe("1.8.0");
+    expect(built.url.searchParams.get("mdns-expiry")).toBe("Expires in 1h 10m");
+    const observed = built.url.searchParams.get("observed")!;
+    expect(observed).toContain("State: online");
+    expect(observed).toContain("Reachability source: mdns");
+    expect(observed).toContain("IP: 192.168.1.5");
+    expect(observed).toContain("ESPHome: 2026.7.2");
+  });
+
+  it("status skip satisfies the required config field", () => {
+    const url = skipDeviceUrl("status", CTX);
+    expect(url.searchParams.get("config")).toBe("not device specific");
+    expect(url.searchParams.get("version")).toBe("1.8.0");
   });
 
   it("reports truncation for a config past the budget", () => {

--- a/test/util/bug-report-prefill.test.ts
+++ b/test/util/bug-report-prefill.test.ts
@@ -199,6 +199,11 @@ describe("buildDeviceIssueUrl", () => {
       runtime_state: { ...DEVICE.runtime_state, ip_addresses: [] },
     } as unknown as ConfiguredDevice;
     expect(deviceFacts(unrecognised, "status", CTX)).toContain("IP: x");
+    const ported = {
+      ...DEVICE,
+      runtime_state: { ...DEVICE.runtime_state, ip_addresses: ["192.168.1.5:6053"] },
+    } as unknown as ConfiguredDevice;
+    expect(deviceFacts(ported, "status", CTX)).toContain("IP: x");
     const addressless = {
       ...DEVICE,
       ip: "",

--- a/test/util/bug-report-prefill.test.ts
+++ b/test/util/bug-report-prefill.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ConfiguredDevice } from "../../src/api/types/devices.js";
+import type { ReachabilityStateEvent } from "../../src/api/types/reachability.js";
 import {
   buildDeviceIssueUrl,
   deviceFacts,
@@ -84,10 +85,11 @@ describe("buildDeviceIssueUrl", () => {
     expect(esphome.url.searchParams.get("version")).toBe("2026.7.1");
   });
 
-  it("prefills the status form with observed facts and extra params", () => {
+  it("prefills the status form with observed facts and the mDNS answer", () => {
     const built = buildDeviceIssueUrl("status", DEVICE, "wifi:\n  ssid: x", CTX, {
-      "mdns-expiry": "Expires in 1h 10m",
-    });
+      mdns_last_seen_seconds_ago: 300,
+      mdns_ptr_ttl_seconds: 4500,
+    } as ReachabilityStateEvent);
     expect(built.url.origin + built.url.pathname).toBe(
       "https://github.com/esphome/device-builder/issues/new"
     );
@@ -99,6 +101,37 @@ describe("buildDeviceIssueUrl", () => {
     expect(observed).toContain("Reachability source: mdns");
     expect(observed).toContain("IP: 192.168.1.5");
     expect(observed).toContain("ESPHome: 2026.7.2");
+  });
+
+  it("names the reason when no mDNS countdown applies", () => {
+    const expiry = (
+      reachability: Partial<ReachabilityStateEvent> | null,
+      device: ConfiguredDevice = DEVICE
+    ) =>
+      buildDeviceIssueUrl(
+        "status",
+        device,
+        "",
+        CTX,
+        reachability as ReachabilityStateEvent | null
+      ).url.searchParams.get("mdns-expiry");
+    expect(expiry(null)).toBe("no mDNS row");
+    expect(expiry({ mdns_last_seen_seconds_ago: 60, mdns_ptr_ttl_seconds: 4500 })).toBe(
+      "no expiry countdown (heard recently)"
+    );
+    expect(expiry({ mdns_last_seen_seconds_ago: 300, mdns_ptr_ttl_seconds: null })).toBe(
+      "no expiry countdown (no PTR TTL)"
+    );
+    const offline = {
+      ...DEVICE,
+      runtime_state: { ...DEVICE.runtime_state, state: "offline" },
+    } as unknown as ConfiguredDevice;
+    expect(
+      expiry({ mdns_last_seen_seconds_ago: 300, mdns_ptr_ttl_seconds: 4500 }, offline)
+    ).toBe("no expiry countdown (device offline)");
+    expect(expiry({ mdns_last_seen_seconds_ago: 4500, mdns_ptr_ttl_seconds: 4500 })).toBe(
+      "Expires soon"
+    );
   });
 
   it("status skip satisfies the required config field", () => {

--- a/test/util/mdns-expiry.test.ts
+++ b/test/util/mdns-expiry.test.ts
@@ -6,6 +6,7 @@ describe("mdnsExpiryPhase", () => {
     expect(mdnsExpiryPhase(300, 4500, false, "mdns")).toEqual({
       kind: "countdown",
       remaining: 4200,
+      ttl: 4500,
     });
   });
 
@@ -20,7 +21,13 @@ describe("mdnsExpiryPhase", () => {
   });
 
   it("says soon for an already-elapsed record", () => {
-    expect(mdnsExpiryPhase(4500, 4500, false, "mdns")).toEqual({ kind: "soon" });
-    expect(mdnsExpiryPhase(5000, 4500, false, "mdns")).toEqual({ kind: "soon" });
+    expect(mdnsExpiryPhase(4500, 4500, false, "mdns")).toEqual({
+      kind: "soon",
+      ttl: 4500,
+    });
+    expect(mdnsExpiryPhase(5000, 4500, false, "mdns")).toEqual({
+      kind: "soon",
+      ttl: 4500,
+    });
   });
 });

--- a/test/util/mdns-expiry.test.ts
+++ b/test/util/mdns-expiry.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { mdnsExpiryRemaining, mdnsExpirySummary } from "../../src/util/mdns-expiry.js";
+
+describe("mdnsExpiryRemaining", () => {
+  it("counts down past the quiet threshold", () => {
+    expect(mdnsExpiryRemaining(300, 4500, false)).toBe(4200);
+  });
+
+  it("shows no hint when fresh, offline, or without a TTL", () => {
+    expect(mdnsExpiryRemaining(60, 4500, false)).toBeNull();
+    expect(mdnsExpiryRemaining(300, 4500, true)).toBeNull();
+    expect(mdnsExpiryRemaining(300, null, false)).toBeNull();
+    expect(mdnsExpiryRemaining(null, 4500, false)).toBeNull();
+  });
+
+  it("clamps an already-elapsed record to zero", () => {
+    expect(mdnsExpiryRemaining(5000, 4500, false)).toBe(0);
+  });
+});
+
+describe("mdnsExpirySummary", () => {
+  it("mirrors the drawer's countdown text", () => {
+    expect(mdnsExpirySummary(300, 4500, false)).toBe("Expires in 1h 10m");
+  });
+
+  it("says soon at the eviction edge", () => {
+    expect(mdnsExpirySummary(4500, 4500, false)).toBe("Expires soon");
+  });
+
+  it("answers the no-row and no-countdown cases", () => {
+    expect(mdnsExpirySummary(null, 4500, false)).toBe("no mDNS row");
+    expect(mdnsExpirySummary(60, 4500, false)).toBe(
+      "no expiry countdown (heard recently)"
+    );
+    expect(mdnsExpirySummary(300, 4500, true)).toBe(
+      "no expiry countdown (device offline)"
+    );
+  });
+});

--- a/test/util/mdns-expiry.test.ts
+++ b/test/util/mdns-expiry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mdnsExpiryRemaining, mdnsExpirySummary } from "../../src/util/mdns-expiry.js";
+import { mdnsExpiresSoon, mdnsExpiryRemaining } from "../../src/util/mdns-expiry.js";
 
 describe("mdnsExpiryRemaining", () => {
   it("counts down past the quiet threshold", () => {
@@ -18,22 +18,10 @@ describe("mdnsExpiryRemaining", () => {
   });
 });
 
-describe("mdnsExpirySummary", () => {
-  it("mirrors the drawer's countdown text", () => {
-    expect(mdnsExpirySummary(300, 4500, false)).toBe("Expires in 1h 10m");
-  });
-
-  it("says soon at the eviction edge", () => {
-    expect(mdnsExpirySummary(4500, 4500, false)).toBe("Expires soon");
-  });
-
-  it("answers the no-row and no-countdown cases", () => {
-    expect(mdnsExpirySummary(null, 4500, false)).toBe("no mDNS row");
-    expect(mdnsExpirySummary(60, 4500, false)).toBe(
-      "no expiry countdown (heard recently)"
-    );
-    expect(mdnsExpirySummary(300, 4500, true)).toBe(
-      "no expiry countdown (device offline)"
-    );
+describe("mdnsExpiresSoon", () => {
+  it("cuts at one second", () => {
+    expect(mdnsExpiresSoon(0)).toBe(true);
+    expect(mdnsExpiresSoon(0.9)).toBe(true);
+    expect(mdnsExpiresSoon(1)).toBe(false);
   });
 });

--- a/test/util/mdns-expiry.test.ts
+++ b/test/util/mdns-expiry.test.ts
@@ -1,28 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { mdnsExpiresSoon, mdnsExpiryRemaining } from "../../src/util/mdns-expiry.js";
+import { mdnsExpiryPhase } from "../../src/util/mdns-expiry.js";
 
-describe("mdnsExpiryRemaining", () => {
+describe("mdnsExpiryPhase", () => {
   it("counts down past the quiet threshold", () => {
-    expect(mdnsExpiryRemaining(300, 4500, false, "mdns")).toBe(4200);
+    expect(mdnsExpiryPhase(300, 4500, false, "mdns")).toEqual({
+      kind: "countdown",
+      remaining: 4200,
+    });
   });
 
-  it("shows no hint when fresh, offline, inactive, or without a TTL", () => {
-    expect(mdnsExpiryRemaining(60, 4500, false, "mdns")).toBeNull();
-    expect(mdnsExpiryRemaining(300, 4500, true, "mdns")).toBeNull();
-    expect(mdnsExpiryRemaining(300, 4500, false, "ping")).toBeNull();
-    expect(mdnsExpiryRemaining(300, null, false, "mdns")).toBeNull();
-    expect(mdnsExpiryRemaining(null, 4500, false, "mdns")).toBeNull();
+  it("names why no hint shows, in priority order", () => {
+    expect(mdnsExpiryPhase(null, 4500, true, "ping")).toEqual({ kind: "no-signal" });
+    expect(mdnsExpiryPhase(300, 4500, true, "ping")).toEqual({ kind: "offline" });
+    expect(mdnsExpiryPhase(300, 4500, false, "ping")).toEqual({
+      kind: "inactive-source",
+    });
+    expect(mdnsExpiryPhase(300, null, false, "mdns")).toEqual({ kind: "no-ttl" });
+    expect(mdnsExpiryPhase(60, 4500, false, "mdns")).toEqual({ kind: "fresh" });
   });
 
-  it("clamps an already-elapsed record to zero", () => {
-    expect(mdnsExpiryRemaining(5000, 4500, false, "mdns")).toBe(0);
-  });
-});
-
-describe("mdnsExpiresSoon", () => {
-  it("cuts at one second", () => {
-    expect(mdnsExpiresSoon(0)).toBe(true);
-    expect(mdnsExpiresSoon(0.9)).toBe(true);
-    expect(mdnsExpiresSoon(1)).toBe(false);
+  it("says soon for an already-elapsed record", () => {
+    expect(mdnsExpiryPhase(4500, 4500, false, "mdns")).toEqual({ kind: "soon" });
+    expect(mdnsExpiryPhase(5000, 4500, false, "mdns")).toEqual({ kind: "soon" });
   });
 });

--- a/test/util/mdns-expiry.test.ts
+++ b/test/util/mdns-expiry.test.ts
@@ -3,18 +3,19 @@ import { mdnsExpiresSoon, mdnsExpiryRemaining } from "../../src/util/mdns-expiry
 
 describe("mdnsExpiryRemaining", () => {
   it("counts down past the quiet threshold", () => {
-    expect(mdnsExpiryRemaining(300, 4500, false)).toBe(4200);
+    expect(mdnsExpiryRemaining(300, 4500, false, "mdns")).toBe(4200);
   });
 
-  it("shows no hint when fresh, offline, or without a TTL", () => {
-    expect(mdnsExpiryRemaining(60, 4500, false)).toBeNull();
-    expect(mdnsExpiryRemaining(300, 4500, true)).toBeNull();
-    expect(mdnsExpiryRemaining(300, null, false)).toBeNull();
-    expect(mdnsExpiryRemaining(null, 4500, false)).toBeNull();
+  it("shows no hint when fresh, offline, inactive, or without a TTL", () => {
+    expect(mdnsExpiryRemaining(60, 4500, false, "mdns")).toBeNull();
+    expect(mdnsExpiryRemaining(300, 4500, true, "mdns")).toBeNull();
+    expect(mdnsExpiryRemaining(300, 4500, false, "ping")).toBeNull();
+    expect(mdnsExpiryRemaining(300, null, false, "mdns")).toBeNull();
+    expect(mdnsExpiryRemaining(null, 4500, false, "mdns")).toBeNull();
   });
 
   it("clamps an already-elapsed record to zero", () => {
-    expect(mdnsExpiryRemaining(5000, 4500, false)).toBe(0);
+    expect(mdnsExpiryRemaining(5000, 4500, false, "mdns")).toBe(0);
   });
 });
 

--- a/test/util/reachability-snapshot.test.ts
+++ b/test/util/reachability-snapshot.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import type { ReachabilityStateEvent } from "../../src/api/types/reachability.js";
+import { captureReachabilitySnapshot } from "../../src/util/reachability-snapshot.js";
+
+const EVENT = {
+  active_source: "mdns",
+  mdns_last_seen_seconds_ago: 300,
+  mdns_ptr_ttl_seconds: 4500,
+} as unknown as ReachabilityStateEvent;
+
+describe("captureReachabilitySnapshot", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves the first event and unsubscribes", async () => {
+    const unsubscribe = vi.fn().mockResolvedValue(undefined);
+    const api = {
+      // The event lands before the subscribe call resolves.
+      subscribeDeviceReachability: vi.fn(
+        async (_name: string, cb: (state: ReachabilityStateEvent) => void) => {
+          cb(EVENT);
+          return { unsubscribe };
+        }
+      ),
+    } as unknown as ESPHomeAPI;
+    expect(await captureReachabilitySnapshot(api, "garage")).toBe(EVENT);
+    await vi.waitFor(() => expect(unsubscribe).toHaveBeenCalledOnce());
+  });
+
+  it("resolves null on timeout and still unsubscribes", async () => {
+    vi.useFakeTimers();
+    const unsubscribe = vi.fn().mockResolvedValue(undefined);
+    const api = {
+      subscribeDeviceReachability: vi.fn(async () => ({ unsubscribe })),
+    } as unknown as ESPHomeAPI;
+    const result = captureReachabilitySnapshot(api, "garage");
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(await result).toBeNull();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("resolves null when the subscribe call rejects", async () => {
+    const api = {
+      subscribeDeviceReachability: vi
+        .fn()
+        .mockRejectedValue(new Error("WebSocket not connected")),
+    } as unknown as ESPHomeAPI;
+    expect(await captureReachabilitySnapshot(api, "garage")).toBeNull();
+  });
+});

--- a/test/util/reachability-snapshot.test.ts
+++ b/test/util/reachability-snapshot.test.ts
@@ -29,8 +29,9 @@ describe("captureReachabilitySnapshot", () => {
     await vi.waitFor(() => expect(unsubscribe).toHaveBeenCalledOnce());
   });
 
-  it("resolves null on timeout and still unsubscribes", async () => {
+  it("resolves null on timeout, logs, and still unsubscribes", async () => {
     vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const unsubscribe = vi.fn().mockResolvedValue(undefined);
     const api = {
       subscribeDeviceReachability: vi.fn(async () => ({ unsubscribe })),
@@ -39,6 +40,8 @@ describe("captureReachabilitySnapshot", () => {
     await vi.advanceTimersByTimeAsync(3000);
     expect(await result).toBeNull();
     expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
   });
 
   it("resolves null when the subscribe call rejects", async () => {

--- a/test/util/reachability-snapshot.test.ts
+++ b/test/util/reachability-snapshot.test.ts
@@ -42,11 +42,14 @@ describe("captureReachabilitySnapshot", () => {
   });
 
   it("resolves null when the subscribe call rejects", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const api = {
       subscribeDeviceReachability: vi
         .fn()
         .mockRejectedValue(new Error("WebSocket not connected")),
     } as unknown as ESPHomeAPI;
     expect(await captureReachabilitySnapshot(api, "garage")).toBeNull();
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The Device status looks wrong row now drills into the same device picker the other two bug paths use. Picking a device opens the status form prefilled with its masked YAML config, an observed block (state, reachability source, IP, board, versions, installation) in the template's new observed field, and the required mDNS row answer computed from a one-shot reachability snapshot; the countdown decision lives in a shared mdns-expiry phase classifier the drawer consumes too, so the report always matches what the drawer shows. The snapshot is bounded by a three second timeout so a reachability hiccup degrades to "reachability read failed" instead of stalling the report, the observed IP line is blunted to network prefixes, and the skip row fills the required config and mdns-expiry fields with the template's own sentence.

Targets the fields esphome/device-builder#2487 added; no behavior change on the other two picker paths.

**Related issue or feature (if applicable):**

- fixes #1596

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

