### PR TITLE
Satisfy dotted dependencies from package-resolved platforms

### DIFF
--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -104,6 +104,9 @@ export interface ConfiguredDevice {
   logger_interface: string | null;
   current_version: string;
   loaded_integrations: string[];
+  /** Dotted `domain.platform` pairs (`ota.esphome`) from the last
+   *  compile's StorageJSON; empty until first compile. */
+  loaded_platforms: string[];
   /**
    * Subset of ``loaded_integrations`` the user directly wrote in
    * YAML — top-level keys (``api:``, ``wifi:``, ``sensor:``) plus

--- a/src/components/device/add-component-deps.ts
+++ b/src/components/device/add-component-deps.ts
@@ -1,6 +1,7 @@
 import type { ESPHomeAPI } from "../../api/index.js";
 import { ComponentCategory } from "../../api/types/components.js";
 import { canonicalComponentKey, hasComponentKey } from "../../util/component-presence.js";
+import { withMergedSourcePresence } from "../../util/merged-source-presence.js";
 import { providerIds } from "../../util/provides-cache.js";
 import {
   parseConfiguredPlatforms,
@@ -18,27 +19,32 @@ const PLATFORM_DOMAINS: ReadonlySet<string> = new Set(Object.values(ComponentCat
  *
  * A dependency is satisfied when any of:
  *  - the presence set carries it (`ld2410:`, `i2c:`);
- *  - a dotted dep (`ota.http_request`) matches a configured platform;
+ *  - a dotted dep (`ota.http_request`) matches a configured platform —
+ *    from the YAML scan, or from `resolvedPlatforms` on a merged-source
+ *    config;
  *  - a configured platform's stem equals the dep and the dep isn't a
  *    platform domain — platform-style hubs (`atm90e32`) live under a
  *    domain (`sensor: - platform: atm90e32`), not at the top level.
  *
  * `presentComponents` is the caller's effective presence — the literal scan
- * widened via `withMergedSourcePresence` on merged-source configs. Widening
- * satisfies bare deps only: matching a dotted dep by stem would
- * false-satisfy (`ota.esphome` vs the always-loaded `esphome` core key), so
- * dotted deps stay on the configured-platform scan. Omitted, the literal
- * scan of *yaml* is used.
+ * widened via `withMergedSourcePresence` on merged-source configs; it
+ * satisfies bare deps only (a bare stem must never match a dotted dep:
+ * `ota.esphome` vs the always-loaded `esphome` core key). Omitted, the
+ * literal scan of *yaml* is used. `resolvedPlatforms` is the dotted
+ * counterpart (`loaded_platforms`), widened here rather than by callers —
+ * the configured-platform scan is internal, so no caller can pre-widen it.
  */
 export function findMissingDependencies(
   dependencies: readonly string[],
   yaml: string,
-  presentComponents?: ReadonlySet<string>
+  presentComponents?: ReadonlySet<string>,
+  resolvedPlatforms: readonly string[] = []
 ): string[] {
   // Most components declare no dependencies — skip the YAML scans.
   if (dependencies.length === 0) return [];
   const present = presentComponents ?? parseTopLevelComponents(yaml);
   const configured = parseConfiguredPlatforms(yaml);
+  const platforms = withMergedSourcePresence(configured, yaml, resolvedPlatforms);
   const platformStems = new Set<string>();
   for (const id of configured) {
     const dot = id.indexOf(".");
@@ -46,7 +52,7 @@ export function findMissingDependencies(
   }
   return dependencies.filter((dep) => {
     if (hasComponentKey(present, dep)) return false;
-    if (dep.includes(".")) return !configured.has(dep);
+    if (dep.includes(".")) return !platforms.has(dep);
     if (!PLATFORM_DOMAINS.has(dep) && platformStems.has(dep)) return false;
     return true;
   });

--- a/src/components/device/add-component-deps.ts
+++ b/src/components/device/add-component-deps.ts
@@ -45,6 +45,8 @@ export function findMissingDependencies(
   const present = presentComponents ?? parseTopLevelComponents(yaml);
   const configured = parseConfiguredPlatforms(yaml);
   const platforms = withMergedSourcePresence(configured, yaml, resolvedPlatforms);
+  // Stems stay on the literal scan: a package-supplied bare dep is already
+  // covered by the widened presentComponents.
   const platformStems = new Set<string>();
   for (const id of configured) {
     const dot = id.indexOf(".");

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -10,6 +10,7 @@ import {
   apiContext,
   localizeContext,
   resolvedComponentsContext,
+  resolvedPlatformsContext,
 } from "../../context/index.js";
 import { primaryHeaderDialogStyles } from "../../styles/dialog-chrome.js";
 import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
@@ -113,6 +114,12 @@ export class ESPHomeAddComponentDialog extends LitElement {
   @consume({ context: resolvedComponentsContext, subscribe: true })
   @state()
   private _resolvedComponents: readonly string[] = [];
+
+  /** Backend-resolved dotted `domain.platform` pairs; forwarded to the
+   *  form. See resolvedPlatformsContext. */
+  @consume({ context: resolvedPlatformsContext, subscribe: true })
+  @state()
+  private _resolvedPlatforms: readonly string[] = [];
 
   /** When non-empty, the dialog locks the catalog to those
    *  categories, hides the category sidebar, and switches its title
@@ -366,6 +373,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
                 .board=${this.board}
                 .yaml=${this.yaml}
                 .resolvedComponents=${this._resolvedComponents}
+                .resolvedPlatforms=${this._resolvedPlatforms}
                 .prefillReference=${this._prefillReference}
                 .prefillFields=${this._depPrefill?.fields ?? null}
                 .restoredValues=${this._returnValues}
@@ -539,7 +547,12 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // top-level-block check, so a stem-satisfied dep doesn't keep a blank
     // form. The form's async `provides` subtraction isn't replicated — this
     // stays stricter, only keeping the form a touch more often.
-    const missing = findMissingDependencies(entry.dependencies ?? [], this.yaml, present);
+    const missing = findMissingDependencies(
+      entry.dependencies ?? [],
+      this.yaml,
+      present,
+      this._resolvedPlatforms
+    );
     if (missing.length > 0) return null;
     const seeded = buildInitialValues({
       entries: entry.config_entries,

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -73,6 +73,11 @@ export class ESPHomeAddComponentForm extends LitElement {
   @property({ attribute: false })
   resolvedComponents: readonly string[] = [];
 
+  /** Backend-resolved dotted `domain.platform` pairs; see
+   *  resolvedPlatformsContext. */
+  @property({ attribute: false })
+  resolvedPlatforms: readonly string[] = [];
+
   /**
    * Optional initial value for an ID-reference field. Used by the
    * dialog after a "+ Add <domain>" detour finishes — we pre-fill the
@@ -251,7 +256,11 @@ export class ESPHomeAddComponentForm extends LitElement {
       changedProperties.has("component") ||
       changedProperties.has("yaml") ||
       changedProperties.has("board");
-    if (scopeChanged || changedProperties.has("resolvedComponents")) {
+    if (
+      scopeChanged ||
+      changedProperties.has("resolvedComponents") ||
+      changedProperties.has("resolvedPlatforms")
+    ) {
       void this._resolveProvidedDeps();
     }
     if (scopeChanged) {
@@ -276,7 +285,8 @@ export class ESPHomeAddComponentForm extends LitElement {
     const missing = findMissingDependencies(
       this.component.dependencies ?? [],
       this.yaml,
-      present
+      present,
+      this.resolvedPlatforms
     ).filter((d) => !this._providedDeps.has(d));
     const blocked = this._busBlockedDep;
     return blocked && !missing.includes(blocked) ? [...missing, blocked] : missing;
@@ -297,7 +307,12 @@ export class ESPHomeAddComponentForm extends LitElement {
     // Common dep-free case: nothing to resolve, so skip the YAML parse too.
     if (!api || deps.length === 0) return;
     const present = this._visibilityPresence();
-    const missing = findMissingDependencies(deps, this.yaml, present);
+    const missing = findMissingDependencies(
+      deps,
+      this.yaml,
+      present,
+      this.resolvedPlatforms
+    );
     if (missing.length === 0) return;
     try {
       const satisfied = await depsSatisfiedByProvides(api, missing, present, {

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -40,6 +40,13 @@ export const resolvedComponentsContext = createContext<readonly string[]>(
   Symbol("esphome-resolved-components")
 );
 
+/** Context for the current device's backend-resolved dotted
+ *  `domain.platform` pairs (loaded_platforms), provided by the device
+ *  page; see withMergedSourcePresence. */
+export const resolvedPlatformsContext = createContext<readonly string[]>(
+  Symbol("esphome-resolved-platforms")
+);
+
 /** Context for the ESPHome version string. */
 export const versionContext = createContext<string>(Symbol("esphome-version"));
 

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -35,6 +35,7 @@ export {
   remoteBuildEnabledContext,
   remoteComputeOnlyContext,
   resolvedComponentsContext,
+  resolvedPlatformsContext,
   serverVersionContext,
   versionContext,
   versionHistoryEnabledContext,

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -43,6 +43,7 @@ import {
   devicesLoadedContext,
   localizeContext,
   resolvedComponentsContext,
+  resolvedPlatformsContext,
 } from "../context/index.js";
 import { loadMessageStyles } from "../styles/load-message.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -194,6 +195,11 @@ export class ESPHomePageDevice extends LitElement {
   @state()
   _providedResolvedComponents: readonly string[] = [];
 
+  /** Dotted `domain.platform` pairs, same identity contract as above. */
+  @provide({ context: resolvedPlatformsContext })
+  @state()
+  _providedResolvedPlatforms: readonly string[] = [];
+
   protected willUpdate(changedProperties: PropertyValues): void {
     super.willUpdate(changedProperties);
     if (!changedProperties.has("_devices") && !changedProperties.has("id")) return;
@@ -206,6 +212,10 @@ export class ESPHomePageDevice extends LitElement {
     const prev = this._providedResolvedComponents;
     if (!arraysEqual(next, prev)) {
       this._providedResolvedComponents = next;
+    }
+    const nextPlatforms = device?.loaded_platforms ?? [];
+    if (!arraysEqual(nextPlatforms, this._providedResolvedPlatforms)) {
+      this._providedResolvedPlatforms = nextPlatforms;
     }
   }
 

--- a/src/util/merged-source-presence.ts
+++ b/src/util/merged-source-presence.ts
@@ -1,8 +1,10 @@
 import { yamlHasMergedSources } from "./config-entry-yaml-scan.js";
 
 /**
- * Widen a present-components set with the backend-resolved list when the
- * YAML root-merges sources the top-level scan can't see (packages: / <<:).
+ * Widen a YAML-scanned presence set with the backend-resolved list when the
+ * YAML root-merges sources the scan can't see (packages: / <<:). Serves both
+ * id shapes: bare components against `loaded_integrations`, and dotted
+ * `domain.platform` pairs against `loaded_platforms`.
  *
  * For a plain config the scan is complete and live, so the resolved set is
  * deliberately ignored: deleting a block in the buffer must re-flag its
@@ -13,10 +15,10 @@ import { yamlHasMergedSources } from "./config-entry-yaml-scan.js";
 export function withMergedSourcePresence(
   present: ReadonlySet<string>,
   yaml: string,
-  resolvedComponents: readonly string[]
+  resolved: readonly string[]
 ): ReadonlySet<string> {
-  if (resolvedComponents.length === 0 || !yamlHasMergedSources(yaml)) return present;
+  if (resolved.length === 0 || !yamlHasMergedSources(yaml)) return present;
   const widened = new Set(present);
-  for (const id of resolvedComponents) widened.add(id);
+  for (const id of resolved) widened.add(id);
   return widened;
 }

--- a/test/_make-configured-device.ts
+++ b/test/_make-configured-device.ts
@@ -37,6 +37,7 @@ const _BASE = {
   logger_interface: null,
   current_version: "",
   loaded_integrations: [],
+  loaded_platforms: [],
   runtime_state: {
     state: DeviceState.UNKNOWN,
     // Live mDNS source so an api-enabled test device shows its out-of-sync /

--- a/test/components/device/_add-component-form-host.ts
+++ b/test/components/device/_add-component-form-host.ts
@@ -13,6 +13,7 @@ export interface AddComponentFormOptions {
   yaml?: string;
   board?: BoardCatalogEntry | null;
   resolvedComponents?: readonly string[];
+  resolvedPlatforms?: readonly string[];
 }
 
 /** An API whose catalog and `provides` queries answer empty. */
@@ -45,6 +46,8 @@ export function makeAddComponentForm(
   if (options.board !== undefined) el.board = options.board;
   if (options.resolvedComponents !== undefined)
     el.resolvedComponents = options.resolvedComponents;
+  if (options.resolvedPlatforms !== undefined)
+    el.resolvedPlatforms = options.resolvedPlatforms;
   Object.assign(el as unknown as Record<string, unknown>, {
     _api: options.api ?? emptyCatalogApi(),
   });

--- a/test/components/device/add-component-deps.test.ts
+++ b/test/components/device/add-component-deps.test.ts
@@ -97,6 +97,28 @@ describe("findMissingDependencies", () => {
     expect(findMissingDependencies(["rp2"], yaml, widened(yaml, ["rp2040"]))).toEqual([]);
   });
 
+  it("satisfies a dotted dep from the resolved platforms when the YAML merges packages", () => {
+    const yaml = "packages:\n  base: github://acme/base.yaml\n";
+    expect(
+      findMissingDependencies(["ota.esphome"], yaml, undefined, ["ota.esphome"])
+    ).toEqual([]);
+  });
+
+  it("ignores the resolved platforms for a plain config", () => {
+    expect(
+      findMissingDependencies(["ota.esphome"], "api:\n", undefined, ["ota.esphome"])
+    ).toEqual(["ota.esphome"]);
+  });
+
+  it("does not let a resolved bare component stem-satisfy a dotted dep", () => {
+    // `esphome` is always loaded, so a bare resolved name must never
+    // pass for the `ota.esphome` pair.
+    const yaml = "packages:\n  base: github://acme/base.yaml\n";
+    expect(
+      findMissingDependencies(["ota.esphome"], yaml, widened(yaml, ["esphome"]))
+    ).toEqual(["ota.esphome"]);
+  });
+
   it("treats an empty dependency list as satisfied", () => {
     expect(findMissingDependencies([], "")).toEqual([]);
   });

--- a/test/components/device/add-component-form-package-dep.test.ts
+++ b/test/components/device/add-component-form-package-dep.test.ts
@@ -59,4 +59,30 @@ describe("add-component-form package-resolved dependency", () => {
     const el = await mountForm(PACKAGES_YAML, ["api", "esp8266", "wifi"]);
     expect(depsBanner(el)).not.toBeNull();
   });
+
+  it("clears the banner when the resolved platforms satisfy a dotted dep", async () => {
+    const el = await mountAddComponentForm({
+      component: makeComponentEntry("wake_on_lan", {
+        name: "Wake on LAN",
+        dependencies: ["ota.esphome"],
+      }),
+      yaml: PACKAGES_YAML,
+      resolvedComponents: ["api", "esp32", "wifi"],
+      resolvedPlatforms: ["ota.esphome", "time.sntp"],
+    });
+    expect(depsBanner(el)).toBeNull();
+  });
+
+  it("keeps the banner when the resolved platforms lack the dotted dep", async () => {
+    const el = await mountAddComponentForm({
+      component: makeComponentEntry("wake_on_lan", {
+        name: "Wake on LAN",
+        dependencies: ["ota.esphome"],
+      }),
+      yaml: PACKAGES_YAML,
+      resolvedComponents: ["api", "esp32", "wifi"],
+      resolvedPlatforms: ["time.sntp"],
+    });
+    expect(depsBanner(el)).not.toBeNull();
+  });
 });

--- a/test/components/device/resolved-components-context.test.ts
+++ b/test/components/device/resolved-components-context.test.ts
@@ -17,7 +17,10 @@ import { html, LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import "../../../src/components/device/add-config-dialog.js";
 import type { ESPHomeComponentCatalog } from "../../../src/components/device/component-catalog.js";
-import { resolvedComponentsContext } from "../../../src/context/index.js";
+import {
+  resolvedComponentsContext,
+  resolvedPlatformsContext,
+} from "../../../src/context/index.js";
 
 @customElement("test-resolved-components-provider")
 class TestResolvedComponentsProvider extends LitElement {
@@ -25,14 +28,22 @@ class TestResolvedComponentsProvider extends LitElement {
   @state()
   resolved: readonly string[] = [];
 
+  @provide({ context: resolvedPlatformsContext })
+  @state()
+  resolvedPlatforms: readonly string[] = [];
+
   protected render() {
     return html`<esphome-add-config-dialog></esphome-add-config-dialog>`;
   }
 }
 
-async function mountChain(resolved: readonly string[]) {
+async function mountChain(
+  resolved: readonly string[],
+  platforms: readonly string[] = []
+) {
   const provider = new TestResolvedComponentsProvider();
   provider.resolved = resolved;
+  provider.resolvedPlatforms = platforms;
   document.body.appendChild(provider);
   await provider.updateComplete;
   const configDialog = provider.shadowRoot!.querySelector("esphome-add-config-dialog")!;
@@ -62,6 +73,18 @@ describe("resolvedComponentsContext wiring", () => {
     await addDialog.updateComplete;
     await catalog.updateComplete;
     expect(catalog.resolvedComponents).toEqual(["api", "esp32", "wifi"]);
+    provider.remove();
+  });
+
+  it("delivers the provided platform pairs to the nested add dialog", async () => {
+    const { provider, addDialog } = await mountChain(["api"], ["ota.esphome"]);
+    const internals = addDialog as unknown as { _resolvedPlatforms: readonly string[] };
+    expect(internals._resolvedPlatforms).toEqual(["ota.esphome"]);
+
+    provider.resolvedPlatforms = ["ota.esphome", "time.sntp"];
+    await provider.updateComplete;
+    await addDialog.updateComplete;
+    expect(internals._resolvedPlatforms).toEqual(["ota.esphome", "time.sntp"]);
     provider.remove();
   });
 });

--- a/test/pages/device.test.ts
+++ b/test/pages/device.test.ts
@@ -361,10 +361,11 @@ describe("esphome-page-device install while a job is running", () => {
 });
 
 describe("esphome-page-device resolved-components provider", () => {
-  const row = (loaded: string[]): ConfiguredDevice =>
+  const row = (loaded: string[], platforms: string[] = []): ConfiguredDevice =>
     ({
       configuration: "foo.yaml",
       loaded_integrations: loaded,
+      loaded_platforms: platforms,
       target_platform: "esp32",
     }) as unknown as ConfiguredDevice;
 
@@ -377,29 +378,34 @@ describe("esphome-page-device resolved-components provider", () => {
     return page as ESPHomePageDevice & {
       willUpdate(changed: Map<PropertyKey, unknown>): void;
       _providedResolvedComponents: readonly string[];
+      _providedResolvedPlatforms: readonly string[];
     };
   }
 
   test("derives the provided list from the matching device row", () => {
-    const page = makeProviderPage([row(["api", "wifi"])]);
+    const page = makeProviderPage([row(["api", "wifi"], ["ota.esphome"])]);
     page.willUpdate(new Map([["_devices", undefined]]));
     expect(page._providedResolvedComponents).toEqual(["api", "wifi", "esp32"]);
+    expect(page._providedResolvedPlatforms).toEqual(["ota.esphome"]);
   });
 
   test("keeps identity when a rebuilt row carries identical contents", () => {
-    const page = makeProviderPage([row(["api", "wifi"])]);
+    const page = makeProviderPage([row(["api", "wifi"], ["ota.esphome"])]);
     page.willUpdate(new Map([["_devices", undefined]]));
     const first = page._providedResolvedComponents;
+    const firstPlatforms = page._providedResolvedPlatforms;
     Object.assign(page as unknown as Record<string, unknown>, {
-      _devices: [row(["api", "wifi"])],
+      _devices: [row(["api", "wifi"], ["ota.esphome"])],
     });
     page.willUpdate(new Map([["_devices", undefined]]));
     expect(page._providedResolvedComponents).toBe(first);
+    expect(page._providedResolvedPlatforms).toBe(firstPlatforms);
   });
 
   test("skips the recompute when unrelated properties change", () => {
-    const page = makeProviderPage([row(["api", "wifi"])]);
+    const page = makeProviderPage([row(["api", "wifi"], ["ota.esphome"])]);
     page.willUpdate(new Map([["_layout", undefined]]));
     expect(page._providedResolvedComponents).toEqual([]);
+    expect(page._providedResolvedPlatforms).toEqual([]);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

A dotted dependency (`ota.esphome`, `time.homeassistant`) supplied by a remote package still showed the false "Add X" detour after #1630, because `loaded_integrations` is bare names only and stem matching would false satisfy. The companion backend PR exposes the device row's `loaded_platforms` (dotted `domain.platform` pairs from StorageJSON, package resolved platforms included); this PR provides them through a new `resolvedPlatformsContext`, threads them dialog to form, and widens `findMissingDependencies`' dotted branch with them via the shared `withMergedSourcePresence` (which turns out to be shape agnostic, so no sibling helper) — merged source configs only, plain configs keep the live literal scan. The catalog's single instance hiding and core locked checks stay on the literal scan by their documented design.

Companion backend PR (lockstep): esphome/device-builder#2536

**Related issue or feature (if applicable):**

- fixes #1631

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
