### PR TITLE
Move per-target report behavior into the DEVICE_TARGETS table

### DIFF
--- a/src/components/feedback-device-picker.ts
+++ b/src/components/feedback-device-picker.ts
@@ -19,6 +19,7 @@ import { espHomeStyles } from "../styles/shared.js";
 import { summaryListStyles } from "../styles/summary-list.js";
 import {
   buildDeviceIssueUrl,
+  DEVICE_TARGETS,
   type DeviceTarget,
   type PrefillContext,
   skipDeviceUrl,
@@ -291,12 +292,12 @@ export class ESPHomeFeedbackDevicePicker extends LitElement {
     this._capturing = device.configuration;
     const abandoned = () =>
       session !== this._session || !this.isConnected || !this.active;
-    // The status form also wants the drawer's mDNS-row answer; fetch the
-    // reachability snapshot alongside the config so neither serializes
+    // A reachability target also wants the drawer's mDNS-row answer;
+    // fetch the snapshot alongside the config so neither serializes
     // the other, and let it degrade to null on a hiccup.
     const [masked, reachability] = await Promise.all([
       captureMaskedConfig(this._api, device.configuration, abandoned),
-      this.target === "status"
+      DEVICE_TARGETS[this.target].reachability
         ? captureReachabilitySnapshot(this._api, device.name)
         : Promise.resolve(null),
     ]);

--- a/src/util/bug-report-prefill.ts
+++ b/src/util/bug-report-prefill.ts
@@ -21,10 +21,13 @@ interface DeviceTargetSpec {
   /** `version` param source: the device's compiled version falling back
    *  to the installed core, or the dashboard's own version. */
   version: "dashboard" | "device";
-  /** Include the installed ESPHome version in the facts (the esphome
-   *  form already carries it in its `version` param). */
+  /** Include the installed ESPHome version in the facts. True exactly
+   *  when `version` is "dashboard" — the "device" form's `version`
+   *  param already carries the core version. */
   esphomeVersionFact: boolean;
-  /** Include the reachability facts and the `mdns-expiry` answer. */
+  /** Include the reachability facts and the `mdns-expiry` answer.
+   *  True requires `"mdns-expiry"` in `skipSentinels` — the field is
+   *  required on the form that has it. */
   reachability: boolean;
   /** Required fields the skip row fills with the template's sentence. */
   skipSentinels: readonly ("config" | "mdns-expiry")[];
@@ -36,7 +39,7 @@ interface DeviceTargetSpec {
 // device-status form has `config` + `observed` + `mdns-expiry`
 // (esphome/device-builder#2487). GitHub silently drops unknown params,
 // so these must track the templates.
-const DEVICE_TARGETS: Record<DeviceTarget, DeviceTargetSpec> = {
+export const DEVICE_TARGETS: Record<DeviceTarget, DeviceTargetSpec> = {
   builder: {
     href: "https://github.com/esphome/device-builder/issues/new?template=bug_report.yml",
     factsParam: "extra",

--- a/src/util/bug-report-prefill.ts
+++ b/src/util/bug-report-prefill.ts
@@ -15,27 +15,51 @@ import { formatCountdown } from "./relative-time.js";
 /** The bug paths that carry a device config. */
 export type DeviceTarget = "builder" | "esphome" | "status";
 
+interface DeviceTargetSpec {
+  href: string;
+  factsParam: "additional" | "extra" | "observed";
+  /** `version` param source: the device's compiled version falling back
+   *  to the installed core, or the dashboard's own version. */
+  version: "dashboard" | "device";
+  /** Include the installed ESPHome version in the facts (the esphome
+   *  form already carries it in its `version` param). */
+  esphomeVersionFact: boolean;
+  /** Include the reachability facts and the `mdns-expiry` answer. */
+  reachability: boolean;
+  /** Required fields the skip row fills with the template's sentence. */
+  skipSentinels: readonly string[];
+}
+
 // Field ids come from each repo's issue templates: esphome/esphome's
 // bug form has `config` + `additional`; the builder bug form has
 // `config` + `extra` (config added in esphome/device-builder#2482); the
 // device-status form has `config` + `observed` + `mdns-expiry`
 // (esphome/device-builder#2487). GitHub silently drops unknown params,
 // so these must track the templates.
-const DEVICE_TARGETS: Record<
-  DeviceTarget,
-  { href: string; factsParam: "additional" | "extra" | "observed" }
-> = {
+const DEVICE_TARGETS: Record<DeviceTarget, DeviceTargetSpec> = {
   builder: {
     href: "https://github.com/esphome/device-builder/issues/new?template=bug_report.yml",
     factsParam: "extra",
+    version: "dashboard",
+    esphomeVersionFact: true,
+    reachability: false,
+    skipSentinels: ["config"],
   },
   esphome: {
     href: ESPHOME_BUG_FORM_URL,
     factsParam: "additional",
+    version: "device",
+    esphomeVersionFact: false,
+    reachability: false,
+    skipSentinels: [],
   },
   status: {
     href: "https://github.com/esphome/device-builder/issues/new?template=device_status.yml",
     factsParam: "observed",
+    version: "dashboard",
+    esphomeVersionFact: true,
+    reachability: true,
+    skipSentinels: ["config", "mdns-expiry"],
   },
 };
 
@@ -66,7 +90,7 @@ export function buildDeviceIssueUrl(
     DEVICE_TARGETS[target].factsParam,
     deviceFacts(device, target, ctx, reachability)
   );
-  if (target === "status") {
+  if (DEVICE_TARGETS[target].reachability) {
     // Set before the config fit so it counts against the URL budget.
     url.searchParams.set("mdns-expiry", mdnsExpirySummary(reachability ?? null, device));
   }
@@ -74,12 +98,13 @@ export function buildDeviceIssueUrl(
   return { url, truncated };
 }
 
-/** Today's URL for the no-specific-device row; the builder and status
- *  paths fill their required fields with the template's own sentence. */
+/** Today's URL for the no-specific-device row; each target's required
+ *  fields fill with the template's own sentence. */
 export function skipDeviceUrl(target: DeviceTarget, ctx: PrefillContext): URL {
   const url = deviceTargetUrl(target, ctx);
-  if (target !== "esphome") url.searchParams.set("config", NOT_DEVICE_SPECIFIC);
-  if (target === "status") url.searchParams.set("mdns-expiry", NOT_DEVICE_SPECIFIC);
+  for (const param of DEVICE_TARGETS[target].skipSentinels) {
+    url.searchParams.set(param, NOT_DEVICE_SPECIFIC);
+  }
   return url;
 }
 
@@ -97,6 +122,7 @@ export function deviceFacts(
    *  transition. */
   reachability?: ReachabilityStateEvent | null
 ): string {
+  const spec = DEVICE_TARGETS[target];
   const platform = issuePlatform(devicePlatform(device));
   return [
     `Device: ${deviceSortKey(device)} (${device.configuration})`,
@@ -104,9 +130,9 @@ export function deviceFacts(
     platform && `Platform: ${platform}`,
     device.runtime_state.deployed_version &&
       `ESPHome running: ${device.runtime_state.deployed_version}`,
-    target !== "esphome" && ctx.esphomeVersion && `ESPHome: ${ctx.esphomeVersion}`,
+    spec.esphomeVersionFact && ctx.esphomeVersion && `ESPHome: ${ctx.esphomeVersion}`,
     ctx.installation && `Installation: ${ctx.installation}`,
-    ...(target === "status"
+    ...(spec.reachability
       ? [
           `State: ${device.runtime_state.state}`,
           `Reachability source: ${
@@ -179,17 +205,17 @@ function mdnsExpirySummary(
   }
 }
 
-// Base form URL for *target* with the version param set: the builder
-// and status forms take the dashboard version, esphome's the device's
-// compiled version falling back to the installed core version.
+// Base form URL for *target* with the version param set from the
+// table's declared source.
 function deviceTargetUrl(
   target: DeviceTarget,
   ctx: PrefillContext,
   device?: ConfiguredDevice
 ): URL {
-  const url = new URL(DEVICE_TARGETS[target].href);
+  const spec = DEVICE_TARGETS[target];
+  const url = new URL(spec.href);
   const version =
-    target === "esphome"
+    spec.version === "device"
       ? device?.current_version || ctx.esphomeVersion
       : ctx.serverVersion;
   if (version) url.searchParams.set("version", version);

--- a/src/util/bug-report-prefill.ts
+++ b/src/util/bug-report-prefill.ts
@@ -27,7 +27,7 @@ interface DeviceTargetSpec {
   /** Include the reachability facts and the `mdns-expiry` answer. */
   reachability: boolean;
   /** Required fields the skip row fills with the template's sentence. */
-  skipSentinels: readonly string[];
+  skipSentinels: readonly ("config" | "mdns-expiry")[];
 }
 
 // Field ids come from each repo's issue templates: esphome/esphome's

--- a/test/util/bug-report-prefill.test.ts
+++ b/test/util/bug-report-prefill.test.ts
@@ -85,6 +85,17 @@ describe("buildDeviceIssueUrl", () => {
     expect(esphome.url.searchParams.get("version")).toBe("2026.7.1");
   });
 
+  it("keeps mdns-expiry off the non-status forms", () => {
+    expect(
+      buildDeviceIssueUrl("builder", DEVICE, "", CTX).url.searchParams.get("mdns-expiry")
+    ).toBeNull();
+    expect(
+      buildDeviceIssueUrl("esphome", DEVICE, "", CTX).url.searchParams.get("mdns-expiry")
+    ).toBeNull();
+    expect(skipDeviceUrl("builder", CTX).searchParams.get("mdns-expiry")).toBeNull();
+    expect(skipDeviceUrl("esphome", CTX).searchParams.get("mdns-expiry")).toBeNull();
+  });
+
   it("prefills the status form with observed facts and the mDNS answer", () => {
     const built = buildDeviceIssueUrl("status", DEVICE, "wifi:\n  ssid: x", CTX, {
       active_source: "mdns",


### PR DESCRIPTION
# What does this implement/fix?

The report prefill encoded per target template behavior as scattered negations; builder and status were paired by `target !== "esphome"` coincidence rather than declaration. `DEVICE_TARGETS` is already the per target registry, so the version source, the ESPHome facts line, the reachability block plus mdns-expiry answer, and the skip row's required field sentinels now live on it as declared properties, and every call site reads the table. A fourth target becomes one new table entry instead of an audit of each negation.

Pure refactor; the existing tests in bug-report-prefill.test.ts pin every branch and pass unchanged.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1603

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
