### PR TITLE
Close open-gated dialogs through the wrapper so the body survives the hide animation

### DIFF
--- a/src/components/desktop-update-dialog.ts
+++ b/src/components/desktop-update-dialog.ts
@@ -87,7 +87,7 @@ export class ESPHomeDesktopUpdateDialog extends LitElement {
   }
 
   close() {
-    this._dialog.open = false;
+    this._dialog.requestClose();
   }
 
   private _runCheck = async (): Promise<void> => {

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -114,6 +114,8 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
   @state() private _query = "";
   /** Per-target open state the user set by clicking; wins over the default. */
   @state() private _targetOverrides = new Map<string, boolean>();
+  /** Set on the first pick; the rows stay live through the hide animation. */
+  private _picked = false;
 
   /**
    * Open the dialog with a fresh search, no clicked-open groups, and the
@@ -124,6 +126,7 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
     this._activeTab = this.kind === "action" ? "by-target" : "by-type";
     this._query = "";
     this._targetOverrides = new Map();
+    this._picked = false;
     this._dialog.open = true;
   }
 
@@ -557,6 +560,8 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
   }
 
   private _pick(id: string, preFilledParams?: Record<string, unknown>) {
+    if (this._picked) return;
+    this._picked = true;
     this.dispatchEvent(
       new CustomEvent<CatalogPickedDetail>("catalog-picked", {
         detail: { id, preFilledParams },

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -564,7 +564,7 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
         composed: true,
       })
     );
-    this._dialog.open = false;
+    this._dialog.requestClose();
   }
 }
 

--- a/src/components/update-all-dialog.ts
+++ b/src/components/update-all-dialog.ts
@@ -124,6 +124,7 @@ export class ESPHomeUpdateAllDialog extends LitElement {
   ];
 
   async open() {
+    this._confirmed = false;
     this._selection = defaultSelection();
     this._dialog.open = true;
     // Sections only exist after the open render; default-expand the two
@@ -230,7 +231,12 @@ export class ESPHomeUpdateAllDialog extends LitElement {
     `;
   }
 
+  /** Set on the first confirm; the button stays live through the hide animation. */
+  private _confirmed = false;
+
   private _confirm = () => {
+    if (this._confirmed) return;
+    this._confirmed = true;
     const configurations = this._matched().map((d) => d.configuration);
     this.close();
     // runBulkUpdate owns the empty case (the Update button is disabled at

--- a/src/components/update-all-dialog.ts
+++ b/src/components/update-all-dialog.ts
@@ -137,7 +137,7 @@ export class ESPHomeUpdateAllDialog extends LitElement {
   }
 
   close() {
-    this._dialog.open = false;
+    this._dialog.requestClose();
   }
 
   private _sectionEls(): (HTMLElement & { expanded: boolean })[] {

--- a/src/util/dialog-open-controller.ts
+++ b/src/util/dialog-open-controller.ts
@@ -1,5 +1,7 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 
+type DialogHost = ReactiveControllerHost & { shadowRoot?: ShadowRoot | null };
+
 /**
  * Owns the reactive open flag for an ``esphome-base-dialog`` host with no
  * close-veto logic.
@@ -31,8 +33,6 @@ import type { ReactiveController, ReactiveControllerHost } from "lit";
  * afterwards, so a body rendered only while ``open`` stays up through the
  * animation instead of vanishing on the first frame.
  */
-type DialogHost = ReactiveControllerHost & { shadowRoot?: ShadowRoot | null };
-
 export class DialogOpenController implements ReactiveController {
   private _open = false;
 
@@ -56,8 +56,9 @@ export class DialogOpenController implements ReactiveController {
     this._host.requestUpdate();
   }
 
-  /** Close via the host's ``esphome-base-dialog`` hide sequence; the host
-   *  must bind ``onRequestClose`` or ``onAfterHide`` for the flag to follow.
+  /** Close via the host's ``esphome-base-dialog`` hide sequence. Only a host
+   *  bound to ``onAfterHide`` keeps an open-gated body through the animation;
+   *  ``onRequestClose`` flips the flag synchronously and gains nothing here.
    *  Flips the flag directly when no wrapper is mounted. */
   requestClose(): void {
     const wrapper = this._host.shadowRoot?.querySelector<

--- a/src/util/dialog-open-controller.ts
+++ b/src/util/dialog-open-controller.ts
@@ -56,7 +56,6 @@ export class DialogOpenController implements ReactiveController {
     this._host.requestUpdate();
   }
 
-  /** The trivial ``@request-close`` handler: flip the flag, veto nothing. */
   /** Close via the host's ``esphome-base-dialog`` hide sequence; the host
    *  must bind ``onRequestClose`` or ``onAfterHide`` for the flag to follow.
    *  Flips the flag directly when no wrapper is mounted. */
@@ -68,6 +67,7 @@ export class DialogOpenController implements ReactiveController {
     else this.open = false;
   }
 
+  /** The trivial ``@request-close`` handler: flip the flag, veto nothing. */
   readonly onRequestClose = (): void => {
     this.open = false;
   };

--- a/src/util/dialog-open-controller.ts
+++ b/src/util/dialog-open-controller.ts
@@ -24,11 +24,19 @@ import type { ReactiveController, ReactiveControllerHost } from "lit";
  * Dialogs with a real veto (busy guard, unsaved-changes prompt) keep their
  * own ``@request-close`` handler instead; the trivial flip here never
  * ``preventDefault()``s.
+ *
+ * A programmatic close (a pick, a finished action) should go through
+ * ``requestClose`` rather than writing ``open = false``: the wrapper then
+ * runs its normal hide sequence and the host's bound handler flips the flag
+ * afterwards, so a body rendered only while ``open`` stays up through the
+ * animation instead of vanishing on the first frame.
  */
+type DialogHost = ReactiveControllerHost & { shadowRoot?: ShadowRoot | null };
+
 export class DialogOpenController implements ReactiveController {
   private _open = false;
 
-  constructor(private readonly _host: ReactiveControllerHost) {
+  constructor(private readonly _host: DialogHost) {
     _host.addController(this);
   }
 
@@ -49,6 +57,17 @@ export class DialogOpenController implements ReactiveController {
   }
 
   /** The trivial ``@request-close`` handler: flip the flag, veto nothing. */
+  /** Close via the host's ``esphome-base-dialog`` hide sequence; the host
+   *  must bind ``onRequestClose`` or ``onAfterHide`` for the flag to follow.
+   *  Flips the flag directly when no wrapper is mounted. */
+  requestClose(): void {
+    const wrapper = this._host.shadowRoot?.querySelector<
+      Element & { requestClose?: () => void }
+    >("esphome-base-dialog");
+    if (wrapper?.requestClose) wrapper.requestClose();
+    else this.open = false;
+  }
+
   readonly onRequestClose = (): void => {
     this.open = false;
   };

--- a/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
@@ -79,7 +79,7 @@ describe("esphome-catalog-picker-dialog base-dialog open contract", () => {
     expect(body()).toBe(0);
   });
 
-  it("picking an item emits catalog-picked and closes the dialog", async () => {
+  it("picking an item emits catalog-picked", async () => {
     const dialog = await mountDialog();
     dialog.open();
     const picked = vi.fn();
@@ -94,7 +94,6 @@ describe("esphome-catalog-picker-dialog base-dialog open contract", () => {
       id: "switch.toggle",
       preFilledParams: { id: "relay" },
     });
-    expect(isOpen(dialog)).toBe(false);
   });
 
   it("a pick closes through the wrapper so the body outlives the hide animation", async () => {

--- a/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
@@ -118,4 +118,31 @@ describe("esphome-catalog-picker-dialog base-dialog open contract", () => {
     expect(isOpen(dialog)).toBe(false);
     expect(dialog.shadowRoot!.querySelector(".picker-body")).toBeNull();
   });
+
+  it("a second pick during the hide is ignored until the picker reopens", async () => {
+    const dialog = await mountDialog();
+    dialog.open();
+    await dialog.updateComplete;
+    const wrapper = dialog.shadowRoot!.querySelector(
+      "esphome-base-dialog"
+    )! as HTMLElement & {
+      requestClose?: () => void;
+    };
+    wrapper.requestClose = vi.fn();
+    const picked = vi.fn();
+    dialog.addEventListener("catalog-picked", picked);
+    const pick = (dialog as unknown as { _pick: (id: string) => void })._pick.bind(
+      dialog
+    );
+
+    pick("switch.toggle");
+    pick("switch.turn_on");
+    expect(picked).toHaveBeenCalledTimes(1);
+
+    afterHide(dialog);
+    dialog.open();
+    await dialog.updateComplete;
+    pick("switch.turn_on");
+    expect(picked).toHaveBeenCalledTimes(2);
+  });
 });

--- a/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
@@ -5,8 +5,9 @@
  * migration onto ``esphome-base-dialog``. The wrapper never mutates
  * its own ``open`` on a user-driven close, so the host owns the
  * reactive ``_open`` flag: ``open()`` sets it, ``@after-hide``
- * clears it once the hide animation ends, and picking an item clears
- * it. The body renders only while open. The sibling
+ * clears it once the hide animation ends, and picking an item requests
+ * a close through the wrapper so the same after-hide clears it. The body
+ * renders only while open. The sibling
  * ``catalog-picker-dialog.test.ts`` covers the filter / grouping
  * contract; this file owns the open/close lifecycle.
  */

--- a/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
@@ -96,4 +96,26 @@ describe("esphome-catalog-picker-dialog base-dialog open contract", () => {
     });
     expect(isOpen(dialog)).toBe(false);
   });
+
+  it("a pick closes through the wrapper so the body outlives the hide animation", async () => {
+    const dialog = await mountDialog();
+    dialog.open();
+    await dialog.updateComplete;
+    const wrapper = dialog.shadowRoot!.querySelector(
+      "esphome-base-dialog"
+    )! as HTMLElement & {
+      requestClose?: () => void;
+    };
+    wrapper.requestClose = vi.fn();
+    (dialog as unknown as { _pick: (id: string) => void })._pick("switch.toggle");
+    await dialog.updateComplete;
+    expect(wrapper.requestClose).toHaveBeenCalledTimes(1);
+    expect(isOpen(dialog)).toBe(true);
+    expect(dialog.shadowRoot!.querySelector(".picker-body")).not.toBeNull();
+
+    afterHide(dialog);
+    await dialog.updateComplete;
+    expect(isOpen(dialog)).toBe(false);
+    expect(dialog.shadowRoot!.querySelector(".picker-body")).toBeNull();
+  });
 });

--- a/test/components/update-all-dialog.test.ts
+++ b/test/components/update-all-dialog.test.ts
@@ -116,6 +116,22 @@ describe("update-all-dialog", () => {
     expect(firmwareInstallBulk).toHaveBeenCalledWith(["a.yaml"]);
   });
 
+  it("a second confirm during the hide animation does not enqueue again", async () => {
+    const { api, firmwareInstallBulk } = fakeApi();
+    const el = await mount([onlineUpdatable, onlineCurrent, offlineUpdatable], api);
+    // With the wrapper routing the close, the button stays live until after-hide.
+    const wrapper = el.shadowRoot!.querySelector(
+      "esphome-base-dialog"
+    )! as HTMLElement & {
+      requestClose?: () => void;
+    };
+    wrapper.requestClose = vi.fn();
+    primaryButton(el).click();
+    primaryButton(el).click();
+    expect(wrapper.requestClose).toHaveBeenCalledTimes(1);
+    expect(firmwareInstallBulk).toHaveBeenCalledTimes(1);
+  });
+
   it("disables Update and skips the API call when nothing matches", async () => {
     const { api, firmwareInstallBulk } = fakeApi();
     const el = await mount([onlineCurrent, offlineUpdatable], api);

--- a/test/util/dialog-open-controller.test.ts
+++ b/test/util/dialog-open-controller.test.ts
@@ -38,6 +38,23 @@ describe("DialogOpenController", () => {
   // The close-animation race guard the copy-pasted host handlers used to
   // pin: the flag must flip on the initiating request-close, before
   // wa-dialog finishes hiding, so a host re-render can't re-assert ?open.
+  it("onRequestClose flips the flag false", () => {
+    const host = new FakeHost();
+    const ctrl = new DialogOpenController(host);
+    ctrl.open = true;
+
+    ctrl.onRequestClose();
+    expect(ctrl.open).toBe(false);
+    expect(host.updates).toBe(2);
+  });
+
+  it("onRequestClose is a stable reference usable as an event listener", () => {
+    const ctrl = new DialogOpenController(new FakeHost());
+    const first = ctrl.onRequestClose;
+    ctrl.open = true;
+    expect(ctrl.onRequestClose).toBe(first);
+  });
+
   it("requestClose flips the flag directly when no wrapper is mounted", () => {
     const host = new FakeHost();
     const ctrl = new DialogOpenController(host);
@@ -59,23 +76,6 @@ describe("DialogOpenController", () => {
     expect(ctrl.open).toBe(true);
     ctrl.onAfterHide();
     expect(ctrl.open).toBe(false);
-  });
-
-  it("onRequestClose flips the flag false", () => {
-    const host = new FakeHost();
-    const ctrl = new DialogOpenController(host);
-    ctrl.open = true;
-
-    ctrl.onRequestClose();
-    expect(ctrl.open).toBe(false);
-    expect(host.updates).toBe(2);
-  });
-
-  it("onRequestClose is a stable reference usable as an event listener", () => {
-    const ctrl = new DialogOpenController(new FakeHost());
-    const first = ctrl.onRequestClose;
-    ctrl.open = true;
-    expect(ctrl.onRequestClose).toBe(first);
   });
 
   it("onAfterHide flips the flag false", () => {

--- a/test/util/dialog-open-controller.test.ts
+++ b/test/util/dialog-open-controller.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { FakeHost } from "../_fake-host.js";
 import { DialogOpenController } from "../../src/util/dialog-open-controller.js";
 
@@ -38,6 +38,29 @@ describe("DialogOpenController", () => {
   // The close-animation race guard the copy-pasted host handlers used to
   // pin: the flag must flip on the initiating request-close, before
   // wa-dialog finishes hiding, so a host re-render can't re-assert ?open.
+  it("requestClose flips the flag directly when no wrapper is mounted", () => {
+    const host = new FakeHost();
+    const ctrl = new DialogOpenController(host);
+    ctrl.open = true;
+    ctrl.requestClose();
+    expect(ctrl.open).toBe(false);
+  });
+
+  it("requestClose defers to the mounted wrapper and leaves the flag to its handlers", () => {
+    const host = new FakeHost();
+    const wrapper = { requestClose: vi.fn() };
+    (host as unknown as { shadowRoot: unknown }).shadowRoot = {
+      querySelector: (sel: string) => (sel === "esphome-base-dialog" ? wrapper : null),
+    };
+    const ctrl = new DialogOpenController(host);
+    ctrl.open = true;
+    ctrl.requestClose();
+    expect(wrapper.requestClose).toHaveBeenCalledTimes(1);
+    expect(ctrl.open).toBe(true);
+    ctrl.onAfterHide();
+    expect(ctrl.open).toBe(false);
+  });
+
   it("onRequestClose flips the flag false", () => {
     const host = new FakeHost();
     const ctrl = new DialogOpenController(host);


### PR DESCRIPTION
# What does this implement/fix?

Dialogs whose body renders only while open close cleanly from Escape, the close button and an outside click, because those paths run the wrapper's hide sequence and the flag flips afterwards. A programmatic close did not: picking an action in the catalog picker, or `close()` on the desktop update and update all dialogs, wrote `open = false` directly, so the body rendered `nothing` in the same frame `wa-dialog` started its hide animation and the shell faded out empty.

`DialogOpenController` gains `requestClose()`, which delegates to the host's `esphome-base-dialog.requestClose()` so the same hide, after hide sequence runs and the bound handler flips the flag once the animation ends. When no wrapper is mounted it flips the flag directly. The three programmatic closes now use it. Checked live: 50 ms after a pick the body and dialog are still up, and 1.5 s later the dialog is closed and the action added.

**Related issue or feature (if applicable):**

- fixes #1700

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
