### PR TITLE
Mask sensitive values in the YAML diff view

### DIFF
--- a/src/components/device/config-migration-preview-dialog.ts
+++ b/src/components/device/config-migration-preview-dialog.ts
@@ -1,4 +1,5 @@
 import { consume } from "@lit/context";
+import { mdiEye, mdiEyeOff } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -11,9 +12,16 @@ import { dialogChromeStyles } from "../../styles/dialog-chrome.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import { fireEvent } from "../../util/fire-event.js";
+import { registerMdiIcons } from "../../util/register-icons.js";
 
+import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "../base-dialog.js";
 import "../yaml-diff.js";
+
+registerMdiIcons({
+  eye: mdiEye,
+  "eye-off": mdiEyeOff,
+});
 
 /**
  * Before/after preview of the one-click config migration: the draft
@@ -35,6 +43,8 @@ export class ESPHomeConfigMigrationPreviewDialog extends LitElement {
   /** The draft with the migration applied. */
   @property({ attribute: false }) newValue = "";
 
+  @state() private _revealSensitive = false;
+
   private readonly _dialog = new DialogOpenController(this);
 
   static styles = [
@@ -45,6 +55,12 @@ export class ESPHomeConfigMigrationPreviewDialog extends LitElement {
     css`
       esphome-base-dialog {
         --width: min(900px, 95vw);
+      }
+
+      .diff-header {
+        display: flex;
+        justify-content: flex-end;
+        margin-bottom: var(--wa-space-2xs);
       }
 
       .diff {
@@ -58,6 +74,7 @@ export class ESPHomeConfigMigrationPreviewDialog extends LitElement {
   ];
 
   open() {
+    this._revealSensitive = false;
     this._dialog.open = true;
   }
 
@@ -77,12 +94,14 @@ export class ESPHomeConfigMigrationPreviewDialog extends LitElement {
       >
         ${
           this._dialog.open
-            ? html`<div class="diff">
-                <esphome-yaml-diff
-                  .oldValue=${this.oldValue}
-                  .newValue=${this.newValue}
-                ></esphome-yaml-diff>
-              </div>`
+            ? html`<div class="diff-header">${this._renderRevealToggle()}</div>
+                <div class="diff">
+                  <esphome-yaml-diff
+                    .oldValue=${this.oldValue}
+                    .newValue=${this.newValue}
+                    .revealSensitive=${this._revealSensitive}
+                  ></esphome-yaml-diff>
+                </div>`
             : nothing
         }
         <div class="actions">
@@ -95,6 +114,28 @@ export class ESPHomeConfigMigrationPreviewDialog extends LitElement {
         </div>
       </esphome-base-dialog>
     `;
+  }
+
+  private _renderRevealToggle() {
+    const label = this._localize(
+      this._revealSensitive
+        ? "device.yaml_mask_sensitive"
+        : "device.yaml_reveal_sensitive"
+    );
+    return html`<button
+      type="button"
+      class="ghost-icon-btn"
+      aria-pressed=${this._revealSensitive}
+      aria-label=${label}
+      title=${label}
+      @click=${this._toggleRevealSensitive}
+    >
+      <wa-icon library="mdi" name=${this._revealSensitive ? "eye-off" : "eye"}></wa-icon>
+    </button>`;
+  }
+
+  private _toggleRevealSensitive() {
+    this._revealSensitive = !this._revealSensitive;
   }
 
   private _confirm() {

--- a/src/components/device/config-migration-preview-dialog.ts
+++ b/src/components/device/config-migration-preview-dialog.ts
@@ -1,5 +1,4 @@
 import { consume } from "@lit/context";
-import { mdiEye, mdiEyeOff } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -12,16 +11,10 @@ import { dialogChromeStyles } from "../../styles/dialog-chrome.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import { fireEvent } from "../../util/fire-event.js";
-import { registerMdiIcons } from "../../util/register-icons.js";
+import { renderRevealSensitiveToggle } from "./reveal-sensitive-toggle.js";
 
-import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "../base-dialog.js";
 import "../yaml-diff.js";
-
-registerMdiIcons({
-  eye: mdiEye,
-  "eye-off": mdiEyeOff,
-});
 
 /**
  * Before/after preview of the one-click config migration: the draft
@@ -94,7 +87,13 @@ export class ESPHomeConfigMigrationPreviewDialog extends LitElement {
       >
         ${
           this._dialog.open
-            ? html`<div class="diff-header">${this._renderRevealToggle()}</div>
+            ? html`<div class="diff-header">
+                  ${renderRevealSensitiveToggle(
+                    this._localize,
+                    this._revealSensitive,
+                    this._toggleRevealSensitive
+                  )}
+                </div>
                 <div class="diff">
                   <esphome-yaml-diff
                     .oldValue=${this.oldValue}
@@ -116,27 +115,9 @@ export class ESPHomeConfigMigrationPreviewDialog extends LitElement {
     `;
   }
 
-  private _renderRevealToggle() {
-    const label = this._localize(
-      this._revealSensitive
-        ? "device.yaml_mask_sensitive"
-        : "device.yaml_reveal_sensitive"
-    );
-    return html`<button
-      type="button"
-      class="ghost-icon-btn"
-      aria-pressed=${this._revealSensitive}
-      aria-label=${label}
-      title=${label}
-      @click=${this._toggleRevealSensitive}
-    >
-      <wa-icon library="mdi" name=${this._revealSensitive ? "eye-off" : "eye"}></wa-icon>
-    </button>`;
-  }
-
-  private _toggleRevealSensitive() {
+  private _toggleRevealSensitive = () => {
     this._revealSensitive = !this._revealSensitive;
-  }
+  };
 
   private _confirm() {
     this.close();

--- a/src/components/device/config-migration-preview-dialog.ts
+++ b/src/components/device/config-migration-preview-dialog.ts
@@ -50,12 +50,6 @@ export class ESPHomeConfigMigrationPreviewDialog extends LitElement {
         --width: min(900px, 95vw);
       }
 
-      .diff-header {
-        display: flex;
-        justify-content: flex-end;
-        margin-bottom: var(--wa-space-2xs);
-      }
-
       .diff {
         display: flex;
         height: min(60vh, 600px);
@@ -87,23 +81,21 @@ export class ESPHomeConfigMigrationPreviewDialog extends LitElement {
       >
         ${
           this._dialog.open
-            ? html`<div class="diff-header">
-                  ${renderRevealSensitiveToggle(
-                    this._localize,
-                    this._revealSensitive,
-                    this._toggleRevealSensitive
-                  )}
-                </div>
-                <div class="diff">
-                  <esphome-yaml-diff
-                    .oldValue=${this.oldValue}
-                    .newValue=${this.newValue}
-                    .revealSensitive=${this._revealSensitive}
-                  ></esphome-yaml-diff>
-                </div>`
+            ? html`<div class="diff">
+                <esphome-yaml-diff
+                  .oldValue=${this.oldValue}
+                  .newValue=${this.newValue}
+                  .revealSensitive=${this._revealSensitive}
+                ></esphome-yaml-diff>
+              </div>`
             : nothing
         }
         <div class="actions">
+          ${renderRevealSensitiveToggle(
+            this._localize,
+            this._revealSensitive,
+            this._toggleRevealSensitive
+          )}
           <button class="btn btn--cancel" @click=${this.close}>
             ${this._localize("layout.cancel")}
           </button>

--- a/src/components/device/device-editor-toolbar.ts
+++ b/src/components/device/device-editor-toolbar.ts
@@ -2,6 +2,7 @@ import { html, nothing, type TemplateResult } from "lit";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { tourAnchor } from "../guided-tour/tour-anchor.js";
 import type { DeviceLayoutMode } from "./device-editor.js";
+import { renderRevealSensitiveToggle } from "./reveal-sensitive-toggle.js";
 
 export interface EditorToolbarProps {
   localize: LocalizeFunc;
@@ -28,26 +29,12 @@ export function renderEditorToolbar(p: EditorToolbarProps): TemplateResult {
   return html`<div class="header-actions">
     ${
       p.effectiveLayout !== "left"
-        ? (() => {
-            const sensitiveLabel = p.localize(
-              p.revealSensitive
-                ? "device.yaml_mask_sensitive"
-                : "device.yaml_reveal_sensitive"
-            );
-            return html`<button
-              type="button"
-              class="ghost-icon-btn diff-toggle"
-              aria-pressed=${p.revealSensitive}
-              aria-label=${sensitiveLabel}
-              @click=${p.onToggleRevealSensitive}
-              title=${sensitiveLabel}
-            >
-              <wa-icon
-                library="mdi"
-                name=${p.revealSensitive ? "eye-off" : "eye"}
-              ></wa-icon>
-            </button>`;
-          })()
+        ? renderRevealSensitiveToggle(
+            p.localize,
+            p.revealSensitive,
+            p.onToggleRevealSensitive,
+            "diff-toggle"
+          )
         : nothing
     }
     ${

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -4,8 +4,6 @@ import {
   mdiContentSave,
   mdiDockLeft,
   mdiDockRight,
-  mdiEye,
-  mdiEyeOff,
   mdiFileCompare,
   mdiUpload,
   mdiViewSplitVertical,
@@ -66,8 +64,6 @@ import "./editor-invalid-banner.js";
 registerMdiIcons({
   "chevron-down": mdiChevronDown,
   "content-save": mdiContentSave,
-  eye: mdiEye,
-  "eye-off": mdiEyeOff,
   "dock-left": mdiDockLeft,
   "dock-right": mdiDockRight,
   "view-split-vertical": mdiViewSplitVertical,

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -405,6 +405,7 @@ export class ESPHomeDeviceEditor extends LitElement {
                     ? html`<esphome-yaml-diff
                         .oldValue=${this.savedYaml}
                         .newValue=${this.yaml}
+                        .revealSensitive=${this._revealSensitive}
                       ></esphome-yaml-diff>`
                     : html`<esphome-yaml-editor
                         .value=${this.yaml}

--- a/src/components/device/reveal-sensitive-toggle.ts
+++ b/src/components/device/reveal-sensitive-toggle.ts
@@ -1,0 +1,36 @@
+import { mdiEye, mdiEyeOff } from "@mdi/js";
+import { html, type TemplateResult } from "lit";
+import type { LocalizeFunc } from "../../common/localize.js";
+import { registerMdiIcons } from "../../util/register-icons.js";
+
+import "@home-assistant/webawesome/dist/components/icon/icon.js";
+
+registerMdiIcons({
+  eye: mdiEye,
+  "eye-off": mdiEyeOff,
+});
+
+/**
+ * The eye toggle every masked-YAML surface shares (editor toolbar, diff
+ * previews). Hosts style it via `ghost-icon-btn` from `espHomeStyles`.
+ */
+export function renderRevealSensitiveToggle(
+  localize: LocalizeFunc,
+  revealed: boolean,
+  onToggle: () => void,
+  extraClass = ""
+): TemplateResult {
+  const label = localize(
+    revealed ? "device.yaml_mask_sensitive" : "device.yaml_reveal_sensitive"
+  );
+  return html`<button
+    type="button"
+    class="ghost-icon-btn ${extraClass}"
+    aria-pressed=${revealed}
+    aria-label=${label}
+    title=${label}
+    @click=${onToggle}
+  >
+    <wa-icon library="mdi" name=${revealed ? "eye-off" : "eye"}></wa-icon>
+  </button>`;
+}

--- a/src/components/yaml-diff.ts
+++ b/src/components/yaml-diff.ts
@@ -1,10 +1,35 @@
 import { consume } from "@lit/context";
-import { css, html, LitElement, nothing } from "lit";
+import { css, html, LitElement, nothing, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { darkModeContext, localizeContext } from "../context/index.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { type DiffLine, diffLines } from "../util/diff-lines.js";
+import {
+  findSensitiveValueRanges,
+  type SensitiveValueRange,
+} from "../util/yaml-sensitive-scan.js";
+
+/** Per-side sensitive-value ranges, keyed by 1-indexed line number. */
+interface SensitiveLineMasks {
+  old: Map<number, SensitiveValueRange[]>;
+  new: Map<number, SensitiveValueRange[]>;
+}
+
+function groupRangesByLine(
+  ranges: SensitiveValueRange[]
+): Map<number, SensitiveValueRange[]> {
+  const byLine = new Map<number, SensitiveValueRange[]>();
+  for (const range of ranges) {
+    const existing = byLine.get(range.line);
+    if (existing) {
+      existing.push(range);
+    } else {
+      byLine.set(range.line, [range]);
+    }
+  }
+  return byLine;
+}
 
 @customElement("esphome-yaml-diff")
 export class ESPHomeYamlDiff extends LitElement {
@@ -19,6 +44,8 @@ export class ESPHomeYamlDiff extends LitElement {
   @property() oldValue = "";
 
   @property() newValue = "";
+
+  @property({ type: Boolean }) revealSensitive = false;
 
   static styles = css`
     :host {
@@ -124,6 +151,12 @@ export class ESPHomeYamlDiff extends LitElement {
     tr.remove .marker {
       background: var(--diff-remove-marker-bg);
     }
+
+    .content .sensitive {
+      -webkit-text-security: disc;
+      text-security: disc;
+      letter-spacing: 0.5px;
+    }
   `;
 
   protected render() {
@@ -138,26 +171,57 @@ export class ESPHomeYamlDiff extends LitElement {
     }
 
     const lines = diffLines(this.oldValue, this.newValue);
+    const masks = this.revealSensitive ? undefined : this._computeMasks();
 
     return html`
       <table>
         <tbody>
-          ${lines.map((line) => this._renderLine(line))}
+          ${lines.map((line) => this._renderLine(line, masks))}
         </tbody>
       </table>
     `;
   }
 
-  private _renderLine(line: DiffLine) {
+  /**
+   * The diff runs on the raw text and masking happens per rendered row:
+   * masking the inputs first would collapse a changed credential into an
+   * unchanged context row. Whole-document scans keep the parent scope
+   * (``key:`` under ``encryption:``) a per-line scan would lose.
+   */
+  private _computeMasks(): SensitiveLineMasks {
+    return {
+      old: groupRangesByLine(findSensitiveValueRanges(this.oldValue)),
+      new: groupRangesByLine(findSensitiveValueRanges(this.newValue)),
+    };
+  }
+
+  private _renderLine(line: DiffLine, masks?: SensitiveLineMasks) {
     const marker = line.type === "add" ? "+" : line.type === "remove" ? "-" : " ";
     const lineNumber = line.type === "remove" ? line.oldLine : line.newLine;
+    const sideLines = line.type === "remove" ? masks?.old : masks?.new;
+    const ranges = lineNumber === undefined ? undefined : sideLines?.get(lineNumber);
     return html`
       <tr class=${line.type}>
         <td class="gutter">${lineNumber ?? html`&nbsp;`}</td>
         <td class="marker">${marker}</td>
-        <td class="content">${line.content || nothing}</td>
+        <td class="content">${this._renderContent(line.content, ranges)}</td>
       </tr>
     `;
+  }
+
+  private _renderContent(content: string, ranges?: SensitiveValueRange[]) {
+    if (!ranges?.length) return content || nothing;
+    const segments: (string | TemplateResult)[] = [];
+    let cursor = 0;
+    for (const { valueFrom, valueTo } of ranges) {
+      if (valueFrom > cursor) segments.push(content.slice(cursor, valueFrom));
+      segments.push(
+        html`<span class="sensitive">${content.slice(valueFrom, valueTo)}</span>`
+      );
+      cursor = valueTo;
+    }
+    if (cursor < content.length) segments.push(content.slice(cursor));
+    return segments;
   }
 }
 

--- a/src/components/yaml-diff.ts
+++ b/src/components/yaml-diff.ts
@@ -181,18 +181,29 @@ export class ESPHomeYamlDiff extends LitElement {
     return html`
       <table>
         <tbody>
-          ${lines.map((line) =>
-            this._renderLine(line, line.type === "remove" ? oldMasks : newMasks)
-          )}
+          ${lines.map((line) => this._renderLine(line, oldMasks, newMasks))}
         </tbody>
       </table>
     `;
   }
 
-  private _renderLine(line: DiffLine, lineMasks?: Map<number, SensitiveValueRange[]>) {
+  private _renderLine(
+    line: DiffLine,
+    oldMasks?: Map<number, SensitiveValueRange[]>,
+    newMasks?: Map<number, SensitiveValueRange[]>
+  ) {
     const marker = line.type === "add" ? "+" : line.type === "remove" ? "-" : " ";
     const lineNumber = line.type === "remove" ? line.oldLine : line.newLine;
-    const ranges = lineNumber === undefined ? undefined : lineMasks?.get(lineNumber);
+    // A context row's text is identical on both sides but its sensitivity
+    // may not be: deleting `encryption:` leaves the byte-identical `key:`
+    // line parented differently, so a row masks when either side's scan
+    // marks it. Remove/add rows exist on one side only, so the fallback
+    // chain degenerates to that side's ranges.
+    const oldRanges =
+      line.oldLine === undefined ? undefined : oldMasks?.get(line.oldLine);
+    const newRanges =
+      line.newLine === undefined ? undefined : newMasks?.get(line.newLine);
+    const ranges = newRanges ?? oldRanges;
     return html`
       <tr class=${line.type}>
         <td class="gutter">${lineNumber ?? html`&nbsp;`}</td>

--- a/src/components/yaml-diff.ts
+++ b/src/components/yaml-diff.ts
@@ -1,8 +1,10 @@
 import { consume } from "@lit/context";
 import { css, html, LitElement, nothing, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import memoizeOne from "memoize-one";
 import type { LocalizeFunc } from "../common/localize.js";
 import { darkModeContext, localizeContext } from "../context/index.js";
+import { sensitiveMaskDeclarationsCss } from "../styles/sensitive-mask.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { type DiffLine, diffLines } from "../util/diff-lines.js";
 import {
@@ -10,17 +12,9 @@ import {
   type SensitiveValueRange,
 } from "../util/yaml-sensitive-scan.js";
 
-/** Per-side sensitive-value ranges, keyed by 1-indexed line number. */
-interface SensitiveLineMasks {
-  old: Map<number, SensitiveValueRange[]>;
-  new: Map<number, SensitiveValueRange[]>;
-}
-
-function groupRangesByLine(
-  ranges: SensitiveValueRange[]
-): Map<number, SensitiveValueRange[]> {
+function sensitiveRangesByLine(yaml: string): Map<number, SensitiveValueRange[]> {
   const byLine = new Map<number, SensitiveValueRange[]>();
-  for (const range of ranges) {
+  for (const range of findSensitiveValueRanges(yaml)) {
     const existing = byLine.get(range.line);
     if (existing) {
       existing.push(range);
@@ -46,6 +40,15 @@ export class ESPHomeYamlDiff extends LitElement {
   @property() newValue = "";
 
   @property({ type: Boolean }) revealSensitive = false;
+
+  // Memoized on the documents: the reveal toggle re-renders this component
+  // without changing them, and the LCS diff is the expensive part. One
+  // memo per side (memoizeOne caches a single call).
+  private _diffLines = memoizeOne(diffLines);
+
+  private _oldMasks = memoizeOne(sensitiveRangesByLine);
+
+  private _newMasks = memoizeOne(sensitiveRangesByLine);
 
   static styles = css`
     :host {
@@ -153,9 +156,7 @@ export class ESPHomeYamlDiff extends LitElement {
     }
 
     .content .sensitive {
-      -webkit-text-security: disc;
-      text-security: disc;
-      letter-spacing: 0.5px;
+      ${sensitiveMaskDeclarationsCss}
     }
   `;
 
@@ -170,36 +171,28 @@ export class ESPHomeYamlDiff extends LitElement {
       return html`<div class="empty">${this._localize("device.diff_no_changes")}</div>`;
     }
 
-    const lines = diffLines(this.oldValue, this.newValue);
-    const masks = this.revealSensitive ? undefined : this._computeMasks();
+    // The diff runs on the raw text and masking wraps each rendered row:
+    // masking the inputs first would collapse a changed credential into an
+    // unchanged context row.
+    const lines = this._diffLines(this.oldValue, this.newValue);
+    const oldMasks = this.revealSensitive ? undefined : this._oldMasks(this.oldValue);
+    const newMasks = this.revealSensitive ? undefined : this._newMasks(this.newValue);
 
     return html`
       <table>
         <tbody>
-          ${lines.map((line) => this._renderLine(line, masks))}
+          ${lines.map((line) =>
+            this._renderLine(line, line.type === "remove" ? oldMasks : newMasks)
+          )}
         </tbody>
       </table>
     `;
   }
 
-  /**
-   * The diff runs on the raw text and masking happens per rendered row:
-   * masking the inputs first would collapse a changed credential into an
-   * unchanged context row. Whole-document scans keep the parent scope
-   * (``key:`` under ``encryption:``) a per-line scan would lose.
-   */
-  private _computeMasks(): SensitiveLineMasks {
-    return {
-      old: groupRangesByLine(findSensitiveValueRanges(this.oldValue)),
-      new: groupRangesByLine(findSensitiveValueRanges(this.newValue)),
-    };
-  }
-
-  private _renderLine(line: DiffLine, masks?: SensitiveLineMasks) {
+  private _renderLine(line: DiffLine, lineMasks?: Map<number, SensitiveValueRange[]>) {
     const marker = line.type === "add" ? "+" : line.type === "remove" ? "-" : " ";
     const lineNumber = line.type === "remove" ? line.oldLine : line.newLine;
-    const sideLines = line.type === "remove" ? masks?.old : masks?.new;
-    const ranges = lineNumber === undefined ? undefined : sideLines?.get(lineNumber);
+    const ranges = lineNumber === undefined ? undefined : lineMasks?.get(lineNumber);
     return html`
       <tr class=${line.type}>
         <td class="gutter">${lineNumber ?? html`&nbsp;`}</td>

--- a/src/styles/sensitive-mask.ts
+++ b/src/styles/sensitive-mask.ts
@@ -1,0 +1,26 @@
+import { unsafeCSS } from "lit";
+
+/**
+ * The bullet styling every masked-credential surface shares — the editor's
+ * CodeMirror decorations and the YAML diff's masked spans sit side by side
+ * in the same pane, so a drift in glyph density is user-visible.
+ *
+ * Standard property is `text-security` (CSS Working Draft); the `-webkit-`
+ * prefix is what actually ships in browsers today. Firefox accepts the
+ * prefixed form since 125; Chromium/Safari have shipped it for years. We
+ * set both so a future un-prefix doesn't regress. The letter-spacing nudge
+ * keeps the bullets from mashing together — purely cosmetic, mirrors how
+ * bullets render in a native `<input type="password">`.
+ */
+export const SENSITIVE_MASK_DECLARATIONS = {
+  "-webkit-text-security": "disc",
+  "text-security": "disc",
+  "letter-spacing": "0.5px",
+} as const;
+
+/** The same declarations as a rule body for Lit `css` templates. */
+export const sensitiveMaskDeclarationsCss = unsafeCSS(
+  Object.entries(SENSITIVE_MASK_DECLARATIONS)
+    .map(([property, value]) => `${property}: ${value};`)
+    .join("\n")
+);

--- a/src/util/yaml-sensitive-mask.ts
+++ b/src/util/yaml-sensitive-mask.ts
@@ -32,6 +32,7 @@ import {
   StateField,
 } from "@codemirror/state";
 import { Decoration, type DecorationSet, EditorView } from "@codemirror/view";
+import { SENSITIVE_MASK_DECLARATIONS } from "../styles/sensitive-mask.js";
 import { findSensitiveValueRanges } from "./yaml-sensitive-scan.js";
 
 export const setRevealSensitiveEffect = StateEffect.define<boolean>();
@@ -109,17 +110,5 @@ export function sensitiveValueMaskExtension(
 }
 
 const sensitiveMaskTheme = EditorView.theme({
-  ".cm-esphome-sensitive-value": {
-    // Standard property is `text-security` (CSS Working Draft); the
-    // `-webkit-` prefix is what actually ships in browsers today.
-    // Firefox accepts the prefixed form since 125; Chromium/Safari
-    // have shipped it for years. We set both so a future un-prefix
-    // doesn't regress.
-    "-webkit-text-security": "disc",
-    "text-security": "disc",
-    // Letter-spacing nudge so the bullets sit a bit looser and don't
-    // mash together — purely cosmetic, mirrors how bullets render in
-    // a native `<input type="password">`.
-    "letter-spacing": "0.5px",
-  },
+  ".cm-esphome-sensitive-value": { ...SENSITIVE_MASK_DECLARATIONS },
 });

--- a/test/components/device/config-migration-preview-dialog.test.ts
+++ b/test/components/device/config-migration-preview-dialog.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the migration preview dialog's reveal toggle: the diff opens
+ * masked, the eye button flips it, and reopening resets to masked.
+ */
+import { describe, expect, it } from "vitest";
+
+import "../../_mock-webawesome.js";
+
+import { ESPHomeConfigMigrationPreviewDialog } from "../../../src/components/device/config-migration-preview-dialog.js";
+import type { ESPHomeYamlDiff } from "../../../src/components/yaml-diff.js";
+
+const OLD_YAML = "wifi:\n  password: hunter2\n  use_addres: 1.2.3.4\n";
+const NEW_YAML = "wifi:\n  password: hunter2\n  use_address: 1.2.3.4\n";
+
+async function mountOpen() {
+  const el = new ESPHomeConfigMigrationPreviewDialog();
+  el.configuration = "kitchen.yaml";
+  el.oldValue = OLD_YAML;
+  el.newValue = NEW_YAML;
+  document.body.appendChild(el);
+  el.open();
+  await el.updateComplete;
+  return el;
+}
+
+function diffEl(el: ESPHomeConfigMigrationPreviewDialog): ESPHomeYamlDiff {
+  return el.shadowRoot!.querySelector<ESPHomeYamlDiff>("esphome-yaml-diff")!;
+}
+
+describe("config-migration preview dialog reveal toggle", () => {
+  it("opens masked and flips the diff on click", async () => {
+    const el = await mountOpen();
+    expect(diffEl(el).revealSensitive).toBe(false);
+
+    const btn = el.shadowRoot!.querySelector<HTMLButtonElement>(
+      '[aria-label="device.yaml_reveal_sensitive"]'
+    )!;
+    expect(btn.getAttribute("aria-pressed")).toBe("false");
+    btn.click();
+    await el.updateComplete;
+
+    expect(diffEl(el).revealSensitive).toBe(true);
+    const masked = el.shadowRoot!.querySelector<HTMLButtonElement>(
+      '[aria-label="device.yaml_mask_sensitive"]'
+    )!;
+    expect(masked.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("resets to masked on reopen", async () => {
+    const el = await mountOpen();
+    el.shadowRoot!.querySelector<HTMLButtonElement>(
+      '[aria-label="device.yaml_reveal_sensitive"]'
+    )!.click();
+    await el.updateComplete;
+    expect(diffEl(el).revealSensitive).toBe(true);
+
+    el.close();
+    await el.updateComplete;
+    el.open();
+    await el.updateComplete;
+    expect(diffEl(el).revealSensitive).toBe(false);
+  });
+});

--- a/test/components/device/config-migration-preview-dialog.test.ts
+++ b/test/components/device/config-migration-preview-dialog.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 
 import "../../_mock-webawesome.js";
 
+import { mount } from "../../_dom.js";
 import { ESPHomeConfigMigrationPreviewDialog } from "../../../src/components/device/config-migration-preview-dialog.js";
 import type { ESPHomeYamlDiff } from "../../../src/components/yaml-diff.js";
 
@@ -15,11 +16,11 @@ const OLD_YAML = "wifi:\n  password: hunter2\n  use_addres: 1.2.3.4\n";
 const NEW_YAML = "wifi:\n  password: hunter2\n  use_address: 1.2.3.4\n";
 
 async function mountOpen() {
-  const el = new ESPHomeConfigMigrationPreviewDialog();
-  el.configuration = "kitchen.yaml";
-  el.oldValue = OLD_YAML;
-  el.newValue = NEW_YAML;
-  document.body.appendChild(el);
+  const el = await mount(new ESPHomeConfigMigrationPreviewDialog(), {
+    configuration: "kitchen.yaml",
+    oldValue: OLD_YAML,
+    newValue: NEW_YAML,
+  });
   el.open();
   await el.updateComplete;
   return el;
@@ -29,30 +30,32 @@ function diffEl(el: ESPHomeConfigMigrationPreviewDialog): ESPHomeYamlDiff {
   return el.shadowRoot!.querySelector<ESPHomeYamlDiff>("esphome-yaml-diff")!;
 }
 
+function toggle(
+  el: ESPHomeConfigMigrationPreviewDialog,
+  key: "reveal" | "mask"
+): HTMLButtonElement {
+  return el.shadowRoot!.querySelector<HTMLButtonElement>(
+    `[aria-label="device.yaml_${key}_sensitive"]`
+  )!;
+}
+
 describe("config-migration preview dialog reveal toggle", () => {
   it("opens masked and flips the diff on click", async () => {
     const el = await mountOpen();
     expect(diffEl(el).revealSensitive).toBe(false);
 
-    const btn = el.shadowRoot!.querySelector<HTMLButtonElement>(
-      '[aria-label="device.yaml_reveal_sensitive"]'
-    )!;
+    const btn = toggle(el, "reveal");
     expect(btn.getAttribute("aria-pressed")).toBe("false");
     btn.click();
     await el.updateComplete;
 
     expect(diffEl(el).revealSensitive).toBe(true);
-    const masked = el.shadowRoot!.querySelector<HTMLButtonElement>(
-      '[aria-label="device.yaml_mask_sensitive"]'
-    )!;
-    expect(masked.getAttribute("aria-pressed")).toBe("true");
+    expect(toggle(el, "mask").getAttribute("aria-pressed")).toBe("true");
   });
 
   it("resets to masked on reopen", async () => {
     const el = await mountOpen();
-    el.shadowRoot!.querySelector<HTMLButtonElement>(
-      '[aria-label="device.yaml_reveal_sensitive"]'
-    )!.click();
+    toggle(el, "reveal").click();
     await el.updateComplete;
     expect(diffEl(el).revealSensitive).toBe(true);
 

--- a/test/components/device/device-editor-toolbar.test.ts
+++ b/test/components/device/device-editor-toolbar.test.ts
@@ -97,6 +97,20 @@ describe("device-editor header toolbar", () => {
     // Flips into diff view: the button now offers the way back to the editor.
     expect(q(on, '[aria-label="device.diff_view_editor"]')).not.toBeNull();
   });
+
+  it("drives the diff pane's reveal state from the toolbar eye", async () => {
+    const el = await mount({
+      layout: "both",
+      _showDiffButton: true,
+      _showDiff: true,
+    });
+    const diff = q(el, "esphome-yaml-diff") as unknown as { revealSensitive: boolean };
+    expect(diff.revealSensitive).toBe(false);
+
+    q(el, '[aria-label="device.yaml_reveal_sensitive"]')!.click();
+    await el.updateComplete;
+    expect(diff.revealSensitive).toBe(true);
+  });
 });
 
 describe("device-editor save button", () => {

--- a/test/components/yaml-diff.test.ts
+++ b/test/components/yaml-diff.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { mount } from "../_dom.js";
 import { ESPHomeYamlDiff } from "../../src/components/yaml-diff.js";
 
 const OLD_YAML = [
@@ -32,29 +33,22 @@ const NEW_YAML = [
   "    key: q1w2e3r4t5y6u7i8o9p0==",
 ].join("\n");
 
-async function mount(props: Partial<ESPHomeYamlDiff> = {}) {
-  const el = new ESPHomeYamlDiff();
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
-
-function rows(el: ESPHomeYamlDiff): HTMLTableRowElement[] {
-  return Array.from(el.shadowRoot!.querySelectorAll<HTMLTableRowElement>("tr"));
-}
-
 function rowsContaining(el: ESPHomeYamlDiff, text: string): HTMLTableRowElement[] {
-  return rows(el).filter((r) => r.textContent!.includes(text));
+  return Array.from(el.shadowRoot!.querySelectorAll<HTMLTableRowElement>("tr")).filter(
+    (r) => r.textContent!.includes(text)
+  );
 }
 
-function sensitiveSpans(scope: { querySelectorAll: Element["querySelectorAll"] }) {
+function sensitiveSpans(scope: ParentNode) {
   return Array.from(scope.querySelectorAll<HTMLSpanElement>(".content .sensitive"));
 }
 
 describe("yaml-diff credential masking", () => {
   it("masks a changed password on both the removed and added rows", async () => {
-    const el = await mount({ oldValue: OLD_YAML, newValue: NEW_YAML });
+    const el = await mount(new ESPHomeYamlDiff(), {
+      oldValue: OLD_YAML,
+      newValue: NEW_YAML,
+    });
     const passwordRows = rowsContaining(el, "password:");
     expect(passwordRows).toHaveLength(2);
     expect(passwordRows[0].className).toBe("remove");
@@ -67,20 +61,26 @@ describe("yaml-diff credential masking", () => {
   });
 
   it("masks a parent-scoped encryption key on context rows", async () => {
-    const el = await mount({ oldValue: OLD_YAML, newValue: NEW_YAML });
+    const el = await mount(new ESPHomeYamlDiff(), {
+      oldValue: OLD_YAML,
+      newValue: NEW_YAML,
+    });
     const keyRow = rowsContaining(el, "key:")[0];
     expect(keyRow.className).toBe("context");
     expect(sensitiveSpans(keyRow)[0].textContent).toBe("q1w2e3r4t5y6u7i8o9p0==");
   });
 
   it("leaves non-sensitive values unwrapped", async () => {
-    const el = await mount({ oldValue: OLD_YAML, newValue: NEW_YAML });
+    const el = await mount(new ESPHomeYamlDiff(), {
+      oldValue: OLD_YAML,
+      newValue: NEW_YAML,
+    });
     expect(sensitiveSpans(rowsContaining(el, "ssid:")[0])).toHaveLength(0);
     expect(sensitiveSpans(rowsContaining(el, "logger:")[0])).toHaveLength(0);
   });
 
   it("reveals everything when revealSensitive is set", async () => {
-    const el = await mount({
+    const el = await mount(new ESPHomeYamlDiff(), {
       oldValue: OLD_YAML,
       newValue: NEW_YAML,
       revealSensitive: true,
@@ -90,13 +90,5 @@ describe("yaml-diff credential masking", () => {
     el.revealSensitive = false;
     await el.updateComplete;
     expect(sensitiveSpans(el.shadowRoot!).length).toBeGreaterThan(0);
-  });
-
-  it("never masks !secret references", async () => {
-    const el = await mount({
-      oldValue: "wifi:\n  password: !secret wifi_password\n",
-      newValue: "logger:\nwifi:\n  password: !secret wifi_password\n",
-    });
-    expect(sensitiveSpans(el.shadowRoot!)).toHaveLength(0);
   });
 });

--- a/test/components/yaml-diff.test.ts
+++ b/test/components/yaml-diff.test.ts
@@ -70,6 +70,18 @@ describe("yaml-diff credential masking", () => {
     expect(sensitiveSpans(keyRow)[0].textContent).toBe("q1w2e3r4t5y6u7i8o9p0==");
   });
 
+  it("masks a context row that is sensitive only on the old side", async () => {
+    // Deleting `encryption:` leaves the byte-identical `key:` line parented
+    // by `api:`, where the new-side scan alone would let it through.
+    const el = await mount(new ESPHomeYamlDiff(), {
+      oldValue: "api:\n  encryption:\n    key: q1w2e3r4==\n",
+      newValue: "api:\n    key: q1w2e3r4==\n",
+    });
+    const keyRow = rowsContaining(el, "key:")[0];
+    expect(keyRow.className).toBe("context");
+    expect(sensitiveSpans(keyRow)[0].textContent).toBe("q1w2e3r4==");
+  });
+
   it("leaves non-sensitive values unwrapped", async () => {
     const el = await mount(new ESPHomeYamlDiff(), {
       oldValue: OLD_YAML,

--- a/test/components/yaml-diff.test.ts
+++ b/test/components/yaml-diff.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the diff renderer's credential masking (#2605): sensitive values
+ * are wrapped in masked spans by default, the diff still shows a changed
+ * credential as a remove/add pair, and `revealSensitive` lifts the mask.
+ */
+import { describe, expect, it } from "vitest";
+
+import { ESPHomeYamlDiff } from "../../src/components/yaml-diff.js";
+
+const OLD_YAML = [
+  "esphome:",
+  "  name: test3",
+  "wifi:",
+  "  ssid: mynetwork",
+  "  password: hunter2",
+  "api:",
+  "  encryption:",
+  "    key: q1w2e3r4t5y6u7i8o9p0==",
+].join("\n");
+
+const NEW_YAML = [
+  "esphome:",
+  "  name: test3",
+  "logger:",
+  "wifi:",
+  "  ssid: mynetwork",
+  "  password: hunter3",
+  "api:",
+  "  encryption:",
+  "    key: q1w2e3r4t5y6u7i8o9p0==",
+].join("\n");
+
+async function mount(props: Partial<ESPHomeYamlDiff> = {}) {
+  const el = new ESPHomeYamlDiff();
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function rows(el: ESPHomeYamlDiff): HTMLTableRowElement[] {
+  return Array.from(el.shadowRoot!.querySelectorAll<HTMLTableRowElement>("tr"));
+}
+
+function rowsContaining(el: ESPHomeYamlDiff, text: string): HTMLTableRowElement[] {
+  return rows(el).filter((r) => r.textContent!.includes(text));
+}
+
+function sensitiveSpans(scope: { querySelectorAll: Element["querySelectorAll"] }) {
+  return Array.from(scope.querySelectorAll<HTMLSpanElement>(".content .sensitive"));
+}
+
+describe("yaml-diff credential masking", () => {
+  it("masks a changed password on both the removed and added rows", async () => {
+    const el = await mount({ oldValue: OLD_YAML, newValue: NEW_YAML });
+    const passwordRows = rowsContaining(el, "password:");
+    expect(passwordRows).toHaveLength(2);
+    expect(passwordRows[0].className).toBe("remove");
+    expect(passwordRows[1].className).toBe("add");
+    expect(sensitiveSpans(passwordRows[0])[0].textContent).toBe("hunter2");
+    expect(sensitiveSpans(passwordRows[1])[0].textContent).toBe("hunter3");
+    // Only the value is inside the masked span; the key stays readable.
+    const content = passwordRows[0].querySelector(".content")!;
+    expect(content.textContent).toBe("  password: hunter2");
+  });
+
+  it("masks a parent-scoped encryption key on context rows", async () => {
+    const el = await mount({ oldValue: OLD_YAML, newValue: NEW_YAML });
+    const keyRow = rowsContaining(el, "key:")[0];
+    expect(keyRow.className).toBe("context");
+    expect(sensitiveSpans(keyRow)[0].textContent).toBe("q1w2e3r4t5y6u7i8o9p0==");
+  });
+
+  it("leaves non-sensitive values unwrapped", async () => {
+    const el = await mount({ oldValue: OLD_YAML, newValue: NEW_YAML });
+    expect(sensitiveSpans(rowsContaining(el, "ssid:")[0])).toHaveLength(0);
+    expect(sensitiveSpans(rowsContaining(el, "logger:")[0])).toHaveLength(0);
+  });
+
+  it("reveals everything when revealSensitive is set", async () => {
+    const el = await mount({
+      oldValue: OLD_YAML,
+      newValue: NEW_YAML,
+      revealSensitive: true,
+    });
+    expect(sensitiveSpans(el.shadowRoot!)).toHaveLength(0);
+
+    el.revealSensitive = false;
+    await el.updateComplete;
+    expect(sensitiveSpans(el.shadowRoot!).length).toBeGreaterThan(0);
+  });
+
+  it("never masks !secret references", async () => {
+    const el = await mount({
+      oldValue: "wifi:\n  password: !secret wifi_password\n",
+      newValue: "logger:\nwifi:\n  password: !secret wifi_password\n",
+    });
+    expect(sensitiveSpans(el.shadowRoot!)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The YAML diff view rendered credential values in plain text, so passwords and encryption keys the editor masks as bullets became visible the moment the diff toggle was flipped. The diff renderer now scans both sides with the same sensitive value detection the editor uses and renders the matched value spans through the same text-security bullet styling. The diff itself still runs on the raw text, so a changed password still shows up as a removed and added row, just with both values masked.

Both diff surfaces get a reveal toggle: the editor diff now honours the existing toolbar eye button, which was rendered but inert in diff mode; the config migration preview dialog gets its own eye button and reopens masked.

Verified against a live dashboard with an inline wifi password, AP password and api encryption key: the diff masks all three by default with computed text-security disc, and the eye toggle reveals them.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2605

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
