### PR TITLE
Hoist a shared add-component-form test host

### DIFF
--- a/test/components/device/_add-component-form-host.ts
+++ b/test/components/device/_add-component-form-host.ts
@@ -1,0 +1,59 @@
+import { flushMicrotasks } from "../../_dom.js";
+import type { ESPHomeAPI } from "../../../src/api/index.js";
+import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
+import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
+import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+
+export interface AddComponentFormOptions {
+  component: ComponentCatalogEntry;
+  /** Stub API injected as the form's `_api`. */
+  api: ESPHomeAPI;
+  yaml?: string;
+  board?: BoardCatalogEntry | null;
+  resolvedComponents?: readonly string[];
+}
+
+/**
+ * A form wired to a stub API, constructed but not mounted.
+ *
+ * Callers must still `vi.mock` the icon (and `config-entry-form` where
+ * the suite renders the inner form) at module scope: those run before
+ * the import, so they can't live here.
+ */
+export function makeAddComponentForm(
+  options: AddComponentFormOptions
+): ESPHomeAddComponentForm {
+  const el = new ESPHomeAddComponentForm();
+  el.component = options.component;
+  if (options.yaml !== undefined) el.yaml = options.yaml;
+  if (options.board !== undefined) el.board = options.board;
+  if (options.resolvedComponents !== undefined)
+    el.resolvedComponents = options.resolvedComponents;
+  Object.assign(el as unknown as Record<string, unknown>, { _api: options.api });
+  return el;
+}
+
+/** Mount the form and let its async dependency lookups settle. */
+export async function mountAddComponentForm(
+  options: AddComponentFormOptions
+): Promise<ESPHomeAddComponentForm> {
+  const el = makeAddComponentForm(options);
+  document.body.appendChild(el);
+  // The first paint shows the literal-missing banner; once the async
+  // provides lookup settles (a few microtask hops through the cache), a
+  // re-render clears it. Flush generously, then await the final update.
+  await el.updateComplete;
+  await flushMicrotasks(10);
+  await el.updateComplete;
+  return el;
+}
+
+/** The missing-deps warning banner, or null once cleared. */
+export function depsBanner(el: ESPHomeAddComponentForm): Element | null {
+  return el.shadowRoot!.querySelector(".deps-warning");
+}
+
+/** The primary Submit button. */
+export function submitButton(el: ESPHomeAddComponentForm): HTMLButtonElement {
+  return el.shadowRoot!.querySelector<HTMLButtonElement>(".btn-primary")!;
+}

--- a/test/components/device/_add-component-form-host.ts
+++ b/test/components/device/_add-component-form-host.ts
@@ -1,4 +1,4 @@
-import { flushMicrotasks } from "../../_dom.js";
+import { flushMicrotasks, mount } from "../../_dom.js";
 import type { ESPHomeAPI } from "../../../src/api/index.js";
 import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
@@ -37,12 +37,11 @@ export function makeAddComponentForm(
 export async function mountAddComponentForm(
   options: AddComponentFormOptions
 ): Promise<ESPHomeAddComponentForm> {
-  const el = makeAddComponentForm(options);
-  document.body.appendChild(el);
-  // The first paint shows the literal-missing banner; once the async
-  // provides lookup settles (a few microtask hops through the cache), a
-  // re-render clears it. Flush generously, then await the final update.
-  await el.updateComplete;
+  // The first paint renders from the synchronous literal-name scan; the
+  // async dependency resolution (provides lookup, bus verdict,
+  // package-resolved components) lands a few microtask hops later through
+  // the caches and re-renders. Flush generously, then await the final update.
+  const el = await mount(makeAddComponentForm(options));
   await flushMicrotasks(10);
   await el.updateComplete;
   return el;

--- a/test/components/device/add-component-form-bus-blocked.test.ts
+++ b/test/components/device/add-component-form-bus-blocked.test.ts
@@ -14,18 +14,22 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 // submit gate, and values, so an inert unknown element suffices.
 vi.mock("../../../src/components/device/config-entry-form.js", () => ({}));
 
-import { flushMicrotasks } from "../../_dom.js";
 import type { ESPHomeAPI } from "../../../src/api/index.js";
 import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
 import type { ConfigEntry } from "../../../src/api/types/config-entries.js";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
-import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+import type { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
 import { _clearProvidesCache } from "../../../src/util/provides-cache.js";
 import { _clearCatalogCache } from "../../../src/util/yaml-completion-catalog.js";
 import { _clearYamlSectionsMemo } from "../../../src/util/yaml-sections-core.js";
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
 import { makeConfigEntry } from "../../util/_make-config-entry.js";
+import {
+  depsBanner,
+  mountAddComponentForm,
+  submitButton,
+} from "./_add-component-form-host.js";
 
 const RX_9600 = { baud_rate: 9600, require_rx: true };
 
@@ -70,23 +74,11 @@ const CLAIMED_BUS =
   "uart:\n  - baud_rate: 9600\n    rx_pin: 44\n    tx_pin: 43\n    id: uart_1\n" +
   "sensor:\n  - platform: a02yyuw\n    name: Level\n    uart_id: uart_1\n";
 
-async function mountForm(
+function mountForm(
   yaml: string,
   api: ESPHomeAPI = makeApi()
 ): Promise<ESPHomeAddComponentForm> {
-  const el = new ESPHomeAddComponentForm();
-  el.component = a01nyub;
-  el.yaml = yaml;
-  Object.assign(el as unknown as Record<string, unknown>, { _api: api });
-  document.body.appendChild(el);
-  await el.updateComplete;
-  await flushMicrotasks(10);
-  await el.updateComplete;
-  return el;
-}
-
-function banner(el: ESPHomeAddComponentForm): Element | null {
-  return el.shadowRoot!.querySelector(".deps-warning");
+  return mountAddComponentForm({ component: a01nyub, yaml, api });
 }
 
 describe("add-component-form bus hostability", () => {
@@ -100,18 +92,17 @@ describe("add-component-form bus hostability", () => {
 
   it("flags the dep missing with the bus copy when the sole bus is claimed", async () => {
     const el = await mountForm(CLAIMED_BUS);
-    const warn = banner(el)!;
+    const warn = depsBanner(el)!;
     expect(warn.textContent).toContain("device.bus_dependency_in_use_body");
     expect(warn.textContent).not.toContain("device.missing_dependencies_body");
-    const submit = el.shadowRoot!.querySelector<HTMLButtonElement>(".btn-primary")!;
-    expect(submit.disabled).toBe(true);
+    expect(submitButton(el).disabled).toBe(true);
   });
 
   it("seeds uart_id with the sole compatible bus", async () => {
     const el = await mountForm(
       "uart:\n  - baud_rate: 9600\n    rx_pin: 44\n    id: uart_1\n"
     );
-    expect(banner(el)).toBeNull();
+    expect(depsBanner(el)).toBeNull();
     expect(el.currentValues.uart_id).toBe("uart_1");
   });
 
@@ -121,7 +112,7 @@ describe("add-component-form bus hostability", () => {
         "  - baud_rate: 9600\n    rx_pin: 6\n    id: uart_2\n" +
         "sensor:\n  - platform: a02yyuw\n    name: Level\n    uart_id: uart_1\n"
     );
-    expect(banner(el)).toBeNull();
+    expect(depsBanner(el)).toBeNull();
     expect(el.currentValues.uart_id).toBe("uart_2");
   });
 
@@ -130,7 +121,7 @@ describe("add-component-form bus hostability", () => {
       "uart:\n  - baud_rate: 9600\n    rx_pin: 44\n    id: uart_1\n" +
         "  - baud_rate: 9600\n    rx_pin: 6\n    id: uart_2\n"
     );
-    expect(banner(el)).toBeNull();
+    expect(depsBanner(el)).toBeNull();
     expect(el.currentValues.uart_id).toBeUndefined();
     const entries = (el as unknown as { _entries: ConfigEntry[] })._entries;
     expect(entries.find((e) => e.key === "uart_id")?.required).toBe(true);
@@ -138,7 +129,7 @@ describe("add-component-form bus hostability", () => {
 
   it("fails open when a configured provider can host the component", async () => {
     const el = await mountForm("usb_uart:\n  id: hub\n" + CLAIMED_BUS);
-    expect(banner(el)).toBeNull();
+    expect(depsBanner(el)).toBeNull();
   });
 
   it("treats an anchor-merged unclaimed bus as hostable, not pinless", async () => {
@@ -146,13 +137,13 @@ describe("add-component-form bus hostability", () => {
       ".base: &base\n  rx_pin: 44\n" +
         "uart:\n  - <<: *base\n    baud_rate: 9600\n    id: uart_1\n"
     );
-    expect(banner(el)).toBeNull();
+    expect(depsBanner(el)).toBeNull();
     expect(el.currentValues.uart_id).toBe("uart_1");
   });
 
   it("fails open entirely when the YAML pulls in external sources", async () => {
     const el = await mountForm("packages:\n  base: !include common.yaml\n" + CLAIMED_BUS);
-    expect(banner(el)).toBeNull();
+    expect(depsBanner(el)).toBeNull();
   });
 
   it("issues no verdict when the catalog index is unavailable", async () => {
@@ -163,7 +154,7 @@ describe("add-component-form bus hostability", () => {
       getComponentBodies: vi.fn(async () => ({})),
     } as unknown as ESPHomeAPI;
     const el = await mountForm(CLAIMED_BUS, down);
-    expect(banner(el)).toBeNull();
+    expect(depsBanner(el)).toBeNull();
     expect(el.currentValues.uart_id).toBeUndefined();
   });
 
@@ -173,7 +164,7 @@ describe("add-component-form bus hostability", () => {
         "  - baud_rate: 9600\n    rx_pin: 6\n" +
         "sensor:\n  - platform: a02yyuw\n    name: Level\n    uart_id: uart_1\n"
     );
-    expect(banner(el)).not.toBeNull();
+    expect(depsBanner(el)).not.toBeNull();
     expect(el.currentValues.uart_id).toBeUndefined();
   });
 });

--- a/test/components/device/add-component-form-package-dep.test.ts
+++ b/test/components/device/add-component-form-package-dep.test.ts
@@ -9,12 +9,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
-import { flushMicrotasks } from "../../_dom.js";
 import type { ESPHomeAPI } from "../../../src/api/index.js";
-import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+import type { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
 import { _clearProvidesCache } from "../../../src/util/provides-cache.js";
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
+import { depsBanner, mountAddComponentForm } from "./_add-component-form-host.js";
 
 const bluetoothProxy = makeComponentEntry("bluetooth_proxy", {
   name: "Bluetooth Proxy",
@@ -24,14 +24,10 @@ const bluetoothProxy = makeComponentEntry("bluetooth_proxy", {
 const PACKAGES_YAML =
   "packages:\n  base: github://acme/device.yaml\napi:\n  encryption:\n    key: k\n";
 
-async function mountForm(
+function mountForm(
   yaml: string,
   resolvedComponents: readonly string[]
 ): Promise<ESPHomeAddComponentForm> {
-  const el = new ESPHomeAddComponentForm();
-  el.component = bluetoothProxy;
-  el.yaml = yaml;
-  el.resolvedComponents = resolvedComponents;
   const getComponents = vi.fn().mockResolvedValue({
     components: [],
     categories: [],
@@ -39,18 +35,12 @@ async function mountForm(
     offset: 0,
     limit: 200,
   });
-  Object.assign(el as unknown as Record<string, unknown>, {
-    _api: { getComponents } as unknown as ESPHomeAPI,
+  return mountAddComponentForm({
+    component: bluetoothProxy,
+    yaml,
+    resolvedComponents,
+    api: { getComponents } as unknown as ESPHomeAPI,
   });
-  document.body.appendChild(el);
-  await el.updateComplete;
-  await flushMicrotasks(10);
-  await el.updateComplete;
-  return el;
-}
-
-function banner(el: ESPHomeAddComponentForm): Element | null {
-  return el.shadowRoot!.querySelector(".deps-warning");
 }
 
 describe("add-component-form package-resolved dependency", () => {
@@ -62,11 +52,11 @@ describe("add-component-form package-resolved dependency", () => {
 
   it("clears the banner when the resolved components satisfy the dep", async () => {
     const el = await mountForm(PACKAGES_YAML, ["api", "esp32", "wifi"]);
-    expect(banner(el)).toBeNull();
+    expect(depsBanner(el)).toBeNull();
   });
 
   it("keeps the banner when the resolved components lack the dep", async () => {
     const el = await mountForm(PACKAGES_YAML, ["api", "esp8266", "wifi"]);
-    expect(banner(el)).not.toBeNull();
+    expect(depsBanner(el)).not.toBeNull();
   });
 });

--- a/test/components/device/add-component-form-provides-dep.test.ts
+++ b/test/components/device/add-component-form-provides-dep.test.ts
@@ -14,10 +14,16 @@ import { flushMicrotasks } from "../../_dom.js";
 import type { ESPHomeAPI } from "../../../src/api/index.js";
 import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
-import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+import type { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
 import { _clearProvidesCache } from "../../../src/util/provides-cache.js";
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
+import {
+  depsBanner,
+  makeAddComponentForm,
+  mountAddComponentForm,
+  submitButton,
+} from "./_add-component-form-host.js";
 
 function providersResponse(ids: string[]) {
   return {
@@ -40,33 +46,16 @@ const libretinyPwm = makeComponentEntry("output.libretiny_pwm", {
   dependencies: ["libretiny"],
 });
 
-async function mountForm(
+function mountForm(
   getComponents: ReturnType<typeof vi.fn>,
   yaml: string
 ): Promise<ESPHomeAddComponentForm> {
-  const el = new ESPHomeAddComponentForm();
-  el.component = libretinyPwm;
-  el.board = bk72xxBoard;
-  el.yaml = yaml;
-  Object.assign(el as unknown as Record<string, unknown>, {
-    _api: { getComponents } as unknown as ESPHomeAPI,
+  return mountAddComponentForm({
+    component: libretinyPwm,
+    board: bk72xxBoard,
+    yaml,
+    api: { getComponents } as unknown as ESPHomeAPI,
   });
-  document.body.appendChild(el);
-  // The first paint shows the literal-missing banner; once the async
-  // provides lookup settles (a few microtask hops through the cache), a
-  // re-render clears it. Flush generously, then await the final update.
-  await el.updateComplete;
-  await flushMicrotasks(10);
-  await el.updateComplete;
-  return el;
-}
-
-function banner(el: ESPHomeAddComponentForm): Element | null {
-  return el.shadowRoot!.querySelector(".deps-warning");
-}
-
-function submitButton(el: ESPHomeAddComponentForm): HTMLButtonElement {
-  return el.shadowRoot!.querySelector<HTMLButtonElement>(".btn-primary")!;
 }
 
 describe("add-component-form provides-satisfied dependency", () => {
@@ -84,7 +73,7 @@ describe("add-component-form provides-satisfied dependency", () => {
     expect(getComponents).toHaveBeenCalledWith(
       expect.objectContaining({ provides: "libretiny" })
     );
-    expect(banner(el)).toBeNull();
+    expect(depsBanner(el)).toBeNull();
     expect(submitButton(el).disabled).toBe(false);
   });
 
@@ -93,7 +82,7 @@ describe("add-component-form provides-satisfied dependency", () => {
     const getComponents = vi.fn().mockResolvedValue(providersResponse(["bk72xx"]));
     const el = await mountForm(getComponents, "esp32:\n");
 
-    expect(banner(el)).not.toBeNull();
+    expect(depsBanner(el)).not.toBeNull();
     expect(submitButton(el).disabled).toBe(true);
   });
 
@@ -104,7 +93,7 @@ describe("add-component-form provides-satisfied dependency", () => {
     const getComponents = vi.fn().mockRejectedValue(new Error("ws down"));
     const el = await mountForm(getComponents, "bk72xx:\n");
 
-    expect(banner(el)).not.toBeNull();
+    expect(depsBanner(el)).not.toBeNull();
     expect(submitButton(el).disabled).toBe(true);
     expect(warn).toHaveBeenCalledWith(
       "[add-component-form] provides lookup failed",
@@ -121,12 +110,11 @@ describe("add-component-form provides-satisfied dependency", () => {
       resolveA = r;
     });
     const getComponents = vi.fn().mockReturnValue(pending);
-    const el = new ESPHomeAddComponentForm();
-    el.component = libretinyPwm;
-    el.board = bk72xxBoard;
-    el.yaml = "bk72xx:\n";
-    Object.assign(el as unknown as Record<string, unknown>, {
-      _api: { getComponents } as unknown as ESPHomeAPI,
+    const el = makeAddComponentForm({
+      component: libretinyPwm,
+      board: bk72xxBoard,
+      yaml: "bk72xx:\n",
+      api: { getComponents } as unknown as ESPHomeAPI,
     });
     document.body.appendChild(el);
     await el.updateComplete; // resolution A kicked off, awaiting getComponents
@@ -150,12 +138,11 @@ describe("add-component-form provides-satisfied dependency", () => {
     // empty Set would only flip identity and force an identical re-render on
     // every YAML change.
     const getComponents = vi.fn().mockResolvedValue(providersResponse(["bk72xx"]));
-    const el = new ESPHomeAddComponentForm();
-    el.component = libretinyPwm;
-    el.board = bk72xxBoard;
-    el.yaml = "esp32:\n";
-    Object.assign(el as unknown as Record<string, unknown>, {
-      _api: { getComponents } as unknown as ESPHomeAPI,
+    const el = makeAddComponentForm({
+      component: libretinyPwm,
+      board: bk72xxBoard,
+      yaml: "esp32:\n",
+      api: { getComponents } as unknown as ESPHomeAPI,
     });
 
     let renders = 0;
@@ -181,6 +168,6 @@ describe("add-component-form provides-satisfied dependency", () => {
     expect(getComponents).toHaveBeenCalled(); // the lookup did run
     expect(renders).toBe(rendersAfterPaint); // …but produced no extra render
     expect(inst._providedDeps).toBe(providedRef); // same Set, never reassigned
-    expect(banner(el)).not.toBeNull(); // and the dep is still correctly flagged
+    expect(depsBanner(el)).not.toBeNull(); // and the dep is still correctly flagged
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The add component form suites each carried their own copy of the mount scaffolding, including the non obvious settle dance (`updateComplete`, `flushMicrotasks(10)`, `updateComplete`) that lets the async provides lookups land. This hoists a shared `_add-component-form-host.ts` mirroring the existing `_add-component-dialog-host.ts`; the provides-dep, bus-blocked and package-dep suites now mount through it, and the duplicated `banner` / submit button shadow DOM readers moved there too. The host also exposes an unmounted `makeAddComponentForm` so the two tests that own their own flush timing (stale in-flight discard, no-re-render) share construction without inheriting the settle dance.

**Related issue or feature (if applicable):**

- fixes #1633

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
