### PR TITLE
Ignore dot-prefixed top-level anchor keys in the section parser

### DIFF
--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -27,7 +27,8 @@ import {
 } from "../util/codemirror-theme.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { editorSearchPhrases } from "../util/editor-search-phrases.js";
-import { ESPHOME_YAML_INDENT, esphomeYaml } from "../util/esphome-yaml-lang.js";
+import { ESPHOME_YAML_INDENT } from "../util/esphome-yaml-indent.js";
+import { esphomeYaml } from "../util/esphome-yaml-lang.js";
 import { fireEvent } from "../util/fire-event.js";
 import { idleCompletion } from "../util/idle-completion.js";
 import { createYamlCompletionSource } from "../util/yaml-completion.js";

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -25,6 +25,11 @@ import { splitYamlDocLines } from "./yaml-doc-lines.js";
 import { readInstanceScalar } from "./yaml-instance-scalars.js";
 import { indentOf } from "./yaml-line-walker.js";
 import {
+  IGNORED_TOP_LEVEL_KEY_RE,
+  TOP_LEVEL_KEY_RE,
+  TOP_LEVEL_KEY_START_RE,
+} from "./yaml-section-lexer.js";
+import {
   collectIdsAtPath,
   findFieldLine,
   parseYamlTopLevelSections,
@@ -228,14 +233,17 @@ export function findUsedPins(
   // Indentation of an open free-text block scalar; continuation lines
   // indented deeper than this are prose and skipped. -1 when none is open.
   let blockScalarIndent = -1;
+  let inIgnoredBlock = false;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    const topMatch = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*):/);
-    if (topMatch) {
-      currentDomain = topMatch[1];
+    const topMatch = line.match(TOP_LEVEL_KEY_RE);
+    if (topMatch || IGNORED_TOP_LEVEL_KEY_RE.test(line)) {
+      currentDomain = topMatch ? topMatch[1] : "";
+      inIgnoredBlock = !topMatch;
       blockScalarIndent = -1;
       continue;
     }
+    if (inIgnoredBlock) continue;
     const lineNo = i + 1;
     if (
       excludeFromLine !== undefined &&
@@ -297,7 +305,7 @@ export function sectionEndLine(yaml: string, fromLine?: number): number | undefi
   for (let i = fromLine; i < lines.length; i++) {
     const line = lines[i];
     if (line === "") continue;
-    if (/^[a-zA-Z]/.test(line)) return i;
+    if (TOP_LEVEL_KEY_START_RE.test(line)) return i;
   }
   return lines.length;
 }

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -295,9 +295,9 @@ export function findUsedPins(
 }
 
 /**
- * 1-indexed line number of the first sibling that comes after the
- * section starting at `fromLine`. Used to bound `excludeToLine` for
- * `findUsedPins`. Returns `lines.length` if the section runs to EOF.
+ * 1-indexed inclusive last line of the section starting at `fromLine`
+ * (the line before the next sibling key). Used to bound `excludeToLine`
+ * for `findUsedPins`. Returns `lines.length` if the section runs to EOF.
  */
 export function sectionEndLine(yaml: string, fromLine?: number): number | undefined {
   if (fromLine === undefined) return undefined;

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -233,17 +233,16 @@ export function findUsedPins(
   // Indentation of an open free-text block scalar; continuation lines
   // indented deeper than this are prose and skipped. -1 when none is open.
   let blockScalarIndent = -1;
-  let inIgnoredBlock = false;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const topMatch = line.match(TOP_LEVEL_KEY_RE);
     if (topMatch || IGNORED_TOP_LEVEL_KEY_RE.test(line)) {
+      // An ignored dot key clears the domain; the !currentDomain
+      // guard below then skips its whole block.
       currentDomain = topMatch ? topMatch[1] : "";
-      inIgnoredBlock = !topMatch;
       blockScalarIndent = -1;
       continue;
     }
-    if (inIgnoredBlock) continue;
     const lineNo = i + 1;
     if (
       excludeFromLine !== undefined &&

--- a/src/util/esphome-yaml-indent.ts
+++ b/src/util/esphome-yaml-indent.ts
@@ -1,0 +1,11 @@
+/**
+ * Single source of truth for ESPHome YAML's indent width. Two
+ * spaces matches the legacy dashboard and the upstream ESPHome
+ * code style. Exported so consumers (the editor, tests) share
+ * the same unit and the indent service derives ``step`` from it.
+ *
+ * A leaf module (no imports) so the lexer and line walkers can
+ * depend on it without pulling in the CodeMirror language stack
+ * or closing an import cycle.
+ */
+export const ESPHOME_YAML_INDENT = "  ";

--- a/src/util/esphome-yaml-lang.ts
+++ b/src/util/esphome-yaml-lang.ts
@@ -31,14 +31,6 @@ const RE_BLOCK_OPENER = /:\s*$/;
 const RE_BLOCK_SCALAR_OPENER = /:\s*[|>][+-]?\s*$/;
 
 /**
- * Single source of truth for ESPHome YAML's indent width. Two
- * spaces matches the legacy dashboard and the upstream ESPHome
- * code style. Exported so consumers (the editor, tests) share
- * the same unit and the indent service derives ``step`` from it.
- */
-export const ESPHOME_YAML_INDENT = "  ";
-
-/**
  * Document span of a `!lambda` value's C++ content: the Literal as-is, the
  * QuotedLiteral's interior (inside the quotes), or the BlockLiteralContent.
  * Null when the Tagged node carries no recognised value node.

--- a/src/util/yaml-completion-items.ts
+++ b/src/util/yaml-completion-items.ts
@@ -21,7 +21,7 @@ import type {
   SchemaConfigVarKey,
   SchemaRegistryEntry,
 } from "./esphome-schema.js";
-import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
+import { ESPHOME_YAML_INDENT } from "./esphome-yaml-indent.js";
 import type { CatalogIndex } from "./yaml-completion-catalog.js";
 import { AUTOMATION_KEYS, CORE_KEYS } from "./yaml-sections.js";
 

--- a/src/util/yaml-component-not-found-fix.ts
+++ b/src/util/yaml-component-not-found-fix.ts
@@ -17,12 +17,8 @@ import {
   YAML_INDENT_STEP,
 } from "./yaml-error-analysis.js";
 import type { YamlFixContext } from "./yaml-fix-context.js";
-import {
-  indentOf,
-  RE_LIST_ITEM,
-  RE_TOP_LEVEL_KEY,
-  stripComment,
-} from "./yaml-line-walker.js";
+import { indentOf, RE_LIST_ITEM, stripComment } from "./yaml-line-walker.js";
+import { TOP_LEVEL_KEY_RE } from "./yaml-section-lexer.js";
 
 const COMPONENT_NOT_FOUND_RE = /^Component not found: ([A-Za-z0-9_]+)\.?$/;
 
@@ -95,7 +91,7 @@ function sectionOpenerAbove(
     const stripped = stripComment(doc.line(n).text);
     if (!stripped.trim()) continue;
     if (indentOf(stripped) !== 0) continue;
-    const m = stripped.match(RE_TOP_LEVEL_KEY);
+    const m = stripped.match(TOP_LEVEL_KEY_RE);
     return m && stripped.slice(m[0].length).trim() === "" ? { key: m[1], line: n } : null;
   }
   return null;

--- a/src/util/yaml-error-analysis.ts
+++ b/src/util/yaml-error-analysis.ts
@@ -10,6 +10,7 @@
  * signed one-line repair — live only here.
  */
 import type { LocalizeFunc } from "../common/localize.js";
+import { ESPHOME_YAML_INDENT } from "./esphome-yaml-indent.js";
 import { indentOf, parseListItemMarker, stripComment } from "./yaml-line-walker.js";
 
 /** Match `line N, column M` (1-indexed) globally in a YAML parse error message. */
@@ -29,10 +30,8 @@ const PAIR_RE = /^\s*([^\s:#][^:]*?)\s*:(?:\s+(.*))?$/;
 /** Analysis walks never scan further than this many lines. */
 export const WALK_BOUND = 50;
 
-/** Canonical child-indent step. A literal two: this module stays free of
- *  esphome-yaml-lang's CodeMirror import graph, where ESPHOME_YAML_INDENT
- *  is the same two spaces. */
-export const YAML_INDENT_STEP = 2;
+/** Canonical child-indent step. */
+export const YAML_INDENT_STEP = ESPHOME_YAML_INDENT.length;
 
 /**
  * Strip absolute directory paths out of a backend error message.

--- a/src/util/yaml-instance-scalars.ts
+++ b/src/util/yaml-instance-scalars.ts
@@ -1,6 +1,6 @@
 import { splitYamlDocLines } from "./yaml-doc-lines.js";
 import { splitInlineComment, stripQuotes } from "./yaml-scalar.js";
-import { TOP_LEVEL_KEY_RE } from "./yaml-section-lexer.js";
+import { IGNORED_TOP_LEVEL_KEY_RE, TOP_LEVEL_KEY_RE } from "./yaml-section-lexer.js";
 
 const _INSTANCE_SCALAR_RE = new Map<string, RegExp>();
 
@@ -53,7 +53,9 @@ export function collectInstanceScalars(
   for (const line of splitYamlDocLines(yaml)) {
     if (!/^\s/.test(line)) {
       const top = line.match(TOP_LEVEL_KEY_RE);
-      if (section !== undefined && top) inSection = top[1] === section;
+      if (section !== undefined && (top || IGNORED_TOP_LEVEL_KEY_RE.test(line))) {
+        inSection = top !== null && top[1] === section;
+      }
       continue;
     }
     if (!inSection) continue;

--- a/src/util/yaml-line-walker.ts
+++ b/src/util/yaml-line-walker.ts
@@ -14,6 +14,8 @@
 
 import type { Text } from "@codemirror/state";
 
+import { IGNORED_TOP_LEVEL_KEY_RE } from "./yaml-section-lexer.js";
+
 // ─── Shared regex constants ─────────────────────────────────────────
 
 /** ``# comment`` boundary — must be at line start or after whitespace.
@@ -229,15 +231,17 @@ export function collectSiblingKeysByIndent(
   return out;
 }
 
-/** Walk back from *lineIdx* to the first column-0 line; its ``key:``, or
- *  ``null`` when that line isn't one (a dot-prefixed ignored key, ``---``). */
+/** Walk back from *lineIdx* to the first column-0 ``key:`` line; a
+ *  dot-prefixed ignored key answers ``null``, other non-key column-0
+ *  lines (a compact-sequence dash, ``---``) are skipped. */
 export function findTopLevelBlock(doc: Text, lineIdx: number): string | null {
   for (let i = lineIdx - 1; i >= 0; i--) {
     const stripped = stripComment(doc.line(i + 1).text);
     if (!stripped.trim()) continue;
     if (indentOf(stripped) !== 0) continue;
     const m = stripped.match(RE_TOP_LEVEL_KEY);
-    return m ? m[1] : null;
+    if (m) return m[1];
+    if (IGNORED_TOP_LEVEL_KEY_RE.test(stripped)) return null;
   }
   return null;
 }

--- a/src/util/yaml-line-walker.ts
+++ b/src/util/yaml-line-walker.ts
@@ -14,7 +14,7 @@
 
 import type { Text } from "@codemirror/state";
 
-import { IGNORED_TOP_LEVEL_KEY_RE } from "./yaml-section-lexer.js";
+import { IGNORED_TOP_LEVEL_KEY_RE, TOP_LEVEL_KEY_RE } from "./yaml-section-lexer.js";
 
 // ─── Shared regex constants ─────────────────────────────────────────
 
@@ -31,10 +31,6 @@ export const RE_INLINE_COMMENT_BOUNDARY = /(^|\s)#/;
  *  argument mapping — without that, ``findParentKey`` walks past
  *  the action and the action-arg completion can't fire. */
 export const RE_PAIR_LINE = /^\s*(?:-\s+)?([A-Za-z0-9_.]+)\s*:\s*(.*)$/;
-
-/** Column-0 pair: key starts at indent 0. Used to identify
- *  top-level component blocks when walking up from the cursor. */
-export const RE_TOP_LEVEL_KEY = /^([A-Za-z0-9_]+)\s*:/;
 
 /** A list-item line — optional indent then a ``- `` dash. The item is an
  *  anonymous container, so an indent walk treating list items as parentless
@@ -238,7 +234,7 @@ export function findTopLevelBlock(doc: Text, lineIdx: number): string | null {
     const stripped = stripComment(doc.line(i + 1).text);
     if (!stripped.trim()) continue;
     if (indentOf(stripped) !== 0) continue;
-    const m = stripped.match(RE_TOP_LEVEL_KEY);
+    const m = stripped.match(TOP_LEVEL_KEY_RE);
     if (m) return m[1];
     if (IGNORED_TOP_LEVEL_KEY_RE.test(stripped)) return null;
   }

--- a/src/util/yaml-line-walker.ts
+++ b/src/util/yaml-line-walker.ts
@@ -229,14 +229,15 @@ export function collectSiblingKeysByIndent(
   return out;
 }
 
-/** Walk back from *lineIdx* to the first column-0 ``key:`` line. */
+/** Walk back from *lineIdx* to the first column-0 line; its ``key:``, or
+ *  ``null`` when that line isn't one (a dot-prefixed ignored key, ``---``). */
 export function findTopLevelBlock(doc: Text, lineIdx: number): string | null {
   for (let i = lineIdx - 1; i >= 0; i--) {
     const stripped = stripComment(doc.line(i + 1).text);
     if (!stripped.trim()) continue;
     if (indentOf(stripped) !== 0) continue;
     const m = stripped.match(RE_TOP_LEVEL_KEY);
-    if (m) return m[1];
+    return m ? m[1] : null;
   }
   return null;
 }

--- a/src/util/yaml-line-walker.ts
+++ b/src/util/yaml-line-walker.ts
@@ -89,9 +89,8 @@ export function stripComment(line: string): string {
  *  *value*. Mirrors the AST's ``readLiteralText`` so the regex
  *  walkers (and ``yaml-hover``) and the AST agree on the
  *  user-facing string. Deliberately NOT ``yaml-scalar``'s
- *  ``stripQuotes``: importing ``yaml-scalar`` here would close an
- *  import cycle (``yaml-scalar`` → ``yaml-serialize`` →
- *  ``esphome-yaml-lang`` → this module). */
+ *  ``stripQuotes``, which also unescapes — these walkers want the
+ *  literal interior. */
 export function unquote(value: string): string {
   if (value.length < 2) return value;
   const q = value[0];

--- a/src/util/yaml-section-block-reader.ts
+++ b/src/util/yaml-section-block-reader.ts
@@ -8,7 +8,7 @@
  * calls back up into the section parser.
  */
 
-import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
+import { ESPHOME_YAML_INDENT } from "./esphome-yaml-indent.js";
 import {
   blockScalarValue,
   isEditableLambdaBlock,

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -5,7 +5,7 @@
  * constant. (Scalar value parsing lives in yaml-scalar.ts.)
  */
 
-import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
+import { ESPHOME_YAML_INDENT } from "./esphome-yaml-indent.js";
 
 /** Non-leading key characters: anything but whitespace, ``:``, ``#``. */
 const KEY_BODY = "[^\\s:#]*";

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -29,14 +29,23 @@ export const KEY_PATTERN = "[a-zA-Z_][^\\s:#]*";
 
 /**
  * Matches a line that begins a top-level YAML section (column-0
- * identifier). Mirrors ``KEY_PATTERN``'s leading-character set —
- * accepts ``_internal:`` and similar underscore-leading keys, not
- * just ASCII letters. Used by every "stop at the next sibling
+ * identifier). Accepts ``_internal:`` and similar underscore-leading
+ * keys, plus a leading ``.`` — ESPHome ignores dot-prefixed top-level
+ * keys (the anchor-container convention), but such a key still ends
+ * the block above it. Used by every "stop at the next sibling
  * section" terminator across these layers so the predicate stays
  * consistent — drift between sites would let one walk past a
  * section header another walk treats as a hard stop.
  */
-export const TOP_LEVEL_KEY_START_RE = /^[a-zA-Z_]/;
+export const TOP_LEVEL_KEY_START_RE = /^[a-zA-Z_.]/;
+
+/**
+ * A column-0 dot-prefixed key (``.defaultfilters:``). ESPHome
+ * ignores these top-level keys entirely (the documented way to
+ * park YAML anchors), so the section parser must close the
+ * preceding section at one but never emit a section for it.
+ */
+export const IGNORED_TOP_LEVEL_KEY_RE = /^\.[^\s:#]*:/;
 
 /**
  * Capture a column-0 top-level key. Group 1 is the key; the prefix

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -25,7 +25,8 @@ import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
  * MAP editor. Supporting them would require a different parsing
  * strategy; see issue tracker for upstream support if needed.
  */
-export const KEY_PATTERN = "[a-zA-Z_][^\\s:#]*";
+const KEY_BODY = "[^\\s:#]*";
+export const KEY_PATTERN = `[a-zA-Z_]${KEY_BODY}`;
 
 /**
  * Matches a line that begins a top-level YAML section (column-0
@@ -45,7 +46,7 @@ export const TOP_LEVEL_KEY_START_RE = /^[a-zA-Z_.]/;
  * park YAML anchors), so the section parser must close the
  * preceding section at one but never emit a section for it.
  */
-export const IGNORED_TOP_LEVEL_KEY_RE = /^\.[^\s:#]*:/;
+export const IGNORED_TOP_LEVEL_KEY_RE = new RegExp(`^\\.${KEY_BODY}:`);
 
 /**
  * Capture a column-0 top-level key. Group 1 is the key; the prefix

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -7,6 +7,9 @@
 
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 
+/** Non-leading key characters: anything but whitespace, ``:``, ``#``. */
+const KEY_BODY = "[^\\s:#]*";
+
 /**
  * Identifier alphabet for plain-scalar YAML keys the parser will
  * accept. The leading character stays strict (``[a-zA-Z_]``) so
@@ -25,7 +28,6 @@ import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
  * MAP editor. Supporting them would require a different parsing
  * strategy; see issue tracker for upstream support if needed.
  */
-const KEY_BODY = "[^\\s:#]*";
 export const KEY_PATTERN = `[a-zA-Z_]${KEY_BODY}`;
 
 /**

--- a/src/util/yaml-section-splice.ts
+++ b/src/util/yaml-section-splice.ts
@@ -8,7 +8,7 @@
  * with this concern.
  */
 
-import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
+import { ESPHOME_YAML_INDENT } from "./esphome-yaml-indent.js";
 import { isPlainObject, isPrimitiveOrNullish } from "./nested-values.js";
 import { arraysEqual } from "./set-equal.js";
 import type { ListItemSource } from "./yaml-section-list.js";

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -7,7 +7,7 @@
  * read and write — not as a general YAML parser.
  */
 
-import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
+import { ESPHOME_YAML_INDENT } from "./esphome-yaml-indent.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import { splitYamlDocLines, yamlDocEol } from "./yaml-doc-lines.js";
 import {

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -10,7 +10,7 @@
  * importing these from `./yaml-sections.js` are unaffected.
  */
 
-import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
+import { ESPHOME_YAML_INDENT } from "./esphome-yaml-indent.js";
 import { isIndexSegment } from "./nested-values.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import { splitYamlDocLines } from "./yaml-doc-lines.js";

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -19,6 +19,7 @@ import { indentOf, RE_PAIR_LINE, stripComment } from "./yaml-line-walker.js";
 import {
   _skipBlankAndCommentLines,
   endsBlockAtIndent,
+  IGNORED_TOP_LEVEL_KEY_RE,
   LIST_ITEM_START_RE,
   TOP_LEVEL_KEY_RE,
 } from "./yaml-section-lexer.js";
@@ -121,11 +122,15 @@ export function parseYamlTopLevelSections(yaml: string): YamlSection[] {
   }
   const lines = splitYamlDocLines(yaml);
   const rawSections: Array<{ key: string; fromLine: number; toLine: number }> = [];
+  let lastClosedByIgnoredKey = false;
 
   for (let i = 0; i < lines.length; i++) {
-    const match = lines[i].match(TOP_LEVEL_KEY_RE);
-    if (match) {
-      if (rawSections.length > 0) {
+    // ESPHome ignores dot-prefixed top-level keys (anchor containers);
+    // close the previous section at one but emit no section for it.
+    const ignored = IGNORED_TOP_LEVEL_KEY_RE.test(lines[i]);
+    const match = ignored ? null : lines[i].match(TOP_LEVEL_KEY_RE);
+    if (ignored || match) {
+      if (rawSections.length > 0 && !lastClosedByIgnoredKey) {
         // The previous section content ends one line before the new
         // top-level key. Walk backward over trailing blank /
         // comment-only lines: those typically decorate the upcoming
@@ -142,6 +147,9 @@ export function parseYamlTopLevelSections(yaml: string): YamlSection[] {
         }
         prev.toLine = endIdx + 1;
       }
+      lastClosedByIgnoredKey = ignored;
+    }
+    if (match) {
       rawSections.push({
         key: match[1],
         fromLine: i + 1, // convert 0-indexed array to 1-indexed CM line
@@ -153,8 +161,9 @@ export function parseYamlTopLevelSections(yaml: string): YamlSection[] {
   // Trim trailing blank / comment-only lines from the final section
   // for the same reason as above — a comment block at the very end
   // of the file (or right before EOF whitespace) shouldn't extend
-  // the last section's hover-highlight range.
-  if (rawSections.length > 0) {
+  // the last section's hover-highlight range. A section already
+  // closed by an ignored dot-key keeps that boundary.
+  if (rawSections.length > 0 && !lastClosedByIgnoredKey) {
     const last = rawSections[rawSections.length - 1];
     const lastStart = last.fromLine - 1; // 0-indexed
     let endIdx = lines.length - 1;

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -121,16 +121,22 @@ export function parseYamlTopLevelSections(yaml: string): YamlSection[] {
     return _topLevelSectionsValue;
   }
   const lines = splitYamlDocLines(yaml);
-  const rawSections: Array<{ key: string; fromLine: number; toLine: number }> = [];
-  let lastClosedByIgnoredKey = false;
+  const rawSections: Array<{
+    key: string;
+    fromLine: number;
+    toLine: number;
+    ignored?: boolean;
+  }> = [];
 
   for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(TOP_LEVEL_KEY_RE);
     // ESPHome ignores dot-prefixed top-level keys (anchor containers);
-    // close the previous section at one but emit no section for it.
-    const ignored = IGNORED_TOP_LEVEL_KEY_RE.test(lines[i]);
-    const match = ignored ? null : lines[i].match(TOP_LEVEL_KEY_RE);
-    if (ignored || match) {
-      if (rawSections.length > 0 && !lastClosedByIgnoredKey) {
+    // they close the previous section but never become one — tracked
+    // as a raw section so both trims work unchanged, dropped before
+    // expansion.
+    const ignored = !match && IGNORED_TOP_LEVEL_KEY_RE.test(lines[i]);
+    if (match || ignored) {
+      if (rawSections.length > 0) {
         // The previous section content ends one line before the new
         // top-level key. Walk backward over trailing blank /
         // comment-only lines: those typically decorate the upcoming
@@ -147,13 +153,11 @@ export function parseYamlTopLevelSections(yaml: string): YamlSection[] {
         }
         prev.toLine = endIdx + 1;
       }
-      lastClosedByIgnoredKey = ignored;
-    }
-    if (match) {
       rawSections.push({
-        key: match[1],
+        key: match ? match[1] : "",
         fromLine: i + 1, // convert 0-indexed array to 1-indexed CM line
         toLine: lines.length,
+        ignored,
       });
     }
   }
@@ -161,9 +165,8 @@ export function parseYamlTopLevelSections(yaml: string): YamlSection[] {
   // Trim trailing blank / comment-only lines from the final section
   // for the same reason as above — a comment block at the very end
   // of the file (or right before EOF whitespace) shouldn't extend
-  // the last section's hover-highlight range. A section already
-  // closed by an ignored dot-key keeps that boundary.
-  if (rawSections.length > 0 && !lastClosedByIgnoredKey) {
+  // the last section's hover-highlight range.
+  if (rawSections.length > 0) {
     const last = rawSections[rawSections.length - 1];
     const lastStart = last.fromLine - 1; // 0-indexed
     let endIdx = lines.length - 1;
@@ -179,6 +182,7 @@ export function parseYamlTopLevelSections(yaml: string): YamlSection[] {
   // Expand list items within each section
   const sections: YamlSection[] = [];
   for (const raw of rawSections) {
+    if (raw.ignored) continue;
     sections.push(..._expandListItems(lines, raw));
   }
 

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -17,6 +17,7 @@ import { isLambdaValue, type LambdaValue } from "../api/types/automations.js";
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import { isPlainObject } from "./nested-values.js";
 import { escapeYamlDoubleQuoted, hasEscapeWorthyChar } from "./yaml-escape.js";
+import { IGNORED_TOP_LEVEL_KEY_RE } from "./yaml-section-lexer.js";
 
 /**
  * Wrap a ``LambdaValue`` sentinel (``{_lambda: "<body>"}``) as a
@@ -474,6 +475,10 @@ export function parseConfiguredPlatforms(yaml: string): Set<string> {
     const top = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*):\s*(?:#.*)?$/);
     if (top) {
       currentDomain = top[1];
+      continue;
+    }
+    if (IGNORED_TOP_LEVEL_KEY_RE.test(line)) {
+      currentDomain = null;
       continue;
     }
     if (!currentDomain) continue;

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -14,7 +14,7 @@
  */
 
 import { isLambdaValue, type LambdaValue } from "../api/types/automations.js";
-import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
+import { ESPHOME_YAML_INDENT } from "./esphome-yaml-indent.js";
 import { isPlainObject } from "./nested-values.js";
 import { escapeYamlDoubleQuoted, hasEscapeWorthyChar } from "./yaml-escape.js";
 import { IGNORED_TOP_LEVEL_KEY_RE } from "./yaml-section-lexer.js";

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -8,6 +8,7 @@ import {
   findReferenceCandidates,
   findUsedPins,
   isCertainlyDanglingId,
+  sectionEndLine,
   yamlHasExternalIdSources,
   yamlHasMergedSources,
 } from "../../src/util/config-entry-yaml-scan.js";
@@ -76,6 +77,21 @@ describe("findUsedPins", () => {
     const map = findUsedPins(yaml);
     expect(map.get(4)).toBe("switch");
     expect(map.get(5)).toBe("binary_sensor");
+  });
+
+  it("bounds sectionEndLine at the next sibling, dot and underscore keys included", () => {
+    const config = [
+      "switch:", //          line 1
+      "  - platform: gpio",
+      ".anchors:", //        line 3
+      "  - &spare 7",
+      "_extras:", //         line 5
+      "  note: x",
+      "",
+    ].join("\n");
+    expect(sectionEndLine(config, 1)).toBe(2);
+    expect(sectionEndLine(config, 3)).toBe(4);
+    expect(sectionEndLine(config, undefined)).toBeUndefined();
   });
 
   it("skips pins inside a dot-prefixed ignored block", () => {

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -78,6 +78,21 @@ describe("findUsedPins", () => {
     expect(map.get(5)).toBe("binary_sensor");
   });
 
+  it("skips pins inside a dot-prefixed ignored block", () => {
+    const config = [
+      "switch:",
+      "  - platform: gpio",
+      "    pin: GPIO4",
+      ".pins:",
+      "  - &spare",
+      "    pin: GPIO7",
+      "",
+    ].join("\n");
+    const map = findUsedPins(config);
+    expect(map.get(4)).toBe("switch");
+    expect(map.has(7)).toBe(false);
+  });
+
   it("namespaces an I/O-expander pin so its channel doesn't alias a board GPIO", () => {
     const config = [
       "binary_sensor:",

--- a/test/util/esphome-yaml-lang.test.ts
+++ b/test/util/esphome-yaml-lang.test.ts
@@ -7,7 +7,8 @@ import {
 } from "@codemirror/language";
 import { EditorState } from "@codemirror/state";
 import { describe, expect, it } from "vitest";
-import { ESPHOME_YAML_INDENT, esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
+import { ESPHOME_YAML_INDENT } from "../../src/util/esphome-yaml-indent.js";
+import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
 
 /**
  * The indent service mirrors the legacy esphome dashboard's Monaco

--- a/test/util/yaml-instance-scalars.test.ts
+++ b/test/util/yaml-instance-scalars.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { collectInstanceScalars } from "../../src/util/yaml-instance-scalars.js";
+
+describe("collectInstanceScalars", () => {
+  const yaml = [
+    "sensor:",
+    "  - platform: dht",
+    "    name: Kitchen",
+    ".defaultfilters:",
+    "  - &tagged",
+    "    name: Parked",
+    "wifi:",
+    "  name: NotASensor",
+    "",
+  ].join("\n");
+
+  it("collects values under the requested section only", () => {
+    expect(collectInstanceScalars(yaml, "name", "sensor")).toEqual(new Set(["Kitchen"]));
+  });
+
+  it("a dot-prefixed ignored key ends the section", () => {
+    expect(collectInstanceScalars(yaml, "name", "sensor").has("Parked")).toBe(false);
+  });
+
+  it("collects across the whole document without a section", () => {
+    expect(collectInstanceScalars(yaml, "name")).toEqual(
+      new Set(["Kitchen", "Parked", "NotASensor"])
+    );
+  });
+});

--- a/test/util/yaml-line-walker.test.ts
+++ b/test/util/yaml-line-walker.test.ts
@@ -134,6 +134,15 @@ describe("findTopLevelBlock", () => {
     expect(findTopLevelBlock(t(lines), 0)).toBeNull();
   });
 
+  it("walks past a column-0 compact-sequence dash to the domain key", () => {
+    const doc = [
+      "sensor:",
+      "- platform: dht",
+      "  name: x", //                  2 — ancestor: sensor
+    ];
+    expect(findTopLevelBlock(t(doc), 2)).toBe("sensor");
+  });
+
   it("returns null inside a dot-prefixed ignored block", () => {
     const doc = [
       "time:",

--- a/test/util/yaml-line-walker.test.ts
+++ b/test/util/yaml-line-walker.test.ts
@@ -133,6 +133,16 @@ describe("findTopLevelBlock", () => {
   it("returns null when the cursor is the top of the doc", () => {
     expect(findTopLevelBlock(t(lines), 0)).toBeNull();
   });
+
+  it("returns null inside a dot-prefixed ignored block", () => {
+    const doc = [
+      "time:",
+      "  - platform: sntp",
+      ".defaultfilters:",
+      "  - &throttle_time", //          3 — ancestor: none (ignored key)
+    ];
+    expect(findTopLevelBlock(t(doc), 3)).toBeNull();
+  });
 });
 
 describe("readPlatformSibling (regex fallback)", () => {

--- a/test/util/yaml-section-lexer.test.ts
+++ b/test/util/yaml-section-lexer.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { endsBlockAtIndent } from "../../src/util/yaml-section-lexer.js";
+import {
+  endsBlockAtIndent,
+  IGNORED_TOP_LEVEL_KEY_RE,
+  TOP_LEVEL_KEY_RE,
+  TOP_LEVEL_KEY_START_RE,
+} from "../../src/util/yaml-section-lexer.js";
+
+describe("dot-prefixed top-level keys", () => {
+  it("terminate the previous block but are not sections themselves", () => {
+    expect(TOP_LEVEL_KEY_START_RE.test(".defaultfilters:")).toBe(true);
+    expect(IGNORED_TOP_LEVEL_KEY_RE.test(".defaultfilters:")).toBe(true);
+    expect(TOP_LEVEL_KEY_RE.test(".defaultfilters:")).toBe(false);
+  });
+
+  it("are only recognised at column 0 with a key shape", () => {
+    expect(IGNORED_TOP_LEVEL_KEY_RE.test("  .indented:")).toBe(false);
+    expect(IGNORED_TOP_LEVEL_KEY_RE.test(".no_colon")).toBe(false);
+    expect(TOP_LEVEL_KEY_START_RE.test("  wifi:")).toBe(false);
+  });
+});
 
 describe("endsBlockAtIndent", () => {
   // The single source of truth for "where does a block end", shared by

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -470,6 +470,30 @@ describe("updateSectionInYaml — trailing comments / blank lines", () => {
     expect(after).toContain("logger:");
   });
 
+  it("saves a list item without eating a following dot-prefixed key", () => {
+    // ESPHome-ignored anchor container below the section; the splice
+    // must stop at it, not swallow its header line (#2651).
+    const before = [
+      "time:",
+      "  - platform: sntp",
+      "    id: my_time",
+      ".defaultfilters:",
+      "  - &throttle_time",
+      "    throttle: 60s",
+      "",
+    ].join("\n");
+    const after = updateSectionInYaml(
+      before,
+      "time.sntp",
+      { platform: "sntp", id: "other_time" },
+      2
+    );
+    expect(after).toContain("id: other_time");
+    expect(after).toContain(".defaultfilters:");
+    expect(after).toContain("- &throttle_time");
+    expect(after).toContain("throttle: 60s");
+  });
+
   it("keeps comments when the section body is comment-only", () => {
     // Exercises the `> start + 1` guard: header replaced, comments kept.
     const before = "wifi:\n  # configure later\n  # see docs\nlogger:\n";
@@ -553,6 +577,26 @@ describe("removeSectionFromYaml — multi-item list", () => {
     // The first item and its sibling field survive.
     expect(after).toContain("- platform: esphome");
     expect(after).toContain("password: foo");
+  });
+
+  it("preserves a following dot-prefixed block when removing an item", () => {
+    const before = [
+      "ota:",
+      "  - platform: esphome",
+      "  - platform: web_server",
+      ".defaultfilters:",
+      "  - &throttle_time",
+      "    throttle: 60s",
+      "",
+    ].join("\n");
+    const after = removeSectionFromYaml(
+      before,
+      "ota.web_server",
+      nthListItemLine(before, "ota", 2)
+    );
+    expect(after).not.toContain("- platform: web_server");
+    expect(after).toContain(".defaultfilters:");
+    expect(after).toContain("throttle: 60s");
   });
 
   it("drops the parent block when removing the only list item", () => {

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -279,6 +279,40 @@ wifi:
     expect(parseYamlTopLevelSections(yaml).map((s) => s.key)).toEqual(["esphome"]);
   });
 
+  it("ignores a dot-prefixed top-level key and closes the section above (#2651)", () => {
+    const yaml = `time:
+  - platform: sntp
+    id: my_time
+.defaultfilters:
+  - &moving_avg
+    sliding_window_moving_average:
+      window_size: 12
+  - &throttle_time
+    throttle: 60s
+`;
+    const sections = parseYamlTopLevelSections(yaml);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].key).toBe("time");
+    expect(sections[0].platform).toBe("sntp");
+    expect(sections[0].toLine).toBe(3);
+    expect(sectionAtLine(yaml, 5)).toBeNull();
+  });
+
+  it("attributes sections after a dot-prefixed block to their own keys", () => {
+    const yaml = `time:
+  - platform: sntp
+.defaultfilters:
+  - &throttle_time
+    throttle: 60s
+wifi:
+  ssid: x
+`;
+    const sections = parseYamlTopLevelSections(yaml);
+    expect(sections.map((s) => s.key)).toEqual(["time", "wifi"]);
+    expect(sections[0].toLine).toBe(2);
+    expect(sections[1].fromLine).toBe(6);
+  });
+
   it("keeps non-list sections as a single entry", () => {
     const yaml = `wifi:
   ssid: foo

--- a/test/util/yaml-serialize.test.ts
+++ b/test/util/yaml-serialize.test.ts
@@ -54,6 +54,13 @@ describe("parseConfiguredPlatforms", () => {
     expect(parseConfiguredPlatforms("  - platform: gpio")).toEqual(new Set());
   });
 
+  it("does not attribute a dot-prefixed anchor block to the domain above", () => {
+    const yaml = ["time:", "  - platform: sntp", ".presets:", "  - platform: dht"].join(
+      "\n"
+    );
+    expect(parseConfiguredPlatforms(yaml)).toEqual(new Set(["time.sntp"]));
+  });
+
   it("returns an empty set for blank input", () => {
     expect(parseConfiguredPlatforms("")).toEqual(new Set());
   });


### PR DESCRIPTION
# What does this implement/fix?

ESPHome ignores top-level keys starting with a dot, the documented way to park YAML anchors. The section parser did not recognise them, so the preceding section never closed and the anchor list items rendered as bogus unnamed cards under it; the save path had the same blind spot, so editing the section above through the structured form silently deleted the dot key's header line.

The parser now closes the previous section at a dot-prefixed key and emits no section for it, and the shared block terminator treats a column-0 dot key as a sibling boundary, which fixes the save and delete splices too. The remaining column-0 scanners with their own inline matchers were widened the same way: the configured-platforms scan, the pin-usage scan and its section-end bound, the instance-scalar pool, and the cursor block walk (`findTopLevelBlock` now answers null inside a dot block while still walking past compact-sequence dashes, and shares the lexer's key regex instead of its own copy).

At review request, `ESPHOME_YAML_INDENT` moved out of the CodeMirror language module into a leaf `esphome-yaml-indent.ts`, breaking the import cycle the lexer import would otherwise close; `yaml-error-analysis` derives `YAML_INDENT_STEP` from it instead of a hand-rolled literal.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2651

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
