### PR TITLE
Fix section splice dropping keys from CRLF documents

### DIFF
--- a/src/components/device/apply-removal.ts
+++ b/src/components/device/apply-removal.ts
@@ -6,6 +6,7 @@
  */
 import type { ESPHomeAPI } from "../../api/esphome-api.js";
 import type { AutomationLocation } from "../../api/types/automations.js";
+import { splitYamlDocLines } from "../../util/yaml-section-lexer.js";
 import { removeSectionFromYaml } from "../../util/yaml-section-values.js";
 import { resolveCurrentSectionLine } from "../../util/yaml-sections.js";
 import { applyYamlDiff } from "./automation-editor/serialise.js";
@@ -78,10 +79,12 @@ export async function applyRemoval(
 }
 
 /** Lines removed going from *before* to *after*, or ``null`` when
- *  the edit is not a pure contiguous removal. */
+ *  the edit is not a pure contiguous removal. Compared CR-stripped:
+ *  the section machinery normalizes a mixed-ending document's line
+ *  endings, and an ending-only difference is not a removal. */
 function removedLines(before: string, after: string): string[] | null {
-  const b = before.split("\n");
-  const a = after.split("\n");
+  const b = splitYamlDocLines(before);
+  const a = splitYamlDocLines(after);
   let start = 0;
   while (start < a.length && b[start] === a[start]) start++;
   let endB = b.length - 1;

--- a/src/components/device/apply-removal.ts
+++ b/src/components/device/apply-removal.ts
@@ -6,7 +6,7 @@
  */
 import type { ESPHomeAPI } from "../../api/esphome-api.js";
 import type { AutomationLocation } from "../../api/types/automations.js";
-import { splitYamlDocLines } from "../../util/yaml-section-lexer.js";
+import { splitYamlDocLines } from "../../util/yaml-doc-lines.js";
 import { removeSectionFromYaml } from "../../util/yaml-section-values.js";
 import { resolveCurrentSectionLine } from "../../util/yaml-sections.js";
 import { applyYamlDiff } from "./automation-editor/serialise.js";

--- a/src/util/bus-availability.ts
+++ b/src/util/bus-availability.ts
@@ -20,6 +20,7 @@
  * error, not to second-guess configs it can't parse.
  */
 import { hasSubstitutionReference } from "./substitutions.js";
+import { splitYamlDocLines } from "./yaml-section-lexer.js";
 import { parseYamlSectionValues } from "./yaml-section-reader.js";
 import { parseYamlTopLevelSections, type YamlSection } from "./yaml-sections-core.js";
 import { sectionKeyOf } from "./yaml-sections.js";
@@ -97,7 +98,7 @@ export function assessBusHostability(
 ): BusHostability {
   const semantics = BUS_SEMANTICS[busDomain];
   const sections = parseYamlTopLevelSections(yaml);
-  const lines = yaml.split("\n");
+  const lines = splitYamlDocLines(yaml);
   const isBus = (s: YamlSection) => (s.parentKey ?? s.key) === busDomain;
   const buses: BusState[] = sections.filter(isBus).map((s) => {
     const values = parseYamlSectionValues(yaml, s.key, s.fromLine);

--- a/src/util/bus-availability.ts
+++ b/src/util/bus-availability.ts
@@ -20,7 +20,7 @@
  * error, not to second-guess configs it can't parse.
  */
 import { hasSubstitutionReference } from "./substitutions.js";
-import { splitYamlDocLines } from "./yaml-section-lexer.js";
+import { splitYamlDocLines } from "./yaml-doc-lines.js";
 import { parseYamlSectionValues } from "./yaml-section-reader.js";
 import { parseYamlTopLevelSections, type YamlSection } from "./yaml-sections-core.js";
 import { sectionKeyOf } from "./yaml-sections.js";

--- a/src/util/yaml-doc-lines.ts
+++ b/src/util/yaml-doc-lines.ts
@@ -1,0 +1,35 @@
+/**
+ * Document-level line splitting and line-ending detection, dependency
+ * free so consumers that must stay lightweight (the sensitive-value
+ * scanner) can use it without pulling in the editor stack.
+ */
+
+/**
+ * Split a document into lines with any trailing CR stripped. CRLF
+ * documents must shed the CR before line classifiers run: JS regexes
+ * treat CR as a line terminator, so patterns ending `(.*)$` cannot
+ * match a line that kept one and every child key silently drops out
+ * of the parse (#1601). Callers that rejoin restore the document's
+ * ending via `yamlDocEol`.
+ */
+export function splitYamlDocLines(yaml: string): string[] {
+  const lines = yaml.split(/\r?\n/);
+  // A final segment with no terminating LF can still end in a bare CR
+  // (a truncated CRLF write); the regex split only consumes CRs that
+  // precede an LF.
+  const last = lines.length - 1;
+  if (lines[last].endsWith("\r")) lines[last] = lines[last].slice(0, -1);
+  return lines;
+}
+
+/**
+ * The document's line ending, by majority vote (ties go to LF). A
+ * mixed-ending document normalizes toward its dominant ending, so one
+ * pasted CRLF line in an LF file costs that line its CR on the next
+ * save instead of converting the whole file.
+ */
+export function yamlDocEol(yaml: string): "\r\n" | "\n" {
+  const crlf = yaml.split("\r\n").length - 1;
+  const bareLf = yaml.split("\n").length - 1 - crlf;
+  return crlf > bareLf ? "\r\n" : "\n";
+}

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -24,9 +24,20 @@ export function splitYamlDocLines(yaml: string): string[] {
   return lines;
 }
 
-/** The document's line ending; a mixed-ending document counts as CRLF. */
+/**
+ * The document's line ending, by majority vote (ties go to LF). A
+ * mixed-ending document normalizes toward its dominant ending, so one
+ * pasted CRLF line in an LF file costs that line its CR on the next
+ * save instead of converting the whole file.
+ */
 export function yamlDocEol(yaml: string): "\r\n" | "\n" {
-  return yaml.includes("\r\n") ? "\r\n" : "\n";
+  let crlf = 0;
+  let lf = 0;
+  for (let i = yaml.indexOf("\n"); i !== -1; i = yaml.indexOf("\n", i + 1)) {
+    if (yaml[i - 1] === "\r") crlf++;
+    else lf++;
+  }
+  return crlf > lf ? "\r\n" : "\n";
 }
 
 /**

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -8,30 +8,6 @@
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 
 /**
- * Split a document into lines with any trailing CR stripped. CRLF
- * documents must shed the CR before the classifiers run: JS regexes
- * treat CR as a line terminator, so patterns ending `(.*)$` cannot
- * match a line that kept one and every child key silently drops out
- * of the parse (#1601). Callers that rejoin restore the document's
- * ending via `yamlDocEol`.
- */
-export function splitYamlDocLines(yaml: string): string[] {
-  return yaml.split(/\r?\n/);
-}
-
-/**
- * The document's line ending, by majority vote (ties go to LF). A
- * mixed-ending document normalizes toward its dominant ending, so one
- * pasted CRLF line in an LF file costs that line its CR on the next
- * save instead of converting the whole file.
- */
-export function yamlDocEol(yaml: string): "\r\n" | "\n" {
-  const crlf = yaml.split("\r\n").length - 1;
-  const bareLf = yaml.split("\n").length - 1 - crlf;
-  return crlf > bareLf ? "\r\n" : "\n";
-}
-
-/**
  * Identifier alphabet for plain-scalar YAML keys the parser will
  * accept. The leading character stays strict (``[a-zA-Z_]``) so
  * list-item dashes, comment lines, and YAML anchors / aliases

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -8,6 +8,28 @@
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 
 /**
+ * Split a document into lines with any trailing CR stripped. CRLF
+ * documents must shed the CR before the classifiers run: JS regexes
+ * treat CR as a line terminator, so patterns ending `(.*)$` cannot
+ * match a line that kept one and every child key silently drops out
+ * of the parse (#1601). Callers that rejoin restore the document's
+ * ending via `yamlDocEol`.
+ */
+export function splitYamlDocLines(yaml: string): string[] {
+  const lines = yaml.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.endsWith("\r")) lines[i] = line.slice(0, -1);
+  }
+  return lines;
+}
+
+/** The document's line ending; a mixed-ending document counts as CRLF. */
+export function yamlDocEol(yaml: string): "\r\n" | "\n" {
+  return yaml.includes("\r\n") ? "\r\n" : "\n";
+}
+
+/**
  * Identifier alphabet for plain-scalar YAML keys the parser will
  * accept. The leading character stays strict (``[a-zA-Z_]``) so
  * list-item dashes, comment lines, and YAML anchors / aliases

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -16,12 +16,7 @@ import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
  * ending via `yamlDocEol`.
  */
 export function splitYamlDocLines(yaml: string): string[] {
-  const lines = yaml.split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (line.endsWith("\r")) lines[i] = line.slice(0, -1);
-  }
-  return lines;
+  return yaml.split(/\r?\n/);
 }
 
 /**
@@ -31,13 +26,9 @@ export function splitYamlDocLines(yaml: string): string[] {
  * save instead of converting the whole file.
  */
 export function yamlDocEol(yaml: string): "\r\n" | "\n" {
-  let crlf = 0;
-  let lf = 0;
-  for (let i = yaml.indexOf("\n"); i !== -1; i = yaml.indexOf("\n", i + 1)) {
-    if (yaml[i - 1] === "\r") crlf++;
-    else lf++;
-  }
-  return crlf > lf ? "\r\n" : "\n";
+  const crlf = yaml.split("\r\n").length - 1;
+  const bareLf = yaml.split("\n").length - 1 - crlf;
+  return crlf > bareLf ? "\r\n" : "\n";
 }
 
 /**

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -9,6 +9,7 @@
 
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import { blockScalarValue } from "./yaml-block-scalar-value.js";
+import { splitYamlDocLines } from "./yaml-doc-lines.js";
 import {
   parseFlowList,
   parseScalar,
@@ -27,7 +28,6 @@ import {
   LIST_ITEM_INLINE_KEY_RE,
   LIST_ITEM_START_RE,
   parseBlockScalarHeader,
-  splitYamlDocLines,
   TOP_LEVEL_KEY_START_RE,
 } from "./yaml-section-lexer.js";
 import { _blockScalarBodyEnd } from "./yaml-section-list.js";

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -27,6 +27,7 @@ import {
   LIST_ITEM_INLINE_KEY_RE,
   LIST_ITEM_START_RE,
   parseBlockScalarHeader,
+  splitYamlDocLines,
   TOP_LEVEL_KEY_START_RE,
 } from "./yaml-section-lexer.js";
 import { _blockScalarBodyEnd } from "./yaml-section-list.js";
@@ -100,7 +101,7 @@ export function parseYamlSectionValues(
   sectionKey: string,
   fromLine?: number
 ): Record<string, unknown> {
-  return parseSectionCore(yaml.split("\n"), sectionKey, fromLine).values;
+  return parseSectionCore(splitYamlDocLines(yaml), sectionKey, fromLine).values;
 }
 
 /**

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -15,7 +15,9 @@ import {
   isCommentLine,
   LIST_ITEM_INLINE_KEY_RE,
   LIST_ITEM_START_RE,
+  splitYamlDocLines,
   TOP_LEVEL_KEY_START_RE,
+  yamlDocEol,
 } from "./yaml-section-lexer.js";
 import { findSectionStart, parseSectionCore } from "./yaml-section-reader.js";
 import { buildSplicedBody, yamlValueEqual } from "./yaml-section-splice.js";
@@ -31,7 +33,7 @@ const NON_BLANK_RE = /\S/;
 /** Trailing newlines and whitespace-only lines at the document end. Leaves
  *  trailing spaces on the last content line alone (a block scalar's final
  *  line may carry meaningful ones). */
-const TRAILING_BLANK_LINES_RE = /(?:\n[ \t]*)+$/;
+const TRAILING_BLANK_LINES_RE = /(?:\r?\n[ \t]*)+$/;
 
 /**
  * Find the 0-indexed line range [start, end) for a section.
@@ -120,7 +122,8 @@ export function updateSectionInYaml(
   fromLine?: number,
   options: SerializeYamlOptions = {}
 ): string {
-  const lines = yaml.split("\n");
+  const eol = yamlDocEol(yaml);
+  const lines = splitYamlDocLines(yaml);
   const { start, end } = findSectionRange(lines, sectionKey, fromLine);
   if (start < 0) return yaml;
 
@@ -181,7 +184,7 @@ export function updateSectionInYaml(
       }
     );
     lines.splice(start, spliceEnd - start, ...block);
-    return lines.join("\n");
+    return lines.join(eol);
   }
 
   // Re-parse the original to recover each key's source-line span and
@@ -303,7 +306,7 @@ export function updateSectionInYaml(
     ...buildSplicedBody(lines, parsed, values, inlineKeys, childIndent, serializeOptions),
   ];
   lines.splice(start, spliceEnd - start, ...newLines);
-  return lines.join("\n");
+  return lines.join(eol);
 }
 
 /**
@@ -329,7 +332,8 @@ export function removeSectionFromYaml(
   sectionKey: string,
   fromLine?: number
 ): string {
-  const lines = yaml.split("\n");
+  const eol = yamlDocEol(yaml);
+  const lines = splitYamlDocLines(yaml);
   const { start, end } = findSectionRange(lines, sectionKey, fromLine);
   if (start < 0) return yaml;
 
@@ -362,7 +366,7 @@ export function removeSectionFromYaml(
     }
   }
 
-  return lines.join("\n");
+  return lines.join(eol);
 }
 
 /** Indent of the first indented child line under any top-level key — the
@@ -402,13 +406,14 @@ export function appendSectionToYaml(
   options: SerializeYamlOptions = {}
 ): string {
   const indentStep =
-    options.indentStep ?? _detectDocumentIndentStep(yaml.split("\n")) ?? undefined;
+    options.indentStep ?? _detectDocumentIndentStep(splitYamlDocLines(yaml)) ?? undefined;
   const block = serializeYamlValues({ [sectionKey]: values }, "", {
     ...options,
     indentStep,
   });
   if (block.length === 0) return yaml;
+  const eol = yamlDocEol(yaml);
   const base = NON_BLANK_RE.test(yaml) ? yaml.replace(TRAILING_BLANK_LINES_RE, "") : "";
-  const body = block.join("\n");
-  return base ? `${base}\n\n${body}\n` : `${body}\n`;
+  const body = block.join(eol);
+  return base ? `${base}${eol}${eol}${body}${eol}` : `${body}${eol}`;
 }

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -405,15 +405,17 @@ export function appendSectionToYaml(
   values: Record<string, unknown>,
   options: SerializeYamlOptions = {}
 ): string {
-  const indentStep =
-    options.indentStep ?? _detectDocumentIndentStep(splitYamlDocLines(yaml)) ?? undefined;
+  const lines = splitYamlDocLines(yaml);
+  const indentStep = options.indentStep ?? _detectDocumentIndentStep(lines) ?? undefined;
   const block = serializeYamlValues({ [sectionKey]: values }, "", {
     ...options,
     indentStep,
   });
   if (block.length === 0) return yaml;
   const eol = yamlDocEol(yaml);
-  const base = NON_BLANK_RE.test(yaml) ? yaml.replace(TRAILING_BLANK_LINES_RE, "") : "";
+  const base = NON_BLANK_RE.test(yaml)
+    ? lines.join(eol).replace(TRAILING_BLANK_LINES_RE, "")
+    : "";
   const body = block.join(eol);
   return base ? `${base}${eol}${eol}${body}${eol}` : `${body}${eol}`;
 }

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -9,15 +9,14 @@
 
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
+import { splitYamlDocLines, yamlDocEol } from "./yaml-doc-lines.js";
 import {
   _detectSectionChildIndent,
   _leadingIndent,
   isCommentLine,
   LIST_ITEM_INLINE_KEY_RE,
   LIST_ITEM_START_RE,
-  splitYamlDocLines,
   TOP_LEVEL_KEY_START_RE,
-  yamlDocEol,
 } from "./yaml-section-lexer.js";
 import { findSectionStart, parseSectionCore } from "./yaml-section-reader.js";
 import { buildSplicedBody, yamlValueEqual } from "./yaml-section-splice.js";
@@ -125,6 +124,9 @@ export function updateSectionInYaml(
   const lines = splitYamlDocLines(yaml);
   const { start, end } = findSectionRange(lines, sectionKey, fromLine);
   if (start < 0) return yaml;
+  // Joining with the majority eol deliberately normalizes the whole
+  // document, so on mixed-ending input the output can differ from the
+  // input byte-wise even when every value is unchanged.
   const eol = yamlDocEol(yaml);
 
   // List-item vs map shape and the section's child indent drive both

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -122,10 +122,10 @@ export function updateSectionInYaml(
   fromLine?: number,
   options: SerializeYamlOptions = {}
 ): string {
-  const eol = yamlDocEol(yaml);
   const lines = splitYamlDocLines(yaml);
   const { start, end } = findSectionRange(lines, sectionKey, fromLine);
   if (start < 0) return yaml;
+  const eol = yamlDocEol(yaml);
 
   // List-item vs map shape and the section's child indent drive both
   // the trailing-comment trim below and the serializer's indent step.
@@ -332,10 +332,10 @@ export function removeSectionFromYaml(
   sectionKey: string,
   fromLine?: number
 ): string {
-  const eol = yamlDocEol(yaml);
   const lines = splitYamlDocLines(yaml);
   const { start, end } = findSectionRange(lines, sectionKey, fromLine);
   if (start < 0) return yaml;
+  const eol = yamlDocEol(yaml);
 
   const isListItem = LIST_ITEM_START_RE.test(lines[start]);
   lines.splice(start, end - start);

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -13,13 +13,13 @@
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import { isIndexSegment } from "./nested-values.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
+import { splitYamlDocLines } from "./yaml-doc-lines.js";
 import { readInstanceScalar } from "./yaml-instance-scalars.js";
 import { indentOf, RE_PAIR_LINE, stripComment } from "./yaml-line-walker.js";
 import {
   _skipBlankAndCommentLines,
   endsBlockAtIndent,
   LIST_ITEM_START_RE,
-  splitYamlDocLines,
   TOP_LEVEL_KEY_RE,
 } from "./yaml-section-lexer.js";
 

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -19,6 +19,7 @@ import {
   _skipBlankAndCommentLines,
   endsBlockAtIndent,
   LIST_ITEM_START_RE,
+  splitYamlDocLines,
   TOP_LEVEL_KEY_RE,
 } from "./yaml-section-lexer.js";
 
@@ -118,7 +119,7 @@ export function parseYamlTopLevelSections(yaml: string): YamlSection[] {
   if (_topLevelSectionsKey === yaml && _topLevelSectionsValue) {
     return _topLevelSectionsValue;
   }
-  const lines = yaml.split("\n");
+  const lines = splitYamlDocLines(yaml);
   const rawSections: Array<{ key: string; fromLine: number; toLine: number }> = [];
 
   for (let i = 0; i < lines.length; i++) {

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -1,6 +1,6 @@
 import { TARGET_PLATFORM_KEYS } from "./component-presence.js";
 import { parseYamlAutomations } from "./yaml-automations.js";
-import { TOP_LEVEL_KEY_RE } from "./yaml-section-lexer.js";
+import { splitYamlDocLines, TOP_LEVEL_KEY_RE } from "./yaml-section-lexer.js";
 import {
   _clearYamlSectionsMemo,
   findFieldLine,
@@ -151,7 +151,7 @@ export function findAddedSection(
   // Disambiguate by the submitted id when multiple instances exist
   // (the common "I added a second sensor.dht" case).
   if (newId) {
-    const lines = yaml.split("\n");
+    const lines = splitYamlDocLines(yaml);
     // The id is form input — escape it so the match is literal.
     const escapedId = newId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const idRe = new RegExp(`^\\s*(?:-\\s+)?id:\\s*["']?${escapedId}["']?\\s*$`);

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -1,6 +1,7 @@
 import { TARGET_PLATFORM_KEYS } from "./component-presence.js";
 import { parseYamlAutomations } from "./yaml-automations.js";
-import { splitYamlDocLines, TOP_LEVEL_KEY_RE } from "./yaml-section-lexer.js";
+import { splitYamlDocLines } from "./yaml-doc-lines.js";
+import { TOP_LEVEL_KEY_RE } from "./yaml-section-lexer.js";
 import {
   _clearYamlSectionsMemo,
   findFieldLine,

--- a/src/util/yaml-sensitive-scan.ts
+++ b/src/util/yaml-sensitive-scan.ts
@@ -20,7 +20,7 @@
  * working YAML which may be mid-edit and not parseable.
  */
 
-import { splitYamlDocLines } from "./yaml-section-lexer.js";
+import { splitYamlDocLines } from "./yaml-doc-lines.js";
 
 export interface SensitiveValueRange {
   /** 1-indexed line number (CodeMirror convention). */

--- a/src/util/yaml-sensitive-scan.ts
+++ b/src/util/yaml-sensitive-scan.ts
@@ -20,6 +20,8 @@
  * working YAML which may be mid-edit and not parseable.
  */
 
+import { splitYamlDocLines } from "./yaml-section-lexer.js";
+
 export interface SensitiveValueRange {
   /** 1-indexed line number (CodeMirror convention). */
   line: number;
@@ -204,7 +206,7 @@ export function findSensitiveValueRanges(
     }
   } else {
     if (!yaml) return ranges;
-    lines = yaml.split("\n").map(stripTrailingCr);
+    lines = splitYamlDocLines(yaml);
   }
 
   // Stack of (indent, key) entries representing the current ancestor

--- a/test/util/yaml-section-crlf.test.ts
+++ b/test/util/yaml-section-crlf.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { parseYamlSectionValues } from "../../src/util/yaml-section-reader.js";
+import {
+  appendSectionToYaml,
+  removeSectionFromYaml,
+  updateSectionInYaml,
+} from "../../src/util/yaml-section-values.js";
+
+const crlf = (...lines: string[]): string => lines.join("\r\n") + "\r\n";
+
+describe("CRLF documents (#1601)", () => {
+  it("parseYamlSectionValues reads every key from a CRLF document", () => {
+    const yaml = crlf("wifi:", "  ssid: net", "  password: hunter2", "sensor:");
+    expect(parseYamlSectionValues(yaml, "wifi")).toEqual({
+      ssid: "net",
+      password: "hunter2",
+    });
+  });
+
+  it("updateSectionInYaml keeps untouched keys and emits CRLF throughout", () => {
+    const out = updateSectionInYaml("wifi:\r\n  ssid: net\r\n", "wifi", {
+      ssid: "net",
+      use_address: "10.0.0.9",
+    });
+    expect(out).toBe(crlf("wifi:", "  ssid: net", "  use_address: 10.0.0.9"));
+  });
+
+  it("updateSectionInYaml round-trips unchanged values byte-identically", () => {
+    const yaml = crlf(
+      "wifi:",
+      '  ssid: "quoted net"  # keep me',
+      "  password: hunter2",
+      "sensor:",
+      "  - platform: dht"
+    );
+    const out = updateSectionInYaml(yaml, "wifi", parseYamlSectionValues(yaml, "wifi"));
+    expect(out).toBe(yaml);
+  });
+
+  it("updateSectionInYaml preserves untouched-line byte layout on a real change", () => {
+    const yaml = crlf(
+      "wifi:",
+      '  ssid: "quoted net"  # keep me',
+      "  password: hunter2",
+      "sensor:"
+    );
+    const out = updateSectionInYaml(yaml, "wifi", {
+      ssid: "quoted net",
+      password: "swordfish",
+    });
+    expect(out).toBe(
+      crlf("wifi:", '  ssid: "quoted net"  # keep me', "  password: swordfish", "sensor:")
+    );
+  });
+
+  it("removeSectionFromYaml drops the section and keeps CRLF elsewhere", () => {
+    const yaml = crlf("wifi:", "  ssid: net", "sensor:", "  - platform: dht");
+    expect(removeSectionFromYaml(yaml, "wifi")).toBe(
+      crlf("sensor:", "  - platform: dht")
+    );
+  });
+
+  it("appendSectionToYaml emits the new block with the document's ending", () => {
+    const yaml = crlf("esphome:", "  name: x");
+    expect(appendSectionToYaml(yaml, "wifi", { ssid: "net" })).toBe(
+      crlf("esphome:", "  name: x", "", "wifi:", "  ssid: net")
+    );
+  });
+
+  it("a mixed-endings document normalizes to CRLF", () => {
+    const out = updateSectionInYaml("wifi:\r\n  ssid: net\nsensor:\n", "wifi", {
+      ssid: "net",
+      use_address: "10.0.0.9",
+    });
+    expect(out).toBe(crlf("wifi:", "  ssid: net", "  use_address: 10.0.0.9", "sensor:"));
+  });
+
+  it("an LF document stays LF", () => {
+    const out = updateSectionInYaml("wifi:\n  ssid: net\n", "wifi", {
+      ssid: "net",
+      use_address: "10.0.0.9",
+    });
+    expect(out).toBe("wifi:\n  ssid: net\n  use_address: 10.0.0.9\n");
+    expect(out).not.toContain("\r");
+  });
+});

--- a/test/util/yaml-section-crlf.test.ts
+++ b/test/util/yaml-section-crlf.test.ts
@@ -67,12 +67,60 @@ describe("CRLF documents (#1601)", () => {
     );
   });
 
-  it("a mixed-endings document normalizes to CRLF", () => {
-    const out = updateSectionInYaml("wifi:\r\n  ssid: net\nsensor:\n", "wifi", {
+  it("a mostly-LF document normalizes the stray CRLF line to LF", () => {
+    const out = updateSectionInYaml("wifi:\n  ssid: net\r\nsensor:\n  id: s\n", "wifi", {
       ssid: "net",
       use_address: "10.0.0.9",
     });
-    expect(out).toBe(crlf("wifi:", "  ssid: net", "  use_address: 10.0.0.9", "sensor:"));
+    expect(out).toBe("wifi:\n  ssid: net\n  use_address: 10.0.0.9\nsensor:\n  id: s\n");
+  });
+
+  it("a mostly-CRLF document normalizes the stray LF line to CRLF", () => {
+    const out = updateSectionInYaml(
+      "wifi:\r\n  ssid: net\nsensor:\r\n  id: s\r\n",
+      "wifi",
+      { ssid: "net", use_address: "10.0.0.9" }
+    );
+    expect(out).toBe(
+      crlf("wifi:", "  ssid: net", "  use_address: 10.0.0.9", "sensor:", "  id: s")
+    );
+  });
+
+  it("updateSectionInYaml on a CRLF list item keeps the inline key single", () => {
+    const yaml = crlf("sensor:", "  - platform: dht", "    pin: D1");
+    const out = updateSectionInYaml(yaml, "sensor", { platform: "dht", pin: "D2" }, 2);
+    expect(out).toBe(crlf("sensor:", "  - platform: dht", "    pin: D2"));
+  });
+
+  it("updateSectionInYaml on a CRLF globals block keeps every entry", () => {
+    const yaml = crlf("globals:", "  - id: my_int", "    type: int");
+    const items = parseYamlSectionValues(yaml, "globals").globals as Record<
+      string,
+      unknown
+    >[];
+    expect(items).toHaveLength(1);
+    const out = updateSectionInYaml(yaml, "globals", { globals: items });
+    expect(parseYamlSectionValues(out, "globals").globals).toEqual(items);
+    expect(out.split("\r\n").length).toBeGreaterThan(1);
+    expect(out).not.toMatch(/[^\r]\n/);
+  });
+
+  it("updateSectionInYaml keeps a CRLF block-scalar body byte-for-byte", () => {
+    const yaml = crlf(
+      "wifi:",
+      "  ssid: net",
+      "  certificate: |-",
+      "    AAA",
+      "    BBB",
+      "sensor:"
+    );
+    const out = updateSectionInYaml(yaml, "wifi", {
+      ...parseYamlSectionValues(yaml, "wifi"),
+      ssid: "other",
+    });
+    expect(out).toBe(
+      crlf("wifi:", "  ssid: other", "  certificate: |-", "    AAA", "    BBB", "sensor:")
+    );
   });
 
   it("an LF document stays LF", () => {

--- a/test/util/yaml-section-crlf.test.ts
+++ b/test/util/yaml-section-crlf.test.ts
@@ -137,6 +137,12 @@ describe("CRLF documents (#1601)", () => {
     expect(out).toBe("wifi:\n  ssid: net\n  use_address: 10.0.0.9\n");
   });
 
+  it("parseYamlSectionValues reads a final line ending in a bare CR", () => {
+    expect(parseYamlSectionValues("wifi:\r\n  password: hunter2\r", "wifi")).toEqual({
+      password: "hunter2",
+    });
+  });
+
   it("parseYamlTopLevelSections reads names from a CRLF document", () => {
     const yaml = crlf("sensor:", "  - platform: dht", '    name: "Kitchen Temp"');
     const sections = parseYamlTopLevelSections(yaml);

--- a/test/util/yaml-section-crlf.test.ts
+++ b/test/util/yaml-section-crlf.test.ts
@@ -5,6 +5,7 @@ import {
   removeSectionFromYaml,
   updateSectionInYaml,
 } from "../../src/util/yaml-section-values.js";
+import { parseYamlTopLevelSections } from "../../src/util/yaml-sections-core.js";
 
 const crlf = (...lines: string[]): string => lines.join("\r\n") + "\r\n";
 
@@ -100,9 +101,7 @@ describe("CRLF documents (#1601)", () => {
     >[];
     expect(items).toHaveLength(1);
     const out = updateSectionInYaml(yaml, "globals", { globals: items });
-    expect(parseYamlSectionValues(out, "globals").globals).toEqual(items);
-    expect(out.split("\r\n").length).toBeGreaterThan(1);
-    expect(out).not.toMatch(/[^\r]\n/);
+    expect(out).toBe(yaml);
   });
 
   it("updateSectionInYaml keeps a CRLF block-scalar body byte-for-byte", () => {
@@ -129,6 +128,13 @@ describe("CRLF documents (#1601)", () => {
       use_address: "10.0.0.9",
     });
     expect(out).toBe("wifi:\n  ssid: net\n  use_address: 10.0.0.9\n");
-    expect(out).not.toContain("\r");
+  });
+
+  it("parseYamlTopLevelSections reads names from a CRLF document", () => {
+    const yaml = crlf("sensor:", "  - platform: dht", '    name: "Kitchen Temp"');
+    const sections = parseYamlTopLevelSections(yaml);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].name).toBe("Kitchen Temp");
+    expect(sections[0].platform).toBe("dht");
   });
 });

--- a/test/util/yaml-section-crlf.test.ts
+++ b/test/util/yaml-section-crlf.test.ts
@@ -68,6 +68,13 @@ describe("CRLF documents (#1601)", () => {
     );
   });
 
+  it("appendSectionToYaml normalizes a mostly-LF body's stray CRLF line", () => {
+    const out = appendSectionToYaml("esphome:\n  name: x\r\n  area: y\n", "wifi", {
+      ssid: "net",
+    });
+    expect(out).toBe("esphome:\n  name: x\n  area: y\n\nwifi:\n  ssid: net\n");
+  });
+
   it("a mostly-LF document normalizes the stray CRLF line to LF", () => {
     const out = updateSectionInYaml("wifi:\n  ssid: net\r\nsensor:\n  id: s\n", "wifi", {
       ssid: "net",


### PR DESCRIPTION
# What does this implement/fix?

The section machinery split documents on `\n` only, so every line of a CRLF config kept a trailing `\r`; the key regexes then failed to match, the parse came back empty, and a section form save wrote back only the caller's values, dropping everything else in the block. The read side had the same problem, a CRLF config opened the form empty and the navigator lost `name:` labels.

Documents are now split through shared helpers in a new dependency free `yaml-doc-lines.ts` module: `splitYamlDocLines` strips the CR per line (including a bare CR on an unterminated final line), and `yamlDocEol` picks the document's ending by majority vote with ties going to LF, so one pasted CRLF line in an LF file normalizes to LF instead of converting the whole file. The section entry points rejoin with that ending, keeping a Windows edited file CRLF throughout with untouched lines round tripping byte for byte. The same helper now feeds the other line scans in the machinery (`parseYamlTopLevelSections`, `findAddedSection`, `assessBusHostability`), the sensitive value scanner, and the superseded delete rebase check, which compared lines byte for byte and would have declined on normalized mixed ending buffers.

Round trip tests cover parse, update (map, list item inline key, globals, block scalar body), remove, append, both mixed ending directions, the bare final CR, and the LF path.

Once this merges, the CRLF refusal added to the use_address writer in #1597 can be lifted on that branch.

**Related issue or feature (if applicable):**

- fixes #1601

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
