### PR TITLE
Extract a shared reachability follower for the drawer and troubleshoot dialog

### DIFF
--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -232,8 +232,10 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
     `;
   }
 
-  protected updated(changed: Map<string, unknown>) {
-    super.updated?.(changed);
+  // willUpdate, not updated: controllers' hostUpdated (the follower's
+  // reconcile) runs before the host's updated, so a memo cleared there
+  // would miss this cycle and wait out a 1 Hz tick.
+  protected willUpdate(changed: Map<string, unknown>) {
     // The dashboard re-binds device on every DEVICE_UPDATED push (state flap,
     // IP/version change). Only reset state when the drawer is reused for a
     // *different* device — compare configuration so same-device updates

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -127,7 +127,7 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
   @state() _ipExpanded = false;
 
   // Registered via addController; drives itself from host updates.
-  readonly _follower = new ReachabilityFollower(this, {
+  private readonly _follower = new ReachabilityFollower(this, {
     api: () => this._api,
     deviceName: () => (this.drawerOpen && this.device ? this.device.name : null),
     onEvent: (state) => {
@@ -244,6 +244,11 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
       (previousDevice?.configuration ?? null) !== (this.device?.configuration ?? null);
     if (deviceTargetMoved) {
       this._ipExpanded = false;
+    }
+    if (deviceTargetMoved || changed.has("drawerOpen")) {
+      // A device switch or drawer reopen is an explicit fresh chance;
+      // don't carry a failed-subscribe memo across it.
+      this._follower.retry();
     }
   }
 }

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -122,17 +122,14 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
   // snapshot.value + (now - anchor) / 1000, advanced by the 1Hz tick.
   @state() _reachabilityAnchorMs = 0;
 
-  // Tick counter the relative-time renderer reads from to force a 1Hz re-render.
-  @state() _tick = 0;
-
   // Collapsed by default — flips when the user clicks the chevron on a
   // multi-IP device (typical when IPv6 is in play).
   @state() _ipExpanded = false;
 
-  private readonly _follower = new ReachabilityFollower(this, {
+  // Registered via addController; drives itself from host updates.
+  readonly _follower = new ReachabilityFollower(this, {
     api: () => this._api,
-    deviceName: () =>
-      this.drawerOpen && this.device && this._api ? this.device.name : null,
+    deviceName: () => (this.drawerOpen && this.device ? this.device.name : null),
     onEvent: (state) => {
       this._reachability = state;
       this._reachabilityAnchorMs = Date.now();
@@ -142,10 +139,8 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
       this._reachabilityAnchorMs = 0;
     },
     // Rendered values (ages, the mDNS-expiry countdown) resolve at
-    // second precision; the tick forces the 1 Hz re-render.
-    onTick: () => {
-      this._tick = (this._tick + 1) % 1000;
-    },
+    // second precision.
+    tickRender: true,
   });
 
   static styles = [espHomeStyles, deviceDrawerContentStyles];
@@ -240,18 +235,15 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
   protected updated(changed: Map<string, unknown>) {
     super.updated?.(changed);
     // The dashboard re-binds device on every DEVICE_UPDATED push (state flap,
-    // IP/version change). Only churn subscriptions / reset state when the
-    // drawer is reused for a *different* device — compare configuration so
-    // same-device updates don't reset _ipExpanded or rotate the subscription.
+    // IP/version change). Only reset state when the drawer is reused for a
+    // *different* device — compare configuration so same-device updates
+    // don't reset _ipExpanded. The follower reconciles itself per update.
     const previousDevice = changed.get("device") as ConfiguredDevice | null | undefined;
     const deviceTargetMoved =
       changed.has("device") &&
       (previousDevice?.configuration ?? null) !== (this.device?.configuration ?? null);
     if (deviceTargetMoved) {
       this._ipExpanded = false;
-    }
-    if (deviceTargetMoved || changed.has("drawerOpen") || changed.has("_api")) {
-      this._follower.reconcile();
     }
   }
 }

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -34,10 +34,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../../api/esphome-api.js";
 import type { IntegrationDoc } from "../../api/types/components.js";
 import type { ConfiguredDevice } from "../../api/types/devices.js";
-import type {
-  ReachabilityStateEvent,
-  ReachabilitySubscription,
-} from "../../api/types/reachability.js";
+import type { ReachabilityStateEvent } from "../../api/types/reachability.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import {
   apiContext,
@@ -47,13 +44,9 @@ import {
 import { espHomeStyles } from "../../styles/shared.js";
 import { showPendingChanges, showUpdateAvailable } from "../../util/device-sync.js";
 import { getEncryptionState } from "../../util/encryption-state.js";
+import { ReachabilityFollower } from "../../util/reachability-follower.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
-import {
-  reconcileSubscription,
-  renderReachabilitySection,
-  syncTickInterval,
-  teardownSubscription,
-} from "./device-drawer-content/reachability.js";
+import { renderReachabilitySection } from "./device-drawer-content/reachability.js";
 import {
   renderBluetoothMacRow,
   renderBuildSizeRow,
@@ -136,23 +129,24 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
   // multi-IP device (typical when IPv6 is in play).
   @state() _ipExpanded = false;
 
-  // Tracked separately from device.configuration so a swap to a new device
-  // cleanly tears down the previous subscription before opening a new one.
-  _subscribedDevice: string | null = null;
-  _subscription: ReachabilitySubscription | null = null;
-
-  // WS connection generation captured when the subscription opened. Compared
-  // against api.connectionGeneration each reconcile — mismatch means the WS
-  // dropped and we need to resubscribe even though the device name didn't change.
-  _subscribedGeneration = 0;
-
-  // "<deviceName>:<generation>" of the last logged failure / failed attempt.
-  // Without these gates the 1Hz tick would log + retry forever during a
-  // WS-down window. Both reset on natural progression (different device,
-  // fresh WS) so transient failures self-heal.
-  _loggedFailureKey: string | null = null;
-  _failedSubscribeKey: string | null = null;
-  _tickInterval: ReturnType<typeof setInterval> | null = null;
+  private readonly _follower = new ReachabilityFollower(this, {
+    api: () => this._api,
+    deviceName: () =>
+      this.drawerOpen && this.device && this._api ? this.device.name : null,
+    onEvent: (state) => {
+      this._reachability = state;
+      this._reachabilityAnchorMs = Date.now();
+    },
+    onTeardown: () => {
+      this._reachability = null;
+      this._reachabilityAnchorMs = 0;
+    },
+    // Rendered values (ages, the mDNS-expiry countdown) resolve at
+    // second precision; the tick forces the 1 Hz re-render.
+    onTick: () => {
+      this._tick = (this._tick + 1) % 1000;
+    },
+  });
 
   static styles = [espHomeStyles, deviceDrawerContentStyles];
 
@@ -257,19 +251,7 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
       this._ipExpanded = false;
     }
     if (deviceTargetMoved || changed.has("drawerOpen") || changed.has("_api")) {
-      reconcileSubscription(this);
-      // Run the tick whenever there's a target, independent of whether the
-      // subscribe succeeded — a failed initial subscribe gets retried at 1Hz.
-      syncTickInterval(this);
-    }
-  }
-
-  override disconnectedCallback() {
-    super.disconnectedCallback();
-    teardownSubscription(this);
-    if (this._tickInterval !== null) {
-      clearInterval(this._tickInterval);
-      this._tickInterval = null;
+      this._follower.reconcile();
     }
   }
 }

--- a/src/components/dashboard/device-drawer-content/reachability.ts
+++ b/src/components/dashboard/device-drawer-content/reachability.ts
@@ -1,10 +1,6 @@
 import { html, nothing, type TemplateResult } from "lit";
-import type { ESPHomeAPI } from "../../../api/esphome-api.js";
 import { DeviceState } from "../../../api/types/devices.js";
-import type {
-  ReachabilitySource,
-  ReachabilityStateEvent,
-} from "../../../api/types/reachability.js";
+import type { ReachabilitySource } from "../../../api/types/reachability.js";
 import { activeLocale, type LocalizeFunc } from "../../../common/localize.js";
 import { mdnsExpiryPhase, type MdnsExpiryPhase } from "../../../util/mdns-expiry.js";
 import {
@@ -148,101 +144,4 @@ function renderReachabilityRow(
       </div>
     </div>
   `;
-}
-
-// Reconcile (open / close / swap) the per-device subscription against
-// (drawerOpen, device.name, api). Called from updated() and the 1Hz tick
-// (which catches WS reconnects — the API clears event listeners on close so
-// the stale _subscribedDevice would otherwise block resubscribe).
-export function reconcileSubscription(host: ESPHomeDeviceDrawerContent): void {
-  const wantName = host.drawerOpen && host.device && host._api ? host.device.name : null;
-  const currentGeneration = host._api?.connectionGeneration ?? 0;
-  const generationChanged =
-    host._subscribedDevice !== null && currentGeneration !== host._subscribedGeneration;
-  if (wantName === host._subscribedDevice && !generationChanged) return;
-
-  teardownSubscription(host);
-  if (wantName === null || host._api === undefined) return;
-
-  // Skip if we already failed on this exact (device, gen). Permanent errors
-  // (NOT_FOUND, INVALID_ARGS) would otherwise re-fire every tick. The key
-  // resets when device selection changes or WS reconnects.
-  const targetKey = `${wantName}:${currentGeneration}`;
-  if (host._failedSubscribeKey === targetKey) return;
-
-  host._subscribedDevice = wantName;
-  host._subscribedGeneration = currentGeneration;
-  void openSubscription(host, wantName, currentGeneration, targetKey, host._api);
-}
-
-async function openSubscription(
-  host: ESPHomeDeviceDrawerContent,
-  deviceName: string,
-  attemptGeneration: number,
-  attemptKey: string,
-  api: ESPHomeAPI
-): Promise<void> {
-  // A WS reconnect (gen bump) or different-device selection between
-  // subscribe-start and resolve/reject makes this attempt stale; catch
-  // must not mutate state belonging to the newer attempt; success must
-  // unsubscribe the just-created handle.
-  const isCurrent = (): boolean =>
-    host._subscribedDevice === deviceName &&
-    host._subscribedGeneration === attemptGeneration;
-
-  try {
-    const subscription = await api.subscribeDeviceReachability(
-      deviceName,
-      (state: ReachabilityStateEvent) => {
-        if (!isCurrent()) return;
-        host._reachability = state;
-        host._reachabilityAnchorMs = Date.now();
-      }
-    );
-    if (!isCurrent()) {
-      void subscription.unsubscribe();
-      return;
-    }
-    host._subscription = subscription;
-    host._failedSubscribeKey = null;
-  } catch (err) {
-    // Rate-limit the warning — the 1Hz tick retries reconcile, and during
-    // a WS-not-yet-connected window each retry would also log.
-    if (host._loggedFailureKey !== attemptKey) {
-      host._loggedFailureKey = attemptKey;
-      console.warn("subscribeDeviceReachability failed", err);
-    }
-    if (isCurrent()) {
-      host._failedSubscribeKey = attemptKey;
-      host._subscribedDevice = null;
-    }
-  }
-}
-
-export function teardownSubscription(host: ESPHomeDeviceDrawerContent): void {
-  host._subscribedDevice = null;
-  host._reachability = null;
-  host._reachabilityAnchorMs = 0;
-  if (host._subscription !== null) {
-    const sub = host._subscription;
-    host._subscription = null;
-    void sub.unsubscribe();
-  }
-}
-
-// 1Hz tick: rendered values (ages, the mDNS-expiry countdown) resolve at
-// second precision. Also probes for WS reconnect / failed-initial-subscribe
-// via reconcileSubscription on every tick.
-export function syncTickInterval(host: ESPHomeDeviceDrawerContent): void {
-  const wantTick =
-    host.drawerOpen && host.device !== undefined && host._api !== undefined;
-  if (wantTick && host._tickInterval === null) {
-    host._tickInterval = setInterval(() => {
-      host._tick = (host._tick + 1) % 1000;
-      reconcileSubscription(host);
-    }, 1000);
-  } else if (!wantTick && host._tickInterval !== null) {
-    clearInterval(host._tickInterval);
-    host._tickInterval = null;
-  }
 }

--- a/src/components/troubleshoot-dialog.ts
+++ b/src/components/troubleshoot-dialog.ts
@@ -126,10 +126,15 @@ export class ESPHomeTroubleshootDialog extends LitElement {
     // Key on the configuration and derive the device name from the
     // catalog: senders variously hold the friendly name, and the
     // reachability subscription needs the esphome name.
+    // A reopen onto the same still-open target keeps the stream, which
+    // redelivers nothing; blanking the snapshot would strand the
+    // section until the device's next signal change.
+    const sameLiveTarget =
+      this._dialog.open && this._configuration === target.configuration;
     this._configuration = target.configuration;
     this._result = null;
     this._checkFailed = false;
-    this._reachability = null;
+    if (!sameLiveTarget) this._reachability = null;
     // An effective address that isn't the default `<name>.local` is a
     // hint (use_address, or a custom wifi `domain:`); it prefills the
     // form only. The diagnosis-driving `_existingAddress` is set solely
@@ -148,12 +153,11 @@ export class ESPHomeTroubleshootDialog extends LitElement {
     this._saveState = "idle";
     this._screen = "main";
     this._untracked = device?.name_add_mac_suffix === true;
-    // A reopen is an explicit retry; don't carry a failed-subscribe gate.
+    // A reopen is an explicit retry; don't carry a failed-subscribe
+    // gate. The follower reconciles after this update settles — an
+    // untracked target reads as idle there and tears the stream down.
     this._follower.retry();
     this._dialog.open = true;
-    // An untracked target reads as idle above, so reconcile tears the
-    // stream down instead of following it.
-    this._follower.reconcile();
     if (this._untracked) return;
     void loadExistingAddress(this);
     void this._runCheck();

--- a/src/components/troubleshoot-dialog.ts
+++ b/src/components/troubleshoot-dialog.ts
@@ -18,10 +18,7 @@ import { html, LitElement, nothing, type PropertyValues, type TemplateResult } f
 import { customElement, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { ConfiguredDevice } from "../api/types/devices.js";
-import type {
-  ReachabilityStateEvent,
-  ReachabilitySubscription,
-} from "../api/types/reachability.js";
+import type { ReachabilityStateEvent } from "../api/types/reachability.js";
 import type { DeviceTroubleshootResult } from "../api/types/troubleshoot.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, devicesContext, localizeContext } from "../context/index.js";
@@ -31,6 +28,7 @@ import { espHomeStyles } from "../styles/shared.js";
 import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { isIpLiteral } from "../util/ip-literal.js";
 import type { NetworkPresence } from "../util/network-sections.js";
+import { ReachabilityFollower } from "../util/reachability-follower.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import {
   buildTroubleshootSections,
@@ -104,11 +102,18 @@ export class ESPHomeTroubleshootDialog extends LitElement {
 
   @state() _networkInYaml: NetworkPresence = "unknown";
 
-  private _subscription: ReachabilitySubscription | null = null;
-  private _reconcileTimer: ReturnType<typeof setInterval> | null = null;
-  private _subscribedGeneration = -1;
-  private _failedGeneration = -1;
-  private _subscribePending = false;
+  // Explainer-only mode (name_add_mac_suffix): the probe keys on a
+  // name no unit broadcasts, so the stream stays idle too.
+  private _untracked = false;
+
+  private readonly _follower = new ReachabilityFollower(this, {
+    api: () => this._api,
+    deviceName: () =>
+      this._dialog.open && this._name && !this._untracked ? this._name : null,
+    onEvent: (state) => {
+      this._reachability = state;
+    },
+  });
 
   static styles = [
     espHomeStyles,
@@ -142,20 +147,14 @@ export class ESPHomeTroubleshootDialog extends LitElement {
     this._addressInvalid = false;
     this._saveState = "idle";
     this._screen = "main";
-    this._teardownSubscription();
+    this._untracked = device?.name_add_mac_suffix === true;
     // A reopen is an explicit retry; don't carry a failed-subscribe gate.
-    this._failedGeneration = -1;
+    this._follower.retry();
     this._dialog.open = true;
-    // Untracked (name_add_mac_suffix) opens in explainer-only mode:
-    // the probe keys on a name no unit broadcasts, so running it can
-    // only manufacture failures under the explanation. Stop the
-    // reconcile tick too; a reopen from a tracked device would
-    // otherwise leave the old interval resubscribing the stream.
-    if (device?.name_add_mac_suffix) {
-      this._stopReconcile();
-      return;
-    }
-    this._startReconcile();
+    // An untracked target reads as idle above, so reconcile tears the
+    // stream down instead of following it.
+    this._follower.reconcile();
+    if (this._untracked) return;
     void loadExistingAddress(this);
     void this._runCheck();
   }
@@ -433,80 +432,15 @@ export class ESPHomeTroubleshootDialog extends LitElement {
     }
   }
 
-  // Reconcile the reachability stream once a second while open: the
-  // API clears listeners on a WS drop, so a reconnect (generation bump)
-  // or a failed initial subscribe needs a fresh attempt (same shape as
-  // the drawer's reconcileSubscription).
-  private _startReconcile(): void {
-    this._stopReconcile();
-    this._reconcileTimer = setInterval(() => this._reconcileSubscription(), 1000);
-    this._reconcileSubscription();
-  }
-
-  private _stopReconcile(): void {
-    if (this._reconcileTimer !== null) {
-      clearInterval(this._reconcileTimer);
-      this._reconcileTimer = null;
-    }
-  }
-
-  private _reconcileSubscription(): void {
-    // An in-flight subscribe must finish before another attempt, or
-    // each 1Hz tick opens a fresh stream while the ack is pending.
-    if (this._subscribePending) return;
-    const generation = this._api?.connectionGeneration ?? 0;
-    if (this._subscription !== null && generation === this._subscribedGeneration) return;
-    if (this._subscription === null && generation === this._failedGeneration) return;
-    this._teardownSubscription();
-    if (this._name) void this._subscribe(this._name, generation);
-  }
-
-  private async _subscribe(name: string, generation: number): Promise<void> {
-    this._subscribePending = true;
-    this._subscribedGeneration = generation;
-    try {
-      const subscription = await this._api.subscribeDeviceReachability(name, (event) => {
-        if (name === this._name) this._reachability = event;
-      });
-      if (name !== this._name || !this._dialog.open) {
-        void subscription.unsubscribe();
-        return;
-      }
-      this._subscription = subscription;
-    } catch (err) {
-      // Advice degrades to device flags + probe result without the
-      // stream; one retry per connection generation.
-      this._failedGeneration = generation;
-      console.warn("subscribeDeviceReachability failed", err);
-    } finally {
-      this._subscribePending = false;
-    }
-  }
-
   protected updated(changed: PropertyValues): void {
     if (changed.has("_screen") && this._screen === "address") {
       this.renderRoot.querySelector<HTMLInputElement>(".address-form input")?.focus();
     }
   }
 
-  private _teardownSubscription(): void {
-    if (this._subscription !== null) {
-      const sub = this._subscription;
-      this._subscription = null;
-      void sub.unsubscribe();
-    }
-  }
-
-  disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this._stopReconcile();
-    this._teardownSubscription();
-  }
-
   private _onAfterHide = (): void => {
     this._dialog.open = false;
-    this._stopReconcile();
-    this._teardownSubscription();
+    this._follower.stop();
   };
 }
 

--- a/src/util/reachability-follower.ts
+++ b/src/util/reachability-follower.ts
@@ -131,6 +131,9 @@ export class ReachabilityFollower implements ReactiveController {
       }
       this._subscription = subscription;
       this._failedKey = null;
+      // The logged memo resets with it: a later genuine re-failure on
+      // this key deserves its one warn again.
+      this._loggedKey = null;
     } catch (err) {
       // A stale failure stays silent and leaves both memos alone — it
       // would otherwise eat the one warn slot for a key that later

--- a/src/util/reachability-follower.ts
+++ b/src/util/reachability-follower.ts
@@ -39,6 +39,11 @@ export class ReachabilityFollower implements ReactiveController {
 
   private _loggedKey: string | null = null;
 
+  // Identity of the newest attempt; teardown bumps it so an in-flight
+  // subscribe with the same (name, generation) is still recognisably
+  // stale — the pair alone can recur within one round-trip.
+  private _attemptId = 0;
+
   private _interval: ReturnType<typeof setInterval> | null = null;
 
   constructor(
@@ -85,7 +90,7 @@ export class ReachabilityFollower implements ReactiveController {
 
     this._subscribedName = wantName;
     this._subscribedGeneration = generation;
-    void this._open(api, wantName, generation, attemptKey);
+    void this._open(api, wantName, ++this._attemptId, attemptKey);
   }
 
   /** Clear the failure memos; call on an explicit user retry (reopen). */
@@ -103,16 +108,15 @@ export class ReachabilityFollower implements ReactiveController {
   private async _open(
     api: ESPHomeAPI,
     deviceName: string,
-    attemptGeneration: number,
+    attemptId: number,
     attemptKey: string
   ): Promise<void> {
-    // A WS reconnect (generation bump) or a target change between
-    // subscribe-start and resolve makes this attempt stale; catch must
-    // not mutate state belonging to the newer attempt, and a stale
-    // success must unsubscribe the just-created handle.
-    const isCurrent = (): boolean =>
-      this._subscribedName === deviceName &&
-      this._subscribedGeneration === attemptGeneration;
+    // Anything that happens between subscribe-start and resolve — a WS
+    // reconnect, a target change, even a teardown-and-return to the
+    // same target — bumps the attempt id and makes this attempt stale;
+    // catch must not mutate state belonging to the newer attempt, and
+    // a stale success must unsubscribe the just-created handle.
+    const isCurrent = (): boolean => this._attemptId === attemptId;
 
     try {
       const subscription = await api.subscribeDeviceReachability(
@@ -128,20 +132,23 @@ export class ReachabilityFollower implements ReactiveController {
       this._subscription = subscription;
       this._failedKey = null;
     } catch (err) {
+      // A stale failure stays silent and leaves both memos alone — it
+      // would otherwise eat the one warn slot for a key that later
+      // fails for real.
+      if (!isCurrent()) return;
       // Rate-limit the warning: the 1 Hz tick retries reconcile, and a
       // WS-not-yet-connected window would otherwise log every second.
       if (this._loggedKey !== attemptKey) {
         this._loggedKey = attemptKey;
         console.warn("subscribeDeviceReachability failed", err);
       }
-      if (isCurrent()) {
-        this._failedKey = attemptKey;
-        this._subscribedName = null;
-      }
+      this._failedKey = attemptKey;
+      this._subscribedName = null;
     }
   }
 
   private _teardown(): void {
+    this._attemptId += 1;
     const hadTarget = this._subscribedName !== null;
     this._subscribedName = null;
     if (this._subscription !== null) {

--- a/src/util/reachability-follower.ts
+++ b/src/util/reachability-follower.ts
@@ -1,0 +1,164 @@
+/**
+ * Shared follower for the per-device reachability stream.
+ *
+ * Owns the subscribe / reconnect / failure / teardown lifecycle the
+ * drawer and the troubleshoot dialog previously each hand-rolled:
+ * generation-gated resubscribe across WS reconnects, a per
+ * `${name}:${generation}` failure memo with a rate-limited warn, stale
+ * attempt discard, and the 1 Hz reconcile tick. Hosts declare what to
+ * follow through `deviceName()` (null means idle) and call
+ * `reconcile()` from their lifecycle hooks; the interval arms and
+ * disarms itself off the same signal.
+ */
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import type { ESPHomeAPI } from "../api/esphome-api.js";
+import type {
+  ReachabilityStateEvent,
+  ReachabilitySubscription,
+} from "../api/types/reachability.js";
+
+export interface ReachabilityFollowerOptions {
+  api: () => ESPHomeAPI | undefined;
+  /** Target to follow; null means idle (closed, hidden, untracked). */
+  deviceName: () => string | null;
+  onEvent: (state: ReachabilityStateEvent) => void;
+  /** Fired when an active target is torn down. */
+  onTeardown?: () => void;
+  /** Fired each 1 Hz interval before reconcile. */
+  onTick?: () => void;
+}
+
+export class ReachabilityFollower implements ReactiveController {
+  private _subscription: ReachabilitySubscription | null = null;
+
+  private _subscribedName: string | null = null;
+
+  private _subscribedGeneration = 0;
+
+  private _failedKey: string | null = null;
+
+  private _loggedKey: string | null = null;
+
+  private _interval: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    host: ReactiveControllerHost,
+    private readonly _options: ReachabilityFollowerOptions
+  ) {
+    host.addController(this);
+  }
+
+  hostConnected(): void {
+    this.reconcile();
+  }
+
+  hostDisconnected(): void {
+    this.stop();
+  }
+
+  /**
+   * Converge the subscription and the tick on the wanted target.
+
+   * Same-target attempts no-op (the in-flight guard: name and
+   * generation register before the await); a target or generation
+   * change tears down and resubscribes; a null target goes idle.
+   */
+  reconcile(): void {
+    const api = this._options.api();
+    const wantName = api !== undefined ? this._options.deviceName() : null;
+    this._syncInterval(wantName !== null);
+    const generation = api?.connectionGeneration ?? 0;
+    const generationChanged =
+      this._subscribedName !== null && generation !== this._subscribedGeneration;
+    if (wantName === this._subscribedName && !generationChanged) return;
+
+    this._teardown();
+    if (wantName === null || api === undefined) return;
+
+    // Skip a (device, generation) that already failed: permanent errors
+    // (NOT_FOUND, INVALID_ARGS) would otherwise re-fire every tick. The
+    // key rotates on target change and WS reconnect.
+    const attemptKey = `${wantName}:${generation}`;
+    if (this._failedKey === attemptKey) return;
+
+    this._subscribedName = wantName;
+    this._subscribedGeneration = generation;
+    void this._open(api, wantName, generation, attemptKey);
+  }
+
+  /** Clear the failure memos; call on an explicit user retry (reopen). */
+  retry(): void {
+    this._failedKey = null;
+    this._loggedKey = null;
+  }
+
+  /** Tear down and disarm now, independent of host disconnect. */
+  stop(): void {
+    this._syncInterval(false);
+    this._teardown();
+  }
+
+  private async _open(
+    api: ESPHomeAPI,
+    deviceName: string,
+    attemptGeneration: number,
+    attemptKey: string
+  ): Promise<void> {
+    // A WS reconnect (generation bump) or a target change between
+    // subscribe-start and resolve makes this attempt stale; catch must
+    // not mutate state belonging to the newer attempt, and a stale
+    // success must unsubscribe the just-created handle.
+    const isCurrent = (): boolean =>
+      this._subscribedName === deviceName &&
+      this._subscribedGeneration === attemptGeneration;
+
+    try {
+      const subscription = await api.subscribeDeviceReachability(
+        deviceName,
+        (state: ReachabilityStateEvent) => {
+          if (isCurrent()) this._options.onEvent(state);
+        }
+      );
+      if (!isCurrent()) {
+        void subscription.unsubscribe();
+        return;
+      }
+      this._subscription = subscription;
+      this._failedKey = null;
+    } catch (err) {
+      // Rate-limit the warning: the 1 Hz tick retries reconcile, and a
+      // WS-not-yet-connected window would otherwise log every second.
+      if (this._loggedKey !== attemptKey) {
+        this._loggedKey = attemptKey;
+        console.warn("subscribeDeviceReachability failed", err);
+      }
+      if (isCurrent()) {
+        this._failedKey = attemptKey;
+        this._subscribedName = null;
+      }
+    }
+  }
+
+  private _teardown(): void {
+    const hadTarget = this._subscribedName !== null;
+    this._subscribedName = null;
+    if (this._subscription !== null) {
+      const sub = this._subscription;
+      this._subscription = null;
+      void sub.unsubscribe();
+    }
+    if (hadTarget) this._options.onTeardown?.();
+  }
+
+  private _syncInterval(want: boolean): void {
+    if (want && this._interval === null) {
+      this._interval = setInterval(() => {
+        this._options.onTick?.();
+        this.reconcile();
+      }, 1000);
+    } else if (!want && this._interval !== null) {
+      clearInterval(this._interval);
+      this._interval = null;
+    }
+  }
+}

--- a/src/util/reachability-follower.ts
+++ b/src/util/reachability-follower.ts
@@ -1,14 +1,13 @@
 /**
  * Shared follower for the per-device reachability stream.
  *
- * Owns the subscribe / reconnect / failure / teardown lifecycle the
- * drawer and the troubleshoot dialog previously each hand-rolled:
+ * Owns the subscribe / reconnect / failure / teardown lifecycle:
  * generation-gated resubscribe across WS reconnects, a per
  * `${name}:${generation}` failure memo with a rate-limited warn, stale
  * attempt discard, and the 1 Hz reconcile tick. Hosts declare what to
- * follow through `deviceName()` (null means idle) and call
- * `reconcile()` from their lifecycle hooks; the interval arms and
- * disarms itself off the same signal.
+ * follow through `deviceName()` (null means idle); reconcile runs
+ * after every host update, and the interval arms and disarms itself
+ * off the same signal.
  */
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
@@ -19,13 +18,14 @@ import type {
 
 export interface ReachabilityFollowerOptions {
   api: () => ESPHomeAPI | undefined;
-  /** Target to follow; null means idle (closed, hidden, untracked). */
+  /** Target to follow; null means idle (closed, hidden, untracked).
+   *  Only consulted while `api()` is defined — no api means idle. */
   deviceName: () => string | null;
   onEvent: (state: ReachabilityStateEvent) => void;
   /** Fired when an active target is torn down. */
   onTeardown?: () => void;
-  /** Fired each 1 Hz interval before reconcile. */
-  onTick?: () => void;
+  /** Request a host render each tick, for second-precision ages. */
+  tickRender?: boolean;
 }
 
 export class ReachabilityFollower implements ReactiveController {
@@ -42,13 +42,20 @@ export class ReachabilityFollower implements ReactiveController {
   private _interval: ReturnType<typeof setInterval> | null = null;
 
   constructor(
-    host: ReactiveControllerHost,
+    private readonly _host: ReactiveControllerHost,
     private readonly _options: ReachabilityFollowerOptions
   ) {
-    host.addController(this);
+    _host.addController(this);
   }
 
   hostConnected(): void {
+    this.reconcile();
+  }
+
+  hostUpdated(): void {
+    // Idempotent and two reads in the steady state, so following every
+    // host update beats a hand-maintained trigger list that fails
+    // silently when a relevant property is missed.
     this.reconcile();
   }
 
@@ -56,13 +63,8 @@ export class ReachabilityFollower implements ReactiveController {
     this.stop();
   }
 
-  /**
-   * Converge the subscription and the tick on the wanted target.
-
-   * Same-target attempts no-op (the in-flight guard: name and
-   * generation register before the await); a target or generation
-   * change tears down and resubscribes; a null target goes idle.
-   */
+  /** Converge the subscription and the tick on the wanted target;
+   *  same-target attempts no-op, a null target goes idle. */
   reconcile(): void {
     const api = this._options.api();
     const wantName = api !== undefined ? this._options.deviceName() : null;
@@ -153,7 +155,7 @@ export class ReachabilityFollower implements ReactiveController {
   private _syncInterval(want: boolean): void {
     if (want && this._interval === null) {
       this._interval = setInterval(() => {
-        this._options.onTick?.();
+        if (this._options.tickRender) this._host.requestUpdate();
         this.reconcile();
       }, 1000);
     } else if (!want && this._interval !== null) {

--- a/test/components/dashboard/device-drawer-content-follower.test.ts
+++ b/test/components/dashboard/device-drawer-content-follower.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the drawer host's follower wiring — the closures the controller
+ * unit tests cannot see: onTeardown is the only path clearing the
+ * snapshot, a device swap retargets the stream, and detach tears down
+ * through hostDisconnected.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("../../../src/components/labels/device-labels-editor.js", () => ({}));
+
+import { flush, identityLocalize } from "../../_dom.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+import { makeReachabilityEvent } from "../../_make-reachability-event.js";
+import type { ESPHomeAPI } from "../../../src/api/esphome-api.js";
+import { ESPHomeDeviceDrawerContent } from "../../../src/components/dashboard/device-drawer-content.js";
+
+function makeApi() {
+  const unsubscribe = vi.fn().mockResolvedValue(undefined);
+  const api = {
+    connectionGeneration: 1,
+    subscribeDeviceReachability: vi.fn().mockResolvedValue({ unsubscribe }),
+  };
+  return { api: api as unknown as ESPHomeAPI, unsubscribe };
+}
+
+async function mountDrawer() {
+  const { api, unsubscribe } = makeApi();
+  const el = new ESPHomeDeviceDrawerContent();
+  el.device = makeConfiguredDevice();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._api = api;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._localize = identityLocalize;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  await flush();
+  return { el, api, unsubscribe };
+}
+
+describe("drawer follower wiring", () => {
+  it("closing the drawer clears the snapshot and unsubscribes", async () => {
+    const { el, api, unsubscribe } = await mountDrawer();
+    const sub = api.subscribeDeviceReachability as ReturnType<typeof vi.fn>;
+    expect(sub).toHaveBeenCalledWith("kitchen", expect.any(Function));
+    const callback = sub.mock.calls[0][1];
+    callback(makeReachabilityEvent());
+    expect(el._reachability).not.toBeNull();
+    expect(el._reachabilityAnchorMs).toBeGreaterThan(0);
+
+    el.drawerOpen = false;
+    await el.updateComplete;
+    // onTeardown is the only remaining path that blanks these.
+    expect(el._reachability).toBeNull();
+    expect(el._reachabilityAnchorMs).toBe(0);
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    el.remove();
+  });
+
+  it("a device swap retargets the stream at the new name", async () => {
+    const { el, api, unsubscribe } = await mountDrawer();
+    el.device = makeConfiguredDevice({
+      name: "garage",
+      configuration: "garage.yaml",
+    });
+    await el.updateComplete;
+    await flush();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(api.subscribeDeviceReachability).toHaveBeenLastCalledWith(
+      "garage",
+      expect.any(Function)
+    );
+    el.remove();
+  });
+
+  it("detaching the element tears the stream down", async () => {
+    const { el, unsubscribe } = await mountDrawer();
+    el.remove();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+});

--- a/test/components/troubleshoot-dialog.test.ts
+++ b/test/components/troubleshoot-dialog.test.ts
@@ -13,6 +13,7 @@ vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => (
 
 import { baseDialogSettled, flush, mount } from "../_dom.js";
 import { makeConfiguredDevice } from "../_make-configured-device.js";
+import { makeReachabilityEvent } from "../_make-reachability-event.js";
 import type { DeviceTroubleshootResult } from "../../src/api/types/troubleshoot.js";
 import { ESPHomeTroubleshootDialog } from "../../src/components/troubleshoot-dialog.js";
 
@@ -359,21 +360,20 @@ describe("troubleshoot-dialog", () => {
     );
   });
 
-  it("does not double-subscribe while an attempt is in flight", async () => {
-    let resolveSub: (v: { unsubscribe: () => void }) => void;
-    const pending = new Promise<{ unsubscribe: () => void }>((r) => {
-      resolveSub = r;
-    });
-    const { el, api } = await openDialog({
-      subscribeDeviceReachability: vi.fn().mockReturnValue(pending),
-    });
+  it("a same-device reopen keeps the last reachability snapshot", async () => {
+    const { el, api } = await openDialog();
+    const callback = api.subscribeDeviceReachability.mock.calls[0][1] as (
+      e: unknown
+    ) => void;
+    const event = makeReachabilityEvent();
+    callback(event);
+    await el.updateComplete;
+    el.open({ configuration: "kitchen.yaml" });
+    await el.updateComplete;
+    // The kept stream redelivers nothing; blanking would strand the
+    // section until the device's next signal change.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (el as any)._follower.reconcile();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (el as any)._follower.reconcile();
-    expect(api.subscribeDeviceReachability).toHaveBeenCalledTimes(1);
-    resolveSub!({ unsubscribe: vi.fn() });
-    await flush();
+    expect((el as any)._reachability).toBe(event);
   });
 
   it("drops the previous stream when reopened onto another device", async () => {

--- a/test/components/troubleshoot-dialog.test.ts
+++ b/test/components/troubleshoot-dialog.test.ts
@@ -360,8 +360,8 @@ describe("troubleshoot-dialog", () => {
     );
   });
 
-  it("a same-device reopen keeps the last reachability snapshot", async () => {
-    const { el, api } = await openDialog();
+  it("a same-device reopen keeps the stream and the last snapshot", async () => {
+    const { el, api, unsubscribe } = await openDialog();
     const callback = api.subscribeDeviceReachability.mock.calls[0][1] as (
       e: unknown
     ) => void;
@@ -370,8 +370,12 @@ describe("troubleshoot-dialog", () => {
     await el.updateComplete;
     el.open({ configuration: "kitchen.yaml" });
     await el.updateComplete;
-    // The kept stream redelivers nothing; blanking would strand the
-    // section until the device's next signal change.
+    await flush();
+    // The established stream survives (no drop, no resubscribe), and
+    // the snapshot stays: the kept stream redelivers nothing, so
+    // blanking would strand the section until the next signal change.
+    expect(unsubscribe).not.toHaveBeenCalled();
+    expect(api.subscribeDeviceReachability).toHaveBeenCalledTimes(1);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((el as any)._reachability).toBe(event);
   });

--- a/test/components/troubleshoot-dialog.test.ts
+++ b/test/components/troubleshoot-dialog.test.ts
@@ -368,19 +368,31 @@ describe("troubleshoot-dialog", () => {
       subscribeDeviceReachability: vi.fn().mockReturnValue(pending),
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (el as any)._reconcileSubscription();
+    (el as any)._follower.reconcile();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (el as any)._reconcileSubscription();
+    (el as any)._follower.reconcile();
     expect(api.subscribeDeviceReachability).toHaveBeenCalledTimes(1);
     resolveSub!({ unsubscribe: vi.fn() });
     await flush();
   });
 
-  it("drops the previous stream when reopened", async () => {
-    const { el, unsubscribe } = await openDialog();
-    el.open({ configuration: "kitchen.yaml" });
+  it("drops the previous stream when reopened onto another device", async () => {
+    const { el, api, unsubscribe } = await openDialog();
+    const other = makeConfiguredDevice({
+      name: "garage",
+      configuration: "garage.yaml",
+      ip: "10.0.0.43",
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._devices = [...(el as any)._devices, other];
+    el.open({ configuration: "garage.yaml" });
     await el.updateComplete;
+    await flush();
     expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(api.subscribeDeviceReachability).toHaveBeenLastCalledWith(
+      "garage",
+      expect.any(Function)
+    );
   });
 
   it("unsubscribes the reachability stream on close", async () => {

--- a/test/util/reachability-follower.test.ts
+++ b/test/util/reachability-follower.test.ts
@@ -149,6 +149,33 @@ describe("ReachabilityFollower", () => {
     follower.stop();
   });
 
+  it("a success resets the warn memo for a later genuine re-failure", async () => {
+    const unsubscribe = vi.fn().mockResolvedValue(undefined);
+    const { api } = makeApi({
+      subscribeDeviceReachability: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("first failure"))
+        .mockResolvedValueOnce({ unsubscribe })
+        .mockRejectedValueOnce(new Error("re-failure")),
+    });
+    const { follower, setName } = makeFollower(api);
+    follower.reconcile();
+    await flush();
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    follower.retry();
+    follower.reconcile();
+    await flush();
+    setName(null);
+    follower.reconcile();
+    setName("kitchen");
+    follower.reconcile();
+    await flush();
+    // Same name:generation key as the first failure; the success in
+    // between must have released its one warn slot.
+    expect(console.warn).toHaveBeenCalledTimes(2);
+    follower.stop();
+  });
+
   it("retry clears the failure memo so reconcile attempts again", async () => {
     const { api } = makeApi({
       subscribeDeviceReachability: vi.fn().mockRejectedValue(new Error("nope")),

--- a/test/util/reachability-follower.test.ts
+++ b/test/util/reachability-follower.test.ts
@@ -1,6 +1,8 @@
 /** Pins the shared reachability follower's subscribe lifecycle. */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { flush, flushTimers } from "../_dom.js";
+import { FakeHost } from "../_fake-host.js";
 import { makeReachabilityEvent } from "../_make-reachability-event.js";
 import type { ESPHomeAPI } from "../../src/api/esphome-api.js";
 import type { ReachabilityStateEvent } from "../../src/api/types/reachability.js";
@@ -8,15 +10,6 @@ import {
   ReachabilityFollower,
   type ReachabilityFollowerOptions,
 } from "../../src/util/reachability-follower.js";
-
-function makeHost() {
-  return {
-    addController: vi.fn(),
-    removeController: vi.fn(),
-    requestUpdate: vi.fn(),
-    updateComplete: Promise.resolve(true),
-  };
-}
 
 function makeApi(
   overrides: Record<string, unknown> = {},
@@ -39,28 +32,26 @@ function makeFollower(
 ) {
   const events: ReachabilityStateEvent[] = [];
   const onTeardown = vi.fn();
-  const onTick = vi.fn();
+  const host = new FakeHost();
   let name: string | null = "kitchen";
-  const follower = new ReachabilityFollower(makeHost(), {
+  const follower = new ReachabilityFollower(host, {
     api: () => api,
     deviceName: () => name,
     onEvent: (state) => events.push(state),
     onTeardown,
-    onTick,
+    tickRender: true,
     ...overrides,
   });
   return {
     follower,
     events,
+    host,
     onTeardown,
-    onTick,
     setName: (n: string | null) => {
       name = n;
     },
   };
 }
-
-const flush = () => new Promise((r) => setTimeout(r, 0));
 
 describe("ReachabilityFollower", () => {
   beforeEach(() => {
@@ -176,32 +167,33 @@ describe("ReachabilityFollower", () => {
   it("an idle target tears down, notifies, and disarms the interval", async () => {
     vi.useFakeTimers();
     const { api, unsubscribe } = makeApi();
-    const { follower, onTeardown, onTick, setName } = makeFollower(api);
+    const { follower, host, onTeardown, setName } = makeFollower(api);
     follower.reconcile();
-    await vi.advanceTimersByTimeAsync(0);
+    await flushTimers();
     await vi.advanceTimersByTimeAsync(2000);
-    expect(onTick).toHaveBeenCalledTimes(2);
+    // tickRender requests a host render each tick.
+    expect(host.updates).toBe(2);
     setName(null);
     follower.reconcile();
-    await vi.advanceTimersByTimeAsync(0);
+    await flushTimers();
     expect(unsubscribe).toHaveBeenCalledOnce();
     expect(onTeardown).toHaveBeenCalledOnce();
-    onTick.mockClear();
+    const settled = host.updates;
     await vi.advanceTimersByTimeAsync(3000);
-    expect(onTick).not.toHaveBeenCalled();
+    expect(host.updates).toBe(settled);
   });
 
   it("hostDisconnected stops the stream and the tick", async () => {
     vi.useFakeTimers();
     const { api, unsubscribe } = makeApi();
-    const { follower, onTick } = makeFollower(api);
+    const { follower, host } = makeFollower(api);
     follower.reconcile();
-    await vi.advanceTimersByTimeAsync(0);
+    await flushTimers();
     follower.hostDisconnected();
     expect(unsubscribe).toHaveBeenCalledOnce();
-    onTick.mockClear();
+    const settled = host.updates;
     await vi.advanceTimersByTimeAsync(3000);
-    expect(onTick).not.toHaveBeenCalled();
+    expect(host.updates).toBe(settled);
   });
 
   it("the tick reconciles, recovering from a WS reconnect", async () => {
@@ -210,7 +202,7 @@ describe("ReachabilityFollower", () => {
     const { api } = makeApi({}, generation);
     const { follower } = makeFollower(api);
     follower.reconcile();
-    await vi.advanceTimersByTimeAsync(0);
+    await flushTimers();
     expect(api.subscribeDeviceReachability).toHaveBeenCalledTimes(1);
     generation.value = 2;
     await vi.advanceTimersByTimeAsync(1000);

--- a/test/util/reachability-follower.test.ts
+++ b/test/util/reachability-follower.test.ts
@@ -210,10 +210,92 @@ describe("ReachabilityFollower", () => {
     follower.stop();
   });
 
-  it("no api means idle regardless of the wanted name", () => {
-    const { follower } = makeFollower(undefined);
+  it("no api means idle: no interval arms and no render is requested", async () => {
+    vi.useFakeTimers();
+    const { follower, host } = makeFollower(undefined);
     follower.reconcile();
-    // Nothing to assert beyond not throwing; no subscribe target exists.
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(host.updates).toBe(0);
+    follower.stop();
+  });
+
+  it("teardown-then-resubscribe onto the same target keeps exactly one stream", async () => {
+    const resolvers: Array<(v: { unsubscribe: () => Promise<void> }) => void> = [];
+    const unsubs = [
+      vi.fn().mockResolvedValue(undefined),
+      vi.fn().mockResolvedValue(undefined),
+    ];
+    const { api } = makeApi({
+      subscribeDeviceReachability: vi.fn().mockImplementation(
+        () =>
+          new Promise((r) => {
+            resolvers.push(r);
+          })
+      ),
+    });
+    const { follower, events, setName } = makeFollower(api);
+    follower.reconcile();
+    const firstCallback = (api.subscribeDeviceReachability as ReturnType<typeof vi.fn>)
+      .mock.calls[0][1];
+    // Same (name, generation) recurs within one round-trip; only the
+    // attempt id tells the two apart.
+    setName(null);
+    follower.reconcile();
+    setName("kitchen");
+    follower.reconcile();
+    expect(api.subscribeDeviceReachability).toHaveBeenCalledTimes(2);
+    resolvers[0]({ unsubscribe: unsubs[0] });
+    resolvers[1]({ unsubscribe: unsubs[1] });
+    await flush();
+    expect(unsubs[0]).toHaveBeenCalledOnce();
+    expect(unsubs[1]).not.toHaveBeenCalled();
+    firstCallback(makeReachabilityEvent());
+    expect(events).toEqual([]);
+    follower.stop();
+    expect(unsubs[1]).toHaveBeenCalledOnce();
+  });
+
+  it("a stale rejection stays silent and leaves the memos alone", async () => {
+    let reject!: (err: Error) => void;
+    const { api } = makeApi({
+      subscribeDeviceReachability: vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise((_r, rej) => {
+              reject = rej;
+            })
+        )
+        .mockRejectedValue(new Error("real failure")),
+    });
+    const { follower, setName } = makeFollower(api);
+    follower.reconcile();
+    setName(null);
+    follower.reconcile();
+    reject(new Error("stale failure"));
+    await flush();
+    expect(console.warn).not.toHaveBeenCalled();
+    // The key is unpoisoned: the same target failing for real warns.
+    setName("kitchen");
+    follower.reconcile();
+    await flush();
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    follower.stop();
+  });
+
+  it("hostConnected and hostUpdated drive reconcile without host plumbing", async () => {
+    const { api } = makeApi();
+    const { follower, setName } = makeFollower(api);
+    follower.hostConnected();
+    await flush();
+    expect(api.subscribeDeviceReachability).toHaveBeenCalledTimes(1);
+    setName("garage");
+    follower.hostUpdated();
+    await flush();
+    expect(api.subscribeDeviceReachability).toHaveBeenLastCalledWith(
+      "garage",
+      expect.any(Function)
+    );
     follower.stop();
   });
 });

--- a/test/util/reachability-follower.test.ts
+++ b/test/util/reachability-follower.test.ts
@@ -1,0 +1,227 @@
+/** Pins the shared reachability follower's subscribe lifecycle. */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { makeReachabilityEvent } from "../_make-reachability-event.js";
+import type { ESPHomeAPI } from "../../src/api/esphome-api.js";
+import type { ReachabilityStateEvent } from "../../src/api/types/reachability.js";
+import {
+  ReachabilityFollower,
+  type ReachabilityFollowerOptions,
+} from "../../src/util/reachability-follower.js";
+
+function makeHost() {
+  return {
+    addController: vi.fn(),
+    removeController: vi.fn(),
+    requestUpdate: vi.fn(),
+    updateComplete: Promise.resolve(true),
+  };
+}
+
+function makeApi(
+  overrides: Record<string, unknown> = {},
+  generation: { value: number } = { value: 1 }
+) {
+  const unsubscribe = vi.fn().mockResolvedValue(undefined);
+  const api = {
+    get connectionGeneration() {
+      return generation.value;
+    },
+    subscribeDeviceReachability: vi.fn().mockResolvedValue({ unsubscribe }),
+    ...overrides,
+  };
+  return { api: api as unknown as ESPHomeAPI, unsubscribe };
+}
+
+function makeFollower(
+  api: ESPHomeAPI | undefined,
+  overrides: Partial<ReachabilityFollowerOptions> = {}
+) {
+  const events: ReachabilityStateEvent[] = [];
+  const onTeardown = vi.fn();
+  const onTick = vi.fn();
+  let name: string | null = "kitchen";
+  const follower = new ReachabilityFollower(makeHost(), {
+    api: () => api,
+    deviceName: () => name,
+    onEvent: (state) => events.push(state),
+    onTeardown,
+    onTick,
+    ...overrides,
+  });
+  return {
+    follower,
+    events,
+    onTeardown,
+    onTick,
+    setName: (n: string | null) => {
+      name = n;
+    },
+  };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("ReachabilityFollower", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("subscribes on reconcile and delivers events", async () => {
+    const { api } = makeApi();
+    const { follower, events } = makeFollower(api);
+    follower.reconcile();
+    await flush();
+    const sub = api.subscribeDeviceReachability as ReturnType<typeof vi.fn>;
+    expect(sub).toHaveBeenCalledWith("kitchen", expect.any(Function));
+    const callback = sub.mock.calls[0][1];
+    const event = makeReachabilityEvent();
+    callback(event);
+    expect(events).toEqual([event]);
+    follower.stop();
+  });
+
+  it("same-target reconcile no-ops while an attempt is in flight", async () => {
+    let resolveSub!: (v: { unsubscribe: () => Promise<void> }) => void;
+    const { api } = makeApi({
+      subscribeDeviceReachability: vi.fn().mockReturnValue(
+        new Promise((r) => {
+          resolveSub = r;
+        })
+      ),
+    });
+    const { follower } = makeFollower(api);
+    follower.reconcile();
+    follower.reconcile();
+    expect(api.subscribeDeviceReachability).toHaveBeenCalledTimes(1);
+    resolveSub({ unsubscribe: vi.fn().mockResolvedValue(undefined) });
+    await flush();
+    follower.reconcile();
+    expect(api.subscribeDeviceReachability).toHaveBeenCalledTimes(1);
+    follower.stop();
+  });
+
+  it("a stale resolve unsubscribes itself and drops its events", async () => {
+    let resolveSub!: (v: { unsubscribe: () => Promise<void> }) => void;
+    const staleUnsub = vi.fn().mockResolvedValue(undefined);
+    const { api } = makeApi({
+      subscribeDeviceReachability: vi.fn().mockReturnValue(
+        new Promise((r) => {
+          resolveSub = r;
+        })
+      ),
+    });
+    const { follower, events, setName } = makeFollower(api);
+    follower.reconcile();
+    const callback = (api.subscribeDeviceReachability as ReturnType<typeof vi.fn>).mock
+      .calls[0][1];
+    setName(null);
+    follower.reconcile();
+    resolveSub({ unsubscribe: staleUnsub });
+    await flush();
+    expect(staleUnsub).toHaveBeenCalledOnce();
+    callback(makeReachabilityEvent());
+    expect(events).toEqual([]);
+  });
+
+  it("memoizes a failed (device, generation) and warns once", async () => {
+    const { api } = makeApi({
+      subscribeDeviceReachability: vi.fn().mockRejectedValue(new Error("nope")),
+    });
+    const { follower } = makeFollower(api);
+    follower.reconcile();
+    await flush();
+    follower.reconcile();
+    follower.reconcile();
+    await flush();
+    expect(api.subscribeDeviceReachability).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    follower.stop();
+  });
+
+  it("a generation bump retries a failed subscribe and rotates the stream", async () => {
+    const generation = { value: 1 };
+    const { api, unsubscribe } = makeApi({}, generation);
+    const { follower } = makeFollower(api);
+    follower.reconcile();
+    await flush();
+    expect(api.subscribeDeviceReachability).toHaveBeenCalledTimes(1);
+    generation.value = 2;
+    follower.reconcile();
+    await flush();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(api.subscribeDeviceReachability).toHaveBeenCalledTimes(2);
+    follower.stop();
+  });
+
+  it("retry clears the failure memo so reconcile attempts again", async () => {
+    const { api } = makeApi({
+      subscribeDeviceReachability: vi.fn().mockRejectedValue(new Error("nope")),
+    });
+    const { follower } = makeFollower(api);
+    follower.reconcile();
+    await flush();
+    follower.retry();
+    follower.reconcile();
+    await flush();
+    expect(api.subscribeDeviceReachability).toHaveBeenCalledTimes(2);
+    expect(console.warn).toHaveBeenCalledTimes(2);
+    follower.stop();
+  });
+
+  it("an idle target tears down, notifies, and disarms the interval", async () => {
+    vi.useFakeTimers();
+    const { api, unsubscribe } = makeApi();
+    const { follower, onTeardown, onTick, setName } = makeFollower(api);
+    follower.reconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(onTick).toHaveBeenCalledTimes(2);
+    setName(null);
+    follower.reconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(onTeardown).toHaveBeenCalledOnce();
+    onTick.mockClear();
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(onTick).not.toHaveBeenCalled();
+  });
+
+  it("hostDisconnected stops the stream and the tick", async () => {
+    vi.useFakeTimers();
+    const { api, unsubscribe } = makeApi();
+    const { follower, onTick } = makeFollower(api);
+    follower.reconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    follower.hostDisconnected();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    onTick.mockClear();
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(onTick).not.toHaveBeenCalled();
+  });
+
+  it("the tick reconciles, recovering from a WS reconnect", async () => {
+    vi.useFakeTimers();
+    const generation = { value: 1 };
+    const { api } = makeApi({}, generation);
+    const { follower } = makeFollower(api);
+    follower.reconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(api.subscribeDeviceReachability).toHaveBeenCalledTimes(1);
+    generation.value = 2;
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(api.subscribeDeviceReachability).toHaveBeenCalledTimes(2);
+    follower.stop();
+  });
+
+  it("no api means idle regardless of the wanted name", () => {
+    const { follower } = makeFollower(undefined);
+    follower.reconcile();
+    // Nothing to assert beyond not throwing; no subscribe target exists.
+    follower.stop();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Extracts one shared `ReachabilityFollower` (a Lit ReactiveController in `src/util/reachability-follower.ts`) from the two hand-rolled copies of the `subscribeDeviceReachability` lifecycle: the device drawer's `reconcileSubscription` / `openSubscription` / `teardownSubscription` / `syncTickInterval` free functions and the troubleshoot dialog's `_startReconcile` / `_reconcileSubscription` / `_subscribe` / `_teardownSubscription` methods. The copies had already diverged in bookkeeping (failure keyed on `device:generation` with a rate-limited warn vs generation alone; synchronous field registration vs an explicit pending flag), and review rounds fixed the same race class in each independently.

The follower owns the subscription handle, the subscribed name and connection generation, a per `name:generation` failure memo with a once-per-key warn, stale-attempt discard on both resolution and every event push (currency is a per-attempt id that teardown bumps, so a teardown-and-return to the same target within one subscribe round-trip cannot double-subscribe or leak the first stream — the property the dialog's old `_subscribePending` flag guarded), and the 1 Hz reconcile tick. Hosts declare what to follow through a `deviceName()` closure (null means idle) plus `onEvent` / `onTeardown` callbacks and an opt-in `tickRender` for second-precision age re-renders; the follower reconciles itself after every host update (`hostUpdated`), so neither host maintains a trigger list, the interval arms and disarms itself off the same signal, and `hostDisconnected` tears everything down. The unified semantics are the drawer's proven discipline applied to both hosts.

The drawer keeps only its render functions in `device-drawer-content/reachability.ts` and drops seven host fields (including the write-only `_tick` render counter); the dialog drops five. The dialog's untracked explainer-only mode now falls out structurally: an untracked target reads as idle, so reconcile tears down and disarms instead of needing the special timer stop the last review round added.

Deliberate deviations from the issue sketch, called out for review:

- `reachability-snapshot.ts` (the one-shot status-report capture) stays standalone. Its contract is a bounded promise where a subscribe rejection resolves `null` immediately; routing it through the poll-driven follower would turn that into a full timeout wait and drag generation and interval concerns it deliberately lacks.
- One benign behavior change: reopening the dialog onto the same device keeps the established stream instead of dropping and resubscribing (reconcile sees an identical target), and the last reachability snapshot is kept alongside it, since the kept stream redelivers nothing to repaint a blanked section. The reopened-onto-another-device case still tears down; tests pin both shapes.

The new `test/util/reachability-follower.test.ts` unit-tests the whole lifecycle (in-flight no-op, stale resolve, failure memo and warn rate-limit, generation-bump recovery, retry, idle teardown, tick recovery, disconnect), which also closes an existing gap: the drawer's subscription logic previously had no tests at all.

**Related issue or feature (if applicable):** fixes #1600

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
