### PR TITLE
Surface esptool-js connect diagnostics in the Web Serial install log

### DIFF
--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -206,11 +206,12 @@ export async function connectToPort(
   // errors) only through debug() and throws a generic connect error; hold a
   // bounded tail of them to replay into the log when detection fails (#2553).
   const debugTail: string[] = [];
-  const originalDebug = loader.debug.bind(loader);
+  const originalDebug = loader.debug;
   if (onLog) {
-    loader.debug = (str: string) => {
+    loader.debug = (str: string, withNewline?: boolean) => {
       debugTail.push(str);
       if (debugTail.length > DEBUG_TAIL_LINES) debugTail.shift();
+      originalDebug.call(loader, str, withNewline);
     };
   }
 
@@ -224,12 +225,15 @@ export async function connectToPort(
       return runStub();
     };
     const chipName = await loader.main();
-    loader.debug = originalDebug;
     return { chipName, port, transport, loader };
   } catch (error) {
     if (onLog) {
-      for (const line of debugTail) onLog(line);
-      onLog(`Failed to connect: ${getErrorMessage(error)}`);
+      // An unsupported chip means the handshake succeeded; the tail would
+      // just be 80 lines of healthy connect chatter.
+      if (!(error instanceof UnsupportedChipError)) {
+        for (const line of debugTail) onLog(line);
+      }
+      onLog(`Error: ${getErrorMessage(error)}`);
     }
     try {
       await transport.disconnect();
@@ -241,6 +245,8 @@ export async function connectToPort(
       }
     }
     throw error;
+  } finally {
+    if (onLog) loader.debug = originalDebug;
   }
 }
 

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -7,6 +7,7 @@
  */
 import { ESPLoader, Transport, UsbJtagSerialReset } from "esptool-js";
 
+import { getErrorMessage } from "./error-message.js";
 import { markSerialActivity } from "./serial-reacquire.js";
 
 /** Espressif's USB Vendor ID — chips with native USB-Serial/JTAG. */
@@ -39,6 +40,9 @@ export interface FlashProgress {
 }
 
 export type LogCallback = (line: string) => void;
+
+/** Bounded tail of esptool-js debug lines replayed into the log on a failed connect. */
+const DEBUG_TAIL_LINES = 80;
 
 /** Why Web Serial can or can't be used here. */
 export type WebSerialAvailability = "available" | "insecure-context" | "unsupported";
@@ -198,6 +202,18 @@ export async function connectToPort(
       : undefined,
   });
 
+  // esptool-js reports its per-attempt connect diagnostics (boot mode, sync
+  // errors) only through debug() and throws a generic connect error; hold a
+  // bounded tail of them to replay into the log when detection fails (#2553).
+  const debugTail: string[] = [];
+  const originalDebug = loader.debug.bind(loader);
+  if (onLog) {
+    loader.debug = (str: string) => {
+      debugTail.push(str);
+      if (debugTail.length > DEBUG_TAIL_LINES) debugTail.shift();
+    };
+  }
+
   try {
     // main() has no hook between magic-register chip detection and the stub
     // upload, so wrap runStub to cross-check the chip id first. Remove when
@@ -208,8 +224,13 @@ export async function connectToPort(
       return runStub();
     };
     const chipName = await loader.main();
+    loader.debug = originalDebug;
     return { chipName, port, transport, loader };
   } catch (error) {
+    if (onLog) {
+      for (const line of debugTail) onLog(line);
+      onLog(`Failed to connect: ${getErrorMessage(error)}`);
+    }
     try {
       await transport.disconnect();
     } catch {

--- a/test/util/web-serial-connect-log.test.ts
+++ b/test/util/web-serial-connect-log.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins connectToPort's failure logging: esptool-js debug diagnostics replay
+ * into the log only when chip detection fails (#2553).
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface TerminalLike {
+  clean: () => void;
+  writeLine: (line: string) => void;
+  write: (text: string) => void;
+}
+
+interface FakeLoaderApi {
+  info: (str: string, withNewline?: boolean) => void;
+  debug: (str: string, withNewline?: boolean) => void;
+}
+
+const state: {
+  main: (loader: FakeLoaderApi) => Promise<string>;
+} = {
+  main: () => Promise.reject(new Error("unset")),
+};
+
+vi.mock("esptool-js", () => {
+  class Transport {
+    constructor(
+      public port: unknown,
+      public trace: boolean
+    ) {}
+
+    async disconnect() {}
+  }
+  class ESPLoader {
+    chip: { CHIP_NAME: string } | null = null;
+
+    constructor(public options: { terminal?: TerminalLike; debugLogging?: boolean }) {}
+
+    // Mirrors the real terminal routing: info() always writes, debug() only
+    // when debugLogging is on (off by default, as in esptool-js).
+    info(str: string, withNewline = true) {
+      if (withNewline) this.options.terminal?.writeLine(str);
+      else this.options.terminal?.write(str);
+    }
+
+    debug(str: string) {
+      if (this.options.debugLogging) this.options.terminal?.writeLine(`Debug: ${str}`);
+    }
+
+    async runStub() {
+      return this.chip;
+    }
+
+    async main() {
+      return state.main(this);
+    }
+  }
+  class UsbJtagSerialReset {}
+  return { ESPLoader, Transport, UsbJtagSerialReset };
+});
+
+import { connectToPort } from "../../src/util/web-serial.js";
+
+const fakePort = { close: vi.fn().mockResolvedValue(undefined) } as unknown as SerialPort;
+
+beforeEach(() => {
+  state.main = () => Promise.reject(new Error("unset"));
+});
+
+describe("connectToPort failure log", () => {
+  it("replays the debug tail and the error into the log on failure", async () => {
+    state.main = async (loader) => {
+      loader.info("Connecting...", false);
+      loader.debug("_connect_attempt default_reset");
+      loader.debug("Sync err Error: Timeout");
+      throw new Error("Failed to connect with the device");
+    };
+    const logs: string[] = [];
+    await expect(connectToPort(fakePort, (line) => logs.push(line))).rejects.toThrow(
+      "Failed to connect with the device"
+    );
+    expect(logs).toContain("Sync err Error: Timeout");
+    expect(logs[logs.length - 1]).toBe(
+      "Failed to connect: Failed to connect with the device"
+    );
+    // Debug lines are held back until the failure, after live output.
+    expect(logs.indexOf("_connect_attempt default_reset")).toBeGreaterThan(
+      logs.indexOf("Connecting...")
+    );
+  });
+
+  it("keeps debug lines out of the log on success", async () => {
+    state.main = async (loader) => {
+      loader.info("Connecting...", false);
+      loader.debug("_connect_attempt default_reset");
+      loader.info("Detecting chip type... ESP8266");
+      return "ESP8266EX";
+    };
+    const logs: string[] = [];
+    const detected = await connectToPort(fakePort, (line) => logs.push(line));
+    expect(detected.chipName).toBe("ESP8266EX");
+    expect(logs).toContain("Detecting chip type... ESP8266");
+    expect(logs).not.toContain("_connect_attempt default_reset");
+    // Capture is disarmed after success: later debug calls are inert again.
+    detected.loader.debug("post-connect line");
+    expect(logs).not.toContain("post-connect line");
+  });
+
+  it("bounds the replayed debug tail to the most recent lines", async () => {
+    state.main = async (loader) => {
+      for (let i = 0; i < 200; i++) loader.debug(`line ${i}`);
+      throw new Error("Failed to connect with the device");
+    };
+    const logs: string[] = [];
+    await expect(connectToPort(fakePort, (line) => logs.push(line))).rejects.toThrow();
+    const debugLines = logs.filter((line) => line.startsWith("line "));
+    expect(debugLines).toHaveLength(80);
+    expect(debugLines[0]).toBe("line 120");
+    expect(debugLines[debugLines.length - 1]).toBe("line 199");
+  });
+
+  it("leaves debug alone without a log callback", async () => {
+    let captured: unknown;
+    state.main = async (loader) => {
+      captured = loader.debug;
+      return "ESP8266EX";
+    };
+    await connectToPort(fakePort);
+    const { ESPLoader } = await import("esptool-js");
+    expect(captured).toBe(ESPLoader.prototype.debug);
+  });
+});

--- a/test/util/web-serial-connect-log.test.ts
+++ b/test/util/web-serial-connect-log.test.ts
@@ -13,6 +13,7 @@ interface TerminalLike {
 }
 
 interface FakeLoaderApi {
+  options: { terminal?: TerminalLike; debugLogging?: boolean };
   info: (str: string, withNewline?: boolean) => void;
   debug: (str: string, withNewline?: boolean) => void;
 }
@@ -60,7 +61,7 @@ vi.mock("esptool-js", () => {
   return { ESPLoader, Transport, UsbJtagSerialReset };
 });
 
-import { connectToPort } from "../../src/util/web-serial.js";
+import { connectToPort, UnsupportedChipError } from "../../src/util/web-serial.js";
 
 const fakePort = { close: vi.fn().mockResolvedValue(undefined) } as unknown as SerialPort;
 
@@ -81,9 +82,7 @@ describe("connectToPort failure log", () => {
       "Failed to connect with the device"
     );
     expect(logs).toContain("Sync err Error: Timeout");
-    expect(logs[logs.length - 1]).toBe(
-      "Failed to connect: Failed to connect with the device"
-    );
+    expect(logs[logs.length - 1]).toBe("Error: Failed to connect with the device");
     // Debug lines are held back until the failure, after live output.
     expect(logs.indexOf("_connect_attempt default_reset")).toBeGreaterThan(
       logs.indexOf("Connecting...")
@@ -102,9 +101,9 @@ describe("connectToPort failure log", () => {
     expect(detected.chipName).toBe("ESP8266EX");
     expect(logs).toContain("Detecting chip type... ESP8266");
     expect(logs).not.toContain("_connect_attempt default_reset");
-    // Capture is disarmed after success: later debug calls are inert again.
-    detected.loader.debug("post-connect line");
-    expect(logs).not.toContain("post-connect line");
+    // Capture is removed after main() settles.
+    const { ESPLoader } = await import("esptool-js");
+    expect(detected.loader.debug).toBe(ESPLoader.prototype.debug);
   });
 
   it("bounds the replayed debug tail to the most recent lines", async () => {
@@ -120,14 +119,36 @@ describe("connectToPort failure log", () => {
     expect(debugLines[debugLines.length - 1]).toBe("line 199");
   });
 
-  it("leaves debug alone without a log callback", async () => {
-    let captured: unknown;
+  it("skips the tail replay for an unsupported chip but still logs the error", async () => {
     state.main = async (loader) => {
-      captured = loader.debug;
-      return "ESP8266EX";
+      loader.debug("healthy handshake line");
+      throw new UnsupportedChipError("ESP32-S31");
     };
-    await connectToPort(fakePort);
+    const logs: string[] = [];
+    await expect(connectToPort(fakePort, (line) => logs.push(line))).rejects.toThrow(
+      UnsupportedChipError
+    );
+    expect(logs).not.toContain("healthy handshake line");
+    expect(logs[logs.length - 1]).toMatch(/^Error: ESP32-S31 is not supported/);
+  });
+
+  it("delegates captured debug lines to the original debug", async () => {
+    state.main = async (loader) => {
+      loader.options.debugLogging = true;
+      loader.debug("verbose line");
+      throw new Error("Failed to connect with the device");
+    };
+    const logs: string[] = [];
+    await expect(connectToPort(fakePort, (line) => logs.push(line))).rejects.toThrow();
+    // Live via the original debug() and replayed raw from the tail.
+    expect(logs).toContain("Debug: verbose line");
+    expect(logs).toContain("verbose line");
+  });
+
+  it("leaves debug alone without a log callback", async () => {
+    state.main = async () => "ESP8266EX";
+    const detected = await connectToPort(fakePort);
     const { ESPLoader } = await import("esptool-js");
-    expect(captured).toBe(ESPLoader.prototype.debug);
+    expect(detected.loader.debug).toBe(ESPLoader.prototype.debug);
   });
 });

--- a/test/util/web-serial-unsupported-chip.test.ts
+++ b/test/util/web-serial-unsupported-chip.test.ts
@@ -36,6 +36,8 @@ vi.mock("esptool-js", () => {
 
     constructor(public options: unknown) {}
 
+    debug(_str: string) {}
+
     async command(op: number): Promise<[number, Uint8Array]> {
       state.commandOps.push(op);
       return state.securityInfo();


### PR DESCRIPTION
# What does this implement/fix?

A failed Web Serial connect left the install log ending at `Connecting...`; esptool-js emits its per attempt connect diagnostics (boot mode, sync errors) only through `debug()` and then throws a generic error, so reports like the linked issue carry nothing to triage. `connectToPort` now keeps a bounded tail of those debug lines and replays them into the log when detection fails, followed by the error itself. The capture is removed once detection succeeds, so successful installs log exactly what they did before.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2553

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
