### PR TITLE
Pass the typed address override through to network logs

### DIFF
--- a/src/util/logs-launch.ts
+++ b/src/util/logs-launch.ts
@@ -1,5 +1,6 @@
 import type { ESPHomeAPI } from "../api/index.js";
 import type { ConfiguredDevice } from "../api/types/devices.js";
+import { OTA_PORT } from "../api/types/streaming.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";
 import { resolveLogBaudRate } from "./log-baud-rate.js";
@@ -74,7 +75,10 @@ export async function launchLogsWithMethod(
   if (method === "ota") {
     host.logsDialog.configuration = device.configuration;
     host.logsDialog.name = device.friendly_name || device.name;
-    host.logsDialog.open();
+    // 'port' carries the user-typed address override from the picker's
+    // expanded form; without it the OTA sentinel targets the default
+    // address (mirrors applyInstallMethod's ota case).
+    host.logsDialog.open(port ?? OTA_PORT);
   } else if (method === "server-serial") {
     // server-serial always carries the chosen port; guard rather than let a
     // missing one fall through to open()'s OTA-sentinel default and silently

--- a/test/util/logs-launch.test.ts
+++ b/test/util/logs-launch.test.ts
@@ -160,12 +160,18 @@ describe("launchLogs", () => {
 });
 
 describe("launchLogsWithMethod", () => {
-  it("routes ota to a portless open()", async () => {
+  it("routes ota without a port to the OTA sentinel", async () => {
     const host = makeHost(async () => []);
     await launchLogsWithMethod(host, makeDevice(), "ota");
-    expect(host.logsDialog.open).toHaveBeenCalledWith();
+    expect(host.logsDialog.open).toHaveBeenCalledWith("OTA");
     expect(host.logsDialog.configuration).toBe("kitchen.yaml");
     expect(host.logsDialog.name).toBe("Kitchen");
+  });
+
+  it("routes ota with an address override to open(port)", async () => {
+    const host = makeHost(async () => []);
+    await launchLogsWithMethod(host, makeDevice(), "ota", "192.168.5.243");
+    expect(host.logsDialog.open).toHaveBeenCalledWith("192.168.5.243");
   });
 
   it("routes server-serial to open(port)", async () => {


### PR DESCRIPTION
# What does this implement/fix?

The logs picker's advanced "Device IP or hostname" box was ignored; `launchLogsWithMethod` dropped the `port` argument for the `ota` method and always opened the default OTA target, so the backend ran `esphome logs --device OTA` and the CLI still did MQTT IP discovery even when the user typed the address. Pass the typed address through to the logs dialog, matching how `applyInstallMethod` handles the same picker for installs. With an explicit address the CLI uses it verbatim and skips the MQTTIP lookup entirely.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18311

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
