### PR TITLE
Link the create error to the Secrets page and flag duplicate secret keys

### DIFF
--- a/src/components/secrets/secrets-structured-editor.ts
+++ b/src/components/secrets/secrets-structured-editor.ts
@@ -22,6 +22,7 @@ import { registerMdiIcons } from "../../util/register-icons.js";
 import { secretHostSlug } from "../../util/secret-eligibility.js";
 import {
   addSecret,
+  duplicateSecretKeys,
   groupSecretsByDevice,
   isValidSecretKey,
   parseSecretsEntries,
@@ -93,6 +94,7 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
 
   protected render() {
     const entries = parseSecretsEntries(this.value);
+    const duplicates = duplicateSecretKeys(entries);
     const groups = groupSecretsByDevice(entries);
     // Headers only earn their keep once a ``<device>__`` prefix appears;
     // a flat shared file stays a plain list.
@@ -105,10 +107,10 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
             </div>`
           : grouped
             ? html`<div class="groups">
-                ${groups.map((group) => this._renderGroup(group, entries))}
+                ${groups.map((group) => this._renderGroup(group, entries, duplicates))}
               </div>`
             : html`<div class="rows">
-                ${entries.map((entry) => this._renderRow(entry, entries))}
+                ${entries.map((entry) => this._renderRow(entry, entries, duplicates))}
               </div>`
       }
       <div class="add-row">
@@ -121,11 +123,15 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
     `;
   }
 
-  private _renderGroup(group: SecretGroup, entries: SecretEntry[]) {
+  private _renderGroup(
+    group: SecretGroup,
+    entries: SecretEntry[],
+    duplicates: Set<string>
+  ) {
     return html`<div class="group">
       ${this._renderGroupHeader(group.device)}
       <div class="rows">
-        ${group.entries.map((entry) => this._renderRow(entry, entries))}
+        ${group.entries.map((entry) => this._renderRow(entry, entries, duplicates))}
       </div>
     </div>`;
   }
@@ -245,19 +251,19 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
     </esphome-base-dialog>`;
   }
 
-  private _renderRow(entry: SecretEntry, entries: SecretEntry[]) {
+  private _renderRow(
+    entry: SecretEntry,
+    entries: SecretEntry[],
+    duplicates: Set<string>
+  ) {
     const keyInvalid = this._keyError?.line === entry.line;
-    // ESPHome's loader rejects the whole file on a repeated top-level key,
-    // so every occurrence is flagged until the user removes the extras.
-    const duplicate = entries.some(
-      (other) => other.line !== entry.line && other.key === entry.key
-    );
     const hint = keyInvalid
-      ? this._keyError?.message
-      : duplicate
+      ? (this._keyError?.message ?? null)
+      : duplicates.has(entry.key)
         ? this._localize("secrets.duplicate_row")
         : null;
-    const hintRow = hint ? html`<div class="key-error">${hint}</div>` : nothing;
+    const invalid = hint !== null;
+    const hintRow = invalid ? html`<div class="key-error">${hint}</div>` : nothing;
     if (!entry.editable) {
       return html`<div class="row row--advanced">
           <input
@@ -277,13 +283,13 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
     return html`<div class="row">
         <input
           type="text"
-          class=${keyInvalid || duplicate ? "invalid" : ""}
+          class=${invalid ? "invalid" : ""}
           .value=${live(entry.key)}
           autocomplete="off"
           spellcheck="false"
           placeholder=${this._localize("secrets.key_placeholder")}
           aria-label=${this._localize("secrets.key_placeholder")}
-          aria-invalid=${keyInvalid || duplicate ? "true" : "false"}
+          aria-invalid=${invalid ? "true" : "false"}
           @change=${(e: Event) =>
             this._onKeyChange(entry, entries, e.currentTarget as HTMLInputElement)}
         />

--- a/src/components/secrets/secrets-structured-editor.ts
+++ b/src/components/secrets/secrets-structured-editor.ts
@@ -263,14 +263,20 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
         ? this._localize("secrets.duplicate_row")
         : null;
     const invalid = hint !== null;
-    const hintRow = invalid ? html`<div class="key-error">${hint}</div>` : nothing;
+    const hintId = `key-hint-${entry.line}`;
+    const hintRow = invalid
+      ? html`<div id=${hintId} class="key-error">${hint}</div>`
+      : nothing;
     if (!entry.editable) {
       return html`<div class="row row--advanced">
           <input
             type="text"
+            class=${invalid ? "invalid" : ""}
             .value=${entry.key}
             readonly
             aria-label=${this._localize("secrets.key_placeholder")}
+            aria-invalid=${invalid ? "true" : "false"}
+            aria-describedby=${invalid ? hintId : nothing}
           />
           <span class="advanced-badge">
             <wa-icon library="mdi" name="alert-circle-outline"></wa-icon>
@@ -290,6 +296,7 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
           placeholder=${this._localize("secrets.key_placeholder")}
           aria-label=${this._localize("secrets.key_placeholder")}
           aria-invalid=${invalid ? "true" : "false"}
+          aria-describedby=${invalid ? hintId : nothing}
           @change=${(e: Event) =>
             this._onKeyChange(entry, entries, e.currentTarget as HTMLInputElement)}
         />

--- a/src/components/secrets/secrets-structured-editor.ts
+++ b/src/components/secrets/secrets-structured-editor.ts
@@ -247,31 +247,43 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
 
   private _renderRow(entry: SecretEntry, entries: SecretEntry[]) {
     const keyInvalid = this._keyError?.line === entry.line;
+    // ESPHome's loader rejects the whole file on a repeated top-level key,
+    // so every occurrence is flagged until the user removes the extras.
+    const duplicate = entries.some(
+      (other) => other.line !== entry.line && other.key === entry.key
+    );
+    const hint = keyInvalid
+      ? this._keyError?.message
+      : duplicate
+        ? this._localize("secrets.duplicate_row")
+        : null;
+    const hintRow = hint ? html`<div class="key-error">${hint}</div>` : nothing;
     if (!entry.editable) {
       return html`<div class="row row--advanced">
-        <input
-          type="text"
-          .value=${entry.key}
-          readonly
-          aria-label=${this._localize("secrets.key_placeholder")}
-        />
-        <span class="advanced-badge">
-          <wa-icon library="mdi" name="alert-circle-outline"></wa-icon>
-          ${this._localize("secrets.advanced_badge")}
-        </span>
-        <span></span>
-      </div>`;
+          <input
+            type="text"
+            .value=${entry.key}
+            readonly
+            aria-label=${this._localize("secrets.key_placeholder")}
+          />
+          <span class="advanced-badge">
+            <wa-icon library="mdi" name="alert-circle-outline"></wa-icon>
+            ${this._localize("secrets.advanced_badge")}
+          </span>
+          <span></span>
+        </div>
+        ${hintRow}`;
     }
     return html`<div class="row">
         <input
           type="text"
-          class=${keyInvalid ? "invalid" : ""}
+          class=${keyInvalid || duplicate ? "invalid" : ""}
           .value=${live(entry.key)}
           autocomplete="off"
           spellcheck="false"
           placeholder=${this._localize("secrets.key_placeholder")}
           aria-label=${this._localize("secrets.key_placeholder")}
-          aria-invalid=${keyInvalid ? "true" : "false"}
+          aria-invalid=${keyInvalid || duplicate ? "true" : "false"}
           @change=${(e: Event) =>
             this._onKeyChange(entry, entries, e.currentTarget as HTMLInputElement)}
         />
@@ -294,11 +306,7 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
           <wa-icon library="mdi" name="close"></wa-icon>
         </button>
       </div>
-      ${
-        keyInvalid
-          ? html`<div class="key-error">${this._keyError?.message}</div>`
-          : nothing
-      }`;
+      ${hintRow}`;
   }
 
   private _onKeyChange(

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -7,9 +7,9 @@ import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry, SlimBoard } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
+import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
 import { primaryHeaderDialogStyles } from "../../styles/dialog-chrome.js";
 import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
-import { linkButtonStyles } from "../../styles/link-button.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { fetchBoard, getCachedBoard } from "../../util/board-body-cache.js";
 import { DialogOpenController } from "../../util/dialog-open-controller.js";
@@ -140,7 +140,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     // Shared primary header + back button (also used by add-component) —
     // see dialog-chrome.ts.
     primaryHeaderDialogStyles,
-    linkButtonStyles,
+    dialogActionButtonStyles,
     css`
       esphome-base-dialog {
         --width: 520px;
@@ -159,16 +159,24 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
         padding: var(--wa-space-l) var(--esphome-dialog-body-gutter, var(--wa-space-xl));
       }
 
-      .error {
-        color: var(--esphome-error);
-        font-size: var(--wa-font-size-s);
+      .error-bar {
         margin-top: var(--wa-space-s);
       }
 
-      /* Delta over .link-button: inherit the error color. */
+      .error {
+        color: var(--esphome-error);
+        font-size: var(--wa-font-size-s);
+        margin: 0;
+      }
+
       .error-action {
-        color: inherit;
-        margin-left: var(--wa-space-2xs);
+        margin-top: var(--wa-space-s);
+        background: var(--wa-color-danger-fill-loud);
+        color: var(--wa-color-danger-on-loud);
+      }
+
+      .error-action:hover {
+        background: color-mix(in srgb, var(--wa-color-danger-fill-loud) 85%, black);
       }
     `,
   ];
@@ -331,23 +339,23 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     `;
   }
 
-  /** Inline error bar; a message naming secrets.yaml gets a link to the Secrets page. */
+  /** Inline error bar; a message naming secrets.yaml gets a button to the Secrets page. */
   private _renderErrorBar(message: string) {
     if (!message) return nothing;
-    return html`<p class="error">
-      ${message}
+    return html`<div class="error-bar">
+      <p class="error">${message}</p>
       ${
         message.includes("secrets.yaml")
           ? html`<button
               type="button"
-              class="error-action link-button"
+              class="btn error-action"
               @click=${this._openSecrets}
             >
               ${this._localize("wizard.open_secrets")}
             </button>`
           : nothing
       }
-    </p>`;
+    </div>`;
   }
 
   private _openSecrets = () => {

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -10,6 +10,7 @@ import { apiContext, localizeContext } from "../../context/index.js";
 import { primaryHeaderDialogStyles } from "../../styles/dialog-chrome.js";
 import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { withBase } from "../../util/base-path.js";
 import { fetchBoard, getCachedBoard } from "../../util/board-body-cache.js";
 import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import { buildFeaturedId } from "../../util/featured-id.js";
@@ -325,7 +326,12 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
   }
 
   private _openSecrets = async () => {
-    if (await navigate("/secrets")) this.close();
+    try {
+      if (await navigate("/secrets")) this.close();
+    } catch {
+      // Fall back to a full navigation so the click is never a silent no-op.
+      window.location.assign(withBase("/secrets"));
+    }
   };
 
   private _renderStep() {
@@ -445,7 +451,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
 
   private _onOpenImportedDevice() {
     if (this._import.partial) {
-      this.navigateToCreated(this._import.partial.configuration);
+      void this.navigateToCreated(this._import.partial.configuration);
     }
   }
 
@@ -490,11 +496,10 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
    * Public so the import controller can reuse it; centralised so the
    * creation paths can't drift on which one-shot signals they arm.
    */
-  navigateToCreated(configuration: string): void {
+  async navigateToCreated(configuration: string): Promise<void> {
     markJustCreated(configuration);
     markPendingHighlight(configuration);
-    this.close();
-    void navigate(`/device/${encodeURIComponent(configuration)}`);
+    if (await navigate(`/device/${encodeURIComponent(configuration)}`)) this.close();
   }
 
   private async _onCreateEmptyConfig(
@@ -585,7 +590,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
         await this._applyFullSetup(configuration, options.board);
       }
       this._created = true; // keep the collision check frozen through the close
-      this.navigateToCreated(configuration);
+      await this.navigateToCreated(configuration);
       // A package board whose upstream failed to load still creates; the
       // toast is the repair signal once the dialog has closed.
       if (warning) {
@@ -645,13 +650,13 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
   /** Build a create-flow error message. Falls back to a localised generic
    *  when the error carries no actionable detail (a blank red bar is worse
    *  than 'create failed'). When 'board' is set, the message names the
-   *  board the wizard tried to use so a template failure is attributable. */
+   *  board the wizard tried to use so a template failure is attributable,
+   *  except for a secrets.yaml refusal, which already says what to fix. */
   private _extractCreateErrorMessage(
     err: unknown,
     board: BoardCatalogEntry | null
   ): string {
     const message = apiErrorDetails(err) || this._localize("wizard.create_general_error");
-    // A secrets.yaml refusal already says what to fix; the board prefix is noise.
     if (board && !isSecretsRefusal(message)) {
       return this._localize("wizard.create_with_board_error", {
         board: board.name,

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -7,7 +7,6 @@ import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry, SlimBoard } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
-import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
 import { primaryHeaderDialogStyles } from "../../styles/dialog-chrome.js";
 import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
@@ -25,6 +24,11 @@ import {
   type ImportFlowHost,
   type ImportStep,
 } from "./import-flow-controller.js";
+import {
+  isSecretsRefusal,
+  renderWizardErrorBar,
+  wizardErrorBarStyles,
+} from "./wizard-error-bar.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "../base-dialog.js";
@@ -140,7 +144,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     // Shared primary header + back button (also used by add-component) —
     // see dialog-chrome.ts.
     primaryHeaderDialogStyles,
-    dialogActionButtonStyles,
+    ...wizardErrorBarStyles,
     css`
       esphome-base-dialog {
         --width: 520px;
@@ -157,26 +161,6 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
         /* Horizontal gutter drops to a tighter value on the mobile sheet via
            --esphome-dialog-body-gutter (set by fullscreenMobileDialog). */
         padding: var(--wa-space-l) var(--esphome-dialog-body-gutter, var(--wa-space-xl));
-      }
-
-      .error-bar {
-        margin-top: var(--wa-space-s);
-      }
-
-      .error {
-        color: var(--esphome-error);
-        font-size: var(--wa-font-size-s);
-        margin: 0;
-      }
-
-      .error-action {
-        margin-top: var(--wa-space-s);
-        background: var(--wa-color-danger-fill-loud);
-        color: var(--wa-color-danger-on-loud);
-      }
-
-      .error-action:hover {
-        background: color-mix(in srgb, var(--wa-color-danger-fill-loud) 85%, black);
       }
     `,
   ];
@@ -333,29 +317,11 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
               </button>`
             : nothing
         }
-        ${this._renderStep()} ${this._renderErrorBar(this._importError)}
-        ${this._renderErrorBar(this._createError)}
+        ${this._renderStep()}
+        ${renderWizardErrorBar(this._importError, this._localize, this._openSecrets)}
+        ${renderWizardErrorBar(this._createError, this._localize, this._openSecrets)}
       </esphome-base-dialog>
     `;
-  }
-
-  /** Inline error bar; a message naming secrets.yaml gets a button to the Secrets page. */
-  private _renderErrorBar(message: string) {
-    if (!message) return nothing;
-    return html`<div class="error-bar">
-      <p class="error">${message}</p>
-      ${
-        message.includes("secrets.yaml")
-          ? html`<button
-              type="button"
-              class="btn error-action"
-              @click=${this._openSecrets}
-            >
-              ${this._localize("wizard.open_secrets")}
-            </button>`
-          : nothing
-      }
-    </div>`;
   }
 
   private _openSecrets = () => {
@@ -687,7 +653,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
   ): string {
     const message = apiErrorDetails(err) || this._localize("wizard.create_general_error");
     // A secrets.yaml refusal already says what to fix; the board prefix is noise.
-    if (board && !message.includes("secrets.yaml")) {
+    if (board && !isSecretsRefusal(message)) {
       return this._localize("wizard.create_with_board_error", {
         board: board.name,
         message,

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -686,7 +686,8 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     board: BoardCatalogEntry | null
   ): string {
     const message = apiErrorDetails(err) || this._localize("wizard.create_general_error");
-    if (board) {
+    // A secrets.yaml refusal already says what to fix; the board prefix is noise.
+    if (board && !message.includes("secrets.yaml")) {
       return this._localize("wizard.create_with_board_error", {
         board: board.name,
         message,

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -324,9 +324,9 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     `;
   }
 
-  private _openSecrets = () => {
-    this.close();
-    void navigate("/secrets");
+  private _openSecrets = async () => {
+    // A leave guard that keeps the page must also keep the error and its action.
+    if (await navigate("/secrets")) this.close();
   };
 
   private _renderStep() {

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -129,6 +129,11 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
   @state()
   private _createError = "";
 
+  // The create failed on a secrets.yaml parse error (read off the raw API
+  // details, not the localized message), so the error bar can link there.
+  @state()
+  private _createErrorSecrets = false;
+
   /** The "Import from file" flow (YAML upload + bundle + overwrite/conflict
    *  round-trips). Kept out of this dialog so it stays a thin step machine. */
   private readonly _import = new ImportFlowController(this);
@@ -161,6 +166,17 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
         color: var(--esphome-error);
         font-size: var(--wa-font-size-s);
         margin-top: var(--wa-space-s);
+      }
+
+      .error-action {
+        background: none;
+        border: none;
+        padding: 0;
+        margin-left: var(--wa-space-2xs);
+        color: inherit;
+        font: inherit;
+        text-decoration: underline;
+        cursor: pointer;
       }
     `,
   ];
@@ -231,6 +247,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
   private _resetCreateErrors(): void {
     this._importError = "";
     this._createError = "";
+    this._createErrorSecrets = false;
   }
 
   public close() {
@@ -319,10 +336,30 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
         }
         ${this._renderStep()}
         ${this._importError ? html`<p class="error">${this._importError}</p>` : nothing}
-        ${this._createError ? html`<p class="error">${this._createError}</p>` : nothing}
+        ${this._renderCreateError()}
       </esphome-base-dialog>
     `;
   }
+
+  /** Inline create error; a secrets.yaml parse failure gets a link to the Secrets page. */
+  private _renderCreateError() {
+    if (!this._createError) return nothing;
+    return html`<p class="error">
+      ${this._createError}
+      ${
+        this._createErrorSecrets
+          ? html`<button type="button" class="error-action" @click=${this._openSecrets}>
+              ${this._localize("wizard.open_secrets")}
+            </button>`
+          : nothing
+      }
+    </p>`;
+  }
+
+  private _openSecrets = () => {
+    this.close();
+    void navigate("/secrets");
+  };
 
   private _renderStep() {
     // Show loading message while import creation is in progress
@@ -593,6 +630,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     } catch (err) {
       console.error("Failed to create device:", err);
       this._createError = this._extractCreateErrorMessage(err, options.board ?? null);
+      this._createErrorSecrets = apiErrorDetails(err).includes("secrets.yaml");
     } finally {
       this._submitting = false;
     }

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -325,7 +325,6 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
   }
 
   private _openSecrets = async () => {
-    // A leave guard that keeps the page must also keep the error and its action.
     if (await navigate("/secrets")) this.close();
   };
 

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -9,6 +9,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { primaryHeaderDialogStyles } from "../../styles/dialog-chrome.js";
 import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
+import { linkButtonStyles } from "../../styles/link-button.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { fetchBoard, getCachedBoard } from "../../util/board-body-cache.js";
 import { DialogOpenController } from "../../util/dialog-open-controller.js";
@@ -129,11 +130,6 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
   @state()
   private _createError = "";
 
-  // The create failed on a secrets.yaml parse error (read off the raw API
-  // details, not the localized message), so the error bar can link there.
-  @state()
-  private _createErrorSecrets = false;
-
   /** The "Import from file" flow (YAML upload + bundle + overwrite/conflict
    *  round-trips). Kept out of this dialog so it stays a thin step machine. */
   private readonly _import = new ImportFlowController(this);
@@ -144,6 +140,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     // Shared primary header + back button (also used by add-component) —
     // see dialog-chrome.ts.
     primaryHeaderDialogStyles,
+    linkButtonStyles,
     css`
       esphome-base-dialog {
         --width: 520px;
@@ -168,15 +165,10 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
         margin-top: var(--wa-space-s);
       }
 
+      /* Delta over .link-button: inherit the error color. */
       .error-action {
-        background: none;
-        border: none;
-        padding: 0;
-        margin-left: var(--wa-space-2xs);
         color: inherit;
-        font: inherit;
-        text-decoration: underline;
-        cursor: pointer;
+        margin-left: var(--wa-space-2xs);
       }
     `,
   ];
@@ -247,7 +239,6 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
   private _resetCreateErrors(): void {
     this._importError = "";
     this._createError = "";
-    this._createErrorSecrets = false;
   }
 
   public close() {
@@ -334,21 +325,24 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
               </button>`
             : nothing
         }
-        ${this._renderStep()}
-        ${this._importError ? html`<p class="error">${this._importError}</p>` : nothing}
-        ${this._renderCreateError()}
+        ${this._renderStep()} ${this._renderErrorBar(this._importError)}
+        ${this._renderErrorBar(this._createError)}
       </esphome-base-dialog>
     `;
   }
 
-  /** Inline create error; a secrets.yaml parse failure gets a link to the Secrets page. */
-  private _renderCreateError() {
-    if (!this._createError) return nothing;
+  /** Inline error bar; a message naming secrets.yaml gets a link to the Secrets page. */
+  private _renderErrorBar(message: string) {
+    if (!message) return nothing;
     return html`<p class="error">
-      ${this._createError}
+      ${message}
       ${
-        this._createErrorSecrets
-          ? html`<button type="button" class="error-action" @click=${this._openSecrets}>
+        message.includes("secrets.yaml")
+          ? html`<button
+              type="button"
+              class="error-action link-button"
+              @click=${this._openSecrets}
+            >
               ${this._localize("wizard.open_secrets")}
             </button>`
           : nothing
@@ -630,7 +624,6 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     } catch (err) {
       console.error("Failed to create device:", err);
       this._createError = this._extractCreateErrorMessage(err, options.board ?? null);
-      this._createErrorSecrets = apiErrorDetails(err).includes("secrets.yaml");
     } finally {
       this._submitting = false;
     }

--- a/src/components/wizard/import-flow-controller.ts
+++ b/src/components/wizard/import-flow-controller.ts
@@ -16,7 +16,7 @@ export interface ImportFlowHost extends ReactiveControllerHost {
   /** Shared "a request is in flight" flag (the dialog's busy state). */
   importBusy: boolean;
   goToImportStep(step: ImportStep): void;
-  navigateToCreated(configuration: string): void;
+  navigateToCreated(configuration: string): Promise<void>;
   setImportError(message: string): void;
   resetErrors(): void;
 }
@@ -150,7 +150,7 @@ export class ImportFlowController implements ReactiveController {
         file_content: fileContent,
         ...(overwrite ? { overwrite: true } : {}),
       });
-      this._host.navigateToCreated(configuration);
+      void this._host.navigateToCreated(configuration);
     } catch (err) {
       if (!overwrite && err instanceof APIError && err.errorCode === "already_exists") {
         this._pendingUpload = { slug, fileContent };
@@ -192,7 +192,7 @@ export class ImportFlowController implements ReactiveController {
         this._host.goToImportStep("import-partial");
         return;
       }
-      this._host.navigateToCreated(res.configuration);
+      void this._host.navigateToCreated(res.configuration);
     } catch (err) {
       this._host.setImportError(
         apiErrorDetails(err) || this._host.localize("wizard.import_general_error")

--- a/src/components/wizard/wizard-error-bar.ts
+++ b/src/components/wizard/wizard-error-bar.ts
@@ -1,0 +1,59 @@
+import { css, html, nothing } from "lit";
+
+import type { LocalizeFunc } from "../../common/localize.js";
+import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
+
+// The backend's secrets.yaml refusal (``Can't <action>: secrets.yaml has a
+// duplicate key …`` / ``… secrets.yaml doesn't parse: …``); keyed on that
+// phrasing so a device merely named ``secrets`` never triggers it.
+const SECRETS_REFUSAL = /\bsecrets\.yaml (has a duplicate key|doesn't parse)\b/;
+
+/** True when *message* is the backend's "secrets.yaml doesn't parse" refusal. */
+export function isSecretsRefusal(message: string): boolean {
+  return SECRETS_REFUSAL.test(message);
+}
+
+/** Styles for ``renderWizardErrorBar``; includes the shared ``.btn`` base. */
+export const wizardErrorBarStyles = [
+  dialogActionButtonStyles,
+  css`
+    .error-bar {
+      margin-top: var(--wa-space-s);
+    }
+
+    .error {
+      color: var(--esphome-error);
+      font-size: var(--wa-font-size-s);
+      margin: 0;
+    }
+
+    .error-action {
+      margin-top: var(--wa-space-s);
+      background: var(--wa-color-danger-fill-loud);
+      color: var(--wa-color-danger-on-loud);
+    }
+
+    .error-action:hover {
+      background: color-mix(in srgb, var(--wa-color-danger-fill-loud) 85%, black);
+    }
+  `,
+];
+
+/** Inline wizard error bar; a secrets.yaml refusal gets an "Open secrets" button. */
+export function renderWizardErrorBar(
+  message: string,
+  localize: LocalizeFunc,
+  onOpenSecrets: () => void
+) {
+  if (!message) return nothing;
+  return html`<div class="error-bar">
+    <p class="error">${message}</p>
+    ${
+      isSecretsRefusal(message)
+        ? html`<button type="button" class="btn error-action" @click=${onOpenSecrets}>
+            ${localize("wizard.open_secrets")}
+          </button>`
+        : nothing
+    }
+  </div>`;
+}

--- a/src/components/wizard/wizard-error-bar.ts
+++ b/src/components/wizard/wizard-error-bar.ts
@@ -6,7 +6,7 @@ import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js"
 // The backend refusal phrasing, not the bare filename: a device named "secrets" must not match.
 const SECRETS_REFUSAL = /\bsecrets\.yaml (has a duplicate key|doesn't parse)\b/;
 
-/** True when *message* is the backend's "secrets.yaml doesn't parse" refusal. */
+/** True when *message* is the backend's secrets.yaml refusal (duplicate key or parse failure). */
 export function isSecretsRefusal(message: string): boolean {
   return SECRETS_REFUSAL.test(message);
 }

--- a/src/components/wizard/wizard-error-bar.ts
+++ b/src/components/wizard/wizard-error-bar.ts
@@ -43,14 +43,18 @@ export const wizardErrorBarStyles = [
 export function renderWizardErrorBar(
   message: string,
   localize: LocalizeFunc,
-  onOpenSecrets: () => void
+  onOpenSecrets: () => Promise<void>
 ) {
   if (!message) return nothing;
-  return html`<div class="error-bar">
+  return html`<div class="error-bar" role="alert">
     <p class="error">${message}</p>
     ${
       isSecretsRefusal(message)
-        ? html`<button type="button" class="btn error-action" @click=${onOpenSecrets}>
+        ? html`<button
+            type="button"
+            class="btn error-action"
+            @click=${() => void onOpenSecrets()}
+          >
             ${localize("wizard.open_secrets")}
           </button>`
         : nothing

--- a/src/components/wizard/wizard-error-bar.ts
+++ b/src/components/wizard/wizard-error-bar.ts
@@ -4,9 +4,9 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
 
 // The backend refusal phrasing, not the bare filename: a device named "secrets" must not match.
-const SECRETS_REFUSAL = /\bsecrets\.yaml (has a duplicate key|doesn't parse)\b/;
+const SECRETS_REFUSAL = /\bsecrets\.yaml (has a duplicate key|doesn't parse|defines ")/;
 
-/** True when *message* is the backend's secrets.yaml refusal (duplicate key or parse failure). */
+/** True when *message* is the backend's secrets.yaml refusal (duplicate key, parse failure, or a key it can't rewrite). */
 export function isSecretsRefusal(message: string): boolean {
   return SECRETS_REFUSAL.test(message);
 }

--- a/src/components/wizard/wizard-error-bar.ts
+++ b/src/components/wizard/wizard-error-bar.ts
@@ -3,9 +3,7 @@ import { css, html, nothing } from "lit";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
 
-// The backend's secrets.yaml refusal (``Can't <action>: secrets.yaml has a
-// duplicate key …`` / ``… secrets.yaml doesn't parse: …``); keyed on that
-// phrasing so a device merely named ``secrets`` never triggers it.
+// The backend refusal phrasing, not the bare filename: a device named "secrets" must not match.
 const SECRETS_REFUSAL = /\bsecrets\.yaml (has a duplicate key|doesn't parse)\b/;
 
 /** True when *message* is the backend's "secrets.yaml doesn't parse" refusal. */

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -659,6 +659,7 @@
     },
     "create_general_error": "Failed to create the device. Please try again.",
     "create_with_board_error": "Failed to create device for {board}: {message}",
+    "open_secrets": "Open secrets",
     "board_load_failed": "Couldn't load the board details. Please try again."
   },
   "device": {
@@ -1720,6 +1721,7 @@
     "empty": "No secrets yet. Add one below or switch to YAML.",
     "invalid_key": "Names may use letters, numbers, dots, dashes and underscores, and can't start with a number.",
     "duplicate_key": "A secret with this name already exists.",
+    "duplicate_row": "Duplicate name; ESPHome rejects secrets.yaml until only one remains.",
     "file_header": "# Secrets — store sensitive values here and reference them\n# in your device configurations using !secret <key>\n#\n# Example:\n#   wifi_ssid: \"your-network-name\"\n#   wifi_password: \"your-password\"\n",
     "loading": "Loading secrets…",
     "load_failed": "Secrets could not be loaded. Check your connection and retry.",

--- a/src/util/navigation.ts
+++ b/src/util/navigation.ts
@@ -21,10 +21,12 @@ function clearLeaveGuard(guard: LeaveGuard): void {
 const DOC_TOKEN = Math.random().toString(36).slice(2);
 let pushCounter = 0;
 
-export async function navigate(url: string): Promise<void> {
-  if (!(await runLeaveGuard())) return;
+/** Navigate to *url*; resolves ``false`` when the active leave guard kept the page. */
+export async function navigate(url: string): Promise<boolean> {
+  if (!(await runLeaveGuard())) return false;
   window.history.pushState({ d: DOC_TOKEN, n: ++pushCounter }, "", withBase(url));
   window.dispatchEvent(new PopStateEvent("popstate"));
+  return true;
 }
 
 /**

--- a/src/util/secrets-entries.ts
+++ b/src/util/secrets-entries.ts
@@ -50,6 +50,17 @@ const ADVANCED_VALUE_START = /^[!&*|>[{]/;
 // vanishes from the form, so force-quote it.
 const LEADING_INDICATOR = /^[!&*|>[\]{}@`%]/;
 
+/** Keys defined on more than one line; ESPHome rejects the file while any exist. */
+export function duplicateSecretKeys(entries: SecretEntry[]): Set<string> {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const { key } of entries) {
+    if (seen.has(key)) duplicates.add(key);
+    seen.add(key);
+  }
+  return duplicates;
+}
+
 export function isValidSecretKey(key: string): boolean {
   return VALID_KEY.test(key);
 }

--- a/test/components/app-shell/serial-setup.test.ts
+++ b/test/components/app-shell/serial-setup.test.ts
@@ -21,7 +21,7 @@ const fakePort = {} as SerialPort;
 describe("dispatchOrStashSerialSetup", () => {
   beforeEach(() => {
     navigate.mockReset();
-    navigate.mockResolvedValue(undefined);
+    navigate.mockResolvedValue(true);
     consumePendingSerialSetup(); // drain any stash leaked by a prior test
   });
 
@@ -56,7 +56,7 @@ describe("dispatchOrStashSerialSetup", () => {
 
   it("clears the stash when the leave guard vetoes the navigation", async () => {
     window.history.replaceState({}, "", "/device/foo.yaml");
-    navigate.mockImplementation(async () => {}); // veto: pathname unchanged
+    navigate.mockImplementation(async () => false); // veto: pathname unchanged
     await dispatchOrStashSerialSetup(fakePort);
 
     expect(consumePendingSerialSetup()).toBeNull();

--- a/test/components/app-shell/serial-setup.test.ts
+++ b/test/components/app-shell/serial-setup.test.ts
@@ -7,7 +7,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { navigate } = vi.hoisted(() => ({ navigate: vi.fn(async () => {}) }));
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn(async () => true) }));
 vi.mock("../../../src/util/navigation.js", async (importActual) => ({
   ...(await importActual<typeof import("../../../src/util/navigation.js")>()),
   navigate,
@@ -46,6 +46,7 @@ describe("dispatchOrStashSerialSetup", () => {
     window.history.replaceState({}, "", "/device/foo.yaml");
     navigate.mockImplementation(async () => {
       window.history.replaceState({}, "", "/");
+      return true;
     });
     await dispatchOrStashSerialSetup(fakePort);
 

--- a/test/components/secrets/secrets-structured-editor.test.ts
+++ b/test/components/secrets/secrets-structured-editor.test.ts
@@ -74,6 +74,17 @@ describe("esphome-secrets-structured-editor", () => {
     ]);
   });
 
+  test("a duplicated advanced row is marked invalid and described by its hint", async () => {
+    const el = await mount("a: !secret x\na: !secret y\n");
+    const inputs = rows(el).map((row) => rowInputs(row)[0]);
+    expect(inputs.map((i) => i.classList.contains("invalid"))).toEqual([true, true]);
+    expect(inputs.map((i) => i.getAttribute("aria-invalid"))).toEqual(["true", "true"]);
+    for (const input of inputs) {
+      const hint = el.shadowRoot!.getElementById(input.getAttribute("aria-describedby")!);
+      expect(hint?.textContent).toContain("secrets.duplicate_row");
+    }
+  });
+
   test("empty buffer shows the empty state and the add button", async () => {
     const el = await mount("");
     expect(rows(el)).toHaveLength(0);

--- a/test/components/secrets/secrets-structured-editor.test.ts
+++ b/test/components/secrets/secrets-structured-editor.test.ts
@@ -58,6 +58,22 @@ describe("esphome-secrets-structured-editor", () => {
     expect(rows(el)).toHaveLength(2);
   });
 
+  test("flags every row of a repeated key and leaves unique rows clean", async () => {
+    const el = await mount(
+      "wifi_ssid: home\nwifi_password: a\napi_key: b\nwifi_password: c\n"
+    );
+    const hints = Array.from(el.shadowRoot!.querySelectorAll(".key-error"));
+    expect(hints).toHaveLength(2);
+    expect(hints[0].textContent).toContain("secrets.duplicate_row");
+    const invalid = rows(el).filter((row) =>
+      rowInputs(row)[0].classList.contains("invalid")
+    );
+    expect(invalid.map((row) => rowInputs(row)[0].value)).toEqual([
+      "wifi_password",
+      "wifi_password",
+    ]);
+  });
+
   test("empty buffer shows the empty state and the add button", async () => {
     const el = await mount("");
     expect(rows(el)).toHaveLength(0);

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -280,6 +280,10 @@ describe("create-config-dialog create de-dupe + retry", () => {
       ".error-bar .error-action"
     );
     expect(action).not.toBeNull();
+    // The board prefix is dropped; the secrets message stands alone.
+    expect(el.shadowRoot!.querySelector("p.error")!.textContent!.trim()).toMatch(
+      /^Can't create — secrets\.yaml/
+    );
     action!.click();
     expect(navigate).toHaveBeenCalledWith("/secrets");
   });

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -6,7 +6,7 @@
  * (the _submitting guard), but a create after a failed attempt is allowed
  * so the user can retry — no permanent lockout.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
@@ -20,8 +20,9 @@ vi.mock("../../../src/components/wizard/wizard-step-setup.js", () => ({}));
 vi.mock("sonner-js", () => ({
   default: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
 }));
-const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }));
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn(async () => true) }));
 vi.mock("../../../src/util/navigation.js", () => ({ navigate }));
+beforeEach(() => navigate.mockClear());
 
 import { IntlMessageFormat } from "intl-messageformat";
 import toast from "sonner-js";
@@ -284,7 +285,6 @@ describe("create-config-dialog create de-dupe + retry", () => {
     expect(el.shadowRoot!.querySelector("p.error")!.textContent!.trim()).toMatch(
       /^Can't create — secrets\.yaml/
     );
-    navigate.mockResolvedValueOnce(true);
     action!.click();
     await flush();
     expect(navigate).toHaveBeenCalledWith("/secrets");

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -20,6 +20,8 @@ vi.mock("../../../src/components/wizard/wizard-step-setup.js", () => ({}));
 vi.mock("sonner-js", () => ({
   default: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
 }));
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }));
+vi.mock("../../../src/util/navigation.js", () => ({ navigate }));
 
 import { IntlMessageFormat } from "intl-messageformat";
 import toast from "sonner-js";
@@ -256,6 +258,45 @@ describe("create-config-dialog create de-dupe + retry", () => {
     expect((el as any)._submitting).toBe(false);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((el as any)._createError).toBeTruthy();
+  });
+
+  it("offers an Open secrets action when the create failed on secrets.yaml", async () => {
+    const createDevice = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new APIError(
+          "invalid_args",
+          "Can't create — secrets.yaml doesn't parse: Duplicate key \"wifi_password\" in secrets.yaml, line 7, column 1. Fix secrets.yaml on the Secrets page and try again."
+        )
+      );
+    const el = await mount({ createDevice });
+
+    emitFinish(el, "kitchen");
+    await flush();
+    await el.updateComplete;
+
+    const action = el.shadowRoot!.querySelector<HTMLButtonElement>(
+      "p.error .error-action"
+    );
+    expect(action).not.toBeNull();
+    action!.click();
+    expect(navigate).toHaveBeenCalledWith("/secrets");
+  });
+
+  it("renders a plain create error without the secrets action", async () => {
+    const createDevice = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new APIError("invalid_args", "Configuration kitchen.yaml exists")
+      );
+    const el = await mount({ createDevice });
+
+    emitFinish(el, "kitchen");
+    await flush();
+    await el.updateComplete;
+
+    expect(el.shadowRoot!.querySelector("p.error")).not.toBeNull();
+    expect(el.shadowRoot!.querySelector("p.error .error-action")).toBeNull();
   });
 
   it("keeps the setup step's collision set frozen through a successful create", async () => {

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -277,7 +277,7 @@ describe("create-config-dialog create de-dupe + retry", () => {
     await el.updateComplete;
 
     const action = el.shadowRoot!.querySelector<HTMLButtonElement>(
-      "p.error .error-action"
+      ".error-bar .error-action"
     );
     expect(action).not.toBeNull();
     action!.click();
@@ -297,7 +297,7 @@ describe("create-config-dialog create de-dupe + retry", () => {
     await el.updateComplete;
 
     expect(el.shadowRoot!.querySelector("p.error")).not.toBeNull();
-    expect(el.shadowRoot!.querySelector("p.error .error-action")).toBeNull();
+    expect(el.shadowRoot!.querySelector(".error-bar .error-action")).toBeNull();
   });
 
   it("keeps the setup step's collision set frozen through a successful create", async () => {

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -270,6 +270,7 @@ describe("create-config-dialog create de-dupe + retry", () => {
         )
       );
     const el = await mount({ createDevice });
+    (el as unknown as { _localize: typeof icuLocalize })._localize = icuLocalize;
 
     emitFinish(el, "kitchen");
     await flush();

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -284,8 +284,36 @@ describe("create-config-dialog create de-dupe + retry", () => {
     expect(el.shadowRoot!.querySelector("p.error")!.textContent!.trim()).toMatch(
       /^Can't create — secrets\.yaml/
     );
+    navigate.mockResolvedValueOnce(true);
     action!.click();
+    await flush();
     expect(navigate).toHaveBeenCalledWith("/secrets");
+    // The dialog closes only once the navigation went through.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._dialog.open).toBe(false);
+  });
+
+  it("keeps the dialog and its error when the Secrets navigation is vetoed", async () => {
+    const createDevice = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new APIError(
+          "invalid_args",
+          "Can't create: secrets.yaml doesn't parse: bad. Fix it."
+        )
+      );
+    const el = await mount({ createDevice });
+
+    emitFinish(el, "kitchen");
+    await flush();
+    await el.updateComplete;
+
+    navigate.mockResolvedValueOnce(false); // leave guard kept the page
+    el.shadowRoot!.querySelector<HTMLButtonElement>(".error-bar .error-action")!.click();
+    await flush();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._dialog.open).toBe(true);
+    expect(el.shadowRoot!.querySelector(".error-bar .error-action")).not.toBeNull();
   });
 
   it("renders a collision on a device named secrets without the secrets action", async () => {

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -288,11 +288,11 @@ describe("create-config-dialog create de-dupe + retry", () => {
     expect(navigate).toHaveBeenCalledWith("/secrets");
   });
 
-  it("renders a plain create error without the secrets action", async () => {
+  it("renders a collision on a device named secrets without the secrets action", async () => {
     const createDevice = vi
       .fn()
       .mockRejectedValueOnce(
-        new APIError("invalid_args", "Configuration kitchen.yaml exists")
+        new APIError("already_exists", "Configuration secrets.yaml exists")
       );
     const el = await mount({ createDevice });
 

--- a/test/components/wizard/wizard-error-bar.test.ts
+++ b/test/components/wizard/wizard-error-bar.test.ts
@@ -6,6 +6,7 @@ describe("isSecretsRefusal", () => {
   it.each([
     'Can\'t create: secrets.yaml has a duplicate key "api_key" (lines 4 and 5). Fix it on the Secrets page and try again.',
     "Can't rename: secrets.yaml doesn't parse: mapping values are not allowed here in secrets.yaml, line 3, column 5. Fix it on the Secrets page and try again.",
+    "Can't save Wi-Fi credentials: secrets.yaml defines \"wifi_password\" where the dashboard can't rewrite it. Fix it on the Secrets page and try again.",
   ])("matches the backend refusal: %s", (message) => {
     expect(isSecretsRefusal(message)).toBe(true);
   });

--- a/test/components/wizard/wizard-error-bar.test.ts
+++ b/test/components/wizard/wizard-error-bar.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { isSecretsRefusal } from "../../../src/components/wizard/wizard-error-bar.js";
+
+describe("isSecretsRefusal", () => {
+  it.each([
+    'Can\'t create: secrets.yaml has a duplicate key "api_key" (lines 4 and 5). Fix it on the Secrets page and try again.',
+    "Can't rename: secrets.yaml doesn't parse: mapping values are not allowed here in secrets.yaml, line 3, column 5. Fix it on the Secrets page and try again.",
+  ])("matches the backend refusal: %s", (message) => {
+    expect(isSecretsRefusal(message)).toBe(true);
+  });
+
+  it.each([
+    "Configuration secrets.yaml exists",
+    "Can't create — config doesn't validate: [esphome] required key not provided",
+    "",
+  ])("ignores other errors: %s", (message) => {
+    expect(isSecretsRefusal(message)).toBe(false);
+  });
+});

--- a/test/guided-tour/tour-pause.test.ts
+++ b/test/guided-tour/tour-pause.test.ts
@@ -147,7 +147,7 @@ describe("guided-tour pause state", () => {
   });
 
   it("pauses when a guarded route transition is cancelled", async () => {
-    vi.mocked(navigate).mockImplementationOnce(async () => {});
+    vi.mocked(navigate).mockImplementationOnce(async () => false);
     setTourPending();
     window.history.replaceState(null, "", "/secrets");
     const state = internals(new ESPHomeGuidedTour());

--- a/test/util/navigation.test.ts
+++ b/test/util/navigation.test.ts
@@ -76,7 +76,7 @@ describe("navigate", () => {
   });
 
   it("pushes state and dispatches popstate when no guard is set", async () => {
-    await navigate("/dashboard");
+    expect(await navigate("/dashboard")).toBe(true);
 
     expect(pushStateSpy).toHaveBeenCalledTimes(1);
     expect(pushStateSpy).toHaveBeenCalledWith(
@@ -109,7 +109,7 @@ describe("navigate", () => {
     const guard = vi.fn(() => Promise.resolve(false));
     setLeaveGuard(guard);
 
-    await navigate("/dashboard");
+    expect(await navigate("/dashboard")).toBe(false);
 
     expect(guard).toHaveBeenCalledTimes(1);
     expect(pushStateSpy).not.toHaveBeenCalled();
@@ -129,7 +129,7 @@ describe("navigate", () => {
     const guard = vi.fn(() => Promise.resolve(true));
     setLeaveGuard(guard);
 
-    await navigate("/");
+    expect(await navigate("/")).toBe(true);
 
     expect(pushStateSpy).toHaveBeenCalledWith(
       { d: expect.any(String), n: expect.any(Number) },

--- a/test/util/secrets-entries.test.ts
+++ b/test/util/secrets-entries.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import {
   addSecret,
+  duplicateSecretKeys,
   groupSecretsByDevice,
   isValidSecretKey,
   parseSecretsEntries,
@@ -224,5 +225,16 @@ describe("isValidSecretKey", () => {
     expect(isValidSecretKey("has space")).toBe(false);
     expect(isValidSecretKey("1leading")).toBe(false);
     expect(isValidSecretKey("<<")).toBe(false);
+  });
+});
+
+describe("duplicateSecretKeys", () => {
+  test("reports keys defined on more than one line", () => {
+    const entries = parseSecretsEntries("a: 1\nb: 2\na: 3\nc: 4\nb: 5\n");
+    expect([...duplicateSecretKeys(entries)].sort()).toEqual(["a", "b"]);
+  });
+
+  test("is empty for unique keys", () => {
+    expect(duplicateSecretKeys(parseSecretsEntries("a: 1\nb: 2\n")).size).toBe(0);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#2624. When a device create fails because `secrets.yaml` does not parse (a duplicate `wifi_password` key in the linked issue), the inline error bar (create or import slot) carries an "Open secrets" action that closes the wizard and navigates to `/secrets`, keyed on the message naming `secrets.yaml`. On the Secrets page, the structured editor flags every row of a repeated key with the same hint row the rename collision uses, so the extra line is visible and can be removed; ESPHome rejects the whole file until it is.

<img width="1250" height="594" alt="Screenshot 2026-08-21 at 7 32 01 PM" src="https://github.com/user-attachments/assets/f6fb9640-f99f-4b64-88e0-82b67ade4826" />


**Related issue or feature (if applicable):**

- related: esphome/device-builder#2622 (closed by the backend PR)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
