### PR TITLE
Unify the dialog restart prologue and the OTA sentinel

### DIFF
--- a/src/components/apply-install-method.ts
+++ b/src/components/apply-install-method.ts
@@ -1,5 +1,6 @@
 import type { ConfiguredDevice } from "../api/types/devices.js";
 import type { ESPHomeFirmwareInstallDialog } from "./firmware-install-dialog.js";
+import { OTA_PORT } from "./logs-session.js";
 
 export interface InstallMethodHandlers {
   device: ConfiguredDevice;
@@ -23,7 +24,7 @@ export function applyInstallMethod(
     case "ota":
       // ``port`` is the user-typed address override from the OTA option's
       // expanded form; the "OTA" sentinel is the default-address path.
-      h.openInstall(port ?? "OTA");
+      h.openInstall(port ?? OTA_PORT);
       break;
     case "server-serial":
       // server-serial always carries the chosen port; guard rather than assert
@@ -31,7 +32,7 @@ export function applyInstallMethod(
       if (port) h.openInstall(port);
       break;
     case "bootloader":
-      h.openInstall("OTA", { bootloader: true });
+      h.openInstall(OTA_PORT, { bootloader: true });
       break;
     case "web-serial":
       h.firmwareDialog?.installWebSerial(h.device);

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -52,6 +52,7 @@ import {
   followJob,
   maybeFollowWakeUpload,
   onForceLocalClick,
+  primedSourceOf,
   resetJobBinding,
   resetRunState,
   startCommand,
@@ -68,6 +69,7 @@ import {
   showRunTimer,
 } from "./command-dialog/renderers.js";
 import { commandDialogStyles } from "./command-dialog/styles.js";
+import { OTA_PORT } from "./logs-session.js";
 import type { ESPHomeProcessTerminal } from "./process-terminal/process-terminal.js";
 import {
   fillTerminalOnMobile,
@@ -218,7 +220,7 @@ export class ESPHomeCommandDialog extends LitElement {
   // Stream id (validate streaming or follow_job streaming).
   _streamId = "";
   // Install target — "OTA" for network, an actual port for server-serial.
-  _port = "OTA";
+  _port = OTA_PORT;
   // Install flashes the bootloader image instead of the app (OTA-only).
   _bootloader = false;
   // Active job id (cancel target). Empty for validate. Cleared when the stream
@@ -321,7 +323,7 @@ export class ESPHomeCommandDialog extends LitElement {
 
   public open(type: CommandType, options?: { port?: string; bootloader?: boolean }) {
     this._commandType = type;
-    this._port = options?.port ?? "OTA";
+    this._port = options?.port ?? OTA_PORT;
     this._bootloader = options?.bootloader ?? false;
     this._state = null;
     this._log.reset();
@@ -358,7 +360,7 @@ export class ESPHomeCommandDialog extends LitElement {
     // "Build locally instead" retry keeps the target address and keeps
     // flashing the bootloader.
     const dependent = findDependentUpload(this._jobs, job);
-    this._port = dependent?.port || job.port || "OTA";
+    this._port = dependent?.port || job.port || OTA_PORT;
     this._bootloader = (dependent ?? job).flash_bootloader === true;
     resetRunState(this);
     // Fresh attach is a fresh session — reset toggle defaults so a prior
@@ -368,12 +370,7 @@ export class ESPHomeCommandDialog extends LitElement {
     this._jobId = job.job_id;
     this._timerJobId = job.job_id;
     this._jobStatus = job.status;
-    this._primedSource = {
-      source: job.source,
-      source_label: job.source_label,
-      source_esphome_version: job.source_esphome_version,
-      source_pin_sha256: job.source_pin_sha256,
-    };
+    this._primedSource = primedSourceOf(job);
     // Reattaching to a still-running (or finished) build: restore the true
     // compile clock so the replayed buffer doesn't restart the timer from now.
     this._timer.attach(job);

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -352,6 +352,8 @@ export class ESPHomeCommandDialog extends LitElement {
   // ``commandType`` overrides the derivation when the caller knows the
   // command before the jobs context does (a just-queued rename's COMPILE
   // head); reattach paths omit it and derive from the chain shape.
+  // Deliberately not restartRunOn: a reattach restores the job's real clock
+  // via _timer.attach, where a restart resets it.
   public followJob(job: FirmwareJob, displayName: string, commandType?: CommandType) {
     this.configuration = job.configuration;
     this.name = displayName;

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -352,8 +352,7 @@ export class ESPHomeCommandDialog extends LitElement {
   // ``commandType`` overrides the derivation when the caller knows the
   // command before the jobs context does (a just-queued rename's COMPILE
   // head); reattach paths omit it and derive from the chain shape.
-  // Deliberately not restartRunOn: a reattach restores the job's real clock
-  // via _timer.attach, where a restart resets it.
+  // Not restartRunOn: a reattach restores the real clock, not resets it.
   public followJob(job: FirmwareJob, displayName: string, commandType?: CommandType) {
     this.configuration = job.configuration;
     this.name = displayName;

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -106,9 +106,8 @@ export function resetJobBinding(host: ESPHomeCommandDialog): void {
   host._timer.reset();
 }
 
-// Restart the dialog onto *job*: fresh run state and binding, closed timer
-// popover, re-pinned scroll, then prime + follow. The cleared binding is what
-// makes the prime take the fresh timer rather than inherit the chain's.
+// Restart the dialog onto *job*. The cleared binding is what makes the prime
+// take the fresh timer rather than inherit the chain's.
 function restartRunOn(host: ESPHomeCommandDialog, job: FirmwareJob): void {
   resetRunState(host);
   resetJobBinding(host);

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -224,11 +224,11 @@ export async function startFirmwareJob(host: ESPHomeCommandDialog): Promise<void
   primeAndFollow(host, job);
 }
 
-// Prime status + source so the overlay paints on the first frame, then follow.
-// Leaves _commandType to the caller (the install chain relies on it).
 // The creation-time source snapshot the overlay paints from before the jobs
 // context catches up.
-export function primedSourceOf(job: FirmwareJob): ESPHomeCommandDialog["_primedSource"] {
+export function primedSourceOf(
+  job: FirmwareJob
+): NonNullable<ESPHomeCommandDialog["_primedSource"]> {
   return {
     source: job.source,
     source_label: job.source_label,
@@ -237,6 +237,8 @@ export function primedSourceOf(job: FirmwareJob): ESPHomeCommandDialog["_primedS
   };
 }
 
+// Prime status + source so the overlay paints on the first frame, then follow.
+// Leaves _commandType to the caller (the install chain relies on it).
 function primeAndFollow(host: ESPHomeCommandDialog, job: FirmwareJob): void {
   host._jobId = job.job_id;
   // Chaining from the compile head into its dependent flash keeps the timer

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -106,6 +106,17 @@ export function resetJobBinding(host: ESPHomeCommandDialog): void {
   host._timer.reset();
 }
 
+// Restart the dialog onto *job*: fresh run state and binding, closed timer
+// popover, re-pinned scroll, then prime + follow. The cleared binding is what
+// makes the prime take the fresh timer rather than inherit the chain's.
+function restartRunOn(host: ESPHomeCommandDialog, job: FirmwareJob): void {
+  resetRunState(host);
+  resetJobBinding(host);
+  host._closeTimerDetail();
+  host._resetAnsiLogScroll();
+  primeAndFollow(host, job);
+}
+
 export async function startCommand(host: ESPHomeCommandDialog): Promise<void> {
   await detachStream(host);
   host._jobId = "";
@@ -215,6 +226,17 @@ export async function startFirmwareJob(host: ESPHomeCommandDialog): Promise<void
 
 // Prime status + source so the overlay paints on the first frame, then follow.
 // Leaves _commandType to the caller (the install chain relies on it).
+// The creation-time source snapshot the overlay paints from before the jobs
+// context catches up.
+export function primedSourceOf(job: FirmwareJob): ESPHomeCommandDialog["_primedSource"] {
+  return {
+    source: job.source,
+    source_label: job.source_label,
+    source_esphome_version: job.source_esphome_version,
+    source_pin_sha256: job.source_pin_sha256,
+  };
+}
+
 function primeAndFollow(host: ESPHomeCommandDialog, job: FirmwareJob): void {
   host._jobId = job.job_id;
   // Chaining from the compile head into its dependent flash keeps the timer
@@ -225,12 +247,7 @@ function primeAndFollow(host: ESPHomeCommandDialog, job: FirmwareJob): void {
     host._timerJobId = job.job_id;
   }
   host._jobStatus = job.status;
-  host._primedSource = {
-    source: job.source,
-    source_label: job.source_label,
-    source_esphome_version: job.source_esphome_version,
-    source_pin_sha256: job.source_pin_sha256,
-  };
+  host._primedSource = primedSourceOf(job);
   followJob(host, job.job_id);
 }
 
@@ -377,11 +394,7 @@ export function maybeFollowWakeUpload(host: ESPHomeCommandDialog): boolean {
       // Fresh buffer on purpose (unlike the in-chain hand-off): the build
       // output can be hours stale by wake time, and the follow replays only
       // the upload's own history.
-      resetRunState(host);
-      resetJobBinding(host);
-      host._closeTimerDetail();
-      host._resetAnsiLogScroll();
-      primeAndFollow(host, j);
+      restartRunOn(host, j);
       return true;
     }
   }
@@ -471,13 +484,10 @@ export async function onForceLocalClick(host: ESPHomeCommandDialog): Promise<voi
       host._bootloader
     );
     // Keep _commandType "install": the public followJob would derive "compile"
-    // from the returned COMPILE (#1131) and skip the chain. Clear the cancelled
-    // attempt and reset the run state (the public followJob did this), then
-    // re-attach via primeAndFollow with a fresh timer.
+    // from the returned COMPILE (#1131) and skip the chain. Clear the
+    // cancelled attempt, then restart onto the fresh compile.
     await detachStream(host);
-    resetRunState(host);
-    resetJobBinding(host);
-    primeAndFollow(host, job);
+    restartRunOn(host, job);
   } catch (err) {
     host._state = "error";
     host._statusMessage = host._localize("command.force_local_failed");

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -47,6 +47,7 @@ import {
   renderServerSerialOption,
 } from "./install-method-dialog-rows.js";
 import { installMethodDialogStyles } from "./install-method-dialog.styles.js";
+import { OTA_PORT } from "./logs-session.js";
 import { renderDisclosure } from "./shared/disclosure.js";
 import {
   renderSerialPortBadges,
@@ -450,7 +451,7 @@ export class ESPHomeInstallMethodDialog extends LitElement {
   private _renderOtaAddressCard() {
     const expanded = this._otaAddressCardExpanded;
     const trimmed = this._otaAddressValue.trim();
-    const canSubmit = trimmed.length > 0 && trimmed !== "OTA";
+    const canSubmit = trimmed.length > 0 && trimmed !== OTA_PORT;
     return html`
       <div class="option-collapsible">
         <button
@@ -527,7 +528,7 @@ export class ESPHomeInstallMethodDialog extends LitElement {
 
   private _submitOtaAddress = () => {
     const port = this._otaAddressValue.trim();
-    if (!port || port === "OTA") return;
+    if (!port || port === OTA_PORT) return;
     this._selectMethod("ota", port);
   };
 

--- a/test/components/command-dialog-deferred-install.test.ts
+++ b/test/components/command-dialog-deferred-install.test.ts
@@ -171,6 +171,10 @@ describe("command-dialog wake re-follow", () => {
   it("re-follows the wake flash and flips to logs on its success", () => {
     const { host, follows, flipped } = queuedHost();
     expect(host._awaitingWakeAfter).toBe("c1");
+    let timerDetailClosed = false;
+    host._closeTimerDetail = () => {
+      timerDetailClosed = true;
+    };
 
     arrive(host);
 
@@ -179,6 +183,8 @@ describe("command-dialog wake re-follow", () => {
     expect(host._jobId).toBe("u2");
     expect(host._timerJobId).toBe("u2");
     expect(follows.u2).toBeDefined();
+    // The restart closes a timer-detail popover left open on the compile.
+    expect(timerDetailClosed).toBe(true);
 
     follows.u2.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });
     expect(host._state).toBe("success");

--- a/test/components/command-dialog-deferred-install.test.ts
+++ b/test/components/command-dialog-deferred-install.test.ts
@@ -183,7 +183,6 @@ describe("command-dialog wake re-follow", () => {
     expect(host._jobId).toBe("u2");
     expect(host._timerJobId).toBe("u2");
     expect(follows.u2).toBeDefined();
-    // The restart closes a timer-detail popover left open on the compile.
     expect(timerDetailClosed).toBe(true);
 
     follows.u2.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });

--- a/test/components/command-dialog-deferred-reopen.test.ts
+++ b/test/components/command-dialog-deferred-reopen.test.ts
@@ -51,6 +51,29 @@ describe("command-dialog reopen of a deferred install", () => {
   });
 });
 
+describe("command-dialog reopen primed source", () => {
+  it("primes the source snapshot from the followed job", () => {
+    const compile = makeFirmwareJob({
+      job_id: "c1",
+      job_type: JobType.COMPILE,
+      status: JobStatus.RUNNING,
+      source_label: "builder",
+      source_esphome_version: "2026.7.3",
+      source_pin_sha256: "abc123",
+    });
+    const { el } = mount([compile]);
+
+    el.followJob(compile, "gen8266");
+
+    expect(el._primedSource).toEqual({
+      source: compile.source,
+      source_label: "builder",
+      source_esphome_version: "2026.7.3",
+      source_pin_sha256: "abc123",
+    });
+  });
+});
+
 describe("command-dialog wake re-follow wiring", () => {
   const originalGetAnimations = Element.prototype.getAnimations;
   beforeAll(() => {

--- a/test/components/command-dialog-install-chain.test.ts
+++ b/test/components/command-dialog-install-chain.test.ts
@@ -186,6 +186,10 @@ describe("command-dialog install chain follow", () => {
     host._closeTimerDetail = () => {
       timerDetailClosed = true;
     };
+    let scrollRePinned = false;
+    host._resetAnsiLogScroll = () => {
+      scrollRePinned = true;
+    };
     host._jobId = "c1"; // the remote compile being cancelled
     // Stale per-session flags from the cancelled remote attempt.
     host._userStopped = true;
@@ -198,8 +202,9 @@ describe("command-dialog install chain follow", () => {
     expect(host._jobId).toBe("c2");
     expect(follows.c2).toBeDefined();
     // The restart closes a timer-detail popover still open on the cancelled
-    // compile's clocks.
+    // compile's clocks and re-pins the log scroll for the fresh buffer.
     expect(timerDetailClosed).toBe(true);
+    expect(scrollRePinned).toBe(true);
     // The new local run starts clean — stale flags can't mis-route its hint.
     expect(host._userStopped).toBe(false);
     expect(host._failedDuringValidate).toBe(false);

--- a/test/components/command-dialog-install-chain.test.ts
+++ b/test/components/command-dialog-install-chain.test.ts
@@ -201,8 +201,6 @@ describe("command-dialog install chain follow", () => {
     expect(host._commandType).toBe("install");
     expect(host._jobId).toBe("c2");
     expect(follows.c2).toBeDefined();
-    // The restart closes a timer-detail popover still open on the cancelled
-    // compile's clocks and re-pins the log scroll for the fresh buffer.
     expect(timerDetailClosed).toBe(true);
     expect(scrollRePinned).toBe(true);
     // The new local run starts clean — stale flags can't mis-route its hint.

--- a/test/components/command-dialog-install-chain.test.ts
+++ b/test/components/command-dialog-install-chain.test.ts
@@ -182,6 +182,10 @@ describe("command-dialog install chain follow", () => {
         return newCompile;
       },
     });
+    let timerDetailClosed = false;
+    host._closeTimerDetail = () => {
+      timerDetailClosed = true;
+    };
     host._jobId = "c1"; // the remote compile being cancelled
     // Stale per-session flags from the cancelled remote attempt.
     host._userStopped = true;
@@ -193,6 +197,9 @@ describe("command-dialog install chain follow", () => {
     expect(host._commandType).toBe("install");
     expect(host._jobId).toBe("c2");
     expect(follows.c2).toBeDefined();
+    // The restart closes a timer-detail popover still open on the cancelled
+    // compile's clocks.
+    expect(timerDetailClosed).toBe(true);
     // The new local run starts clean — stale flags can't mis-route its hint.
     expect(host._userStopped).toBe(false);
     expect(host._failedDuringValidate).toBe(false);


### PR DESCRIPTION
# What does this implement/fix?

Extracts `restartRunOn` so the two "restart the dialog onto a new job" preludes share one sequence; the build locally path thereby gains the two steps it was missing, closing the stale compile timer popover and re-pinning the log scroll when it retargets the fresh compile. The duplicated primed-source snapshot collapses into a shared `primedSourceOf`, and the remaining component layer "OTA" literals move to the existing `OTA_PORT` constant. `open()` stays distinct on purpose; it holds `_state = null` until submission and has no job to follow.

**Related issue or feature (if applicable):**

- fixes #1618

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
