### PR TITLE
Open the editor from the migration dot and badge

### DIFF
--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -20,27 +20,31 @@ import {
 } from "../../util/web-serial.js";
 import { chipNameToFilterLabel } from "../wizard/wizard-step-board-platforms.js";
 
-/** ``reveal`` opts into the one-shot ``reveal=1`` intent: show the visual
- *  pane even in a YAML-only or mobile layout (e.g. so the migration nudge
- *  a dashboard indicator promised is actually on screen). */
-export function editDevice(device: ConfiguredDevice, opts: { reveal?: boolean } = {}) {
-  const reveal = opts.reveal ? "?reveal=1" : "";
-  void navigate(`/device/${encodeURIComponent(device.configuration)}${reveal}`);
+/** Open the editor. ``section`` deep-links a component section (read from
+ *  ``?section=`` on load); ``reveal`` opts into the one-shot ``reveal=1``
+ *  intent — show the visual pane even in a YAML-only or mobile layout,
+ *  consumed and stripped on arrival so a reload keeps the saved layout. */
+export function editDevice(
+  device: ConfiguredDevice,
+  opts: { section?: string; reveal?: boolean } = {}
+) {
+  const params = new URLSearchParams();
+  if (opts.section) params.set("section", opts.section);
+  if (opts.reveal) params.set("reveal", "1");
+  const query = params.toString();
+  void navigate(
+    `/device/${encodeURIComponent(device.configuration)}${query ? `?${query}` : ""}`
+  );
 }
 
 /** Open the editor deep-linked to a component section (e.g. ``api`` for the
- *  encryption affordance); the section is read from ``?section=`` on load.
- *  ``reveal`` opts into the one-shot ``reveal=1`` intent: show the visual
- *  pane even in a YAML-only or mobile layout — consumed and stripped on
- *  arrival, so a reload keeps the user's saved layout. */
+ *  encryption affordance); see {@link editDevice} for the opts semantics. */
 export function editDeviceSection(
   device: ConfiguredDevice,
   section: string,
   opts: { reveal?: boolean } = {}
 ) {
-  const path = `/device/${encodeURIComponent(device.configuration)}`;
-  const reveal = opts.reveal ? "&reveal=1" : "";
-  void navigate(`${path}?section=${encodeURIComponent(section)}${reveal}`);
+  editDevice(device, { ...opts, section });
 }
 
 /**

--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -20,8 +20,12 @@ import {
 } from "../../util/web-serial.js";
 import { chipNameToFilterLabel } from "../wizard/wizard-step-board-platforms.js";
 
-export function editDevice(device: ConfiguredDevice) {
-  void navigate(`/device/${encodeURIComponent(device.configuration)}`);
+/** ``reveal`` opts into the one-shot ``reveal=1`` intent: show the visual
+ *  pane even in a YAML-only or mobile layout (e.g. so the migration nudge
+ *  a dashboard indicator promised is actually on screen). */
+export function editDevice(device: ConfiguredDevice, opts: { reveal?: boolean } = {}) {
+  const reveal = opts.reveal ? "?reveal=1" : "";
+  void navigate(`/device/${encodeURIComponent(device.configuration)}${reveal}`);
 }
 
 /** Open the editor deep-linked to a component section (e.g. ``api`` for the

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -191,6 +191,9 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
                       type="button"
                       class="status-badge status-badge--migration"
                       title=${this._localize("dashboard.status_migration_available_action")}
+                      aria-label=${this._localize(
+                        "dashboard.status_migration_available_action"
+                      )}
                       @click=${() => fireEvent(this, "open-config-migration", d)}
                     >
                       <wa-icon library="mdi" name="auto-fix"></wa-icon>

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -45,6 +45,7 @@ import {
 import { espHomeStyles } from "../../styles/shared.js";
 import { showPendingChanges, showUpdateAvailable } from "../../util/device-sync.js";
 import { getEncryptionState } from "../../util/encryption-state.js";
+import { fireEvent } from "../../util/fire-event.js";
 import { ReachabilityFollower } from "../../util/reachability-follower.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { renderReachabilitySection } from "./device-drawer-content/reachability.js";
@@ -186,10 +187,15 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
               }
               ${
                 migrationAvailable
-                  ? html`<span class="status-badge status-badge--migration">
+                  ? html`<button
+                      type="button"
+                      class="status-badge status-badge--migration"
+                      title=${this._localize("dashboard.status_migration_available_action")}
+                      @click=${() => fireEvent(this, "open-config-migration", d)}
+                    >
                       <wa-icon library="mdi" name="auto-fix"></wa-icon>
                       ${this._localize("dashboard.status_migration_available")}
-                    </span>`
+                    </button>`
                   : nothing
               }
               ${apiEnabled ? renderEncryptionBadge(this, d, encState) : nothing}

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -151,6 +151,7 @@ export function renderCardGrid(
             ?select-mode=${host._selectMode}
             ?selected=${host._selectedDevices.has(device.configuration)}
             @edit-device=${() => editDevice(device)}
+            @open-config-migration=${() => editDevice(device, { reveal: true })}
             @open-encryption-settings=${() => editDeviceSection(device, "api", { reveal: true })}
             @install-device=${() => host._openInstallMethod(device)}
             @update-device=${() => host._openCommand(device, "install")}
@@ -203,6 +204,8 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
       @select-all=${(e: CustomEvent<string[]>) => host._addToSelection(e.detail)}
       @deselect-all=${(e: CustomEvent<string[]>) => host._removeFromSelection(e.detail)}
       @edit-device=${(e: CustomEvent<ConfiguredDevice>) => editDevice(e.detail)}
+      @open-config-migration=${(e: CustomEvent<ConfiguredDevice>) =>
+        editDevice(e.detail, { reveal: true })}
       @open-encryption-settings=${(e: CustomEvent<ConfiguredDevice>) =>
         editDeviceSection(e.detail, "api", { reveal: true })}
       @update-device=${(e: CustomEvent<ConfiguredDevice>) =>
@@ -273,6 +276,10 @@ export function renderDrawer(host: ESPHomePageDashboard): TemplateResult {
       @edit-device=${(e: CustomEvent) => {
         host._drawerOpen = false;
         editDevice(e.detail);
+      }}
+      @open-config-migration=${(e: CustomEvent<ConfiguredDevice>) => {
+        host._drawerOpen = false;
+        editDevice(e.detail, { reveal: true });
       }}
       @open-encryption-settings=${(e: CustomEvent<ConfiguredDevice>) => {
         host._drawerOpen = false;

--- a/src/components/dashboard/table-cell-styles.ts
+++ b/src/components/dashboard/table-cell-styles.ts
@@ -188,9 +188,17 @@ export const tableCellStyles = css`
   /* The migration dot deep-links to the editor; reset the native chrome
      so it matches the passive dots. */
   button.cell-indicator {
+    position: relative;
     padding: 0;
     border: none;
     cursor: pointer;
+  }
+  /* Invisible hit-area extender — the 8px dot alone is too small a
+     touch target (24px minimum). */
+  button.cell-indicator::before {
+    content: "";
+    position: absolute;
+    inset: -8px;
   }
   button.cell-indicator:focus-visible {
     outline: 2px solid var(--esphome-primary);

--- a/src/components/dashboard/table-cell-styles.ts
+++ b/src/components/dashboard/table-cell-styles.ts
@@ -185,6 +185,18 @@ export const tableCellStyles = css`
     box-shadow: 0 0 5px color-mix(in srgb, var(--esphome-migration), transparent 50%);
   }
 
+  /* The migration dot deep-links to the editor; reset the native chrome
+     so it matches the passive dots. */
+  button.cell-indicator {
+    padding: 0;
+    border: none;
+    cursor: pointer;
+  }
+  button.cell-indicator:focus-visible {
+    outline: 2px solid var(--esphome-primary);
+    outline-offset: 2px;
+  }
+
   .cell-indicator-queued {
     font-size: 14px;
     flex-shrink: 0;

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -101,6 +101,7 @@ export function createDeviceColumns(
           title=${localize(labelKey)}
         ></span>`
       : nothing;
+  const migrationTitle = localize("dashboard.status_migration_available_action");
   return [
     {
       accessorKey: "status",
@@ -239,26 +240,24 @@ export function createDeviceColumns(
               encVisual.actionable ? encVisual.actionTooltipKey : encVisual.tooltipKey
             )
           : "";
-        const migrationTitle = localize("dashboard.status_migration_available_action");
+        const migrationAvailable = row._device.migration_available === true;
         return html`<span class="cell-name-wrap">
           <span class="cell-name">${row.friendly_name || row.name}</span>
           ${indicatorDot(row.showModified, "modified", "dashboard.status_modified")}
           ${indicatorDot(row.showUpdate, "update", "dashboard.status_update_available")}
           ${
-            row._device.migration_available === true && !selectMode
-              ? html`<button
-                  type="button"
-                  class="cell-indicator cell-indicator--migration"
-                  title=${migrationTitle}
-                  aria-label=${migrationTitle}
-                  @click=${(e: Event) =>
-                    dispatchRowEvent(e, "open-config-migration", row._device)}
-                ></button>`
-              : indicatorDot(
-                  row._device.migration_available === true,
-                  "migration",
-                  "dashboard.status_migration_available"
-                )
+            !migrationAvailable
+              ? nothing
+              : selectMode
+                ? indicatorDot(true, "migration", "dashboard.status_migration_available")
+                : html`<button
+                    type="button"
+                    class="cell-indicator cell-indicator--migration"
+                    title=${migrationTitle}
+                    aria-label=${migrationTitle}
+                    @click=${(e: Event) =>
+                      dispatchRowEvent(e, "open-config-migration", row._device)}
+                  ></button>`
           }
           ${
             row.hasQueuedUpdate

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -239,15 +239,27 @@ export function createDeviceColumns(
               encVisual.actionable ? encVisual.actionTooltipKey : encVisual.tooltipKey
             )
           : "";
+        const migrationTitle = localize("dashboard.status_migration_available_action");
         return html`<span class="cell-name-wrap">
           <span class="cell-name">${row.friendly_name || row.name}</span>
           ${indicatorDot(row.showModified, "modified", "dashboard.status_modified")}
           ${indicatorDot(row.showUpdate, "update", "dashboard.status_update_available")}
-          ${indicatorDot(
-            row._device.migration_available === true,
-            "migration",
-            "dashboard.status_migration_available"
-          )}
+          ${
+            row._device.migration_available === true && !selectMode
+              ? html`<button
+                  type="button"
+                  class="cell-indicator cell-indicator--migration"
+                  title=${migrationTitle}
+                  aria-label=${migrationTitle}
+                  @click=${(e: Event) =>
+                    dispatchRowEvent(e, "open-config-migration", row._device)}
+                ></button>`
+              : indicatorDot(
+                  row._device.migration_available === true,
+                  "migration",
+                  "dashboard.status_migration_available"
+                )
+          }
           ${
             row.hasQueuedUpdate
               ? html`<wa-icon

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -36,6 +36,7 @@ import { navigateCards, onHostContextMenu } from "./device-card/keyboard-nav.js"
 import {
   renderEncryptionIcon,
   renderLabels,
+  renderMigrationDot,
   renderStatusBadge,
 } from "./device-card/render-bits.js";
 import { deviceCardStyles } from "./device-card/styles.js";
@@ -221,20 +222,7 @@ export class ESPHomeDeviceCard extends LitElement {
                       </wa-tooltip>`
                   : nothing
               }
-              ${
-                this.migrationAvailable
-                  ? html`<span
-                        id="ind-migration"
-                        class="indicator-dot indicator-dot--migration"
-                        tabindex="0"
-                        role="img"
-                        aria-label=${this._localize("dashboard.status_migration_available")}
-                      ></span>
-                      <wa-tooltip for="ind-migration">
-                        ${this._localize("dashboard.status_migration_available")}
-                      </wa-tooltip>`
-                  : nothing
-              }
+              ${renderMigrationDot(this)}
               ${
                 this.queuedUpdate
                   ? html`<wa-icon

--- a/src/components/device-card/render-bits.ts
+++ b/src/components/device-card/render-bits.ts
@@ -41,6 +41,37 @@ export function renderLabels(card: ESPHomeDeviceCard): TemplateResult | typeof n
   </div>`;
 }
 
+export function renderMigrationDot(
+  card: ESPHomeDeviceCard
+): TemplateResult | typeof nothing {
+  if (!card.migrationAvailable) return nothing;
+  // Actionable except while selecting — in select mode the whole card is
+  // one toggle target, same rule as the encryption button below.
+  if (!card.selectMode) {
+    const label = card._localize("dashboard.status_migration_available_action");
+    return html`<button
+        id="ind-migration"
+        type="button"
+        class="indicator-dot indicator-dot--migration"
+        aria-label=${label}
+        @click=${(e: Event) => {
+          e.stopPropagation();
+          fireEvent(card, "open-config-migration");
+        }}
+      ></button>
+      <wa-tooltip for="ind-migration">${label}</wa-tooltip>`;
+  }
+  const tooltip = card._localize("dashboard.status_migration_available");
+  return html`<span
+      id="ind-migration"
+      class="indicator-dot indicator-dot--migration"
+      tabindex="0"
+      role="img"
+      aria-label=${tooltip}
+    ></span>
+    <wa-tooltip for="ind-migration">${tooltip}</wa-tooltip>`;
+}
+
 // Compact view: no lock for encrypted devices, only the attention
 // states (plaintext / pending / mismatch) get an icon.
 export function renderEncryptionIcon(

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -147,9 +147,17 @@ export const deviceCardStyles = [
     /* The migration dot is a button that opens the editor; reset the
        native chrome so it matches the passive dots. */
     button.indicator-dot {
+      position: relative;
       padding: 0;
       border: none;
       cursor: pointer;
+    }
+    /* Invisible hit-area extender — the 8px dot alone is too small a
+       touch target (24px minimum). */
+    button.indicator-dot::before {
+      content: "";
+      position: absolute;
+      inset: -8px;
     }
     button.indicator-dot:focus-visible {
       outline: 2px solid var(--esphome-primary);

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -144,6 +144,18 @@ export const deviceCardStyles = [
       box-shadow: 0 0 5px color-mix(in srgb, var(--esphome-migration), transparent 50%);
     }
 
+    /* The migration dot is a button that opens the editor; reset the
+       native chrome so it matches the passive dots. */
+    button.indicator-dot {
+      padding: 0;
+      border: none;
+      cursor: pointer;
+    }
+    button.indicator-dot:focus-visible {
+      outline: 2px solid var(--esphome-primary);
+      outline-offset: 2px;
+    }
+
     /* 4-state encryption icon — secure / insecure / pending / mismatch. */
     .encryption-icon {
       font-size: 14px;

--- a/src/components/device/config-migration-notice.ts
+++ b/src/components/device/config-migration-notice.ts
@@ -84,6 +84,8 @@ export class ESPHomeConfigMigrationNotice extends LitElement {
     css`
       :host {
         display: block;
+        /* Migration identity color — matches the dashboard dot and badge. */
+        --notice-accent: var(--esphome-migration);
       }
       :host([hidden]) {
         display: none;

--- a/src/components/device/notice-banner.styles.ts
+++ b/src/components/device/notice-banner.styles.ts
@@ -1,7 +1,8 @@
 /**
- * Shared styles for the inline notice banners shown above a section's form
- * the warning
- * `.notice` box, its `.body` column, and the `.cta` button.
+ * Shared styles for the inline notice banners shown above a section's form:
+ * the `.notice` box, its `.body` column, and the `.cta` button.
+ * Accent color is `--notice-accent`, defaulting to the warning color; set
+ * it on `:host` to retheme (the migration notice sets the migration purple).
  */
 import { css } from "lit";
 
@@ -12,8 +13,13 @@ export const noticeBannerStyles = css`
     gap: var(--wa-space-s);
     margin-bottom: var(--wa-space-m);
     padding: var(--wa-space-s) var(--wa-space-m);
-    border: var(--wa-border-width-s) solid var(--esphome-warning, #f59e0b);
-    background: color-mix(in srgb, var(--esphome-warning, #f59e0b), transparent 90%);
+    border: var(--wa-border-width-s) solid
+      var(--notice-accent, var(--esphome-warning, #f59e0b));
+    background: color-mix(
+      in srgb,
+      var(--notice-accent, var(--esphome-warning, #f59e0b)),
+      transparent 90%
+    );
     border-radius: var(--wa-border-radius-m);
     color: var(--wa-color-text-normal);
     font-size: var(--wa-font-size-s);
@@ -23,7 +29,7 @@ export const noticeBannerStyles = css`
   .notice wa-icon {
     flex-shrink: 0;
     font-size: 20px;
-    color: var(--esphome-warning, #f59e0b);
+    color: var(--notice-accent, var(--esphome-warning, #f59e0b));
   }
 
   .body {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -361,6 +361,7 @@
     "status_modified": "Modified",
     "status_update_available": "Update available",
     "status_migration_available": "Config migration available",
+    "status_migration_available_action": "Config migration available. Open the editor to update.",
     "status_installing": "Installing…",
     "status_compiling": "Compiling…",
     "status_renaming": "Renaming…",

--- a/test/components/dashboard/device-drawer-content-migration.test.ts
+++ b/test/components/dashboard/device-drawer-content-migration.test.ts
@@ -13,13 +13,20 @@ import { makeConfiguredDevice } from "../../_make-configured-device.js";
 import { mountDrawerContent } from "./_drawer-content.js";
 
 describe("drawer migration badge", () => {
-  it("renders with its label when migration_available is set", async () => {
-    const { el } = await mountDrawerContent(
-      makeConfiguredDevice({ migration_available: true })
+  it("is a labeled button that opens the editor with the device", async () => {
+    const device = makeConfiguredDevice({ migration_available: true });
+    const { el } = await mountDrawerContent(device);
+    const badge = el.shadowRoot!.querySelector<HTMLButtonElement>(
+      "button.status-badge--migration"
     );
-    const badge = el.shadowRoot!.querySelector(".status-badge--migration");
     expect(badge).not.toBeNull();
     expect(badge!.textContent).toContain("dashboard.status_migration_available");
+    let detail: unknown;
+    el.addEventListener("open-config-migration", (e) => {
+      detail = (e as CustomEvent).detail;
+    });
+    badge!.click();
+    expect(detail).toBe(device);
   });
 
   it("stays absent by default", async () => {

--- a/test/components/dashboard/render-content-migration-wiring.test.ts
+++ b/test/components/dashboard/render-content-migration-wiring.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the open-config-migration → editDevice({ reveal: true }) wiring on
+ * all three dashboard surfaces — the reveal intent is what puts the
+ * migrate nudge on screen in a YAML-only or mobile layout.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("../../../src/util/navigation.js", () => ({ navigate: vi.fn() }));
+
+import { renderInto } from "../../_dom.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
+import {
+  renderCardGrid,
+  renderDrawer,
+  renderTable,
+} from "../../../src/components/dashboard/render-content.js";
+import { navigate } from "../../../src/util/navigation.js";
+import { makeDashboardHost, makeTableHost } from "./_host.js";
+
+const DEEP_LINK = "/device/kitchen.yaml?reveal=1";
+
+afterEach(() => {
+  vi.mocked(navigate).mockClear();
+});
+
+function dispatchOpen(el: Element, detail?: ConfiguredDevice) {
+  el.dispatchEvent(new CustomEvent("open-config-migration", { detail }));
+}
+
+describe("open-config-migration wiring", () => {
+  it("card grid opens the editor with the reveal intent", () => {
+    const device = makeConfiguredDevice();
+    const host = makeDashboardHost({
+      _devices: [device],
+      _activeJobs: new Map(),
+      _recentJobs: new Map(),
+      _recentlyAdopted: null,
+      _selectMode: false,
+      _selectedDevices: new Set<string>(),
+    });
+    const container = renderInto(renderCardGrid(host, [device]));
+    const card = container.querySelector("esphome-device-card");
+    expect(card).not.toBeNull();
+
+    dispatchOpen(card!);
+    expect(navigate).toHaveBeenCalledWith(DEEP_LINK);
+  });
+
+  it("table opens the event's device with the reveal intent", () => {
+    const device = makeConfiguredDevice();
+    const host = makeTableHost({ _devices: [device], _sortedDevices: [device] });
+    const container = renderInto(renderTable(host));
+    const table = container.querySelector("esphome-device-table");
+    expect(table).not.toBeNull();
+
+    dispatchOpen(table!, device);
+    expect(navigate).toHaveBeenCalledWith(DEEP_LINK);
+  });
+
+  it("drawer closes and opens the event's device with the reveal intent", () => {
+    const device = makeConfiguredDevice();
+    const host = makeDashboardHost({
+      _drawerOpen: true,
+      _drawerDevice: device,
+      _activeJobs: new Map(),
+    });
+    const container = renderInto(renderDrawer(host));
+    const drawer = container.querySelector("esphome-device-drawer");
+    expect(drawer).not.toBeNull();
+
+    dispatchOpen(drawer!, device);
+    expect(navigate).toHaveBeenCalledWith(DEEP_LINK);
+    expect(host._drawerOpen).toBe(false);
+  });
+});

--- a/test/components/dashboard/table-columns.test.ts
+++ b/test/components/dashboard/table-columns.test.ts
@@ -203,8 +203,12 @@ describe("device table busy install/update actions", () => {
   });
 });
 
-function renderNameCell(rowOverrides: Partial<DeviceRow> = {}): TemplateResult {
-  const col = columns.find((c) => "accessorKey" in c && c.accessorKey === "name");
+function renderNameCell(
+  rowOverrides: Partial<DeviceRow> = {},
+  selectMode = false
+): TemplateResult {
+  const cols = selectMode ? createDeviceColumns(identityLocalize, true) : columns;
+  const col = cols.find((c) => "accessorKey" in c && c.accessorKey === "name");
   if (!col?.cell || typeof col.cell !== "function") {
     throw new Error("no cell renderer for name column");
   }
@@ -248,24 +252,14 @@ describe("name-cell migration dot", () => {
   });
 
   it("renders passive while selecting", () => {
-    const selectColumns = createDeviceColumns(identityLocalize, true);
-    const col = selectColumns.find((c) => "accessorKey" in c && c.accessorKey === "name");
-    if (!col?.cell || typeof col.cell !== "function") {
-      throw new Error("no cell renderer for name column");
-    }
-    const row = {
-      name: "kitchen",
-      friendly_name: "Kitchen",
-      showModified: false,
-      showUpdate: false,
-      hasPendingChanges: false,
-      api_enabled: false,
-      api_encrypted: false,
-      api_encryption_active: null,
-      _device: { web_port: null, migration_available: true },
-    } as unknown as DeviceRow;
-    const info = { row: { original: row } } as unknown as CellContext<DeviceRow, unknown>;
-    const container = renderInto(col.cell(info) as TemplateResult);
+    const container = renderInto(
+      renderNameCell(
+        {
+          _device: { web_port: null, migration_available: true },
+        } as unknown as Partial<DeviceRow>,
+        true
+      )
+    );
     expect(container.querySelector("button.cell-indicator--migration")).toBeNull();
     expect(container.querySelector("span.cell-indicator--migration")).not.toBeNull();
   });

--- a/test/components/dashboard/table-columns.test.ts
+++ b/test/components/dashboard/table-columns.test.ts
@@ -225,13 +225,52 @@ function renderNameCell(rowOverrides: Partial<DeviceRow> = {}): TemplateResult {
 }
 
 describe("name-cell migration dot", () => {
-  it("renders from the raw device flag and hides by default", () => {
-    const shown = renderInto(
-      renderNameCell({
-        _device: { web_port: null, migration_available: true },
-      } as unknown as Partial<DeviceRow>)
+  it("deep-links to the editor and stops the row click", () => {
+    const device = { web_port: null, migration_available: true };
+    const container = renderInto(
+      renderNameCell({ _device: device } as unknown as Partial<DeviceRow>)
     );
-    expect(shown.querySelector(".cell-indicator--migration")).not.toBeNull();
+    const btn = container.querySelector<HTMLButtonElement>(
+      "button.cell-indicator--migration"
+    );
+    expect(btn).not.toBeNull();
+    let detail: unknown;
+    let rowClicked = false;
+    container.addEventListener("open-config-migration", (e) => {
+      detail = (e as CustomEvent).detail;
+    });
+    container.addEventListener("click", () => {
+      rowClicked = true;
+    });
+    btn!.click();
+    expect(detail).toBe(device);
+    expect(rowClicked).toBe(false);
+  });
+
+  it("renders passive while selecting", () => {
+    const selectColumns = createDeviceColumns(identityLocalize, true);
+    const col = selectColumns.find((c) => "accessorKey" in c && c.accessorKey === "name");
+    if (!col?.cell || typeof col.cell !== "function") {
+      throw new Error("no cell renderer for name column");
+    }
+    const row = {
+      name: "kitchen",
+      friendly_name: "Kitchen",
+      showModified: false,
+      showUpdate: false,
+      hasPendingChanges: false,
+      api_enabled: false,
+      api_encrypted: false,
+      api_encryption_active: null,
+      _device: { web_port: null, migration_available: true },
+    } as unknown as DeviceRow;
+    const info = { row: { original: row } } as unknown as CellContext<DeviceRow, unknown>;
+    const container = renderInto(col.cell(info) as TemplateResult);
+    expect(container.querySelector("button.cell-indicator--migration")).toBeNull();
+    expect(container.querySelector("span.cell-indicator--migration")).not.toBeNull();
+  });
+
+  it("hides by default", () => {
     const hidden = renderInto(renderNameCell());
     expect(hidden.querySelector(".cell-indicator--migration")).toBeNull();
   });

--- a/test/components/device-card-migration-dot.test.ts
+++ b/test/components/device-card-migration-dot.test.ts
@@ -2,7 +2,9 @@
  * @vitest-environment happy-dom
  *
  * The migration dot reads the raw migration_available flag — YAML-derived,
- * so unlike the modified / update dots it is never mDNS-gated.
+ * never mDNS-gated — and deep-links to the editor, where the migrate nudge
+ * is the next click. Passive while selecting: the whole card is one toggle
+ * target in select mode.
  */
 import { describe, expect, it, vi } from "vitest";
 
@@ -13,12 +15,32 @@ vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => (
 import { mountDeviceCard as mount } from "./_device-card.js";
 
 describe("device-card migration dot", () => {
-  it("shows the dot with its tooltip when migration_available is set", async () => {
+  it("is a button that opens the editor without triggering the card click", async () => {
     const el = await mount({ migrationAvailable: true });
-    expect(el.shadowRoot!.querySelector(".indicator-dot--migration")).not.toBeNull();
+    const dot = el.shadowRoot!.querySelector<HTMLButtonElement>(
+      "button.indicator-dot--migration"
+    );
+    expect(dot).not.toBeNull();
     expect(
       el.shadowRoot!.querySelector("wa-tooltip[for='ind-migration']")?.textContent
-    ).toContain("dashboard.status_migration_available");
+    ).toContain("dashboard.status_migration_available_action");
+    let opens = 0;
+    let cardClicks = 0;
+    el.addEventListener("open-config-migration", () => {
+      opens++;
+    });
+    el.addEventListener("card-click", () => {
+      cardClicks++;
+    });
+    dot!.click();
+    expect(opens).toBe(1);
+    expect(cardClicks).toBe(0);
+  });
+
+  it("renders passive while selecting", async () => {
+    const el = await mount({ migrationAvailable: true, selectMode: true });
+    expect(el.shadowRoot!.querySelector("button.indicator-dot--migration")).toBeNull();
+    expect(el.shadowRoot!.querySelector("span.indicator-dot--migration")).not.toBeNull();
   });
 
   it("hides the dot by default", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Clicking the purple migration dot on a device card or table row, or the "Config migration available" badge in the drawer, now opens the editor; the migrate nudge is right there, so the next click is Update config. The indicators fire a dedicated `open-config-migration` event bound to `editDevice(device, { reveal: true })`; the reveal intent matters because on mobile, or a saved YAML only layout, a plain editor open lands in the YAML pane where the nudge never renders. The card dot goes passive in select mode, same rule as the encryption button, and the table dot falls back to the passive indicator there too.

The editor's migration notice is also retinted to the migration purple so the identity is consistent from dashboard to nudge; the shared notice banner gains a `--notice-accent` hook that defaults to the old warning color, so the mac suffix and security notices are unchanged.

Verified in the browser on desktop and mobile viewports: all three surfaces land on the visual pane with the notice visible, Update config applies, and the notice clears.

Followup to esphome/device-builder-frontend#1652.

**Related issue or feature (if applicable):**

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
