### PR TITLE
Show the device comment on the tile card

### DIFF
--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -131,6 +131,7 @@ export function renderCardGrid(
             data-configuration=${device.configuration}
             .name=${device.friendly_name || device.name}
             .configuration=${device.configuration}
+            .comment=${device.comment ?? ""}
             .state=${rt.state}
             .labelIds=${device.labels ?? []}
             ?has-pending-changes=${device.has_pending_changes === true}

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -80,6 +80,8 @@ export class ESPHomeDeviceCard extends LitElement {
 
   @property({ attribute: false }) name = "";
   @property() configuration = "";
+  // ``esphome.comment`` from the YAML — free-form user text.
+  @property({ attribute: false }) comment = "";
   @property() state: DeviceState = DeviceState.UNKNOWN;
   // Truthy name_add_mac_suffix in the YAML — OFFLINE/UNKNOWN verdicts
   // are meaningless for such a device, so the badge shows "No status".
@@ -242,6 +244,11 @@ export class ESPHomeDeviceCard extends LitElement {
               ${renderEncryptionIcon(this)}
             </div>
             <p class="device-config truncate">${this.configuration}</p>
+            ${
+              this.comment
+                ? html`<p class="device-comment truncate">${this.comment}</p>`
+                : nothing
+            }
           </div>
           ${renderStatusBadge(this)}
         </div>

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -246,7 +246,9 @@ export class ESPHomeDeviceCard extends LitElement {
             <p class="device-config truncate">${this.configuration}</p>
             ${
               this.comment
-                ? html`<p class="device-comment truncate">${this.comment}</p>`
+                ? html`<p class="device-comment truncate" title=${this.comment}>
+                    ${this.comment}
+                  </p>`
                 : nothing
             }
           </div>

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -205,6 +205,14 @@ export const deviceCardStyles = [
       color: var(--wa-color-text-quiet);
     }
 
+    /* Italic to match the archived-devices dialog's comment rows. */
+    .device-comment {
+      margin: 2px 0 0;
+      font-size: var(--wa-font-size-xs);
+      color: var(--wa-color-text-quiet);
+      font-style: italic;
+    }
+
     .device-status {
       display: inline-flex;
       align-items: center;

--- a/test/components/dashboard/render-content-comment-wiring.test.ts
+++ b/test/components/dashboard/render-content-comment-wiring.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the card grid's ``device.comment ?? ""`` pass-through: the wire
+ * type is ``string | null`` and the fixture defaults to null, so dropping
+ * the coalesce would bind "null" onto every uncommented tile.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("../../../src/util/navigation.js", () => ({ navigate: vi.fn() }));
+
+import { renderInto } from "../../_dom.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
+import { renderCardGrid } from "../../../src/components/dashboard/render-content.js";
+// Side-effect import so the grid's <esphome-device-card> actually upgrades.
+import "../../../src/components/device-card.js";
+import type { ESPHomeDeviceCard } from "../../../src/components/device-card.js";
+import { makeDashboardHost } from "./_host.js";
+
+async function renderCard(device: ConfiguredDevice): Promise<ESPHomeDeviceCard> {
+  const host = makeDashboardHost({
+    _devices: [device],
+    _activeJobs: new Map(),
+    _recentJobs: new Map(),
+    _recentlyAdopted: null,
+    _selectMode: false,
+    _selectedDevices: new Set<string>(),
+  });
+  const container = renderInto(renderCardGrid(host, [device]));
+  const card = container.querySelector<ESPHomeDeviceCard>("esphome-device-card");
+  expect(card).not.toBeNull();
+  await card!.updateComplete;
+  return card!;
+}
+
+describe("card grid comment wiring", () => {
+  it("binds the device comment onto the card", async () => {
+    const card = await renderCard(makeConfiguredDevice({ comment: "Garage" }));
+    expect(card.comment).toBe("Garage");
+    expect(card.shadowRoot!.querySelector(".device-comment")).not.toBeNull();
+  });
+
+  it("coalesces a null comment to an empty string and renders no node", async () => {
+    const card = await renderCard(makeConfiguredDevice({ comment: null }));
+    expect(card.comment).toBe("");
+    expect(card.shadowRoot!.querySelector(".device-comment")).toBeNull();
+  });
+});

--- a/test/components/device-card-comment.test.ts
+++ b/test/components/device-card-comment.test.ts
@@ -1,0 +1,27 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The tile shows the device's ``esphome.comment`` under the filename;
+ * a device without one renders no comment node.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/tooltip/tooltip.js", () => ({}));
+
+import { mountDeviceCard as mount } from "./_device-card.js";
+
+describe("device-card comment", () => {
+  it("renders the comment under the configuration filename", async () => {
+    const el = await mount({ comment: "Garage, behind the freezer" });
+    const node = el.shadowRoot!.querySelector(".device-comment")!;
+    expect(node.textContent).toContain("Garage, behind the freezer");
+    expect(node.previousElementSibling?.classList.contains("device-config")).toBe(true);
+  });
+
+  it("renders no comment node when the device has none", async () => {
+    const el = await mount({});
+    expect(el.shadowRoot!.querySelector(".device-comment")).toBeNull();
+  });
+});

--- a/test/components/device-card-comment.test.ts
+++ b/test/components/device-card-comment.test.ts
@@ -18,6 +18,8 @@ describe("device-card comment", () => {
     const node = el.shadowRoot!.querySelector(".device-comment")!;
     expect(node.textContent).toContain("Garage, behind the freezer");
     expect(node.previousElementSibling?.classList.contains("device-config")).toBe(true);
+    // The line is ellipsis-truncated; the native tooltip carries the full text.
+    expect(node.getAttribute("title")).toBe("Garage, behind the freezer");
   });
 
   it("renders no comment node when the device has none", async () => {


### PR DESCRIPTION
# What does this implement/fix?

The legacy dashboard showed a device's `esphome.comment` on its tile; the new tile view doesn't. This renders the comment on the card under the configuration filename — quiet color, italic (matching the archived-devices dialog's comment rows), truncated to one line, and only rendered when the device carries one. The drawer and the opt-in table column already surface the comment; the tile was the one surface missing it.

No backend change needed — `ConfiguredDevice.comment` is already on the wire.

Verified in the live dashboard against a dev backend (three configs, two with comments), in dark and light themes: commented devices show the line, uncommented devices render no node, and card heights in a grid row stay equalized either way.

**Related issue or feature (if applicable):**

- https://github.com/orgs/esphome/discussions/3719 (Bring back display of Comment on Tile view)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

Note on the test suite: the two new tests pass and the changed files are clean; the full local run shows 107 failures that reproduce identically on a clean `main` checkout under Node 25 (CI pins Node 24), so they're environmental, not from this change.
