### PR TITLE
Mark the tile comment with an icon and drop the italic

### DIFF
--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -7,6 +7,7 @@ import {
   mdiCheckNetworkOutline,
   mdiClockOutline,
   mdiCloseCircle,
+  mdiCommentTextOutline,
   mdiDotsVertical,
   mdiHelpNetworkOutline,
   mdiLock,
@@ -51,6 +52,7 @@ registerMdiIcons({
   "checkbox-blank-outline": mdiCheckboxBlankOutline,
   "checkbox-marked": mdiCheckboxMarked,
   "close-circle": mdiCloseCircle,
+  "comment-text-outline": mdiCommentTextOutline,
   "text-box-outline": mdiTextBoxOutline,
   "dots-vertical": mdiDotsVertical,
   "check-network-outline": mdiCheckNetworkOutline,
@@ -246,8 +248,9 @@ export class ESPHomeDeviceCard extends LitElement {
             <p class="device-config truncate">${this.configuration}</p>
             ${
               this.comment
-                ? html`<p class="device-comment truncate" title=${this.comment}>
-                    ${this.comment}
+                ? html`<p class="device-comment" title=${this.comment}>
+                    <wa-icon library="mdi" name="comment-text-outline"></wa-icon>
+                    <span class="truncate">${this.comment}</span>
                   </p>`
                 : nothing
             }

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -248,7 +248,11 @@ export class ESPHomeDeviceCard extends LitElement {
             <p class="device-config truncate">${this.configuration}</p>
             ${
               this.comment
-                ? html`<p class="device-comment" title=${this.comment}>
+                ? html`<p
+                    class="device-comment"
+                    title=${this.comment}
+                    aria-label="${this._localize("dashboard.device_comment")}: ${this.comment}"
+                  >
                     <wa-icon library="mdi" name="comment-text-outline"></wa-icon>
                     <span class="truncate">${this.comment}</span>
                   </p>`

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -250,6 +250,7 @@ export class ESPHomeDeviceCard extends LitElement {
               this.comment
                 ? html`<p
                     class="device-comment"
+                    role="note"
                     title=${this.comment}
                     aria-label="${this._localize("dashboard.device_comment")}: ${this.comment}"
                   >

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -252,7 +252,9 @@ export class ESPHomeDeviceCard extends LitElement {
                     class="device-comment"
                     role="note"
                     title=${this.comment}
-                    aria-label="${this._localize("dashboard.device_comment")}: ${this.comment}"
+                    aria-label=${this._localize("dashboard.device_comment", {
+                      comment: this.comment,
+                    })}
                   >
                     <wa-icon library="mdi" name="comment-text-outline"></wa-icon>
                     <span class="truncate">${this.comment}</span>

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -88,22 +88,45 @@ export const deviceCardStyles = [
       }
     }
 
+    /* Three columns: select checkbox, text, status badge. Only the name row
+       shares its line with the badge; the filename and comment span under
+       it, so a long path or note is not cut short by dead space beneath
+       the badge. Spacing is on the outer items rather than a column gap so
+       an absent checkbox leaves no phantom indent. */
     .device-card-header {
       padding: var(--wa-space-m) var(--wa-space-m) var(--wa-space-s);
       border-bottom: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-      display: flex;
-      align-items: flex-start;
-      justify-content: space-between;
-      gap: var(--wa-space-xs);
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      align-items: start;
     }
 
     .device-card-header:last-child {
       border-bottom: none;
     }
 
+    /* Its children lay out on the header grid directly. */
     .device-card-header-left {
-      flex: 1;
+      display: contents;
+    }
+    .device-checkbox {
+      grid-column: 1;
+      grid-row: 1;
+      margin-right: var(--wa-space-xs);
+    }
+    .device-name-wrap {
+      grid-column: 2;
+      grid-row: 1;
       min-width: 0;
+    }
+    .device-status {
+      grid-column: 3;
+      grid-row: 1;
+      margin-left: var(--wa-space-xs);
+    }
+    .device-config,
+    .device-comment {
+      grid-column: 2 / -1;
     }
 
     .device-name-wrap {

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -109,20 +109,11 @@ export const deviceCardStyles = [
     .device-card-header-left {
       display: contents;
     }
-    .device-checkbox {
-      grid-column: 1;
-      grid-row: 1;
-      margin-right: var(--wa-space-xs);
-    }
-    .device-name-wrap {
-      grid-column: 2;
-      grid-row: 1;
-      min-width: 0;
-    }
-    .device-status {
+    /* The badge's tooltip is a sibling referenced by for=; keep it out of
+       auto-placement so it can never claim a cell (and a column) of its own. */
+    .device-card-header > wa-tooltip {
       grid-column: 3;
       grid-row: 1;
-      margin-left: var(--wa-space-xs);
     }
     .device-config,
     .device-comment {
@@ -130,6 +121,9 @@ export const deviceCardStyles = [
     }
 
     .device-name-wrap {
+      grid-column: 2;
+      grid-row: 1;
+      min-width: 0;
       display: flex;
       align-items: center;
       gap: 6px;
@@ -248,13 +242,15 @@ export const deviceCardStyles = [
       flex: none;
       width: 1em;
       font-size: 14px;
-      opacity: 0.8;
     }
     .device-comment .truncate {
       min-width: 0;
     }
 
     .device-status {
+      grid-column: 3;
+      grid-row: 1;
+      margin-left: var(--wa-space-xs);
       display: inline-flex;
       align-items: center;
       gap: 4px;
@@ -263,7 +259,6 @@ export const deviceCardStyles = [
       font-size: var(--wa-font-size-2xs);
       font-weight: var(--wa-font-weight-bold);
       letter-spacing: 0.02em;
-      flex-shrink: 0;
       margin-top: 2px;
     }
 
@@ -357,13 +352,15 @@ export const deviceCardStyles = [
     }
 
     .device-checkbox {
+      grid-column: 1;
+      grid-row: 1;
+      margin-right: var(--wa-space-xs);
       font-size: 22px;
       color: var(--wa-color-text-quiet);
-      flex-shrink: 0;
       transition: color 0.12s;
       /* Box the glyph to the title's first-line height so it centers
-         on the device name while the header keeps align-items:
-         flex-start (the status badge stays top-anchored). */
+         on the device name while the header grid keeps align-items:
+         start (the status badge stays top-anchored). */
       display: flex;
       align-items: center;
       height: calc(var(--wa-font-size-m) * var(--wa-line-height-normal));

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -205,12 +205,26 @@ export const deviceCardStyles = [
       color: var(--wa-color-text-quiet);
     }
 
-    /* Italic to match the archived-devices dialog's comment rows. */
+    /* Free-form user text under the filename. The icon is what tells it
+       apart from the filename line above it, which shares the same size
+       and quiet colour; italic alone did not read as a different thing. */
     .device-comment {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      min-width: 0;
       margin: 2px 0 0;
       font-size: var(--wa-font-size-xs);
       color: var(--wa-color-text-quiet);
       font-style: italic;
+    }
+    .device-comment wa-icon {
+      flex: none;
+      font-size: var(--wa-font-size-s);
+      opacity: 0.8;
+    }
+    .device-comment .truncate {
+      min-width: 0;
     }
 
     .device-status {

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -205,9 +205,10 @@ export const deviceCardStyles = [
       color: var(--wa-color-text-quiet);
     }
 
-    /* Free-form user text under the filename. The icon is what tells it
-       apart from the filename line above it, which shares the same size
-       and quiet colour; italic alone did not read as a different thing. */
+    /* Free-form user text under the filename, set as a standard metadata
+       row: a leading glyph on an upright quiet line. The icon is what tells
+       it apart from the filename above (same size, same colour); the italic
+       #1671 shipped did not read as a different thing at this size. */
     .device-comment {
       display: flex;
       align-items: center;
@@ -216,7 +217,6 @@ export const deviceCardStyles = [
       margin: 2px 0 0;
       font-size: var(--wa-font-size-xs);
       color: var(--wa-color-text-quiet);
-      font-style: italic;
     }
     .device-comment wa-icon {
       flex: none;

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -109,8 +109,9 @@ export const deviceCardStyles = [
     .device-card-header-left {
       display: contents;
     }
-    /* The badge's tooltip is a sibling referenced by for=; keep it out of
-       auto-placement so it can never claim a cell (and a column) of its own. */
+    /* The badge's tooltip is a sibling referenced by for=. Its host is
+       position: absolute, so it never takes part in auto-placement; the
+       pin only makes the intended cell explicit for the next reader. */
     .device-card-header > wa-tooltip {
       grid-column: 3;
       grid-row: 1;

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -212,15 +212,19 @@ export const deviceCardStyles = [
     .device-comment {
       display: flex;
       align-items: center;
-      gap: 4px;
+      gap: 5px;
       min-width: 0;
       margin: 2px 0 0;
       font-size: var(--wa-font-size-xs);
       color: var(--wa-color-text-quiet);
     }
+    /* wa-icon's host is 1.25em wide with the glyph centred, which pushed
+       the text ~7px past the icon; hug the glyph so the line reads as one
+       row starting at the filename's left edge. */
     .device-comment wa-icon {
       flex: none;
-      font-size: var(--wa-font-size-s);
+      width: 1em;
+      font-size: 14px;
       opacity: 0.8;
     }
     .device-comment .truncate {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -232,7 +232,7 @@
     "table_col_platform": "Platform",
     "table_col_version": "ESPHome Version",
     "table_col_comment": "Comment",
-    "device_comment": "Comment",
+    "device_comment": "Comment: {comment}",
     "table_col_area": "Area",
     "table_col_labels": "Labels",
     "table_col_config": "Config File",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -232,6 +232,7 @@
     "table_col_platform": "Platform",
     "table_col_version": "ESPHome Version",
     "table_col_comment": "Comment",
+    "device_comment": "Comment",
     "table_col_area": "Area",
     "table_col_labels": "Labels",
     "table_col_config": "Config File",

--- a/test/components/device-card-comment.test.ts
+++ b/test/components/device-card-comment.test.ts
@@ -27,9 +27,16 @@ describe("device-card comment", () => {
     // The icon is aria-hidden, so the paragraph names itself for AT; a bare
     // <p> would not expose an author label, hence role="note".
     expect(node.getAttribute("role")).toBe("note");
-    expect(node.getAttribute("aria-label")).toBe(
-      "dashboard.device_comment: Garage, behind the freezer"
-    );
+    // The helper's identity localizer drops params; swap one in that echoes
+    // them so the comment is proven to reach the ICU key.
+    (el as unknown as { _localize: unknown })._localize = (
+      k: string,
+      v?: Record<string, string | number>
+    ) => `${k}|${v?.comment ?? ""}`;
+    await el.updateComplete;
+    expect(
+      el.shadowRoot!.querySelector(".device-comment")!.getAttribute("aria-label")
+    ).toBe("dashboard.device_comment|Garage, behind the freezer");
   });
 
   it("renders no comment node when the device has none", async () => {

--- a/test/components/device-card-comment.test.ts
+++ b/test/components/device-card-comment.test.ts
@@ -24,6 +24,10 @@ describe("device-card comment", () => {
     expect(node.querySelector("wa-icon")?.getAttribute("name")).toBe(
       "comment-text-outline"
     );
+    // The icon is aria-hidden, so the paragraph names itself for AT.
+    expect(node.getAttribute("aria-label")).toBe(
+      "dashboard.device_comment: Garage, behind the freezer"
+    );
   });
 
   it("renders no comment node when the device has none", async () => {

--- a/test/components/device-card-comment.test.ts
+++ b/test/components/device-card-comment.test.ts
@@ -20,6 +20,10 @@ describe("device-card comment", () => {
     expect(node.previousElementSibling?.classList.contains("device-config")).toBe(true);
     // The line is ellipsis-truncated; the native tooltip carries the full text.
     expect(node.getAttribute("title")).toBe("Garage, behind the freezer");
+    // The icon is the cue that separates it from the filename line above.
+    expect(node.querySelector("wa-icon")?.getAttribute("name")).toBe(
+      "comment-text-outline"
+    );
   });
 
   it("renders no comment node when the device has none", async () => {

--- a/test/components/device-card-comment.test.ts
+++ b/test/components/device-card-comment.test.ts
@@ -24,7 +24,9 @@ describe("device-card comment", () => {
     expect(node.querySelector("wa-icon")?.getAttribute("name")).toBe(
       "comment-text-outline"
     );
-    // The icon is aria-hidden, so the paragraph names itself for AT.
+    // The icon is aria-hidden, so the paragraph names itself for AT; a bare
+    // <p> would not expose an author label, hence role="note".
+    expect(node.getAttribute("role")).toBe("note");
     expect(node.getAttribute("aria-label")).toBe(
       "dashboard.device_comment: Garage, behind the freezer"
     );


### PR DESCRIPTION
# What does this implement/fix?

#1671 put the device comment on the tile under the filename, but the only cue separating the two lines was italic, at the same size and quiet colour; on a grid of cards the comment read as a second filename. This sets the line as a standard metadata row: a leading comment icon, upright text, same size and colour as before, with the full text in the title tooltip and a localized aria-label so screen readers can tell the note from the path.

While checking it on real cards two layout problems showed up and are fixed here too: wa-icon boxes its glyph in a 1.25em centred host, which indented the text past the icon; and the header was a two-column flex row, so the filename and comment truncated at the status badge's left edge with dead space beneath it. The header is now a three-column grid (checkbox, text, badge) where only the name row shares its line with the badge and the two lines below span the full width.

**Related issue or feature (if applicable):**

- follow-up to https://github.com/esphome/device-builder-frontend/pull/1671

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally. (Checked on the live dashboard against a dev backend in both themes, with and without select mode.)
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

