### PR TITLE
Match board locks by dotted path so nested clk fields lock

### DIFF
--- a/src/components/device/pin/renderer.ts
+++ b/src/components/device/pin/renderer.ts
@@ -10,7 +10,11 @@ import type { BoardPin } from "../../../api/types/boards.js";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { PinFeature, PinMode } from "../../../api/types/config-entries.js";
 import { findUsedPins, sectionEndLine } from "../../../util/config-entry-yaml-scan.js";
-import { isPlainObject, isPrimitiveOrNullish } from "../../../util/nested-values.js";
+import {
+  getIn,
+  isPlainObject,
+  isPrimitiveOrNullish,
+} from "../../../util/nested-values.js";
 import {
   formatPinValue,
   isExpanderPinValue,
@@ -94,14 +98,20 @@ function boardGpioOf(value: unknown, pins: BoardPin[]): number | null {
  *    pins under ``ethernet:``); flash/PSRAM pins and other components'
  *    locks remain disabled.
  *  - ``gpios`` — the wider board-defined set (locked plus field presets
- *    keyed by *entryKey*, like the RGB header pin a board pre-fills
- *    without locking); a current value here gets the wiring guard.
+ *    keyed by the field's dotted path, like the RGB header pin a board
+ *    pre-fills without locking); a current value here gets the wiring
+ *    guard.
  *  - ``tokens`` — expander-channel ``provider:hub:channel`` identities,
- *    the non-GPIO half of the same guard. */
+ *    the non-GPIO half of the same guard.
+ *
+ *  Matching is on the field's dotted *path* (``mdc_pin``, ``clk.pin``),
+ *  the same form ``locked_pins`` keys use, so a nested pin (ethernet's
+ *  ``clk.pin``) guards like a top-level one. */
 function boardPinsForSection(
   ctx: RenderCtx,
-  entryKey: string
+  path: string[]
 ): { lockedGpios: Set<number>; gpios: Set<number>; tokens: Set<string> } {
+  const fieldKey = path.join(".");
   const lockedGpios = new Set<number>();
   const gpios = new Set<number>();
   const tokens = new Set<string>();
@@ -113,12 +123,19 @@ function boardPinsForSection(
       // (ethernet's clk vs miso) doesn't read-only this field's wiring.
       if (typeof pin === "number") {
         lockedGpios.add(pin);
-        if (key === entryKey) gpios.add(pin);
-      } else if (typeof pin === "string" && key === entryKey) {
+        if (key === fieldKey) gpios.add(pin);
+      } else if (typeof pin === "string" && key === fieldKey) {
         tokens.add(pin);
       }
     }
-    const preset = fc.fields?.[entryKey]?.value;
+    // A nested pin's preset lives inside the parent field's mapping
+    // value (ethernet's ``clk: {pin, mode}`` under ``fields.clk``).
+    const fieldPreset = fc.fields?.[path[0]]?.value;
+    const preset = isPlainObject(fieldPreset)
+      ? getIn(fieldPreset, path.slice(1))
+      : path.length === 1
+        ? fieldPreset
+        : undefined;
     if (preset == null) continue;
     // ``parsePinGpio`` so an object-form expander preset
     // (``{pcf8574: hub, number: 0}``) yields its channel token instead
@@ -341,7 +358,7 @@ export function renderPinField(
       identity,
       rawValue,
       suggestedTokens ||
-        designationMatches(boardPinsForSection(ctx, entry.key).tokens, identity)
+        designationMatches(boardPinsForSection(ctx, path).tokens, identity)
     );
   }
   // Fall back to alias resolution (`RX` → GPIO3) when the value isn't a
@@ -421,7 +438,7 @@ export function renderPinField(
     ctx.fromLine,
     sectionEndLine(ctx.yaml, ctx.fromLine)
   );
-  const boardPins = boardPinsForSection(ctx, entry.key);
+  const boardPins = boardPinsForSection(ctx, path);
   const ownLockedGpios = boardPins.lockedGpios;
   // The current pin sitting on a board-defined GPIO for this section
   // (locked, field preset, or suggestion) means the wiring is the
@@ -543,7 +560,7 @@ function renderSubstitutionPin(
   const resolved =
     parsePinGpio(longForm ? { ...longForm, number: resolvedNumber } : resolvedNumber) ??
     (isExpanderPinValue(rawValue) ? null : gpioFromAlias(resolvedNumber, pins));
-  const boardPins = boardPinsForSection(ctx, entry.key);
+  const boardPins = boardPinsForSection(ctx, path);
   const boardPreset =
     resolved !== null &&
     (typeof resolved === "number"

--- a/src/components/device/pin/renderer.ts
+++ b/src/components/device/pin/renderer.ts
@@ -112,6 +112,9 @@ function boardPinsForSection(
   path: string[]
 ): { lockedGpios: Set<number>; gpios: Set<number>; tokens: Set<string> } {
   const fieldKey = path.join(".");
+  // The field's preset lives at ``fields[<head>].value[<rest…>]`` — for a
+  // nested pin (ethernet's ``clk.pin``) inside the parent's mapping value.
+  const presetPath = [path[0], "value", ...path.slice(1)];
   const lockedGpios = new Set<number>();
   const gpios = new Set<number>();
   const tokens = new Set<string>();
@@ -128,14 +131,7 @@ function boardPinsForSection(
         tokens.add(pin);
       }
     }
-    // A nested pin's preset lives inside the parent field's mapping
-    // value (ethernet's ``clk: {pin, mode}`` under ``fields.clk``).
-    const fieldPreset = fc.fields?.[path[0]]?.value;
-    const preset = isPlainObject(fieldPreset)
-      ? getIn(fieldPreset, path.slice(1))
-      : path.length === 1
-        ? fieldPreset
-        : undefined;
+    const preset = getIn(fc.fields ?? {}, presetPath);
     if (preset == null) continue;
     // ``parsePinGpio`` so an object-form expander preset
     // (``{pcf8574: hub, number: 0}``) yields its channel token instead

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -432,16 +432,20 @@ export function findComponentsByProviders(
 
 // An instance's GPIO for a pin field, handling both the bare scalar
 // (`scl: 0`) and the expanded block (`scl:\n  number: GPIO0`) forms; null
-// when the field is absent or its value isn't a parseable pin.
+// when the field is absent or its value isn't a parseable pin. The key is
+// the schema's dotted pin path (`mdc_pin`, ethernet's nested `clk.pin`).
 function readInstancePinGpio(
   yaml: string,
   lines: string[],
   section: YamlSection,
   key: string
 ): number | string | null {
-  const lineNo = findFieldLine(yaml, section, [key]);
+  const path = key.split(".");
+  const lineNo = findFieldLine(yaml, section, path);
   if (lineNo === null) return null;
-  const scalar = parsePinGpio(readInstanceScalar(lines[lineNo - 1], key));
+  const scalar = parsePinGpio(
+    readInstanceScalar(lines[lineNo - 1], path[path.length - 1])
+  );
   if (scalar !== null) return scalar;
   // Expanded form: read the long-form block (board GPIO, or the
   // `provider:hub_id:channel` token when the pin sits on an I/O expander).

--- a/src/util/featured-id.ts
+++ b/src/util/featured-id.ts
@@ -35,7 +35,7 @@ export function isPlatformComponentId(id: string): boolean {
  * ``id`` against the entry's ``id`` preset — the per-instance
  * counterpart to the pin guard's physical per-GPIO matching. An entry
  * without an ``id`` preset (ethernet's singleton wiring) matches by
- * section alone.
+ * section alone; an exact ``id`` match wins over it.
  */
 export function featuredEntryForInstance(
   board: BoardCatalogEntry | null,
@@ -43,14 +43,17 @@ export function featuredEntryForInstance(
   instanceId: unknown
 ): FeaturedComponent | null {
   if (!board || !sectionKey) return null;
+  const inSection =
+    board.featured_components?.filter((fc) => fc.component_id === sectionKey) ?? [];
   return (
-    board.featured_components?.find(
+    inSection.find(
       (fc) =>
-        fc.component_id === sectionKey &&
-        (fc.fields.id === undefined
-          ? true
-          : typeof instanceId === "string" && fc.fields.id.value === instanceId)
-    ) ?? null
+        fc.fields.id !== undefined &&
+        typeof instanceId === "string" &&
+        fc.fields.id.value === instanceId
+    ) ??
+    inSection.find((fc) => fc.fields.id === undefined) ??
+    null
   );
 }
 

--- a/src/util/featured-id.ts
+++ b/src/util/featured-id.ts
@@ -33,17 +33,23 @@ export function isPlatformComponentId(id: string): boolean {
 
  * Matches by section (``component_id``) plus the instance's emitted
  * ``id`` against the entry's ``id`` preset — the per-instance
- * counterpart to the pin guard's physical per-GPIO matching.
+ * counterpart to the pin guard's physical per-GPIO matching. An entry
+ * without an ``id`` preset (ethernet's singleton wiring) matches by
+ * section alone.
  */
 export function featuredEntryForInstance(
   board: BoardCatalogEntry | null,
   sectionKey: string,
   instanceId: unknown
 ): FeaturedComponent | null {
-  if (!board || !sectionKey || typeof instanceId !== "string") return null;
+  if (!board || !sectionKey) return null;
   return (
     board.featured_components?.find(
-      (fc) => fc.component_id === sectionKey && fc.fields.id?.value === instanceId
+      (fc) =>
+        fc.component_id === sectionKey &&
+        (fc.fields.id === undefined
+          ? true
+          : typeof instanceId === "string" && fc.fields.id.value === instanceId)
     ) ?? null
   );
 }

--- a/src/util/featured-id.ts
+++ b/src/util/featured-id.ts
@@ -34,8 +34,10 @@ export function isPlatformComponentId(id: string): boolean {
  * Matches by section (``component_id``) plus the instance's emitted
  * ``id`` against the entry's ``id`` preset — the per-instance
  * counterpart to the pin guard's physical per-GPIO matching. An entry
- * without an ``id`` preset (ethernet's singleton wiring) matches by
- * section alone; an exact ``id`` match wins over it.
+ * without an ``id`` preset matches by section alone, but only for a
+ * single-instance component (ethernet's singleton wiring) — a
+ * repeatable section's instance must match an ``id`` preset exactly,
+ * or a hand-added sibling would borrow the entry's presets.
  */
 export function featuredEntryForInstance(
   board: BoardCatalogEntry | null,
@@ -52,7 +54,7 @@ export function featuredEntryForInstance(
         typeof instanceId === "string" &&
         fc.fields.id.value === instanceId
     ) ??
-    inSection.find((fc) => fc.fields.id === undefined) ??
+    inSection.find((fc) => fc.fields.id === undefined && fc.multi_conf === false) ??
     null
   );
 }

--- a/src/util/featured-locks.ts
+++ b/src/util/featured-locks.ts
@@ -20,11 +20,11 @@ import { featuredEntryForInstance } from "./featured-id.js";
 import { isPlainObject } from "./nested-values.js";
 
 // Stable locked copies so re-renders hand the form identical entry
-// references (same rationale as the pin wiring's lock cache). Nested
-// copies are keyed on which children locked, so a child moving off its
-// preset rebuilds the parent copy exactly once.
+// references (same rationale as the pin wiring's lock cache). A nested
+// copy stays valid while its children are identical, which the child
+// caches make an identity check.
 const lockedCopies = new WeakMap<ConfigEntry, ConfigEntry>();
-const nestedCopies = new WeakMap<ConfigEntry, { sig: string; copy: ConfigEntry }>();
+const nestedCopies = new WeakMap<ConfigEntry, ConfigEntry>();
 
 export function overlayBoardLockedPresets(
   entries: ConfigEntry[],
@@ -34,11 +34,15 @@ export function overlayBoardLockedPresets(
 ): ConfigEntry[] {
   const fc = featuredEntryForInstance(board, sectionKey, values.id);
   if (!fc) return entries;
-  return entries.map((entry) => {
+  let changed = false;
+  const mapped = entries.map((entry) => {
     const preset = fc.fields[entry.key];
     if (!preset?.locked) return entry;
-    return overlayEntry(entry, preset.value, values[entry.key]);
+    const out = overlayEntry(entry, preset.value, values[entry.key]);
+    if (out !== entry) changed = true;
+    return out;
   });
+  return changed ? mapped : entries;
 }
 
 /** Locked copy of *entry* while *current* still sits on the locked
@@ -57,13 +61,14 @@ function overlayEntry(
   if (isPlainObject(preset)) {
     const children = entry.config_entries;
     if (!children || !isPlainObject(current)) return entry;
-    const mapped = children.map((child) =>
-      child.key in preset
-        ? overlayEntry(child, preset[child.key], current[child.key])
-        : child
-    );
-    if (mapped.every((child, i) => child === children[i])) return entry;
-    return nestedCopy(entry, mapped);
+    let changed = false;
+    const mapped = children.map((child) => {
+      if (!(child.key in preset)) return child;
+      const out = overlayEntry(child, preset[child.key], current[child.key]);
+      if (out !== child) changed = true;
+      return out;
+    });
+    return changed ? nestedCopy(entry, mapped) : entry;
   }
   return presetValueMatches(current, preset) ? lockedCopy(entry) : entry;
 }
@@ -82,14 +87,12 @@ function lockedCopy(entry: ConfigEntry): ConfigEntry {
 }
 
 function nestedCopy(entry: ConfigEntry, children: ConfigEntry[]): ConfigEntry {
-  const sig = children
-    .filter((child, i) => child !== entry.config_entries?.[i])
-    .map((child) => child.key)
-    .join(",");
   const hit = nestedCopies.get(entry);
-  if (hit && hit.sig === sig) return hit.copy;
+  if (hit && children.every((child, i) => child === hit.config_entries![i])) {
+    return hit;
+  }
   const copy = { ...entry, config_entries: children };
-  nestedCopies.set(entry, { sig, copy });
+  nestedCopies.set(entry, copy);
   return copy;
 }
 

--- a/src/util/featured-locks.ts
+++ b/src/util/featured-locks.ts
@@ -7,7 +7,9 @@
  * editable there. Overlay ``locked`` onto entries whose instance still
  * sits on the locked preset — matched to the featured entry by the
  * instance's ``id``, and released once the user moves the value off
- * the preset in YAML (their own config, like the pin guard).
+ * the preset in YAML (their own config, like the pin guard). A mapping
+ * preset (ethernet's ``clk: {pin, mode}``) descends into the nested
+ * group's children, locking each leaf still on its preset value.
  */
 
 import type { BoardCatalogEntry } from "../api/types/boards.js";
@@ -15,10 +17,14 @@ import type { ConfigEntry } from "../api/types/config-entries.js";
 import { ConfigEntryType } from "../api/types/config-entries.js";
 import type { LockedReasonCarrier } from "../components/device/config-entry-renderers-shared.js";
 import { featuredEntryForInstance } from "./featured-id.js";
+import { isPlainObject } from "./nested-values.js";
 
 // Stable locked copies so re-renders hand the form identical entry
-// references (same rationale as the pin wiring's lock cache).
+// references (same rationale as the pin wiring's lock cache). Nested
+// copies are keyed on which children locked, so a child moving off its
+// preset rebuilds the parent copy exactly once.
 const lockedCopies = new WeakMap<ConfigEntry, ConfigEntry>();
+const nestedCopies = new WeakMap<ConfigEntry, { sig: string; copy: ConfigEntry }>();
 
 export function overlayBoardLockedPresets(
   entries: ConfigEntry[],
@@ -26,55 +32,70 @@ export function overlayBoardLockedPresets(
   sectionKey: string,
   values: Record<string, unknown>
 ): ConfigEntry[] {
-  const lockedKeys = boardLockedPresetKeys(board, sectionKey, values);
-  if (lockedKeys.size === 0) return entries;
+  const fc = featuredEntryForInstance(board, sectionKey, values.id);
+  if (!fc) return entries;
   return entries.map((entry) => {
-    // Pins keep their own value-dependent guard (the picker's
-    // board-preset lock); stamping ``locked`` would demote it to the
-    // hard-lock chrome and hide the wiring guard row. An already-locked
-    // entry (the add dialog's server-hydrated featured schema) keeps its
-    // own lock and reason verbatim.
-    if (
-      !lockedKeys.has(entry.key) ||
-      entry.locked ||
-      entry.type === ConfigEntryType.PIN
-    ) {
-      return entry;
-    }
-    let copy = lockedCopies.get(entry);
-    if (!copy) {
-      copy = {
-        ...entry,
-        locked: true,
-        locked_reason_key: "device.pin_wiring_guard_tooltip",
-      } as ConfigEntry & LockedReasonCarrier;
-      lockedCopies.set(entry, copy);
-    }
-    return copy;
+    const preset = fc.fields[entry.key];
+    if (!preset?.locked) return entry;
+    return overlayEntry(entry, preset.value, values[entry.key]);
   });
 }
 
-/** Keys of *sectionKey*'s board-locked presets the instance in *values*
- *  still holds, matched to the featured entry by its ``id`` preset. */
-function boardLockedPresetKeys(
-  board: BoardCatalogEntry | null,
-  sectionKey: string,
-  values: Record<string, unknown>
-): Set<string> {
-  const out = new Set<string>();
-  const fc = featuredEntryForInstance(board, sectionKey, values.id);
-  if (!fc) return out;
-  for (const [key, preset] of Object.entries(fc.fields)) {
-    if (preset.locked && presetValueMatches(values[key], preset.value)) {
-      out.add(key);
-    }
+/** Locked copy of *entry* while *current* still sits on the locked
+ *  *preset*, descending mapping presets into nested children. Pins keep
+ *  their own value-dependent guard (the picker's board-preset lock);
+ *  stamping ``locked`` would demote it to the hard-lock chrome and hide
+ *  the wiring guard row. An already-locked entry (the add dialog's
+ *  server-hydrated featured schema) keeps its own lock and reason
+ *  verbatim. */
+function overlayEntry(
+  entry: ConfigEntry,
+  preset: unknown,
+  current: unknown
+): ConfigEntry {
+  if (entry.locked || entry.type === ConfigEntryType.PIN) return entry;
+  if (isPlainObject(preset)) {
+    const children = entry.config_entries;
+    if (!children || !isPlainObject(current)) return entry;
+    const mapped = children.map((child) =>
+      child.key in preset
+        ? overlayEntry(child, preset[child.key], current[child.key])
+        : child
+    );
+    if (mapped.every((child, i) => child === children[i])) return entry;
+    return nestedCopy(entry, mapped);
   }
-  return out;
+  return presetValueMatches(current, preset) ? lockedCopy(entry) : entry;
+}
+
+function lockedCopy(entry: ConfigEntry): ConfigEntry {
+  let copy = lockedCopies.get(entry);
+  if (!copy) {
+    copy = {
+      ...entry,
+      locked: true,
+      locked_reason_key: "device.pin_wiring_guard_tooltip",
+    } as ConfigEntry & LockedReasonCarrier;
+    lockedCopies.set(entry, copy);
+  }
+  return copy;
+}
+
+function nestedCopy(entry: ConfigEntry, children: ConfigEntry[]): ConfigEntry {
+  const sig = children
+    .filter((child, i) => child !== entry.config_entries?.[i])
+    .map((child) => child.key)
+    .join(",");
+  const hit = nestedCopies.get(entry);
+  if (hit && hit.sig === sig) return hit.copy;
+  const copy = { ...entry, config_entries: children };
+  nestedCopies.set(entry, { sig, copy });
+  return copy;
 }
 
 /** Loose scalar match (YAML round-trips ``48`` and ``"48"``); lists via
- *  JSON. Mapping presets never match — their only locked use is pins,
- *  which the overlay skips anyway. */
+ *  JSON. A mapping preset never reaches here — ``overlayEntry`` descends
+ *  it — so an object on either side means a shape mismatch. */
 function presetValueMatches(current: unknown, preset: unknown): boolean {
   if (current === undefined || current === null || preset === null) return false;
   if (Array.isArray(preset) || Array.isArray(current)) {

--- a/src/util/featured-locks.ts
+++ b/src/util/featured-locks.ts
@@ -25,6 +25,8 @@ import { isPlainObject } from "./nested-values.js";
 // caches make an identity check.
 const lockedCopies = new WeakMap<ConfigEntry, ConfigEntry>();
 const nestedCopies = new WeakMap<ConfigEntry, ConfigEntry>();
+// Catalog-drift warnings fire once per schema entry, not per render.
+const warnedDrift = new WeakSet<ConfigEntry>();
 
 export function overlayBoardLockedPresets(
   entries: ConfigEntry[],
@@ -60,7 +62,19 @@ function overlayEntry(
   if (entry.locked || entry.type === ConfigEntryType.PIN) return entry;
   if (isPlainObject(preset)) {
     const children = entry.config_entries;
-    if (!children || !isPlainObject(current)) return entry;
+    if (!children) {
+      // A mapping preset over a leaf entry is catalog/schema drift: the
+      // board's lock can't apply, so surface it instead of silently
+      // rendering the field editable.
+      if (!warnedDrift.has(entry)) {
+        warnedDrift.add(entry);
+        console.warn(
+          `Board mapping preset for '${entry.key}' has no nested schema entries; lock not applied`
+        );
+      }
+      return entry;
+    }
+    if (!isPlainObject(current)) return entry;
     let changed = false;
     const mapped = children.map((child) => {
       if (!(child.key in preset)) return child;

--- a/test/components/device/pin/renderer.test.ts
+++ b/test/components/device/pin/renderer.test.ts
@@ -424,6 +424,36 @@ describe("renderPinField reserved pins locked to the edited component", () => {
     // GPIO6 (flash) isn't in ethernet's locked_pins — stays disabled.
     expect(optionFor(result, "GPIO6")?.["?disabled"]).toBe(true);
   });
+
+  it("arms the wiring guard on a nested pin matching its dotted designation", () => {
+    // ``locked_pins`` keys the nested clk pin as ``clk.pin``; the guard
+    // must match the field's dotted path, not the leaf key.
+    const ctx = makeRenderCtx(
+      { clk: { pin: "GPIO0" } },
+      { board: ethBoard(), overrides: { sectionKey: "ethernet" } }
+    );
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, { key: "pin" }),
+      ["clk", "pin"],
+      ctx
+    );
+    const select = findElementBindings(result, "wa-select")[0];
+    expect(String(select.id)).toContain("pin-guard-tip");
+  });
+
+  it("leaves a nested pin moved off the designation unguarded", () => {
+    const ctx = makeRenderCtx(
+      { clk: { pin: "GPIO2" } },
+      { board: ethBoard(), overrides: { sectionKey: "ethernet" } }
+    );
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, { key: "pin" }),
+      ["clk", "pin"],
+      ctx
+    );
+    const select = findElementBindings(result, "wa-select")[0];
+    expect(String(select.id)).not.toContain("pin-guard-tip");
+  });
 });
 
 describe("renderPinField suggestion narrowing", () => {

--- a/test/components/device/section-header-featured.test.ts
+++ b/test/components/device/section-header-featured.test.ts
@@ -109,3 +109,58 @@ describe("section header featured presentation", () => {
     expect(out).not.toContain("section-subtitle");
   });
 });
+
+describe("section header id-less featured presentation", () => {
+  // The ethernet shape: a singleton featured entry with no id preset
+  // matches its section's one instance by section alone.
+  const ethBoard = (multiConf: boolean | undefined) =>
+    makeTestBoard({
+      overrides: {
+        id: "esp32-poe-iso",
+        featured_components: [
+          {
+            id: "onboard_ethernet",
+            component_id: "ethernet",
+            name: "Onboard Ethernet",
+            description: "Built-in Ethernet PHY.",
+            ...(multiConf === undefined ? {} : { multi_conf: multiConf }),
+            fields: { type: { value: "LAN8720", locked: true } },
+          },
+        ],
+      } as never,
+    });
+
+  const ethConfig = {
+    section_key: "ethernet",
+    title: "Ethernet Component",
+    description: "Generic ethernet description.",
+    docs_url: "",
+    image_url: "https://cdn.example/ethernet.png",
+  } as SectionConfigResponse;
+
+  const ethHost = (multiConf: boolean | undefined) =>
+    ({
+      _isUnknown: false,
+      _isPlatformDomain: false,
+      _localize: (key: string) => key,
+      board: ethBoard(multiConf),
+      sectionKey: "ethernet",
+      _values: { type: "LAN8720" },
+    }) as unknown as ESPHomeDeviceSectionConfig;
+
+  it("adopts the singleton entry's presentation without an instance id", () => {
+    const tpl = renderSectionHeader(ethHost(false), ethConfig, []);
+    const out = serialize(tpl);
+    expect(out).toContain("Ethernet Component");
+    expect(out).toContain("section-subtitle");
+    expect(out).toContain("Onboard Ethernet");
+    expect(out).toContain("Built-in Ethernet PHY.");
+  });
+
+  it("keeps the catalog presentation for a repeatable id-less entry", () => {
+    const tpl = renderSectionHeader(ethHost(undefined), ethConfig, []);
+    const out = serialize(tpl);
+    expect(out).toContain("Generic ethernet description.");
+    expect(out).not.toContain("section-subtitle");
+  });
+});

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -389,6 +389,23 @@ describe("domainOccupiesPins", () => {
     expect(domainOccupiesPins(yaml, "binary_sensor", { pin: 0 })).toBe(false);
   });
 
+  it("matches a nested pin keyed by its dotted path", () => {
+    // ethernet's ``locked_pins`` keys the nested clk pin as ``clk.pin``.
+    const yaml = [
+      "ethernet:",
+      "  type: LAN8720",
+      "  mdc_pin: GPIO23",
+      "  clk:",
+      "    mode: CLK_OUT",
+      "    pin: GPIO17",
+      "",
+    ].join("\n");
+    expect(domainOccupiesPins(yaml, "ethernet", { "clk.pin": 17, mdc_pin: 23 })).toBe(
+      true
+    );
+    expect(domainOccupiesPins(yaml, "ethernet", { "clk.pin": 0 })).toBe(false);
+  });
+
   it("is false when the pins are split across two instances", () => {
     const yaml =
       "i2c:\n  - scl: 0\n    sda: 9\n    id: a\n  - scl: 8\n    sda: 1\n    id: b\n";

--- a/test/util/featured-id.test.ts
+++ b/test/util/featured-id.test.ts
@@ -83,4 +83,16 @@ describe("featuredEntryForInstance", () => {
     expect(featuredEntryForInstance(board, "wifi", undefined)).toBeNull();
     expect(featuredEntryForInstance(null, "ethernet", undefined)).toBeNull();
   });
+
+  it("prefers an exact id match over an id-less sibling", () => {
+    const mixed = {
+      id: "board",
+      featured_components: [
+        { id: "generic", component_id: "spi", fields: {} },
+        { id: "lcd_spi", component_id: "spi", fields: { id: preset("lcd_spi") } },
+      ],
+    } as unknown as BoardCatalogEntry;
+    expect(featuredEntryForInstance(mixed, "spi", "lcd_spi")?.id).toBe("lcd_spi");
+    expect(featuredEntryForInstance(mixed, "spi", "other")?.id).toBe("generic");
+  });
 });

--- a/test/util/featured-id.test.ts
+++ b/test/util/featured-id.test.ts
@@ -59,6 +59,7 @@ describe("featuredEntryForInstance", () => {
       {
         id: "onboard_ethernet",
         component_id: "ethernet",
+        multi_conf: false,
         fields: { type: preset("LAN8720") },
       },
     ],
@@ -70,7 +71,7 @@ describe("featuredEntryForInstance", () => {
     expect(featuredEntryForInstance(board, "spi", undefined)).toBeNull();
   });
 
-  it("matches an id-less entry by section alone", () => {
+  it("matches an id-less singleton entry by section alone", () => {
     expect(featuredEntryForInstance(board, "ethernet", undefined)?.id).toBe(
       "onboard_ethernet"
     );
@@ -79,20 +80,31 @@ describe("featuredEntryForInstance", () => {
     );
   });
 
+  it("never falls back to an id-less entry of a repeatable section", () => {
+    // multi_conf is absent (repeatable) — a hand-added instance must not
+    // borrow the entry's presets.
+    const repeatable = {
+      id: "board",
+      featured_components: [{ id: "generic", component_id: "spi", fields: {} }],
+    } as unknown as BoardCatalogEntry;
+    expect(featuredEntryForInstance(repeatable, "spi", undefined)).toBeNull();
+    expect(featuredEntryForInstance(repeatable, "spi", "my_own_spi")).toBeNull();
+  });
+
   it("returns null outside the section or without a board", () => {
     expect(featuredEntryForInstance(board, "wifi", undefined)).toBeNull();
     expect(featuredEntryForInstance(null, "ethernet", undefined)).toBeNull();
   });
 
-  it("prefers an exact id match over an id-less sibling", () => {
+  it("prefers an exact id match over an id-less singleton sibling", () => {
     const mixed = {
       id: "board",
       featured_components: [
-        { id: "generic", component_id: "spi", fields: {} },
-        { id: "lcd_spi", component_id: "spi", fields: { id: preset("lcd_spi") } },
+        { id: "generic", component_id: "i2s", multi_conf: false, fields: {} },
+        { id: "amp_i2s", component_id: "i2s", fields: { id: preset("amp_i2s") } },
       ],
     } as unknown as BoardCatalogEntry;
-    expect(featuredEntryForInstance(mixed, "spi", "lcd_spi")?.id).toBe("lcd_spi");
-    expect(featuredEntryForInstance(mixed, "spi", "other")?.id).toBe("generic");
+    expect(featuredEntryForInstance(mixed, "i2s", "amp_i2s")?.id).toBe("amp_i2s");
+    expect(featuredEntryForInstance(mixed, "i2s", undefined)?.id).toBe("generic");
   });
 });

--- a/test/util/featured-id.test.ts
+++ b/test/util/featured-id.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { isFeaturedId, resolveFeaturedComponentId } from "../../src/util/featured-id.js";
+import type { BoardCatalogEntry } from "../../src/api/types/boards.js";
+import {
+  featuredEntryForInstance,
+  isFeaturedId,
+  resolveFeaturedComponentId,
+} from "../../src/util/featured-id.js";
 
 describe("isFeaturedId", () => {
   it("is true for a featured.<board>.<local> id", () => {
@@ -38,5 +43,44 @@ describe("resolveFeaturedComponentId", () => {
       "featured.esp32-poe-iso.unknown"
     );
     expect(resolveFeaturedComponentId("featured.x.y", null)).toBe("featured.x.y");
+  });
+});
+
+describe("featuredEntryForInstance", () => {
+  const preset = (value: unknown) => ({ value, locked: false, suggestions: null });
+  const board = {
+    id: "board",
+    featured_components: [
+      {
+        id: "lcd_spi",
+        component_id: "spi",
+        fields: { id: preset("lcd_spi") },
+      },
+      {
+        id: "onboard_ethernet",
+        component_id: "ethernet",
+        fields: { type: preset("LAN8720") },
+      },
+    ],
+  } as unknown as BoardCatalogEntry;
+
+  it("matches an id-preset entry only on the exact instance id", () => {
+    expect(featuredEntryForInstance(board, "spi", "lcd_spi")?.id).toBe("lcd_spi");
+    expect(featuredEntryForInstance(board, "spi", "my_own_spi")).toBeNull();
+    expect(featuredEntryForInstance(board, "spi", undefined)).toBeNull();
+  });
+
+  it("matches an id-less entry by section alone", () => {
+    expect(featuredEntryForInstance(board, "ethernet", undefined)?.id).toBe(
+      "onboard_ethernet"
+    );
+    expect(featuredEntryForInstance(board, "ethernet", "eth0")?.id).toBe(
+      "onboard_ethernet"
+    );
+  });
+
+  it("returns null outside the section or without a board", () => {
+    expect(featuredEntryForInstance(board, "wifi", undefined)).toBeNull();
+    expect(featuredEntryForInstance(null, "ethernet", undefined)).toBeNull();
   });
 });

--- a/test/util/featured-locks.test.ts
+++ b/test/util/featured-locks.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { BoardCatalogEntry } from "../../src/api/types/boards.js";
 import { ConfigEntryType } from "../../src/api/types/config-entries.js";
@@ -111,6 +111,7 @@ describe("overlayBoardLockedPresets nested presets", () => {
       {
         id: "onboard_ethernet",
         component_id: "ethernet",
+        multi_conf: false,
         fields: {
           type: preset("LAN8720"),
           clk: preset({ pin: "GPIO17", mode: "CLK_OUT" }),
@@ -173,5 +174,18 @@ describe("overlayBoardLockedPresets nested presets", () => {
     const a = overlayBoardLockedPresets(ETH_ENTRIES, ETH_BOARD, "ethernet", ETH_VALUES);
     const b = overlayBoardLockedPresets(ETH_ENTRIES, ETH_BOARD, "ethernet", ETH_VALUES);
     expect(a.find((e) => e.key === "clk")).toBe(b.find((e) => e.key === "clk"));
+  });
+
+  it("warns once on a mapping preset over a leaf entry (catalog drift)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // The schema renders clk as a plain string field while the board
+    // preset is a mapping — the lock can't apply.
+    const drifted = [makeConfigEntry({ key: "clk", type: ConfigEntryType.STRING })];
+    const out = overlayBoardLockedPresets(drifted, ETH_BOARD, "ethernet", ETH_VALUES);
+    expect(out).toBe(drifted);
+    expect(warn).toHaveBeenCalledTimes(1);
+    overlayBoardLockedPresets(drifted, ETH_BOARD, "ethernet", ETH_VALUES);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
   });
 });

--- a/test/util/featured-locks.test.ts
+++ b/test/util/featured-locks.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { BoardCatalogEntry } from "../../src/api/types/boards.js";
 import { ConfigEntryType } from "../../src/api/types/config-entries.js";
 import { overlayBoardLockedPresets } from "../../src/util/featured-locks.js";
-import { makeConfigEntry } from "./_make-config-entry.js";
+import { makeConfigEntry, makeNestedEntry } from "./_make-config-entry.js";
 
 const preset = (value: unknown, locked = true) => ({ value, locked, suggestions: null });
 
@@ -99,5 +99,79 @@ describe("overlayBoardLockedPresets", () => {
     const a = overlayBoardLockedPresets(ENTRIES, BOARD, SECTION, VALUES);
     const b = overlayBoardLockedPresets(ENTRIES, BOARD, SECTION, VALUES);
     expect(a.find((e) => e.key === "chipset")).toBe(b.find((e) => e.key === "chipset"));
+  });
+});
+
+// The ethernet shape: an id-less featured entry with a mapping preset
+// (nested `clk: {pin, mode}`) whose leaves lock individually.
+describe("overlayBoardLockedPresets nested presets", () => {
+  const ETH_BOARD = {
+    id: "esp32-poe-iso",
+    featured_components: [
+      {
+        id: "onboard_ethernet",
+        component_id: "ethernet",
+        fields: {
+          type: preset("LAN8720"),
+          clk: preset({ pin: "GPIO17", mode: "CLK_OUT" }),
+        },
+      },
+    ],
+  } as unknown as BoardCatalogEntry;
+
+  const ETH_ENTRIES = [
+    makeConfigEntry({ key: "type", type: ConfigEntryType.STRING }),
+    makeNestedEntry("clk", [
+      makeConfigEntry({ key: "pin", type: ConfigEntryType.PIN }),
+      makeConfigEntry({ key: "mode", type: ConfigEntryType.STRING }),
+    ]),
+  ];
+
+  const ETH_VALUES = {
+    type: "LAN8720",
+    clk: { pin: "GPIO17", mode: "CLK_OUT" },
+  };
+
+  const clkChild = (out: ReturnType<typeof overlayBoardLockedPresets>, key: string) =>
+    out.find((e) => e.key === "clk")!.config_entries!.find((e) => e.key === key)!;
+
+  it("matches an id-less featured entry by section alone", () => {
+    const out = overlayBoardLockedPresets(ETH_ENTRIES, ETH_BOARD, "ethernet", ETH_VALUES);
+    expect(out.find((e) => e.key === "type")!.locked).toBe(true);
+  });
+
+  it("locks a nested leaf still on its preset value", () => {
+    const out = overlayBoardLockedPresets(ETH_ENTRIES, ETH_BOARD, "ethernet", ETH_VALUES);
+    const mode = clkChild(out, "mode");
+    expect(mode.locked).toBe(true);
+    expect((mode as { locked_reason_key?: string }).locked_reason_key).toBe(
+      "device.pin_wiring_guard_tooltip"
+    );
+  });
+
+  it("never stamps a nested PIN leaf (the picker guard owns pins)", () => {
+    const out = overlayBoardLockedPresets(ETH_ENTRIES, ETH_BOARD, "ethernet", ETH_VALUES);
+    expect(clkChild(out, "pin").locked).toBeFalsy();
+  });
+
+  it("releases a nested leaf the user moved off the preset", () => {
+    const out = overlayBoardLockedPresets(ETH_ENTRIES, ETH_BOARD, "ethernet", {
+      ...ETH_VALUES,
+      clk: { pin: 0, mode: "CLK_EXT_IN" },
+    });
+    expect(out.find((e) => e.key === "clk")).toBe(ETH_ENTRIES[1]);
+  });
+
+  it("leaves the nested group untouched when the block is absent", () => {
+    const out = overlayBoardLockedPresets(ETH_ENTRIES, ETH_BOARD, "ethernet", {
+      type: "LAN8720",
+    });
+    expect(out.find((e) => e.key === "clk")).toBe(ETH_ENTRIES[1]);
+  });
+
+  it("hands back stable nested copies across renders", () => {
+    const a = overlayBoardLockedPresets(ETH_ENTRIES, ETH_BOARD, "ethernet", ETH_VALUES);
+    const b = overlayBoardLockedPresets(ETH_ENTRIES, ETH_BOARD, "ethernet", ETH_VALUES);
+    expect(a.find((e) => e.key === "clk")).toBe(b.find((e) => e.key === "clk"));
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Board locked presets never locked nested fields in the visual editor. On esp32-poe-iso the ethernet clk group (pin and mode) rendered editable while mdc_pin and mdio_pin showed the board lock; the board data already carries locked_pins keyed as clk.pin plus a locked clk mapping preset, but every lock consumer matched flat keys only.

The pin wiring guard now matches locked_pins against the field's dotted path and reads nested presets through getIn. The value dependent lock overlay matches an id-less featured entry by its section (ethernet has no id preset, so the overlay previously never matched that section at all) and descends mapping presets into nested children, locking each leaf that still sits on its preset value. The duplicate card pin scan resolves dotted locked_pins keys the same way. Verified in the live editor against esp32-poe-iso: every board defined ethernet field shows the lock including clk pin and mode, and moving clk pin off the board wiring releases only that field.

**Related issue or feature (if applicable):**

- None, reported directly with a screenshot of the esp32-poe-iso ethernet editor

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
