### PR TITLE
Move the OTA sentinel beside the streaming types

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -53,11 +53,10 @@ import type {
   EventSubscriptionCallback,
   VersionMatchPolicy,
 } from "./types/event-subscription.js";
-import {
-  type FirmwareBinary,
-  type FirmwareJob,
-  type FirmwareJobResult,
-  OTA_PORT,
+import type {
+  FirmwareBinary,
+  FirmwareJob,
+  FirmwareJobResult,
 } from "./types/firmware-jobs.js";
 import type {
   CommandMessage,
@@ -77,7 +76,7 @@ import type {
   PairingWindowState,
   RemoteBuildSettings,
 } from "./types/remote-build.js";
-import type { StreamCallbacks } from "./types/streaming.js";
+import { OTA_PORT, type StreamCallbacks } from "./types/streaming.js";
 import type {
   ArchivedDevice,
   BulkActionResult,

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -53,10 +53,11 @@ import type {
   EventSubscriptionCallback,
   VersionMatchPolicy,
 } from "./types/event-subscription.js";
-import type {
-  FirmwareBinary,
-  FirmwareJob,
-  FirmwareJobResult,
+import {
+  type FirmwareBinary,
+  type FirmwareJob,
+  type FirmwareJobResult,
+  OTA_PORT,
 } from "./types/firmware-jobs.js";
 import type {
   CommandMessage,
@@ -1426,7 +1427,7 @@ export class ESPHomeAPI {
    *  targets only, refused while the device is offline. */
   async firmwareInstall(
     configuration: string,
-    port = "OTA",
+    port = OTA_PORT,
     forceLocal = false,
     bootloader = false
   ): Promise<FirmwareJob> {
@@ -1456,7 +1457,7 @@ export class ESPHomeAPI {
   /** Queue install for multiple devices. */
   async firmwareInstallBulk(
     configurations: string[],
-    port = "OTA"
+    port = OTA_PORT
   ): Promise<FirmwareJob[]> {
     return this.sendCommand<FirmwareJob[]>("firmware/install_bulk", {
       configurations,

--- a/src/api/types/firmware-jobs.ts
+++ b/src/api/types/firmware-jobs.ts
@@ -39,6 +39,9 @@ export enum JobSource {
   REMOTE_PENDING = "remote_pending",
 }
 
+/** Sentinel port for the network / OTA path, vs. a server serial device path. */
+export const OTA_PORT = "OTA";
+
 export interface FirmwareJob {
   job_id: string;
   configuration: string;

--- a/src/api/types/firmware-jobs.ts
+++ b/src/api/types/firmware-jobs.ts
@@ -39,9 +39,6 @@ export enum JobSource {
   REMOTE_PENDING = "remote_pending",
 }
 
-/** Sentinel port for the network / OTA path, vs. a server serial device path. */
-export const OTA_PORT = "OTA";
-
 export interface FirmwareJob {
   job_id: string;
   configuration: string;

--- a/src/api/types/streaming.ts
+++ b/src/api/types/streaming.ts
@@ -17,3 +17,8 @@ export interface StreamCallbacks<TResult = { success: boolean; code: number }> {
    *  stop from a command error without parsing the message. */
   onConnectionLost?: () => void;
 }
+
+/** Sentinel port for the network / OTA path (vs. a server serial device path
+ *  like ``/dev/cu.usbserial-110``), carried by ``firmware/install*`` and the
+ *  ``devices/logs`` stream. */
+export const OTA_PORT = "OTA";

--- a/src/api/types/streaming.ts
+++ b/src/api/types/streaming.ts
@@ -1,8 +1,13 @@
 /**
- * Streaming command callbacks.
+ * Streaming command callbacks and the shared OTA port sentinel.
  *
  * Part of the src/api/types.ts barrel split.
  */
+
+/** Sentinel port for the network / OTA path (vs. a server serial device path
+ *  like ``/dev/cu.usbserial-110``), carried by ``firmware/install*`` and the
+ *  ``devices/logs`` stream. */
+export const OTA_PORT = "OTA";
 
 // ─── Streaming Commands ──────────────────────────────────────
 
@@ -17,8 +22,3 @@ export interface StreamCallbacks<TResult = { success: boolean; code: number }> {
    *  stop from a command error without parsing the message. */
   onConnectionLost?: () => void;
 }
-
-/** Sentinel port for the network / OTA path (vs. a server serial device path
- *  like ``/dev/cu.usbserial-110``), carried by ``firmware/install*`` and the
- *  ``devices/logs`` stream. */
-export const OTA_PORT = "OTA";

--- a/src/components/apply-install-method.ts
+++ b/src/components/apply-install-method.ts
@@ -1,6 +1,6 @@
 import type { ConfiguredDevice } from "../api/types/devices.js";
+import { OTA_PORT } from "../api/types/firmware-jobs.js";
 import type { ESPHomeFirmwareInstallDialog } from "./firmware-install-dialog.js";
-import { OTA_PORT } from "./logs-session.js";
 
 export interface InstallMethodHandlers {
   device: ConfiguredDevice;

--- a/src/components/apply-install-method.ts
+++ b/src/components/apply-install-method.ts
@@ -1,5 +1,5 @@
 import type { ConfiguredDevice } from "../api/types/devices.js";
-import { OTA_PORT } from "../api/types/firmware-jobs.js";
+import { OTA_PORT } from "../api/types/streaming.js";
 import type { ESPHomeFirmwareInstallDialog } from "./firmware-install-dialog.js";
 
 export interface InstallMethodHandlers {

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -18,8 +18,8 @@ import type { ESPHomeAPI } from "../api/index.js";
 import type { ConfiguredDevice } from "../api/types/devices.js";
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
 import { JobSource, JobStatus } from "../api/types/firmware-jobs.js";
-import { OTA_PORT } from "../api/types/firmware-jobs.js";
 import type { PairingSummary } from "../api/types/remote-build.js";
+import { OTA_PORT } from "../api/types/streaming.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type { RemoteBuildJobState } from "../context/index.js";
 import {

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -18,6 +18,7 @@ import type { ESPHomeAPI } from "../api/index.js";
 import type { ConfiguredDevice } from "../api/types/devices.js";
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
 import { JobSource, JobStatus } from "../api/types/firmware-jobs.js";
+import { OTA_PORT } from "../api/types/firmware-jobs.js";
 import type { PairingSummary } from "../api/types/remote-build.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type { RemoteBuildJobState } from "../context/index.js";
@@ -69,7 +70,6 @@ import {
   showRunTimer,
 } from "./command-dialog/renderers.js";
 import { commandDialogStyles } from "./command-dialog/styles.js";
-import { OTA_PORT } from "./logs-session.js";
 import type { ESPHomeProcessTerminal } from "./process-terminal/process-terminal.js";
 import {
   fillTerminalOnMobile,

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -1,7 +1,7 @@
 import { APIError } from "../../api/api-error.js";
 import { type FirmwareJob, JobStatus, JobType } from "../../api/types/firmware-jobs.js";
-import { OTA_PORT } from "../../api/types/firmware-jobs.js";
 import { ErrorCode } from "../../api/types/protocol.js";
+import { OTA_PORT } from "../../api/types/streaming.js";
 import { isTerminalJob, isTerminalJobStatus } from "../../util/firmware-job-status.js";
 import { isNeverFlashed } from "../../util/never-flashed.js";
 import { resumeFollowOnReady } from "../../util/resume-follow.js";

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -1,5 +1,6 @@
 import { APIError } from "../../api/api-error.js";
 import { type FirmwareJob, JobStatus, JobType } from "../../api/types/firmware-jobs.js";
+import { OTA_PORT } from "../../api/types/firmware-jobs.js";
 import { ErrorCode } from "../../api/types/protocol.js";
 import { isTerminalJob, isTerminalJobStatus } from "../../util/firmware-job-status.js";
 import { isNeverFlashed } from "../../util/never-flashed.js";
@@ -7,7 +8,6 @@ import { resumeFollowOnReady } from "../../util/resume-follow.js";
 import { isValidationFailureLine } from "../../util/validation-log.js";
 import { classifyNoCompatiblePeerReason } from "../../util/version-mismatch.js";
 import type { CommandType, ESPHomeCommandDialog } from "../command-dialog.js";
-import { OTA_PORT } from "../logs-session.js";
 
 const JOB_TYPE_TO_COMMAND: Record<JobType, CommandType> = {
   [JobType.COMPILE]: "compile",

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -3,6 +3,7 @@ import {
   JobSource,
   JobStatus,
 } from "../../api/types/firmware-jobs.js";
+import { OTA_PORT } from "../../api/types/firmware-jobs.js";
 import { fetchBoard } from "../../util/board-body-cache.js";
 import { chipNameToVariant, chipPlatformFamily } from "../../util/chip-variant.js";
 import { triggerDownload } from "../../util/download-text.js";
@@ -23,7 +24,6 @@ import {
   UnsupportedChipError,
 } from "../../util/web-serial.js";
 import type { ESPHomeFirmwareInstallDialog } from "../firmware-install-dialog.js";
-import { OTA_PORT } from "../logs-session.js";
 
 export function compileFailureDetail(err: unknown): string {
   return err instanceof Error ? err.message.trim() : String(err ?? "").trim();

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -3,7 +3,7 @@ import {
   JobSource,
   JobStatus,
 } from "../../api/types/firmware-jobs.js";
-import { OTA_PORT } from "../../api/types/firmware-jobs.js";
+import { OTA_PORT } from "../../api/types/streaming.js";
 import { fetchBoard } from "../../util/board-body-cache.js";
 import { chipNameToVariant, chipPlatformFamily } from "../../util/chip-variant.js";
 import { triggerDownload } from "../../util/download-text.js";

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -16,7 +16,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import { DeviceState } from "../api/types/devices.js";
-import { OTA_PORT } from "../api/types/firmware-jobs.js";
+import { OTA_PORT } from "../api/types/streaming.js";
 import { esphomeWebUrl } from "../common/docs.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -16,6 +16,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import { DeviceState } from "../api/types/devices.js";
+import { OTA_PORT } from "../api/types/firmware-jobs.js";
 import { esphomeWebUrl } from "../common/docs.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
@@ -47,7 +48,6 @@ import {
   renderServerSerialOption,
 } from "./install-method-dialog-rows.js";
 import { installMethodDialogStyles } from "./install-method-dialog.styles.js";
-import { OTA_PORT } from "./logs-session.js";
 import { renderDisclosure } from "./shared/disclosure.js";
 import {
   renderSerialPortBadges,

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -14,6 +14,7 @@ import {
 import { html, LitElement } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
+import { OTA_PORT } from "../api/types/firmware-jobs.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
   apiConnectedContext,
@@ -56,7 +57,6 @@ import {
   isPassive,
   isStreaming,
   type LogsSession,
-  OTA_PORT,
 } from "./logs-session.js";
 import {
   crashCalloutStyles,

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -14,7 +14,7 @@ import {
 import { html, LitElement } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
-import { OTA_PORT } from "../api/types/firmware-jobs.js";
+import { OTA_PORT } from "../api/types/streaming.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
   apiConnectedContext,

--- a/src/components/logs-dialog/session.ts
+++ b/src/components/logs-dialog/session.ts
@@ -1,10 +1,10 @@
-import { OTA_PORT } from "../../api/types/firmware-jobs.js";
 /**
  * The logs dialog's log source and its lifecycle.
  *
  * Every transition of ``host._session`` lives here; the element renders it and
  * owns nothing about how a stream is started, paused, or torn down.
  */
+import { OTA_PORT } from "../../api/types/streaming.js";
 import { notifyError } from "../../util/notify.js";
 import type { ESPHomeLogsDialog } from "../logs-dialog.js";
 import { isPassive, isStreaming } from "../logs-session.js";

--- a/src/components/logs-dialog/session.ts
+++ b/src/components/logs-dialog/session.ts
@@ -1,3 +1,4 @@
+import { OTA_PORT } from "../../api/types/firmware-jobs.js";
 /**
  * The logs dialog's log source and its lifecycle.
  *
@@ -6,7 +7,7 @@
  */
 import { notifyError } from "../../util/notify.js";
 import type { ESPHomeLogsDialog } from "../logs-dialog.js";
-import { isPassive, isStreaming, OTA_PORT } from "../logs-session.js";
+import { isPassive, isStreaming } from "../logs-session.js";
 
 /** Open on a backend OTA / server-serial stream for *port*. */
 export function openOta(

--- a/src/components/logs-session.ts
+++ b/src/components/logs-session.ts
@@ -1,3 +1,5 @@
+import { OTA_PORT } from "../api/types/firmware-jobs.js";
+
 /**
  * State machine for the logs dialog's active session.
  *
@@ -44,12 +46,6 @@ export type LogsSession =
       readonly paused: boolean;
     }
   | { readonly kind: "dead" };
-
-/** Sentinel ``ota`` port for the network / OTA log source (as opposed to a
- *  server serial device path like ``/dev/cu.usbserial-110``). Both run through
- *  the backend ``logs`` WS subscription and so share the ``ota`` session kind;
- *  the port is what tells them apart. */
-export const OTA_PORT = "OTA";
 
 /** Whether the streaming dot / Stop button should show (vs. the Start button). */
 export const isStreaming = (s: LogsSession): boolean =>

--- a/src/components/logs-session.ts
+++ b/src/components/logs-session.ts
@@ -1,5 +1,3 @@
-import { OTA_PORT } from "../api/types/firmware-jobs.js";
-
 /**
  * State machine for the logs dialog's active session.
  *
@@ -27,6 +25,7 @@ import { OTA_PORT } from "../api/types/firmware-jobs.js";
  * - ``dead``         a Web Serial reopen failed; the port is gone. Start runs
  *                    the reconnect hook (the #636 "click Start to reconnect").
  */
+import { OTA_PORT } from "../api/types/streaming.js";
 export type LogsSession =
   | { readonly kind: "idle" }
   | {

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -1,4 +1,4 @@
-import { OTA_PORT } from "../api/types/firmware-jobs.js";
+import { OTA_PORT } from "../api/types/streaming.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { streamSerialToDialog } from "../components/dashboard/actions.js";
 import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -1,7 +1,7 @@
+import { OTA_PORT } from "../api/types/firmware-jobs.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { streamSerialToDialog } from "../components/dashboard/actions.js";
 import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";
-import { OTA_PORT } from "../components/logs-session.js";
 import { resolveLogBaudRate } from "./log-baud-rate.js";
 import { notifyError, notifyInfo } from "./notify.js";
 import { serialConsoleMismatch } from "./serial-console-match.js";

--- a/test/components/logs-dialog-quiet-serial.test.ts
+++ b/test/components/logs-dialog-quiet-serial.test.ts
@@ -8,8 +8,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { call, makeLogsDialog, session } from "./_logs-dialog-env.js";
 
+import { OTA_PORT } from "../../src/api/types/firmware-jobs.js";
 import { switchToOtaLogs } from "../../src/components/logs-dialog/session.js";
-import { OTA_PORT } from "../../src/components/logs-session.js";
 import type { ESPHomeLogsDialog } from "./_logs-dialog-env.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/test/components/logs-dialog-quiet-serial.test.ts
+++ b/test/components/logs-dialog-quiet-serial.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { call, makeLogsDialog, session } from "./_logs-dialog-env.js";
 
-import { OTA_PORT } from "../../src/api/types/firmware-jobs.js";
+import { OTA_PORT } from "../../src/api/types/streaming.js";
 import { switchToOtaLogs } from "../../src/components/logs-dialog/session.js";
 import type { ESPHomeLogsDialog } from "./_logs-dialog-env.js";
 

--- a/test/components/logs-session.test.ts
+++ b/test/components/logs-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { OTA_PORT } from "../../src/api/types/firmware-jobs.js";
+import { OTA_PORT } from "../../src/api/types/streaming.js";
 import {
   hasSerialPort,
   isOtaNetwork,

--- a/test/components/logs-session.test.ts
+++ b/test/components/logs-session.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { OTA_PORT } from "../../src/api/types/firmware-jobs.js";
 import {
   hasSerialPort,
   isOtaNetwork,
   isPassive,
   isStreaming,
   type LogsSession,
-  OTA_PORT,
 } from "../../src/components/logs-session.js";
 
 const fakePort = {} as SerialPort;


### PR DESCRIPTION
# What does this implement/fix?

Moves the `OTA_PORT` sentinel from `components/logs-session.ts` to `api/types/streaming.ts`, a neutral home since both `firmware/install*` and the `devices/logs` stream carry it. Every consumer changes only its import path, and the two remaining bare "OTA" defaults in `esphome-api.ts` now use the constant since the transport layer can import its own types without a layering inversion; the sentinel has one home.

**Related issue or feature (if applicable):**

- fixes #1625

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
