### PR TITLE
Prefill the offloader label with the name the receiver will display

### DIFF
--- a/src/api/types/protocol.ts
+++ b/src/api/types/protocol.ts
@@ -39,6 +39,9 @@ export interface ServerInfoMessage {
   esphome_version: string;
   port: number;
   ha_addon: boolean;
+  /** The dashboard's advertised display name (mDNS TXT / pairing
+   * handshake); absent on older backends. */
+  friendly_name?: string;
   /** True only when served through HA Supervisor ingress (the panel
    * iframe). Distinct from ha_addon, which is also true when the add-on
    * is reached directly on its exposed port. Drives the slim header. */

--- a/src/api/types/protocol.ts
+++ b/src/api/types/protocol.ts
@@ -40,8 +40,9 @@ export interface ServerInfoMessage {
   port: number;
   ha_addon: boolean;
   /** The dashboard's advertised display name (mDNS TXT / pairing
-   * handshake); "" on a connection that still needs the in-band
-   * auth handshake. */
+   * handshake); "" for the lifetime of a connection that required
+   * the in-band auth handshake (server info is sent once, pre-auth,
+   * and never re-pushed). */
   friendly_name: string;
   /** True only when served through HA Supervisor ingress (the panel
    * iframe). Distinct from ha_addon, which is also true when the add-on

--- a/src/api/types/protocol.ts
+++ b/src/api/types/protocol.ts
@@ -40,8 +40,9 @@ export interface ServerInfoMessage {
   port: number;
   ha_addon: boolean;
   /** The dashboard's advertised display name (mDNS TXT / pairing
-   * handshake); absent on older backends. */
-  friendly_name?: string;
+   * handshake); "" on a connection that still needs the in-band
+   * auth handshake. */
+  friendly_name: string;
   /** True only when served through HA Supervisor ingress (the panel
    * iframe). Distinct from ha_addon, which is also true when the add-on
    * is reached directly on its exposed port. Drives the slim header. */

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -19,6 +19,7 @@ import { pinHexStyles } from "../styles/pin-hex.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { EnterController } from "../util/enter-controller.js";
 import { friendlyHostname, parsePortInput } from "../util/hostname.js";
+import { offloaderSelfLabel } from "../util/pairing-display-name.js";
 import "./base-dialog.js";
 import {
   onConfirmSubmit,
@@ -88,7 +89,8 @@ export class ESPHomePairBuildServerDialog extends LitElement {
 
   // Mirrors _receiverLabelTouched for the offloader-label field. An
   // untouched prefill is sent as offloader_label_auto so the receiver's
-  // UI may replace it with this dashboard's advertised friendly name.
+  // display keeps tracking this dashboard's advertised name; the prefill
+  // already shows that same resolution.
   @state() _offloaderLabelTouched = false;
 
   // True when the confirm step was reached by auto-preview (mDNS-discovered
@@ -151,12 +153,13 @@ export class ESPHomePairBuildServerDialog extends LitElement {
     this._port = prefill?.port !== undefined ? String(prefill.port) : "6055";
     this._previewedPin = "";
     // Pre-fill the receiver label from the caller-supplied friendly_name,
-    // falling back to one derived from the hostname. The offloader label is
-    // sourced from window.location.hostname and doesn't auto-update afterwards.
+    // falling back to one derived from the hostname. The offloader label
+    // prefill is the same resolution the receiver applies to a still-auto
+    // label, so the field shows what the receiver will display.
     this._receiverLabel =
       prefill?.receiverLabel?.trim() || friendlyHostname(this._hostname);
     this._receiverLabelTouched = false;
-    this._offloaderLabel = friendlyHostname(window.location.hostname);
+    this._offloaderLabel = offloaderSelfLabel(this._api?.serverInfo);
     this._offloaderLabelTouched = false;
     this._pairingKey = "";
     this._pairingKeyRequired = false;

--- a/src/components/reauth-wizard-dialog.ts
+++ b/src/components/reauth-wizard-dialog.ts
@@ -16,8 +16,10 @@ import { pinHexStyles } from "../styles/pin-hex.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { fireEvent } from "../util/fire-event.js";
 import { trimTrailingDot } from "../util/hostname.js";
-import { offloaderSelfLabel } from "../util/pairing-display-name.js";
-import { pairingDisplayNameForPin } from "../util/pairing-display-name.js";
+import {
+  offloaderSelfLabel,
+  pairingDisplayNameForPin,
+} from "../util/pairing-display-name.js";
 import { formatPinSha256 } from "../util/pin-format.js";
 import {
   buildReauthPairRequest,

--- a/src/components/reauth-wizard-dialog.ts
+++ b/src/components/reauth-wizard-dialog.ts
@@ -15,7 +15,8 @@ import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { fireEvent } from "../util/fire-event.js";
-import { friendlyHostname, trimTrailingDot } from "../util/hostname.js";
+import { trimTrailingDot } from "../util/hostname.js";
+import { offloaderSelfLabel } from "../util/pairing-display-name.js";
 import { pairingDisplayNameForPin } from "../util/pairing-display-name.js";
 import { formatPinSha256 } from "../util/pin-format.js";
 import {
@@ -217,10 +218,7 @@ export class ESPHomeReauthWizardDialog extends LitElement {
     // rejects on mismatch -- which is how the wizard's
     // verification cryptographically binds to the eventual
     // stored pairing.
-    const args = buildReauthPairRequest(
-      alert,
-      friendlyHostname(window.location.hostname)
-    );
+    const args = buildReauthPairRequest(alert, offloaderSelfLabel(this._api.serverInfo));
     this._busy = true;
     this._errorKey = null;
     let summary: PairingSummary;

--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -403,8 +403,9 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
       {
         hostname: peer.hostname,
         port: peer.remote_build_port > 0 ? peer.remote_build_port : undefined,
-        // Seed the receiver label from the friendly_name.
-        receiverLabel: peer.friendly_name || undefined,
+        // Seed the receiver label as the discovery row displays it, so the
+        // prefill matches what the pairings list will later show.
+        receiverLabel: remoteBuildPeerName(peer),
       },
       // Host + peer-link port are known from mDNS — skip the manual entry step
       // and preview the fingerprint straight away.

--- a/src/util/pairing-display-name.ts
+++ b/src/util/pairing-display-name.ts
@@ -1,4 +1,5 @@
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
+import type { ServerInfoMessage } from "../api/types/protocol.js";
 import type { PairingSummary, PeerSummary } from "../api/types/remote-build.js";
 import { friendlyHostname } from "./hostname.js";
 import { remoteBuildPeerName } from "./remote-build-peer-name.js";
@@ -11,7 +12,7 @@ import { remoteBuildPeerName } from "./remote-build-peer-name.js";
  * the reauth re-pair's offloader_label.
  */
 export function offloaderSelfLabel(
-  serverInfo: { friendly_name?: string; ha_addon?: boolean } | null | undefined
+  serverInfo: Pick<ServerInfoMessage, "friendly_name" | "ha_addon"> | null | undefined
 ): string {
   const host = typeof window === "undefined" ? "" : window.location.hostname;
   return remoteBuildPeerName({

--- a/src/util/pairing-display-name.ts
+++ b/src/util/pairing-display-name.ts
@@ -6,10 +6,11 @@ import { remoteBuildPeerName } from "./remote-build-peer-name.js";
 
 /**
  * This dashboard's own display name, as a receiver shows it: the
- * advertised friendly name resolved like a still-auto peer label,
- * falling back to the browser URL host when the backend withheld
- * the name (pre-auth connection). Prefills "How this dashboard
- * introduces itself" and the reauth re-pair's offloader_label.
+ * advertised friendly name resolved like a still-auto peer label;
+ * when the backend withheld the name (pre-auth connection) it falls
+ * back to the ha_addon mapping, then the browser URL host. Prefills
+ * "How this dashboard introduces itself" and the reauth re-pair's
+ * offloader_label.
  */
 export function offloaderSelfLabel(
   serverInfo: Pick<ServerInfoMessage, "friendly_name" | "ha_addon"> | null | undefined

--- a/src/util/pairing-display-name.ts
+++ b/src/util/pairing-display-name.ts
@@ -7,9 +7,9 @@ import { remoteBuildPeerName } from "./remote-build-peer-name.js";
 /**
  * This dashboard's own display name, as a receiver shows it: the
  * advertised friendly name resolved like a still-auto peer label,
- * falling back to the browser URL host without serverInfo (older
- * backends). Prefills "How this dashboard introduces itself" and
- * the reauth re-pair's offloader_label.
+ * falling back to the browser URL host when the backend withheld
+ * the name (pre-auth connection). Prefills "How this dashboard
+ * introduces itself" and the reauth re-pair's offloader_label.
  */
 export function offloaderSelfLabel(
   serverInfo: Pick<ServerInfoMessage, "friendly_name" | "ha_addon"> | null | undefined

--- a/src/util/pairing-display-name.ts
+++ b/src/util/pairing-display-name.ts
@@ -1,6 +1,25 @@
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
 import type { PairingSummary, PeerSummary } from "../api/types/remote-build.js";
+import { friendlyHostname } from "./hostname.js";
 import { remoteBuildPeerName } from "./remote-build-peer-name.js";
+
+/**
+ * This dashboard's own display name, as a receiver shows it: the
+ * advertised friendly name resolved like a still-auto peer label,
+ * falling back to the browser URL host without serverInfo (older
+ * backends). Prefills "How this dashboard introduces itself" and
+ * the reauth re-pair's offloader_label.
+ */
+export function offloaderSelfLabel(
+  serverInfo: { friendly_name?: string; ha_addon?: boolean } | null | undefined
+): string {
+  const host = typeof window === "undefined" ? "" : window.location.hostname;
+  return remoteBuildPeerName({
+    friendly_name: serverInfo?.friendly_name,
+    name: friendlyHostname(host),
+    ha_addon: serverInfo?.ha_addon,
+  });
+}
 
 /**
  * Display name for a paired build server (offloader side).

--- a/test/components/build-offload-section/pair-discovered-prefill.test.ts
+++ b/test/components/build-offload-section/pair-discovered-prefill.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that a discovered host's pair-dialog prefill seeds the receiver label
+ * as the discovery row displays it (``remoteBuildPeerName``), so the field
+ * matches what the pairings list will later show.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { RemoteBuildPeer } from "../../../src/api/types/remote-build.js";
+import { ESPHomeSettingsBuildOffload } from "../../../src/components/settings-dialog/build-offload-section.js";
+
+function peer(overrides: Partial<RemoteBuildPeer> = {}): RemoteBuildPeer {
+  return {
+    name: "esphome-builder-xnnspgdv",
+    hostname: "buildbox.local",
+    port: 6052,
+    source: "mdns",
+    addresses: ["192.168.1.10"],
+    server_version: "0.1.0",
+    esphome_version: "2026.5.0",
+    friendly_name: "",
+    pin_sha256: "abc",
+    remote_build_port: 6055,
+    ...overrides,
+  };
+}
+
+function openArgsFor(p: RemoteBuildPeer) {
+  const section = new ESPHomeSettingsBuildOffload();
+  const open = vi.fn();
+  // _pairDialog is a @query getter; shadow it on the instance.
+  Object.defineProperty(section, "_pairDialog", { value: { open } });
+  (
+    section as unknown as { _onPairDiscovered: (p: RemoteBuildPeer) => void }
+  )._onPairDiscovered(p);
+  expect(open).toHaveBeenCalledOnce();
+  return open.mock.calls[0][0] as { receiverLabel?: string };
+}
+
+describe("discovered-host pair prefill", () => {
+  it("seeds the receiver label from the friendly name", () => {
+    expect(openArgsFor(peer({ friendly_name: "nas" })).receiverLabel).toBe("nas");
+  });
+
+  it("falls back to the instance name when no friendly name broadcast", () => {
+    expect(openArgsFor(peer()).receiverLabel).toBe("esphome-builder-xnnspgdv");
+  });
+
+  it("maps an HA add-on receiver like the discovery row does", () => {
+    expect(openArgsFor(peer({ friendly_name: "a1b2c3d4-esphome" })).receiverLabel).toBe(
+      "Home Assistant App"
+    );
+  });
+});

--- a/test/components/pair-build-server-dialog/open-orchestration.test.ts
+++ b/test/components/pair-build-server-dialog/open-orchestration.test.ts
@@ -133,4 +133,10 @@ describe("pair dialog open() auto-preview orchestration", () => {
     d.open();
     expect(d._offloaderLabel).toBe(friendlyHostname(window.location.hostname));
   });
+
+  it("falls back to the browser host when the backend withheld the name", () => {
+    const d = makeDialog(makeApi({ friendly_name: "", ha_addon: false }));
+    d.open();
+    expect(d._offloaderLabel).toBe(friendlyHostname(window.location.hostname));
+  });
 });

--- a/test/components/pair-build-server-dialog/open-orchestration.test.ts
+++ b/test/components/pair-build-server-dialog/open-orchestration.test.ts
@@ -12,9 +12,11 @@ import "../../_mock-webawesome.js";
 
 import { identityLocalize } from "../../_dom.js";
 import { ESPHomePairBuildServerDialog } from "../../../src/components/pair-build-server-dialog.js";
+import { friendlyHostname } from "../../../src/util/hostname.js";
 
-function makeApi() {
+function makeApi(serverInfo?: { friendly_name?: string; ha_addon?: boolean }) {
   return {
+    serverInfo,
     getRemoteBuildIdentity: vi.fn(async () => ({
       dashboard_id: "x",
       pin_sha256: "p",
@@ -115,5 +117,20 @@ describe("pair dialog open() auto-preview orchestration", () => {
     const d = makeDialog(api);
     d.open({ hostname: "buildbox.local", port: 6055 });
     expect(d._receiverLabel).toBe("buildbox");
+  });
+
+  // The offloader-label prefill mirrors the receiver's still-auto-label
+  // resolution: what the field shows is what the receiver displays.
+  it("prefills the offloader label from the advertised friendly name", () => {
+    const d = makeDialog(makeApi({ friendly_name: "nas", ha_addon: false }));
+    d.open();
+    expect(d._offloaderLabel).toBe("nas");
+    expect(d._offloaderLabelTouched).toBe(false);
+  });
+
+  it("falls back to the browser host for the offloader label without serverInfo", () => {
+    const d = makeDialog(makeApi());
+    d.open();
+    expect(d._offloaderLabel).toBe(friendlyHostname(window.location.hostname));
   });
 });

--- a/test/components/reauth-wizard-dialog-label.test.ts
+++ b/test/components/reauth-wizard-dialog-label.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that the re-pair request introduces this dashboard with the same
+ * resolved self-label the fresh-pair dialog prefills (``offloaderSelfLabel``
+ * over ``serverInfo``), while the OOB-verified pin still binds the request.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { OffloaderPinMismatchAlert } from "../../src/api/types/remote-build-events.js";
+import { ESPHomeReauthWizardDialog } from "../../src/components/reauth-wizard-dialog.js";
+
+const alert: OffloaderPinMismatchAlert = {
+  kind: "pin_mismatch",
+  receiver_hostname: "buildbox.local",
+  receiver_port: 6055,
+  pin_sha256: "a".repeat(64),
+  receiver_label: "buildbox",
+  expected_pin: "a".repeat(64),
+  observed_pin: "b".repeat(64),
+  fired_at: 1,
+};
+
+describe("reauth re-pair offloader label", () => {
+  it("sources the sent label from serverInfo via offloaderSelfLabel", async () => {
+    const d = new ESPHomeReauthWizardDialog();
+    const requestRemoteBuildPair = vi.fn(async (..._args: unknown[]) => ({
+      pin_sha256: alert.observed_pin,
+    }));
+    Object.assign(d as unknown as Record<string, unknown>, {
+      _api: {
+        serverInfo: { friendly_name: "a1b2c3d4-esphome", ha_addon: true },
+        requestRemoteBuildPair,
+      },
+      _alert: alert,
+      _verified: true,
+    });
+    await (d as unknown as { _onConfirm: () => Promise<void> })._onConfirm();
+    expect(requestRemoteBuildPair).toHaveBeenCalledOnce();
+    const args = requestRemoteBuildPair.mock.calls[0][0] as unknown as {
+      offloader_label: string;
+      pin_sha256: string;
+    };
+    expect(args.offloader_label).toBe("Home Assistant App");
+    // The security contract rides along untouched.
+    expect(args.pin_sha256).toBe(alert.observed_pin);
+  });
+});

--- a/test/util/pairing-display-name.test.ts
+++ b/test/util/pairing-display-name.test.ts
@@ -120,6 +120,12 @@ describe("offloaderSelfLabel", () => {
     expect(offloaderSelfLabel({ friendly_name: "nas", ha_addon: false })).toBe("nas");
   });
 
+  it("maps a withheld name on an add-on to the app label", () => {
+    expect(offloaderSelfLabel({ friendly_name: "", ha_addon: true })).toBe(
+      "Home Assistant App"
+    );
+  });
+
   it("maps the HA add-on container hostname, flavors included", () => {
     expect(
       offloaderSelfLabel({ friendly_name: "a1b2c3d4-esphome", ha_addon: true })

--- a/test/util/pairing-display-name.test.ts
+++ b/test/util/pairing-display-name.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { PairingSummary, PeerSummary } from "../../src/api/types/remote-build.js";
 import {
   jobPeerDisplayName,
+  offloaderSelfLabel,
   pairingDisplayName,
   pairingDisplayNameForPin,
   peerDisplayName,
@@ -111,6 +112,24 @@ describe("peerDisplayName", () => {
 
   it("keeps the label when no friendly name arrived", () => {
     expect(peerDisplayName(peer({ label_auto: true }))).toBe("localhost");
+  });
+});
+
+describe("offloaderSelfLabel", () => {
+  it("resolves the advertised friendly name", () => {
+    expect(offloaderSelfLabel({ friendly_name: "nas", ha_addon: false })).toBe("nas");
+  });
+
+  it("maps the HA add-on container hostname, flavors included", () => {
+    expect(
+      offloaderSelfLabel({ friendly_name: "a1b2c3d4-esphome", ha_addon: true })
+    ).toBe("Home Assistant App");
+    expect(
+      offloaderSelfLabel({ friendly_name: "a1b2c3d4-esphome-beta", ha_addon: true })
+    ).toBe("Home Assistant App (Beta)");
+    expect(offloaderSelfLabel({ friendly_name: "renamed-host", ha_addon: true })).toBe(
+      "Home Assistant App"
+    );
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

The pair dialog's "How this dashboard introduces itself" field prefilled with the browser URL host, but an untouched prefill is sent as `offloader_label_auto`, so the receiver shows the advertised friendly name instead; on an HA add-on the user saw their HA hostname while the receiver admin saw "Home Assistant App". The prefill now resolves through the new `offloaderSelfLabel` helper, the same resolution the receiver applies to a still-auto label, using `ServerInfoMessage.friendly_name` from the companion backend PR; when the backend withholds the name on a pre-auth connection the browser host fallback keeps today's behavior. The reauth re-pair path sends the same label, and the discovered-host receiver-label prefill now seeds `remoteBuildPeerName(peer)` so that field also matches what the pairings list will display.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2521
- companion backend PR: esphome/device-builder#2526

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
