### PR TITLE
Keep the States toggle for typed-address network logs

### DIFF
--- a/src/components/logs-session.ts
+++ b/src/components/logs-session.ts
@@ -25,7 +25,6 @@
  * - ``dead``         a Web Serial reopen failed; the port is gone. Start runs
  *                    the reconnect hook (the #636 "click Start to reconnect").
  */
-import { OTA_PORT } from "../api/types/streaming.js";
 export type LogsSession =
   | { readonly kind: "idle" }
   | {
@@ -60,10 +59,15 @@ export const isPassive = (s: LogsSession): boolean =>
  *  and the port can be torn down. */
 export const hasSerialPort = (s: LogsSession): boolean => s.kind === "serial";
 
+/** A server serial device path (/dev/..., COMn) vs a network address. */
+export const isServerSerialPath = (port: string): boolean =>
+  port.startsWith("/") || /^COM\d+$/i.test(port);
+
 /** Whether the States toggle applies. Device states arrive only over the API /
  *  network connection, so the toggle (which sets the backend ``--no-states``
  *  flag) is meaningful only for the OTA source. Server serial shares the
- *  ``ota`` kind but carries a device path instead of the ``OTA`` sentinel, so
- *  it's excluded — toggling states there is a no-op (#539). */
+ *  ``ota`` kind but carries a device path, so it's excluded — toggling states
+ *  there is a no-op (#539). A typed address override counts as network: the
+ *  stream still runs over the API, only the target changes. */
 export const isOtaNetwork = (s: LogsSession): boolean =>
-  s.kind === "ota" && s.port === OTA_PORT;
+  s.kind === "ota" && !isServerSerialPath(s.port);

--- a/test/components/logs-dialog.test.ts
+++ b/test/components/logs-dialog.test.ts
@@ -79,6 +79,29 @@ describe("logs-dialog states-toggle restart", () => {
     expect(stopStream).toHaveBeenCalledTimes(1);
     expect(session(el)).toMatchObject({ kind: "ota", streamId: "stream-2" });
   });
+
+  it("respawns a typed-address session against the same target", async () => {
+    el.open("192.168.5.243");
+    expect(logs).toHaveBeenLastCalledWith(
+      expect.anything(),
+      "192.168.5.243",
+      expect.anything(),
+      expect.anything()
+    );
+
+    const restart = call(el, "_toggleShowStates");
+    stop.resolve();
+    await restart;
+
+    expect(logs).toHaveBeenCalledTimes(2);
+    expect(logs).toHaveBeenLastCalledWith(
+      expect.anything(),
+      "192.168.5.243",
+      expect.anything(),
+      expect.anything()
+    );
+    expect(session(el)).toMatchObject({ kind: "ota", port: "192.168.5.243" });
+  });
 });
 
 describe("logs-dialog OTA stale-callback guard", () => {

--- a/test/components/logs-session.test.ts
+++ b/test/components/logs-session.test.ts
@@ -4,6 +4,7 @@ import {
   hasSerialPort,
   isOtaNetwork,
   isPassive,
+  isServerSerialPath,
   isStreaming,
   type LogsSession,
 } from "../../src/components/logs-session.js";
@@ -58,13 +59,20 @@ describe("logs-session selectors", () => {
     }
   });
 
-  it("isOtaNetwork: only the OTA sentinel port, not a server serial path", () => {
+  it("isOtaNetwork: network targets including typed addresses, not serial paths", () => {
     expect(isOtaNetwork({ kind: "ota", port: OTA_PORT, streamId: "s1" })).toBe(true);
     expect(isOtaNetwork({ kind: "ota", port: OTA_PORT, streamId: null })).toBe(true);
+    // A typed address override is still a backend network stream.
+    expect(isOtaNetwork({ kind: "ota", port: "192.168.5.243", streamId: "s1" })).toBe(
+      true
+    );
+    expect(isOtaNetwork({ kind: "ota", port: "kitchen.local", streamId: null })).toBe(
+      true
+    );
     // Server serial rides the same `ota` kind but carries a device path (#539).
-    expect(
-      isOtaNetwork({ kind: "ota", port: "/dev/cu.usbserial-110", streamId: "s1" })
-    ).toBe(false);
+    for (const port of ["/dev/cu.usbserial-110", "/dev/ttyUSB0", "COM3", "com12"]) {
+      expect(isOtaNetwork({ kind: "ota", port, streamId: "s1" })).toBe(false);
+    }
     for (const s of [
       { kind: "serial", port: fakePort, cancel: noop, paused: false },
       { kind: "reconnecting", paused: false },
@@ -72,6 +80,15 @@ describe("logs-session selectors", () => {
       { kind: "idle" },
     ] as LogsSession[]) {
       expect(isOtaNetwork(s)).toBe(false);
+    }
+  });
+
+  it("isServerSerialPath: device paths yes, addresses and the sentinel no", () => {
+    for (const port of ["/dev/ttyUSB0", "/dev/cu.usbserial-110", "COM3", "com12"]) {
+      expect(isServerSerialPath(port)).toBe(true);
+    }
+    for (const port of [OTA_PORT, "192.168.5.243", "kitchen.local", "commodore.lan"]) {
+      expect(isServerSerialPath(port)).toBe(false);
     }
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

`isOtaNetwork` gated the States toggle on the port being the `OTA` sentinel, so a typed address override from the logs picker (or a post install hand off carrying one) hid the toggle even though the stream still runs over the backend API where `--no-states` applies. The predicate's real intent since #539 is to exclude server serial device paths, so test for that axis directly: a new `isServerSerialPath` helper classifies `/dev/...` and `COMn` as serial, everything else as network. Session tagging was considered instead, but the job reattach path restores the port from the backend `FirmwareJob` as a bare string, so a tag would still need this same classification at that boundary; the backend classifies serial ports by path shape the same way.

**Related issue or feature (if applicable):**

- follow-up to the review finding on #1639 (https://github.com/esphome/device-builder-frontend/pull/1639#issuecomment-5263017699)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
