### PR TITLE
Render catalog card and list row glyphs inline instead of one wa-icon each

### DIFF
--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -31,8 +31,6 @@ import {
 import { renderBundleCard, renderCard } from "./component-catalog/renderers.js";
 import { componentCatalogStyles } from "./component-catalog/styles.js";
 
-import "@home-assistant/webawesome/dist/components/badge/badge.js";
-import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/tooltip/tooltip.js";
 
 @customElement("esphome-component-catalog")

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -1,12 +1,4 @@
 import { consume } from "@lit/context";
-import {
-  mdiArrowCollapseAll,
-  mdiArrowExpandAll,
-  mdiMemory,
-  mdiOpenInNew,
-  mdiPackageVariantClosed,
-  mdiPlus,
-} from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, queryAll, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../../api/index.js";
@@ -25,7 +17,6 @@ import { fireEvent } from "../../util/fire-event.js";
 import { IntersectionController } from "../../util/intersection-controller.js";
 import { isVisible } from "../../util/is-visible.js";
 import { PagedListController } from "../../util/paged-list-controller.js";
-import { registerMdiIcons } from "../../util/register-icons.js";
 import { ResizeController } from "../../util/resize-controller.js";
 import { setsEqual } from "../../util/set-equal.js";
 import { renderLoadMoreFooter } from "../shared/load-more-footer.js";
@@ -43,15 +34,6 @@ import { componentCatalogStyles } from "./component-catalog/styles.js";
 import "@home-assistant/webawesome/dist/components/badge/badge.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/tooltip/tooltip.js";
-
-registerMdiIcons({
-  "arrow-collapse-all": mdiArrowCollapseAll,
-  "arrow-expand-all": mdiArrowExpandAll,
-  memory: mdiMemory,
-  "open-in-new": mdiOpenInNew,
-  "package-variant-closed": mdiPackageVariantClosed,
-  plus: mdiPlus,
-});
 
 @customElement("esphome-component-catalog")
 export class ESPHomeComponentCatalog extends LitElement {

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -1,8 +1,17 @@
+import {
+  mdiArrowCollapseAll,
+  mdiArrowExpandAll,
+  mdiMemory,
+  mdiOpenInNew,
+  mdiPackageVariantClosed,
+  mdiPlus,
+} from "@mdi/js";
 import { html, nothing, type TemplateResult } from "lit";
 import type { FeaturedBundle } from "../../../api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../../api/types/components.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { isSafeLinkHref, renderMarkdown } from "../../../util/markdown.js";
+import { mdiSvg } from "../../../util/mdi-svg.js";
 import {
   categoryChipLabel,
   platformLabel,
@@ -41,10 +50,7 @@ function renderExpandButton(host: ESPHomeComponentCatalog, id: string): Template
     title=${host._localize("wizard.expand_board")}
     @click=${() => host._onToggleExpand(id)}
   >
-    <wa-icon
-      library="mdi"
-      name=${expanded ? "arrow-collapse-all" : "arrow-expand-all"}
-    ></wa-icon>
+    ${mdiSvg(expanded ? mdiArrowCollapseAll : mdiArrowExpandAll)}
   </button>`;
 }
 
@@ -84,7 +90,7 @@ export function renderBundleCard(
                 />
               </div>`
             : html`<div class="component-image--placeholder">
-                <wa-icon library="mdi" name="package-variant-closed"></wa-icon>
+                ${mdiSvg(mdiPackageVariantClosed)}
               </div>`
         }
         <div class="component-card-header-text">
@@ -95,7 +101,7 @@ export function renderBundleCard(
           )}
         </div>
         <span class="bundle-badge">
-          <wa-icon library="mdi" name="package-variant-closed"></wa-icon>
+          ${mdiSvg(mdiPackageVariantClosed)}
           ${host._localize("device.featured_bundle_badge")}
         </span>
         ${expandable ? renderExpandButton(host, expandKey) : nothing}
@@ -119,8 +125,7 @@ export function renderBundleCard(
           type="button"
           @click=${() => host._onAddBundle(bundle)}
         >
-          <wa-icon library="mdi" name="plus"></wa-icon>
-          ${host._localize("device.add_component_action")}
+          ${mdiSvg(mdiPlus)} ${host._localize("device.add_component_action")}
         </button>
       </div>
     </article>
@@ -177,9 +182,7 @@ export function renderCard(
                   @error=${() => host._onImageError(component.id)}
                 />
               </div>`
-            : html`<div class="component-image--placeholder">
-                <wa-icon library="mdi" name="memory"></wa-icon>
-              </div>`
+            : html`<div class="component-image--placeholder">${mdiSvg(mdiMemory)}</div>`
         }
         <div class="component-card-header-text">
           <h3 class="component-title truncate">${component.name}</h3>
@@ -219,8 +222,7 @@ export function renderCard(
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                ${localize("device.more_info")}
-                <wa-icon library="mdi" name="open-in-new"></wa-icon>
+                ${localize("device.more_info")} ${mdiSvg(mdiOpenInNew)}
               </a>`
             : html`<span></span>`
         }
@@ -229,8 +231,7 @@ export function renderCard(
           type="button"
           @click=${() => host._onAdd(component)}
         >
-          <wa-icon library="mdi" name="plus"></wa-icon>
-          ${localize("device.add_component_action")}
+          ${mdiSvg(mdiPlus)} ${localize("device.add_component_action")}
         </button>
       </div>
     </article>

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -47,6 +47,7 @@ function renderExpandButton(host: ESPHomeComponentCatalog, id: string): Template
     class="expand-button"
     type="button"
     aria-pressed=${expanded}
+    aria-label=${host._localize("wizard.expand_board")}
     title=${host._localize("wizard.expand_board")}
     @click=${() => host._onToggleExpand(id)}
   >

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -221,7 +221,7 @@ export const componentCatalogStyles = css`
     outline-offset: 1px;
   }
 
-  .expand-button wa-icon {
+  .expand-button svg {
     transition: transform var(--wa-transition-normal) var(--wa-transition-easing);
   }
 
@@ -339,7 +339,7 @@ export const componentCatalogStyles = css`
     text-decoration: underline;
   }
 
-  .more-info wa-icon {
+  .more-info svg {
     font-size: 11px;
   }
 
@@ -414,7 +414,7 @@ export const componentCatalogStyles = css`
     padding: 1px 6px;
   }
 
-  .bundle-badge wa-icon {
+  .bundle-badge svg {
     font-size: 11px;
   }
 `;

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -221,10 +221,6 @@ export const componentCatalogStyles = css`
     outline-offset: 1px;
   }
 
-  .expand-button svg {
-    transition: transform var(--wa-transition-normal) var(--wa-transition-easing);
-  }
-
   .component-card-header {
     display: flex;
     align-items: center;

--- a/src/components/device/config-entry-form.styles.ts
+++ b/src/components/device/config-entry-form.styles.ts
@@ -357,7 +357,7 @@ export const configEntryFormStyles = css`
     color: var(--wa-color-text-normal);
   }
 
-  .multi-btn wa-icon {
+  .multi-btn svg {
     font-size: 14px;
   }
 

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -20,7 +20,6 @@ import {
   mdiChevronUp,
   mdiClose,
   mdiOpenInNew,
-  mdiPlus,
 } from "@mdi/js";
 import { css, html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -123,7 +122,6 @@ registerMdiIcons({
   "chevron-up": mdiChevronUp,
   close: mdiClose,
   "open-in-new": mdiOpenInNew,
-  plus: mdiPlus,
 });
 
 /** Detail emitted with `value-change` events. */

--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -5,6 +5,7 @@
  * literal sentinel as a config value.
  */
 
+import { mdiPlus } from "@mdi/js";
 import { html, nothing } from "lit";
 import type { ConfigEntry } from "../../api/types/config-entries.js";
 import {
@@ -12,6 +13,7 @@ import {
   isCertainlyDanglingId,
   resolveSoleCandidate,
 } from "../../util/config-entry-yaml-scan.js";
+import { registerMdiIcons } from "../../util/register-icons.js";
 import { renderInlineError } from "../../util/render-error.js";
 import { resolveSubstitutions } from "../../util/substitutions.js";
 import { parseTopLevelComponents } from "../../util/yaml-serialize.js";
@@ -23,6 +25,8 @@ import {
   renderLabel,
   renderYamlOnlyFallbackIfNonPrimitive,
 } from "./config-entry-renderers-shared.js";
+
+registerMdiIcons({ plus: mdiPlus });
 
 export const ADD_NEW_SENTINEL = "__esphome_add_new__";
 export const AUTO_SENTINEL = "__esphome_auto__";

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -1,8 +1,10 @@
+import { mdiClose, mdiPlus } from "@mdi/js";
 import { html, nothing } from "lit";
 import { isLambdaValue } from "../../../api/types/automations.js";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../../api/types/config-entries.js";
 import { coerceValueToEntryType } from "../../../util/coerce-entry-value.js";
+import { mdiSvg } from "../../../util/mdi-svg.js";
 import { asMappingList, isPrimitiveOrNullish } from "../../../util/nested-values.js";
 import { escapeForInput, unescapeForInput } from "../../../util/yaml-escape.js";
 import { YamlRawValue } from "../../../util/yaml-serialize.js";
@@ -73,7 +75,7 @@ export function renderListRemoveButton(
       aria-label=${ctx.localize("device.multi_value_remove")}
       @click=${onClick}
     >
-      <wa-icon library="mdi" name="close"></wa-icon>
+      ${mdiSvg(mdiClose)}
     </button>
   `;
 }
@@ -90,8 +92,7 @@ export function renderListAddButton(
       ?disabled=${disabled}
       @click=${onClick}
     >
-      <wa-icon library="mdi" name="plus"></wa-icon>
-      ${ctx.localize("device.multi_value_add")}
+      ${mdiSvg(mdiPlus)} ${ctx.localize("device.multi_value_add")}
     </button>
   `;
 }
@@ -310,7 +311,7 @@ export function renderMapField(entry: ConfigEntry, path: string[], ctx: RenderCt
           aria-label=${ctx.localize("device.map_remove")}
           @click=${() => removeEntry(rowKey)}
         >
-          <wa-icon library="mdi" name="close"></wa-icon>
+          ${mdiSvg(mdiClose)}
         </button>
       </div>
     `;
@@ -331,8 +332,7 @@ export function renderMapField(entry: ConfigEntry, path: string[], ctx: RenderCt
         ?disabled=${disabled}
         @click=${addEntry}
       >
-        <wa-icon library="mdi" name="plus"></wa-icon>
-        ${ctx.localize("device.map_add")}
+        ${mdiSvg(mdiPlus)} ${ctx.localize("device.map_add")}
       </button>
       ${renderFieldError(path, ctx)}
     </div>

--- a/test/components/device/component-catalog-renderers.test.ts
+++ b/test/components/device/component-catalog-renderers.test.ts
@@ -264,10 +264,13 @@ describe("shouldHandleCardClick", () => {
     // the icon, not the button. closest() must walk up to find it.
     const card = document.createElement("article");
     const addButton = document.createElement("button");
-    const icon = document.createElement("svg");
+    const svgNs = "http://www.w3.org/2000/svg";
+    const icon = document.createElementNS(svgNs, "svg");
+    const path = document.createElementNS(svgNs, "path");
+    icon.append(path);
     addButton.append(icon);
     card.append(addButton);
-    expect(shouldHandleCardClick(clickFrom(icon))).toBe(false);
+    expect(shouldHandleCardClick(clickFrom(path))).toBe(false);
   });
 
   it("skips when the click landed on the more-info anchor", () => {

--- a/test/components/device/component-catalog-renderers.test.ts
+++ b/test/components/device/component-catalog-renderers.test.ts
@@ -260,11 +260,11 @@ describe("shouldHandleCardClick", () => {
   });
 
   it("skips when the click landed inside the inner + Add button", () => {
-    // The button contains a <wa-icon> child — the click target is
+    // The button contains an inline svg glyph — the click target is
     // the icon, not the button. closest() must walk up to find it.
     const card = document.createElement("article");
     const addButton = document.createElement("button");
-    const icon = document.createElement("wa-icon");
+    const icon = document.createElement("svg");
     addButton.append(icon);
     card.append(addButton);
     expect(shouldHandleCardClick(clickFrom(icon))).toBe(false);


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #1702, which added the inline `mdiSvg` glyph helper. The same per row `wa-icon` cost remained in two other long lists: every component card in the add component catalog mounted three icon elements (the image placeholder, the plus on the add button, the external link on more info; bundle cards two more), and every list or map row in the config forms mounted one for its remove button. Each `wa-icon` is a custom element upgrade with its own shadow root and an async icon library resolve, so a catalog of several hundred cards paid that hundreds of times on open.

Those static glyphs now render through `mdiSvg`. Styles that sized the old elements target `svg` instead, so the sizes are unchanged: the placeholder inherits its 28px container font size, the more info and bundle badge glyphs stay at 11px, the list buttons at 14px. The expand toggle on catalog cards keeps its two states by swapping the path. Icon registrations that only backed these sites are gone. Live check on the scratch config: the open catalog renders zero `wa-icon` elements where it had one per glyph before, and map rows show the inline remove and add glyphs.

**Related issue or feature (if applicable):**

- fixes #1703

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
