### PR TITLE
Hoist an arraysEqual helper next to setsEqual

### DIFF
--- a/src/components/crash-decode-controller.ts
+++ b/src/components/crash-decode-controller.ts
@@ -8,6 +8,7 @@ import {
   interleaveDecoded,
 } from "../util/crash-decode.js";
 import type { LogBuffer } from "../util/log-buffer.js";
+import { arraysEqual } from "../util/set-equal.js";
 
 /** Read lazily so the host can construct this alongside its buffer. */
 export interface CrashDecodeHost {
@@ -80,7 +81,7 @@ export class CrashDecodeController {
   private _paint(region: CrashRegion): CrashRegion | null {
     const buffer = this.host.buffer();
     const raw = colorizeCrash(region.raw);
-    if (raw.every((line, i) => line === region.raw[i])) {
+    if (arraysEqual(raw, region.raw)) {
       // An OTA crash arrives red from the device's logger, so there is nothing
       // to replace. It still has to be present to be worth decoding.
       return buffer.indexOf(region.startIndex, region.raw) === null ? null : region;

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -26,6 +26,7 @@ import { fireEvent } from "../../util/fire-event.js";
 import { notifyError, notifyWarning } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { SaveShortcutController } from "../../util/save-shortcut-controller.js";
+import { arraysEqual } from "../../util/set-equal.js";
 import {
   clampSplitRatio,
   loadSplitRatio,
@@ -522,18 +523,17 @@ export class ESPHomeDeviceEditor extends LitElement {
     // Compare the fix too: its payload can change (or appear/disappear) while
     // a localized message stays the same, and it drives the auto-fix button.
     if (
-      next.length === this._liveErrors.length &&
-      next.every((err, i) => {
-        const prev = this._liveErrors[i];
-        return (
+      arraysEqual(
+        next,
+        this._liveErrors,
+        (err, prev) =>
           err.message === prev.message &&
           err.line === prev.line &&
           err.kind === prev.kind &&
           err.fix?.line === prev.fix?.line &&
           err.fix?.indent === prev.fix?.indent &&
           err.fix?.key === prev.fix?.key
-        );
-      })
+      )
     ) {
       return;
     }

--- a/src/components/device/field-scroll-controller.ts
+++ b/src/components/device/field-scroll-controller.ts
@@ -1,4 +1,5 @@
 import type { PropertyValues } from "lit";
+import { arraysEqual } from "../../util/set-equal.js";
 import { fieldKeyAttr, parseFieldKey } from "./config-entry-renderers-shared.js";
 import { flashHighlight } from "./field-highlight.js";
 
@@ -187,7 +188,7 @@ export class FieldScrollController {
   private _find(root: ParentNode, path: string[]): HTMLElement | null {
     for (const el of root.querySelectorAll<HTMLElement>("[data-field-key]")) {
       const p = parseFieldKey(el.getAttribute("data-field-key") ?? "");
-      if (p.length === path.length && p.every((k, i) => k === path[i])) return el;
+      if (arraysEqual(p, path)) return el;
     }
     // Only custom elements (hyphenated tag) carry a shadow root, so skip the
     // plain-element subtree and recurse just into those.

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -70,6 +70,7 @@ import { notifyError, notifyInfo, notifySuccess, notifyWarning } from "../util/n
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { renderAsyncState } from "../util/render-async-state.js";
+import { arraysEqual } from "../util/set-equal.js";
 import { isTypingTarget } from "../util/typing-target.js";
 import { UnsavedGuard } from "../util/unsaved-guard.js";
 import {
@@ -203,7 +204,7 @@ export class ESPHomePageDevice extends LitElement {
         ? [...device.loaded_integrations, device.target_platform]
         : device.loaded_integrations;
     const prev = this._providedResolvedComponents;
-    if (next.length !== prev.length || next.some((id, i) => id !== prev[i])) {
+    if (!arraysEqual(next, prev)) {
       this._providedResolvedComponents = next;
     }
   }

--- a/src/util/set-equal.ts
+++ b/src/util/set-equal.ts
@@ -4,3 +4,12 @@ export function setsEqual<T>(a: ReadonlySet<T>, b: ReadonlySet<T>): boolean {
   for (const item of a) if (!b.has(item)) return false;
   return true;
 }
+
+/** Same items in the same order. */
+export function arraysEqual<T>(
+  a: readonly T[],
+  b: readonly T[],
+  equals: (x: T, y: T) => boolean = (x, y) => x === y
+): boolean {
+  return a.length === b.length && a.every((v, i) => equals(v, b[i]));
+}

--- a/src/util/set-equal.ts
+++ b/src/util/set-equal.ts
@@ -5,11 +5,16 @@ export function setsEqual<T>(a: ReadonlySet<T>, b: ReadonlySet<T>): boolean {
   return true;
 }
 
-/** Same items in the same order. */
+/** Same items in the same order; `===` per item unless `equals` is given. */
 export function arraysEqual<T>(
   a: readonly T[],
   b: readonly T[],
-  equals: (x: T, y: T) => boolean = (x, y) => x === y
+  equals?: (x: T, y: T) => boolean
 ): boolean {
-  return a.length === b.length && a.every((v, i) => equals(v, b[i]));
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (equals ? !equals(a[i], b[i]) : a[i] !== b[i]) return false;
+  }
+  return true;
 }

--- a/src/util/yaml-invalid-option-fix.ts
+++ b/src/util/yaml-invalid-option-fix.ts
@@ -11,6 +11,7 @@
  * offered — the gate fails closed, so packages / `!extend` / unknown
  * components simply get no fix rather than a wrong one.
  */
+import { arraysEqual } from "./set-equal.js";
 import { getKeyPath, getPlatformValue } from "./yaml-ast.js";
 import { loadCatalog, resolveAvailableEntries } from "./yaml-completion-catalog.js";
 import {
@@ -86,8 +87,7 @@ async function gateCandidate(
     (!nest && blamedPath.length < 3) ||
     blamedPath[blamedPath.length - 1] !== parsed.key ||
     parsed.parent !== blamedPath[blamedPath.length - 2] ||
-    openerPath.length !== expectedOpener.length ||
-    openerPath.some((k, i) => expectedOpener[i] !== k)
+    !arraysEqual(openerPath, expectedOpener)
   ) {
     return null;
   }

--- a/src/util/yaml-section-splice.ts
+++ b/src/util/yaml-section-splice.ts
@@ -10,6 +10,7 @@
 
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import { isPlainObject, isPrimitiveOrNullish } from "./nested-values.js";
+import { arraysEqual } from "./set-equal.js";
 import type { ListItemSource } from "./yaml-section-list.js";
 import {
   formatYamlFlowList,
@@ -79,17 +80,11 @@ export function yamlValueEqual(a: unknown, b: unknown): boolean {
       a instanceof YamlRawValue &&
       b instanceof YamlRawValue &&
       a.inlineHeader === b.inlineHeader &&
-      a.lines.length === b.lines.length &&
-      a.lines.every((line, i) => line === b.lines[i])
+      arraysEqual(a.lines, b.lines)
     );
   }
   if (Array.isArray(a) || Array.isArray(b)) {
-    return (
-      Array.isArray(a) &&
-      Array.isArray(b) &&
-      a.length === b.length &&
-      a.every((item, i) => yamlValueEqual(item, b[i]))
-    );
+    return Array.isArray(a) && Array.isArray(b) && arraysEqual(a, b, yamlValueEqual);
   }
   if (isPlainObject(a) && isPlainObject(b)) {
     const ak = Object.keys(a);

--- a/test/util/set-equal.test.ts
+++ b/test/util/set-equal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { setsEqual } from "../../src/util/set-equal.js";
+import { arraysEqual, setsEqual } from "../../src/util/set-equal.js";
 
 describe("setsEqual", () => {
   it("matches sets regardless of insertion order", () => {
@@ -10,5 +10,24 @@ describe("setsEqual", () => {
   it("rejects a size mismatch and a same-size membership mismatch", () => {
     expect(setsEqual(new Set(["a"]), new Set(["a", "b"]))).toBe(false);
     expect(setsEqual(new Set(["a", "c"]), new Set(["a", "b"]))).toBe(false);
+  });
+});
+
+describe("arraysEqual", () => {
+  it("matches same items in the same order", () => {
+    expect(arraysEqual(["a", "b"], ["a", "b"])).toBe(true);
+    expect(arraysEqual([], [])).toBe(true);
+  });
+
+  it("rejects a length mismatch, an element mismatch, and reordering", () => {
+    expect(arraysEqual(["a"], ["a", "b"])).toBe(false);
+    expect(arraysEqual(["a", "c"], ["a", "b"])).toBe(false);
+    expect(arraysEqual(["a", "b"], ["b", "a"])).toBe(false);
+  });
+
+  it("compares elements with the supplied comparator", () => {
+    const byId = (x: { id: number }, y: { id: number }) => x.id === y.id;
+    expect(arraysEqual([{ id: 1 }], [{ id: 1 }], byId)).toBe(true);
+    expect(arraysEqual([{ id: 1 }], [{ id: 2 }], byId)).toBe(false);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Adds `arraysEqual` next to `setsEqual` in `set-equal.ts` (with an optional element comparator) and migrates the inline shallow array equality copies: both `yaml-section-splice.ts` sites (the second via the comparator with `yamlValueEqual`), `crash-decode-controller.ts` (the added length check is a no-op since `colorizeCrash` is a length preserving map), `device-editor.ts` (comparator carries the existing per field error comparison), `field-scroll-controller.ts` line 190, the `pages/device.ts` copy from #1630, and the `yaml-invalid-option-fix.ts` opener path check the bot review caught.

Two sites the issue lists are left alone on purpose: the `field-scroll-controller.ts` gating filter is a prefix match and `automation-focus.ts` is a subsequence match at an offset, so neither is array equality and routing them through the helper would need throwaway `slice()` allocations.

**Related issue or feature (if applicable):**

- fixes #1634

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

