### PR TITLE
CR-strip the remaining readInstanceScalar line feeds

### DIFF
--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -21,6 +21,7 @@ import { isValidEspHomeId } from "./esphome-id.js";
 import { isPinFieldKey, parsePinGpio, scanPinGpios } from "./pin/gpio.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import { hasSubstitutionReference } from "./substitutions.js";
+import { splitYamlDocLines } from "./yaml-doc-lines.js";
 import { readInstanceScalar } from "./yaml-instance-scalars.js";
 import { indentOf } from "./yaml-line-walker.js";
 import {
@@ -222,7 +223,7 @@ export function findUsedPins(
     // doesn't render its pin selectors until yaml has loaded).
     return used;
   }
-  const lines = yaml.split("\n");
+  const lines = splitYamlDocLines(yaml);
   let currentDomain = "";
   // Indentation of an open free-text block scalar; continuation lines
   // indented deeper than this are prose and skipped. -1 when none is open.
@@ -292,7 +293,7 @@ export function findUsedPins(
  */
 export function sectionEndLine(yaml: string, fromLine?: number): number | undefined {
   if (fromLine === undefined) return undefined;
-  const lines = yaml.split("\n");
+  const lines = splitYamlDocLines(yaml);
   for (let i = fromLine; i < lines.length; i++) {
     const line = lines[i];
     if (line === "") continue;
@@ -399,7 +400,7 @@ export function findComponentsByProviders(
         hasIdPathProvider = true;
         // The interface id is nested (usb_uart channels[].id): collect the
         // ids at those paths, not the section's own (non-interface) id.
-        lines ??= yaml.split("\n");
+        lines ??= splitYamlDocLines(yaml);
         for (const path of p.idPaths) {
           for (const inst of collectIdsAtPath(lines, section, path))
             add(inst.id, inst.name);
@@ -419,7 +420,7 @@ export function findComponentsByProviders(
       } else if (LIST_SECTIONS.has(section.key)) {
         // A LIST_SECTIONS block stays un-expanded (no per-item sections
         // carrying an id), so enumerate its item ids directly.
-        lines ??= yaml.split("\n");
+        lines ??= splitYamlDocLines(yaml);
         for (const inst of collectIdsAtPath(lines, section, ["id"]))
           add(inst.id, inst.name);
       }
@@ -463,7 +464,7 @@ export function domainOccupiesPins(
 ): boolean {
   const keys = Object.keys(lockedPins);
   if (keys.length === 0) return false;
-  const lines = yaml.split("\n");
+  const lines = splitYamlDocLines(yaml);
   for (const section of parseYamlTopLevelSections(yaml)) {
     if ((section.parentKey ?? section.key) !== domain) continue;
     const occupies = keys.every(

--- a/src/util/default-component-id.ts
+++ b/src/util/default-component-id.ts
@@ -1,5 +1,6 @@
 import { isValidEspHomeId, normalizeEspHomeId } from "./esphome-id.js";
 import { isPlatformComponentId } from "./featured-id.js";
+import { splitYamlDocLines } from "./yaml-doc-lines.js";
 import { collectInstanceScalars, readInstanceScalar } from "./yaml-instance-scalars.js";
 import { YamlRawValue } from "./yaml-serialize.js";
 
@@ -73,7 +74,7 @@ export function collectExistingIds(yaml: string): Set<string> {
  */
 export function collectTakenIds(yaml: string): Set<string> {
   const taken = new Set<string>();
-  for (const line of yaml.split("\n")) {
+  for (const line of splitYamlDocLines(yaml)) {
     const key = line.match(ID_NAMING_LINE_RE)?.[1];
     if (key === undefined) continue;
     const value = readInstanceScalar(line, key);

--- a/src/util/yaml-board.ts
+++ b/src/util/yaml-board.ts
@@ -1,6 +1,7 @@
 import type { SlimBoard } from "../api/types/boards.js";
 import { chipNameToVariant } from "./chip-variant.js";
 import { canonicalComponentKey, TARGET_PLATFORM_KEYS } from "./component-presence.js";
+import { splitYamlDocLines } from "./yaml-doc-lines.js";
 import { readInstanceScalar } from "./yaml-instance-scalars.js";
 import { lineIndent, parseYamlTopLevelSections } from "./yaml-sections-core.js";
 
@@ -23,7 +24,7 @@ export function readPlatformBoard(yaml: string): YamlPlatformBoard | null {
     TARGET_PLATFORM_KEYS.has(s.key)
   );
   if (!section) return null;
-  const lines = yaml.split("\n");
+  const lines = splitYamlDocLines(yaml);
   let board: string | null = null;
   let variant: string | null = null;
   let childIndent: number | null = null;

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -350,6 +350,11 @@ describe("domainOccupiesPins", () => {
     expect(domainOccupiesPins(yaml, "i2c", { scl: 0, sda: 1 })).toBe(true);
   });
 
+  it("matches pins in a CRLF document", () => {
+    const yaml = "i2c:\r\n  - scl: 0\r\n    sda: 1\r\n    id: i2c_1\r\n";
+    expect(domainOccupiesPins(yaml, "i2c", { scl: 0, sda: 1 })).toBe(true);
+  });
+
   it("canonicalizes the existing GPIO form before comparing", () => {
     const yaml = "i2c:\n  - scl: GPIO0\n    sda: GPIO1\n    id: i2c_1\n";
     expect(domainOccupiesPins(yaml, "i2c", { scl: 0, sda: 1 })).toBe(true);

--- a/test/util/default-component-id.test.ts
+++ b/test/util/default-component-id.test.ts
@@ -135,6 +135,12 @@ sensor:
   it("ignores top-level keys", () => {
     expect(collectTakenIds("id: something\n")).toEqual(new Set());
   });
+
+  it("collects wildcard id keys from a CRLF document", () => {
+    const yaml =
+      "tca9548a:\r\n  - id: mux\r\n    channels:\r\n      - bus_id: channels_1\r\n";
+    expect(collectTakenIds(yaml)).toEqual(new Set(["mux", "channels_1"]));
+  });
 });
 
 describe("addTakenIdsFromValues", () => {

--- a/test/util/yaml-board.test.ts
+++ b/test/util/yaml-board.test.ts
@@ -17,6 +17,15 @@ describe("readPlatformBoard", () => {
     });
   });
 
+  it("reads board and variant from a CRLF document", () => {
+    const yaml = "esp32:\r\n  board: esp32-s3-devkitc-1\r\n  variant: ESP32S3\r\n";
+    expect(readPlatformBoard(yaml)).toEqual({
+      platform: "esp32",
+      board: "esp32-s3-devkitc-1",
+      variant: "ESP32S3",
+    });
+  });
+
   it("reads an esp8266 section with no variant", () => {
     const yaml = "esp8266:\n  board: d1_mini\n";
     expect(readPlatformBoard(yaml)).toEqual({


### PR DESCRIPTION
# What does this implement/fix?

Sweeps the last CRLF blind readInstanceScalar feeders flagged in the #1606 review. collectTakenIds dropped every `*_id` key on CRLF configs (the same collision hazard as #1605, one file over), readPlatformBoard reported board and variant as null so board mismatch detection went quiet, and the pin scans in config-entry-yaml-scan under reported used pins. All seven raw splits now go through the shared `splitYamlDocLines`; each fix is pinned by a CRLF test verified to fail against the previous code.

**Related issue or feature (if applicable):**

- follow up to #1606, same defect class as #1605

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
