### PR TITLE
Honour package-resolved components in depends_on_component visibility

### DIFF
--- a/src/components/device/add-component-deps.ts
+++ b/src/components/device/add-component-deps.ts
@@ -1,7 +1,6 @@
 import type { ESPHomeAPI } from "../../api/index.js";
 import { ComponentCategory } from "../../api/types/components.js";
 import { canonicalComponentKey, hasComponentKey } from "../../util/component-presence.js";
-import { withMergedSourcePresence } from "../../util/merged-source-presence.js";
 import { providerIds } from "../../util/provides-cache.js";
 import {
   parseConfiguredPlatforms,
@@ -18,35 +17,27 @@ const PLATFORM_DOMAINS: ReadonlySet<string> = new Set(Object.values(ComponentCat
  * Catalog dependencies not yet satisfied by the current YAML.
  *
  * A dependency is satisfied when any of:
- *  - a top-level block of that name exists (`ld2410:`, `i2c:`);
+ *  - the presence set carries it (`ld2410:`, `i2c:`);
  *  - a dotted dep (`ota.http_request`) matches a configured platform;
  *  - a configured platform's stem equals the dep and the dep isn't a
  *    platform domain — platform-style hubs (`atm90e32`) live under a
- *    domain (`sensor: - platform: atm90e32`), not at the top level; or
- *  - `resolvedComponents` (the device's backend-resolved list) carries it
- *    and the YAML root-merges other sources — see `withMergedSourcePresence`.
+ *    domain (`sensor: - platform: atm90e32`), not at the top level.
  *
- * `resolvedComponents` satisfies bare deps only: it is a flat list of bare
- * names, and matching a dotted dep by stem would false-satisfy (`ota.esphome`
- * vs the always-loaded `esphome` core key), so dotted deps stay on the
- * configured-platform scan even for merged-source configs.
- *
- * `presentComponents` may be passed precomputed to avoid re-parsing
- * the top-level blocks when the caller already has them.
+ * `presentComponents` is the caller's effective presence — the literal scan
+ * widened via `withMergedSourcePresence` on merged-source configs. Widening
+ * satisfies bare deps only: matching a dotted dep by stem would
+ * false-satisfy (`ota.esphome` vs the always-loaded `esphome` core key), so
+ * dotted deps stay on the configured-platform scan. Omitted, the literal
+ * scan of *yaml* is used.
  */
 export function findMissingDependencies(
   dependencies: readonly string[],
   yaml: string,
-  presentComponents?: ReadonlySet<string>,
-  resolvedComponents: readonly string[] = []
+  presentComponents?: ReadonlySet<string>
 ): string[] {
   // Most components declare no dependencies — skip the YAML scans.
   if (dependencies.length === 0) return [];
-  const present = withMergedSourcePresence(
-    presentComponents ?? parseTopLevelComponents(yaml),
-    yaml,
-    resolvedComponents
-  );
+  const present = presentComponents ?? parseTopLevelComponents(yaml);
   const configured = parseConfiguredPlatforms(yaml);
   const platformStems = new Set<string>();
   for (const id of configured) {

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -26,6 +26,7 @@ import {
 } from "../../util/featured-id.js";
 import { fireEvent } from "../../util/fire-event.js";
 import { formatApiError } from "../../util/format-api-error.js";
+import { withMergedSourcePresence } from "../../util/merged-source-presence.js";
 import { notifyError, notifySuccess } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { findAddedSection } from "../../util/yaml-sections.js";
@@ -556,9 +557,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
         seeded,
         entry.required_groups ?? [],
         this.board,
-        // Literal scan on purpose: depends_on_component field visibility is
-        // presence-for-rendering, not dependency satisfaction.
-        present
+        // Widened to match the form's render (#1632): a field gated on a
+        // package-resolved component is visible there, so the fast-path
+        // must not skip it.
+        withMergedSourcePresence(present, this.yaml, this._resolvedComponents)
       )
     )
       return null;

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -529,17 +529,17 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // constrained on an exclusive-claim bus always gets the form so the
     // verdict can gate the add.
     if (exclusiveBusTarget(entry)) return null;
-    const present = parseTopLevelComponents(this.yaml);
+    // Widened to match the form's render (#1632).
+    const present = withMergedSourcePresence(
+      parseTopLevelComponents(this.yaml),
+      this.yaml,
+      this._resolvedComponents
+    );
     // `findMissingDependencies` (dotted deps, platform stems) over a plain
     // top-level-block check, so a stem-satisfied dep doesn't keep a blank
     // form. The form's async `provides` subtraction isn't replicated — this
     // stays stricter, only keeping the form a touch more often.
-    const missing = findMissingDependencies(
-      entry.dependencies ?? [],
-      this.yaml,
-      present,
-      this._resolvedComponents
-    );
+    const missing = findMissingDependencies(entry.dependencies ?? [], this.yaml, present);
     if (missing.length > 0) return null;
     const seeded = buildInitialValues({
       entries: entry.config_entries,
@@ -557,10 +557,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
         seeded,
         entry.required_groups ?? [],
         this.board,
-        // Widened to match the form's render (#1632): a field gated on a
-        // package-resolved component is visible there, so the fast-path
-        // must not skip it.
-        withMergedSourcePresence(present, this.yaml, this._resolvedComponents)
+        present
       )
     )
       return null;

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -259,25 +259,24 @@ export class ESPHomeAddComponentForm extends LitElement {
     }
   }
 
+  private _widenPresence = memoizeOne((yaml: string, resolved: readonly string[]) =>
+    withMergedSourcePresence(parseTopLevelComponents(yaml), yaml, resolved)
+  );
+
   /** Literal scan widened by package-resolved components, for
-   *  `depends_on_component` visibility and validation. */
+   *  `depends_on_component` visibility and validation; identity-stable. */
   private _visibilityPresence(): ReadonlySet<string> {
-    return withMergedSourcePresence(
-      parseTopLevelComponents(this.yaml),
-      this.yaml,
-      this.resolvedComponents
-    );
+    return this._widenPresence(this.yaml, this.resolvedComponents);
   }
 
-  /** Net-missing deps driving the banner and submit gate: the literal-name
+  /** Net-missing deps driving the banner and submit gate: the widened
    *  scan minus those a present component provides (`_providedDeps`), plus
    *  a bus dep present but with no attachable bus (`_busBlockedDep`). */
   private _missingDeps(present: ReadonlySet<string>): string[] {
     const missing = findMissingDependencies(
       this.component.dependencies ?? [],
       this.yaml,
-      present,
-      this.resolvedComponents
+      present
     ).filter((d) => !this._providedDeps.has(d));
     const blocked = this._busBlockedDep;
     return blocked && !missing.includes(blocked) ? [...missing, blocked] : missing;
@@ -297,13 +296,7 @@ export class ESPHomeAddComponentForm extends LitElement {
     const deps = this.component?.dependencies ?? [];
     // Common dep-free case: nothing to resolve, so skip the YAML parse too.
     if (!api || deps.length === 0) return;
-    // Widened here (not just inside findMissingDependencies) because the
-    // provides membership check below reads the same set.
-    const present = withMergedSourcePresence(
-      parseTopLevelComponents(this.yaml),
-      this.yaml,
-      this.resolvedComponents
-    );
+    const present = this._visibilityPresence();
     const missing = findMissingDependencies(deps, this.yaml, present);
     if (missing.length === 0) return;
     try {

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -259,6 +259,16 @@ export class ESPHomeAddComponentForm extends LitElement {
     }
   }
 
+  /** Literal scan widened by package-resolved components, for
+   *  `depends_on_component` visibility and validation. */
+  private _visibilityPresence(): ReadonlySet<string> {
+    return withMergedSourcePresence(
+      parseTopLevelComponents(this.yaml),
+      this.yaml,
+      this.resolvedComponents
+    );
+  }
+
   /** Net-missing deps driving the banner and submit gate: the literal-name
    *  scan minus those a present component provides (`_providedDeps`), plus
    *  a bus dep present but with no attachable bus (`_busBlockedDep`). */
@@ -361,7 +371,7 @@ export class ESPHomeAddComponentForm extends LitElement {
 
   protected render() {
     const disabled = this.submitting;
-    const presentComponents = parseTopLevelComponents(this.yaml);
+    const presentComponents = this._visibilityPresence();
     // Dependencies the catalog entry declares as required but the YAML
     // doesn't satisfy yet — a top-level block (`output:`, `i2c:`) or a
     // configured platform for hub-style deps (`atm90e32` under
@@ -550,7 +560,7 @@ export class ESPHomeAddComponentForm extends LitElement {
    */
   private _anyErrorIsVisible(
     errors: Map<string, ValidationError>,
-    presentComponents: Set<string>
+    presentComponents: ReadonlySet<string>
   ): boolean {
     // The caller (``_onSubmit``) only enters this branch when
     // ``errors.size > 0``, but we keep the guard so the helper is
@@ -639,7 +649,7 @@ export class ESPHomeAddComponentForm extends LitElement {
     // alongside a fresh result. Both bail paths below set their
     // own message; the success path leaves it cleared.
     this._localBlockMessage = "";
-    const presentComponents = parseTopLevelComponents(this.yaml);
+    const presentComponents = this._visibilityPresence();
     // Block submit when a declared dependency isn't satisfied. The Add
     // button is disabled in that case, but Enter (requestSubmit) still
     // lands here.

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -263,8 +263,8 @@ export class ESPHomeConfigEntryForm extends LitElement {
   @property()
   configuration = "";
 
-  /** Top-level component keys present in the YAML — drives the
-   *  `depends_on_component` visibility predicate. */
+  /** Effective top-level component presence (literal scan, widened via
+   *  `withMergedSourcePresence`) — drives `depends_on_component` visibility. */
   @property({ attribute: false })
   presentComponents: ReadonlySet<string> = new Set();
 

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -266,7 +266,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
   /** Top-level component keys present in the YAML — drives the
    *  `depends_on_component` visibility predicate. */
   @property({ attribute: false })
-  presentComponents: Set<string> = new Set();
+  presentComponents: ReadonlySet<string> = new Set();
 
   /** Instance-relative field path to scroll into view, from the YAML cursor. */
   @property({ attribute: false })

--- a/src/components/device/config-entry-renderers-types.ts
+++ b/src/components/device/config-entry-renderers-types.ts
@@ -39,8 +39,9 @@ export interface RenderCtx {
    *  ``renderChildEntries({ includeAdvanced })`` so an exclusive-group's
    *  chosen member can reveal all its fields regardless of the toggle. */
   showAdvanced: boolean;
-  /** Top-level component keys present in the YAML — for the
-   *  ``depends_on_component`` visibility predicate when filtering directly. */
+  /** Effective top-level component presence (literal scan, widened via
+   *  ``withMergedSourcePresence``) — for the ``depends_on_component``
+   *  visibility predicate when filtering directly. */
   presentComponents: ReadonlySet<string>;
   /** Top-level keys whose backend constraint prose the form replaces with a
    *  reactive banner/cluster (``required_groups`` keys + inclusive-``group``

--- a/src/components/device/config-entry-renderers-types.ts
+++ b/src/components/device/config-entry-renderers-types.ts
@@ -41,7 +41,7 @@ export interface RenderCtx {
   showAdvanced: boolean;
   /** Top-level component keys present in the YAML — for the
    *  ``depends_on_component`` visibility predicate when filtering directly. */
-  presentComponents: Set<string>;
+  presentComponents: ReadonlySet<string>;
   /** Top-level keys whose backend constraint prose the form replaces with a
    *  reactive banner/cluster (``required_groups`` keys + inclusive-``group``
    *  members). ``_fieldDescription`` strips the baked prose only for these, so

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -13,7 +13,11 @@ import memoizeOne from "memoize-one";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
-import { apiContext, localizeContext } from "../../context/index.js";
+import {
+  apiContext,
+  localizeContext,
+  resolvedComponentsContext,
+} from "../../context/index.js";
 import { dangerBannerStyles } from "../../styles/banners.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
@@ -25,6 +29,7 @@ import {
 import type { ValidationError } from "../../util/config-validation.js";
 import { fireEvent } from "../../util/fire-event.js";
 import { formatApiError } from "../../util/format-api-error.js";
+import { withMergedSourcePresence } from "../../util/merged-source-presence.js";
 import { notifyError } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { resolveSectionEntries } from "../../util/section-entry-overrides.js";
@@ -104,6 +109,10 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
   _localize: LocalizeFunc = (key) => key;
   @consume({ context: apiContext }) _api!: ESPHomeAPI;
 
+  @consume({ context: resolvedComponentsContext, subscribe: true })
+  @state()
+  _resolvedComponents: readonly string[] = [];
+
   @property() configuration = "";
   @property() sectionKey = "";
 
@@ -175,6 +184,17 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
   // Per-section so switching components doesn't bleed state.
   @state() _advancedShownSections = new Set<string>();
   @state() _presentComponents: Set<string> = new Set();
+
+  private _widenPresence = memoizeOne(withMergedSourcePresence);
+
+  /** Literal scan widened by package-resolved components; identity-stable. */
+  get _effectivePresentComponents(): ReadonlySet<string> {
+    return this._widenPresence(
+      this._presentComponents,
+      this.yaml,
+      this._resolvedComponents
+    );
+  }
 
   // Sections whose advanced fields we've auto-revealed for caret-follow once.
   // Not reactive — bookkeeping so a later deliberate collapse isn't reopened.

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -288,6 +288,8 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
     }
     // A late-arriving device row can reveal dep-gated fields; refresh an
     // existing error map so a revealed required field surfaces immediately.
+    // Deliberately gated on a non-empty map: errors appear on edit, and a
+    // context arrival the user didn't cause must not flag a pristine section.
     if (
       changedProperties.has("_resolvedComponents") &&
       this._config &&

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -54,6 +54,7 @@ import {
   flushDraft,
   onDeleteConfirmed,
   onValueChange,
+  revalidateFields,
   settleOwnDraft,
 } from "./device-section-config/draft-and-delete.js";
 import {
@@ -284,6 +285,15 @@ export class ESPHomeDeviceSectionConfig extends LitElement implements SectionEdi
     // suppressions so still-broken fields regain their error.
     if (changedProperties.has("backendErrors") && this._clearedBackendPaths.size) {
       this._clearedBackendPaths = new Set();
+    }
+    // A late-arriving device row can reveal dep-gated fields; refresh an
+    // existing error map so a revealed required field surfaces immediately.
+    if (
+      changedProperties.has("_resolvedComponents") &&
+      this._config &&
+      this._fieldErrors.size
+    ) {
+      revalidateFields(this);
     }
     // loadConfig synchronously flips _loading/_config/_error; running it in
     // willUpdate folds those into the in-progress render rather than

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -57,7 +57,7 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): string | null {
 }
 
 /** Recompute the section's field errors against the render schema. */
-function revalidateFields(host: ESPHomeDeviceSectionConfig): void {
+export function revalidateFields(host: ESPHomeDeviceSectionConfig): void {
   if (!host._config) return;
   host._fieldErrors = validateEntries(
     resolveSectionEntries(host.sectionKey, host._config.entries),

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -62,7 +62,7 @@ function revalidateFields(host: ESPHomeDeviceSectionConfig): void {
   host._fieldErrors = validateEntries(
     resolveSectionEntries(host.sectionKey, host._config.entries),
     host._values,
-    host._presentComponents,
+    host._effectivePresentComponents,
     host.board?.esphome.platform ?? null,
     host.sectionKey
   );

--- a/src/components/device/device-section-config/render-branches.ts
+++ b/src/components/device/device-section-config/render-branches.ts
@@ -95,7 +95,7 @@ export function renderStructuredFormBranch(
       .sectionKey=${host.sectionKey}
       .configuration=${host.configuration}
       .focusFieldPath=${host.focusFieldPath}
-      .presentComponents=${host._presentComponents}
+      .presentComponents=${host._effectivePresentComponents}
       advanced-section
       gate-advanced
       ?show-advanced=${host._showAdvanced}

--- a/test/components/device/_add-component-form-host.ts
+++ b/test/components/device/_add-component-form-host.ts
@@ -1,3 +1,5 @@
+import { vi } from "vitest";
+
 import { flushMicrotasks, mount } from "../../_dom.js";
 import type { ESPHomeAPI } from "../../../src/api/index.js";
 import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
@@ -6,11 +8,25 @@ import { ESPHomeAddComponentForm } from "../../../src/components/device/add-comp
 
 export interface AddComponentFormOptions {
   component: ComponentCatalogEntry;
-  /** Stub API injected as the form's `_api`. */
-  api: ESPHomeAPI;
+  /** Stub API injected as the form's `_api`; defaults to an empty catalog. */
+  api?: ESPHomeAPI;
   yaml?: string;
   board?: BoardCatalogEntry | null;
   resolvedComponents?: readonly string[];
+}
+
+/** An API whose catalog and `provides` queries answer empty. */
+export function emptyCatalogApi(): ESPHomeAPI {
+  return {
+    getComponents: vi.fn(async () => ({
+      components: [],
+      categories: [],
+      total: 0,
+      offset: 0,
+      limit: 200,
+    })),
+    getComponentBodies: vi.fn(async () => ({})),
+  } as unknown as ESPHomeAPI;
 }
 
 /**
@@ -29,7 +45,9 @@ export function makeAddComponentForm(
   if (options.board !== undefined) el.board = options.board;
   if (options.resolvedComponents !== undefined)
     el.resolvedComponents = options.resolvedComponents;
-  Object.assign(el as unknown as Record<string, unknown>, { _api: options.api });
+  Object.assign(el as unknown as Record<string, unknown>, {
+    _api: options.api ?? emptyCatalogApi(),
+  });
   return el;
 }
 

--- a/test/components/device/add-component-deps.test.ts
+++ b/test/components/device/add-component-deps.test.ts
@@ -5,7 +5,9 @@ import {
   depsSatisfiedByProvides,
   findMissingDependencies,
 } from "../../../src/components/device/add-component-deps.js";
+import { withMergedSourcePresence } from "../../../src/util/merged-source-presence.js";
 import { _clearProvidesCache } from "../../../src/util/provides-cache.js";
+import { parseTopLevelComponents } from "../../../src/util/yaml-serialize.js";
 
 function providersResponse(ids: string[]) {
   return {
@@ -71,20 +73,28 @@ describe("findMissingDependencies", () => {
     ]);
   });
 
-  it("satisfies a dep from the resolved components when the YAML merges packages", () => {
+  // Callers own the merged-source widening; these pin the widened set
+  // flowing through the dep check the way production passes it.
+  function widened(yaml: string, resolved: readonly string[]): ReadonlySet<string> {
+    return withMergedSourcePresence(parseTopLevelComponents(yaml), yaml, resolved);
+  }
+
+  it("satisfies a dep from the widened presence when the YAML merges packages", () => {
     const yaml = "packages:\n  base: github://acme/base.yaml\n";
-    expect(findMissingDependencies(["esp32"], yaml, undefined, ["esp32"])).toEqual([]);
+    expect(findMissingDependencies(["esp32"], yaml, widened(yaml, ["esp32"]))).toEqual(
+      []
+    );
   });
 
   it("ignores the resolved components for a plain config", () => {
-    expect(findMissingDependencies(["esp32"], "api:\n", undefined, ["esp32"])).toEqual([
-      "esp32",
-    ]);
+    expect(
+      findMissingDependencies(["esp32"], "api:\n", widened("api:\n", ["esp32"]))
+    ).toEqual(["esp32"]);
   });
 
   it("matches a resolved platform against its alias-spelled dep", () => {
     const yaml = "packages:\n  base: github://acme/base.yaml\n";
-    expect(findMissingDependencies(["rp2"], yaml, undefined, ["rp2040"])).toEqual([]);
+    expect(findMissingDependencies(["rp2"], yaml, widened(yaml, ["rp2040"]))).toEqual([]);
   });
 
   it("treats an empty dependency list as satisfied", () => {

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -143,6 +143,61 @@ describe("add-component-dialog skips the form for configless components", () => 
     );
   });
 
+  it("opens the form when a package-resolved component reveals a required field", async () => {
+    // The gated `port` is hidden by the literal scan but visible in the
+    // form once `web_server` resolves from the package (#1632); the gate
+    // must not fast-path past a field the user would have seen.
+    const entry = makeComponentEntry("thing", {
+      name: "Thing",
+      config_entries: [
+        makeConfigEntry({
+          key: "port",
+          required: true,
+          depends_on_component: "web_server",
+        }),
+      ],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+    dialog.yaml = "packages:\n  base: github://acme/base.yaml\n";
+    Object.assign(dialog as unknown as Record<string, unknown>, {
+      _resolvedComponents: ["web_server"],
+    });
+
+    await select(dialog, "thing");
+
+    expect(addComponent).not.toHaveBeenCalled();
+    expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(true);
+  });
+
+  it("fast-paths the same gated field on a plain config (dep stays hidden)", async () => {
+    const entry = makeComponentEntry("thing", {
+      name: "Thing",
+      config_entries: [
+        makeConfigEntry({
+          key: "port",
+          required: true,
+          depends_on_component: "web_server",
+        }),
+      ],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+    Object.assign(dialog as unknown as Record<string, unknown>, {
+      _resolvedComponents: ["web_server"],
+    });
+
+    await select(dialog, "thing");
+
+    expect(addComponent).toHaveBeenCalledWith(
+      "foo.yaml",
+      { component_id: "thing", fields: {} },
+      "esphome:\n  name: foo\n"
+    );
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(
+      false
+    );
+  });
+
   it("opens the form (no direct add) when the component has a required field", async () => {
     const entry = makeComponentEntry("wifi", {
       name: "WiFi",

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -143,11 +143,9 @@ describe("add-component-dialog skips the form for configless components", () => 
     );
   });
 
-  it("opens the form when a package-resolved component reveals a required field", async () => {
-    // The gated `port` is hidden by the literal scan but visible in the
-    // form once `web_server` resolves from the package (#1632); the gate
-    // must not fast-path past a field the user would have seen.
-    const entry = makeComponentEntry("thing", {
+  // A required field the literal scan hides behind `depends_on_component`.
+  const gatedEntry = () =>
+    makeComponentEntry("thing", {
       name: "Thing",
       config_entries: [
         makeConfigEntry({
@@ -157,6 +155,11 @@ describe("add-component-dialog skips the form for configless components", () => 
         }),
       ],
     });
+
+  it("opens the form when a package-resolved component reveals a required field", async () => {
+    // `port` is visible in the form once `web_server` resolves from the
+    // package (#1632); the gate must not fast-path past it.
+    const entry = gatedEntry();
     const { dialog, addComponent } = makeDialog(entry);
     dialog.yaml = "packages:\n  base: github://acme/base.yaml\n";
     Object.assign(dialog as unknown as Record<string, unknown>, {
@@ -171,17 +174,7 @@ describe("add-component-dialog skips the form for configless components", () => 
   });
 
   it("fast-paths the same gated field on a plain config (dep stays hidden)", async () => {
-    const entry = makeComponentEntry("thing", {
-      name: "Thing",
-      config_entries: [
-        makeConfigEntry({
-          key: "port",
-          required: true,
-          depends_on_component: "web_server",
-        }),
-      ],
-    });
-    const { dialog, addComponent } = makeDialog(entry);
+    const { dialog, addComponent } = makeDialog(gatedEntry());
     Object.assign(dialog as unknown as Record<string, unknown>, {
       _resolvedComponents: ["web_server"],
     });

--- a/test/components/device/add-component-form-package-visibility.test.ts
+++ b/test/components/device/add-component-form-package-visibility.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the add form's packages-aware `depends_on_component` visibility
+ * (#1632): the inner form's `presentComponents` binding is widened by
+ * the resolved components on a merged-source config only.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("../../../src/components/device/config-entry-form.js", () => ({}));
+
+import type { ESPHomeAPI } from "../../../src/api/index.js";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import type { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
+import { _clearProvidesCache } from "../../../src/util/provides-cache.js";
+import { makeComponentEntry } from "../../util/_make-component-entry.js";
+import { makeConfigEntry } from "../../util/_make-config-entry.js";
+import { mountAddComponentForm } from "./_add-component-form-host.js";
+
+const uptime = makeComponentEntry("sensor.uptime", {
+  name: "Uptime",
+  config_entries: [
+    makeConfigEntry({ key: "name", type: ConfigEntryType.STRING, required: true }),
+    makeConfigEntry({ key: "web", depends_on_component: "web_server" }),
+  ],
+});
+
+const PACKAGES_YAML = "packages:\n  base: github://acme/base.yaml\n";
+
+function mountForm(
+  yaml: string,
+  resolvedComponents: readonly string[]
+): Promise<ESPHomeAddComponentForm> {
+  const getComponents = vi.fn().mockResolvedValue({
+    components: [],
+    categories: [],
+    total: 0,
+    offset: 0,
+    limit: 200,
+  });
+  return mountAddComponentForm({
+    component: uptime,
+    yaml,
+    resolvedComponents,
+    api: { getComponents } as unknown as ESPHomeAPI,
+  });
+}
+
+function formPresence(el: ESPHomeAddComponentForm): ReadonlySet<string> {
+  const form = el.shadowRoot!.querySelector("esphome-config-entry-form") as unknown as {
+    presentComponents: ReadonlySet<string>;
+  };
+  expect(form).not.toBeNull();
+  return form.presentComponents;
+}
+
+describe("add-component-form package-resolved presence", () => {
+  afterEach(() => {
+    _clearComponentCache();
+    _clearProvidesCache();
+    document.body.innerHTML = "";
+  });
+
+  it("widens the inner form's presentComponents on a packages config", async () => {
+    const el = await mountForm(PACKAGES_YAML, ["web_server", "esp32"]);
+    expect(formPresence(el).has("web_server")).toBe(true);
+  });
+
+  it("keeps the literal scan on a plain config", async () => {
+    const el = await mountForm("esphome:\n  name: foo\n", ["web_server"]);
+    expect(formPresence(el).has("web_server")).toBe(false);
+    expect(formPresence(el).has("esphome")).toBe(true);
+  });
+});

--- a/test/components/device/add-component-form-package-visibility.test.ts
+++ b/test/components/device/add-component-form-package-visibility.test.ts
@@ -1,16 +1,14 @@
 /**
  * @vitest-environment happy-dom
  *
- * Pins the add form's packages-aware `depends_on_component` visibility
- * (#1632): the inner form's `presentComponents` binding is widened by
- * the resolved components on a merged-source config only.
+ * Pins the add form's packages-aware `depends_on_component` presence
+ * binding (#1632).
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("../../../src/components/device/config-entry-form.js", () => ({}));
 
-import type { ESPHomeAPI } from "../../../src/api/index.js";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import type { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
@@ -29,25 +27,6 @@ const uptime = makeComponentEntry("sensor.uptime", {
 
 const PACKAGES_YAML = "packages:\n  base: github://acme/base.yaml\n";
 
-function mountForm(
-  yaml: string,
-  resolvedComponents: readonly string[]
-): Promise<ESPHomeAddComponentForm> {
-  const getComponents = vi.fn().mockResolvedValue({
-    components: [],
-    categories: [],
-    total: 0,
-    offset: 0,
-    limit: 200,
-  });
-  return mountAddComponentForm({
-    component: uptime,
-    yaml,
-    resolvedComponents,
-    api: { getComponents } as unknown as ESPHomeAPI,
-  });
-}
-
 function formPresence(el: ESPHomeAddComponentForm): ReadonlySet<string> {
   const form = el.shadowRoot!.querySelector("esphome-config-entry-form") as unknown as {
     presentComponents: ReadonlySet<string>;
@@ -60,16 +39,23 @@ describe("add-component-form package-resolved presence", () => {
   afterEach(() => {
     _clearComponentCache();
     _clearProvidesCache();
-    document.body.innerHTML = "";
   });
 
   it("widens the inner form's presentComponents on a packages config", async () => {
-    const el = await mountForm(PACKAGES_YAML, ["web_server", "esp32"]);
+    const el = await mountAddComponentForm({
+      component: uptime,
+      yaml: PACKAGES_YAML,
+      resolvedComponents: ["web_server", "esp32"],
+    });
     expect(formPresence(el).has("web_server")).toBe(true);
   });
 
   it("keeps the literal scan on a plain config", async () => {
-    const el = await mountForm("esphome:\n  name: foo\n", ["web_server"]);
+    const el = await mountAddComponentForm({
+      component: uptime,
+      yaml: "esphome:\n  name: foo\n",
+      resolvedComponents: ["web_server"],
+    });
     expect(formPresence(el).has("web_server")).toBe(false);
     expect(formPresence(el).has("esphome")).toBe(true);
   });

--- a/test/components/device/add-component-form-request-submit.test.ts
+++ b/test/components/device/add-component-form-request-submit.test.ts
@@ -103,6 +103,32 @@ describe("add-component-form requestSubmit (#2400)", () => {
     expect(message).toContain("device.add_component_hidden_validation_error");
   });
 
+  it("routes a package-revealed field's error to the inline branch (#1632)", () => {
+    // The literal scan hides `port`, which would send its error to the
+    // hidden-validation block message; the widened presence renders the
+    // field, so the error must surface inline instead.
+    const gated = {
+      id: "thing",
+      config_entries: [
+        makeConfigEntry({
+          key: "port",
+          type: ConfigEntryType.INTEGER,
+          required: true,
+          depends_on_component: "web_server",
+        }),
+      ],
+    } as unknown as ComponentCatalogEntry;
+    const { form, submits } = makeForm(gated);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = form as any;
+    internals.yaml = "packages:\n  base: github://acme/base.yaml\n";
+    internals.resolvedComponents = ["web_server"];
+    form.requestSubmit();
+    expect(submits).toHaveLength(0);
+    expect((internals._errors as Map<string, unknown>).has("port")).toBe(true);
+    expect(internals._localBlockMessage).toBe("");
+  });
+
   it("ignores a request while a submit is in flight", () => {
     const { form, submits } = makeForm();
     const onSubmit = vi.fn();

--- a/test/components/device/section-config-merged-presence.test.ts
+++ b/test/components/device/section-config-merged-presence.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the visual editor's packages-aware `depends_on_component`
+ * visibility (#1632): the section form's `presentComponents` binding is
+ * the literal scan widened by the backend-resolved components on a
+ * merged-source config — reacting to a late-arriving device row,
+ * identity-stable across no-op renders, and feeding validation the same
+ * set so a revealed required field is enforced in lockstep.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+vi.mock("../../../src/components/device/config-entry-form.js", () => ({}));
+
+import "../../_mock-webawesome.js";
+
+import { type ConfigEntry } from "../../../src/api/types/config-entries.js";
+import { ESPHomeDeviceSectionConfig } from "../../../src/components/device/device-section-config.js";
+import { flushDraft } from "../../../src/components/device/device-section-config/draft-and-delete.js";
+import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const PACKAGES_YAML = "packages:\n  base: github://acme/base.yaml\nwifi:\n  ssid: foo\n";
+const PLAIN_YAML = "wifi:\n  ssid: foo\n";
+
+// ``configuration`` stays unset so mounting doesn't kick loadConfig.
+function makeHost(yaml: string, entries: ConfigEntry[]) {
+  const c = new ESPHomeDeviceSectionConfig();
+  const inner = c as any;
+  inner.sectionKey = "wifi";
+  inner.yaml = yaml;
+  inner._localize = (key: string) => key;
+  inner._config = { title: "wifi", entries };
+  inner._presentComponents = new Set<string>(["wifi", "esphome"]);
+  return { c, inner };
+}
+
+function formPresence(c: ESPHomeDeviceSectionConfig): ReadonlySet<string> {
+  const form = c.shadowRoot!.querySelector("esphome-config-entry-form") as any;
+  expect(form).not.toBeNull();
+  return form.presentComponents;
+}
+
+describe("section-config merged-source presence", () => {
+  it("widens the form's presentComponents with resolved components on a packages config", async () => {
+    const { c, inner } = makeHost(PACKAGES_YAML, [makeConfigEntry({ key: "ssid" })]);
+    inner._resolvedComponents = ["web_server", "esp32"];
+    document.body.appendChild(c);
+    await c.updateComplete;
+
+    const present = formPresence(c);
+    expect(present.has("web_server")).toBe(true);
+    expect(present.has("wifi")).toBe(true);
+  });
+
+  it("widens after a late-arriving device row", async () => {
+    const { c, inner } = makeHost(PACKAGES_YAML, [makeConfigEntry({ key: "ssid" })]);
+    document.body.appendChild(c);
+    await c.updateComplete;
+    expect(formPresence(c).has("web_server")).toBe(false);
+
+    inner._resolvedComponents = ["web_server"];
+    await c.updateComplete;
+    expect(formPresence(c).has("web_server")).toBe(true);
+  });
+
+  it("keeps the widened set identity-stable across no-op renders", async () => {
+    const { c, inner } = makeHost(PACKAGES_YAML, [makeConfigEntry({ key: "ssid" })]);
+    inner._resolvedComponents = ["web_server"];
+    document.body.appendChild(c);
+    await c.updateComplete;
+
+    const first = formPresence(c);
+    c.requestUpdate();
+    await c.updateComplete;
+    expect(formPresence(c)).toBe(first);
+  });
+
+  it("passes the literal set through unchanged on a plain config", async () => {
+    const { c, inner } = makeHost(PLAIN_YAML, [makeConfigEntry({ key: "ssid" })]);
+    inner._resolvedComponents = ["web_server"];
+    document.body.appendChild(c);
+    await c.updateComplete;
+
+    expect(formPresence(c)).toBe(inner._presentComponents);
+  });
+
+  it("validates a dep-revealed required field with the same widened set", () => {
+    const entries = [
+      makeConfigEntry({ key: "ssid", required: true }),
+      makeConfigEntry({
+        key: "port",
+        required: true,
+        depends_on_component: "web_server",
+      }),
+    ];
+    const { c, inner } = makeHost(PACKAGES_YAML, entries);
+    inner.configuration = "device.yaml";
+    inner.fromLine = 2;
+    inner._values = { ssid: "foo" };
+
+    // Hidden while the dep is unresolved: no phantom required error.
+    flushDraft(c);
+    expect(inner._fieldErrors.has("port")).toBe(false);
+
+    // Resolved components reveal the field — validation enforces it.
+    inner._resolvedComponents = ["web_server"];
+    flushDraft(c);
+    expect(inner._fieldErrors.has("port")).toBe(true);
+  });
+});

--- a/test/components/device/section-config-merged-presence.test.ts
+++ b/test/components/device/section-config-merged-presence.test.ts
@@ -105,4 +105,27 @@ describe("section-config merged-source presence", () => {
     flushDraft(c);
     expect(inner._fieldErrors.has("port")).toBe(true);
   });
+
+  it("refreshes an existing error map when the device row arrives late", async () => {
+    const entries = [
+      makeConfigEntry({ key: "ssid", required: true }),
+      makeConfigEntry({
+        key: "port",
+        required: true,
+        depends_on_component: "web_server",
+      }),
+    ];
+    // `configuration` stays unset: mounting must not kick loadConfig, and
+    // flushDraft's revalidate runs before its fromLine resolution.
+    const { c, inner } = makeHost(PACKAGES_YAML, entries);
+    inner._values = {};
+    await mount(c);
+    flushDraft(c);
+    expect(inner._fieldErrors.has("ssid")).toBe(true);
+    expect(inner._fieldErrors.has("port")).toBe(false);
+
+    inner._resolvedComponents = ["web_server"];
+    await c.updateComplete;
+    expect(inner._fieldErrors.has("port")).toBe(true);
+  });
 });

--- a/test/components/device/section-config-merged-presence.test.ts
+++ b/test/components/device/section-config-merged-presence.test.ts
@@ -1,12 +1,8 @@
 /**
  * @vitest-environment happy-dom
  *
- * Pins the visual editor's packages-aware `depends_on_component`
- * visibility (#1632): the section form's `presentComponents` binding is
- * the literal scan widened by the backend-resolved components on a
- * merged-source config — reacting to a late-arriving device row,
- * identity-stable across no-op renders, and feeding validation the same
- * set so a revealed required field is enforced in lockstep.
+ * Pins the section editor's packages-aware `depends_on_component`
+ * presence wiring (#1632).
  */
 import { describe, expect, it, vi } from "vitest";
 
@@ -17,6 +13,7 @@ vi.mock("../../../src/components/device/config-entry-form.js", () => ({}));
 
 import "../../_mock-webawesome.js";
 
+import { identityLocalize, mount } from "../../_dom.js";
 import { type ConfigEntry } from "../../../src/api/types/config-entries.js";
 import { ESPHomeDeviceSectionConfig } from "../../../src/components/device/device-section-config.js";
 import { flushDraft } from "../../../src/components/device/device-section-config/draft-and-delete.js";
@@ -33,7 +30,7 @@ function makeHost(yaml: string, entries: ConfigEntry[]) {
   const inner = c as any;
   inner.sectionKey = "wifi";
   inner.yaml = yaml;
-  inner._localize = (key: string) => key;
+  inner._localize = identityLocalize;
   inner._config = { title: "wifi", entries };
   inner._presentComponents = new Set<string>(["wifi", "esphome"]);
   return { c, inner };
@@ -49,8 +46,7 @@ describe("section-config merged-source presence", () => {
   it("widens the form's presentComponents with resolved components on a packages config", async () => {
     const { c, inner } = makeHost(PACKAGES_YAML, [makeConfigEntry({ key: "ssid" })]);
     inner._resolvedComponents = ["web_server", "esp32"];
-    document.body.appendChild(c);
-    await c.updateComplete;
+    await mount(c);
 
     const present = formPresence(c);
     expect(present.has("web_server")).toBe(true);
@@ -59,8 +55,7 @@ describe("section-config merged-source presence", () => {
 
   it("widens after a late-arriving device row", async () => {
     const { c, inner } = makeHost(PACKAGES_YAML, [makeConfigEntry({ key: "ssid" })]);
-    document.body.appendChild(c);
-    await c.updateComplete;
+    await mount(c);
     expect(formPresence(c).has("web_server")).toBe(false);
 
     inner._resolvedComponents = ["web_server"];
@@ -71,8 +66,7 @@ describe("section-config merged-source presence", () => {
   it("keeps the widened set identity-stable across no-op renders", async () => {
     const { c, inner } = makeHost(PACKAGES_YAML, [makeConfigEntry({ key: "ssid" })]);
     inner._resolvedComponents = ["web_server"];
-    document.body.appendChild(c);
-    await c.updateComplete;
+    await mount(c);
 
     const first = formPresence(c);
     c.requestUpdate();
@@ -83,8 +77,7 @@ describe("section-config merged-source presence", () => {
   it("passes the literal set through unchanged on a plain config", async () => {
     const { c, inner } = makeHost(PLAIN_YAML, [makeConfigEntry({ key: "ssid" })]);
     inner._resolvedComponents = ["web_server"];
-    document.body.appendChild(c);
-    await c.updateComplete;
+    await mount(c);
 
     expect(formPresence(c)).toBe(inner._presentComponents);
   });


### PR DESCRIPTION
# What does this implement/fix?

PR #1630 fixed dependency satisfaction for packages based configs but scoped the widening to the add component gate; the `depends_on_component` field visibility check still received the literal top level scan everywhere, so a field gated on a package supplied component stayed hidden in the visual editor. This wires `withMergedSourcePresence` into the remaining producers. The section editor consumes `resolvedComponentsContext` and exposes a memoized `_effectivePresentComponents` used by both the form binding and `revalidateFields`, so a late arriving device row widens reactively and render and validation stay in lockstep. The add form widens its render and submit presence the same way, and the dialog's configless gate now uses the widened set too, so the fast path cannot skip a field the form would have shown. Three signatures loosened from `Set` to `ReadonlySet` to accept the widened set.

**Related issue or feature (if applicable):**

- fixes #1632

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

