### PR TITLE
Parse quoted top-level keys in the structured secrets editor

### DIFF
--- a/src/util/secret-eligibility.ts
+++ b/src/util/secret-eligibility.ts
@@ -199,7 +199,7 @@ export function secretValueFromYaml(yaml: string, key: string): string | null {
     // The mapping separator is the first `:` followed by whitespace or EOL,
     // so a key (or value) that itself contains a colon doesn't mis-match.
     const colon = line.search(/:(\s|$)/);
-    if (colon < 0 || line.slice(0, colon).trim() !== key) continue;
+    if (colon < 0 || stripQuotes(line.slice(0, colon).trim()) !== key) continue;
     const rhs = splitInlineComment(line.slice(colon + 1)).value.trim();
     // A double-quoted scalar (what `formatYamlScalar` emits when escaping) must
     // be unescaped to invert the write — `parseScalar`/`stripQuotes` only slice

--- a/src/util/secrets-entries.ts
+++ b/src/util/secrets-entries.ts
@@ -33,8 +33,26 @@ export interface SecretGroup {
 // scalar in YAML, not a mapping). No leading indent — nested children
 // are indented and never match, so a parent with a block value is left
 // to the advanced (read-only) path. ``<<`` matches so an HA-style merge
-// key surfaces as an advanced row rather than vanishing.
-const TOP_LEVEL_KEY = /^(<<|[A-Za-z_][A-Za-z0-9_.\-]*):(?:[ \t]+([^\n]*))?$/;
+// key surfaces as an advanced row rather than vanishing. A quoted key
+// (``"wifi_password":``) matches too; its quoting is kept on rewrite.
+const TOP_LEVEL_KEY =
+  /^(?:(?<merge><<)|(?<quote>["']?)(?<name>[A-Za-z_][A-Za-z0-9_.\-]*)\k<quote>):(?:[ \t]+(?<rest>[^\n]*))?$/;
+
+interface TopLevelKeyMatch {
+  key: string;
+  quote: string;
+  rest: string | undefined;
+}
+
+function matchTopLevelKey(line: string | undefined): TopLevelKeyMatch | null {
+  const groups = line?.match(TOP_LEVEL_KEY)?.groups;
+  if (!groups) return null;
+  return {
+    key: groups.merge ?? groups.name,
+    quote: groups.quote ?? "",
+    rest: groups.rest,
+  };
+}
 
 const VALID_KEY = /^[A-Za-z_][A-Za-z0-9_.\-]*$/;
 
@@ -100,18 +118,17 @@ export function parseSecretsEntries(yaml: string): SecretEntry[] {
   const lines = yaml.split("\n");
   const entries: SecretEntry[] = [];
   for (let i = 0; i < lines.length; i++) {
-    const match = lines[i].match(TOP_LEVEL_KEY);
+    const match = matchTopLevelKey(lines[i]);
     if (!match) continue;
-    const [, key, rest] = match;
-    entries.push({ key, line: i, ...readValue(rest, lines, i) });
+    entries.push({ key: match.key, line: i, ...readValue(match.rest, lines, i) });
   }
   return entries;
 }
 
 /** Replace the value of the entry at *line*, or null when it no longer matches. */
 export function setSecretValue(yaml: string, line: number, value: string): string | null {
-  return rewriteLine(yaml, line, (key, _value, comment) => {
-    return `${key}: ${formatSecretValue(value)}${comment}`;
+  return rewriteLine(yaml, line, (key, _value, comment, quote) => {
+    return `${quote}${key}${quote}: ${formatSecretValue(value)}${comment}`;
   });
 }
 
@@ -121,12 +138,12 @@ export function renameSecretKey(
   line: number,
   newKey: string
 ): string | null {
-  return rewriteLine(yaml, line, (_key, value, comment) => {
+  return rewriteLine(yaml, line, (_key, value, comment, quote) => {
     // A bare ``key:`` has no value or comment; keep it bare so the rename
     // doesn't leave a trailing space.
     return value === "" && comment === ""
-      ? `${newKey}:`
-      : `${newKey}: ${value}${comment}`;
+      ? `${quote}${newKey}${quote}:`
+      : `${quote}${newKey}${quote}: ${value}${comment}`;
   });
 }
 
@@ -143,7 +160,7 @@ export function removeSecret(yaml: string, line: number): string | null {
   const lines = yaml.split("\n");
   // Validate the target still holds a key so a stale index can't delete an
   // unrelated comment / blank / other line.
-  if (line < 0 || line >= lines.length || !TOP_LEVEL_KEY.test(lines[line])) return null;
+  if (line < 0 || line >= lines.length || !matchTopLevelKey(lines[line])) return null;
   lines.splice(line, 1);
   return lines.join("\n");
 }
@@ -177,13 +194,12 @@ function hasIndentedChild(lines: string[], index: number): boolean {
 function rewriteLine(
   yaml: string,
   line: number,
-  build: (key: string, value: string, comment: string) => string
+  build: (key: string, value: string, comment: string, quote: string) => string
 ): string | null {
   const lines = yaml.split("\n");
-  const match = lines[line]?.match(TOP_LEVEL_KEY);
+  const match = matchTopLevelKey(lines[line]);
   if (!match) return null;
-  const [, key, rest] = match;
-  const { value, comment } = splitInlineComment(rest ?? "");
-  lines[line] = build(key, value, comment);
+  const { value, comment } = splitInlineComment(match.rest ?? "");
+  lines[line] = build(match.key, value, comment, match.quote);
   return lines.join("\n");
 }

--- a/src/util/secrets-entries.ts
+++ b/src/util/secrets-entries.ts
@@ -8,7 +8,11 @@
 
 import { secretHostSlug } from "./secret-eligibility.js";
 import { escapeYamlDoubleQuoted } from "./yaml-escape.js";
-import { splitInlineComment, stripQuotes } from "./yaml-scalar.js";
+import {
+  splitInlineComment,
+  splitTrimmedInlineComment,
+  stripQuotes,
+} from "./yaml-scalar.js";
 import { formatYamlScalar } from "./yaml-serialize.js";
 
 export interface SecretEntry {
@@ -134,10 +138,9 @@ export function renameSecretKey(
   newKey: string
 ): string | null {
   return rewriteLine(yaml, line, (_key, quote, value, comment) => {
-    // A bare ``key:`` has no value or comment; keep it bare so the rename
-    // doesn't leave a trailing space.
-    return value === "" && comment === ""
-      ? `${quote}${newKey}${quote}:`
+    // No value: keep ``key:`` bare (the comment, if any, brings its own space).
+    return value === ""
+      ? `${quote}${newKey}${quote}:${comment}`
       : `${quote}${newKey}${quote}: ${value}${comment}`;
   });
 }
@@ -195,7 +198,8 @@ function rewriteLine(
   const match = lines[line]?.match(TOP_LEVEL_KEY);
   if (!match) return null;
   const [, quote = "", quoted, bare, rest] = match;
-  const { value, comment } = splitInlineComment(rest ?? "");
+  // The regex ate the separator, so a comment-only value arrives as ``# note``.
+  const { value, comment } = splitTrimmedInlineComment(rest ?? "");
   lines[line] = build(quoted ?? bare, quote, value, comment);
   return lines.join("\n");
 }

--- a/src/util/secrets-entries.ts
+++ b/src/util/secrets-entries.ts
@@ -33,26 +33,11 @@ export interface SecretGroup {
 // scalar in YAML, not a mapping). No leading indent — nested children
 // are indented and never match, so a parent with a block value is left
 // to the advanced (read-only) path. ``<<`` matches so an HA-style merge
-// key surfaces as an advanced row rather than vanishing. A quoted key
-// (``"wifi_password":``) matches too; its quoting is kept on rewrite.
+// key surfaces as an advanced row rather than vanishing, and so does a
+// quoted key (``"wifi_password":``). Groups: quote, quoted name, bare
+// name, rest.
 const TOP_LEVEL_KEY =
-  /^(?:(?<merge><<)|(?<quote>["']?)(?<name>[A-Za-z_][A-Za-z0-9_.\-]*)\k<quote>):(?:[ \t]+(?<rest>[^\n]*))?$/;
-
-interface TopLevelKeyMatch {
-  key: string;
-  quote: string;
-  rest: string | undefined;
-}
-
-function matchTopLevelKey(line: string | undefined): TopLevelKeyMatch | null {
-  const groups = line?.match(TOP_LEVEL_KEY)?.groups;
-  if (!groups) return null;
-  return {
-    key: groups.merge ?? groups.name,
-    quote: groups.quote ?? "",
-    rest: groups.rest,
-  };
-}
+  /^(?:(["'])([^"'\n]+)\1|(<<|[A-Za-z_][A-Za-z0-9_.\-]*)):(?:[ \t]+([^\n]*))?$/;
 
 const VALID_KEY = /^[A-Za-z_][A-Za-z0-9_.\-]*$/;
 
@@ -118,16 +103,26 @@ export function parseSecretsEntries(yaml: string): SecretEntry[] {
   const lines = yaml.split("\n");
   const entries: SecretEntry[] = [];
   for (let i = 0; i < lines.length; i++) {
-    const match = matchTopLevelKey(lines[i]);
+    const match = lines[i].match(TOP_LEVEL_KEY);
     if (!match) continue;
-    entries.push({ key: match.key, line: i, ...readValue(match.rest, lines, i) });
+    const [, , quoted, bare, rest] = match;
+    const key = quoted ?? bare;
+    const { value, editable } = readValue(rest, lines, i);
+    // A quoted key outside the identifier charset can't be renamed or
+    // rewritten by the form; show it read-only like other advanced rows.
+    entries.push({
+      key,
+      line: i,
+      value,
+      editable: editable && (!quoted || VALID_KEY.test(key)),
+    });
   }
   return entries;
 }
 
 /** Replace the value of the entry at *line*, or null when it no longer matches. */
 export function setSecretValue(yaml: string, line: number, value: string): string | null {
-  return rewriteLine(yaml, line, (key, _value, comment, quote) => {
+  return rewriteLine(yaml, line, (key, quote, _value, comment) => {
     return `${quote}${key}${quote}: ${formatSecretValue(value)}${comment}`;
   });
 }
@@ -138,7 +133,7 @@ export function renameSecretKey(
   line: number,
   newKey: string
 ): string | null {
-  return rewriteLine(yaml, line, (_key, value, comment, quote) => {
+  return rewriteLine(yaml, line, (_key, quote, value, comment) => {
     // A bare ``key:`` has no value or comment; keep it bare so the rename
     // doesn't leave a trailing space.
     return value === "" && comment === ""
@@ -160,7 +155,7 @@ export function removeSecret(yaml: string, line: number): string | null {
   const lines = yaml.split("\n");
   // Validate the target still holds a key so a stale index can't delete an
   // unrelated comment / blank / other line.
-  if (line < 0 || line >= lines.length || !matchTopLevelKey(lines[line])) return null;
+  if (line < 0 || line >= lines.length || !TOP_LEVEL_KEY.test(lines[line])) return null;
   lines.splice(line, 1);
   return lines.join("\n");
 }
@@ -194,12 +189,13 @@ function hasIndentedChild(lines: string[], index: number): boolean {
 function rewriteLine(
   yaml: string,
   line: number,
-  build: (key: string, value: string, comment: string, quote: string) => string
+  build: (key: string, quote: string, value: string, comment: string) => string
 ): string | null {
   const lines = yaml.split("\n");
-  const match = matchTopLevelKey(lines[line]);
+  const match = lines[line]?.match(TOP_LEVEL_KEY);
   if (!match) return null;
-  const { value, comment } = splitInlineComment(match.rest ?? "");
-  lines[line] = build(match.key, value, comment, match.quote);
+  const [, quote = "", quoted, bare, rest] = match;
+  const { value, comment } = splitInlineComment(rest ?? "");
+  lines[line] = build(quoted ?? bare, quote, value, comment);
   return lines.join("\n");
 }

--- a/src/util/secrets-entries.ts
+++ b/src/util/secrets-entries.ts
@@ -8,11 +8,7 @@
 
 import { secretHostSlug } from "./secret-eligibility.js";
 import { escapeYamlDoubleQuoted } from "./yaml-escape.js";
-import {
-  splitInlineComment,
-  splitTrimmedInlineComment,
-  stripQuotes,
-} from "./yaml-scalar.js";
+import { splitTrimmedInlineComment, stripQuotes } from "./yaml-scalar.js";
 import { formatYamlScalar } from "./yaml-serialize.js";
 
 export interface SecretEntry {
@@ -125,7 +121,13 @@ export function parseSecretsEntries(yaml: string): SecretEntry[] {
     const { value, editable } = readValue(rest, lines, i);
     // A key the form can't write back (``<<``, a quoted key outside the
     // identifier charset) is shown read-only like other advanced rows.
-    entries.push({ key, line: i, value, editable: editable && isValidSecretKey(key) });
+    const writable = isValidSecretKey(key);
+    entries.push({
+      key,
+      line: i,
+      value: writable ? value : "",
+      editable: editable && writable,
+    });
   }
   return entries;
 }
@@ -174,12 +176,12 @@ function readValue(
   lines: string[],
   index: number
 ): { value: string; editable: boolean } {
-  const { value } = splitInlineComment(rest ?? "");
+  const { value } = splitTrimmedInlineComment(rest ?? "");
   const trimmed = value.trim();
   // A bare ``key:`` or a comment-only value (``key: # note``) is an editable
   // empty scalar unless an indented block sits below it, which makes it
   // advanced — editing it inline would orphan the nested children.
-  if (trimmed === "" || trimmed.startsWith("#")) {
+  if (trimmed === "") {
     return { value: "", editable: !hasIndentedChild(lines, index) };
   }
   if (ADVANCED_VALUE_START.test(trimmed)) return { value: "", editable: false };

--- a/src/util/secrets-entries.ts
+++ b/src/util/secrets-entries.ts
@@ -38,10 +38,22 @@ export interface SecretGroup {
 // are indented and never match, so a parent with a block value is left
 // to the advanced (read-only) path. ``<<`` matches so an HA-style merge
 // key surfaces as an advanced row rather than vanishing, and so does a
-// quoted key (``"wifi_password":``). Groups: quote, quoted name, bare
-// name, rest.
+// quoted key (``"wifi_password":``). Groups: double-quoted name,
+// single-quoted name, bare name, rest.
 const TOP_LEVEL_KEY =
-  /^(?:(["'])([^"'\n]+)\1|(<<|[A-Za-z_][A-Za-z0-9_.\-]*)):(?:[ \t]+([^\n]*))?$/;
+  /^(?:"([^"\n]+)"|'([^'\n]+)'|(<<|[A-Za-z_][A-Za-z0-9_.\-]*)):(?:[ \t]+([^\n]*))?$/;
+
+/** The key, its source quote (``"``, ``'`` or ``""``) and the rest of a matched line. */
+function keyParts(match: RegExpMatchArray): {
+  key: string;
+  quote: string;
+  rest?: string;
+} {
+  const [, dq, sq, bare, rest] = match;
+  if (dq !== undefined) return { key: dq, quote: '"', rest };
+  if (sq !== undefined) return { key: sq, quote: "'", rest };
+  return { key: bare, quote: "", rest };
+}
 
 const VALID_KEY = /^[A-Za-z_][A-Za-z0-9_.\-]*$/;
 
@@ -109,17 +121,11 @@ export function parseSecretsEntries(yaml: string): SecretEntry[] {
   for (let i = 0; i < lines.length; i++) {
     const match = lines[i].match(TOP_LEVEL_KEY);
     if (!match) continue;
-    const [, , quoted, bare, rest] = match;
-    const key = quoted ?? bare;
+    const { key, rest } = keyParts(match);
     const { value, editable } = readValue(rest, lines, i);
-    // A quoted key outside the identifier charset can't be renamed or
-    // rewritten by the form; show it read-only like other advanced rows.
-    entries.push({
-      key,
-      line: i,
-      value,
-      editable: editable && (!quoted || VALID_KEY.test(key)),
-    });
+    // A key the form can't write back (``<<``, a quoted key outside the
+    // identifier charset) is shown read-only like other advanced rows.
+    entries.push({ key, line: i, value, editable: editable && isValidSecretKey(key) });
   }
   return entries;
 }
@@ -197,9 +203,9 @@ function rewriteLine(
   const lines = yaml.split("\n");
   const match = lines[line]?.match(TOP_LEVEL_KEY);
   if (!match) return null;
-  const [, quote = "", quoted, bare, rest] = match;
+  const { key, quote, rest } = keyParts(match);
   // The regex ate the separator, so a comment-only value arrives as ``# note``.
   const { value, comment } = splitTrimmedInlineComment(rest ?? "");
-  lines[line] = build(quoted ?? bare, quote, value, comment);
+  lines[line] = build(key, quote, value, comment);
   return lines.join("\n");
 }

--- a/src/util/secrets-entries.ts
+++ b/src/util/secrets-entries.ts
@@ -34,10 +34,11 @@ export interface SecretGroup {
 // are indented and never match, so a parent with a block value is left
 // to the advanced (read-only) path. ``<<`` matches so an HA-style merge
 // key surfaces as an advanced row rather than vanishing, and so does a
-// quoted key (``"wifi_password":``). Groups: double-quoted name,
-// single-quoted name, bare name, rest.
+// quoted key (``"wifi_password":``); an escaped quote inside the name is
+// kept verbatim (such a key is read-only anyway). Groups: double-quoted
+// name, single-quoted name, bare name, rest.
 const TOP_LEVEL_KEY =
-  /^(?:"([^"\n]+)"|'([^'\n]+)'|(<<|[A-Za-z_][A-Za-z0-9_.\-]*)):(?:[ \t]+([^\n]*))?$/;
+  /^(?:"((?:[^"\\\n]|\\.)+)"|'((?:[^'\n]|'')+)'|(<<|[A-Za-z_][A-Za-z0-9_.\-]*)):(?:[ \t]+([^\n]*))?$/;
 
 /** The key, its source quote (``"``, ``'`` or ``""``) and the rest of a matched line. */
 function keyParts(match: RegExpMatchArray): {

--- a/test/util/secret-eligibility.test.ts
+++ b/test/util/secret-eligibility.test.ts
@@ -248,6 +248,7 @@ describe("visibleSecretKeys", () => {
 describe("secretValueFromYaml", () => {
   it("reads a quoted top-level key", () => {
     expect(secretValueFromYaml('"wifi_ssid": home\n', "wifi_ssid")).toBe("home");
+    expect(secretValueFromYaml("'wifi_ssid': home\n", "wifi_ssid")).toBe("home");
   });
 
   const secrets = [

--- a/test/util/secret-eligibility.test.ts
+++ b/test/util/secret-eligibility.test.ts
@@ -246,6 +246,10 @@ describe("visibleSecretKeys", () => {
 });
 
 describe("secretValueFromYaml", () => {
+  it("reads a quoted top-level key", () => {
+    expect(secretValueFromYaml('"wifi_ssid": home\n', "wifi_ssid")).toBe("home");
+  });
+
   const secrets = [
     "# secrets",
     'wifi_ssid: "my ssid"',

--- a/test/util/secrets-entries.test.ts
+++ b/test/util/secrets-entries.test.ts
@@ -248,7 +248,7 @@ describe("quoted top-level keys", () => {
     ]);
   });
 
-  test("outside the identifier charset surface as read-only rows", () => {
+  test("a key outside the identifier charset surfaces as a read-only row", () => {
     const [entry] = parseSecretsEntries('"wifi password": a\n');
     expect([entry.key, entry.editable]).toEqual(["wifi password", false]);
   });

--- a/test/util/secrets-entries.test.ts
+++ b/test/util/secrets-entries.test.ts
@@ -241,20 +241,19 @@ describe("duplicateSecretKeys", () => {
 
 describe("quoted top-level keys", () => {
   test("parse as rows keyed by the bare name", () => {
-    const entries = parseSecretsEntries("\"wifi_password\": a\n'api_key': b\nplain: c\n");
+    const entries = parseSecretsEntries("\"wifi_password\": a\n'api_key': b\n");
     expect(entries.map((e) => [e.key, e.value, e.editable])).toEqual([
       ["wifi_password", "a", true],
       ["api_key", "b", true],
-      ["plain", "c", true],
     ]);
   });
 
-  test("count toward duplicate detection", () => {
-    const entries = parseSecretsEntries('"wifi_password": a\nwifi_password: b\n');
-    expect([...duplicateSecretKeys(entries)]).toEqual(["wifi_password"]);
+  test("outside the identifier charset surface as read-only rows", () => {
+    const [entry] = parseSecretsEntries('"wifi password": a\n');
+    expect([entry.key, entry.editable]).toEqual(["wifi password", false]);
   });
 
-  test("keep their quoting when the value or key is rewritten", () => {
+  test("rewrites and removal target the quoted line and keep its quoting", () => {
     const yaml = '"wifi_password": a  # note\n';
     expect(setSecretValue(yaml, 0, "new")).toBe('"wifi_password": new  # note\n');
     expect(renameSecretKey(yaml, 0, "wifi_psk")).toBe('"wifi_psk": a  # note\n');

--- a/test/util/secrets-entries.test.ts
+++ b/test/util/secrets-entries.test.ts
@@ -238,3 +238,30 @@ describe("duplicateSecretKeys", () => {
     expect(duplicateSecretKeys(parseSecretsEntries("a: 1\nb: 2\n")).size).toBe(0);
   });
 });
+
+describe("quoted top-level keys", () => {
+  test("parse as rows keyed by the bare name", () => {
+    const entries = parseSecretsEntries("\"wifi_password\": a\n'api_key': b\nplain: c\n");
+    expect(entries.map((e) => [e.key, e.value, e.editable])).toEqual([
+      ["wifi_password", "a", true],
+      ["api_key", "b", true],
+      ["plain", "c", true],
+    ]);
+  });
+
+  test("count toward duplicate detection", () => {
+    const entries = parseSecretsEntries('"wifi_password": a\nwifi_password: b\n');
+    expect([...duplicateSecretKeys(entries)]).toEqual(["wifi_password"]);
+  });
+
+  test("keep their quoting when the value or key is rewritten", () => {
+    const yaml = '"wifi_password": a  # note\n';
+    expect(setSecretValue(yaml, 0, "new")).toBe('"wifi_password": new  # note\n');
+    expect(renameSecretKey(yaml, 0, "wifi_psk")).toBe('"wifi_psk": a  # note\n');
+    expect(removeSecret(yaml, 0)).toBe("");
+  });
+
+  test("mismatched quotes are not a key line", () => {
+    expect(parseSecretsEntries('"wifi_password: a\n')).toEqual([]);
+  });
+});

--- a/test/util/secrets-entries.test.ts
+++ b/test/util/secrets-entries.test.ts
@@ -240,10 +240,10 @@ describe("duplicateSecretKeys", () => {
 });
 
 describe("quoted top-level keys", () => {
-  test("parse as rows keyed by the bare name", () => {
-    const entries = parseSecretsEntries("\"wifi_password\": a\n'api_key': b\n");
+  test("parse as rows keyed by the bare name, values unquoted", () => {
+    const entries = parseSecretsEntries("\"wifi_password\": 'a b'\n'api_key': b\n");
     expect(entries.map((e) => [e.key, e.value, e.editable])).toEqual([
-      ["wifi_password", "a", true],
+      ["wifi_password", "a b", true],
       ["api_key", "b", true],
     ]);
   });
@@ -258,11 +258,12 @@ describe("quoted top-level keys", () => {
     expect([...duplicateSecretKeys(entries)]).toEqual(["wifi_password"]);
   });
 
-  test("may contain the other quote character and a quoted value", () => {
+  test("may contain the other quote character", () => {
     const entries = parseSecretsEntries("\"don't\": 'a b'\n'say \"hi\"': x\n");
+    // Read-only rows carry no value, per the SecretEntry contract.
     expect(entries.map((e) => [e.key, e.value, e.editable])).toEqual([
-      ["don't", "a b", false],
-      ['say "hi"', "x", false],
+      ["don't", "", false],
+      ['say "hi"', "", false],
     ]);
   });
 

--- a/test/util/secrets-entries.test.ts
+++ b/test/util/secrets-entries.test.ts
@@ -253,6 +253,19 @@ describe("quoted top-level keys", () => {
     expect([entry.key, entry.editable]).toEqual(["wifi password", false]);
   });
 
+  test("a quoted key duplicates its bare spelling", () => {
+    const entries = parseSecretsEntries('wifi_password: a\n"wifi_password": b\n');
+    expect([...duplicateSecretKeys(entries)]).toEqual(["wifi_password"]);
+  });
+
+  test("may contain the other quote character and a quoted value", () => {
+    const entries = parseSecretsEntries("\"don't\": 'a b'\n'say \"hi\"': x\n");
+    expect(entries.map((e) => [e.key, e.value, e.editable])).toEqual([
+      ["don't", "a b", false],
+      ['say "hi"', "x", false],
+    ]);
+  });
+
   test("rewrites and removal target the quoted line and keep its quoting", () => {
     const yaml = '"wifi_password": a  # note\n';
     expect(setSecretValue(yaml, 0, "new")).toBe('"wifi_password": new  # note\n');

--- a/test/util/secrets-entries.test.ts
+++ b/test/util/secrets-entries.test.ts
@@ -258,6 +258,23 @@ describe("quoted top-level keys", () => {
     expect([...duplicateSecretKeys(entries)]).toEqual(["wifi_password"]);
   });
 
+  test("a bare merge key is read-only too", () => {
+    expect(parseSecretsEntries("<<:\n")[0]).toMatchObject({ key: "<<", editable: false });
+  });
+
+  test("with an escaped quote surface read-only, name kept verbatim", () => {
+    const entries = parseSecretsEntries("'wifi''s': a\n\"a\\\"b\": c\n");
+    expect(entries.map((e) => [e.key, e.editable])).toEqual([
+      ["wifi''s", false],
+      ['a\\"b', false],
+    ]);
+  });
+
+  test("single-quoted keys round-trip rewrites too", () => {
+    expect(setSecretValue("'api_key': a\n", 0, "b")).toBe("'api_key': b\n");
+    expect(renameSecretKey("'api_key': a\n", 0, "token")).toBe("'token': a\n");
+  });
+
   test("may contain the other quote character", () => {
     const entries = parseSecretsEntries("\"don't\": 'a b'\n'say \"hi\"': x\n");
     // Read-only rows carry no value, per the SecretEntry contract.

--- a/test/util/secrets-entries.test.ts
+++ b/test/util/secrets-entries.test.ts
@@ -260,6 +260,13 @@ describe("quoted top-level keys", () => {
     expect(removeSecret(yaml, 0)).toBe("");
   });
 
+  test("a comment-only value keeps its comment through a rewrite", () => {
+    expect(setSecretValue("wifi_ssid: # note\n", 0, "home")).toBe(
+      "wifi_ssid: home # note\n"
+    );
+    expect(renameSecretKey("wifi_ssid: # note\n", 0, "ssid")).toBe("ssid: # note\n");
+  });
+
   test("mismatched quotes are not a key line", () => {
     expect(parseSecretsEntries('"wifi_password: a\n')).toEqual([]);
   });


### PR DESCRIPTION
# What does this implement/fix?

Follow-up deferred from #1673. The structured secrets editor's line parser only recognised bare `key:` lines, so a quoted top-level key (`"wifi_password": a`, valid YAML that ESPHome resolves like any other) never showed up as a row, and a duplicate of a bare key spelled that way got no hint. The parser now accepts `"key":` / `'key':` with the same identifier charset, the row's key is the bare name (so duplicate detection and rename collisions see it), and value edits or renames keep the source quoting; a quoted key outside the identifier charset (`"wifi password":`) surfaces as a read-only row instead of vanishing; mismatched quotes are still not a key line. The secret picker's `secretValueFromYaml` reads a quoted key too, so "show value" and "revert to manual" resolve for such a key.

**Related issue or feature (if applicable):**

- related: #1673 (deferred review note), esphome/device-builder#2622

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
