### PR TITLE
Link TCP-buffer-full warnings to the network tcp_send_buffer docs on ESP32

### DIFF
--- a/src/components/ansi-log-render.ts
+++ b/src/components/ansi-log-render.ts
@@ -164,6 +164,10 @@ const CURATED_COPY: Record<
     title: "dashboard.logs_doc_ble_slots_title",
     body: "dashboard.logs_doc_ble_slots_body",
   },
+  tcp_buffer: {
+    title: "dashboard.logs_doc_tcp_buffer_title",
+    body: "dashboard.logs_doc_tcp_buffer_body",
+  },
 };
 
 export function docPopoverText(

--- a/src/components/ansi-log.ts
+++ b/src/components/ansi-log.ts
@@ -227,6 +227,11 @@ export class ESPHomeAnsiLog extends LitElement {
   @property({ type: Boolean, attribute: "auto-scroll" })
   autoScroll = true;
 
+  /** The device's ``target_platform``; gates platform-specific doc links.
+   *  Empty when the host has no configured device. */
+  @property({ attribute: "target-platform" })
+  targetPlatform = "";
+
   @state()
   private _isUserScrolled = false;
 
@@ -329,9 +334,14 @@ export class ESPHomeAnsiLog extends LitElement {
   ];
 
   protected willUpdate(changedProperties: Map<string, unknown>) {
-    // Resolutions are pure in (line, docs map); a docs-map change is the one
-    // input the line-keyed cache can't see, so drop it here.
-    if (changedProperties.has("_integrationDocs")) this._docLinkCache.clear();
+    // Resolutions are pure in (line, docs map, platform); the latter two are
+    // the inputs the line-keyed cache can't see, so drop it here.
+    if (
+      changedProperties.has("_integrationDocs") ||
+      changedProperties.has("targetPlatform")
+    ) {
+      this._docLinkCache.clear();
+    }
   }
 
   protected updated(changedProperties: Map<string, unknown>) {
@@ -427,7 +437,10 @@ export class ESPHomeAnsiLog extends LitElement {
     const cache = this._docLinkCache;
     const hit = cache.get(line);
     if (hit !== undefined) return hit ?? undefined;
-    const links = resolveLogDocLink(line, this._integrationDocs) ?? null;
+    const links =
+      resolveLogDocLink(line, this._integrationDocs, {
+        targetPlatform: this.targetPlatform,
+      }) ?? null;
     if (cache.size >= DOC_LINK_CACHE_MAX) {
       // Prune the oldest half (Map iterates in insertion order).
       let drop = cache.size - DOC_LINK_CACHE_MAX / 2;

--- a/src/components/ansi-log.ts
+++ b/src/components/ansi-log.ts
@@ -227,9 +227,8 @@ export class ESPHomeAnsiLog extends LitElement {
   @property({ type: Boolean, attribute: "auto-scroll" })
   autoScroll = true;
 
-  /** The device's ``target_platform``; gates platform-specific doc links.
-   *  Empty when the host has no configured device. */
-  @property({ attribute: "target-platform" })
+  /** The device's ``target_platform``; "" when the host has no configured device. */
+  @property({ attribute: false })
   targetPlatform = "";
 
   @state()
@@ -438,9 +437,7 @@ export class ESPHomeAnsiLog extends LitElement {
     const hit = cache.get(line);
     if (hit !== undefined) return hit ?? undefined;
     const links =
-      resolveLogDocLink(line, this._integrationDocs, {
-        targetPlatform: this.targetPlatform,
-      }) ?? null;
+      resolveLogDocLink(line, this._integrationDocs, this.targetPlatform) ?? null;
     if (cache.size >= DOC_LINK_CACHE_MAX) {
       // Prune the oldest half (Map iterates in insertion order).
       let drop = cache.size - DOC_LINK_CACHE_MAX / 2;

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -38,7 +38,7 @@ import {
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { linkButtonStyles } from "../styles/link-button.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { devicePlatform } from "../util/crash-report.js";
+import { resolveDevicePlatform } from "../util/crash-report.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { configurationStem, downloadAnsiText } from "../util/download-text.js";
 import { fireEvent } from "../util/fire-event.js";
@@ -295,6 +295,9 @@ export class ESPHomeCommandDialog extends LitElement {
     if (changedProperties.has("_darkMode")) {
       this.toggleAttribute("light", !this._darkMode);
     }
+    if (changedProperties.has("configuration") || changedProperties.has("_devices")) {
+      this._targetPlatform = resolveDevicePlatform(this._devices, this.configuration);
+    }
     // When a job ends, the success/error banner takes ~56px of flex space
     // below the log; the container shrinks, scrollTop is preserved, and
     // the bottom slides out of view — which trips ansi-log's _isUserScrolled
@@ -428,10 +431,9 @@ export class ESPHomeCommandDialog extends LitElement {
     return this._localize(`command.${this._commandType}_title`, { name: this.name });
   }
 
-  private get _targetPlatform(): string {
-    const device = this._devices.find((d) => d.configuration === this.configuration);
-    return device ? devicePlatform(device) : "";
-  }
+  // Derived in willUpdate, not per render: the dialog re-renders per frame
+  // while streaming and the device list can be long.
+  private _targetPlatform = "";
 
   // True when following a queued job. Context wins once it has the entry —
   // the backend may transition QUEUED → RUNNING before we see it locally;

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -38,6 +38,7 @@ import {
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { linkButtonStyles } from "../styles/link-button.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { devicePlatform } from "../util/crash-report.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { configurationStem, downloadAnsiText } from "../util/download-text.js";
 import { fireEvent } from "../util/fire-event.js";
@@ -427,6 +428,11 @@ export class ESPHomeCommandDialog extends LitElement {
     return this._localize(`command.${this._commandType}_title`, { name: this.name });
   }
 
+  private get _targetPlatform(): string {
+    const device = this._devices.find((d) => d.configuration === this.configuration);
+    return device ? devicePlatform(device) : "";
+  }
+
   // True when following a queued job. Context wins once it has the entry —
   // the backend may transition QUEUED → RUNNING before we see it locally;
   // _jobStatus only fills the gap before the first context update.
@@ -529,6 +535,7 @@ export class ESPHomeCommandDialog extends LitElement {
       >
         <esphome-process-terminal
           .lines=${this._log.lines}
+          .targetPlatform=${this._targetPlatform}
           ?light=${!this._darkMode}
           ?streaming=${this._state === "running" && !showRunTimer(this)}
           .state=${this._state}

--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -2,6 +2,7 @@ import { html, nothing, type TemplateResult } from "lit";
 import { type FirmwareBinary, JobSource } from "../../api/types/firmware-jobs.js";
 import { FLASHER_HOST } from "../../common/docs.js";
 import { activeLocale } from "../../common/localize.js";
+import { devicePlatform } from "../../util/crash-report.js";
 import { configurationStem, downloadAnsiText } from "../../util/download-text.js";
 import { formatElapsed } from "../../util/format-job-time.js";
 import { pairingDisplayNameForPin } from "../../util/pairing-display-name.js";
@@ -288,6 +289,7 @@ export function renderLogs(
         ? html`<div class="logs-container">
             <esphome-ansi-log
               .lines=${host._log.lines}
+              .targetPlatform=${host._device ? devicePlatform(host._device) : ""}
               ?light=${!host._darkMode}
             ></esphome-ansi-log>
           </div>`

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -14,6 +14,7 @@ import {
 import { html, LitElement } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
+import type { ConfiguredDevice } from "../api/types/devices.js";
 import { OTA_PORT } from "../api/types/streaming.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
@@ -21,6 +22,7 @@ import {
   apiConnectionLostContext,
   apiContext,
   darkModeContext,
+  devicesContext,
   localizeContext,
 } from "../context/index.js";
 import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
@@ -28,6 +30,7 @@ import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { textStyles } from "../styles/text.js";
 import { classifyLine, type CrashKind, latchCrashKind } from "../util/crash-detector.js";
+import { devicePlatform } from "../util/crash-report.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { configurationStem, downloadAnsiText } from "../util/download-text.js";
 import { LogBuffer } from "../util/log-buffer.js";
@@ -128,6 +131,11 @@ export class ESPHomeLogsDialog extends LitElement {
   @state()
   _connectionLost = false;
 
+  // Resolves the streamed device's platform for platform-gated doc links.
+  @consume({ context: devicesContext, subscribe: true })
+  @state()
+  _devices: ConfiguredDevice[] = [];
+
   @property()
   configuration = "";
 
@@ -206,6 +214,11 @@ export class ESPHomeLogsDialog extends LitElement {
   get _serialPaused(): boolean {
     const s = this._session;
     return (s.kind === "serial" || s.kind === "reconnecting") && s.paused;
+  }
+
+  private get _targetPlatform(): string {
+    const device = this._devices.find((d) => d.configuration === this.configuration);
+    return device ? devicePlatform(device) : "";
   }
 
   static styles = [
@@ -344,6 +357,7 @@ export class ESPHomeLogsDialog extends LitElement {
         <esphome-process-terminal
           .lines=${this._log.lines}
           placeholder=${this._localize("dashboard.logs_placeholder")}
+          .targetPlatform=${this._targetPlatform}
           ?light=${!this._darkMode}
           ?streaming=${streaming}
           .connectionLost=${wsDown}

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -30,7 +30,7 @@ import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { textStyles } from "../styles/text.js";
 import { classifyLine, type CrashKind, latchCrashKind } from "../util/crash-detector.js";
-import { devicePlatform } from "../util/crash-report.js";
+import { resolveDevicePlatform } from "../util/crash-report.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { configurationStem, downloadAnsiText } from "../util/download-text.js";
 import { LogBuffer } from "../util/log-buffer.js";
@@ -216,10 +216,9 @@ export class ESPHomeLogsDialog extends LitElement {
     return (s.kind === "serial" || s.kind === "reconnecting") && s.paused;
   }
 
-  private get _targetPlatform(): string {
-    const device = this._devices.find((d) => d.configuration === this.configuration);
-    return device ? devicePlatform(device) : "";
-  }
+  // Derived in willUpdate, not per render: the dialog re-renders per frame
+  // while streaming and the device list can be long.
+  private _targetPlatform = "";
 
   static styles = [
     espHomeStyles,
@@ -238,6 +237,9 @@ export class ESPHomeLogsDialog extends LitElement {
   protected willUpdate(changedProperties: Map<string, unknown>) {
     if (changedProperties.has("_darkMode")) {
       this.toggleAttribute("light", !this._darkMode);
+    }
+    if (changedProperties.has("configuration") || changedProperties.has("_devices")) {
+      this._targetPlatform = resolveDevicePlatform(this._devices, this.configuration);
     }
     if (changedProperties.has("_expanded")) {
       this.toggleAttribute("expanded", this._expanded);

--- a/src/components/process-terminal/process-terminal.ts
+++ b/src/components/process-terminal/process-terminal.ts
@@ -52,6 +52,9 @@ export class ESPHomeProcessTerminal extends LitElement {
 
   @property() placeholder = "";
 
+  /** Forwarded to the built-in ansi-log's platform-gated doc links. */
+  @property() targetPlatform = "";
+
   /** Mirror of ``!darkMode``; drives the ``--term-*`` light palette + ansi-log. */
   @property({ type: Boolean, reflect: true }) light = false;
 
@@ -124,6 +127,7 @@ export class ESPHomeProcessTerminal extends LitElement {
           <esphome-ansi-log
             .lines=${this.lines}
             placeholder=${this.placeholder}
+            .targetPlatform=${this.targetPlatform}
             ?light=${this.light}
           ></esphome-ansi-log>
           <slot name="overlay"></slot>

--- a/src/components/process-terminal/process-terminal.ts
+++ b/src/components/process-terminal/process-terminal.ts
@@ -52,8 +52,7 @@ export class ESPHomeProcessTerminal extends LitElement {
 
   @property() placeholder = "";
 
-  /** Forwarded to the built-in ansi-log's platform-gated doc links. */
-  @property() targetPlatform = "";
+  @property({ attribute: false }) targetPlatform = "";
 
   /** Mirror of ``!darkMode``; drives the ``--term-*`` light palette + ansi-log. */
   @property({ type: Boolean, reflect: true }) light = false;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -76,6 +76,8 @@
     "logs_doc_nvs_body": "The device could not open its NVS storage, so component states may not restore after reboot. The FAQ explains recovery options.",
     "logs_doc_ble_slots_title": "No free BLE connection slots",
     "logs_doc_ble_slots_body": "Every active connection slot is in use. The Bluetooth proxy documentation explains how active connections and slot limits work.",
+    "logs_doc_tcp_buffer_title": "Outgoing TCP buffer full",
+    "logs_doc_tcp_buffer_body": "The device's outgoing TCP send buffer filled up, so a message was dropped or delayed. Raising tcp_send_buffer under network: gives bursty senders like Bluetooth proxies more headroom.",
     "logs_doc_sram1_title": "Reclaim SRAM1 as IRAM",
     "logs_doc_sram1_body": "This device's bootloader can use SRAM1 as instruction RAM. Setting sram1_as_iram frees about 40KB.",
     "logs_source_web_serial": "Web Serial",

--- a/src/util/crash-report.ts
+++ b/src/util/crash-report.ts
@@ -1,3 +1,4 @@
+import type { ConfiguredDevice } from "../api/types/devices.js";
 import { RP2_ALIAS_KEY, RP2_CANONICAL_KEY } from "./component-presence.js";
 import { STALE_BUILD_LOG_LINE, STALE_BUILD_NOTE } from "./crash-decode.js";
 import {
@@ -15,6 +16,7 @@ import {
   TRIM_MARKER,
 } from "./crash-report-budget.js";
 import { clampTitle, suggestTitleFor, unwoundFramesOf } from "./crash-report-title.js";
+import { isEsp32Platform } from "./esptool-platform.js";
 import { normalizeLogLine, parseLogLine, tagged } from "./log-line.js";
 
 /**
@@ -80,9 +82,8 @@ const ISSUE_PLATFORMS: Record<string, string> = {
 
 export function issuePlatform(targetPlatform: string): string {
   if (!targetPlatform) return "";
-  const upper = targetPlatform.toUpperCase();
-  if (upper.startsWith("ESP32")) return "ESP32";
-  return ISSUE_PLATFORMS[upper] ?? "Other";
+  if (isEsp32Platform(targetPlatform)) return "ESP32";
+  return ISSUE_PLATFORMS[targetPlatform.toUpperCase()] ?? "Other";
 }
 
 export interface CrashReportMeta {
@@ -254,6 +255,15 @@ export function devicePlatform(device: {
   return (
     device.target_platform || platformFromIntegrations(device.loaded_integrations ?? [])
   );
+}
+
+/** ``devicePlatform`` of the device with this *configuration* id, or "" when unknown. */
+export function resolveDevicePlatform(
+  devices: readonly ConfiguredDevice[],
+  configuration: string
+): string {
+  const device = devices.find((d) => d.configuration === configuration);
+  return device ? devicePlatform(device) : "";
 }
 
 /** Component owning the top decoded frame, for the form's component field. */

--- a/src/util/esptool-platform.ts
+++ b/src/util/esptool-platform.ts
@@ -11,7 +11,14 @@
  * browser flasher that won't work.
  */
 export function isEsptoolPlatform(targetPlatform: string | null | undefined): boolean {
-  const p = (targetPlatform ?? "").toLowerCase();
   // esp82… covers esp8266 and esp8285.
-  return p.startsWith("esp32") || p.startsWith("esp82");
+  return (
+    isEsp32Platform(targetPlatform) ||
+    (targetPlatform ?? "").toLowerCase().startsWith("esp82")
+  );
+}
+
+/** ESP32 family, any variant (esp32s3, esp32c6, ...); false for empty / unknown. */
+export function isEsp32Platform(targetPlatform: string | null | undefined): boolean {
+  return (targetPlatform ?? "").toLowerCase().startsWith("esp32");
 }

--- a/src/util/log-doc-links.ts
+++ b/src/util/log-doc-links.ts
@@ -13,6 +13,7 @@
 import type { IntegrationDoc } from "../api/types/components.js";
 import { isSafeDocsUrl } from "../common/docs.js";
 import { stripAnsi } from "./ansi-escapes.js";
+import { isEsp32Platform } from "./esptool-platform.js";
 import { parseLogLine } from "./log-line.js";
 
 export interface ActionableLogDocLink {
@@ -72,38 +73,12 @@ interface ActionableEntry {
   pattern: RegExp;
   url: string;
   body: ActionableLogDocLink["body"];
-  /** Lower-case ``target_platform`` prefixes the fix applies to; unset
-   *  means every platform. A gated entry never fires for an unknown
-   *  platform. */
-  platforms?: readonly string[];
-}
-
-/** Per-device inputs the line text alone can't carry. */
-export interface LogDocLinkOptions {
-  /** The device's ``target_platform`` (``esp32``, ``ESP8266``, …); empty
-   *  or absent when the host has no configured device. */
-  targetPlatform?: string;
+  /** The fix only exists on ESP32; never fires for an unknown platform. */
+  esp32Only?: true;
 }
 
 const ESP32_ADVANCED_URL = "https://esphome.io/components/esp32/#advanced-configuration";
-const NETWORK_CONFIG_URL =
-  "https://esphome.io/components/network/#configuration-variables";
 const TROUBLESHOOTING_URL = "https://esphome.io/guides/troubleshooting/";
-
-// Every WARN-level send refusal the api / proxy components log when the
-// lwIP send buffer is full; the fix is network: tcp_send_buffer, which
-// only exists on ESP32. Verified against the esphome source: the shared
-// API_LOG_MSG_DROPPED helper ("<what> dropped, TCP buffer full") under
-// api / api.connection / voice_assistant / zwave_proxy, and the
-// bluetooth_proxy / bluetooth_connection reply deferrals and drops.
-const TCP_BUFFER_TAGS = [
-  "api",
-  "api.connection",
-  "voice_assistant",
-  "zwave_proxy",
-  "bluetooth_proxy",
-  "bluetooth_connection",
-] as const;
 
 // Verified live against esphome.io (200, anchor present, no redirect).
 // Keep this list small and URL-verified; most lines resolve through the
@@ -188,51 +163,22 @@ const ACTIONABLE: readonly ActionableEntry[] = [
     body: "ble_slots",
   },
   {
+    // Every send refusal these components warn about when the lwIP send
+    // buffer is full, literal "TCP buffer full" text or not.
     level: "W",
-    tags: TCP_BUFFER_TAGS,
-    pattern: /TCP buffer full/,
-    url: NETWORK_CONFIG_URL,
-    body: "tcp_buffer",
-    platforms: ["esp32"],
-  },
-  {
-    // Same refusal without the literal text: a GATT reply displaced by a
-    // newer one or abandoned after retries, and the read / notify /
-    // services-done sends that report the failure directly. Only newer
-    // firmware appends the handle to the notify line.
-    level: "W",
-    tags: ["bluetooth_connection"],
+    tags: [
+      "api",
+      "api.connection",
+      "voice_assistant",
+      "zwave_proxy",
+      "bluetooth_proxy",
+      "bluetooth_connection",
+    ],
     pattern:
-      /GATT reply for handle 0x[0-9A-F]{4} (?:dropped for handle|undeliverable)|Failed to send (?:read|notify data) response|Failed to send services done|Services done undeliverable/,
-    url: NETWORK_CONFIG_URL,
+      /TCP buffer full|Buffer full, ping queued|Could not request start|dropped, displaced by|GATT reply for handle 0x[0-9A-F]{4} (?:dropped for handle|undeliverable)|Failed to send (?:read|notify data) response|Failed to send services done|Services done undeliverable/,
+    url: "https://esphome.io/components/network/#configuration-variables",
     body: "tcp_buffer",
-    platforms: ["esp32"],
-  },
-  {
-    level: "W",
-    tags: ["bluetooth_proxy"],
-    pattern: /dropped, displaced by/,
-    url: NETWORK_CONFIG_URL,
-    body: "tcp_buffer",
-    platforms: ["esp32"],
-  },
-  {
-    // The keepalive ping refused by a full buffer (check_keepalive_).
-    level: "W",
-    tags: ["api.connection"],
-    pattern: /Buffer full, ping queued/,
-    url: NETWORK_CONFIG_URL,
-    body: "tcp_buffer",
-    platforms: ["esp32"],
-  },
-  {
-    // The pipeline-start request refused by a full buffer.
-    level: "W",
-    tags: ["voice_assistant"],
-    pattern: /Could not request start/,
-    url: NETWORK_CONFIG_URL,
-    body: "tcp_buffer",
-    platforms: ["esp32"],
+    esp32Only: true,
   },
 ] as const;
 
@@ -305,25 +251,22 @@ const PLATFORM_SUFFIX_RE = /_(esp32\w*|esp8266|lt)$/;
  * catalogued tag carries both. *integrationDocs* is the backend
  * ``components/get_integration_docs`` map (component name → docs URL,
  * display name, and trimmed description); a present entry guarantees
- * the page exists. *options.targetPlatform* gates the platform-specific
- * curated entries; a gated entry never fires when it is unknown.
+ * the page exists. *targetPlatform* is the device's ``target_platform``
+ * ("" when unknown); it gates the ESP32-only curated entries.
  */
 export function resolveLogDocLink(
   line: string,
   integrationDocs: Record<string, IntegrationDoc>,
-  options: LogDocLinkOptions = {}
+  targetPlatform = ""
 ): LogDocLinks | undefined {
   const clean = stripAnsi(line);
   const parsed = parseLogLine(clean);
-  const platform = options.targetPlatform?.trim().toLowerCase() ?? "";
 
   let actionable: ActionableLogDocLink | undefined;
   if (parsed) {
     for (const entry of ACTIONABLE_BY_TAG.get(parsed.tag) ?? []) {
       if (entry.level !== parsed.level) continue;
-      // Prefix match: ESP32 variants may report as esp32s3 etc.
-      if (entry.platforms && !entry.platforms.some((p) => platform.startsWith(p)))
-        continue;
+      if (entry.esp32Only && !isEsp32Platform(targetPlatform)) continue;
       if (entry.pattern.test(clean)) {
         actionable = { kind: "actionable", url: entry.url, body: entry.body };
         break;

--- a/src/util/log-doc-links.ts
+++ b/src/util/log-doc-links.ts
@@ -216,6 +216,24 @@ const ACTIONABLE: readonly ActionableEntry[] = [
     body: "tcp_buffer",
     platforms: ["esp32"],
   },
+  {
+    // The keepalive ping refused by a full buffer (check_keepalive_).
+    level: "W",
+    tags: ["api.connection"],
+    pattern: /Buffer full, ping queued/,
+    url: NETWORK_CONFIG_URL,
+    body: "tcp_buffer",
+    platforms: ["esp32"],
+  },
+  {
+    // The pipeline-start request refused by a full buffer.
+    level: "W",
+    tags: ["voice_assistant"],
+    pattern: /Could not request start/,
+    url: NETWORK_CONFIG_URL,
+    body: "tcp_buffer",
+    platforms: ["esp32"],
+  },
 ] as const;
 
 // Tag-keyed index so the per-line check is one Map miss for the vast

--- a/src/util/log-doc-links.ts
+++ b/src/util/log-doc-links.ts
@@ -31,6 +31,7 @@ export interface ActionableLogDocLink {
     | "ota_rollback"
     | "slow_component"
     | "sram1_as_iram"
+    | "tcp_buffer"
     | "wifi_ap_no_portal"
     | "wifi_reconnect";
 }
@@ -71,10 +72,38 @@ interface ActionableEntry {
   pattern: RegExp;
   url: string;
   body: ActionableLogDocLink["body"];
+  /** Lower-case ``target_platform`` prefixes the fix applies to; unset
+   *  means every platform. A gated entry never fires for an unknown
+   *  platform. */
+  platforms?: readonly string[];
+}
+
+/** Per-device inputs the line text alone can't carry. */
+export interface LogDocLinkOptions {
+  /** The device's ``target_platform`` (``esp32``, ``ESP8266``, …); empty
+   *  or absent when the host has no configured device. */
+  targetPlatform?: string;
 }
 
 const ESP32_ADVANCED_URL = "https://esphome.io/components/esp32/#advanced-configuration";
+const NETWORK_CONFIG_URL =
+  "https://esphome.io/components/network/#configuration-variables";
 const TROUBLESHOOTING_URL = "https://esphome.io/guides/troubleshooting/";
+
+// Every WARN-level send refusal the api / proxy components log when the
+// lwIP send buffer is full; the fix is network: tcp_send_buffer, which
+// only exists on ESP32. Verified against the esphome source: the shared
+// API_LOG_MSG_DROPPED helper ("<what> dropped, TCP buffer full") under
+// api / api.connection / voice_assistant / zwave_proxy, and the
+// bluetooth_proxy / bluetooth_connection reply deferrals and drops.
+const TCP_BUFFER_TAGS = [
+  "api",
+  "api.connection",
+  "voice_assistant",
+  "zwave_proxy",
+  "bluetooth_proxy",
+  "bluetooth_connection",
+] as const;
 
 // Verified live against esphome.io (200, anchor present, no redirect).
 // Keep this list small and URL-verified; most lines resolve through the
@@ -158,6 +187,35 @@ const ACTIONABLE: readonly ActionableEntry[] = [
     url: "https://esphome.io/components/bluetooth_proxy/#how-active-connections-work",
     body: "ble_slots",
   },
+  {
+    level: "W",
+    tags: TCP_BUFFER_TAGS,
+    pattern: /TCP buffer full/,
+    url: NETWORK_CONFIG_URL,
+    body: "tcp_buffer",
+    platforms: ["esp32"],
+  },
+  {
+    // Same refusal without the literal text: a GATT reply displaced by a
+    // newer one or abandoned after retries, and the read / notify /
+    // services-done sends that report the failure directly. Only newer
+    // firmware appends the handle to the notify line.
+    level: "W",
+    tags: ["bluetooth_connection"],
+    pattern:
+      /GATT reply for handle 0x[0-9A-F]{4} (?:dropped for handle|undeliverable)|Failed to send (?:read|notify data) response|Failed to send services done|Services done undeliverable/,
+    url: NETWORK_CONFIG_URL,
+    body: "tcp_buffer",
+    platforms: ["esp32"],
+  },
+  {
+    level: "W",
+    tags: ["bluetooth_proxy"],
+    pattern: /dropped, displaced by/,
+    url: NETWORK_CONFIG_URL,
+    body: "tcp_buffer",
+    platforms: ["esp32"],
+  },
 ] as const;
 
 // Tag-keyed index so the per-line check is one Map miss for the vast
@@ -229,19 +287,26 @@ const PLATFORM_SUFFIX_RE = /_(esp32\w*|esp8266|lt)$/;
  * catalogued tag carries both. *integrationDocs* is the backend
  * ``components/get_integration_docs`` map (component name → docs URL,
  * display name, and trimmed description); a present entry guarantees
- * the page exists.
+ * the page exists. *options.targetPlatform* gates the platform-specific
+ * curated entries; a gated entry never fires when it is unknown.
  */
 export function resolveLogDocLink(
   line: string,
-  integrationDocs: Record<string, IntegrationDoc>
+  integrationDocs: Record<string, IntegrationDoc>,
+  options: LogDocLinkOptions = {}
 ): LogDocLinks | undefined {
   const clean = stripAnsi(line);
   const parsed = parseLogLine(clean);
+  const platform = options.targetPlatform?.trim().toLowerCase() ?? "";
 
   let actionable: ActionableLogDocLink | undefined;
   if (parsed) {
     for (const entry of ACTIONABLE_BY_TAG.get(parsed.tag) ?? []) {
-      if (entry.level === parsed.level && entry.pattern.test(clean)) {
+      if (entry.level !== parsed.level) continue;
+      // Prefix match: ESP32 variants may report as esp32s3 etc.
+      if (entry.platforms && !entry.platforms.some((p) => platform.startsWith(p)))
+        continue;
+      if (entry.pattern.test(clean)) {
         actionable = { kind: "actionable", url: entry.url, body: entry.body };
         break;
       }

--- a/src/util/log-doc-links.ts
+++ b/src/util/log-doc-links.ts
@@ -13,7 +13,6 @@
 import type { IntegrationDoc } from "../api/types/components.js";
 import { isSafeDocsUrl } from "../common/docs.js";
 import { stripAnsi } from "./ansi-escapes.js";
-import { isEsp32Platform } from "./esptool-platform.js";
 import { parseLogLine } from "./log-line.js";
 
 export interface ActionableLogDocLink {
@@ -73,8 +72,10 @@ interface ActionableEntry {
   pattern: RegExp;
   url: string;
   body: ActionableLogDocLink["body"];
-  /** The fix only exists on ESP32; never fires for an unknown platform. */
-  esp32Only?: true;
+  /** Target platforms the fix exists on, as lowercase prefixes of the
+   *  device's ``target_platform`` (``"esp32"`` covers every variant).
+   *  Unset = all platforms. A gated entry never fires for an unknown one. */
+  platforms?: readonly string[];
 }
 
 const ESP32_ADVANCED_URL = "https://esphome.io/components/esp32/#advanced-configuration";
@@ -178,9 +179,16 @@ const ACTIONABLE: readonly ActionableEntry[] = [
       /TCP buffer full|Buffer full, ping queued|Could not request start|dropped, displaced by|GATT reply for handle 0x[0-9A-F]{4} (?:dropped for handle|undeliverable)|Failed to send (?:read|notify data) response|Failed to send services done|Services done undeliverable/,
     url: "https://esphome.io/components/network/#configuration-variables",
     body: "tcp_buffer",
-    esp32Only: true,
+    // tcp_send_buffer is cv.only_on_esp32 in esphome/components/network.
+    platforms: ["esp32"],
   },
 ] as const;
+
+/** Whether ``targetPlatform`` (any casing, "" = unknown) is one of ``platforms``. */
+function onPlatform(platforms: readonly string[], targetPlatform: string): boolean {
+  const target = targetPlatform.toLowerCase();
+  return target !== "" && platforms.some((p) => target.startsWith(p));
+}
 
 // Tag-keyed index so the per-line check is one Map miss for the vast
 // majority of tags, with zero regex work. URLs are static, so the safety
@@ -252,7 +260,7 @@ const PLATFORM_SUFFIX_RE = /_(esp32\w*|esp8266|lt)$/;
  * ``components/get_integration_docs`` map (component name → docs URL,
  * display name, and trimmed description); a present entry guarantees
  * the page exists. *targetPlatform* is the device's ``target_platform``
- * ("" when unknown); it gates the ESP32-only curated entries.
+ * ("" when unknown); it gates the platform-specific curated entries.
  */
 export function resolveLogDocLink(
   line: string,
@@ -266,7 +274,7 @@ export function resolveLogDocLink(
   if (parsed) {
     for (const entry of ACTIONABLE_BY_TAG.get(parsed.tag) ?? []) {
       if (entry.level !== parsed.level) continue;
-      if (entry.esp32Only && !isEsp32Platform(targetPlatform)) continue;
+      if (entry.platforms && !onPlatform(entry.platforms, targetPlatform)) continue;
       if (entry.pattern.test(clean)) {
         actionable = { kind: "actionable", url: entry.url, body: entry.body };
         break;

--- a/test/components/ansi-log-doc-links.test.ts
+++ b/test/components/ansi-log-doc-links.test.ts
@@ -19,6 +19,7 @@ const BOOTLOADER =
   "[13:22:07][W][app:193]: Bootloader too old for OTA rollback. Flash via USB once to update the bootloader";
 const ETHERNET = "[13:22:07][C][ethernet:495]: Ethernet:";
 const PLAIN = "[13:22:07][I][main:042]: Some unremarkable status line";
+const TCP_FULL = "[13:22:07][W][api:127]: Disconnect request dropped, TCP buffer full";
 
 async function mountLog(lines: string[]): Promise<ESPHomeAnsiLog> {
   const el = new ESPHomeAnsiLog();
@@ -121,6 +122,16 @@ describe("ansi-log doc-link annotations", () => {
     internals(bare)._integrationDocs = DOCS;
     await bare.updateComplete;
     expect(root(bare).querySelector(".log-tag-link")).not.toBeNull();
+  });
+
+  it("re-resolves cached lines when the target platform arrives late", async () => {
+    // The dialogs render once with "" before the devices context resolves;
+    // a platform-gated entry must appear once the platform is known.
+    const el = await mountLog([TCP_FULL]);
+    expect(root(el).querySelector(".log-line--doc")).toBeNull();
+    el.targetPlatform = "ESP32";
+    await el.updateComplete;
+    expect(root(el).querySelector(".log-line--doc")).not.toBeNull();
   });
 });
 

--- a/test/util/crash-report.test.ts
+++ b/test/util/crash-report.test.ts
@@ -5,6 +5,7 @@ import {
   CRASH_BLOCK_STACK_SCAN,
   MASKED_CONFIG_YAML,
 } from "../_crash-lines.js";
+import { makeConfiguredDevice } from "../_make-configured-device.js";
 import {
   buildFullReport,
   buildIssueUrl,
@@ -12,6 +13,7 @@ import {
   inferComponentName,
   issuePlatform,
   platformFromIntegrations,
+  resolveDevicePlatform,
   scrapeCrashData,
 } from "../../src/util/crash-report.js";
 
@@ -161,6 +163,21 @@ describe("issuePlatform / inferComponentName", () => {
     expect(platformFromIntegrations(["logger", "rp2"])).toBe("rp2");
     expect(platformFromIntegrations(["logger", "rp2040"])).toBe("rp2040");
     expect(platformFromIntegrations(["logger"])).toBe("");
+  });
+
+  it("resolves a device's platform by configuration, '' when unknown", () => {
+    const devices = [
+      makeConfiguredDevice({ configuration: "a.yaml", target_platform: "ESP32S3" }),
+      makeConfiguredDevice({
+        configuration: "b.yaml",
+        target_platform: "",
+        loaded_integrations: ["logger", "rp2"],
+      }),
+    ];
+    expect(resolveDevicePlatform(devices, "a.yaml")).toBe("ESP32S3");
+    expect(resolveDevicePlatform(devices, "b.yaml")).toBe("rp2");
+    expect(resolveDevicePlatform(devices, "missing.yaml")).toBe("");
+    expect(resolveDevicePlatform([], "a.yaml")).toBe("");
   });
 
   it("names the first component-owned decoded frame", () => {

--- a/test/util/log-doc-links.test.ts
+++ b/test/util/log-doc-links.test.ts
@@ -288,7 +288,7 @@ describe("resolveLogDocLink — tcp_buffer", () => {
     ["an empty platform", ""],
     ["ESP8266", "ESP8266"],
     ["rp2", "rp2"],
-  ])("does not fire with %s (the option is ESP32-only)", (_what, platform) => {
+  ])("does not fire with %s (the entry is gated to esp32)", (_what, platform) => {
     expect(resolveLogDocLink(NOTIFY_DROP, {}, platform)?.actionable).toBeUndefined();
   });
 

--- a/test/util/log-doc-links.test.ts
+++ b/test/util/log-doc-links.test.ts
@@ -202,6 +202,115 @@ describe("resolveLogDocLink — actionable", () => {
   });
 });
 
+describe("resolveLogDocLink — tcp_buffer", () => {
+  const ESP32 = { targetPlatform: "ESP32" };
+  const NETWORK_URL = "https://esphome.io/components/network/#configuration-variables";
+  const NOTIFY_DROP =
+    "[10:24:27.031][W][bluetooth_connection:376]: [0] [AA:BB:CC:DD:EE:FF] Failed to send notify data response, handle 0x002A";
+
+  it.each([
+    [
+      "api.connection",
+      "[10:24:27.031][W][api.connection:2066]: Action response dropped, TCP buffer full",
+    ],
+    ["api", "[10:24:27.031][W][api:127]: Disconnect request dropped, TCP buffer full"],
+    [
+      "voice_assistant",
+      "[10:24:27.031][W][voice_assistant:753]: Stop request dropped, TCP buffer full",
+    ],
+    [
+      "zwave_proxy",
+      "[10:24:27.031][W][zwave_proxy:334]: Home ID notification dropped, TCP buffer full",
+    ],
+    [
+      "bluetooth_proxy",
+      "[10:24:27.031][W][bluetooth_proxy:132]: GATT read reply for AABBCCDDEEFF deferred, TCP buffer full",
+    ],
+    [
+      "bluetooth_connection",
+      "[10:24:27.031][W][bluetooth_connection:283]: [0] [AA:BB:CC:DD:EE:FF] GATT reply for handle 0x002A deferred, TCP buffer full",
+    ],
+  ])(
+    "maps a %s 'TCP buffer full' warning to the network config docs on ESP32",
+    (_tag, line) => {
+      expect(resolveLogDocLink(line, {}, ESP32)?.actionable).toEqual({
+        kind: "actionable",
+        url: NETWORK_URL,
+        body: "tcp_buffer",
+      });
+    }
+  );
+
+  it.each([
+    ["notify drop with handle", NOTIFY_DROP],
+    [
+      "notify drop without handle (older firmware)",
+      "[10:24:27.031][W][bluetooth_connection:376]: [0] [AA:BB:CC:DD:EE:FF] Failed to send notify data response",
+    ],
+    [
+      "read response",
+      "[10:24:27.031][W][bluetooth_connection:333]: [0] [AA:BB:CC:DD:EE:FF] Failed to send read response",
+    ],
+    [
+      "displaced GATT reply",
+      "[10:24:27.031][W][bluetooth_connection:288]: [0] [AA:BB:CC:DD:EE:FF] GATT reply for handle 0x002A dropped for handle 0x002C",
+    ],
+    [
+      "abandoned GATT reply",
+      "[10:24:27.031][W][bluetooth_connection:308]: [0] [AA:BB:CC:DD:EE:FF] GATT reply for handle 0x002A undeliverable, abandoning",
+    ],
+    [
+      "services done retry",
+      "[10:24:27.031][W][bluetooth_connection:459]: [0] [AA:BB:CC:DD:EE:FF] Failed to send services done, retrying",
+    ],
+    [
+      "services done abandon",
+      "[10:24:27.031][W][bluetooth_connection:470]: [0] [AA:BB:CC:DD:EE:FF] Services done undeliverable, abandoning",
+    ],
+    [
+      "displaced proxy reply",
+      "[10:24:27.031][W][bluetooth_proxy:136]: GATT error reply for AABBCCDDEEFF dropped, displaced by AABBCCDDEE00",
+    ],
+  ])("maps the same-cause %s warning on ESP32", (_what, line) => {
+    expect(resolveLogDocLink(line, {}, ESP32)?.actionable?.body).toBe("tcp_buffer");
+  });
+
+  it.each([
+    ["no platform", {}],
+    ["an empty platform", { targetPlatform: "" }],
+    ["ESP8266", { targetPlatform: "ESP8266" }],
+    ["rp2", { targetPlatform: "rp2" }],
+  ])("does not fire with %s (the option is ESP32-only)", (_what, options) => {
+    expect(resolveLogDocLink(NOTIFY_DROP, {}, options)?.actionable).toBeUndefined();
+  });
+
+  it("prefix-matches ESP32 variants", () => {
+    expect(
+      resolveLogDocLink(NOTIFY_DROP, {}, { targetPlatform: "esp32s3" })?.actionable?.body
+    ).toBe("tcp_buffer");
+  });
+
+  it("does not match the verbose notify-drop variant", () => {
+    const line =
+      "[10:24:27.031][V][bluetooth_connection:379]: [0] [AA:BB:CC:DD:EE:FF] Failed to send notify data response, handle 0x002A";
+    expect(resolveLogDocLink(line, {}, ESP32)?.actionable).toBeUndefined();
+  });
+
+  it("does not match an unrelated bluetooth_connection warning", () => {
+    const line =
+      "[10:24:27.031][W][bluetooth_connection:058]: [0] [AA:BB:CC:DD:EE:FF] connect failed, err=133";
+    expect(resolveLogDocLink(line, {}, ESP32)?.actionable).toBeUndefined();
+  });
+
+  it("leaves ungated entries alone when a platform is passed", () => {
+    const line =
+      "[13:22:07][W][app:193]: Bootloader too old for OTA rollback. Flash via USB once to update the bootloader";
+    expect(
+      resolveLogDocLink(line, {}, { targetPlatform: "ESP8266" })?.actionable?.body
+    ).toBe("bootloader");
+  });
+});
+
 describe("resolveLogDocLink — component", () => {
   it("links a simple tag to its component page and ranges the token", () => {
     const line = "[13:22:07][C][ethernet:495]: Ethernet:";

--- a/test/util/log-doc-links.test.ts
+++ b/test/util/log-doc-links.test.ts
@@ -271,6 +271,14 @@ describe("resolveLogDocLink — tcp_buffer", () => {
       "displaced proxy reply",
       "[10:24:27.031][W][bluetooth_proxy:136]: GATT error reply for AABBCCDDEEFF dropped, displaced by AABBCCDDEE00",
     ],
+    [
+      "queued keepalive ping",
+      "[10:24:27.031][W][api.connection:370]: Buffer full, ping queued",
+    ],
+    [
+      "voice assistant start request",
+      "[10:24:27.031][W][voice_assistant:366]: Could not request start",
+    ],
   ])("maps the same-cause %s warning on ESP32", (_what, line) => {
     expect(resolveLogDocLink(line, {}, ESP32)?.actionable?.body).toBe("tcp_buffer");
   });

--- a/test/util/log-doc-links.test.ts
+++ b/test/util/log-doc-links.test.ts
@@ -203,7 +203,7 @@ describe("resolveLogDocLink — actionable", () => {
 });
 
 describe("resolveLogDocLink — tcp_buffer", () => {
-  const ESP32 = { targetPlatform: "ESP32" };
+  const ESP32 = "ESP32";
   const NETWORK_URL = "https://esphome.io/components/network/#configuration-variables";
   const NOTIFY_DROP =
     "[10:24:27.031][W][bluetooth_connection:376]: [0] [AA:BB:CC:DD:EE:FF] Failed to send notify data response, handle 0x002A";
@@ -284,18 +284,18 @@ describe("resolveLogDocLink — tcp_buffer", () => {
   });
 
   it.each([
-    ["no platform", {}],
-    ["an empty platform", { targetPlatform: "" }],
-    ["ESP8266", { targetPlatform: "ESP8266" }],
-    ["rp2", { targetPlatform: "rp2" }],
-  ])("does not fire with %s (the option is ESP32-only)", (_what, options) => {
-    expect(resolveLogDocLink(NOTIFY_DROP, {}, options)?.actionable).toBeUndefined();
+    ["no platform", undefined],
+    ["an empty platform", ""],
+    ["ESP8266", "ESP8266"],
+    ["rp2", "rp2"],
+  ])("does not fire with %s (the option is ESP32-only)", (_what, platform) => {
+    expect(resolveLogDocLink(NOTIFY_DROP, {}, platform)?.actionable).toBeUndefined();
   });
 
   it("prefix-matches ESP32 variants", () => {
-    expect(
-      resolveLogDocLink(NOTIFY_DROP, {}, { targetPlatform: "esp32s3" })?.actionable?.body
-    ).toBe("tcp_buffer");
+    expect(resolveLogDocLink(NOTIFY_DROP, {}, "esp32s3")?.actionable?.body).toBe(
+      "tcp_buffer"
+    );
   });
 
   it("does not match the verbose notify-drop variant", () => {
@@ -313,9 +313,7 @@ describe("resolveLogDocLink — tcp_buffer", () => {
   it("leaves ungated entries alone when a platform is passed", () => {
     const line =
       "[13:22:07][W][app:193]: Bootloader too old for OTA rollback. Flash via USB once to update the bootloader";
-    expect(
-      resolveLogDocLink(line, {}, { targetPlatform: "ESP8266" })?.actionable?.body
-    ).toBe("bootloader");
+    expect(resolveLogDocLink(line, {}, "ESP8266")?.actionable?.body).toBe("bootloader");
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Adds a curated log-help popover for the TCP send-buffer congestion warnings, pointing at the new `network: tcp_send_buffer` option (esphome/esphome#18610, documented in esphome/esphome-docs#7239 under the existing `#configuration-variables` anchor on the network page).

Every WARN-level send refusal esphome logs when the lwIP send buffer is full now resolves to the popover (verified against the esphome source):

- `<what> dropped, TCP buffer full` via the shared `API_LOG_MSG_DROPPED` helper under `api`, `api.connection`, `voice_assistant`, `zwave_proxy`
- `bluetooth_proxy`: `<what> reply for <addr> dropped / deferred, TCP buffer full`, and the displaced variant `dropped, displaced by <addr>`
- `bluetooth_connection`: `Connected reply deferred`, `Service batch deferred`, `GATT reply for handle … deferred, TCP buffer full`, plus the same-cause lines without the literal text: `GATT reply … dropped for handle …`, `GATT reply … undeliverable, abandoning`, `Failed to send read response`, `Failed to send notify data response[, handle …]`, `Failed to send services done, retrying`, `Services done undeliverable, abandoning`
- `api.connection`: `Buffer full, ping queued` (the keepalive ping refused by a full buffer)
- `voice_assistant`: `Could not request start` (the pipeline-start request refused by a full buffer)

Audited every `send_message(` call site; the remaining refusals are either silent retries (camera frames, voice audio, HA state subscriptions, scanner-state pushes, the shutdown disconnect), verbose-level lines, or `on_fatal_error()` paths with no buffer-specific log.

`tcp_send_buffer` only exists on ESP32, so the resolver gains a platform gate: `resolveLogDocLink` takes an optional `targetPlatform`, `ActionableEntry` gains an `esp32Only` flag checked through a shared `isEsp32Platform()` predicate (also now used by `issuePlatform()`), and a gated entry never fires when the platform is unknown. All the lines above resolve through a single `ACTIONABLE` entry (one pattern over the six tags). The platform is threaded through `esphome-process-terminal` / `esphome-ansi-log` by the logs dialog and command dialog (a `resolveDevicePlatform(devices, configuration)` helper, derived in `willUpdate`) and the install dialog's log; hosts without a configured device (adopt dialog, web flash receiver) leave it unset.

**Related issue or feature (if applicable):**

- esphome/esphome#18610
- esphome/esphome-docs#7239

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
