### PR TITLE
Show a migration dot on device cards and table rows

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -137,6 +137,8 @@
         --esphome-warning: var(--warning-color, #f39c12);
         --esphome-error: var(--error-color, #e74c3c);
         --esphome-offline: var(--disabled-text-color, #95a5a6);
+        /* No HA status var maps to purple; plain hex, still theme-overridable here. */
+        --esphome-migration: #a855f7;
       }
       :root,
       .wa-light,

--- a/public/web/index.html
+++ b/public/web/index.html
@@ -40,6 +40,8 @@
         --esphome-warning: var(--warning-color, #f39c12);
         --esphome-error: var(--error-color, #e74c3c);
         --esphome-offline: var(--disabled-text-color, #95a5a6);
+        /* No HA status var maps to purple; plain hex, still theme-overridable here. */
+        --esphome-migration: #a855f7;
 
         /* Bridge the Material Web (MWC) theme vars the Improv Wi-Fi
            provisioning dialog uses onto the ESPHome palette, so that

--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -156,6 +156,17 @@ export interface ConfiguredDevice {
   /** True if compiled with older ESPHome version */
   update_available: boolean;
   /**
+   * True when the raw main-file YAML carries a legacy spelling the
+   * backend migration fold would respell (``editor/migrate_config``
+   * would return a non-null diff). Main file only — packages /
+   * ``!include`` contents are not scanned. Optional: absent means
+   * false (the backend omits default-false fields). The editor's
+   * ``config-migration-notice`` answers the same question for the
+   * unsaved draft via a dry-run; this flag tracks the saved file, so
+   * the two can briefly disagree until a migrated draft is saved.
+   */
+  migration_available?: boolean;
+  /**
    * True when the resolved YAML carries a top-level ``api:`` block
    * (the device exposes the Native API at all). Gates the lock-icon
    * indicator next to the device name in the table + card views and

--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -159,8 +159,9 @@ export interface ConfiguredDevice {
    * True when the raw main-file YAML carries a legacy spelling the
    * backend migration fold would respell (``editor/migrate_config``
    * would return a non-null diff). Main file only — packages /
-   * ``!include`` contents are not scanned. Optional: absent means
-   * false (the backend omits default-false fields). The editor's
+   * ``!include`` contents are not scanned. Optional only because a
+   * backend predating the field never sends it; current backends
+   * always serialize it (``false`` when clean). The editor's
    * ``config-migration-notice`` answers the same question for the
    * unsaved draft via a dry-run; this flag tracks the saved file, so
    * the two can briefly disagree until a migrated draft is saved.

--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -159,14 +159,13 @@ export interface ConfiguredDevice {
    * True when the raw main-file YAML carries a legacy spelling the
    * backend migration fold would respell (``editor/migrate_config``
    * would return a non-null diff). Main file only — packages /
-   * ``!include`` contents are not scanned. Optional only because a
-   * backend predating the field never sends it; current backends
-   * always serialize it (``false`` when clean). The editor's
+   * ``!include`` contents are not scanned. Always serialized
+   * (``false`` when clean). The editor's
    * ``config-migration-notice`` answers the same question for the
    * unsaved draft via a dry-run; this flag tracks the saved file, so
    * the two can briefly disagree until a migrated draft is saved.
    */
-  migration_available?: boolean;
+  migration_available: boolean;
   /**
    * True when the resolved YAML carries a top-level ``api:`` block
    * (the device exposes the Native API at all). Gates the lock-icon

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -2,6 +2,7 @@ import { consume } from "@lit/context";
 import {
   mdiAccessPointNetwork,
   mdiAlertCircleOutline,
+  mdiAutoFix,
   mdiBluetooth,
   mdiBroom,
   mdiCheckCircleOutline,
@@ -69,6 +70,7 @@ import "../labels/device-labels-editor.js";
 registerMdiIcons({
   "access-point-network": mdiAccessPointNetwork,
   "alert-circle-outline": mdiAlertCircleOutline,
+  "auto-fix": mdiAutoFix,
   bluetooth: mdiBluetooth,
   broom: mdiBroom,
   "check-circle-outline": mdiCheckCircleOutline,
@@ -159,7 +161,8 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
       has_pending_changes: d.has_pending_changes,
     });
     const apiEnabled = encState !== "none";
-    const showAnyBadge = showModified || showUpdate || apiEnabled;
+    const migrationAvailable = d.migration_available === true;
+    const showAnyBadge = showModified || showUpdate || migrationAvailable || apiEnabled;
 
     return html`
       ${
@@ -178,6 +181,14 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
                   ? html`<span class="status-badge status-badge--update">
                       <wa-icon library="mdi" name="update"></wa-icon>
                       ${this._localize("dashboard.status_update_available")}
+                    </span>`
+                  : nothing
+              }
+              ${
+                migrationAvailable
+                  ? html`<span class="status-badge status-badge--migration">
+                      <wa-icon library="mdi" name="auto-fix"></wa-icon>
+                      ${this._localize("dashboard.status_migration_available")}
                     </span>`
                   : nothing
               }

--- a/src/components/dashboard/device-drawer-content/styles.ts
+++ b/src/components/dashboard/device-drawer-content/styles.ts
@@ -315,6 +315,11 @@ export const deviceDrawerContentStyles = css`
     color: var(--esphome-primary);
   }
 
+  .status-badge--migration {
+    background: color-mix(in srgb, var(--esphome-migration), transparent 85%);
+    color: var(--esphome-migration);
+  }
+
   .status-badge--encrypted {
     background: color-mix(in srgb, var(--esphome-success), transparent 88%);
     color: var(--esphome-success);

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -135,6 +135,7 @@ export function renderCardGrid(
             ?has-pending-changes=${device.has_pending_changes === true}
             ?show-modified=${showPendingChanges(device)}
             ?show-update=${showUpdateAvailable(device)}
+            ?migration-available=${device.migration_available === true}
             .installedVersion=${rt.deployed_version}
             .availableVersion=${device.current_version}
             ?api-enabled=${device.api_enabled === true}

--- a/src/components/dashboard/table-cell-styles.ts
+++ b/src/components/dashboard/table-cell-styles.ts
@@ -180,6 +180,11 @@ export const tableCellStyles = css`
     box-shadow: 0 0 5px color-mix(in srgb, var(--esphome-primary), transparent 50%);
   }
 
+  .cell-indicator--migration {
+    background: var(--esphome-migration);
+    box-shadow: 0 0 5px color-mix(in srgb, var(--esphome-migration), transparent 50%);
+  }
+
   .cell-indicator-queued {
     font-size: 14px;
     flex-shrink: 0;

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -94,6 +94,13 @@ export function createDeviceColumns(
   localize: LocalizeFunc,
   selectMode = false
 ): ColumnDef<DeviceRow>[] {
+  const indicatorDot = (show: boolean, variant: string, labelKey: string) =>
+    show
+      ? html`<span
+          class="cell-indicator cell-indicator--${variant}"
+          title=${localize(labelKey)}
+        ></span>`
+      : nothing;
   return [
     {
       accessorKey: "status",
@@ -234,22 +241,13 @@ export function createDeviceColumns(
           : "";
         return html`<span class="cell-name-wrap">
           <span class="cell-name">${row.friendly_name || row.name}</span>
-          ${
-            row.showModified
-              ? html`<span
-                  class="cell-indicator cell-indicator--modified"
-                  title=${localize("dashboard.status_modified")}
-                ></span>`
-              : nothing
-          }
-          ${
-            row.showUpdate
-              ? html`<span
-                  class="cell-indicator cell-indicator--update"
-                  title=${localize("dashboard.status_update_available")}
-                ></span>`
-              : nothing
-          }
+          ${indicatorDot(row.showModified, "modified", "dashboard.status_modified")}
+          ${indicatorDot(row.showUpdate, "update", "dashboard.status_update_available")}
+          ${indicatorDot(
+            row._device.migration_available === true,
+            "migration",
+            "dashboard.status_migration_available"
+          )}
           ${
             row.hasQueuedUpdate
               ? html`<wa-icon

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -92,6 +92,9 @@ export class ESPHomeDeviceCard extends LitElement {
   // modified / update affordances (dot + install / update button).
   @property({ type: Boolean, attribute: "show-modified" }) showModified = false;
   @property({ type: Boolean, attribute: "show-update" }) showUpdate = false;
+  // Raw device truth — drives the migration dot only, never mDNS-gated.
+  @property({ type: Boolean, attribute: "migration-available" }) migrationAvailable =
+    false;
   @property({ type: Boolean, attribute: "queued-update" }) queuedUpdate = false;
 
   // Installed + target ESPHome versions for the Update hover.
@@ -215,6 +218,20 @@ export class ESPHomeDeviceCard extends LitElement {
                       ></span>
                       <wa-tooltip for="ind-update">
                         ${this._localize("dashboard.status_update_available")}
+                      </wa-tooltip>`
+                  : nothing
+              }
+              ${
+                this.migrationAvailable
+                  ? html`<span
+                        id="ind-migration"
+                        class="indicator-dot indicator-dot--migration"
+                        tabindex="0"
+                        role="img"
+                        aria-label=${this._localize("dashboard.status_migration_available")}
+                      ></span>
+                      <wa-tooltip for="ind-migration">
+                        ${this._localize("dashboard.status_migration_available")}
                       </wa-tooltip>`
                   : nothing
               }

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -139,6 +139,11 @@ export const deviceCardStyles = [
       box-shadow: 0 0 5px color-mix(in srgb, var(--esphome-primary), transparent 50%);
     }
 
+    .indicator-dot--migration {
+      background: var(--esphome-migration);
+      box-shadow: 0 0 5px color-mix(in srgb, var(--esphome-migration), transparent 50%);
+    }
+
     /* 4-state encryption icon — secure / insecure / pending / mismatch. */
     .encryption-icon {
       font-size: 14px;

--- a/src/components/device/config-migration-notice.ts
+++ b/src/components/device/config-migration-notice.ts
@@ -7,7 +7,9 @@
  * options, and one typed mid-session waits for the next load — then
  * re-checks (debounced; each check is a WS round-trip) only while the
  * nudge is visible so a completed migration clears it. The CTA asks
- * the page to run the same command on the draft.
+ * the page to run the same command on the draft. The dashboard's
+ * per-device ``migration_available`` flag answers the same question
+ * for the saved main file; this notice sees the unsaved draft.
  */
 import { consume } from "@lit/context";
 import { mdiClose, mdiUpdate } from "@mdi/js";

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -360,6 +360,7 @@
     "context_select": "Select",
     "status_modified": "Modified",
     "status_update_available": "Update available",
+    "status_migration_available": "Config migration available",
     "status_installing": "Installing…",
     "status_compiling": "Compiling…",
     "status_renaming": "Renaming…",

--- a/test/_make-configured-device.ts
+++ b/test/_make-configured-device.ts
@@ -58,6 +58,7 @@ const _BASE = {
   expected_config_hash: "",
   has_pending_changes: false,
   update_available: false,
+  migration_available: false,
   api_enabled: false,
   api_encrypted: false,
   name_add_mac_suffix: false,

--- a/test/components/dashboard/_drawer-content.ts
+++ b/test/components/dashboard/_drawer-content.ts
@@ -1,0 +1,34 @@
+import { vi } from "vitest";
+
+import { flush, identityLocalize } from "../../_dom.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+import type { ESPHomeAPI } from "../../../src/api/esphome-api.js";
+import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
+import { ESPHomeDeviceDrawerContent } from "../../../src/components/dashboard/device-drawer-content.js";
+
+/**
+ * Drawer-content test harness (stubbed api + identity localize).
+ *
+ * Callers still need their own ``vi.mock`` lines for the webawesome
+ * icon module and the labels editor — vi.mock is hoisted per test
+ * module.
+ */
+export async function mountDrawerContent(
+  device: ConfiguredDevice = makeConfiguredDevice()
+) {
+  const unsubscribe = vi.fn().mockResolvedValue(undefined);
+  const api = {
+    connectionGeneration: 1,
+    subscribeDeviceReachability: vi.fn().mockResolvedValue({ unsubscribe }),
+  };
+  const el = new ESPHomeDeviceDrawerContent();
+  el.device = device;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._api = api as unknown as ESPHomeAPI;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._localize = identityLocalize;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  await flush();
+  return { el, api: api as unknown as ESPHomeAPI, unsubscribe };
+}

--- a/test/components/dashboard/device-drawer-content-follower.test.ts
+++ b/test/components/dashboard/device-drawer-content-follower.test.ts
@@ -11,34 +11,10 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("../../../src/components/labels/device-labels-editor.js", () => ({}));
 
-import { flush, identityLocalize } from "../../_dom.js";
+import { flush } from "../../_dom.js";
 import { makeConfiguredDevice } from "../../_make-configured-device.js";
 import { makeReachabilityEvent } from "../../_make-reachability-event.js";
-import type { ESPHomeAPI } from "../../../src/api/esphome-api.js";
-import { ESPHomeDeviceDrawerContent } from "../../../src/components/dashboard/device-drawer-content.js";
-
-function makeApi() {
-  const unsubscribe = vi.fn().mockResolvedValue(undefined);
-  const api = {
-    connectionGeneration: 1,
-    subscribeDeviceReachability: vi.fn().mockResolvedValue({ unsubscribe }),
-  };
-  return { api: api as unknown as ESPHomeAPI, unsubscribe };
-}
-
-async function mountDrawer() {
-  const { api, unsubscribe } = makeApi();
-  const el = new ESPHomeDeviceDrawerContent();
-  el.device = makeConfiguredDevice();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (el as any)._api = api;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (el as any)._localize = identityLocalize;
-  document.body.appendChild(el);
-  await el.updateComplete;
-  await flush();
-  return { el, api, unsubscribe };
-}
+import { mountDrawerContent as mountDrawer } from "./_drawer-content.js";
 
 describe("drawer follower wiring", () => {
   it("closing the drawer clears the snapshot and unsubscribes", async () => {

--- a/test/components/dashboard/device-drawer-content-migration.test.ts
+++ b/test/components/dashboard/device-drawer-content-migration.test.ts
@@ -9,41 +9,21 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("../../../src/components/labels/device-labels-editor.js", () => ({}));
 
-import { flush, identityLocalize } from "../../_dom.js";
 import { makeConfiguredDevice } from "../../_make-configured-device.js";
-import type { ESPHomeAPI } from "../../../src/api/esphome-api.js";
-import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
-import { ESPHomeDeviceDrawerContent } from "../../../src/components/dashboard/device-drawer-content.js";
-
-async function mountContent(
-  device: ConfiguredDevice
-): Promise<ESPHomeDeviceDrawerContent> {
-  const api = {
-    connectionGeneration: 1,
-    subscribeDeviceReachability: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
-  };
-  const el = new ESPHomeDeviceDrawerContent();
-  el.device = device;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (el as any)._api = api as unknown as ESPHomeAPI;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (el as any)._localize = identityLocalize;
-  document.body.appendChild(el);
-  await el.updateComplete;
-  await flush();
-  return el;
-}
+import { mountDrawerContent } from "./_drawer-content.js";
 
 describe("drawer migration badge", () => {
   it("renders with its label when migration_available is set", async () => {
-    const el = await mountContent(makeConfiguredDevice({ migration_available: true }));
+    const { el } = await mountDrawerContent(
+      makeConfiguredDevice({ migration_available: true })
+    );
     const badge = el.shadowRoot!.querySelector(".status-badge--migration");
     expect(badge).not.toBeNull();
     expect(badge!.textContent).toContain("dashboard.status_migration_available");
   });
 
   it("stays absent by default", async () => {
-    const el = await mountContent(makeConfiguredDevice());
+    const { el } = await mountDrawerContent();
     expect(el.shadowRoot!.querySelector(".status-badge--migration")).toBeNull();
   });
 });

--- a/test/components/dashboard/device-drawer-content-migration.test.ts
+++ b/test/components/dashboard/device-drawer-content-migration.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The drawer's migration badge reads the raw migration_available flag,
+ * agreeing with the dashboard dot.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("../../../src/components/labels/device-labels-editor.js", () => ({}));
+
+import { flush, identityLocalize } from "../../_dom.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+import type { ESPHomeAPI } from "../../../src/api/esphome-api.js";
+import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
+import { ESPHomeDeviceDrawerContent } from "../../../src/components/dashboard/device-drawer-content.js";
+
+async function mountContent(
+  device: ConfiguredDevice
+): Promise<ESPHomeDeviceDrawerContent> {
+  const api = {
+    connectionGeneration: 1,
+    subscribeDeviceReachability: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
+  };
+  const el = new ESPHomeDeviceDrawerContent();
+  el.device = device;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._api = api as unknown as ESPHomeAPI;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._localize = identityLocalize;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  await flush();
+  return el;
+}
+
+describe("drawer migration badge", () => {
+  it("renders with its label when migration_available is set", async () => {
+    const el = await mountContent(makeConfiguredDevice({ migration_available: true }));
+    const badge = el.shadowRoot!.querySelector(".status-badge--migration");
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toContain("dashboard.status_migration_available");
+  });
+
+  it("stays absent by default", async () => {
+    const el = await mountContent(makeConfiguredDevice());
+    expect(el.shadowRoot!.querySelector(".status-badge--migration")).toBeNull();
+  });
+});

--- a/test/components/dashboard/render-card-grid.test.ts
+++ b/test/components/dashboard/render-card-grid.test.ts
@@ -71,6 +71,13 @@ describe("renderCardGrid", () => {
     expect(card.hasAttribute("show-update")).toBe(true);
   });
 
+  it("binds the raw migration flag onto the card, ungated", () => {
+    const shown = renderCard(makeConfiguredDevice({ migration_available: true }));
+    expect(shown.hasAttribute("migration-available")).toBe(true);
+    const hidden = renderCard(makeConfiguredDevice());
+    expect(hidden.hasAttribute("migration-available")).toBe(false);
+  });
+
   it("hides the update indicator when an api device's mDNS is dark", () => {
     const device = makeConfiguredDevice({
       update_available: true,

--- a/test/components/dashboard/table-columns.test.ts
+++ b/test/components/dashboard/table-columns.test.ts
@@ -224,6 +224,19 @@ function renderNameCell(rowOverrides: Partial<DeviceRow> = {}): TemplateResult {
   return col.cell(info) as TemplateResult;
 }
 
+describe("name-cell migration dot", () => {
+  it("renders from the raw device flag and hides by default", () => {
+    const shown = renderInto(
+      renderNameCell({
+        _device: { web_port: null, migration_available: true },
+      } as unknown as Partial<DeviceRow>)
+    );
+    expect(shown.querySelector(".cell-indicator--migration")).not.toBeNull();
+    const hidden = renderInto(renderNameCell());
+    expect(hidden.querySelector(".cell-indicator--migration")).toBeNull();
+  });
+});
+
 // The encryption lock reads the raw has_pending_changes, the modified dot reads
 // the mDNS-gated flag — so for an mDNS-dark, hash-pending, encrypted device the
 // table agrees with the drawer's raw-flag badge instead of diverging (#1037).

--- a/test/components/device-card-migration-dot.test.ts
+++ b/test/components/device-card-migration-dot.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The migration dot reads the raw migration_available flag — YAML-derived,
+ * so unlike the modified / update dots it is never mDNS-gated.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
+
+import { mountDeviceCard as mount } from "./_device-card.js";
+
+describe("device-card migration dot", () => {
+  it("shows the dot with its tooltip when migration_available is set", async () => {
+    const el = await mount({ migrationAvailable: true });
+    expect(el.shadowRoot!.querySelector(".indicator-dot--migration")).not.toBeNull();
+    expect(
+      el.shadowRoot!.querySelector("wa-tooltip[for='ind-migration']")?.textContent
+    ).toContain("dashboard.status_migration_available");
+  });
+
+  it("hides the dot by default", async () => {
+    const el = await mount({});
+    expect(el.shadowRoot!.querySelector(".indicator-dot--migration")).toBeNull();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Shows a purple migration dot on device cards and table rows when the backend reports `migration_available`, so an out of date config is visible from the main dashboard instead of only after opening the editor. The drawer gets a matching "Config migration available" badge next to Modified and Update available. The flag is YAML derived, so it is read raw and never routed through the mDNS gated display helpers; the frontend ships in lockstep with the backend, so the field is required. The dot color is a new `--esphome-migration` palette token defined in both index.html palettes.

Companion backend PR: esphome/device-builder#2563

Deliberately out of scope for this PR: a "needs migration" filter facet, and seeding the editor nudge from the flag to skip its dry run round trip.

**Related issue or feature (if applicable):**

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
