### PR TITLE
Lift bottom-right toasts above a page's action buttons

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -456,10 +456,9 @@ export class ESPHomeApp extends LitElement {
   private async _init() {
     toast.config({
       toastOptions: {
-        // bottom-right by maintainer preference. Known trade-off: a toast
-        // can briefly cover the editor's bottom-right Install/Validate/Save
-        // cluster (#921 moved it left for that reason) — toasts auto-dismiss
-        // and carry a close button, so the overlap is transient.
+        // bottom-right by maintainer preference. Pages with buttons in that
+        // corner (device editor, secrets) lift the toaster above them via
+        // ToastClearanceController + the sonner override in apply-theme.ts.
         position: "bottom-right",
         richColors: true,
         duration: 4000,

--- a/src/components/archived-devices-dialog.ts
+++ b/src/components/archived-devices-dialog.ts
@@ -74,7 +74,8 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
       }
 
       /* Cap the dialog short of the viewport edges so toasts that
-         render bottom-right (sonner-js, ~24px gap + ~80px height)
+         render bottom-right (sonner-js, ~24px gap + ~80px height, lifted
+         further on pages with corner buttons)
          aren't covered by a long archive list. The dialog body
          itself scrolls (see the .body rule below) so the visible
          chrome (header / desc / footer) always fits in the

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -33,6 +33,7 @@ import {
   nextSplitRatioForKey,
   saveSplitRatio,
 } from "../../util/split-ratio.js";
+import { ToastClearanceController } from "../../util/toast-clearance-controller.js";
 import type { BannerError, YamlDiagnosticsDetail } from "../../util/yaml-lint-backend.js";
 import type { ESPHomeConfirmDialog } from "../confirm-dialog.js";
 import {
@@ -262,6 +263,14 @@ export class ESPHomeDeviceEditor extends LitElement {
 
   @query("esphome-confirm-dialog.auto-fix-confirm")
   private _autoFixConfirmDialog?: ESPHomeConfirmDialog;
+
+  @query(".editor-floating-actions")
+  private _floatingActionsEl?: HTMLElement;
+
+  protected readonly _toastClearance = new ToastClearanceController(
+    this,
+    () => this._floatingActionsEl
+  );
 
   static styles = [espHomeStyles, textStyles, deviceEditorStyles];
 

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -29,6 +29,7 @@ import { registerMdiIcons } from "../util/register-icons.js";
 import { renderAsyncState } from "../util/render-async-state.js";
 import { SaveShortcutController } from "../util/save-shortcut-controller.js";
 import { parseSecretsEntries } from "../util/secrets-entries.js";
+import { ToastClearanceController } from "../util/toast-clearance-controller.js";
 import { UnsavedGuard } from "../util/unsaved-guard.js";
 import { secretsStyles } from "./secrets.styles.js";
 
@@ -114,6 +115,14 @@ export class ESPHomePageSecrets extends LitElement {
 
   @query("esphome-confirm-dialog")
   private _wipeDialog?: ESPHomeConfirmDialog;
+
+  @query(".save-button")
+  private _saveButton?: HTMLElement;
+
+  protected readonly _toastClearance = new ToastClearanceController(
+    this,
+    () => this._saveButton
+  );
 
   private _unsavedGuard = new UnsavedGuard();
 

--- a/src/styles/apply-theme.ts
+++ b/src/styles/apply-theme.ts
@@ -1,3 +1,4 @@
+import { TOAST_CLEARANCE_PROPERTY } from "../util/toast-clearance-controller.js";
 /**
  * Applies the Web Awesome theme to the document.
  *
@@ -94,6 +95,19 @@ function applySonnerOverrides(): void {
     }
     [data-sonner-toast] [data-button]:hover {
       background: color-mix(in srgb, var(--wa-color-brand-fill-loud), black 10%) !important;
+    }
+    /* Pages with corner buttons publish ${TOAST_CLEARANCE_PROPERTY}
+       (see ToastClearanceController); sit above it. Only bottom moves:
+       sonner shares one --offset for bottom and right, so its offset
+       option can't do this. The breakpoint mirrors sonner's own. */
+    [data-sonner-toaster][data-position*="bottom"][data-position*="right"] {
+      --esphome-toast-lift: calc(var(${TOAST_CLEARANCE_PROPERTY}, 0px) + var(--gap));
+      bottom: max(var(--offset), var(--esphome-toast-lift)) !important;
+    }
+    @media (max-width: 600px) {
+      [data-sonner-toaster][data-position*="bottom"][data-position*="right"] {
+        bottom: max(var(--mobile-offset), var(--esphome-toast-lift)) !important;
+      }
     }
   `;
 

--- a/src/styles/apply-theme.ts
+++ b/src/styles/apply-theme.ts
@@ -99,7 +99,9 @@ function applySonnerOverrides(): void {
     /* Pages with corner buttons publish ${TOAST_CLEARANCE_PROPERTY}
        (see ToastClearanceController); sit above it. Only bottom moves:
        sonner shares one --offset for bottom and right, so its offset
-       option can't do this. The breakpoint mirrors sonner's own. */
+       option can't do this. With no publisher the lift is just --gap,
+       which stays below sonner's offsets, so other pages and ESPHome Web
+       keep the default placement. The breakpoint mirrors sonner's own. */
     [data-sonner-toaster][data-position*="bottom"][data-position*="right"] {
       --esphome-toast-lift: calc(var(${TOAST_CLEARANCE_PROPERTY}, 0px) + var(--gap));
       bottom: max(var(--offset), var(--esphome-toast-lift)) !important;

--- a/src/util/toast-clearance-controller.ts
+++ b/src/util/toast-clearance-controller.ts
@@ -19,8 +19,11 @@ export const TOAST_CLEARANCE_PROPERTY = "--esphome-toast-clearance";
  * mounted at a time (each opt-in page is its own route). Re-measures follow
  * the target's box (ResizeObserver) and the viewport (window resize); host
  * updates only re-resolve the target, which can render late behind a load
- * ladder. The host itself is not observed because page hosts are
- * ``display: contents`` and never report a box.
+ * ladder. The host itself is not observed: the current hosts either report
+ * no box (``display: contents``) or are pinned to the viewport height, which
+ * window resize already covers. The target is expected to live in a
+ * non-scrolling container; the clearance is clamped to the viewport so a
+ * target above the fold only over-lifts instead of hiding toasts.
  */
 export class ToastClearanceController implements ReactiveController {
   private _observer = new ResizeObserver(() => this._measure());
@@ -90,7 +93,7 @@ export class ToastClearanceController implements ReactiveController {
       return;
     }
     const clearance = Math.round(window.innerHeight - rect.top);
-    this._publish(`${Math.max(0, clearance)}px`);
+    this._publish(`${Math.min(Math.max(0, clearance), window.innerHeight)}px`);
   };
 
   /** Skips the write when unchanged: a root property write restyles the whole document. */

--- a/src/util/toast-clearance-controller.ts
+++ b/src/util/toast-clearance-controller.ts
@@ -26,6 +26,7 @@ export class ToastClearanceController implements ReactiveController {
   private _observer = new ResizeObserver(() => this._measure());
   private _observed: HTMLElement | null = null;
   private _published: string | null = null;
+  private _frame: number | null = null;
 
   constructor(
     host: ReactiveControllerHost,
@@ -46,17 +47,33 @@ export class ToastClearanceController implements ReactiveController {
       if (this._observed) this._observer.unobserve(this._observed);
       this._observed = target;
       if (target) this._observer.observe(target);
+      this._measure();
+      return;
     }
-    // Always measure: ResizeObserver reports the target's box, not its
-    // position, and siblings above can move the row without resizing it.
-    this._measure();
+    // Same target: still re-measure, since ResizeObserver reports the
+    // target's box, not its position, and siblings above can move the row
+    // without resizing it. Coalesced to one layout read per frame because
+    // the editor re-renders on every keystroke.
+    this._scheduleMeasure();
   }
 
   hostDisconnected(): void {
     window.removeEventListener("resize", this._measure);
     this._observer.disconnect();
     this._observed = null;
+    if (this._frame !== null) {
+      cancelAnimationFrame(this._frame);
+      this._frame = null;
+    }
     this._publish(null);
+  }
+
+  private _scheduleMeasure(): void {
+    if (this._frame !== null) return;
+    this._frame = requestAnimationFrame(() => {
+      this._frame = null;
+      this._measure();
+    });
   }
 
   private _measure = (): void => {

--- a/src/util/toast-clearance-controller.ts
+++ b/src/util/toast-clearance-controller.ts
@@ -1,0 +1,75 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+
+/** Root custom property read by the sonner override in apply-theme.ts. */
+export const TOAST_CLEARANCE_PROPERTY = "--esphome-toast-clearance";
+
+/**
+ * Keeps bottom-right toasts clear of a page's bottom-right action buttons.
+ *
+ * Pages that anchor buttons in the corner toasts land in (the device
+ * editor's Save/Install row, the secrets Save button) opt in by pointing
+ * this at that element. It measures how far the element's top edge sits
+ * above the viewport bottom and publishes it as
+ * ``--esphome-toast-clearance`` on ``<html>``; custom properties inherit
+ * into the sonner toaster's shadow root, where the override in
+ * apply-theme.ts lifts the toaster above that line. The property is
+ * removed on disconnect so every other page keeps sonner's default offset.
+ *
+ * The property is a single slot, so only one publisher is expected to be
+ * mounted at a time (each opt-in page is its own route). Re-measures follow
+ * the target's box (ResizeObserver) and the viewport (window resize); host
+ * updates only re-resolve the target, which can render late behind a load
+ * ladder. The host itself is not observed because page hosts are
+ * ``display: contents`` and never report a box.
+ */
+export class ToastClearanceController implements ReactiveController {
+  private _observer = new ResizeObserver(() => this._measure());
+  private _observed: HTMLElement | null = null;
+  private _published: string | null = null;
+
+  constructor(
+    host: ReactiveControllerHost,
+    private readonly _target: () => HTMLElement | null | undefined
+  ) {
+    host.addController(this);
+  }
+
+  hostConnected(): void {
+    window.addEventListener("resize", this._measure);
+  }
+
+  hostUpdated(): void {
+    const target = this._target() ?? null;
+    if (target === this._observed) return;
+    if (this._observed) this._observer.unobserve(this._observed);
+    this._observed = target;
+    if (target) this._observer.observe(target);
+    this._measure();
+  }
+
+  hostDisconnected(): void {
+    window.removeEventListener("resize", this._measure);
+    this._observer.disconnect();
+    this._observed = null;
+    this._publish(null);
+  }
+
+  private _measure = (): void => {
+    const target = this._observed;
+    if (!target) {
+      this._publish(null);
+      return;
+    }
+    const clearance = Math.round(window.innerHeight - target.getBoundingClientRect().top);
+    this._publish(`${Math.max(0, clearance)}px`);
+  };
+
+  /** Skips the write when unchanged: a root property write restyles the whole document. */
+  private _publish(value: string | null): void {
+    if (value === this._published) return;
+    this._published = value;
+    const style = document.documentElement.style;
+    if (value === null) style.removeProperty(TOAST_CLEARANCE_PROPERTY);
+    else style.setProperty(TOAST_CLEARANCE_PROPERTY, value);
+  }
+}

--- a/src/util/toast-clearance-controller.ts
+++ b/src/util/toast-clearance-controller.ts
@@ -36,14 +36,19 @@ export class ToastClearanceController implements ReactiveController {
 
   hostConnected(): void {
     window.addEventListener("resize", this._measure);
+    // A cache()d host can reattach without a render; re-resolve here too.
+    this.hostUpdated();
   }
 
   hostUpdated(): void {
     const target = this._target() ?? null;
-    if (target === this._observed) return;
-    if (this._observed) this._observer.unobserve(this._observed);
-    this._observed = target;
-    if (target) this._observer.observe(target);
+    if (target !== this._observed) {
+      if (this._observed) this._observer.unobserve(this._observed);
+      this._observed = target;
+      if (target) this._observer.observe(target);
+    }
+    // Always measure: ResizeObserver reports the target's box, not its
+    // position, and siblings above can move the row without resizing it.
     this._measure();
   }
 
@@ -60,15 +65,27 @@ export class ToastClearanceController implements ReactiveController {
       this._publish(null);
       return;
     }
-    const clearance = Math.round(window.innerHeight - target.getBoundingClientRect().top);
+    const rect = target.getBoundingClientRect();
+    // A hidden target reports an all-zero rect, which would read as a
+    // full-viewport clearance and push toasts off-screen.
+    if (rect.width === 0 && rect.height === 0) {
+      this._publish(null);
+      return;
+    }
+    const clearance = Math.round(window.innerHeight - rect.top);
     this._publish(`${Math.max(0, clearance)}px`);
   };
 
   /** Skips the write when unchanged: a root property write restyles the whole document. */
   private _publish(value: string | null): void {
-    if (value === this._published) return;
-    this._published = value;
     const style = document.documentElement.style;
+    if (
+      value === this._published &&
+      style.getPropertyValue(TOAST_CLEARANCE_PROPERTY) === (value ?? "")
+    ) {
+      return;
+    }
+    this._published = value;
     if (value === null) style.removeProperty(TOAST_CLEARANCE_PROPERTY);
     else style.setProperty(TOAST_CLEARANCE_PROPERTY, value);
   }

--- a/test/styles/apply-theme-sonner.test.ts
+++ b/test/styles/apply-theme-sonner.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the sonner shadow-root override that lifts bottom-right toasts
+ * above a page's published --esphome-toast-clearance.
+ */
+
+import { describe, expect, it } from "vitest";
+
+describe("applySonnerOverrides", () => {
+  it("injects the toast clearance rule into the toaster shadow root", async () => {
+    const host = document.createElement("div");
+    host.setAttribute("data-sonner-toasters", "");
+    host.attachShadow({ mode: "open" });
+    document.body.appendChild(host);
+
+    await import("../../src/styles/apply-theme.js");
+
+    const style = host.shadowRoot?.querySelector("style[data-esphome-overrides]");
+    expect(style?.textContent).toContain("--esphome-toast-clearance");
+    expect(style?.textContent).toContain(
+      '[data-position*="bottom"][data-position*="right"]'
+    );
+  });
+});

--- a/test/util/toast-clearance-controller.test.ts
+++ b/test/util/toast-clearance-controller.test.ts
@@ -3,7 +3,7 @@
  *
  * Pins the toast clearance publisher: measured from the target's top edge
  * to the viewport bottom, re-measured on resize, cleared when the target is
- * gone or the host leaves.
+ * gone or the host leaves, and same-target host updates coalesce to a frame.
  */
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -13,6 +13,8 @@ import {
   TOAST_CLEARANCE_PROPERTY,
   ToastClearanceController,
 } from "../../src/util/toast-clearance-controller.js";
+
+const nextFrame = () => new Promise((r) => requestAnimationFrame(() => r(undefined)));
 
 const clearance = () =>
   document.documentElement.style.getPropertyValue(TOAST_CLEARANCE_PROPERTY);
@@ -30,7 +32,7 @@ describe("ToastClearanceController", () => {
     document.documentElement.style.removeProperty(TOAST_CLEARANCE_PROPERTY);
   });
 
-  it("publishes the target clearance and follows window resizes", () => {
+  it("publishes the target clearance and follows window resizes", async () => {
     let fromBottom = 40;
     const target = targetAt(() => fromBottom);
     const ctrl = new ToastClearanceController(new FakeHost(), () => target);
@@ -41,6 +43,9 @@ describe("ToastClearanceController", () => {
     expect(clearance()).toBe("64px");
     fromBottom = 48;
     ctrl.hostUpdated();
+    ctrl.hostUpdated();
+    expect(clearance()).toBe("64px");
+    await nextFrame();
     expect(clearance()).toBe("48px");
     ctrl.hostDisconnected();
     expect(clearance()).toBe("");
@@ -58,12 +63,13 @@ describe("ToastClearanceController", () => {
     ctrl.hostDisconnected();
   });
 
-  it("restores the property if another writer cleared it", () => {
+  it("restores the property if another writer cleared it", async () => {
     const target = targetAt(() => 40);
     const ctrl = new ToastClearanceController(new FakeHost(), () => target);
     ctrl.hostConnected();
     document.documentElement.style.removeProperty(TOAST_CLEARANCE_PROPERTY);
     ctrl.hostUpdated();
+    await nextFrame();
     expect(clearance()).toBe("40px");
     ctrl.hostDisconnected();
   });

--- a/test/util/toast-clearance-controller.test.ts
+++ b/test/util/toast-clearance-controller.test.ts
@@ -35,11 +35,36 @@ describe("ToastClearanceController", () => {
     const target = targetAt(() => fromBottom);
     const ctrl = new ToastClearanceController(new FakeHost(), () => target);
     ctrl.hostConnected();
-    ctrl.hostUpdated();
     expect(clearance()).toBe("40px");
     fromBottom = 64;
     window.dispatchEvent(new Event("resize"));
     expect(clearance()).toBe("64px");
+    fromBottom = 48;
+    ctrl.hostUpdated();
+    expect(clearance()).toBe("48px");
+    ctrl.hostDisconnected();
+    expect(clearance()).toBe("");
+    ctrl.hostConnected();
+    expect(clearance()).toBe("48px");
+    ctrl.hostDisconnected();
+  });
+
+  it("falls back to the default offset for a hidden target", () => {
+    const target = document.createElement("div");
+    target.getBoundingClientRect = () => ({ top: 0, width: 0, height: 0 }) as DOMRect;
+    const ctrl = new ToastClearanceController(new FakeHost(), () => target);
+    ctrl.hostConnected();
+    expect(clearance()).toBe("");
+    ctrl.hostDisconnected();
+  });
+
+  it("restores the property if another writer cleared it", () => {
+    const target = targetAt(() => 40);
+    const ctrl = new ToastClearanceController(new FakeHost(), () => target);
+    ctrl.hostConnected();
+    document.documentElement.style.removeProperty(TOAST_CLEARANCE_PROPERTY);
+    ctrl.hostUpdated();
+    expect(clearance()).toBe("40px");
     ctrl.hostDisconnected();
   });
 

--- a/test/util/toast-clearance-controller.test.ts
+++ b/test/util/toast-clearance-controller.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the toast clearance publisher: measured from the target's top edge
+ * to the viewport bottom, re-measured on resize, cleared when the target is
+ * gone or the host leaves.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { FakeHost } from "../_fake-host.js";
+import {
+  TOAST_CLEARANCE_PROPERTY,
+  ToastClearanceController,
+} from "../../src/util/toast-clearance-controller.js";
+
+const clearance = () =>
+  document.documentElement.style.getPropertyValue(TOAST_CLEARANCE_PROPERTY);
+
+/** Element whose top edge sits `fromBottom()` px above the viewport bottom. */
+const targetAt = (fromBottom: () => number): HTMLElement => {
+  const el = document.createElement("div");
+  el.getBoundingClientRect = () =>
+    ({ top: window.innerHeight - fromBottom() }) as DOMRect;
+  return el;
+};
+
+describe("ToastClearanceController", () => {
+  afterEach(() => {
+    document.documentElement.style.removeProperty(TOAST_CLEARANCE_PROPERTY);
+  });
+
+  it("publishes the target clearance and follows window resizes", () => {
+    let fromBottom = 40;
+    const target = targetAt(() => fromBottom);
+    const ctrl = new ToastClearanceController(new FakeHost(), () => target);
+    ctrl.hostConnected();
+    ctrl.hostUpdated();
+    expect(clearance()).toBe("40px");
+    fromBottom = 64;
+    window.dispatchEvent(new Event("resize"));
+    expect(clearance()).toBe("64px");
+    ctrl.hostDisconnected();
+  });
+
+  it("clears the property when the target is missing or the host disconnects", () => {
+    let target: HTMLElement | null = null;
+    const ctrl = new ToastClearanceController(new FakeHost(), () => target);
+    ctrl.hostConnected();
+    ctrl.hostUpdated();
+    expect(clearance()).toBe("");
+    target = targetAt(() => 40);
+    ctrl.hostUpdated();
+    expect(clearance()).toBe("40px");
+    target = null;
+    ctrl.hostUpdated();
+    expect(clearance()).toBe("");
+    target = targetAt(() => 40);
+    ctrl.hostUpdated();
+    expect(clearance()).toBe("40px");
+    ctrl.hostDisconnected();
+    expect(clearance()).toBe("");
+  });
+});

--- a/test/util/toast-clearance-controller.test.ts
+++ b/test/util/toast-clearance-controller.test.ts
@@ -63,6 +63,14 @@ describe("ToastClearanceController", () => {
     ctrl.hostDisconnected();
   });
 
+  it("clamps a target above the viewport to the viewport height", () => {
+    const target = targetAt(() => window.innerHeight + 500);
+    const ctrl = new ToastClearanceController(new FakeHost(), () => target);
+    ctrl.hostConnected();
+    expect(clearance()).toBe(`${window.innerHeight}px`);
+    ctrl.hostDisconnected();
+  });
+
   it("restores the property if another writer cleared it", async () => {
     const target = targetAt(() => 40);
     const ctrl = new ToastClearanceController(new FakeHost(), () => target);


### PR DESCRIPTION
# What does this implement/fix?

The save toast lands on top of the editor's Install and Save buttons, and on the secrets page it covers Save the same way. This keeps toasts bottom right but lifts them above the button row on pages that have one; the device editor and the secrets page measure their button row and publish the clearance as a root custom property, and the sonner override in apply-theme reads it. Pages without corner buttons keep the default offset, nothing is hardcoded, and the right edge is untouched since sonner shares one offset for bottom and right.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1675
- https://github.com/orgs/esphome/discussions/3818

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
