### PR TITLE
Assert entity matched picker groups carry no count pill

### DIFF
--- a/test/components/device/automation-editor/catalog-picker-dialog.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog.test.ts
@@ -363,6 +363,7 @@ describe("catalog-picker-dialog by-target groups", () => {
     await search(dialog, "valve");
     expect(groupLabels(dialog)).toHaveLength(1);
     expect(groupLabels(dialog)[0]).toContain("Valve");
+    expect(dialog.shadowRoot!.querySelectorAll(".picker-group-count")).toHaveLength(0);
     expect(rowTitles(dialog)).toEqual(["Turn On", "Turn Off"]);
   });
 


### PR DESCRIPTION
# What does this implement/fix?

One assertion that was pushed to #1702 after it had already been squashed: the entity query test now also checks that entity matched groups carry no count pill, pinning the fix from that review round.

**Related issue or feature (if applicable):**

- follow up to #1702

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
