### PR TITLE
CR-strip the substitutions and automation line scans

### DIFF
--- a/src/util/substitutions.ts
+++ b/src/util/substitutions.ts
@@ -8,6 +8,8 @@
  * reach those sources without a backend round-trip.
  */
 
+import { splitYamlDocLines } from "./yaml-doc-lines.js";
+
 /** Strip surrounding quotes / an inline ``# comment`` from a raw scalar. */
 function rawScalar(raw: string): string {
   const v = raw.trim();
@@ -29,7 +31,7 @@ export function parseSubstitutions(yaml: string): Map<string, string> {
   const subs = new Map<string, string>();
   if (!yaml.includes("substitutions:")) return subs;
   let inBlock = false;
-  for (const line of yaml.split("\n")) {
+  for (const line of splitYamlDocLines(yaml)) {
     if (!inBlock) {
       if (/^substitutions:\s*(#.*)?$/.test(line)) inBlock = true;
       continue;

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -6,6 +6,7 @@
  */
 
 import { joinActionFieldPath } from "./action-field-path.js";
+import { splitYamlDocLines } from "./yaml-doc-lines.js";
 import { walkIndexedPaths } from "./yaml-indexed-path.js";
 import { readInstanceScalar } from "./yaml-instance-scalars.js";
 import {
@@ -88,7 +89,7 @@ let _automationsKey: string | undefined;
 let _automationsValue: YamlSection[] | undefined;
 
 function _parseYamlAutomations(yaml: string): YamlSection[] {
-  const lines = yaml.split("\n");
+  const lines = splitYamlDocLines(yaml);
   // `parseYamlTopLevelSections` has its own memo, so resolving an
   // id-less host's positional id is free when the caller already
   // parsed sections this render.

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -342,6 +342,13 @@ describe("findUsedPins", () => {
     expect(a).not.toBe(b);
     expect(a.size).toBe(0);
   });
+
+  it("reads a long-form pin block in a CRLF document", () => {
+    const yaml =
+      "switch:\r\n  - platform: gpio\r\n    pin:\r\n" +
+      "      number: GPIO5\r\n      inverted: true\r\n";
+    expect(findUsedPins(yaml).get(5)).toBe("switch");
+  });
 });
 
 describe("domainOccupiesPins", () => {
@@ -353,13 +360,6 @@ describe("domainOccupiesPins", () => {
   it("matches pins in a CRLF document", () => {
     const yaml = "i2c:\r\n  - scl: 0\r\n    sda: 1\r\n    id: i2c_1\r\n";
     expect(domainOccupiesPins(yaml, "i2c", { scl: 0, sda: 1 })).toBe(true);
-  });
-
-  it("reads a long-form pin block in a CRLF document", () => {
-    const yaml =
-      "switch:\r\n  - platform: gpio\r\n    pin:\r\n" +
-      "      number: GPIO5\r\n      inverted: true\r\n";
-    expect(findUsedPins(yaml).get(5)).toBe("switch");
   });
 
   it("canonicalizes the existing GPIO form before comparing", () => {

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -355,6 +355,13 @@ describe("domainOccupiesPins", () => {
     expect(domainOccupiesPins(yaml, "i2c", { scl: 0, sda: 1 })).toBe(true);
   });
 
+  it("reads a long-form pin block in a CRLF document", () => {
+    const yaml =
+      "switch:\r\n  - platform: gpio\r\n    pin:\r\n" +
+      "      number: GPIO5\r\n      inverted: true\r\n";
+    expect(findUsedPins(yaml).get(5)).toBe("switch");
+  });
+
   it("canonicalizes the existing GPIO form before comparing", () => {
     const yaml = "i2c:\n  - scl: GPIO0\n    sda: GPIO1\n    id: i2c_1\n";
     expect(domainOccupiesPins(yaml, "i2c", { scl: 0, sda: 1 })).toBe(true);

--- a/test/util/substitutions.test.ts
+++ b/test/util/substitutions.test.ts
@@ -22,6 +22,11 @@ describe("parseSubstitutions", () => {
     expect(subs.get("close_duration")).toBe("34.1sec");
   });
 
+  it("reads a CRLF substitutions block", () => {
+    const subs = parseSubstitutions("substitutions:\r\n  devicename: gate\r\n");
+    expect(subs.get("devicename")).toBe("gate");
+  });
+
   it("returns an empty map when there is no block", () => {
     expect(parseSubstitutions("esphome:\n  name: x\n").size).toBe(0);
   });

--- a/test/util/yaml-automations.test.ts
+++ b/test/util/yaml-automations.test.ts
@@ -76,6 +76,25 @@ describe("parseYamlAutomations — component triggers", () => {
     expect(press?.eventKey).toBe("on_press");
   });
 
+  it("resolves a sub-entity's name identically from a CRLF document", () => {
+    const doc = (eol: string) =>
+      [
+        "sensor:",
+        "  - platform: aht10",
+        "    id: my_aht",
+        "    temperature:",
+        "      id: temp_1",
+        "      name: Temp One",
+        "      on_value:",
+        "        then:",
+        "          - logger.log: hi",
+        "",
+      ].join(eol);
+    const lfRows = parseYamlAutomations(doc("\n"));
+    expect(JSON.stringify(lfRows)).toContain("Temp One");
+    expect(parseYamlAutomations(doc("\r\n"))).toEqual(lfRows);
+  });
+
   it("splits a list-form on_time into one indexed row per cron entry", () => {
     const yaml = [
       "time:",

--- a/test/util/yaml-automations.test.ts
+++ b/test/util/yaml-automations.test.ts
@@ -91,7 +91,8 @@ describe("parseYamlAutomations — component triggers", () => {
         "",
       ].join(eol);
     const lfRows = parseYamlAutomations(doc("\n"));
-    expect(JSON.stringify(lfRows)).toContain("Temp One");
+    const row = lfRows.find((r) => r.id === "temp_1");
+    expect(row?.name).toBe("Temp One");
     expect(parseYamlAutomations(doc("\r\n"))).toEqual(lfRows);
   });
 


### PR DESCRIPTION
# What does this implement/fix?

Follow up from the #1607 review, closing out the CRLF defect class. parseSubstitutions returned an empty map on CRLF configs (the header regex matched but the `(.*)$` value regex could not), so pin numbers, navigator labels, and id reference names all rendered raw `$var` tokens; it now splits through `splitYamlDocLines`. The sixth readInstanceScalar feeder in yaml-automations gets the same swap, its sub entity name read was CRLF blind and navigator automation rows fell back to raw ids. Also adds the missing regression test for findUsedPins on a CRLF long form pin block, the one converted path in #1607 without one.

Each fix is pinned by a test verified to fail against the previous code.

**Related issue or feature (if applicable):**

- follow up to #1607, same defect class as #1605

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
