### PR TITLE
Retire the quiet-serial banner once the console has produced output

### DIFF
--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -40,13 +40,13 @@ import type { ESPHomeCrashReportDialog } from "./crash-report-dialog.js";
 import { logsDialogStyles } from "./logs-dialog.styles.js";
 import {
   abortSerialReconnect,
+  expectSerialOutput,
   markSerialOutput,
   onStart,
   onStop,
   openOta,
   openPassive,
   resumeAfterReconnect,
-  resumeSerial,
   setSerialOpenFailed,
   setSerialStream,
   switchToOtaLogs,
@@ -538,10 +538,14 @@ export class ESPHomeLogsDialog extends LitElement {
   private _onResetDevice = async () => {
     const s = this._session;
     if (s.kind !== "serial") return;
-    resumeSerial(this);
+    this._session = { ...s, paused: false };
     try {
       await s.port.setSignals({ dataTerminalReady: false, requestToSend: true });
       await s.port.setSignals({ dataTerminalReady: false, requestToSend: false });
+      // Boot output can't precede the pulse; expecting it only once the pulse
+      // has landed keeps a stale pre-reset line from retiring the watchdog
+      // for a reset that never took.
+      expectSerialOutput(this);
     } catch {
       // setSignals fails if the cable was pulled; tell the user the reset didn't
       // land rather than letting them assume the device rebooted.

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -40,11 +40,13 @@ import type { ESPHomeCrashReportDialog } from "./crash-report-dialog.js";
 import { logsDialogStyles } from "./logs-dialog.styles.js";
 import {
   abortSerialReconnect,
+  markSerialOutput,
   onStart,
   onStop,
   openOta,
   openPassive,
   resumeAfterReconnect,
+  resumeSerial,
   setSerialOpenFailed,
   setSerialStream,
   switchToOtaLogs,
@@ -163,10 +165,8 @@ export class ESPHomeLogsDialog extends LitElement {
 
   // Watchdog for a Web Serial reader that shows nothing (uart: repurposed
   // the console pins, wrong baud). Armed/disarmed off the session state in
-  // willUpdate; the first displayed line (_noteSerialActivity) retires it
-  // until output is expected afresh (a new attach, Start, Reset Device).
-  // When it goes quiet the toolbar area offers switching to network logs
-  // (#1430).
+  // willUpdate. When it goes quiet the toolbar area offers switching to
+  // network logs (#1430).
   _quietSerial = new QuietTimerController(this, QUIET_SERIAL_TIMEOUT_MS);
 
   // The visible log, its cap, and the stream-position map inline decoding
@@ -236,10 +236,7 @@ export class ESPHomeLogsDialog extends LitElement {
       // reopen retries (several seconds on a re-enumerating native-USB
       // chip), which isn't silence — and a failed reopen lands in dead,
       // which offers the banner anyway. A deliberate Stop (pause, #526)
-      // disarms rather than counting as silence. Once output has landed the
-      // console is proven and a quiet device (bursty logging at INFO) must
-      // not re-trip the banner; a fresh attach, Start after a Stop, and
-      // Reset Device each expect output anew and watch again.
+      // disarms rather than counting as silence.
       const s = this._session;
       const watching = this._open && s.kind === "serial" && !s.paused && !s.outputSeen;
       if (watching) this._quietSerial.ensureArmed();
@@ -506,13 +503,9 @@ export class ESPHomeLogsDialog extends LitElement {
     this._log.enqueue(line);
   }
 
-  // Called by `streamSerialToDialog` for every displayed serial line; the
-  // first one marks the reader as producing output, which retires the
-  // quiet-serial watchdog for this session (willUpdate disarms it).
+  // Called by `streamSerialToDialog` for every displayed serial line.
   _noteSerialActivity(): void {
-    const s = this._session;
-    if (s.kind !== "serial" || s.outputSeen) return;
-    this._session = { ...s, outputSeen: true };
+    markSerialOutput(this);
   }
 
   // Every line the buffer takes on, batched or direct, passes through here.
@@ -541,12 +534,11 @@ export class ESPHomeLogsDialog extends LitElement {
   // Reset Device button (Web Serial only). Pulses RTS (wired to EN on the
   // standard auto-reset circuit) to reboot the device, like the old dashboard's
   // console; the reader stays attached so the boot log follows. Resumes display
-  // first so a Stopped log shows the boot output instead of dropping it, and
-  // expects the boot output afresh (the quiet-serial watchdog watches again).
+  // first so a Stopped log shows the boot output instead of dropping it.
   private _onResetDevice = async () => {
     const s = this._session;
     if (s.kind !== "serial") return;
-    this._session = { ...s, paused: false, outputSeen: false };
+    resumeSerial(this);
     try {
       await s.port.setSignals({ dataTerminalReady: false, requestToSend: true });
       await s.port.setSignals({ dataTerminalReady: false, requestToSend: false });

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -96,10 +96,10 @@ registerMdiIcons({
 // DOM grow until the tab locks up. Trimmed to the newest on every flush.
 const MAX_LOG_LINES = 5000;
 
-// How long a Web Serial session may show nothing before the dialog offers
-// network logs instead. Long enough for a normal boot's first line; short
-// enough that a dead-end console (uart: on the console pins, #1430) doesn't
-// strand the user staring at the placeholder.
+// How long a freshly attached Web Serial reader may show nothing before the
+// dialog offers network logs instead. Long enough for a normal boot's first
+// line; short enough that a dead-end console (uart: on the console pins,
+// #1430) doesn't strand the user staring at the placeholder.
 const QUIET_SERIAL_TIMEOUT_MS = 5000;
 
 @customElement("esphome-logs-dialog")
@@ -161,10 +161,12 @@ export class ESPHomeLogsDialog extends LitElement {
   // failed -> `dead`); the "click Start to reconnect" recovery (#636).
   _reconnect: (() => Promise<void>) | null = null;
 
-  // Watchdog for a Web Serial session that shows nothing (uart: repurposed
+  // Watchdog for a Web Serial reader that shows nothing (uart: repurposed
   // the console pins, wrong baud). Armed/disarmed off the session state in
-  // willUpdate; fed displayed lines via _noteSerialActivity. When it goes
-  // quiet the toolbar area offers switching to network logs (#1430).
+  // willUpdate; the first displayed line (_noteSerialActivity) retires it
+  // until output is expected afresh (a new attach, Start, Reset Device).
+  // When it goes quiet the toolbar area offers switching to network logs
+  // (#1430).
   _quietSerial = new QuietTimerController(this, QUIET_SERIAL_TIMEOUT_MS);
 
   // The visible log, its cap, and the stream-position map inline decoding
@@ -229,14 +231,17 @@ export class ESPHomeLogsDialog extends LitElement {
     if (changedProperties.has("_session") || changedProperties.has("_open")) {
       // Every session transition flows through logs-dialog/session.ts and
       // replaces _session, so keying here covers open/attach/pause/teardown
-      // without touching each transition. Only a live reader arms: the
-      // reconnecting phase is the settle delay + reopen retries (several
-      // seconds on a re-enumerating native-USB chip), which isn't silence —
-      // and a failed reopen lands in dead, which offers the banner anyway.
-      // A deliberate Stop (pause, #526) disarms rather than counting as
-      // silence.
+      // without touching each transition. Only a live reader that has yet
+      // to show a line arms: the reconnecting phase is the settle delay +
+      // reopen retries (several seconds on a re-enumerating native-USB
+      // chip), which isn't silence — and a failed reopen lands in dead,
+      // which offers the banner anyway. A deliberate Stop (pause, #526)
+      // disarms rather than counting as silence. Once output has landed the
+      // console is proven and a quiet device (bursty logging at INFO) must
+      // not re-trip the banner; a fresh attach, Start after a Stop, and
+      // Reset Device each expect output anew and watch again.
       const s = this._session;
-      const watching = this._open && s.kind === "serial" && !s.paused;
+      const watching = this._open && s.kind === "serial" && !s.paused && !s.outputSeen;
       if (watching) this._quietSerial.ensureArmed();
       else this._quietSerial.disarm();
     }
@@ -501,10 +506,13 @@ export class ESPHomeLogsDialog extends LitElement {
     this._log.enqueue(line);
   }
 
-  // Called by `streamSerialToDialog` for every displayed serial line; feeds
-  // the quiet-serial watchdog so a healthy stream never trips the banner.
+  // Called by `streamSerialToDialog` for every displayed serial line; the
+  // first one marks the reader as producing output, which retires the
+  // quiet-serial watchdog for this session (willUpdate disarms it).
   _noteSerialActivity(): void {
-    this._quietSerial.activity();
+    const s = this._session;
+    if (s.kind !== "serial" || s.outputSeen) return;
+    this._session = { ...s, outputSeen: true };
   }
 
   // Every line the buffer takes on, batched or direct, passes through here.
@@ -533,11 +541,12 @@ export class ESPHomeLogsDialog extends LitElement {
   // Reset Device button (Web Serial only). Pulses RTS (wired to EN on the
   // standard auto-reset circuit) to reboot the device, like the old dashboard's
   // console; the reader stays attached so the boot log follows. Resumes display
-  // first so a Stopped log shows the boot output instead of dropping it.
+  // first so a Stopped log shows the boot output instead of dropping it, and
+  // expects the boot output afresh (the quiet-serial watchdog watches again).
   private _onResetDevice = async () => {
     const s = this._session;
     if (s.kind !== "serial") return;
-    this._session = { ...s, paused: false };
+    this._session = { ...s, paused: false, outputSeen: false };
     try {
       await s.port.setSignals({ dataTerminalReady: false, requestToSend: true });
       await s.port.setSignals({ dataTerminalReady: false, requestToSend: false });

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -165,8 +165,9 @@ export class ESPHomeLogsDialog extends LitElement {
 
   // Watchdog for a Web Serial reader that shows nothing (uart: repurposed
   // the console pins, wrong baud). Armed/disarmed off the session state in
-  // willUpdate. When it goes quiet the toolbar area offers switching to
-  // network logs (#1430).
+  // willUpdate; a fired banner counts as armed, so expectSerialOutput drops
+  // it before rebuilding the session. When it goes quiet the toolbar area
+  // offers switching to network logs (#1430).
   _quietSerial = new QuietTimerController(this, QUIET_SERIAL_TIMEOUT_MS);
 
   // The visible log, its cap, and the stream-position map inline decoding

--- a/src/components/logs-dialog/session.ts
+++ b/src/components/logs-dialog/session.ts
@@ -76,7 +76,7 @@ export function setSerialStream(
   // reader (defensive — `reconnecting` holds none).
   const paused = host._session.kind === "reconnecting" ? host._session.paused : false;
   if (host._session.kind === "serial") host._session.cancel();
-  host._session = { kind: "serial", port, cancel, paused };
+  host._session = { kind: "serial", port, cancel, paused, outputSeen: false };
 }
 
 /**
@@ -175,6 +175,9 @@ export function onStart(host: ESPHomeLogsDialog): void {
       startOtaStream(host);
       break;
     case "serial":
+      // Output is expected afresh: the quiet-serial watchdog watches again.
+      host._session = { ...s, paused: false, outputSeen: false };
+      break;
     case "reconnecting":
       host._session = { ...s, paused: false };
       break;

--- a/src/components/logs-dialog/session.ts
+++ b/src/components/logs-dialog/session.ts
@@ -175,8 +175,7 @@ export function onStart(host: ESPHomeLogsDialog): void {
       startOtaStream(host);
       break;
     case "serial":
-      // Output is expected afresh: the quiet-serial watchdog watches again.
-      host._session = { ...s, paused: false, outputSeen: false };
+      resumeSerial(host);
       break;
     case "reconnecting":
       host._session = { ...s, paused: false };
@@ -185,6 +184,21 @@ export function onStart(host: ESPHomeLogsDialog): void {
       reconnectSerial(host);
       break;
   }
+}
+
+/** Resume display on a Web Serial session and expect its output afresh
+ *  (Start after a Stop, Reset Device). */
+export function resumeSerial(host: ESPHomeLogsDialog): void {
+  const s = host._session;
+  if (s.kind !== "serial") return;
+  host._session = { ...s, paused: false, outputSeen: false };
+}
+
+/** Record that the Web Serial reader has shown a line; a no-op once seen. */
+export function markSerialOutput(host: ESPHomeLogsDialog): void {
+  const s = host._session;
+  if (s.kind !== "serial" || s.outputSeen) return;
+  host._session = { ...s, outputSeen: true };
 }
 
 // Stop button. OTA kills the subprocess (Start respawns it); a Web Serial

--- a/src/components/logs-dialog/session.ts
+++ b/src/components/logs-dialog/session.ts
@@ -191,6 +191,9 @@ export function onStart(host: ESPHomeLogsDialog): void {
 export function resumeSerial(host: ESPHomeLogsDialog): void {
   const s = host._session;
   if (s.kind !== "serial") return;
+  // A banner already up (the watchdog fired) counts as armed, so drop it
+  // first and let willUpdate open a fresh window off the rebuilt session.
+  host._quietSerial.disarm();
   host._session = { ...s, paused: false, outputSeen: false };
 }
 

--- a/src/components/logs-dialog/session.ts
+++ b/src/components/logs-dialog/session.ts
@@ -175,8 +175,6 @@ export function onStart(host: ESPHomeLogsDialog): void {
       startOtaStream(host);
       break;
     case "serial":
-      resumeSerial(host);
-      break;
     case "reconnecting":
       host._session = { ...s, paused: false };
       break;
@@ -186,15 +184,15 @@ export function onStart(host: ESPHomeLogsDialog): void {
   }
 }
 
-/** Resume display on a Web Serial session and expect its output afresh
- *  (Start after a Stop, Reset Device). */
-export function resumeSerial(host: ESPHomeLogsDialog): void {
+/** Expect a Web Serial session's output afresh (the device was just reset):
+ *  the quiet-serial watchdog opens a new window. */
+export function expectSerialOutput(host: ESPHomeLogsDialog): void {
   const s = host._session;
   if (s.kind !== "serial") return;
   // A banner already up (the watchdog fired) counts as armed, so drop it
   // first and let willUpdate open a fresh window off the rebuilt session.
   host._quietSerial.disarm();
-  host._session = { ...s, paused: false, outputSeen: false };
+  host._session = { ...s, outputSeen: false };
 }
 
 /** Record that the Web Serial reader has shown a line; a no-op once seen. */

--- a/src/components/logs-session.ts
+++ b/src/components/logs-session.ts
@@ -23,10 +23,10 @@
  *                    draining either way, so resuming needn't reopen the port
  *                    and pulse DTR/RTS — #526). ``outputSeen`` flips on the
  *                    first displayed line and retires the quiet-serial
- *                    watchdog; a fresh attach, Start after a Stop, and Reset
- *                    Device expect output afresh and clear it, so a quiet
- *                    device (bursty logging at INFO) never re-trips the
- *                    banner.
+ *                    watchdog; only a fresh attach and Reset Device expect
+ *                    output afresh and clear it, so a quiet device (bursty
+ *                    logging at INFO) never re-trips the banner, a Stop/Start
+ *                    included.
  * - ``dead``         a Web Serial reopen failed; the port is gone. Start runs
  *                    the reconnect hook (the #636 "click Start to reconnect").
  */

--- a/src/components/logs-session.ts
+++ b/src/components/logs-session.ts
@@ -21,7 +21,9 @@
  * - ``serial``       a Web Serial reader is attached and draining the open
  *                    port. ``paused`` gates the on-screen log (the reader keeps
  *                    draining either way, so resuming needn't reopen the port
- *                    and pulse DTR/RTS — #526).
+ *                    and pulse DTR/RTS — #526). ``outputSeen`` flips on the
+ *                    first displayed line; the quiet-serial watchdog watches
+ *                    only until then.
  * - ``dead``         a Web Serial reopen failed; the port is gone. Start runs
  *                    the reconnect hook (the #636 "click Start to reconnect").
  */
@@ -42,6 +44,7 @@ export type LogsSession =
       readonly port: SerialPort;
       readonly cancel: () => void;
       readonly paused: boolean;
+      readonly outputSeen: boolean;
     }
   | { readonly kind: "dead" };
 

--- a/src/components/logs-session.ts
+++ b/src/components/logs-session.ts
@@ -22,8 +22,11 @@
  *                    port. ``paused`` gates the on-screen log (the reader keeps
  *                    draining either way, so resuming needn't reopen the port
  *                    and pulse DTR/RTS — #526). ``outputSeen`` flips on the
- *                    first displayed line; the quiet-serial watchdog watches
- *                    only until then.
+ *                    first displayed line and retires the quiet-serial
+ *                    watchdog; a fresh attach, Start after a Stop, and Reset
+ *                    Device expect output afresh and clear it, so a quiet
+ *                    device (bursty logging at INFO) never re-trips the
+ *                    banner.
  * - ``dead``         a Web Serial reopen failed; the port is gone. Start runs
  *                    the reconnect hook (the #636 "click Start to reconnect").
  */

--- a/src/util/quiet-timer-controller.ts
+++ b/src/util/quiet-timer-controller.ts
@@ -1,21 +1,15 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 
 /**
- * Inactivity watchdog: flags ``quiet`` when no activity lands for
- * *timeoutMs* while armed.
+ * One-shot silence watchdog: flags ``quiet`` when *timeoutMs* elapses
+ * after arming.
  *
- * The host arms it around the stream it watches and reports each unit of
- * activity; the window restarts on every report, so a healthy stream never
- * goes quiet. When the window elapses ``quiet`` flips true with a host
- * update. Disarmed, activity is ignored and ``quiet`` is false.
- *
- * activity() is hot-path safe: it only stamps a timestamp. The single
- * pending timeout re-checks the stamp when it fires and re-arms for the
- * remainder, so a line flood costs no timer churn.
+ * The host arms it when the stream it watches starts and disarms it once
+ * the stream has proven itself (or ends). When the window elapses ``quiet``
+ * flips true with a host update. Disarmed, ``quiet`` is false.
  */
 export class QuietTimerController implements ReactiveController {
   private _handle: ReturnType<typeof setTimeout> | null = null;
-  private _lastActivity = 0;
   private _quiet = false;
 
   constructor(
@@ -42,40 +36,18 @@ export class QuietTimerController implements ReactiveController {
   /** Arm if not already armed; an armed window keeps its current deadline. */
   ensureArmed(): void {
     if (this._armed) return;
-    this._lastActivity = Date.now();
-    this._schedule(this._timeoutMs);
-  }
-
-  /** Restart the window and clear ``quiet``. No-op while disarmed. */
-  activity(): void {
-    if (!this._armed) return;
-    this._lastActivity = Date.now();
-    if (this._handle === null) this._schedule(this._timeoutMs);
-    this._setQuiet(false);
+    this._handle = setTimeout(() => {
+      this._handle = null;
+      this._setQuiet(true);
+    }, this._timeoutMs);
   }
 
   disarm(): void {
-    this._clear();
-    this._setQuiet(false);
-  }
-
-  private _schedule(delayMs: number): void {
-    this._handle = setTimeout(() => {
-      const remaining = this._lastActivity + this._timeoutMs - Date.now();
-      if (remaining > 0) {
-        this._schedule(remaining);
-        return;
-      }
-      this._handle = null;
-      this._setQuiet(true);
-    }, delayMs);
-  }
-
-  private _clear(): void {
     if (this._handle !== null) {
       clearTimeout(this._handle);
       this._handle = null;
     }
+    this._setQuiet(false);
   }
 
   private _setQuiet(quiet: boolean): void {

--- a/src/util/quiet-timer-controller.ts
+++ b/src/util/quiet-timer-controller.ts
@@ -27,15 +27,10 @@ export class QuietTimerController implements ReactiveController {
     return this._quiet;
   }
 
-  // Armed means a window is pending or has already gone quiet; disarmed is
-  // the only state with neither.
-  private get _armed(): boolean {
-    return this._handle !== null || this._quiet;
-  }
-
-  /** Arm if not already armed; an armed window keeps its current deadline. */
+  /** Arm if not already armed (a window pending or already quiet); an armed
+   *  window keeps its current deadline. */
   ensureArmed(): void {
-    if (this._armed) return;
+    if (this._handle !== null || this._quiet) return;
     this._handle = setTimeout(() => {
       this._handle = null;
       this._setQuiet(true);

--- a/test/components/logs-dialog-quiet-serial.test.ts
+++ b/test/components/logs-dialog-quiet-serial.test.ts
@@ -50,16 +50,6 @@ describe("logs-dialog quiet-serial banner", () => {
     expect(banner(el)!.textContent).toContain("dashboard.logs_no_serial_output");
   });
 
-  it("stays hidden while serial lines keep arriving", async () => {
-    await startSerial();
-    for (let i = 0; i < 5; i++) {
-      vi.advanceTimersByTime(3000);
-      call(el, "_noteSerialActivity");
-    }
-    await el.updateComplete;
-    expect(banner(el)).toBeNull();
-  });
-
   it("the first line retires the watchdog for the rest of the session", async () => {
     await startSerial();
     vi.advanceTimersByTime(5000);
@@ -75,59 +65,39 @@ describe("logs-dialog quiet-serial banner", () => {
     expect(banner(el)).toBeNull();
   });
 
-  it("Start after a Stop expects output afresh and watches again", async () => {
+  it.each([
+    [
+      "Start after a Stop",
+      async () => {
+        call(el, "_onStop");
+        await el.updateComplete;
+        call(el, "_onStart");
+      },
+    ],
+    ["Reset Device", () => call(el, "_onResetDevice")],
+    [
+      "a fresh attach after a reopen failure",
+      async () => {
+        el.setSerialOpenFailed("reopen failed");
+        await el.updateComplete;
+        call(el, "_onStart");
+        await el.updateComplete;
+        el.setSerialStream(port, cancel as unknown as () => void);
+      },
+    ],
+  ])("%s expects output afresh and watches again", async (_label, rearm) => {
     await startSerial();
     call(el, "_noteSerialActivity");
     await el.updateComplete;
-    call(el, "_onStop");
-    await el.updateComplete;
-    vi.advanceTimersByTime(60_000);
+    await rearm();
     await el.updateComplete;
     expect(banner(el)).toBeNull();
-    call(el, "_onStart");
-    await el.updateComplete;
-    vi.advanceTimersByTime(4999);
-    await el.updateComplete;
-    expect(banner(el)).toBeNull();
-    vi.advanceTimersByTime(1);
-    await el.updateComplete;
-    expect(banner(el)!.textContent).toContain("dashboard.logs_no_serial_output");
-    call(el, "_noteSerialActivity");
-    await el.updateComplete;
-    expect(banner(el)).toBeNull();
-  });
-
-  it("Reset Device expects the boot output afresh and watches again", async () => {
-    await startSerial();
-    call(el, "_noteSerialActivity");
-    await el.updateComplete;
-    vi.advanceTimersByTime(60_000);
-    await el.updateComplete;
-    expect(banner(el)).toBeNull();
-    call(el, "_onResetDevice");
-    await el.updateComplete;
     vi.advanceTimersByTime(5000);
     await el.updateComplete;
     expect(banner(el)!.textContent).toContain("dashboard.logs_no_serial_output");
     call(el, "_noteSerialActivity");
     await el.updateComplete;
     expect(banner(el)).toBeNull();
-  });
-
-  it("a fresh attach after a reopen failure watches again", async () => {
-    await startSerial();
-    call(el, "_noteSerialActivity");
-    await el.updateComplete;
-    el.setSerialOpenFailed("reopen failed");
-    await el.updateComplete;
-    call(el, "_onStart");
-    await el.updateComplete;
-    el.setSerialStream(port, cancel as unknown as () => void);
-    await el.updateComplete;
-    expect(banner(el)).toBeNull();
-    vi.advanceTimersByTime(5000);
-    await el.updateComplete;
-    expect(banner(el)!.textContent).toContain("dashboard.logs_no_serial_output");
   });
 
   it("a deliberate Stop (pause) never counts as silence", async () => {

--- a/test/components/logs-dialog-quiet-serial.test.ts
+++ b/test/components/logs-dialog-quiet-serial.test.ts
@@ -100,6 +100,22 @@ describe("logs-dialog quiet-serial banner", () => {
     expect(banner(el)).toBeNull();
   });
 
+  it("Reset Device with the banner up restarts the window", async () => {
+    await startSerial();
+    vi.advanceTimersByTime(5000);
+    await el.updateComplete;
+    expect(banner(el)).not.toBeNull();
+    call(el, "_onResetDevice");
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+    vi.advanceTimersByTime(4999);
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+    vi.advanceTimersByTime(1);
+    await el.updateComplete;
+    expect(banner(el)).not.toBeNull();
+  });
+
   it("a deliberate Stop (pause) never counts as silence", async () => {
     await startSerial();
     call(el, "_onStop");

--- a/test/components/logs-dialog-quiet-serial.test.ts
+++ b/test/components/logs-dialog-quiet-serial.test.ts
@@ -60,7 +60,7 @@ describe("logs-dialog quiet-serial banner", () => {
     expect(banner(el)).toBeNull();
   });
 
-  it("hides again when lines resume after going quiet", async () => {
+  it("the first line retires the watchdog for the rest of the session", async () => {
     await startSerial();
     vi.advanceTimersByTime(5000);
     await el.updateComplete;
@@ -68,6 +68,66 @@ describe("logs-dialog quiet-serial banner", () => {
     call(el, "_noteSerialActivity");
     await el.updateComplete;
     expect(banner(el)).toBeNull();
+    // A quiet device (bursty logging) must not re-trip it: the console is
+    // proven.
+    vi.advanceTimersByTime(60_000);
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+  });
+
+  it("Start after a Stop expects output afresh and watches again", async () => {
+    await startSerial();
+    call(el, "_noteSerialActivity");
+    await el.updateComplete;
+    call(el, "_onStop");
+    await el.updateComplete;
+    vi.advanceTimersByTime(60_000);
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+    call(el, "_onStart");
+    await el.updateComplete;
+    vi.advanceTimersByTime(4999);
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+    vi.advanceTimersByTime(1);
+    await el.updateComplete;
+    expect(banner(el)!.textContent).toContain("dashboard.logs_no_serial_output");
+    call(el, "_noteSerialActivity");
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+  });
+
+  it("Reset Device expects the boot output afresh and watches again", async () => {
+    await startSerial();
+    call(el, "_noteSerialActivity");
+    await el.updateComplete;
+    vi.advanceTimersByTime(60_000);
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+    call(el, "_onResetDevice");
+    await el.updateComplete;
+    vi.advanceTimersByTime(5000);
+    await el.updateComplete;
+    expect(banner(el)!.textContent).toContain("dashboard.logs_no_serial_output");
+    call(el, "_noteSerialActivity");
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+  });
+
+  it("a fresh attach after a reopen failure watches again", async () => {
+    await startSerial();
+    call(el, "_noteSerialActivity");
+    await el.updateComplete;
+    el.setSerialOpenFailed("reopen failed");
+    await el.updateComplete;
+    call(el, "_onStart");
+    await el.updateComplete;
+    el.setSerialStream(port, cancel as unknown as () => void);
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+    vi.advanceTimersByTime(5000);
+    await el.updateComplete;
+    expect(banner(el)!.textContent).toContain("dashboard.logs_no_serial_output");
   });
 
   it("a deliberate Stop (pause) never counts as silence", async () => {

--- a/test/components/logs-dialog-quiet-serial.test.ts
+++ b/test/components/logs-dialog-quiet-serial.test.ts
@@ -65,15 +65,20 @@ describe("logs-dialog quiet-serial banner", () => {
     expect(banner(el)).toBeNull();
   });
 
+  it("Start after a Stop keeps a proven console proven", async () => {
+    await startSerial();
+    call(el, "_noteSerialActivity");
+    await el.updateComplete;
+    call(el, "_onStop");
+    await el.updateComplete;
+    call(el, "_onStart");
+    await el.updateComplete;
+    vi.advanceTimersByTime(60_000);
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+  });
+
   it.each([
-    [
-      "Start after a Stop",
-      async () => {
-        call(el, "_onStop");
-        await el.updateComplete;
-        call(el, "_onStart");
-      },
-    ],
     ["Reset Device", () => call(el, "_onResetDevice")],
     [
       "a fresh attach after a reopen failure",
@@ -100,12 +105,29 @@ describe("logs-dialog quiet-serial banner", () => {
     expect(banner(el)).toBeNull();
   });
 
+  it("a line delivered before the reset pulse lands does not retire the watchdog", async () => {
+    await startSerial();
+    call(el, "_noteSerialActivity");
+    await el.updateComplete;
+    // The reader keeps draining during the two setSignals awaits; a stale
+    // pre-reset line must not count as the boot output.
+    vi.mocked(port.setSignals).mockImplementationOnce(() => {
+      call(el, "_noteSerialActivity");
+      return Promise.resolve();
+    });
+    await call(el, "_onResetDevice");
+    await el.updateComplete;
+    vi.advanceTimersByTime(5000);
+    await el.updateComplete;
+    expect(banner(el)!.textContent).toContain("dashboard.logs_no_serial_output");
+  });
+
   it("Reset Device with the banner up restarts the window", async () => {
     await startSerial();
     vi.advanceTimersByTime(5000);
     await el.updateComplete;
     expect(banner(el)).not.toBeNull();
-    call(el, "_onResetDevice");
+    await call(el, "_onResetDevice");
     await el.updateComplete;
     expect(banner(el)).toBeNull();
     vi.advanceTimersByTime(4999);

--- a/test/components/logs-session.test.ts
+++ b/test/components/logs-session.test.ts
@@ -11,6 +11,13 @@ import {
 
 const fakePort = {} as SerialPort;
 const noop = () => {};
+const serial = (paused = false): LogsSession => ({
+  kind: "serial",
+  port: fakePort,
+  cancel: noop,
+  paused,
+  outputSeen: false,
+});
 
 describe("logs-session selectors", () => {
   it("isStreaming: ota streams only with a live streamId", () => {
@@ -19,24 +26,8 @@ describe("logs-session selectors", () => {
   });
 
   it("isStreaming: serial/reconnecting stream unless paused", () => {
-    expect(
-      isStreaming({
-        kind: "serial",
-        port: fakePort,
-        cancel: noop,
-        paused: false,
-        outputSeen: false,
-      })
-    ).toBe(true);
-    expect(
-      isStreaming({
-        kind: "serial",
-        port: fakePort,
-        cancel: noop,
-        paused: true,
-        outputSeen: false,
-      })
-    ).toBe(false);
+    expect(isStreaming(serial())).toBe(true);
+    expect(isStreaming(serial(true))).toBe(false);
     expect(isStreaming({ kind: "reconnecting", paused: false })).toBe(true);
     expect(isStreaming({ kind: "reconnecting", paused: true })).toBe(false);
   });
@@ -48,7 +39,7 @@ describe("logs-session selectors", () => {
 
   it("isPassive: every Web Serial phase, never OTA/idle", () => {
     const passive: LogsSession[] = [
-      { kind: "serial", port: fakePort, cancel: noop, paused: false, outputSeen: false },
+      serial(),
       { kind: "reconnecting", paused: false },
       { kind: "dead" },
     ];
@@ -58,15 +49,7 @@ describe("logs-session selectors", () => {
   });
 
   it("hasSerialPort: only the serial state holds a live port", () => {
-    expect(
-      hasSerialPort({
-        kind: "serial",
-        port: fakePort,
-        cancel: noop,
-        paused: true,
-        outputSeen: false,
-      })
-    ).toBe(true);
+    expect(hasSerialPort(serial(true))).toBe(true);
     for (const s of [
       { kind: "reconnecting", paused: false },
       { kind: "dead" },
@@ -92,7 +75,7 @@ describe("logs-session selectors", () => {
       expect(isOtaNetwork({ kind: "ota", port, streamId: "s1" })).toBe(false);
     }
     for (const s of [
-      { kind: "serial", port: fakePort, cancel: noop, paused: false, outputSeen: false },
+      serial(),
       { kind: "reconnecting", paused: false },
       { kind: "dead" },
       { kind: "idle" },

--- a/test/components/logs-session.test.ts
+++ b/test/components/logs-session.test.ts
@@ -20,10 +20,22 @@ describe("logs-session selectors", () => {
 
   it("isStreaming: serial/reconnecting stream unless paused", () => {
     expect(
-      isStreaming({ kind: "serial", port: fakePort, cancel: noop, paused: false })
+      isStreaming({
+        kind: "serial",
+        port: fakePort,
+        cancel: noop,
+        paused: false,
+        outputSeen: false,
+      })
     ).toBe(true);
     expect(
-      isStreaming({ kind: "serial", port: fakePort, cancel: noop, paused: true })
+      isStreaming({
+        kind: "serial",
+        port: fakePort,
+        cancel: noop,
+        paused: true,
+        outputSeen: false,
+      })
     ).toBe(false);
     expect(isStreaming({ kind: "reconnecting", paused: false })).toBe(true);
     expect(isStreaming({ kind: "reconnecting", paused: true })).toBe(false);
@@ -36,7 +48,7 @@ describe("logs-session selectors", () => {
 
   it("isPassive: every Web Serial phase, never OTA/idle", () => {
     const passive: LogsSession[] = [
-      { kind: "serial", port: fakePort, cancel: noop, paused: false },
+      { kind: "serial", port: fakePort, cancel: noop, paused: false, outputSeen: false },
       { kind: "reconnecting", paused: false },
       { kind: "dead" },
     ];
@@ -47,7 +59,13 @@ describe("logs-session selectors", () => {
 
   it("hasSerialPort: only the serial state holds a live port", () => {
     expect(
-      hasSerialPort({ kind: "serial", port: fakePort, cancel: noop, paused: true })
+      hasSerialPort({
+        kind: "serial",
+        port: fakePort,
+        cancel: noop,
+        paused: true,
+        outputSeen: false,
+      })
     ).toBe(true);
     for (const s of [
       { kind: "reconnecting", paused: false },
@@ -74,7 +92,7 @@ describe("logs-session selectors", () => {
       expect(isOtaNetwork({ kind: "ota", port, streamId: "s1" })).toBe(false);
     }
     for (const s of [
-      { kind: "serial", port: fakePort, cancel: noop, paused: false },
+      { kind: "serial", port: fakePort, cancel: noop, paused: false, outputSeen: false },
       { kind: "reconnecting", paused: false },
       { kind: "dead" },
       { kind: "idle" },

--- a/test/util/quiet-timer-controller.test.ts
+++ b/test/util/quiet-timer-controller.test.ts
@@ -41,27 +41,6 @@ describe("QuietTimerController", () => {
     expect(host.requestUpdate).toHaveBeenCalled();
   });
 
-  it("activity restarts the window and clears quiet", () => {
-    timer.ensureArmed();
-    vi.advanceTimersByTime(5000);
-    expect(timer.quiet).toBe(true);
-    timer.activity();
-    expect(timer.quiet).toBe(false);
-    vi.advanceTimersByTime(4999);
-    expect(timer.quiet).toBe(false);
-    vi.advanceTimersByTime(1);
-    expect(timer.quiet).toBe(true);
-  });
-
-  it("a steady stream of activity never goes quiet", () => {
-    timer.ensureArmed();
-    for (let i = 0; i < 10; i++) {
-      vi.advanceTimersByTime(3000);
-      timer.activity();
-    }
-    expect(timer.quiet).toBe(false);
-  });
-
   it("ensureArmed while armed keeps the current deadline", () => {
     timer.ensureArmed();
     vi.advanceTimersByTime(4000);
@@ -84,12 +63,6 @@ describe("QuietTimerController", () => {
     timer.disarm();
     expect(timer.quiet).toBe(false);
     expect(host.requestUpdate).toHaveBeenCalledTimes(2);
-  });
-
-  it("activity while disarmed does not arm", () => {
-    timer.activity();
-    vi.advanceTimersByTime(10_000);
-    expect(timer.quiet).toBe(false);
   });
 
   it("hostDisconnected disarms", () => {

--- a/test/util/quiet-timer-controller.test.ts
+++ b/test/util/quiet-timer-controller.test.ts
@@ -65,6 +65,21 @@ describe("QuietTimerController", () => {
     expect(host.requestUpdate).toHaveBeenCalledTimes(2);
   });
 
+  it("disarm after quiet lets ensureArmed open a fresh full window", () => {
+    timer.ensureArmed();
+    vi.advanceTimersByTime(5000);
+    expect(timer.quiet).toBe(true);
+    // Quiet counts as armed, so a re-arm must disarm first.
+    timer.ensureArmed();
+    expect(timer.quiet).toBe(true);
+    timer.disarm();
+    timer.ensureArmed();
+    vi.advanceTimersByTime(4999);
+    expect(timer.quiet).toBe(false);
+    vi.advanceTimersByTime(1);
+    expect(timer.quiet).toBe(true);
+  });
+
   it("hostDisconnected disarms", () => {
     timer.ensureArmed();
     timer.hostDisconnected();


### PR DESCRIPTION
# What does this implement/fix?

The Web Serial logs dialog kept re-showing "No serial output from the device yet" while lines were on screen. The watchdog behind it was a sliding inactivity window, so a device that logs in bursts (boot, then nothing for a while at INFO) tripped the banner again five seconds after every burst, and it read as if the banner never dropped.

The watchdog now arms once when a reader attaches and the first displayed line drops the banner immediately and retires it for the rest of the session, a Stop/Start included since that is a display-only pause. Reset Device expects the boot output afresh, so it arms the watchdog again once the RTS pulse has landed; the next line clears it the same way. The controller loses its sliding window since nothing feeds it any more.

**Related issue or feature (if applicable):**

- related: https://github.com/esphome/device-builder-frontend/issues/1430 (the banner this tunes)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).


