### PR TITLE
Fix CRLF-blind entity name pool and address CRLF review nits

### DIFF
--- a/src/util/yaml-doc-lines.ts
+++ b/src/util/yaml-doc-lines.ts
@@ -26,10 +26,15 @@ export function splitYamlDocLines(yaml: string): string[] {
  * The document's line ending, by majority vote (ties go to LF). A
  * mixed-ending document normalizes toward its dominant ending, so one
  * pasted CRLF line in an LF file costs that line its CR on the next
- * save instead of converting the whole file.
+ * save instead of converting the whole file. An index scan, not a
+ * split: this runs on every debounced section-form keystroke.
  */
 export function yamlDocEol(yaml: string): "\r\n" | "\n" {
-  const crlf = yaml.split("\r\n").length - 1;
-  const bareLf = yaml.split("\n").length - 1 - crlf;
+  let crlf = 0;
+  let bareLf = 0;
+  for (let i = yaml.indexOf("\n"); i !== -1; i = yaml.indexOf("\n", i + 1)) {
+    if (yaml[i - 1] === "\r") crlf++;
+    else bareLf++;
+  }
   return crlf > bareLf ? "\r\n" : "\n";
 }

--- a/src/util/yaml-instance-scalars.ts
+++ b/src/util/yaml-instance-scalars.ts
@@ -1,3 +1,4 @@
+import { splitYamlDocLines } from "./yaml-doc-lines.js";
 import { splitInlineComment, stripQuotes } from "./yaml-scalar.js";
 import { TOP_LEVEL_KEY_RE } from "./yaml-section-lexer.js";
 
@@ -49,7 +50,7 @@ export function collectInstanceScalars(
   const values = new Set<string>();
   if (!yaml) return values;
   let inSection = section === undefined;
-  for (const line of yaml.split("\n")) {
+  for (const line of splitYamlDocLines(yaml)) {
     if (!/^\s/.test(line)) {
       const top = line.match(TOP_LEVEL_KEY_RE);
       if (section !== undefined && top) inSection = top[1] === section;

--- a/test/util/default-entity-name.test.ts
+++ b/test/util/default-entity-name.test.ts
@@ -94,6 +94,11 @@ describe("collectExistingNames", () => {
     expect(collectExistingNames("", "switch")).toEqual(new Set());
   });
 
+  it("collects names from a CRLF document", () => {
+    const yaml = 'switch:\r\n  - platform: gpio\r\n    name: "Porch Light"\r\n';
+    expect(collectExistingNames(yaml, "switch")).toEqual(new Set(["Porch Light"]));
+  });
+
   it("picks up multi-word names on indented and list-item lines, peeling quotes", () => {
     const yaml = [
       "sensor:",

--- a/test/util/yaml-doc-lines.test.ts
+++ b/test/util/yaml-doc-lines.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { splitYamlDocLines, yamlDocEol } from "../../src/util/yaml-doc-lines.js";
+
+describe("splitYamlDocLines", () => {
+  it("strips the CR from every CRLF line", () => {
+    expect(splitYamlDocLines("a\r\nb\r\n")).toEqual(["a", "b", ""]);
+  });
+
+  it("strips a bare CR on an unterminated final line", () => {
+    expect(splitYamlDocLines("a\r\nb\r")).toEqual(["a", "b"]);
+  });
+
+  it("handles degenerate inputs", () => {
+    expect(splitYamlDocLines("")).toEqual([""]);
+    expect(splitYamlDocLines("a\r\nb")).toEqual(["a", "b"]);
+    expect(splitYamlDocLines("a\nb")).toEqual(["a", "b"]);
+  });
+});
+
+describe("yamlDocEol", () => {
+  it("picks the majority ending", () => {
+    expect(yamlDocEol("a\r\nb\r\nc\n")).toBe("\r\n");
+    expect(yamlDocEol("a\nb\nc\r\n")).toBe("\n");
+  });
+
+  it("ties go to LF", () => {
+    expect(yamlDocEol("a: 1\r\nb: 2\n")).toBe("\n");
+  });
+
+  it("defaults to LF with no newline at all", () => {
+    expect(yamlDocEol("")).toBe("\n");
+    expect(yamlDocEol("a: 1")).toBe("\n");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Follow up to the post merge review on #1602. The default entity name uniqueness pool was empty on CRLF configs: collectInstanceScalars fed readInstanceScalar raw split lines, the name regex ends `(.*)$` which cannot match a CR bearing line, so suggested names could collide with existing ones. It now splits through the shared `splitYamlDocLines`.

Also from the review notes: `yamlDocEol` is now an allocation free index scan instead of two whole document splits, since it runs on every debounced section form keystroke; and the documented tie to LF rule plus the degenerate inputs get direct tests in a new `yaml-doc-lines.test.ts`.

**Related issue or feature (if applicable):**

- fixes #1605

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
