### PR TITLE
Add an erase option to the prepare for first use dialog

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1913,6 +1913,8 @@
       "adoptable_intro": "This installs a basic version of ESPHome on your device and helps you connect it to your network.",
       "adoptable_detail": "Once installed, your ESPHome Device Builder shows the device and lets you take control, creating a local configuration you can manage over the network.",
       "adoptable_done": "Your device is ready. Continue to connect it to Wi-Fi.",
+      "adoptable_erase": "Erase the device first",
+      "adoptable_erase_helper": "Wipes everything on the device, including saved Wi-Fi credentials. Use this if the device ran other firmware before; it takes a little longer.",
       "connect_failed_hint": "Failed to initialize. Try resetting your device or holding the BOOT button while selecting your serial port until it starts preparing the installation.",
       "no_firmware": "No firmware to flash."
     }

--- a/src/web/install/esphome-web-install-adoptable-dialog.ts
+++ b/src/web/install/esphome-web-install-adoptable-dialog.ts
@@ -87,7 +87,7 @@ export class ESPHomeWebInstallAdoptableDialog extends LitElement {
         <wa-checkbox
           .checked=${this._erase}
           @change=${(e: Event) => {
-            this._erase = (e.target as HTMLInputElement).checked;
+            this._erase = (e.currentTarget as HTMLElement & { checked: boolean }).checked;
           }}
           >${this._localize("web.install.adoptable_erase")}</wa-checkbox
         >

--- a/src/web/install/esphome-web-install-adoptable-dialog.ts
+++ b/src/web/install/esphome-web-install-adoptable-dialog.ts
@@ -15,6 +15,7 @@ import { InstallFlowController } from "./install-flow-controller.js";
 import { renderInstallProgress } from "./install-progress.js";
 
 import "@home-assistant/webawesome/dist/components/button/button.js";
+import "@home-assistant/webawesome/dist/components/checkbox/checkbox.js";
 
 /**
  * "Prepare for first use": flash the prebuilt esphome-web firmware fetched
@@ -32,8 +33,16 @@ export class ESPHomeWebInstallAdoptableDialog extends LitElement {
 
   private _flow = new InstallFlowController(this);
 
+  // Erase the whole flash before writing. Off by default: the factory image
+  // alone is enough for a fresh board, and erasing costs extra time. On a
+  // board that ran something before, leftover NVS (old Wi-Fi credentials, an
+  // AP password) survives a plain write, so the new firmware may come up
+  // already "provisioned" and skip the Wi-Fi scan; erasing fixes that.
+  @state() private _erase = false;
+
   private async _install(): Promise<void> {
     await this._flow.start(this.port, {
+      erase: this._erase,
       filesCallback: async (chipFamily) => {
         const manifest = await fetchEsphomeWebManifest();
         const build = selectBuild(manifest, chipFamily);
@@ -66,6 +75,7 @@ export class ESPHomeWebInstallAdoptableDialog extends LitElement {
 
   private _onAfterHide(): void {
     this._flow.reset();
+    this._erase = false;
     this.dispatchEvent(new CustomEvent("after-hide", { bubbles: true }));
   }
 
@@ -73,6 +83,18 @@ export class ESPHomeWebInstallAdoptableDialog extends LitElement {
     return html`
       <p>${this._localize("web.install.adoptable_intro")}</p>
       <p>${this._localize("web.install.adoptable_detail")}</p>
+      <div class="erase-row">
+        <wa-checkbox
+          .checked=${this._erase}
+          @change=${(e: Event) => {
+            this._erase = (e.target as HTMLInputElement).checked;
+          }}
+          >${this._localize("web.install.adoptable_erase")}</wa-checkbox
+        >
+        <span class="helper"
+          >${this._localize("web.install.adoptable_erase_helper")}</span
+        >
+      </div>
     `;
   }
 
@@ -120,6 +142,16 @@ export class ESPHomeWebInstallAdoptableDialog extends LitElement {
       .done {
         color: var(--esphome-success);
         font-weight: var(--wa-font-weight-semibold);
+      }
+      .erase-row {
+        display: flex;
+        flex-direction: column;
+        gap: var(--wa-space-2xs);
+        margin-top: var(--wa-space-m);
+      }
+      .helper {
+        color: var(--wa-color-text-quiet);
+        font-size: var(--wa-font-size-s);
       }
       .actions {
         display: flex;

--- a/src/web/install/esphome-web-install-adoptable-dialog.ts
+++ b/src/web/install/esphome-web-install-adoptable-dialog.ts
@@ -89,11 +89,9 @@ export class ESPHomeWebInstallAdoptableDialog extends LitElement {
           @change=${(e: Event) => {
             this._erase = (e.currentTarget as HTMLElement & { checked: boolean }).checked;
           }}
-          >${this._localize("web.install.adoptable_erase")}</wa-checkbox
-        >
-        <span class="helper"
-          >${this._localize("web.install.adoptable_erase_helper")}</span
-        >
+          >${this._localize("web.install.adoptable_erase")}
+          <span slot="hint">${this._localize("web.install.adoptable_erase_helper")}</span>
+        </wa-checkbox>
       </div>
     `;
   }
@@ -144,14 +142,7 @@ export class ESPHomeWebInstallAdoptableDialog extends LitElement {
         font-weight: var(--wa-font-weight-semibold);
       }
       .erase-row {
-        display: flex;
-        flex-direction: column;
-        gap: var(--wa-space-2xs);
         margin-top: var(--wa-space-m);
-      }
-      .helper {
-        color: var(--wa-color-text-quiet);
-        font-size: var(--wa-font-size-s);
       }
       .actions {
         display: flex;

--- a/test/web/install-adoptable-dialog.test.ts
+++ b/test/web/install-adoptable-dialog.test.ts
@@ -13,8 +13,10 @@ vi.mock("../../src/web/install/run-flash.js", () => ({
 }));
 vi.mock("../../src/components/base-dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/button/button.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/checkbox/checkbox.js", () => ({}));
 
 import { ESPHomeWebInstallAdoptableDialog } from "../../src/web/install/esphome-web-install-adoptable-dialog.js";
+import { runFlash } from "../../src/web/install/run-flash.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -58,5 +60,34 @@ describe("esphome-web-install-adoptable-dialog Wi-Fi hand-off", () => {
     (el as any)._continue();
 
     expect(spy).toHaveBeenCalledOnce();
+  });
+});
+
+describe("esphome-web-install-adoptable-dialog erase option", () => {
+  it("flashes without erasing by default", async () => {
+    const el = await mount();
+    await (el as any)._install();
+    expect(vi.mocked(runFlash).mock.calls[0][1]).toMatchObject({ erase: false });
+  });
+
+  it("asks the flow to erase first when the checkbox is ticked", async () => {
+    const el = await mount();
+    const box = el.shadowRoot!.querySelector(
+      "wa-checkbox"
+    ) as unknown as HTMLInputElement;
+    expect(box).toBeTruthy();
+    box.checked = true;
+    box.dispatchEvent(new Event("change"));
+    await el.updateComplete;
+
+    await (el as any)._install();
+    expect(vi.mocked(runFlash).mock.calls[0][1]).toMatchObject({ erase: true });
+  });
+
+  it("forgets the erase choice when the dialog closes", async () => {
+    const el = await mount();
+    (el as any)._erase = true;
+    (el as any)._onAfterHide();
+    expect((el as any)._erase).toBe(false);
   });
 });

--- a/test/web/install-adoptable-dialog.test.ts
+++ b/test/web/install-adoptable-dialog.test.ts
@@ -72,9 +72,9 @@ describe("esphome-web-install-adoptable-dialog erase option", () => {
 
   it("asks the flow to erase first when the checkbox is ticked", async () => {
     const el = await mount();
-    const box = el.shadowRoot!.querySelector(
-      "wa-checkbox"
-    ) as unknown as HTMLInputElement;
+    const box = el.shadowRoot!.querySelector("wa-checkbox") as HTMLElement & {
+      checked: boolean;
+    };
     expect(box).toBeTruthy();
     box.checked = true;
     box.dispatchEvent(new Event("change"));


### PR DESCRIPTION
# What does this implement/fix?

"Prepare for first use" on web.esphome.io writes the factory image without erasing, so anything left in NVS on a board that ran other firmware survives: old Wi-Fi credentials make the new firmware come up already provisioned and skip the network scan, and there was no way to clear it from the site.

This adds an "Erase the device first" checkbox to the dialog, off by default. When ticked the flow runs the existing `erase` step in `runFlash` before writing, with the "Erasing" progress state that the upload dialog already uses. The choice resets when the dialog closes.

**Related issue or feature (if applicable):**

- follow-up to https://github.com/esphome/device-builder-frontend/pull/1679

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally. (Verified on an ESP32-C6-GEEK together with #1679: erase runs before the write and the fresh install comes up unprovisioned.)
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

