### PR TITLE
Surface Web Serial unavailability in the flash receiver

### DIFF
--- a/src/web/flash-receiver/esphome-web-flash-receiver.ts
+++ b/src/web/flash-receiver/esphome-web-flash-receiver.ts
@@ -68,7 +68,8 @@ export class ESPHomeWebFlashReceiver extends LitElement {
   // The dashboard always hands off through this component (opener + nonce),
   // so unlike <esphome-web-dashboard> this is the only place that ever tells
   // a Safari (or insecure-context) user their browser can't do this at all.
-  private readonly _unsupported = webSerialAvailability() !== "available";
+  private readonly _serialAvailability = webSerialAvailability();
+  private readonly _unsupported = this._serialAvailability !== "available";
   // Supersedes a pending boot-log acquisition (a second manual flash during
   // the re-enumeration wait, or an unmount mid-await).
   private _bootLogsGen = 0;
@@ -107,6 +108,20 @@ export class ESPHomeWebFlashReceiver extends LitElement {
   }
 
   private _onFirmware(msg: FirmwareMessage): void {
+    if (this._unsupported) {
+      // The tab already shows <esphome-web-unsupported-card> (see render());
+      // relay it as an error too so the dashboard — now handed off — doesn't
+      // just sit waiting up to its own timeout for a tab that can never flash.
+      // Bail before retaining the firmware or retitling the tab "Flashing …":
+      // nothing below applies to a page that can't flash.
+      this._setState(
+        "error",
+        this._serialAvailability === "insecure-context"
+          ? this._localize("web.unsupported.insecure")
+          : this._localize("web.unsupported.browser")
+      );
+      return;
+    }
     this._firmware = msg;
     // Name the tab + card after the device so several concurrent flash tabs are
     // distinguishable (legacy did the same with the transmitted device name).
@@ -115,18 +130,6 @@ export class ESPHomeWebFlashReceiver extends LitElement {
       document.title = this._localize("web.flash.tab_title", {
         name: msg.deviceName,
       });
-    }
-    if (this._unsupported) {
-      // The tab already shows <esphome-web-unsupported-card> (see render());
-      // relay it as an error too so the dashboard — now handed off — doesn't
-      // just sit waiting up to its own timeout for a tab that can never flash.
-      this._setState(
-        "error",
-        webSerialAvailability() === "insecure-context"
-          ? this._localize("web.unsupported.insecure")
-          : this._localize("web.unsupported.browser")
-      );
-      return;
     }
     this._setState(
       "connecting",
@@ -423,7 +426,9 @@ export class ESPHomeWebFlashReceiver extends LitElement {
 
   protected render() {
     if (this._unsupported) {
-      return html`<esphome-web-unsupported-card></esphome-web-unsupported-card>`;
+      return html`<div class="wrap">
+        <esphome-web-unsupported-card></esphome-web-unsupported-card>
+      </div>`;
     }
     return html`
       <div class="wrap">

--- a/src/web/flash-receiver/esphome-web-flash-receiver.ts
+++ b/src/web/flash-receiver/esphome-web-flash-receiver.ts
@@ -9,9 +9,10 @@ import { localizeContext } from "../../context/index.js";
 import { actionBtnStyles } from "../../styles/action-buttons.js";
 import { warningBannerStyles } from "../../styles/banners.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import { isPortPickerCancel } from "../../util/web-serial.js";
+import { isPortPickerCancel, webSerialAvailability } from "../../util/web-serial.js";
 import { cardActionsRowStyles } from "../dashboard/card-actions-row.js";
 import "../dashboard/esphome-web-card.js";
+import "../dashboard/esphome-web-unsupported-card.js";
 import { runFlash } from "../install/run-flash.js";
 import { openPortForLogs } from "../logs/esphome-web-logs-dialog.js";
 import type { FlashPart } from "../util/esphome-web-firmware.js";
@@ -63,6 +64,11 @@ export class ESPHomeWebFlashReceiver extends LitElement {
 
   private _handshake?: FlashHandshake;
   private _hasOpener = false;
+  // Computed once: Web Serial support doesn't change over the page's life.
+  // The dashboard always hands off through this component (opener + nonce),
+  // so unlike <esphome-web-dashboard> this is the only place that ever tells
+  // a Safari (or insecure-context) user their browser can't do this at all.
+  private readonly _unsupported = webSerialAvailability() !== "available";
   // Supersedes a pending boot-log acquisition (a second manual flash during
   // the re-enumeration wait, or an unmount mid-await).
   private _bootLogsGen = 0;
@@ -109,6 +115,18 @@ export class ESPHomeWebFlashReceiver extends LitElement {
       document.title = this._localize("web.flash.tab_title", {
         name: msg.deviceName,
       });
+    }
+    if (this._unsupported) {
+      // The tab already shows <esphome-web-unsupported-card> (see render());
+      // relay it as an error too so the dashboard — now handed off — doesn't
+      // just sit waiting up to its own timeout for a tab that can never flash.
+      this._setState(
+        "error",
+        webSerialAvailability() === "insecure-context"
+          ? this._localize("web.unsupported.insecure")
+          : this._localize("web.unsupported.browser")
+      );
+      return;
     }
     this._setState(
       "connecting",
@@ -404,6 +422,9 @@ export class ESPHomeWebFlashReceiver extends LitElement {
   }
 
   protected render() {
+    if (this._unsupported) {
+      return html`<esphome-web-unsupported-card></esphome-web-unsupported-card>`;
+    }
     return html`
       <div class="wrap">
         <esphome-web-card status=${this._localize("web.flash.status")} variant="neutral">

--- a/test/web/flash-receiver-boot-logs.test.ts
+++ b/test/web/flash-receiver-boot-logs.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/util/web-serial.js", () => ({
   isPortPickerCancel: vi.fn(() => false),
+  webSerialAvailability: vi.fn(() => "available"),
 }));
 vi.mock("../../src/web/install/run-flash.js", () => ({ runFlash: vi.fn() }));
 vi.mock("../../src/web/dashboard/esphome-web-card.js", () => ({}));

--- a/test/web/flash-receiver-unsupported.test.ts
+++ b/test/web/flash-receiver-unsupported.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/util/web-serial.js", () => ({
+  isPortPickerCancel: vi.fn(() => false),
+  webSerialAvailability: vi.fn(() => "unsupported"),
+}));
+vi.mock("../../src/web/install/run-flash.js", () => ({ runFlash: vi.fn() }));
+vi.mock("../../src/web/dashboard/esphome-web-card.js", () => ({}));
+vi.mock("../../src/web/dashboard/esphome-web-unsupported-card.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("../../src/components/ansi-log.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+vi.mock("../../src/web/logs/esphome-web-logs-dialog.js", () => ({
+  openPortForLogs: vi.fn(async () => true),
+}));
+
+import { ESPHomeWebFlashReceiver } from "../../src/web/flash-receiver/esphome-web-flash-receiver.js";
+import { MSG_FIRMWARE } from "../../src/web/flash-receiver/protocol.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+});
+
+describe("esphome-web-flash-receiver on an unsupported browser", () => {
+  it("renders the unsupported card instead of the flash UI", async () => {
+    const el = new ESPHomeWebFlashReceiver();
+    (el as any)._localize = (k: string) => k;
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.querySelector("esphome-web-unsupported-card")).not.toBeNull();
+    expect(el.shadowRoot?.querySelector(".wrap")).toBeNull();
+  });
+
+  it("relays an error to the opener instead of hanging once firmware arrives", async () => {
+    const openerPost = vi.fn();
+    const opener = { postMessage: openerPost };
+    Object.defineProperty(window, "opener", { value: opener, configurable: true });
+    const origHash = window.location.hash;
+    window.location.hash = "#nonce=n1";
+    try {
+      const el = new ESPHomeWebFlashReceiver();
+      (el as any)._localize = (k: string) => k;
+      document.body.appendChild(el);
+      await el.updateComplete;
+
+      const ev = new MessageEvent("message", {
+        data: {
+          type: MSG_FIRMWARE,
+          nonce: "n1",
+          parts: [{ address: 0, data: new ArrayBuffer(4) }],
+        },
+      });
+      Object.defineProperty(ev, "source", { value: opener });
+      window.dispatchEvent(ev);
+      await el.updateComplete;
+
+      expect((el as any)._state).toBe("error");
+      expect((el as any)._statusMessage).toBe("web.unsupported.browser");
+      // Handed off (firmware arrived), so the opener's own handedOff-gated
+      // listener actually accepts this state frame instead of it being
+      // dropped pre-handoff.
+      const stateFrame = openerPost.mock.calls
+        .map((args) => args[0])
+        .find((msg) => msg.type === "esphome-web-flash:state");
+      expect(stateFrame).toMatchObject({ state: "error" });
+    } finally {
+      window.location.hash = origHash;
+      delete (window as any).opener;
+    }
+  });
+});

--- a/test/web/flash-receiver-unsupported.test.ts
+++ b/test/web/flash-receiver-unsupported.test.ts
@@ -15,6 +15,7 @@ vi.mock("../../src/web/logs/esphome-web-logs-dialog.js", () => ({
   openPortForLogs: vi.fn(async () => true),
 }));
 
+import { webSerialAvailability } from "../../src/util/web-serial.js";
 import { ESPHomeWebFlashReceiver } from "../../src/web/flash-receiver/esphome-web-flash-receiver.js";
 import { MSG_FIRMWARE } from "../../src/web/flash-receiver/protocol.js";
 
@@ -23,7 +24,35 @@ import { MSG_FIRMWARE } from "../../src/web/flash-receiver/protocol.js";
 afterEach(() => {
   document.body.innerHTML = "";
   vi.clearAllMocks();
+  vi.mocked(webSerialAvailability).mockReturnValue("unsupported");
 });
+
+// Mounts a receiver with a fake opener and delivers one firmware frame to it,
+// exactly as the dashboard would after the nonce handshake.
+async function handOffFirmware(
+  opener: { postMessage: ReturnType<typeof vi.fn> },
+  deviceName?: string
+) {
+  Object.defineProperty(window, "opener", { value: opener, configurable: true });
+  window.location.hash = "#nonce=n1";
+  const el = new ESPHomeWebFlashReceiver();
+  (el as any)._localize = (k: string) => k;
+  document.body.appendChild(el);
+  await el.updateComplete;
+
+  const ev = new MessageEvent("message", {
+    data: {
+      type: MSG_FIRMWARE,
+      nonce: "n1",
+      deviceName,
+      parts: [{ address: 0, data: new ArrayBuffer(4) }],
+    },
+  });
+  Object.defineProperty(ev, "source", { value: opener });
+  window.dispatchEvent(ev);
+  await el.updateComplete;
+  return el;
+}
 
 describe("esphome-web-flash-receiver on an unsupported browser", () => {
   it("renders the unsupported card instead of the flash UI", async () => {
@@ -32,32 +61,19 @@ describe("esphome-web-flash-receiver on an unsupported browser", () => {
     document.body.appendChild(el);
     await el.updateComplete;
 
-    expect(el.shadowRoot?.querySelector("esphome-web-unsupported-card")).not.toBeNull();
-    expect(el.shadowRoot?.querySelector(".wrap")).toBeNull();
+    const card = el.shadowRoot?.querySelector("esphome-web-unsupported-card");
+    expect(card).not.toBeNull();
+    // Same width container as the flash UI so it doesn't render full-bleed.
+    expect(card?.closest(".wrap")).not.toBeNull();
+    expect(el.shadowRoot?.querySelector("esphome-web-card")).toBeNull();
   });
 
   it("relays an error to the opener instead of hanging once firmware arrives", async () => {
     const openerPost = vi.fn();
-    const opener = { postMessage: openerPost };
-    Object.defineProperty(window, "opener", { value: opener, configurable: true });
     const origHash = window.location.hash;
-    window.location.hash = "#nonce=n1";
+    const origTitle = document.title;
     try {
-      const el = new ESPHomeWebFlashReceiver();
-      (el as any)._localize = (k: string) => k;
-      document.body.appendChild(el);
-      await el.updateComplete;
-
-      const ev = new MessageEvent("message", {
-        data: {
-          type: MSG_FIRMWARE,
-          nonce: "n1",
-          parts: [{ address: 0, data: new ArrayBuffer(4) }],
-        },
-      });
-      Object.defineProperty(ev, "source", { value: opener });
-      window.dispatchEvent(ev);
-      await el.updateComplete;
+      const el = await handOffFirmware({ postMessage: openerPost }, "kitchen");
 
       expect((el as any)._state).toBe("error");
       expect((el as any)._statusMessage).toBe("web.unsupported.browser");
@@ -68,6 +84,24 @@ describe("esphome-web-flash-receiver on an unsupported browser", () => {
         .map((args) => args[0])
         .find((msg) => msg.type === "esphome-web-flash:state");
       expect(stateFrame).toMatchObject({ state: "error" });
+      // Bails before claiming a flash is in progress or holding the firmware.
+      expect(document.title).toBe(origTitle);
+      expect((el as any)._firmware).toBeUndefined();
+    } finally {
+      window.location.hash = origHash;
+      delete (window as any).opener;
+    }
+  });
+
+  it("relays the insecure-context message when that is the cause", async () => {
+    vi.mocked(webSerialAvailability).mockReturnValue("insecure-context");
+    const openerPost = vi.fn();
+    const origHash = window.location.hash;
+    try {
+      const el = await handOffFirmware({ postMessage: openerPost });
+
+      expect((el as any)._state).toBe("error");
+      expect((el as any)._statusMessage).toBe("web.unsupported.insecure");
     } finally {
       window.location.hash = origHash;
       delete (window as any).opener;


### PR DESCRIPTION
# What does this implement/fix?

The flash-receiver page (`<esphome-web-flash-receiver>`, the tab the dashboard
hands firmware to over `postMessage` when it can't flash itself) never checked
Web Serial support — only `<esphome-web-dashboard>` did. On a browser without
Web Serial (e.g. Safari, or an insecure context), the receiver rendered its
normal flash UI and sat there after firmware arrived, and no error was relayed
to the opener, so the dashboard — already handed off — waited out its full
10-minute watchdog on a tab that could never flash.

`ESPHomeWebFlashReceiver` now checks `webSerialAvailability()` once at
construction and, when unavailable:

- renders the existing `<esphome-web-unsupported-card>` (inside the normal
  `.wrap` width container) instead of the flash UI, and
- relays an `error` state to the opener as soon as firmware arrives — before
  retitling the tab or retaining the firmware buffer — so the dashboard fails
  immediately with a message the user can act on, instead of hanging.

Both the unsupported-browser and insecure-context messages are covered by
tests.

**Related issue or feature (if applicable):**

- fixes #1656

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally, using `window.open("http://localhost:5174/#nonce=test123&origin=http://localhost:5174")`.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

## Remarks for reviewers

- Only tested by hand on Safari (macOS); not exercised on Windows/Linux or in
  other browsers.
