### PR TITLE
Suppress the build failure hint when the flash failed, not the build

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -189,6 +189,10 @@ export class ESPHomeCommandDialog extends LitElement {
   // missing — the build itself was fine, so the clean/reset hint is suppressed.
   @state() _compileMissingDependent = false;
 
+  // Flips true when the failed job was the flash, not the build — cleaning or
+  // resetting the build environment can't help a network-layer failure.
+  @state() _failedDuringFlash = false;
+
   // Run ended on a lost connection; suppresses the failure hints.
   @state() _connectionInterrupted = false;
 
@@ -223,7 +227,6 @@ export class ESPHomeCommandDialog extends LitElement {
   // The job the timer reports on — the followed (compile) job. Unlike _jobId it
   // survives the stream ending, so the detail popover can still read the job's
   // started_at/completed_at for the total run time after an install's flash.
-  // Doubles as the run's head job for renderResetSuggestion's phase gate.
   _timerJobId = "";
   // Finished job id armed by a queued-update outcome. Plain field — the
   // _jobs context updates already schedule the render.

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -223,6 +223,7 @@ export class ESPHomeCommandDialog extends LitElement {
   // The job the timer reports on — the followed (compile) job. Unlike _jobId it
   // survives the stream ending, so the detail popover can still read the job's
   // started_at/completed_at for the total run time after an install's flash.
+  // Doubles as the run's head job for renderResetSuggestion's phase gate.
   _timerJobId = "";
   // Finished job id armed by a queued-update outcome. Plain field — the
   // _jobs context updates already schedule the render.

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -92,6 +92,7 @@ export function resetRunState(host: ESPHomeCommandDialog): void {
   host._userStopped = false;
   host._failedDuringValidate = false;
   host._compileMissingDependent = false;
+  host._failedDuringFlash = false;
   host._connectionInterrupted = false;
   host._awaitingWakeAfter = "";
 }
@@ -310,6 +311,10 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
           ? `command.${host._commandType}_success`
           : `command.${host._commandType}_failed`
       );
+      // Latched here, where the outcome is known — a render-time read of the
+      // jobs context would degrade when history pruning evicts the job. A
+      // combined INSTALL job can't be attributed to a phase and stays false.
+      host._failedDuringFlash = !success && finished?.job_type === JobType.UPLOAD;
       host._jobId = "";
       if (
         success &&

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -1,10 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
-import {
-  type FirmwareJob,
-  JobSource,
-  JobStatus,
-  JobType,
-} from "../../api/types/firmware-jobs.js";
+import { type FirmwareJob, JobSource, JobStatus } from "../../api/types/firmware-jobs.js";
 import { activeLocale } from "../../common/localize.js";
 import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
@@ -153,17 +148,8 @@ export function renderResetSuggestion(
   ) {
     return nothing;
   }
-  // The run's head job tells whether the *build* is what failed: a failed
-  // standalone UPLOAD, or a chain whose COMPILE head completed, died at the
-  // flash — cleaning or resetting the build environment can't help a
-  // network-layer failure. A combined INSTALL head can't be attributed to a
-  // phase, and a head evicted from the jobs context can't be read — both
-  // conservatively keep the hint.
-  const head = host._timerJobId ? host._jobs.get(host._timerJobId) : undefined;
-  if (head?.job_type === JobType.UPLOAD) return nothing;
-  if (head?.job_type === JobType.COMPILE && head.status === JobStatus.COMPLETED) {
-    return nothing;
-  }
+  // The flash failed, not the build — clean/reset can't help.
+  if (host._failedDuringFlash) return nothing;
   return renderBuildFailureSuggestion(host, remotePeerLabel(host), remoteResetPin(host));
 }
 

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -1,5 +1,10 @@
 import { html, nothing, type TemplateResult } from "lit";
-import { type FirmwareJob, JobSource, JobStatus } from "../../api/types/firmware-jobs.js";
+import {
+  type FirmwareJob,
+  JobSource,
+  JobStatus,
+  JobType,
+} from "../../api/types/firmware-jobs.js";
 import { activeLocale } from "../../common/localize.js";
 import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
@@ -146,6 +151,15 @@ export function renderResetSuggestion(
     host._commandType !== "compile" &&
     host._commandType !== "offline_compile"
   ) {
+    return nothing;
+  }
+  // The run's head job tells whether the *build* is what failed: a failed
+  // standalone UPLOAD, or a chain whose COMPILE head completed, died at the
+  // flash — cleaning or resetting the build environment can't help a
+  // network-layer failure.
+  const head = host._timerJobId ? host._jobs.get(host._timerJobId) : undefined;
+  if (head?.job_type === JobType.UPLOAD) return nothing;
+  if (head?.job_type === JobType.COMPILE && head.status === JobStatus.COMPLETED) {
     return nothing;
   }
   return renderBuildFailureSuggestion(host, remotePeerLabel(host), remoteResetPin(host));

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -156,7 +156,9 @@ export function renderResetSuggestion(
   // The run's head job tells whether the *build* is what failed: a failed
   // standalone UPLOAD, or a chain whose COMPILE head completed, died at the
   // flash — cleaning or resetting the build environment can't help a
-  // network-layer failure.
+  // network-layer failure. A combined INSTALL head can't be attributed to a
+  // phase, and a head evicted from the jobs context can't be read — both
+  // conservatively keep the hint.
   const head = host._timerJobId ? host._jobs.get(host._timerJobId) : undefined;
   if (head?.job_type === JobType.UPLOAD) return nothing;
   if (head?.job_type === JobType.COMPILE && head.status === JobStatus.COMPLETED) {

--- a/test/components/_command-dialog-host.ts
+++ b/test/components/_command-dialog-host.ts
@@ -80,6 +80,7 @@ export function makeCommandDialogHost(
     _userStopped: false,
     _failedDuringValidate: false,
     _compileMissingDependent: false,
+    _failedDuringFlash: false,
     _localize: (key: string) => key,
     _resetAnsiLogScroll: () => {},
     _flipToLogs: () => {

--- a/test/components/command-dialog-install-chain.test.ts
+++ b/test/components/command-dialog-install-chain.test.ts
@@ -130,6 +130,32 @@ describe("command-dialog install chain follow", () => {
     expect(host._jobId).toBe("");
     expect(follows.u1).toBeUndefined();
     expect(flipped()).toBe(false);
+    // A build failure keeps the clean/reset hint.
+    expect(host._failedDuringFlash).toBe(false);
+  });
+
+  it("latches the flash failure when the chain's upload fails", () => {
+    const { host, follows } = installChainHost();
+
+    host._jobId = "c1";
+    followJob(host, "c1");
+    follows.c1.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });
+    follows.u1.onResult({ status: JobStatus.FAILED, exit_code: 1 });
+
+    expect(host._state).toBe("error");
+    expect(host._failedDuringFlash).toBe(true);
+  });
+
+  it("latches the flash failure on a reattached standalone upload", () => {
+    const upload = makeJob({ job_id: "u1", job_type: JobType.UPLOAD });
+    const { host, follows } = makeHost(new Map([["u1", upload]]));
+
+    host._jobId = "u1";
+    followJob(host, "u1");
+    follows.u1.onResult({ status: JobStatus.FAILED, exit_code: 1 });
+
+    expect(host._state).toBe("error");
+    expect(host._failedDuringFlash).toBe(true);
   });
 
   it("build-locally stays in install mode and follows the new compile into its upload", async () => {

--- a/test/components/command-dialog-reset-suggestion.test.ts
+++ b/test/components/command-dialog-reset-suggestion.test.ts
@@ -44,6 +44,7 @@ interface Host {
   _failedDuringValidate: boolean;
   _compileMissingDependent: boolean;
   _jobId: string;
+  _timerJobId: string;
   _jobs: Map<string, FirmwareJob>;
   _primedSource: {
     source: JobSource;
@@ -64,6 +65,7 @@ function baseHost(overrides: Partial<Host> = {}): Host {
     _failedDuringValidate: false,
     _compileMissingDependent: false,
     _jobId: "job-1",
+    _timerJobId: "",
     _jobs: new Map(),
     _primedSource: null,
     _tryCleanBuild: () => {},
@@ -96,6 +98,43 @@ describe("renderResetSuggestion — local build", () => {
     // The compile was fine; clean/reset wouldn't help a missing dependent flash.
     const host = baseHost({ _compileMissingDependent: true });
     expectNoSuggestion(render(host));
+  });
+});
+
+describe("renderResetSuggestion — flash failures", () => {
+  it("renders nothing when a standalone upload failed", () => {
+    const host = baseHost({
+      _timerJobId: "u1",
+      _jobs: new Map([["u1", fakeJob({ job_id: "u1", job_type: JobType.UPLOAD })]]),
+    });
+    expectNoSuggestion(render(host));
+  });
+
+  it("renders nothing when the chain's compile completed and the flash failed", () => {
+    const host = baseHost({
+      _timerJobId: "c1",
+      _jobs: new Map([
+        [
+          "c1",
+          fakeJob({
+            job_id: "c1",
+            job_type: JobType.COMPILE,
+            status: JobStatus.COMPLETED,
+          }),
+        ],
+        ["u1", fakeJob({ job_id: "u1", job_type: JobType.UPLOAD, depends_on: "c1" })],
+      ]),
+    });
+    expectNoSuggestion(render(host));
+  });
+
+  it("keeps the hint for a failed compile head", () => {
+    const host = baseHost({
+      _timerJobId: "c1",
+      _jobId: "",
+      _jobs: new Map([["c1", fakeJob({ job_id: "c1", job_type: JobType.COMPILE })]]),
+    });
+    expectFallbackToLocal(render(host), host);
   });
 });
 

--- a/test/components/command-dialog-reset-suggestion.test.ts
+++ b/test/components/command-dialog-reset-suggestion.test.ts
@@ -136,6 +136,27 @@ describe("renderResetSuggestion — flash failures", () => {
     });
     expectFallbackToLocal(render(host), host);
   });
+
+  it("keeps the hint for an in-flight compile head", () => {
+    const host = baseHost({
+      _timerJobId: "c1",
+      _jobId: "",
+      _jobs: new Map([
+        [
+          "c1",
+          fakeJob({ job_id: "c1", job_type: JobType.COMPILE, status: JobStatus.RUNNING }),
+        ],
+      ]),
+    });
+    expectFallbackToLocal(render(host), host);
+  });
+
+  it("keeps the hint when the head job left the jobs context", () => {
+    // Clear-history pruning while the failed dialog is open; degrade to the
+    // pre-gate behavior rather than guessing the phase.
+    const host = baseHost({ _timerJobId: "u1", _jobId: "", _jobs: new Map() });
+    expectFallbackToLocal(render(host), host);
+  });
 });
 
 describe("renderResetSuggestion — remote build", () => {

--- a/test/components/command-dialog-reset-suggestion.test.ts
+++ b/test/components/command-dialog-reset-suggestion.test.ts
@@ -43,8 +43,8 @@ interface Host {
   _commandType: string;
   _failedDuringValidate: boolean;
   _compileMissingDependent: boolean;
+  _failedDuringFlash: boolean;
   _jobId: string;
-  _timerJobId: string;
   _jobs: Map<string, FirmwareJob>;
   _primedSource: {
     source: JobSource;
@@ -64,8 +64,8 @@ function baseHost(overrides: Partial<Host> = {}): Host {
     _commandType: "install",
     _failedDuringValidate: false,
     _compileMissingDependent: false,
+    _failedDuringFlash: false,
     _jobId: "job-1",
-    _timerJobId: "",
     _jobs: new Map(),
     _primedSource: null,
     _tryCleanBuild: () => {},
@@ -102,60 +102,9 @@ describe("renderResetSuggestion — local build", () => {
 });
 
 describe("renderResetSuggestion — flash failures", () => {
-  it("renders nothing when a standalone upload failed", () => {
-    const host = baseHost({
-      _timerJobId: "u1",
-      _jobs: new Map([["u1", fakeJob({ job_id: "u1", job_type: JobType.UPLOAD })]]),
-    });
+  it("renders nothing when the flash failed", () => {
+    const host = baseHost({ _failedDuringFlash: true, _jobId: "" });
     expectNoSuggestion(render(host));
-  });
-
-  it("renders nothing when the chain's compile completed and the flash failed", () => {
-    const host = baseHost({
-      _timerJobId: "c1",
-      _jobs: new Map([
-        [
-          "c1",
-          fakeJob({
-            job_id: "c1",
-            job_type: JobType.COMPILE,
-            status: JobStatus.COMPLETED,
-          }),
-        ],
-        ["u1", fakeJob({ job_id: "u1", job_type: JobType.UPLOAD, depends_on: "c1" })],
-      ]),
-    });
-    expectNoSuggestion(render(host));
-  });
-
-  it("keeps the hint for a failed compile head", () => {
-    const host = baseHost({
-      _timerJobId: "c1",
-      _jobId: "",
-      _jobs: new Map([["c1", fakeJob({ job_id: "c1", job_type: JobType.COMPILE })]]),
-    });
-    expectFallbackToLocal(render(host), host);
-  });
-
-  it("keeps the hint for an in-flight compile head", () => {
-    const host = baseHost({
-      _timerJobId: "c1",
-      _jobId: "",
-      _jobs: new Map([
-        [
-          "c1",
-          fakeJob({ job_id: "c1", job_type: JobType.COMPILE, status: JobStatus.RUNNING }),
-        ],
-      ]),
-    });
-    expectFallbackToLocal(render(host), host);
-  });
-
-  it("keeps the hint when the head job left the jobs context", () => {
-    // Clear-history pruning while the failed dialog is open; degrade to the
-    // pre-gate behavior rather than guessing the phase.
-    const host = baseHost({ _timerJobId: "u1", _jobId: "", _jobs: new Map() });
-    expectFallbackToLocal(render(host), host);
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

A failed network flash showed the build failure hint ("try cleaning the build files, if that doesn't help try resetting the build environment"), pointing the user at the wrong subsystem when the compile had already succeeded. `renderResetSuggestion` now consults the run's head job in the jobs context: a failed standalone UPLOAD, or a chain whose COMPILE head completed, did not fail in the build, so the clean and reset hints are suppressed. A failed compile keeps the hint exactly as before.

Verified against a live backend by queueing a deep sleep install, waking the device, and letting the wake flash fail at the network layer; the dialog shows "Install failed." with no build hint.

**Related issue or feature (if applicable):**

- fixes #1619

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
