### PR TITLE
Patch the peers list from the peer-refreshed event

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -2148,6 +2148,7 @@ export class ESPHomeAPI {
   // ``subscribe_events``'s ``initial_state.peers`` field at
   // subscribe time + the three live events
   // (``REMOTE_BUILD_PAIR_REQUEST_RECEIVED`` /
+  // ``REMOTE_BUILD_PEER_REFRESHED`` /
   // ``REMOTE_BUILD_PAIR_STATUS_CHANGED``) drive every mutation.
   // A separate ``list_peers`` snapshot read would be a redundant
   // round-trip on the WS the frontend already has open.

--- a/src/api/types/event-subscription.ts
+++ b/src/api/types/event-subscription.ts
@@ -49,10 +49,9 @@ export enum DeviceEventType {
   REMOTE_BUILD_IDENTITY_ROTATED = "remote_build_identity_rotated",
   REMOTE_BUILD_LISTENER_CHANGED = "remote_build_listener_changed",
   REMOTE_BUILD_PAIR_REQUEST_RECEIVED = "remote_build_pair_request_received",
-  // Re-pair against an APPROVED row refreshed its introduction fields.
-  REMOTE_BUILD_PEER_REFRESHED = "remote_build_peer_refreshed",
   REMOTE_BUILD_PAIR_STATUS_CHANGED = "remote_build_pair_status_changed",
   REMOTE_BUILD_PAIRING_WINDOW_CHANGED = "remote_build_pairing_window_changed",
+  REMOTE_BUILD_PEER_REFRESHED = "remote_build_peer_refreshed",
   // Offloader-side counterpart to ``REMOTE_BUILD_PAIR_STATUS_CHANGED``;
   // fires from the offloader's pair-status listener task and from
   // ``remote_build/unpair``.

--- a/src/api/types/event-subscription.ts
+++ b/src/api/types/event-subscription.ts
@@ -49,6 +49,8 @@ export enum DeviceEventType {
   REMOTE_BUILD_IDENTITY_ROTATED = "remote_build_identity_rotated",
   REMOTE_BUILD_LISTENER_CHANGED = "remote_build_listener_changed",
   REMOTE_BUILD_PAIR_REQUEST_RECEIVED = "remote_build_pair_request_received",
+  // Re-pair against an APPROVED row refreshed its introduction fields.
+  REMOTE_BUILD_PEER_REFRESHED = "remote_build_peer_refreshed",
   REMOTE_BUILD_PAIR_STATUS_CHANGED = "remote_build_pair_status_changed",
   REMOTE_BUILD_PAIRING_WINDOW_CHANGED = "remote_build_pairing_window_changed",
   // Offloader-side counterpart to ``REMOTE_BUILD_PAIR_STATUS_CHANGED``;

--- a/src/api/types/event-subscription.ts
+++ b/src/api/types/event-subscription.ts
@@ -179,6 +179,7 @@ export interface InitialStateEventData {
    *  Accept / Reject) and APPROVED (persisted) rows. Live updates
    *  flow through the same ``subscribe_events`` stream as
    *  ``REMOTE_BUILD_PAIR_REQUEST_RECEIVED`` (upsert),
+   *  ``REMOTE_BUILD_PEER_REFRESHED`` (introduction-field patch),
    *  ``REMOTE_BUILD_PAIR_STATUS_CHANGED`` (status flip / row
    *  drop) events. Optional for the same reason as
    *  ``pairings`` — absent controller, omitted field. */

--- a/src/api/types/remote-build-events.ts
+++ b/src/api/types/remote-build-events.ts
@@ -8,6 +8,7 @@ import { JobStatus } from "./firmware-jobs.js";
 import type {
   PairingSummary,
   PairingWindowState,
+  PeerSummary,
   RemoteBuildPeer,
 } from "./remote-build.js";
 
@@ -45,9 +46,11 @@ export interface RemoteBuildPairRequestReceivedEventData {
  * refreshed its introduction fields; carries the refreshed row
  * minus ``status``/``connected``, so the peers list patches
  * from the event alone with both left as they were.
- * ``paired_at`` is always the original pair time.
+ * ``paired_at`` is always the original pair time. Declared off
+ * the row shape so the handler's spread can't silently widen
+ * with another event's payload.
  */
-export type RemoteBuildPeerRefreshedEventData = RemoteBuildPairRequestReceivedEventData;
+export type RemoteBuildPeerRefreshedEventData = Omit<PeerSummary, "status" | "connected">;
 
 /**
  * Data payload for the ``remote_build_pair_status_changed`` event.

--- a/src/api/types/remote-build-events.ts
+++ b/src/api/types/remote-build-events.ts
@@ -39,6 +39,16 @@ export interface RemoteBuildPairRequestReceivedEventData {
 }
 
 /**
+ * Data payload for the ``remote_build_peer_refreshed`` event.
+ *
+ * Receiver-side. A re-pair against an existing APPROVED row
+ * refreshed its introduction fields; carries the full refreshed
+ * row so the peers list patches from the event alone, leaving
+ * ``status`` and ``connected`` as they were.
+ */
+export type RemoteBuildPeerRefreshedEventData = RemoteBuildPairRequestReceivedEventData;
+
+/**
  * Data payload for the ``remote_build_pair_status_changed`` event.
  *
  * Receiver-side. Fires from three paths: ``approve_peer``

--- a/src/api/types/remote-build-events.ts
+++ b/src/api/types/remote-build-events.ts
@@ -42,9 +42,9 @@ export interface RemoteBuildPairRequestReceivedEventData {
  * Data payload for the ``remote_build_peer_refreshed`` event.
  *
  * Receiver-side. A re-pair against an existing APPROVED row
- * refreshed its introduction fields; carries the full refreshed
- * row so the peers list patches from the event alone, leaving
- * ``status`` and ``connected`` as they were.
+ * refreshed its introduction fields; carries the refreshed row
+ * minus ``status``/``connected``, so the peers list patches
+ * from the event alone with both left as they were.
  */
 export type RemoteBuildPeerRefreshedEventData = RemoteBuildPairRequestReceivedEventData;
 

--- a/src/api/types/remote-build-events.ts
+++ b/src/api/types/remote-build-events.ts
@@ -45,6 +45,7 @@ export interface RemoteBuildPairRequestReceivedEventData {
  * refreshed its introduction fields; carries the refreshed row
  * minus ``status``/``connected``, so the peers list patches
  * from the event alone with both left as they were.
+ * ``paired_at`` is always the original pair time.
  */
 export type RemoteBuildPeerRefreshedEventData = RemoteBuildPairRequestReceivedEventData;
 

--- a/src/api/types/remote-build.ts
+++ b/src/api/types/remote-build.ts
@@ -55,6 +55,7 @@ export interface PeerSummary {
   dashboard_id: string;
   pin_sha256: string;
   label: string;
+  /** Original pair time; a re-pair never changes it. */
   paired_at: number;
   status: PeerStatus;
   peer_ip: string;

--- a/src/components/app-shell/events.ts
+++ b/src/components/app-shell/events.ts
@@ -233,25 +233,6 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
           : [...current.slice(0, idx), incoming, ...current.slice(idx + 1)];
       break;
     }
-    case DeviceEventType.REMOTE_BUILD_PEER_REFRESHED: {
-      if (host._buildServerPeers === null) break;
-      const evt = data as RemoteBuildPeerRefreshedEventData;
-      host._buildServerPeers = host._buildServerPeers.map((p) =>
-        p.dashboard_id === evt.dashboard_id
-          ? {
-              ...p,
-              pin_sha256: evt.pin_sha256,
-              label: evt.label,
-              peer_ip: evt.peer_ip,
-              paired_at: evt.paired_at,
-              friendly_name: evt.friendly_name,
-              ha_addon: evt.ha_addon,
-              label_auto: evt.label_auto,
-            }
-          : p
-      );
-      break;
-    }
     case DeviceEventType.REMOTE_BUILD_PAIR_STATUS_CHANGED: {
       const evt = data as RemoteBuildPairStatusChangedEventData;
       const current = host._buildServerPeers ?? [];
@@ -264,6 +245,17 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
           p.dashboard_id === evt.dashboard_id ? { ...p, status: "approved" as const } : p
         );
       }
+      break;
+    }
+    case DeviceEventType.REMOTE_BUILD_PEER_REFRESHED: {
+      // The payload is the row minus status/connected, so the spread patches
+      // exactly the introduction fields (pin_sha256 rides along unchanged —
+      // a differing pin is refused before this event fires).
+      if (host._buildServerPeers === null) break;
+      const evt = data as RemoteBuildPeerRefreshedEventData;
+      host._buildServerPeers = host._buildServerPeers.map((p) =>
+        p.dashboard_id === evt.dashboard_id ? { ...p, ...evt } : p
+      );
       break;
     }
     case DeviceEventType.RECEIVER_PEER_LINK_SESSION_OPENED: {

--- a/src/components/app-shell/events.ts
+++ b/src/components/app-shell/events.ts
@@ -29,6 +29,7 @@ import type {
   RemoteBuildPairingWindowChangedEventData,
   RemoteBuildPairRequestReceivedEventData,
   RemoteBuildPairStatusChangedEventData,
+  RemoteBuildPeerRefreshedEventData,
 } from "../../api/types/remote-build-events.js";
 import type { PairingSummary, PeerSummary } from "../../api/types/remote-build.js";
 import { type RemoteBuildJobState } from "../../context/index.js";
@@ -230,6 +231,25 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
         idx === -1
           ? [...current, incoming]
           : [...current.slice(0, idx), incoming, ...current.slice(idx + 1)];
+      break;
+    }
+    case DeviceEventType.REMOTE_BUILD_PEER_REFRESHED: {
+      if (host._buildServerPeers === null) break;
+      const evt = data as RemoteBuildPeerRefreshedEventData;
+      host._buildServerPeers = host._buildServerPeers.map((p) =>
+        p.dashboard_id === evt.dashboard_id
+          ? {
+              ...p,
+              pin_sha256: evt.pin_sha256,
+              label: evt.label,
+              peer_ip: evt.peer_ip,
+              paired_at: evt.paired_at,
+              friendly_name: evt.friendly_name,
+              ha_addon: evt.ha_addon,
+              label_auto: evt.label_auto,
+            }
+          : p
+      );
       break;
     }
     case DeviceEventType.REMOTE_BUILD_PAIR_STATUS_CHANGED: {

--- a/test/components/app-shell/events-peer-refreshed.test.ts
+++ b/test/components/app-shell/events-peer-refreshed.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { DeviceEventType } from "../../../src/api/types/event-subscription.js";
+import type { RemoteBuildPeerRefreshedEventData } from "../../../src/api/types/remote-build-events.js";
+import type { PeerSummary } from "../../../src/api/types/remote-build.js";
+import type { ESPHomeApp } from "../../../src/components/app-shell.js";
+import { handleEvent } from "../../../src/components/app-shell/events.js";
+
+function makePeer(dashboard_id: string): PeerSummary {
+  return {
+    dashboard_id,
+    pin_sha256: "a".repeat(64),
+    label: "old-label",
+    paired_at: 1,
+    status: "approved",
+    peer_ip: "10.0.0.1",
+    connected: true,
+    friendly_name: "Old-PC",
+    ha_addon: false,
+    label_auto: false,
+  };
+}
+
+function refreshed(dashboard_id: string): RemoteBuildPeerRefreshedEventData {
+  return {
+    dashboard_id,
+    pin_sha256: "a".repeat(64),
+    label: "renamed",
+    peer_ip: "10.0.0.9",
+    paired_at: 2,
+    friendly_name: "Office-PC",
+    ha_addon: true,
+    label_auto: true,
+  };
+}
+
+type Host = Pick<ESPHomeApp, "_buildServerPeers">;
+
+function dispatch(host: Host, evt: RemoteBuildPeerRefreshedEventData): void {
+  handleEvent(host as ESPHomeApp, DeviceEventType.REMOTE_BUILD_PEER_REFRESHED, evt);
+}
+
+describe("handleEvent REMOTE_BUILD_PEER_REFRESHED", () => {
+  it("patches the introduction fields, leaving status and connected alone", () => {
+    const host: Host = { _buildServerPeers: [makePeer("alpha")] };
+
+    dispatch(host, refreshed("alpha"));
+
+    const [row] = host._buildServerPeers ?? [];
+    expect(row.label).toBe("renamed");
+    expect(row.label_auto).toBe(true);
+    expect(row.friendly_name).toBe("Office-PC");
+    expect(row.ha_addon).toBe(true);
+    expect(row.peer_ip).toBe("10.0.0.9");
+    expect(row.paired_at).toBe(2);
+    expect(row.status).toBe("approved");
+    expect(row.connected).toBe(true);
+  });
+
+  it("leaves other rows untouched and no-ops on an unknown dashboard_id", () => {
+    const other = makePeer("beta");
+    const host: Host = { _buildServerPeers: [other] };
+
+    dispatch(host, refreshed("alpha"));
+
+    expect(host._buildServerPeers).toEqual([other]);
+  });
+
+  it("no-ops before the initial snapshot seeded the list", () => {
+    const host: Host = { _buildServerPeers: null };
+
+    dispatch(host, refreshed("alpha"));
+
+    expect(host._buildServerPeers).toBeNull();
+  });
+});

--- a/test/components/app-shell/events-peer-refreshed.test.ts
+++ b/test/components/app-shell/events-peer-refreshed.test.ts
@@ -8,7 +8,8 @@ import { handleEvent } from "../../../src/components/app-shell/events.js";
 function makePeer(dashboard_id: string): PeerSummary {
   return {
     dashboard_id,
-    pin_sha256: "a".repeat(64),
+    // Distinct per row so a widened match predicate can't hide.
+    pin_sha256: dashboard_id[0].repeat(64),
     label: "old-label",
     paired_at: 1,
     status: "approved",
@@ -56,7 +57,19 @@ describe("handleEvent REMOTE_BUILD_PEER_REFRESHED", () => {
     expect(row.connected).toBe(true);
   });
 
-  it("leaves other rows untouched and no-ops on an unknown dashboard_id", () => {
+  it("leaves other rows untouched while patching the match", () => {
+    const alpha = makePeer("alpha");
+    const beta = makePeer("beta");
+    const host: Host = { _buildServerPeers: [alpha, beta] };
+
+    dispatch(host, refreshed("alpha"));
+
+    const [patched, untouched] = host._buildServerPeers ?? [];
+    expect(patched.label).toBe("renamed");
+    expect(untouched).toEqual(beta);
+  });
+
+  it("no-ops on an unknown dashboard_id", () => {
     const other = makePeer("beta");
     const host: Host = { _buildServerPeers: [other] };
 

--- a/test/components/app-shell/events-peer-refreshed.test.ts
+++ b/test/components/app-shell/events-peer-refreshed.test.ts
@@ -27,6 +27,8 @@ function refreshed(dashboard_id: string): RemoteBuildPeerRefreshedEventData {
     pin_sha256: dashboard_id[0].repeat(64),
     label: "renamed",
     peer_ip: "10.0.0.9",
+    // A real payload always carries the original pair time; the bump
+    // just proves the field is inside the spread's write set.
     paired_at: 2,
     friendly_name: "Office-PC",
     ha_addon: true,

--- a/test/components/app-shell/events-peer-refreshed.test.ts
+++ b/test/components/app-shell/events-peer-refreshed.test.ts
@@ -24,7 +24,7 @@ function makePeer(dashboard_id: string): PeerSummary {
 function refreshed(dashboard_id: string): RemoteBuildPeerRefreshedEventData {
   return {
     dashboard_id,
-    pin_sha256: "a".repeat(64),
+    pin_sha256: dashboard_id[0].repeat(64),
     label: "renamed",
     peer_ip: "10.0.0.9",
     paired_at: 2,


### PR DESCRIPTION
# What does this implement/fix?

Handles the new `remote_build_peer_refreshed` event from the companion backend PR: a re-pair against an already approved offloader now patches the row's introduction fields (label, label_auto, friendly_name, ha_addon, peer_ip, paired_at) in the receiver's peers list, leaving status and connected untouched, so a corrected label shows up live instead of after a reload.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder/issues/2524 (the backend companion closes it)
- companion backend PR: esphome/device-builder#2528

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
