### PR TITLE
Count text search matches in the table view device count

### DIFF
--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -2,6 +2,7 @@ import type { ColumnVisibilityState, SortingState } from "@tanstack/lit-table";
 import { html, type TemplateResult } from "lit";
 import type { AdoptableDevice, ConfiguredDevice } from "../../api/types/devices.js";
 import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
+import { matchesDeviceSearch } from "../../util/device-filter.js";
 import {
   DEVICE_SORT_COLLATOR,
   deviceSortKey,
@@ -175,10 +176,15 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
   // Sorted input so the no-column-sort default matches the card grid's
   // collator order instead of the backend's path order (#1917); an active
   // column sort still re-sorts on top.
-  const filteredDevices = includeTourDevice(
-    host._applyFacetFilters(host._sortedDevices),
-    host._sortedDevices
-  );
+  const facetFiltered = host._applyFacetFilters(host._sortedDevices);
+  const filteredDevices = includeTourDevice(facetFiltered, host._sortedDevices);
+  // The table applies the text search itself (device-table.ts
+  // _globalFilterFn), so the count row has to re-run the same predicate
+  // over the facet list or it only reflects the facets (device-builder#2627).
+  const q = host._search.trim().toLowerCase();
+  const matchCount = q
+    ? facetFiltered.filter((d) => matchesDeviceSearch(d, q, true)).length
+    : facetFiltered.length;
   return html`
     <esphome-device-table
       .devices=${filteredDevices}
@@ -239,7 +245,7 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
         </div>
       </div>
       <div slot="below-controls" class="table-device-count-row">
-        ${renderDeviceCountRow(host, filteredDevices.length, host._devices.length)}
+        ${renderDeviceCountRow(host, matchCount, host._devices.length)}
       </div>
       <button
         ${tourAnchor("create-device-fab")}

--- a/test/components/dashboard/render-table-device-count.test.ts
+++ b/test/components/dashboard/render-table-device-count.test.ts
@@ -5,7 +5,7 @@
  * as the facets. The table applies the search inside its own global
  * filter, so the count used to reflect facets only (device-builder#2627).
  */
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
@@ -14,6 +14,11 @@ import { makeConfiguredDevice } from "../../_make-configured-device.js";
 import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
 import { DashboardView } from "../../../src/api/types/system.js";
 import { renderTable } from "../../../src/components/dashboard/render-content.js";
+import {
+  clearTourConfiguration,
+  setTourActive,
+  setTourConfiguration,
+} from "../../../src/components/guided-tour/tour-session.js";
 import { makeTableHost } from "./_host.js";
 
 const DEVICES = [
@@ -55,6 +60,11 @@ function countRow(host: ReturnType<typeof makeHost>): { count: string; text: str
   };
 }
 
+afterEach(() => {
+  setTourActive(false);
+  clearTourConfiguration();
+});
+
 describe("renderTable device count", () => {
   it("counts every facet-visible device when the search is empty", () => {
     const row = countRow(makeHost());
@@ -81,5 +91,19 @@ describe("renderTable device count", () => {
     // "Servion" matches, "Garland" doesn't; "ECU Boiler" is hidden by
     // the facet before the search runs.
     expect(countRow(host).count).toBe("1");
+  });
+
+  it("leaves the forced guided-tour row out of the count", () => {
+    // The table keeps the tour target visible even when it doesn't match
+    // the search; the count mirrors the card view and only counts matches.
+    setTourConfiguration("garland.yaml");
+    setTourActive(true);
+    const host = makeHost({ _search: "ecu" });
+    const container = renderInto(renderTable(host));
+    const table = container.querySelector("esphome-device-table") as unknown as {
+      devices: ConfiguredDevice[];
+    };
+    expect(table.devices.map((d) => d.configuration)).toContain("garland.yaml");
+    expect(container.querySelector(".device-count strong")!.textContent).toBe("1");
   });
 });

--- a/test/components/dashboard/render-table-device-count.test.ts
+++ b/test/components/dashboard/render-table-device-count.test.ts
@@ -94,11 +94,16 @@ describe("renderTable device count", () => {
   });
 
   it("leaves the forced guided-tour row out of the count", () => {
-    // The table keeps the tour target visible even when it doesn't match
+    // The facets drop the tour target and includeTourDevice puts it back
+    // for the table, which also keeps it visible when it doesn't match
     // the search; the count mirrors the card view and only counts matches.
     setTourConfiguration("garland.yaml");
     setTourActive(true);
-    const host = makeHost({ _search: "ecu" });
+    const host = makeHost({
+      _search: "ecu",
+      _applyFacetFilters: (list: ConfiguredDevice[]) =>
+        list.filter((d) => d.configuration !== "garland.yaml"),
+    });
     const container = renderInto(renderTable(host));
     const table = container.querySelector("esphome-device-table") as unknown as {
       devices: ConfiguredDevice[];

--- a/test/components/dashboard/render-table-device-count.test.ts
+++ b/test/components/dashboard/render-table-device-count.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the table view's device-count row tracking the text search as well
+ * as the facets. The table applies the search inside its own global
+ * filter, so the count used to reflect facets only (device-builder#2627).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { renderInto } from "../../_dom.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
+import { DashboardView } from "../../../src/api/types/system.js";
+import { renderTable } from "../../../src/components/dashboard/render-content.js";
+import { makeTableHost } from "./_host.js";
+
+const DEVICES = [
+  makeConfiguredDevice({
+    name: "garland",
+    friendly_name: "Garland",
+    configuration: "garland.yaml",
+    address: "garland.local",
+  }),
+  makeConfiguredDevice({
+    name: "ecu-boiler",
+    friendly_name: "ECU Boiler",
+    configuration: "ecu-boiler.yaml",
+    address: "10.0.0.42",
+  }),
+  makeConfiguredDevice({
+    name: "servion",
+    friendly_name: "Servion",
+    configuration: "servion.yaml",
+    address: "servion.local",
+  }),
+];
+
+function makeHost(overrides: Record<string, unknown> = {}) {
+  return makeTableHost({
+    _devices: DEVICES,
+    _sortedDevices: DEVICES,
+    _view: DashboardView.TABLE,
+    ...overrides,
+  });
+}
+
+function countRow(host: ReturnType<typeof makeHost>): { count: string; text: string } {
+  const container = renderInto(renderTable(host));
+  const el = container.querySelector(".device-count") as HTMLElement;
+  return {
+    count: el.querySelector("strong")!.textContent ?? "",
+    text: el.textContent ?? "",
+  };
+}
+
+describe("renderTable device count", () => {
+  it("counts every facet-visible device when the search is empty", () => {
+    const row = countRow(makeHost());
+    expect(row.count).toBe("3");
+    expect(row.text).not.toContain("dashboard.search_of");
+  });
+
+  it("narrows the count to the devices matching the search", () => {
+    const row = countRow(makeHost({ _search: "ecu" }));
+    expect(row.count).toBe("1");
+    expect(row.text).toContain("dashboard.search_of");
+  });
+
+  it("uses the table predicate so an address match is counted", () => {
+    expect(countRow(makeHost({ _search: "10.0.0" })).count).toBe("1");
+  });
+
+  it("applies the search on top of the facet filter", () => {
+    const facetFiltered = DEVICES.filter((d) => d.name !== "ecu-boiler");
+    const host = makeHost({
+      _search: "on",
+      _applyFacetFilters: (_list: ConfiguredDevice[]) => facetFiltered,
+    });
+    // "Servion" matches, "Garland" doesn't; "ECU Boiler" is hidden by
+    // the facet before the search runs.
+    expect(countRow(host).count).toBe("1");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

In the table view the "N devices of M" row only reflected the facet filters; typing in the search box narrowed the rows but left the count unchanged. The table applies the search inside its own global filter, so the count row now re-runs the same predicate over the facet list and matches what is on screen.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2627

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
