### PR TITLE
Hide More info link when a component has no docs_url

### DIFF
--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -222,7 +222,7 @@ export function renderCard(
                 ${localize("device.more_info")}
                 <wa-icon library="mdi" name="open-in-new"></wa-icon>
               </a>`
-            : nothing
+            : html`<span></span>`
         }
         <button
           class="select-component"

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -217,7 +217,7 @@ export function renderCard(
                 class="more-info"
                 href=${component.docs_url}
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
               >
                 ${localize("device.more_info")}
                 <wa-icon library="mdi" name="open-in-new"></wa-icon>

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -2,7 +2,7 @@ import { html, nothing, type TemplateResult } from "lit";
 import type { FeaturedBundle } from "../../../api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../../api/types/components.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
-import { renderMarkdown } from "../../../util/markdown.js";
+import { isSafeLinkHref, renderMarkdown } from "../../../util/markdown.js";
 import {
   categoryChipLabel,
   platformLabel,
@@ -211,10 +211,19 @@ export function renderCard(
         ${renderMarkdown(component.description)}
       </p>
       <div class="card-footer">
-        <a class="more-info" href=${component.docs_url} target="_blank" rel="noreferrer">
-          ${localize("device.more_info")}
-          <wa-icon library="mdi" name="open-in-new"></wa-icon>
-        </a>
+        ${
+          isSafeLinkHref(component.docs_url)
+            ? html`<a
+                class="more-info"
+                href=${component.docs_url}
+                target="_blank"
+                rel="noreferrer"
+              >
+                ${localize("device.more_info")}
+                <wa-icon library="mdi" name="open-in-new"></wa-icon>
+              </a>`
+            : nothing
+        }
         <button
           class="select-component"
           type="button"

--- a/test/components/device/component-catalog-renderers.test.ts
+++ b/test/components/device/component-catalog-renderers.test.ts
@@ -142,11 +142,13 @@ describe("renderCard", () => {
   });
 
   it("omits the More info link when the entry has no docs_url", () => {
-    // The backend ships an empty docs_url for components no docs page
-    // covers; an unguarded anchor would link the dashboard page itself.
+    // The backend ships an empty docs_url for components without a docs
+    // page; an unguarded anchor would link the dashboard page itself.
     const container = document.createElement("div");
     render(renderCard(makeHost(), makeEntry({}), false, false, localize), container);
     expect(container.querySelector(".more-info")).toBeNull();
+    // The spacer keeps the space-between footer pushing Add to the right.
+    expect(container.querySelector(".card-footer span")).not.toBeNull();
   });
 
   it("renders the More info link for a safe docs_url", () => {

--- a/test/components/device/component-catalog-renderers.test.ts
+++ b/test/components/device/component-catalog-renderers.test.ts
@@ -140,6 +140,23 @@ describe("renderCard", () => {
     expect(description?.dataset.componentId).toBe("spi");
     expect(description?.classList.contains("component-description--clamp")).toBe(true);
   });
+
+  it("omits the More info link when the entry has no docs_url", () => {
+    // The backend ships an empty docs_url for components no docs page
+    // covers; an unguarded anchor would link the dashboard page itself.
+    const container = document.createElement("div");
+    render(renderCard(makeHost(), makeEntry({}), false, false, localize), container);
+    expect(container.querySelector(".more-info")).toBeNull();
+  });
+
+  it("renders the More info link for a safe docs_url", () => {
+    const container = document.createElement("div");
+    const entry = makeEntry({ docs_url: "https://example.test/docs" });
+    render(renderCard(makeHost(), entry, false, false, localize), container);
+    const link = container.querySelector("a.more-info");
+    expect(link?.getAttribute("href")).toBe("https://example.test/docs");
+    expect(link?.getAttribute("target")).toBe("_blank");
+  });
 });
 
 describe("renderBundleCard", () => {

--- a/test/components/device/component-catalog-renderers.test.ts
+++ b/test/components/device/component-catalog-renderers.test.ts
@@ -158,6 +158,7 @@ describe("renderCard", () => {
     const link = container.querySelector("a.more-info");
     expect(link?.getAttribute("href")).toBe("https://example.test/docs");
     expect(link?.getAttribute("target")).toBe("_blank");
+    expect(link?.getAttribute("rel")).toBe("noopener noreferrer");
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Hide the component card's "More info" link when the catalog entry has no `docs_url`. The backend stops inventing links to docs pages that do not exist and ships an empty `docs_url` for components with no documentation page, so an unguarded link would point at the dashboard page itself. Uses the same `isSafeLinkHref` gate the section header already uses.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2577
- backend PR: esphome/device-builder#2581

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
