### PR TITLE
Spell out the migration sentence keys so translators can grep them

### DIFF
--- a/src/components/device/config-migration-copy.ts
+++ b/src/components/device/config-migration-copy.ts
@@ -1,11 +1,21 @@
 /** Phrasing for the config-migration nudge: one sentence per ``MigrationChange``. */
 import { html, type TemplateResult } from "lit";
-import type { MigrationChange } from "../../api/types/editor.js";
+import type { MigrationChange, MigrationChangeKind } from "../../api/types/editor.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { releaseLine } from "../../util/version-mismatch.js";
 
 /** A run of a sentence: plain prose, or a config spelling to set in code. */
 export type MigrationCopySegment = string | { code: string };
+
+// Spelled out per kind (not built from the kind) so each key is greppable
+// from en.json; a kind the backend adds must be given a sentence here.
+const CHANGE_SENTENCE_KEYS: Record<MigrationChangeKind, string> = {
+  key: "device.config_migration_change_key",
+  field: "device.config_migration_change_field",
+  fold: "device.config_migration_change_fold",
+  convert: "device.config_migration_change_convert",
+  action: "device.config_migration_change_action",
+};
 
 // Markers wrapped around each config spelling before localisation, so the
 // translated sentence can be split back into prose and code runs.
@@ -19,7 +29,7 @@ export function migrationChangeSegments(
   change: MigrationChange
 ): MigrationCopySegment[] {
   const code = (value: string) => `${CODE_OPEN}${value}${CODE_CLOSE}`;
-  let sentence = localize(`device.config_migration_change_${change.kind}`, {
+  let sentence = localize(CHANGE_SENTENCE_KEYS[change.kind], {
     old: code(change.old),
     new: code(change.new),
     scope: code(change.scope),

--- a/test/components/device/config-migration-copy.test.ts
+++ b/test/components/device/config-migration-copy.test.ts
@@ -22,6 +22,14 @@ const base: MigrationChange = {
 };
 
 describe("migrationChangeSegments", () => {
+  it.each(["key", "field", "fold", "convert", "action"] as const)(
+    "%s uses its own sentence key",
+    (kind) => {
+      const [first] = migrationChangeSegments(localize, { ...base, kind });
+      expect(first).toBe(`device.config_migration_change_${kind}`);
+    }
+  );
+
   it("phrases by kind with the spellings as code runs", () => {
     expect(migrationChangeSegments(localize, base)).toEqual([
       "device.config_migration_change_field",


### PR DESCRIPTION
# What does this implement/fix?

Translators and a grep for orphaned keys both flagged `config_migration_change_key` / `_field` / `_fold` / `_convert` / `_action` as unused after #1662; they are used, but through a template literal built from `change.kind`, so the literal key never appears in the source. The lookup is now an explicit per kind map, so every key is greppable from `en.json` and a new backend kind has to be given a sentence here instead of silently falling through to the raw key.

For reference, the placeholders: `{old}` / `{new}` are YAML option names, `{scope}` is the block or `domain.platform` they live in; e.g. `voc` changed to `voc_index` in `sensor.sgp4x`, or `rgb_order` and its flags folded into `channel_colors` in `light.esp32_rmt_led_strip`.

**Related issue or feature (if applicable):**

- follow up to #1662 (Discord translator report)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
