### PR TITLE
Render the stamped receiver esphome version verbatim in the build sub-line

### DIFF
--- a/src/api/types/firmware-jobs.ts
+++ b/src/api/types/firmware-jobs.ts
@@ -92,12 +92,9 @@ export interface FirmwareJob {
    *  track later renames (the install dialog should show what the
    *  user saw when they clicked Install). */
   source_label: string;
-  /** Receiver's installed ``esphome`` version, snapshotted at
-   *  job-creation time only when the receiver builds with it instead
-   *  of ours. Empty for LOCAL jobs, same-version receivers, receivers
-   *  that provision our version into a venv, and pairings that hadn't
-   *  yet completed a peer-link session. Rendered next to
-   *  ``source_label`` so the operator can spot a real version skew. */
+  /** The receiver's ``esphome`` when it compiles with its own instead
+   *  of ours; empty otherwise (LOCAL, same version, or the receiver
+   *  provisions ours into a venv). */
   source_esphome_version: string;
   /** Offloader's ``dashboard_id`` when this job came in via the
    *  peer-link ``submit_job`` flow. Empty for locally-submitted

--- a/src/api/types/firmware-jobs.ts
+++ b/src/api/types/firmware-jobs.ts
@@ -93,8 +93,8 @@ export interface FirmwareJob {
    *  user saw when they clicked Install). */
   source_label: string;
   /** The receiver's ``esphome`` when it compiles with its own instead
-   *  of ours; empty otherwise (LOCAL, same version, or the receiver
-   *  provisions ours into a venv). */
+   *  of ours; empty otherwise (LOCAL, same version, the receiver
+   *  provisions ours into a venv, or its version isn't known yet). */
   source_esphome_version: string;
   /** Offloader's ``dashboard_id`` when this job came in via the
    *  peer-link ``submit_job`` flow. Empty for locally-submitted

--- a/src/api/types/firmware-jobs.ts
+++ b/src/api/types/firmware-jobs.ts
@@ -92,13 +92,12 @@ export interface FirmwareJob {
    *  track later renames (the install dialog should show what the
    *  user saw when they clicked Install). */
   source_label: string;
-  /** Receiver's bundled ``esphome`` version at job-creation time,
-   *  snapshotted from the pairing's last-known
-   *  ``esphome_version``. Empty for LOCAL jobs and for REMOTE jobs
-   *  whose pairing hadn't yet completed a peer-link session. The
-   *  install dialog renders this next to ``source_label`` so the
-   *  operator can spot a version skew between the offloader and
-   *  the receiver actually compiling the firmware. */
+  /** Receiver's installed ``esphome`` version, snapshotted at
+   *  job-creation time only when the receiver builds with it instead
+   *  of ours. Empty for LOCAL jobs, same-version receivers, receivers
+   *  that provision our version into a venv, and pairings that hadn't
+   *  yet completed a peer-link session. Rendered next to
+   *  ``source_label`` so the operator can spot a real version skew. */
   source_esphome_version: string;
   /** Offloader's ``dashboard_id`` when this job came in via the
    *  peer-link ``submit_job`` flow. Empty for locally-submitted

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -4,7 +4,10 @@ import { activeLocale } from "../../common/localize.js";
 import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
 import { formatElapsed } from "../../util/format-job-time.js";
-import { pairingDisplayNameForPin } from "../../util/pairing-display-name.js";
+import {
+  jobBuildServerDisplay,
+  pairingDisplayNameForPin,
+} from "../../util/pairing-display-name.js";
 import type { ESPHomeCommandDialog } from "../command-dialog.js";
 import {
   renderOffloadHint,
@@ -35,16 +38,15 @@ export function renderRemoteBuilderSubLine(
   const source = liveJob?.source ?? host._primedSource?.source;
   const label = liveJob?.source_label ?? host._primedSource?.source_label;
   if (source !== JobSource.REMOTE || !label) return nothing;
-  // source_esphome_version is also a job-creation-time snapshot; the backend
-  // stamps it only when the receiver builds with its own esphome instead of
-  // ours, so a non-empty value is always the version that builds the firmware.
-  const version =
-    liveJob?.source_esphome_version ?? host._primedSource?.source_esphome_version ?? "";
   const pin = liveJob?.source_pin_sha256 ?? host._primedSource?.source_pin_sha256 ?? "";
   // The live pairing's display name (handshake friendly name, rename-aware)
   // wins over the job's creation-time source_label snapshot.
-  const name = pairingDisplayNameForPin(host._pairings, pin, label);
-  const display = version ? `${name} (${version})` : name;
+  const display = jobBuildServerDisplay(host._pairings, {
+    source_pin_sha256: pin,
+    source_label: label,
+    source_esphome_version:
+      liveJob?.source_esphome_version ?? host._primedSource?.source_esphome_version ?? "",
+  });
   // Only allow override for an in-flight install chain — a deferred install
   // (offline_compile) is the same chain head and keeps the link it had when
   // it derived "install". Switching a plain compile has no UI today.

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -5,7 +5,6 @@ import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
 import { formatElapsed } from "../../util/format-job-time.js";
 import { pairingDisplayNameForPin } from "../../util/pairing-display-name.js";
-import { isPinnableVersion } from "../../util/version-mismatch.js";
 import type { ESPHomeCommandDialog } from "../command-dialog.js";
 import {
   renderOffloadHint,
@@ -36,20 +35,12 @@ export function renderRemoteBuilderSubLine(
   const source = liveJob?.source ?? host._primedSource?.source;
   const label = liveJob?.source_label ?? host._primedSource?.source_label;
   if (source !== JobSource.REMOTE || !label) return nothing;
-  // source_esphome_version is also a job-creation-time snapshot; empty when
-  // the pairing hadn't completed a peer-link session yet. Render "<label>
-  // (<version>)" with the version that actually builds the firmware: a
-  // receiver that auto-provisions a mismatch compiles with this
-  // dashboard's own esphome in a venv, not its installed one.
-  const receiverVersion =
+  // source_esphome_version is also a job-creation-time snapshot; the backend
+  // stamps it only when the receiver builds with its own esphome instead of
+  // ours, so a non-empty value is always the version that builds the firmware.
+  const version =
     liveJob?.source_esphome_version ?? host._primedSource?.source_esphome_version ?? "";
   const pin = liveJob?.source_pin_sha256 ?? host._primedSource?.source_pin_sha256 ?? "";
-  const buildsLocalVersion =
-    receiverVersion !== "" &&
-    receiverVersion !== host._appVersion &&
-    isPinnableVersion(host._appVersion) &&
-    (host._pairings?.get(pin)?.auto_provision_supported ?? false);
-  const version = buildsLocalVersion ? host._appVersion : receiverVersion;
   // The live pairing's display name (handshake friendly name, rename-aware)
   // wins over the job's creation-time source_label snapshot.
   const name = pairingDisplayNameForPin(host._pairings, pin, label);

--- a/src/components/shared/firmware-jobs-list.ts
+++ b/src/components/shared/firmware-jobs-list.ts
@@ -11,8 +11,8 @@ import { firmwareJobTypeLabel } from "../../util/firmware-job-display.js";
 import { isTerminalJob as isTerminal } from "../../util/firmware-job-status.js";
 import { formatAbsoluteTime, formatRelativeTime } from "../../util/format-job-time.js";
 import {
+  jobBuildServerDisplay,
   jobPeerDisplayName,
-  pairingDisplayNameForPin,
 } from "../../util/pairing-display-name.js";
 
 /**
@@ -182,7 +182,7 @@ function renderRowAction(host: FirmwareJobsListHost, job: FirmwareJob): Template
 }
 
 // Names the build server from the live pairing (rename-aware, handshake
-// friendly name) via pairingDisplayNameForPin, falling back to the job's
+// friendly name) via jobBuildServerDisplay, falling back to the job's
 // creation-time source_label snapshot when the pairing is gone. Symmetric
 // receiver-side rendering: when remote_peer is set, the job was submitted
 // from another dashboard's offloader.
@@ -193,18 +193,10 @@ export function renderSourceLine(
   job: FirmwareJob
 ): TemplateResult | typeof nothing {
   if (job.source === JobSource.REMOTE && job.source_label) {
-    const name = pairingDisplayNameForPin(
-      host._pairings,
-      job.source_pin_sha256,
-      job.source_label
-    );
-    const display = job.source_esphome_version
-      ? `${name} (${job.source_esphome_version})`
-      : name;
     return html`
       <div class="job-source">
         ${host._localize("firmware_jobs.building_on", {
-          label: display,
+          label: jobBuildServerDisplay(host._pairings, job),
         })}
       </div>
     `;

--- a/src/util/pairing-display-name.ts
+++ b/src/util/pairing-display-name.ts
@@ -63,6 +63,22 @@ export function pairingDisplayNameForPin(
 }
 
 /**
+ * "Building on" text for a REMOTE job: the server's display name, with
+ * the stamped `source_esphome_version` in parentheses when present.
+ */
+export function jobBuildServerDisplay(
+  pairings: Map<string, PairingSummary> | null | undefined,
+  job: Pick<FirmwareJob, "source_pin_sha256" | "source_label" | "source_esphome_version">
+): string {
+  const name = pairingDisplayNameForPin(
+    pairings,
+    job.source_pin_sha256,
+    job.source_label
+  );
+  return job.source_esphome_version ? `${name} (${job.source_esphome_version})` : name;
+}
+
+/**
  * Display name for a paired offloader (receiver side).
  *
  * The receiver can't derive "was this label auto-prefilled" from a

--- a/test/components/command-dialog-remote-sub-line.test.ts
+++ b/test/components/command-dialog-remote-sub-line.test.ts
@@ -1,9 +1,8 @@
 // @vitest-environment happy-dom
 //
 // Pins the "Building on <receiver> (<version>)" sub-line: the version
-// shown is the one that actually builds — the receiver's installed
-// esphome normally, this dashboard's own when the receiver
-// auto-provisions a mismatch.
+// renders verbatim from source_esphome_version, which the backend stamps
+// only when the receiver builds with its own esphome instead of ours.
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -40,7 +39,7 @@ function makePairing(auto: boolean): PairingSummary {
 
 function makeHost(opts: {
   auto: boolean;
-  localVersion?: string;
+  sourceVersion?: string;
   commandType?: string;
 }): ESPHomeCommandDialog {
   return {
@@ -51,32 +50,28 @@ function makeHost(opts: {
     _primedSource: {
       source: JobSource.REMOTE,
       source_label: "builder",
-      source_esphome_version: "2026.6.5",
+      source_esphome_version: opts.sourceVersion ?? "2026.6.5",
       source_pin_sha256: PIN,
     },
     _pairings: new Map([[PIN, makePairing(opts.auto)]]),
-    _appVersion: opts.localVersion ?? "2026.7.0b2",
+    _appVersion: "2026.7.0b2",
     _commandType: opts.commandType ?? "compile",
     _switchingToLocal: false,
   } as unknown as ESPHomeCommandDialog;
 }
 
 describe("renderRemoteBuilderSubLine version", () => {
-  it("shows the local version when the receiver auto-provisions the mismatch", () => {
+  it("renders the stamped version verbatim, ignoring the pairing's provisioning", () => {
     const el = renderInto(renderRemoteBuilderSubLine(makeHost({ auto: true })));
-    expect(el.textContent).toContain("builder (2026.7.0b2)");
-  });
-
-  it("shows the receiver's version when it can't auto-provision", () => {
-    const el = renderInto(renderRemoteBuilderSubLine(makeHost({ auto: false })));
     expect(el.textContent).toContain("builder (2026.6.5)");
   });
 
-  it("shows the receiver's version for a dev local build (unprovisionable)", () => {
+  it("renders just the receiver name when no version is stamped", () => {
     const el = renderInto(
-      renderRemoteBuilderSubLine(makeHost({ auto: true, localVersion: "2026.8.0-dev" }))
+      renderRemoteBuilderSubLine(makeHost({ auto: true, sourceVersion: "" }))
     );
-    expect(el.textContent).toContain("builder (2026.6.5)");
+    expect(el.textContent).toContain("builder");
+    expect(el.textContent).not.toContain("(");
   });
 
   it("offers Build locally for a reopened remote deferred install", () => {

--- a/test/components/command-dialog-remote-sub-line.test.ts
+++ b/test/components/command-dialog-remote-sub-line.test.ts
@@ -16,7 +16,7 @@ import { renderRemoteBuilderSubLine } from "../../src/components/command-dialog/
 
 const PIN = "a".repeat(64);
 
-function makePairing(auto: boolean): PairingSummary {
+function makePairing(): PairingSummary {
   return {
     receiver_hostname: "esphome-builder-x.local",
     receiver_port: 6055,
@@ -29,7 +29,7 @@ function makePairing(auto: boolean): PairingSummary {
     last_connect_error: "",
     esphome_version: "2026.6.5",
     enabled: true,
-    auto_provision_supported: auto,
+    auto_provision_supported: false,
     friendly_name: "",
     ha_addon: false,
     reset_build_env_supported: false,
@@ -37,11 +37,9 @@ function makePairing(auto: boolean): PairingSummary {
   };
 }
 
-function makeHost(opts: {
-  auto: boolean;
-  sourceVersion?: string;
-  commandType?: string;
-}): ESPHomeCommandDialog {
+function makeHost(
+  opts: { sourceVersion?: string; commandType?: string } = {}
+): ESPHomeCommandDialog {
   return {
     _localize: (key: string, values?: Record<string, unknown>) =>
       values ? `${key}:${JSON.stringify(values)}` : key,
@@ -53,45 +51,40 @@ function makeHost(opts: {
       source_esphome_version: opts.sourceVersion ?? "2026.6.5",
       source_pin_sha256: PIN,
     },
-    _pairings: new Map([[PIN, makePairing(opts.auto)]]),
-    _appVersion: "2026.7.0b2",
+    _pairings: new Map([[PIN, makePairing()]]),
     _commandType: opts.commandType ?? "compile",
     _switchingToLocal: false,
   } as unknown as ESPHomeCommandDialog;
 }
 
 describe("renderRemoteBuilderSubLine version", () => {
-  it("renders the stamped version verbatim, ignoring the pairing's provisioning", () => {
-    const el = renderInto(renderRemoteBuilderSubLine(makeHost({ auto: true })));
+  it("renders the stamped version", () => {
+    const el = renderInto(renderRemoteBuilderSubLine(makeHost()));
     expect(el.textContent).toContain("builder (2026.6.5)");
   });
 
   it("renders just the receiver name when no version is stamped", () => {
-    const el = renderInto(
-      renderRemoteBuilderSubLine(makeHost({ auto: true, sourceVersion: "" }))
-    );
+    const el = renderInto(renderRemoteBuilderSubLine(makeHost({ sourceVersion: "" })));
     expect(el.textContent).toContain("builder");
     expect(el.textContent).not.toContain("(");
   });
 
   it("offers Build locally for a reopened remote deferred install", () => {
     const el = renderInto(
-      renderRemoteBuilderSubLine(
-        makeHost({ auto: false, commandType: "offline_compile" })
-      )
+      renderRemoteBuilderSubLine(makeHost({ commandType: "offline_compile" }))
     );
     expect(el.querySelector(".force-local-link")).not.toBeNull();
   });
 
   it("keeps the override hidden for a plain compile", () => {
-    const el = renderInto(renderRemoteBuilderSubLine(makeHost({ auto: false })));
+    const el = renderInto(renderRemoteBuilderSubLine(makeHost()));
     expect(el.querySelector(".force-local-link")).toBeNull();
   });
 
   it("prefers the pairing's friendly name over the auto-derived snapshot label", () => {
-    const host = makeHost({ auto: false });
+    const host = makeHost();
     const pairing = {
-      ...makePairing(false),
+      ...makePairing(),
       label: "esphome-builder-x",
       friendly_name: "Nicks-Mac-Studio",
       receiver_label_auto: true,

--- a/test/components/command-dialog-remote-sub-line.test.ts
+++ b/test/components/command-dialog-remote-sub-line.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 //
-// Pins the "Building on <receiver> (<version>)" sub-line: the version
-// renders verbatim from source_esphome_version, which the backend stamps
-// only when the receiver builds with its own esphome instead of ours.
+// Pins the "Building on <receiver>" sub-line: source_esphome_version, which
+// the backend stamps only when the receiver builds with its own esphome
+// instead of ours, renders as a "(<version>)" suffix when present.
 
 import { describe, expect, it, vi } from "vitest";
 

--- a/test/util/pairing-display-name.test.ts
+++ b/test/util/pairing-display-name.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { PairingSummary, PeerSummary } from "../../src/api/types/remote-build.js";
 import {
+  jobBuildServerDisplay,
   jobPeerDisplayName,
   offloaderSelfLabel,
   pairingDisplayName,
@@ -96,6 +97,20 @@ describe("pairingDisplayNameForPin", () => {
       "snapshot"
     );
     expect(pairingDisplayNameForPin(null, undefined, "snapshot")).toBe("snapshot");
+  });
+});
+
+describe("jobBuildServerDisplay", () => {
+  it("appends the stamped version to the resolved name", () => {
+    const p = pairing({ receiver_label_auto: true, friendly_name: "Nicks-Mac-Studio" });
+    const map = new Map([[p.pin_sha256, p]]);
+    const job = { source_pin_sha256: p.pin_sha256, source_label: "snapshot" };
+    expect(
+      jobBuildServerDisplay(map, { ...job, source_esphome_version: "2026.8.0" })
+    ).toBe("Nicks-Mac-Studio (2026.8.0)");
+    expect(jobBuildServerDisplay(map, { ...job, source_esphome_version: "" })).toBe(
+      "Nicks-Mac-Studio"
+    );
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#2628. The backend now stamps `source_esphome_version` on a remote job only when the receiver builds with its own esphome instead of ours, so the install dialog's "Building on <receiver> (<version>)" sub-line no longer needs to guess whether the pairing will provision a venv. The `buildsLocalVersion` branch in `renderers.ts` is removed; the stamped version renders verbatim, or just the receiver name when it is empty. The wire type comment is updated to match, and the sub-line tests pin the new contract.

**Related issue or feature (if applicable):**

- fixes N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
