### PR TITLE
Keep the device card divider hugging the action row

### DIFF
--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -322,7 +322,7 @@ export function createDeviceColumns(
       cell: (info) => {
         const labels = info.getValue() as Label[];
         if (!labels || labels.length === 0) return EMPTY_CELL;
-        return renderLabelChips(labels, { max: 3 });
+        return renderLabelChips(labels, { max: 4 });
       },
       sortFn: (rowA, rowB) => {
         const a = rowA.original.labels.map((l) => l.name).join(",");

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -197,7 +197,7 @@ export class ESPHomeDeviceCard extends LitElement {
           }
           <div class="device-card-header-left">
             <div class="device-name-wrap">
-              <h3 class="device-name truncate">${this.name}</h3>
+              <h3 class="device-name truncate" title=${this.name}>${this.name}</h3>
               ${
                 this.showModified
                   ? html`<span
@@ -245,7 +245,9 @@ export class ESPHomeDeviceCard extends LitElement {
               }
               ${renderEncryptionIcon(this)}
             </div>
-            <p class="device-config truncate">${this.configuration}</p>
+            <p class="device-config truncate" title=${this.configuration}>
+              ${this.configuration}
+            </p>
             ${
               this.comment
                 ? html`<p

--- a/src/components/device-card/render-bits.ts
+++ b/src/components/device-card/render-bits.ts
@@ -31,7 +31,7 @@ const RECENT_JOB_LABEL: Record<JobStatus, string> = {
   [JobStatus.CANCELLED]: "firmware_jobs.status_cancelled",
 };
 
-// Caps at 4 visible chips with a "+N" overflow chip — heavily-tagged
+// Caps the row at 4 items (overflow "+N" chip included) — heavily-tagged
 // devices don't blow out the card height; full set lives in the drawer.
 export function renderLabels(card: ESPHomeDeviceCard): TemplateResult | typeof nothing {
   const labels = resolveLabelIds(card.labelIds, card._labelCatalog);

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -375,7 +375,7 @@ export const deviceCardStyles = [
       display: flex;
       align-items: center;
       justify-content: center;
-      width: 22px;
+      width: 1em;
       height: calc(var(--wa-font-size-m) * var(--wa-line-height-normal));
     }
 

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -95,14 +95,9 @@ export const deviceCardStyles = [
        an absent checkbox leaves no phantom indent. */
     .device-card-header {
       padding: var(--wa-space-m) var(--wa-space-m) var(--wa-space-s);
-      border-bottom: var(--wa-border-width-s) solid var(--wa-color-surface-border);
       display: grid;
       grid-template-columns: auto minmax(0, 1fr) auto;
       align-items: start;
-    }
-
-    .device-card-header:last-child {
-      border-bottom: none;
     }
 
     /* Its children lay out on the header grid directly. */
@@ -371,11 +366,15 @@ export const deviceCardStyles = [
       color: var(--esphome-primary);
     }
 
+    /* The divider rides on the actions row, not the header, so the
+       margin-top: auto spacer that equalizes grid-row card heights opens
+       above the line and it always hugs the buttons. */
     .device-actions {
       display: flex;
       align-items: center;
       gap: var(--wa-space-2xs);
       padding: var(--wa-space-s) var(--wa-space-m);
+      border-top: var(--wa-border-width-s) solid var(--wa-color-surface-border);
       margin-top: auto;
     }
   `,

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -18,6 +18,12 @@ export const deviceCardStyles = [
       gap: 4px;
       padding: 4px var(--wa-space-m) 10px;
     }
+
+    /* In select mode no actions row follows; the card edge needs more
+       clearance than the divider does. */
+    .device-card-labels:last-child {
+      padding-bottom: var(--wa-space-m);
+    }
   `,
   css`
     :host {
@@ -116,9 +122,11 @@ export const deviceCardStyles = [
       grid-column: 3;
       grid-row: 1;
     }
+    /* Full-width from column 1 so select mode's checkbox doesn't indent
+       them; only the name row shares its line with the checkbox. */
     .device-config,
     .device-comment {
-      grid-column: 2 / -1;
+      grid-column: 1 / -1;
     }
 
     .device-name-wrap {
@@ -355,15 +363,19 @@ export const deviceCardStyles = [
     .device-checkbox {
       grid-column: 1;
       grid-row: 1;
-      margin-right: var(--wa-space-xs);
+      margin-right: var(--wa-space-2xs);
       font-size: 22px;
       color: var(--wa-color-text-quiet);
       transition: color 0.12s;
       /* Box the glyph to the title's first-line height so it centers
          on the device name while the header grid keeps align-items:
-         start (the status badge stays top-anchored). */
+         start (the status badge stays top-anchored). The explicit width
+         pins the host to the glyph so the icon's slack doesn't widen
+         the checkbox column and eat into the name. */
       display: flex;
       align-items: center;
+      justify-content: center;
+      width: 22px;
       height: calc(var(--wa-font-size-m) * var(--wa-line-height-normal));
     }
 

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -9,14 +9,17 @@ export const deviceCardStyles = [
   textStyles,
   css`
     /* Only rendered when the device carries labels; an untagged device
-       gets no chip row and the card collapses naturally. Padding leans
-       top-heavy because the actions row below carries its own top padding. */
+       gets no chip row and the card collapses naturally. margin-top: auto
+       bottom-anchors the row so chips line up across a grid row of
+       stretched cards instead of trailing each header; bottom padding
+       keeps them off the divider the actions row now carries. */
     .device-card-labels {
       display: flex;
       flex-wrap: wrap;
       align-items: center;
       gap: 4px;
-      padding: 8px var(--wa-space-m) 4px;
+      padding: 4px var(--wa-space-m) 10px;
+      margin-top: auto;
     }
   `,
   css`
@@ -376,6 +379,12 @@ export const deviceCardStyles = [
       padding: var(--wa-space-s) var(--wa-space-m);
       border-top: var(--wa-border-width-s) solid var(--wa-color-surface-border);
       margin-top: auto;
+    }
+
+    /* When a labels row precedes the actions, it already carries the auto
+       spacer; a second one here would split the free space between them. */
+    .device-card-labels + .device-actions {
+      margin-top: 0;
     }
   `,
 ];

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -9,17 +9,14 @@ export const deviceCardStyles = [
   textStyles,
   css`
     /* Only rendered when the device carries labels; an untagged device
-       gets no chip row and the card collapses naturally. margin-top: auto
-       bottom-anchors the row so chips line up across a grid row of
-       stretched cards instead of trailing each header; bottom padding
-       keeps them off the divider the actions row now carries. */
+       gets no chip row and the card collapses naturally. Bottom padding
+       keeps the chips off the divider the actions row carries. */
     .device-card-labels {
       display: flex;
       flex-wrap: wrap;
       align-items: center;
       gap: 4px;
       padding: 4px var(--wa-space-m) 10px;
-      margin-top: auto;
     }
   `,
   css`
@@ -101,6 +98,11 @@ export const deviceCardStyles = [
       display: grid;
       grid-template-columns: auto minmax(0, 1fr) auto;
       align-items: start;
+      /* Grid rows stretch every card to the tallest sibling; the auto
+         margin soaks up the extra height so the rows below (labels,
+         divider, actions) stay bottom-anchored and line up across the
+         row. */
+      margin-bottom: auto;
     }
 
     /* Its children lay out on the header grid directly. */
@@ -370,21 +372,14 @@ export const deviceCardStyles = [
     }
 
     /* The divider rides on the actions row, not the header, so the
-       margin-top: auto spacer that equalizes grid-row card heights opens
-       above the line and it always hugs the buttons. */
+       header's auto bottom margin opens above the line and it always
+       hugs the buttons. */
     .device-actions {
       display: flex;
       align-items: center;
       gap: var(--wa-space-2xs);
       padding: var(--wa-space-s) var(--wa-space-m);
       border-top: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-      margin-top: auto;
-    }
-
-    /* When a labels row precedes the actions, it already carries the auto
-       spacer; a second one here would split the free space between them. */
-    .device-card-labels + .device-actions {
-      margin-top: 0;
     }
   `,
 ];

--- a/src/util/label-chip-template.ts
+++ b/src/util/label-chip-template.ts
@@ -81,11 +81,12 @@ export function renderLabelChip(
 
 /** Render a (possibly truncated) list of label chips.
  *
- *  ``max`` caps how many chips render before collapsing the rest
- *  into a "+N" overflow chip; the overflow chip's tooltip lists the
- *  hidden labels by name. Pass ``null`` / omit ``max`` to render
- *  every chip. Returns ``nothing`` for an empty list so the caller
- *  doesn't have to gate. */
+ *  ``max`` caps the row at that many items total: an overflowing
+ *  list renders ``max - 1`` chips plus a "+N" overflow chip, so the
+ *  collapsed row is never wider than the uncollapsed one. The
+ *  overflow chip's tooltip lists the hidden labels by name. Pass
+ *  ``null`` / omit ``max`` to render every chip. Returns ``nothing``
+ *  for an empty list so the caller doesn't have to gate. */
 export function renderLabelChips(
   labels: Label[],
   options: { max?: number | null } = {}
@@ -97,8 +98,8 @@ export function renderLabelChips(
       ${labels.map((l) => renderLabelChip(l))}
     </span>`;
   }
-  const visible = labels.slice(0, max);
-  const hidden = labels.slice(max);
+  const visible = labels.slice(0, max - 1);
+  const hidden = labels.slice(max - 1);
   const overflowTitle = hidden.map((l) => l.name).join(", ");
   return html`<span class="label-chips">
     ${visible.map((l) => renderLabelChip(l))}

--- a/src/util/label-chip-template.ts
+++ b/src/util/label-chip-template.ts
@@ -98,7 +98,8 @@ export function renderLabelChips(
       ${labels.map((l) => renderLabelChip(l))}
     </span>`;
   }
-  // A cap below 1 collapses the whole list into the "+N" chip.
+  // max 1 leaves no room for a chip beside the "+N"; a cap of 0 or
+  // less would slice from the end, so clamp to a full collapse.
   const visibleCount = Math.max(0, max - 1);
   const visible = labels.slice(0, visibleCount);
   const hidden = labels.slice(visibleCount);

--- a/src/util/label-chip-template.ts
+++ b/src/util/label-chip-template.ts
@@ -98,8 +98,10 @@ export function renderLabelChips(
       ${labels.map((l) => renderLabelChip(l))}
     </span>`;
   }
-  const visible = labels.slice(0, max - 1);
-  const hidden = labels.slice(max - 1);
+  // A cap below 1 collapses the whole list into the "+N" chip.
+  const visibleCount = Math.max(0, max - 1);
+  const visible = labels.slice(0, visibleCount);
+  const hidden = labels.slice(visibleCount);
   const overflowTitle = hidden.map((l) => l.name).join(", ");
   return html`<span class="label-chips">
     ${visible.map((l) => renderLabelChip(l))}

--- a/test/util/label-chip-template.test.ts
+++ b/test/util/label-chip-template.test.ts
@@ -171,6 +171,11 @@ describe("renderLabelChips", () => {
     expect(container.querySelector(".label-chip--overflow")).not.toBeNull();
   });
 
+  it("collapses the whole list into the overflow chip when max is below 2", () => {
+    expect(chipTexts(renderInto(renderLabelChips(labels, { max: 1 })))).toEqual(["+4"]);
+    expect(chipTexts(renderInto(renderLabelChips(labels, { max: 0 })))).toEqual(["+4"]);
+  });
+
   it("lists the hidden label names in the overflow chip's tooltip", () => {
     const container = renderInto(renderLabelChips(labels, { max: 2 }));
     expect(container.querySelector(".label-chip--overflow")?.getAttribute("title")).toBe(

--- a/test/util/label-chip-template.test.ts
+++ b/test/util/label-chip-template.test.ts
@@ -14,7 +14,7 @@
  *  - ``renderLabelChip`` — one pill; ``suppressTitle`` opts out of the
  *    chip's native tooltip when the parent owns a row-level ``title``.
  *  - ``renderLabelChips`` — a (possibly truncated) row; ``max`` caps
- *    the visible chips and collapses the rest into a "+N" overflow
+ *    the total items, collapsing an overflowing tail into a "+N"
  *    chip whose tooltip lists the hidden labels. Empty list renders
  *    ``nothing`` so the caller doesn't have to gate.
  *
@@ -164,17 +164,17 @@ describe("renderLabelChips", () => {
     expect(container.querySelector(".label-chip--overflow")).toBeNull();
   });
 
-  it("collapses the tail into a +N overflow chip when count exceeds max", () => {
+  it("collapses the tail into a +N overflow chip within the max item count", () => {
     const container = renderInto(renderLabelChips(labels, { max: 2 }));
-    // Two visible labels, then the "+2" overflow chip.
-    expect(chipTexts(container)).toEqual(["Alpha", "Beta", "+2"]);
+    // One visible label, then the overflow chip: two items total.
+    expect(chipTexts(container)).toEqual(["Alpha", "+3"]);
     expect(container.querySelector(".label-chip--overflow")).not.toBeNull();
   });
 
   it("lists the hidden label names in the overflow chip's tooltip", () => {
     const container = renderInto(renderLabelChips(labels, { max: 2 }));
     expect(container.querySelector(".label-chip--overflow")?.getAttribute("title")).toBe(
-      "Gamma, Delta"
+      "Beta, Gamma, Delta"
     );
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Fixes the floating divider on the device grid cards and cleans up the card layout issues found while testing the fix.

- The divider floated mid card on short cards: grid rows stretch every card to the tallest sibling and the spare height opened below the header's `border-bottom`. The divider now lives as `border-top` on `.device-actions` and a single `margin-bottom: auto` on the header soaks up the spare height, so the labels row and the action row stay bottom anchored and the line always hugs the buttons. The old `:last-child` border suppression for select mode is no longer needed; the actions row simply is not rendered there.
- Label chips line up across a row instead of trailing each header, with breathing room above the divider.
- The `+N` overflow chip counts against the row cap so a capped row no longer wraps: the card shows 3 chips plus `+N`, the table cap is bumped to keep its density, and a cap below 2 collapses the whole list into `+N`.
- The truncated device name and filename show the full text on hover.
- Select mode: the filename and comment span the full card width instead of indenting past the checkbox, the checkbox column is pinned to its glyph so it stops eating into the name, and the labels row keeps clearance from the card edge when no actions row follows.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).




