### PR TITLE
Boot the firmware after flashing on native USB-Serial/JTAG chips

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1806,6 +1806,7 @@
     },
     "improv": {
       "open_failed": "Could not open the serial port for Wi-Fi setup: {error}",
+      "port_not_found": "Could not open the serial port for Wi-Fi setup: the device did not come back after its reset. Unplug it, plug it in again and retry.",
       "port_busy": "The device is busy with another operation. Close it and try again.",
       "load_failed": "Could not load the Wi-Fi setup dialog. Check your connection and try again."
     },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1805,7 +1805,6 @@
       "failed": "Failed to connect: {error}"
     },
     "improv": {
-      "open_failed": "Could not open the serial port for Wi-Fi setup: {error}",
       "port_not_found": "Could not open the serial port for Wi-Fi setup: the device did not come back after its reset. Unplug it, plug it in again and retry.",
       "port_busy": "The device is busy with another operation. Close it and try again.",
       "load_failed": "Could not load the Wi-Fi setup dialog. Check your connection and try again."

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1805,7 +1805,7 @@
       "failed": "Failed to connect: {error}"
     },
     "improv": {
-      "port_not_found": "Could not open the serial port for Wi-Fi setup: the device did not come back after its reset. Unplug it, plug it in again and retry.",
+      "open_failed": "Could not open the serial port for Wi-Fi setup. If the device just restarted, unplug it, plug it back in and retry.",
       "port_busy": "The device is busy with another operation. Close it and try again.",
       "load_failed": "Could not load the Wi-Fi setup dialog. Check your connection and try again."
     },

--- a/src/util/serial-reacquire.ts
+++ b/src/util/serial-reacquire.ts
@@ -129,6 +129,10 @@ export async function reacquirePort(
  * ``open()`` attempt is the real liveness test. Each round prefers a
  * freshly-granted handle (Chrome's re-enumerated port), then the cached
  * handle (Firefox / UART bridges reopen it in place).
+ *
+ * ``onOpened`` fires only when this call performed the ``open()``; a
+ * candidate found already open belongs to whoever opened it, so a caller
+ * that closes on teardown can tell the two apart.
  */
 export async function openLiveSerialPort(
   cachedPort: SerialPort,
@@ -137,6 +141,7 @@ export async function openLiveSerialPort(
     bufferSize?: number;
     timeoutMs?: number;
     cancelled?: () => boolean;
+    onOpened?: (port: SerialPort) => void;
   }
 ): Promise<SerialPort | null> {
   const {
@@ -144,6 +149,7 @@ export async function openLiveSerialPort(
     bufferSize,
     timeoutMs = SERIAL_REOPEN_TIMEOUT_MS,
     cancelled = () => false,
+    onOpened,
   } = options;
   const deadline = Date.now() + timeoutMs;
   let lastErr: unknown = null;
@@ -163,6 +169,7 @@ export async function openLiveSerialPort(
       }
       try {
         await p.open(bufferSize ? { baudRate, bufferSize } : { baudRate });
+        onOpened?.(p);
         return p;
       } catch (err) {
         lastErr = err;

--- a/src/util/serial-reacquire.ts
+++ b/src/util/serial-reacquire.ts
@@ -157,6 +157,13 @@ export async function openLiveSerialPort(
     const { fresh } = await grantedHandlesFor(cachedPort);
     const candidates = [...fresh, cachedPort];
     for (const p of candidates) {
+      // Same liveness test as reacquirePort: a handle whose device dropped
+      // off the bus can still be open (a reset that threw mid-disconnect),
+      // and reusing it would hand the caller a dead stream.
+      if (p.connected === false) {
+        lastErr = new Error("port device disconnected");
+        continue;
+      }
       if (p.readable) {
         // Open but locked by an existing reader → unusable: the caller's
         // getReader() would throw "already locked". Skip it and try the

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -5,10 +5,11 @@
  * Web Serial API. No backend involvement — talks directly to the
  * USB-connected ESP device.
  */
-import { ESPLoader, Transport, UsbJtagSerialReset } from "esptool-js";
+import { ESPLoader, Transport } from "esptool-js";
 
 import { getErrorMessage } from "./error-message.js";
 import { markSerialActivity } from "./serial-reacquire.js";
+import { sleep } from "./sleep.js";
 
 /** Espressif's USB Vendor ID — chips with native USB-Serial/JTAG. */
 const ESPRESSIF_USB_VID = 0x303a;
@@ -466,17 +467,39 @@ async function watchdogReset(loader: ESPLoader, transport: Transport): Promise<b
 }
 
 /**
- * Boot the just-flashed firmware on a classic ESP32 / ESP8266 behind a UART
- * bridge: pulse EN (RTS) low→high while leaving GPIO0 (DTR) released, so the
+ * Boot the just-flashed firmware with an EN pulse: drive EN (RTS) low then
+ * high while leaving the boot strap (DTR / GPIO0 / GPIO9) released, so the
  * chip resets out of the bootloader and runs the app. Mirrors esptool's
- * ``--after hard-reset`` and the legacy dashboard's ``resetSerialDevice``.
+ * ``--after hard-reset`` (``HardReset``) and the legacy dashboard's
+ * ``resetSerialDevice``.
+ *
+ * ``holdMs`` is how long EN stays low; ``postReleaseMs`` waits after release
+ * before the caller closes the port. esptool uses 100 / 0 through a UART
+ * bridge and 200 / 200 over a chip's own USB peripheral, where the device
+ * drops off the bus during reset and needs the extra time to re-enumerate.
  */
-async function classicHardReset(transport: Transport): Promise<void> {
-  await transport.setDTR(false); // GPIO0 high → boot from flash, not download mode
+async function enPulseHardReset(
+  transport: Transport,
+  holdMs: number,
+  postReleaseMs: number
+): Promise<void> {
+  await transport.setDTR(false); // boot strap released → boot from flash
   await transport.setRTS(true); // EN low (hold in reset)
-  await new Promise((resolve) => setTimeout(resolve, 100));
+  await sleep(holdMs);
   await transport.setRTS(false); // EN high → boot the app
+  if (postReleaseMs > 0) await sleep(postReleaseMs);
 }
+
+/** esptool's ``HardReset`` timings through an external UART bridge. */
+const classicHardReset = (transport: Transport) => enPulseHardReset(transport, 100, 0);
+
+/**
+ * esptool's ``HardReset(uses_usb=True)`` timings for a chip's own
+ * USB-Serial/JTAG peripheral. The controller maps RTS to EN and DTR to the
+ * boot strap, so the same EN pulse works; the longer delays cover the USB
+ * drop + re-enumeration that the reset causes.
+ */
+const usbJtagHardReset = (transport: Transport) => enPulseHardReset(transport, 200, 200);
 
 /**
  * Pick a reset strategy based on the chip and how it's connected.
@@ -495,9 +518,14 @@ async function classicHardReset(transport: Transport): Promise<void> {
  *   "cancellation" behaviour the DTR/RTS sequence implicitly assumes.
  * - Native USB-Serial/JTAG (0x303a:0x1001 — esptool-js discriminates on
  *   the PID; other 0x303a products like the ESP-USB-Bridge are real UART
- *   bridges) for chips not in the WDT
- *   list (mostly fall-through; safety net): esptool-js's
- *   ``UsbJtagSerialReset``.
+ *   bridges) for chips not in the WDT list (ESP32-C6 / H2 / P4 …): the
+ *   EN pulse with esptool's USB timings (``usbJtagHardReset``). NOT
+ *   esptool-js's ``UsbJtagSerialReset``: that is esptool's
+ *   ``usb_jtag_bootloader_reset``, the *enter download mode* sequence
+ *   (drives the boot strap via DTR while pulsing EN), so running it after
+ *   ``writeFlash`` reset the chip straight back into the ROM bootloader.
+ *   The ROM's USB CDC re-enumerates and opens fine, so nothing looked
+ *   wrong until Improv / the logs never answered (#1678, XIAO ESP32-C6).
  * - Everything else (classic ESP32 / ESP8266 via CP210x / CH340 /
  *   FTDI / etc. bridges): an EN pulse with GPIO0 released
  *   (``classicHardReset``), matching esptool's ``--after hard-reset``.
@@ -512,7 +540,7 @@ async function hardResetChip(
 ): Promise<void> {
   if (await watchdogReset(loader, transport)) return;
   if (isEspressifUsbJtagPort(port)) {
-    await new UsbJtagSerialReset(transport).reset();
+    await usbJtagHardReset(transport);
   } else {
     await classicHardReset(transport);
   }

--- a/src/web/dashboard/esphome-web-esp-device-card.ts
+++ b/src/web/dashboard/esphome-web-esp-device-card.ts
@@ -15,7 +15,11 @@ import { actionBtnStyles } from "../../styles/action-buttons.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { sleep } from "../../util/sleep.js";
-import { IMPROV_OPEN_DELAY_MS, openImprovDialog } from "../improv/open-improv-dialog.js";
+import {
+  IMPROV_OPEN_DELAY_MS,
+  type ImprovResult,
+  openImprovDialog,
+} from "../improv/open-improv-dialog.js";
 import "../install/esphome-web-install-adoptable-dialog.js";
 import "../install/esphome-web-install-upload-dialog.js";
 import { openPortForLogs } from "../logs/esphome-web-logs-dialog.js";
@@ -72,7 +76,7 @@ export class ESPHomeWebEspDeviceCard extends LitElement {
   // Improv may have to reopen on a fresh handle (native-USB re-enumeration
   // after the post-flash reset); hand it to the parent card like the logs
   // dialog does, so the other actions stop using the dead pre-reset one.
-  private _openImprov(): Promise<unknown> {
+  private _openImprov(): Promise<ImprovResult> {
     return openImprovDialog(this.port, this._localize, {
       onPortReplaced: (port) =>
         this.dispatchEvent(

--- a/src/web/dashboard/esphome-web-esp-device-card.ts
+++ b/src/web/dashboard/esphome-web-esp-device-card.ts
@@ -70,14 +70,15 @@ export class ESPHomeWebEspDeviceCard extends LitElement {
   }
 
   private _configureWifi(): void {
-    void this._openImprov();
+    void this._openImprov(false);
   }
 
   // Improv may have to reopen on a fresh handle (native-USB re-enumeration
   // after the post-flash reset); hand it to the parent card like the logs
   // dialog does, so the other actions stop using the dead pre-reset one.
-  private _openImprov(): Promise<ImprovResult> {
+  private _openImprov(afterReset: boolean): Promise<ImprovResult> {
     return openImprovDialog(this.port, this._localize, {
+      afterReset,
       onPortReplaced: (port) =>
         this.dispatchEvent(
           new CustomEvent("port-replaced", {
@@ -97,7 +98,7 @@ export class ESPHomeWebEspDeviceCard extends LitElement {
   private async _onProvisionWifi(): Promise<void> {
     this._adoptableOpen = false;
     await sleep(IMPROV_OPEN_DELAY_MS);
-    void this._openImprov();
+    void this._openImprov(true);
   }
 
   private _disconnect(): void {

--- a/src/web/dashboard/esphome-web-esp-device-card.ts
+++ b/src/web/dashboard/esphome-web-esp-device-card.ts
@@ -66,7 +66,23 @@ export class ESPHomeWebEspDeviceCard extends LitElement {
   }
 
   private _configureWifi(): void {
-    void openImprovDialog(this.port, this._localize);
+    void this._openImprov();
+  }
+
+  // Improv may have to reopen on a fresh handle (native-USB re-enumeration
+  // after the post-flash reset); hand it to the parent card like the logs
+  // dialog does, so the other actions stop using the dead pre-reset one.
+  private _openImprov(): Promise<unknown> {
+    return openImprovDialog(this.port, this._localize, {
+      onPortReplaced: (port) =>
+        this.dispatchEvent(
+          new CustomEvent("port-replaced", {
+            detail: port,
+            bubbles: true,
+            composed: true,
+          })
+        ),
+    });
   }
 
   // Fired by the adoptable dialog's Continue button after a successful flash.
@@ -77,7 +93,7 @@ export class ESPHomeWebEspDeviceCard extends LitElement {
   private async _onProvisionWifi(): Promise<void> {
     this._adoptableOpen = false;
     await sleep(IMPROV_OPEN_DELAY_MS);
-    void openImprovDialog(this.port, this._localize);
+    void this._openImprov();
   }
 
   private _disconnect(): void {

--- a/src/web/dashboard/esphome-web-esp-device-card.ts
+++ b/src/web/dashboard/esphome-web-esp-device-card.ts
@@ -70,10 +70,10 @@ export class ESPHomeWebEspDeviceCard extends LitElement {
   }
 
   // Fired by the adoptable dialog's Continue button after a successful flash.
-  // Close the (native modal) install dialog first, then give the freshly-reset
-  // device a moment to re-enumerate and boot the new firmware before Improv
-  // grabs the port — legacy slept 1s here for the same reason. The delay also
-  // lets the modal finish hiding so Improv doesn't open behind its backdrop.
+  // Close the (native modal) install dialog first and let it finish hiding so
+  // Improv doesn't open behind its backdrop. Waiting for the freshly-reset
+  // device to re-enumerate is openImprovDialog's job (it reopens through
+  // openLiveSerialPort); this.port may be a dead pre-reset handle by now.
   private async _onProvisionWifi(): Promise<void> {
     this._adoptableOpen = false;
     await sleep(IMPROV_OPEN_DELAY_MS);

--- a/src/web/improv/open-improv-dialog.ts
+++ b/src/web/improv/open-improv-dialog.ts
@@ -25,6 +25,15 @@ export interface ImprovResult {
 
 const NO_IMPROV: ImprovResult = { improv: false, provisioned: false };
 
+export interface ImprovOptions {
+  /**
+   * Called when the session had to reopen on a different handle than the one
+   * passed in (a native-USB chip re-enumerated after its post-flash reset).
+   * The card should adopt it for its other actions; see ``port-replaced``.
+   */
+  onPortReplaced?: (port: SerialPort) => void;
+}
+
 /**
  * Delay before opening Improv after a first-time install/setup. Covers the
  * native install-dialog's hide animation so Improv doesn't open behind its
@@ -54,12 +63,13 @@ const activePorts = new WeakSet<SerialPort>();
  */
 export async function openImprovDialog(
   port: SerialPort,
-  localize: LocalizeFunc
+  localize: LocalizeFunc,
+  options: ImprovOptions = {}
 ): Promise<ImprovResult> {
   if (activePorts.has(port)) return NO_IMPROV;
   activePorts.add(port);
   try {
-    return await runImprov(port, localize);
+    return await runImprov(port, localize, options);
   } finally {
     activePorts.delete(port);
   }
@@ -72,7 +82,9 @@ export async function openImprovDialog(
  * ``openLiveSerialPort``: right after a flash the device has just been reset,
  * and a native-USB chip (ESP32-C6 / S3 / C3 …) drops off the bus and comes
  * back as a *new* handle, so a bare ``port.open()`` on the cached handle races
- * the re-enumeration (#1678). DTR / RTS are cleared afterwards so an
+ * the re-enumeration (#1678). ``weOpened`` is true only for a handle that
+ * call actually opened, so a candidate it found already open is never closed
+ * out from under its owner. DTR / RTS are cleared after opening so an
  * auto-reset circuit on a UART-bridge board isn't left holding EN low.
  */
 async function acquirePort(
@@ -86,29 +98,37 @@ async function acquirePort(
     }
     return { port, weOpened: false };
   }
+  let weOpened = false;
   const live = await openLiveSerialPort(port, {
     baudRate: IMPROV_BAUD_RATE,
     bufferSize: IMPROV_BUFFER_SIZE,
+    onOpened: () => {
+      weOpened = true;
+    },
   });
   if (!live) {
-    toast.error(localize("web.improv.port_not_found"));
+    toast.error(localize("web.improv.open_failed"));
     return null;
   }
-  try {
-    await live.setSignals({ dataTerminalReady: false, requestToSend: false });
-  } catch {
-    /* Recoverable: the chip is most likely booting fine already. */
+  if (weOpened) {
+    try {
+      await live.setSignals({ dataTerminalReady: false, requestToSend: false });
+    } catch {
+      /* Recoverable: the chip is most likely booting fine already. */
+    }
   }
-  return { port: live, weOpened: true };
+  return { port: live, weOpened };
 }
 
 async function runImprov(
   cachedPort: SerialPort,
-  localize: LocalizeFunc
+  localize: LocalizeFunc,
+  options: ImprovOptions
 ): Promise<ImprovResult> {
   const acquired = await acquirePort(cachedPort, localize);
   if (!acquired) return NO_IMPROV;
   const { port, weOpened } = acquired;
+  if (port !== cachedPort) options.onPortReplaced?.(port);
 
   // The SDK loads as a lazy chunk; a chunk-load / CSP / network failure here
   // would otherwise throw out of a ``void openImprovDialog(...)`` call as an

--- a/src/web/improv/open-improv-dialog.ts
+++ b/src/web/improv/open-improv-dialog.ts
@@ -32,7 +32,16 @@ export interface ImprovOptions {
    * The card should adopt it for its other actions; see ``port-replaced``.
    */
   onPortReplaced?: (port: SerialPort) => void;
+  /**
+   * The device was just reset (post-flash hand-off), so give the reopen the
+   * full re-enumeration budget. Off for the manual Configure Wi-Fi button,
+   * where nothing is re-enumerating and a dead port should fail fast.
+   */
+  afterReset?: boolean;
 }
+
+/** Reopen budget when no reset preceded the click: fail fast, not in 8 s. */
+const MANUAL_OPEN_TIMEOUT_MS = 2000;
 
 /**
  * Delay before opening Improv after a first-time install/setup. Covers the
@@ -67,11 +76,17 @@ export async function openImprovDialog(
   options: ImprovOptions = {}
 ): Promise<ImprovResult> {
   if (activePorts.has(port)) return NO_IMPROV;
+  // Also guard the handle the session actually runs on: after a
+  // ``port-replaced`` adoption the card's next click passes the fresh handle.
+  const guarded = [port];
   activePorts.add(port);
   try {
-    return await runImprov(port, localize, options);
+    return await runImprov(port, localize, options, (live) => {
+      guarded.push(live);
+      activePorts.add(live);
+    });
   } finally {
-    activePorts.delete(port);
+    for (const p of guarded) activePorts.delete(p);
   }
 }
 
@@ -89,7 +104,8 @@ export async function openImprovDialog(
  */
 async function acquirePort(
   port: SerialPort,
-  localize: LocalizeFunc
+  localize: LocalizeFunc,
+  afterReset: boolean
 ): Promise<{ port: SerialPort; weOpened: boolean } | null> {
   if (port.readable) {
     if (port.readable.locked || port.writable?.locked) {
@@ -102,6 +118,7 @@ async function acquirePort(
   const live = await openLiveSerialPort(port, {
     baudRate: IMPROV_BAUD_RATE,
     bufferSize: IMPROV_BUFFER_SIZE,
+    ...(afterReset ? {} : { timeoutMs: MANUAL_OPEN_TIMEOUT_MS }),
     onOpened: () => {
       weOpened = true;
     },
@@ -129,12 +146,16 @@ async function acquirePort(
 async function runImprov(
   cachedPort: SerialPort,
   localize: LocalizeFunc,
-  options: ImprovOptions
+  options: ImprovOptions,
+  onReplaced: (port: SerialPort) => void
 ): Promise<ImprovResult> {
-  const acquired = await acquirePort(cachedPort, localize);
+  const acquired = await acquirePort(cachedPort, localize, options.afterReset ?? false);
   if (!acquired) return NO_IMPROV;
   const { port, weOpened } = acquired;
-  if (port !== cachedPort) options.onPortReplaced?.(port);
+  if (port !== cachedPort) {
+    onReplaced(port);
+    options.onPortReplaced?.(port);
+  }
 
   // The SDK loads as a lazy chunk; a chunk-load / CSP / network failure here
   // would otherwise throw out of a ``void openImprovDialog(...)`` call as an

--- a/src/web/improv/open-improv-dialog.ts
+++ b/src/web/improv/open-improv-dialog.ts
@@ -7,6 +7,7 @@ import type {} from "improv-wifi-serial-sdk/dist/serial-provision-dialog";
 import toast from "sonner-js";
 
 import type { LocalizeFunc } from "../../common/localize.js";
+import { openLiveSerialPort } from "../../util/web-serial.js";
 
 /** Baud rate the ESPHome Improv serial service speaks at. */
 const IMPROV_BAUD_RATE = 115200;
@@ -26,9 +27,10 @@ const NO_IMPROV: ImprovResult = { improv: false, provisioned: false };
 
 /**
  * Delay before opening Improv after a first-time install/setup. Covers the
- * native install-dialog's hide animation (so Improv doesn't open behind its
- * backdrop) and gives a just-reset device time to re-enumerate and boot the new
- * firmware. Legacy slept 1s post-reset for the same reason.
+ * native install-dialog's hide animation so Improv doesn't open behind its
+ * backdrop. Riding out the post-reset USB re-enumeration is NOT this delay's
+ * job: ``runImprov`` reopens through ``openLiveSerialPort``, which retries
+ * until a live handle opens.
  */
 export const IMPROV_OPEN_DELAY_MS = 1000;
 
@@ -63,35 +65,50 @@ export async function openImprovDialog(
   }
 }
 
-async function runImprov(
+/**
+ * Resolve an open, unlocked port for the SDK. An already-open port belongs to
+ * whoever opened it and is used as-is (``weOpened`` false) unless another
+ * consumer holds its streams. A closed one is reopened through
+ * ``openLiveSerialPort``: right after a flash the device has just been reset,
+ * and a native-USB chip (ESP32-C6 / S3 / C3 …) drops off the bus and comes
+ * back as a *new* handle, so a bare ``port.open()`` on the cached handle races
+ * the re-enumeration (#1678). DTR / RTS are cleared afterwards so an
+ * auto-reset circuit on a UART-bridge board isn't left holding EN low.
+ */
+async function acquirePort(
   port: SerialPort,
   localize: LocalizeFunc
-): Promise<ImprovResult> {
-  // Track whether *we* opened the port, so on close we only release a port we
-  // own — an already-open port belongs to whoever opened it.
-  let weOpened = false;
-  try {
-    await port.open({ baudRate: IMPROV_BAUD_RATE, bufferSize: IMPROV_BUFFER_SIZE });
-    weOpened = true;
-  } catch (err) {
-    // ``InvalidStateError`` means the port is already open. That's fine ONLY if
-    // nothing else holds its reader/writer — the Improv SDK takes its own
-    // reader + writer, so a locked stream (another consumer mid-op) would make
-    // it fail cryptically. Surface a clear toast and bail in that case.
-    if (err instanceof DOMException && err.name === "InvalidStateError") {
-      if (port.readable?.locked || port.writable?.locked) {
-        toast.error(localize("web.improv.port_busy"));
-        return NO_IMPROV;
-      }
-    } else {
-      toast.error(
-        localize("web.improv.open_failed", {
-          error: err instanceof Error ? err.message : String(err),
-        })
-      );
-      return NO_IMPROV;
+): Promise<{ port: SerialPort; weOpened: boolean } | null> {
+  if (port.readable) {
+    if (port.readable.locked || port.writable?.locked) {
+      toast.error(localize("web.improv.port_busy"));
+      return null;
     }
+    return { port, weOpened: false };
   }
+  const live = await openLiveSerialPort(port, {
+    baudRate: IMPROV_BAUD_RATE,
+    bufferSize: IMPROV_BUFFER_SIZE,
+  });
+  if (!live) {
+    toast.error(localize("web.improv.port_not_found"));
+    return null;
+  }
+  try {
+    await live.setSignals({ dataTerminalReady: false, requestToSend: false });
+  } catch {
+    /* Recoverable: the chip is most likely booting fine already. */
+  }
+  return { port: live, weOpened: true };
+}
+
+async function runImprov(
+  cachedPort: SerialPort,
+  localize: LocalizeFunc
+): Promise<ImprovResult> {
+  const acquired = await acquirePort(cachedPort, localize);
+  if (!acquired) return NO_IMPROV;
+  const { port, weOpened } = acquired;
 
   // The SDK loads as a lazy chunk; a chunk-load / CSP / network failure here
   // would otherwise throw out of a ``void openImprovDialog(...)`` call as an

--- a/src/web/improv/open-improv-dialog.ts
+++ b/src/web/improv/open-improv-dialog.ts
@@ -107,7 +107,10 @@ async function acquirePort(
   localize: LocalizeFunc,
   afterReset: boolean
 ): Promise<{ port: SerialPort; weOpened: boolean } | null> {
-  if (port.readable) {
+  // An open handle is reused only while its device is still attached: a
+  // reset that threw out of transport.disconnect() can leave the pre-reset
+  // handle open but dead, and that one must go through the reopen loop.
+  if (port.readable && port.connected !== false) {
     if (port.readable.locked || port.writable?.locked) {
       toast.error(localize("web.improv.port_busy"));
       return null;

--- a/src/web/improv/open-improv-dialog.ts
+++ b/src/web/improv/open-improv-dialog.ts
@@ -117,6 +117,13 @@ async function acquirePort(
     }
     return { port, weOpened: false };
   }
+  if (port.readable) {
+    // Open but its device is gone: close it so the reopen loop can actually
+    // reopen it if the same handle comes back (UART bridge / same-handle
+    // re-enumeration), instead of handing the SDK the errored stream. Mirrors
+    // the logs dialog's recovery.
+    await port.close().catch(() => {});
+  }
   let weOpened = false;
   const live = await openLiveSerialPort(port, {
     baudRate: IMPROV_BAUD_RATE,

--- a/src/web/improv/open-improv-dialog.ts
+++ b/src/web/improv/open-improv-dialog.ts
@@ -110,6 +110,12 @@ async function acquirePort(
     toast.error(localize("web.improv.open_failed"));
     return null;
   }
+  // openLiveSerialPort only screens readable.locked; a handle it found open
+  // can still have its writer held, and the SDK takes both.
+  if (live.readable?.locked || live.writable?.locked) {
+    toast.error(localize("web.improv.port_busy"));
+    return null;
+  }
   if (weOpened) {
     try {
       await live.setSignals({ dataTerminalReady: false, requestToSend: false });

--- a/src/web/install/run-flash.ts
+++ b/src/web/install/run-flash.ts
@@ -129,7 +129,7 @@ export async function runFlash(
   }
 
   // The firmware is already written and committed at this point. The final
-  // reset is best-effort: native-USB chips (C6/H2/P4 → UsbJtagSerialReset)
+  // reset is best-effort: native-USB chips (C6/H2/P4 → the USB-JTAG EN pulse)
   // drop and re-enumerate mid-reset, so resetAndDisconnect can throw even
   // though the write succeeded. Swallow it — a reset hiccup must not turn a
   // successful flash into a reported failure (which would also skip the

--- a/test/util/serial-reacquire.test.ts
+++ b/test/util/serial-reacquire.test.ts
@@ -131,6 +131,16 @@ describe("openLiveSerialPort", () => {
     expect(onOpened).not.toHaveBeenCalled();
   });
 
+  it("skips an open cached handle whose device is gone and takes the fresh one", async () => {
+    const dead = fakePort({ readable: { locked: false }, connected: false });
+    const fresh = fakePort({ readable: null, open: vi.fn(async () => {}) });
+    stubGetPorts(async () => [fresh]);
+
+    const got = await openLiveSerialPort(dead, { baudRate: 115200, timeoutMs: 500 });
+    expect(got).toBe(fresh);
+    expect((fresh as any).open).toHaveBeenCalledOnce();
+  });
+
   it("reports the handle it opened through onOpened", async () => {
     const cached = fakePort({ readable: null, open: vi.fn(async () => {}) });
     stubGetPorts(async () => []);

--- a/test/util/serial-reacquire.test.ts
+++ b/test/util/serial-reacquire.test.ts
@@ -120,8 +120,29 @@ describe("openLiveSerialPort", () => {
     const openUnlocked = fakePort({ readable: { locked: false } });
     stubGetPorts(async () => [openUnlocked]);
 
-    const got = await openLiveSerialPort(cached, { baudRate: 115200, timeoutMs: 500 });
+    const onOpened = vi.fn();
+    const got = await openLiveSerialPort(cached, {
+      baudRate: 115200,
+      timeoutMs: 500,
+      onOpened,
+    });
     expect(got).toBe(openUnlocked);
+    // Found open, not opened here: the caller must not take ownership.
+    expect(onOpened).not.toHaveBeenCalled();
+  });
+
+  it("reports the handle it opened through onOpened", async () => {
+    const cached = fakePort({ readable: null, open: vi.fn(async () => {}) });
+    stubGetPorts(async () => []);
+
+    const onOpened = vi.fn();
+    const got = await openLiveSerialPort(cached, {
+      baudRate: 115200,
+      timeoutMs: 500,
+      onOpened,
+    });
+    expect(got).toBe(cached);
+    expect(onOpened).toHaveBeenCalledWith(cached);
   });
 
   it("gives up past the deadline when every candidate stays unopenable", async () => {

--- a/test/util/web-serial-connect-log.test.ts
+++ b/test/util/web-serial-connect-log.test.ts
@@ -57,8 +57,7 @@ vi.mock("esptool-js", () => {
       return state.main(this);
     }
   }
-  class UsbJtagSerialReset {}
-  return { ESPLoader, Transport, UsbJtagSerialReset };
+  return { ESPLoader, Transport };
 });
 
 import { connectToPort, UnsupportedChipError } from "../../src/util/web-serial.js";

--- a/test/util/web-serial-reset.test.ts
+++ b/test/util/web-serial-reset.test.ts
@@ -5,17 +5,13 @@
  * For a classic ESP32 / ESP8266 behind a UART bridge that means an EN (RTS)
  * pulse with GPIO0 (DTR) released — esptool-js's ClassicReset would instead
  * drive GPIO0 low and strand the chip in the serial bootloader (#1529).
+ * A chip on its own USB-Serial/JTAG peripheral (ESP32-C6 and friends outside
+ * the watchdog list) needs the same EN pulse with esptool's USB timings;
+ * esptool-js's UsbJtagSerialReset is the *enter download mode* sequence and
+ * left the XIAO ESP32-C6 in the ROM bootloader after flashing (#1678).
  */
 import type { ESPLoader, Transport } from "esptool-js";
-import { describe, expect, it, vi } from "vitest";
-
-const { jtagResetSpy } = vi.hoisted(() => ({ jtagResetSpy: vi.fn() }));
-vi.mock("esptool-js", async (importOriginal) => ({
-  ...(await importOriginal<object>()),
-  UsbJtagSerialReset: class {
-    reset = jtagResetSpy;
-  },
-}));
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { resetAndDisconnect } from "../../src/util/web-serial.js";
 
@@ -50,30 +46,71 @@ describe("resetAndDisconnect — classic ESP32 / ESP8266 over a UART bridge", ()
   });
 });
 
-describe("resetAndDisconnect — Espressif USB identity discriminator", () => {
-  it("uses the JTAG reset only for the on-chip USB-Serial-JTAG device", async () => {
-    jtagResetSpy.mockClear();
+const jtagPort = {
+  getInfo: () => ({ usbVendorId: 0x303a, usbProductId: 0x1001 }),
+} as unknown as SerialPort;
+// ESP32-C6: no watchdog reset (its USB-Serial/JTAG controller can drop the
+// port), so it takes the USB-JTAG branch.
+const c6Loader = { chip: { CHIP_NAME: "ESP32-C6" } } as unknown as ESPLoader;
+
+describe("resetAndDisconnect — chip's own USB-Serial/JTAG peripheral", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("boots the app on an ESP32-C6 with an EN pulse, boot strap released", async () => {
+    vi.useFakeTimers();
     const transport = fakeTransport();
-    const jtagPort = {
-      getInfo: () => ({ usbVendorId: 0x303a, usbProductId: 0x1001 }),
-    } as unknown as SerialPort;
-    await resetAndDisconnect(esp8266Loader, transport as unknown as Transport, jtagPort);
-    expect(jtagResetSpy).toHaveBeenCalledTimes(1);
-    expect(transport.setRTS).not.toHaveBeenCalled();
+    const done = resetAndDisconnect(
+      c6Loader,
+      transport as unknown as Transport,
+      jtagPort
+    );
+    await vi.runAllTimersAsync();
+    await done;
+
+    // EN pulse only: RTS true (reset) then false (boot). The download-mode
+    // sequence would toggle RTS three times and drive DTR high.
+    expect(transport.setRTS.mock.calls.map((c) => c[0])).toEqual([true, false]);
+    expect(transport.setDTR).toHaveBeenCalledWith(false);
+    expect(transport.setDTR.mock.calls.every((c) => c[0] === false)).toBe(true);
+    expect(transport.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds EN low for esptool's 200 ms USB timing before releasing", async () => {
+    vi.useFakeTimers();
+    const transport = fakeTransport();
+    const done = resetAndDisconnect(
+      c6Loader,
+      transport as unknown as Transport,
+      jtagPort
+    );
+    await vi.advanceTimersByTimeAsync(150);
+    expect(transport.setRTS.mock.calls.map((c) => c[0])).toEqual([true]);
+    await vi.advanceTimersByTimeAsync(60);
+    expect(transport.setRTS.mock.calls.map((c) => c[0])).toEqual([true, false]);
+    // Then waits out the USB re-enumeration window before closing the port.
+    expect(transport.disconnect).not.toHaveBeenCalled();
+    await vi.runAllTimersAsync();
+    await done;
+    expect(transport.disconnect).toHaveBeenCalledTimes(1);
   });
 
   it("treats the ESP-USB-Bridge as a bridge despite the Espressif vendor id", async () => {
-    jtagResetSpy.mockClear();
+    vi.useFakeTimers();
     const transport = fakeTransport();
     const bridgePort = {
       getInfo: () => ({ usbVendorId: 0x303a, usbProductId: 0x1002 }),
     } as unknown as SerialPort;
-    await resetAndDisconnect(
+    const done = resetAndDisconnect(
       esp8266Loader,
       transport as unknown as Transport,
       bridgePort
     );
-    expect(jtagResetSpy).not.toHaveBeenCalled();
+    // Bridge timing: EN released after 100 ms, no post-release wait.
+    await vi.advanceTimersByTimeAsync(100);
+    await done;
     expect(transport.setRTS.mock.calls.map((c) => c[0])).toEqual([true, false]);
+    expect(transport.disconnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/util/web-serial-unsupported-chip.test.ts
+++ b/test/util/web-serial-unsupported-chip.test.ts
@@ -55,8 +55,7 @@ vi.mock("esptool-js", () => {
       return this.chip?.CHIP_NAME ?? "unknown";
     }
   }
-  class UsbJtagSerialReset {}
-  return { ESPLoader, Transport, UsbJtagSerialReset };
+  return { ESPLoader, Transport };
 });
 
 import { connectToPort, UnsupportedChipError } from "../../src/util/web-serial.js";

--- a/test/web/esp-device-card-provision.test.ts
+++ b/test/web/esp-device-card-provision.test.ts
@@ -54,7 +54,7 @@ describe("esphome-web-esp-device-card Improv hand-off", () => {
     expect(openImprovDialog).toHaveBeenCalledWith(
       port,
       expect.any(Function),
-      expect.objectContaining({ onPortReplaced: expect.any(Function) })
+      expect.objectContaining({ afterReset: true, onPortReplaced: expect.any(Function) })
     );
   });
 
@@ -81,6 +81,9 @@ describe("esphome-web-esp-device-card Improv hand-off", () => {
     (el as any)._configureWifi();
 
     expect(openImprovDialog).toHaveBeenCalledOnce();
+    // No reset preceded the click: the reopen must fail fast, not wait out
+    // the re-enumeration budget.
+    expect(openImprovDialog.mock.calls[0][2]).toMatchObject({ afterReset: false });
   });
 
   it("anchors every action tooltip to a real button id", async () => {

--- a/test/web/esp-device-card-provision.test.ts
+++ b/test/web/esp-device-card-provision.test.ts
@@ -51,7 +51,28 @@ describe("esphome-web-esp-device-card Improv hand-off", () => {
     // Modal closed first, then Improv opened on the same port.
     expect((el as any)._adoptableOpen).toBe(false);
     expect(openImprovDialog).toHaveBeenCalledOnce();
-    expect(openImprovDialog).toHaveBeenCalledWith(port, expect.any(Function));
+    expect(openImprovDialog).toHaveBeenCalledWith(
+      port,
+      expect.any(Function),
+      expect.objectContaining({ onPortReplaced: expect.any(Function) })
+    );
+  });
+
+  it("re-dispatches Improv's replacement handle as a bubbling port-replaced event", async () => {
+    const el = await mount();
+    const seen = vi.fn();
+    document.body.addEventListener("port-replaced", (e) =>
+      seen((e as CustomEvent).detail)
+    );
+
+    (el as any)._configureWifi();
+    const options = openImprovDialog.mock.calls[0][2] as {
+      onPortReplaced: (p: SerialPort) => void;
+    };
+    const fresh = { id: "fresh" } as unknown as SerialPort;
+    options.onPortReplaced(fresh);
+
+    expect(seen).toHaveBeenCalledWith(fresh);
   });
 
   it("opens Improv directly for the manual Configure Wi-Fi action", async () => {

--- a/test/web/open-improv-dialog-load-failure.test.ts
+++ b/test/web/open-improv-dialog-load-failure.test.ts
@@ -9,7 +9,12 @@ vi.mock("improv-wifi-serial-sdk/dist/serial-provision-dialog", () => {
 vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
 // The reopen retry loop is exercised elsewhere; here the cached handle just opens.
 vi.mock("../../src/util/web-serial.js", () => ({
-  openLiveSerialPort: vi.fn(async (port: SerialPort) => port),
+  openLiveSerialPort: vi.fn(
+    async (port: SerialPort, opts: { onOpened?: (p: SerialPort) => void }) => {
+      opts.onOpened?.(port);
+      return port;
+    }
+  ),
 }));
 
 import toast from "sonner-js";

--- a/test/web/open-improv-dialog-load-failure.test.ts
+++ b/test/web/open-improv-dialog-load-failure.test.ts
@@ -7,6 +7,10 @@ vi.mock("improv-wifi-serial-sdk/dist/serial-provision-dialog", () => {
   throw new Error("chunk load failed");
 });
 vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+// The reopen retry loop is exercised elsewhere; here the cached handle just opens.
+vi.mock("../../src/util/web-serial.js", () => ({
+  openLiveSerialPort: vi.fn(async (port: SerialPort) => port),
+}));
 
 import toast from "sonner-js";
 import { openImprovDialog } from "../../src/web/improv/open-improv-dialog.js";
@@ -15,8 +19,8 @@ describe("openImprovDialog — SDK load failure", () => {
   it("closes the port and returns false with a toast when the chunk fails to load", async () => {
     const close = vi.fn(async () => {});
     const port = {
-      open: vi.fn(async () => {}),
       close,
+      setSignals: vi.fn(async () => {}),
       readable: null,
       writable: null,
     };

--- a/test/web/open-improv-dialog.test.ts
+++ b/test/web/open-improv-dialog.test.ts
@@ -171,6 +171,24 @@ describe("openImprovDialog", () => {
     await p;
   });
 
+  it("reopens instead of reusing an open handle whose device is gone", async () => {
+    const dead = makePort();
+    dead.readable = { locked: false };
+    (dead as unknown as { connected: boolean }).connected = false;
+    const fresh = makePort();
+    openLiveSerialPort.mockImplementation(async (_p: SerialPort, opts: LiveOptions) => {
+      opts.onOpened?.(fresh as unknown as SerialPort);
+      return fresh;
+    });
+    const promise = openImprovDialog(dead as unknown as SerialPort, localize);
+    await flush();
+
+    expect(openLiveSerialPort).toHaveBeenCalledOnce();
+    expect((dialogEl() as unknown as { port: unknown }).port).toBe(fresh);
+    dialogEl()!.dispatchEvent(new CustomEvent("closed", { detail: {} }));
+    await promise;
+  });
+
   it("does not report a replacement when the cached handle reopened in place", async () => {
     const port = makePort();
     const onPortReplaced = vi.fn();

--- a/test/web/open-improv-dialog.test.ts
+++ b/test/web/open-improv-dialog.test.ts
@@ -184,6 +184,9 @@ describe("openImprovDialog", () => {
     await flush();
 
     expect(openLiveSerialPort).toHaveBeenCalledOnce();
+    // Released first so the reopen loop can reopen the same handle if it
+    // comes back, rather than handing the SDK the errored stream.
+    expect(dead.close).toHaveBeenCalledOnce();
     expect((dialogEl() as unknown as { port: unknown }).port).toBe(fresh);
     dialogEl()!.dispatchEvent(new CustomEvent("closed", { detail: {} }));
     await promise;

--- a/test/web/open-improv-dialog.test.ts
+++ b/test/web/open-improv-dialog.test.ts
@@ -37,9 +37,14 @@ function dialogEl(): HTMLElement | null {
   return document.querySelector("improv-wifi-serial-provision-dialog");
 }
 
+type LiveOptions = { onOpened?: (port: SerialPort) => void };
+
 beforeEach(() => {
   // Default: the cached handle reopens in place (UART bridge / Firefox).
-  openLiveSerialPort.mockImplementation(async (port: SerialPort) => port);
+  openLiveSerialPort.mockImplementation(async (port: SerialPort, opts: LiveOptions) => {
+    opts.onOpened?.(port);
+    return port;
+  });
 });
 
 afterEach(() => {
@@ -53,10 +58,10 @@ describe("openImprovDialog", () => {
     const promise = openImprovDialog(port as unknown as SerialPort, localize);
     await flush();
 
-    expect(openLiveSerialPort).toHaveBeenCalledWith(port, {
-      baudRate: 115200,
-      bufferSize: 8192,
-    });
+    expect(openLiveSerialPort).toHaveBeenCalledWith(
+      port,
+      expect.objectContaining({ baudRate: 115200, bufferSize: 8192 })
+    );
     // DTR/RTS released so a bridge board's auto-reset circuit can't hold EN low.
     expect(port.setSignals).toHaveBeenCalledWith({
       dataTerminalReady: false,
@@ -108,11 +113,19 @@ describe("openImprovDialog", () => {
   it("hands the SDK the fresh handle a re-enumerated device came back as (#1678)", async () => {
     const stale = makePort();
     const fresh = makePort();
-    openLiveSerialPort.mockResolvedValue(fresh as unknown as SerialPort);
-    const promise = openImprovDialog(stale as unknown as SerialPort, localize);
+    openLiveSerialPort.mockImplementation(async (_p: SerialPort, opts: LiveOptions) => {
+      opts.onOpened?.(fresh as unknown as SerialPort);
+      return fresh;
+    });
+    const onPortReplaced = vi.fn();
+    const promise = openImprovDialog(stale as unknown as SerialPort, localize, {
+      onPortReplaced,
+    });
     await flush();
 
     expect((dialogEl() as unknown as { port: unknown }).port).toBe(fresh);
+    // The card is told so its other actions drop the dead pre-reset handle.
+    expect(onPortReplaced).toHaveBeenCalledWith(fresh);
     dialogEl()!.dispatchEvent(
       new CustomEvent("closed", { detail: { improv: true, provisioned: true } })
     );
@@ -120,6 +133,33 @@ describe("openImprovDialog", () => {
     // The handle we opened is the one we release.
     expect(fresh.close).toHaveBeenCalledOnce();
     expect(stale.close).not.toHaveBeenCalled();
+  });
+
+  it("does not report a replacement when the cached handle reopened in place", async () => {
+    const port = makePort();
+    const onPortReplaced = vi.fn();
+    const promise = openImprovDialog(port as unknown as SerialPort, localize, {
+      onPortReplaced,
+    });
+    await flush();
+    expect(onPortReplaced).not.toHaveBeenCalled();
+    dialogEl()!.dispatchEvent(new CustomEvent("closed", { detail: {} }));
+    await promise;
+  });
+
+  it("does not close a handle openLiveSerialPort found already open", async () => {
+    const stale = makePort();
+    const theirs = makePort();
+    theirs.readable = { locked: false };
+    // Found open (no onOpened): it belongs to whoever opened it.
+    openLiveSerialPort.mockResolvedValue(theirs as unknown as SerialPort);
+    const promise = openImprovDialog(stale as unknown as SerialPort, localize);
+    await flush();
+
+    expect(theirs.setSignals).not.toHaveBeenCalled();
+    dialogEl()!.dispatchEvent(new CustomEvent("closed", { detail: {} }));
+    await promise;
+    expect(theirs.close).not.toHaveBeenCalled();
   });
 
   it("proceeds when the port is already open, and does NOT close a port it didn't open", async () => {

--- a/test/web/open-improv-dialog.test.ts
+++ b/test/web/open-improv-dialog.test.ts
@@ -147,6 +147,20 @@ describe("openImprovDialog", () => {
     await promise;
   });
 
+  it("bails with the busy toast when the live handle's writer is held", async () => {
+    const stale = makePort();
+    const theirs = makePort();
+    theirs.readable = { locked: false };
+    theirs.writable = { locked: true };
+    openLiveSerialPort.mockResolvedValue(theirs as unknown as SerialPort);
+    const result = await openImprovDialog(stale as unknown as SerialPort, localize);
+
+    expect(result).toEqual({ improv: false, provisioned: false });
+    expect(toast.error).toHaveBeenCalledWith("web.improv.port_busy");
+    expect(dialogEl()).toBeNull();
+    expect(theirs.close).not.toHaveBeenCalled();
+  });
+
   it("does not close a handle openLiveSerialPort found already open", async () => {
     const stale = makePort();
     const theirs = makePort();

--- a/test/web/open-improv-dialog.test.ts
+++ b/test/web/open-improv-dialog.test.ts
@@ -1,10 +1,14 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // The SDK module only needs to register the custom element as a side effect;
 // in happy-dom ``createElement`` yields a generic element we drive directly.
 vi.mock("improv-wifi-serial-sdk/dist/serial-provision-dialog", () => ({}));
 vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+// Post-reset reopen goes through openLiveSerialPort (re-enumeration retry
+// loop); stub it so the suite can hand back the cached or a fresh handle.
+const { openLiveSerialPort } = vi.hoisted(() => ({ openLiveSerialPort: vi.fn() }));
+vi.mock("../../src/util/web-serial.js", () => ({ openLiveSerialPort }));
 
 import toast from "sonner-js";
 import { openImprovDialog } from "../../src/web/improv/open-improv-dialog.js";
@@ -12,15 +16,15 @@ import { openImprovDialog } from "../../src/web/improv/open-improv-dialog.js";
 const localize: (k: string, v?: Record<string, string | number>) => string = (k) => k;
 const flush = () => new Promise((r) => setTimeout(r, 0));
 
-function makePort(openImpl?: () => Promise<void>): {
-  open: ReturnType<typeof vi.fn>;
+function makePort(): {
   close: ReturnType<typeof vi.fn>;
+  setSignals: ReturnType<typeof vi.fn>;
   readable: unknown;
   writable: unknown;
 } {
   return {
-    open: vi.fn(openImpl ?? (async () => {})),
     close: vi.fn(async () => {}),
+    setSignals: vi.fn(async () => {}),
     readable: null,
     writable: null,
   };
@@ -33,18 +37,31 @@ function dialogEl(): HTMLElement | null {
   return document.querySelector("improv-wifi-serial-provision-dialog");
 }
 
+beforeEach(() => {
+  // Default: the cached handle reopens in place (UART bridge / Firefox).
+  openLiveSerialPort.mockImplementation(async (port: SerialPort) => port);
+});
+
 afterEach(() => {
   document.body.innerHTML = "";
   vi.clearAllMocks();
 });
 
 describe("openImprovDialog", () => {
-  it("opens the port at 115200 with an 8k buffer and mounts the SDK dialog", async () => {
+  it("reopens the port at 115200 with an 8k buffer and mounts the SDK dialog", async () => {
     const port = makePort();
     const promise = openImprovDialog(port as unknown as SerialPort, localize);
     await flush();
 
-    expect(port.open).toHaveBeenCalledWith({ baudRate: 115200, bufferSize: 8192 });
+    expect(openLiveSerialPort).toHaveBeenCalledWith(port, {
+      baudRate: 115200,
+      bufferSize: 8192,
+    });
+    // DTR/RTS released so a bridge board's auto-reset circuit can't hold EN low.
+    expect(port.setSignals).toHaveBeenCalledWith({
+      dataTerminalReady: false,
+      requestToSend: false,
+    });
     const el = dialogEl();
     expect(el).toBeTruthy();
     expect((el as unknown as { port: unknown }).port).toBe(port);
@@ -88,13 +105,30 @@ describe("openImprovDialog", () => {
     expect(dialogEl()).toBeTruthy();
   });
 
+  it("hands the SDK the fresh handle a re-enumerated device came back as (#1678)", async () => {
+    const stale = makePort();
+    const fresh = makePort();
+    openLiveSerialPort.mockResolvedValue(fresh as unknown as SerialPort);
+    const promise = openImprovDialog(stale as unknown as SerialPort, localize);
+    await flush();
+
+    expect((dialogEl() as unknown as { port: unknown }).port).toBe(fresh);
+    dialogEl()!.dispatchEvent(
+      new CustomEvent("closed", { detail: { improv: true, provisioned: true } })
+    );
+    await expect(promise).resolves.toEqual({ improv: true, provisioned: true });
+    // The handle we opened is the one we release.
+    expect(fresh.close).toHaveBeenCalledOnce();
+    expect(stale.close).not.toHaveBeenCalled();
+  });
+
   it("proceeds when the port is already open, and does NOT close a port it didn't open", async () => {
-    const port = makePort(async () => {
-      throw new DOMException("already open", "InvalidStateError");
-    });
+    const port = makePort();
+    port.readable = { locked: false };
     const promise = openImprovDialog(port as unknown as SerialPort, localize);
     await flush();
 
+    expect(openLiveSerialPort).not.toHaveBeenCalled();
     expect(dialogEl()).toBeTruthy();
     dialogEl()!.dispatchEvent(
       new CustomEvent("closed", { detail: { improv: true, provisioned: false } })
@@ -128,9 +162,7 @@ describe("openImprovDialog", () => {
   });
 
   it("bails with a toast when the already-open port's streams are locked", async () => {
-    const port = makePort(async () => {
-      throw new DOMException("already open", "InvalidStateError");
-    });
+    const port = makePort();
     port.readable = { locked: true };
     const result = await openImprovDialog(port as unknown as SerialPort, localize);
 
@@ -139,10 +171,9 @@ describe("openImprovDialog", () => {
     expect(dialogEl()).toBeNull();
   });
 
-  it("toasts and returns a false result without mounting when open fails", async () => {
-    const port = makePort(async () => {
-      throw new Error("device gone");
-    });
+  it("toasts and returns a false result without mounting when no live port opens", async () => {
+    const port = makePort();
+    openLiveSerialPort.mockResolvedValue(null);
     const result = await openImprovDialog(port as unknown as SerialPort, localize);
 
     expect(result).toEqual({ improv: false, provisioned: false });

--- a/test/web/open-improv-dialog.test.ts
+++ b/test/web/open-improv-dialog.test.ts
@@ -135,6 +135,42 @@ describe("openImprovDialog", () => {
     expect(stale.close).not.toHaveBeenCalled();
   });
 
+  it("guards the swapped-in handle against a second mount too", async () => {
+    const stale = makePort();
+    const fresh = makePort();
+    openLiveSerialPort.mockImplementation(async (_p: SerialPort, opts: LiveOptions) => {
+      opts.onOpened?.(fresh as unknown as SerialPort);
+      return fresh;
+    });
+    const first = openImprovDialog(stale as unknown as SerialPort, localize);
+    await flush();
+    // After port-replaced adoption the card's next click passes the fresh handle.
+    const second = await openImprovDialog(fresh as unknown as SerialPort, localize);
+    expect(second).toEqual({ improv: false, provisioned: false });
+    expect(dialogEls().length).toBe(1);
+
+    dialogEl()!.dispatchEvent(new CustomEvent("closed", { detail: {} }));
+    await first;
+  });
+
+  it("uses the full re-enumeration budget only after a reset", async () => {
+    const port = makePort();
+    let p = openImprovDialog(port as unknown as SerialPort, localize, {
+      afterReset: true,
+    });
+    await flush();
+    expect(openLiveSerialPort.mock.calls[0][1]).not.toHaveProperty("timeoutMs");
+    dialogEl()!.dispatchEvent(new CustomEvent("closed", { detail: {} }));
+    await p;
+    dialogEls().forEach((el) => el.remove());
+
+    p = openImprovDialog(port as unknown as SerialPort, localize);
+    await flush();
+    expect(openLiveSerialPort.mock.calls[1][1]).toMatchObject({ timeoutMs: 2000 });
+    dialogEl()!.dispatchEvent(new CustomEvent("closed", { detail: {} }));
+    await p;
+  });
+
   it("does not report a replacement when the cached handle reopened in place", async () => {
     const port = makePort();
     const onPortReplaced = vi.fn();


### PR DESCRIPTION
# What does this implement/fix?

After flashing, chips on their own USB-Serial/JTAG peripheral that are outside the watchdog reset list (ESP32-C6, H2, P4) were reset with esptool-js's `UsbJtagSerialReset`. That class is esptool's `usb_jtag_bootloader_reset`, the enter download mode sequence, so the chip landed straight back in the ROM bootloader instead of booting the new firmware. The ROM's USB CDC re-enumerates and opens fine, so nothing looked wrong until Improv never answered; on web.esphome.io the Wi-Fi dialog sat on "Connecting" forever with a XIAO ESP32-C6, and the dashboard's post-install logs stayed empty for the same reason.

The USB-JTAG branch now does the same EN pulse as `classicHardReset` with esptool's `HardReset(uses_usb=True)` timings (200 ms hold, 200 ms for re-enumeration). Same trap as `ClassicReset` in #1529, different class.

Once the C6 actually boots it comes back as a new port handle, and `openImprovDialog` did a single `port.open()` on the cached one after a fixed 1 s. It now reopens through `openLiveSerialPort` like the logs paths, clears DTR/RTS after opening, and gives a clear toast when no live port turns up.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1678

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally. (Verified on an ESP32-C6-GEEK: prepare for first use, then the Improv Wi-Fi form appears and logs show boot output.)
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

