### PR TITLE
Raise the improv-wifi-serial-sdk floor to 2.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@tanstack/lit-table": "^8.21.3",
     "codemirror": "^6.0.2",
     "esptool-js": "^0.6.0",
-    "improv-wifi-serial-sdk": "^2.5.1",
+    "improv-wifi-serial-sdk": "^2.8.1",
     "intl-messageformat": "^11.2.12",
     "lit": "3.3.3",
     "lit-html": "3.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
         specifier: ^0.6.0
         version: 0.6.0
       improv-wifi-serial-sdk:
-        specifier: ^2.5.1
+        specifier: ^2.8.1
         version: 2.8.1
       intl-messageformat:
         specifier: ^11.2.12


### PR DESCRIPTION
# What does this implement/fix?

Raises the `improv-wifi-serial-sdk` floor from `^2.5.1` to `^2.8.1`. This is the web.esphome.io equivalent of esp-web-tools 10.4.0, whose headline change was bumping the same SDK to 2.8.x for the serialized Improv RPC commands (improv-wifi/sdk-serial-js#160). That fixes the Wi-Fi picker scan race ("Only 1 RPC command that requires feedback can be active") and the default selection dropping to "Join other"; 2.8.1 adds a timeout on `requestCurrentState`.

The lockfile already resolved 2.8.1, so this is a specifier-only change; the floor now guarantees the fix instead of relying on lockfile float. Everything else esp-web-tools shipped in the 10.3/10.4 picker work (signal icons, RSSI, continuous scanning, traffic light colors) lives in the SDK provisioning dialog we open, so no source changes are needed. The `serialType` manifest field from 10.3.0 is skipped on purpose; the esphome-web manifest does not ship it.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [x] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
