### PR TITLE
Resolve automation target parents through a per-render id map

### DIFF
--- a/src/components/device/automation-editor/automation-target-picker.ts
+++ b/src/components/device/automation-editor/automation-target-picker.ts
@@ -41,10 +41,8 @@ import { espHomeStyles } from "../../../styles/shared.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import {
   firstSelectableTarget,
-  instanceContext,
+  indexTargets,
   instanceName,
-  selectableTargets,
-  targetsById,
 } from "./component-targets.js";
 
 import "@home-assistant/webawesome/dist/components/option/option.js";
@@ -168,8 +166,8 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
         this.value?.kind === "component_on" ? this.value.component_id : "";
       // A multi-entity container isn't a valid trigger target — its
       // sub-entities are (offered as their own instances).
-      const targets = selectableTargets(this.devices);
-      const byId = targetsById(this.devices);
+      const index = indexTargets(this.devices);
+      const targets = index.selectable;
       if (targets.length === 0) {
         return html`<p class="ae-empty" role="status">
           ${this._localize("device.automation_target_no_components")}
@@ -190,7 +188,7 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
             (d) =>
               html`<wa-option value=${d.id} ?selected=${d.id === selectedId}
                 >${instanceName(d)}
-                <span class="ae-muted">(${instanceContext(d, byId)})</span></wa-option
+                <span class="ae-muted">(${index.context(d)})</span></wa-option
               >`
           )}
         </wa-select>

--- a/src/components/device/automation-editor/automation-target-picker.ts
+++ b/src/components/device/automation-editor/automation-target-picker.ts
@@ -44,6 +44,7 @@ import {
   instanceContext,
   instanceName,
   selectableTargets,
+  targetsById,
 } from "./component-targets.js";
 
 import "@home-assistant/webawesome/dist/components/option/option.js";
@@ -168,6 +169,7 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
       // A multi-entity container isn't a valid trigger target — its
       // sub-entities are (offered as their own instances).
       const targets = selectableTargets(this.devices);
+      const byId = targetsById(this.devices);
       if (targets.length === 0) {
         return html`<p class="ae-empty" role="status">
           ${this._localize("device.automation_target_no_components")}
@@ -188,9 +190,7 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
             (d) =>
               html`<wa-option value=${d.id} ?selected=${d.id === selectedId}
                 >${instanceName(d)}
-                <span class="ae-muted"
-                  >(${instanceContext(d, this.devices)})</span
-                ></wa-option
+                <span class="ae-muted">(${instanceContext(d, byId)})</span></wa-option
               >`
           )}
         </wa-select>

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -66,6 +66,7 @@ import {
   instanceName,
   preFillIdParam,
   selectableTargets,
+  targetsById,
 } from "./component-targets.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -439,6 +440,7 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
       </p>`;
     }
     const byDomain = groupByDomain(items);
+    const byId = targetsById(this.devices);
     // A multi-entity container isn't itself a referenceable entity — its
     // sub-entities are surfaced as their own instances. The query matches
     // either axis: an entity hit lists all of that entity's actions.
@@ -464,6 +466,7 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
         localize: this._localize,
         labelText: this._renderGroupLabel(
           device,
+          byId,
           q && !entityMatch ? matching.length : null
         ),
         body: () =>
@@ -476,8 +479,12 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
     })}`;
   }
 
-  private _renderGroupLabel(device: AvailableComponentInstance, count: number | null) {
-    const context = instanceContext(device, this.devices);
+  private _renderGroupLabel(
+    device: AvailableComponentInstance,
+    byId: ReadonlyMap<string, AvailableComponentInstance>,
+    count: number | null
+  ) {
+    const context = instanceContext(device, byId);
     // Whitespace in this template would be a text node per header.
     // prettier-ignore
     return html`<span class="picker-group-label">${instanceName(device)}<span class="ae-muted">(${context})</span>${count === null ? nothing : html`<span class="picker-group-count" aria-hidden="true">${count}</span>`}</span>`;

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -448,9 +448,10 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
     // sub-entities are surfaced as their own instances. The query matches
     // either axis: an entity hit lists all of that entity's actions.
     const sections = index.selectable.flatMap((device) => {
-      const entityMatch = q !== "" && navItemMatches(q, instanceName(device), device.id);
+      const name = instanceName(device);
+      const entityMatch = q !== "" && navItemMatches(q, name, device.id);
       const matching = itemsForDevice(entityMatch ? byDomain : filteredByDomain, device);
-      return matching.length ? [{ device, matching, entityMatch }] : [];
+      return matching.length ? [{ device, name, matching, entityMatch }] : [];
     });
     if (sections.length === 0) {
       return html`<p class="picker-empty">
@@ -460,14 +461,14 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
     // Open by default when the list is already small; a click overrides that
     // default for the target, so an auto-opened group can still be closed.
     const defaultOpen = sections.length <= (q ? AUTO_EXPAND_MAX_GROUPS : 1);
-    return html`${sections.map(({ device, matching, entityMatch }) => {
+    return html`${sections.map(({ device, name, matching, entityMatch }) => {
       const open = this._targetOverrides.get(device.id) ?? defaultOpen;
       return renderDisclosure({
         open,
         onToggle: () => this._setTargetOpen(device.id, !open),
         localize: this._localize,
         labelText: this._renderGroupLabel(
-          instanceName(device),
+          name,
           index.context(device),
           q && !entityMatch ? matching.length : null
         ),

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -62,11 +62,9 @@ import {
 } from "./catalog-picker-filter.js";
 import {
   componentDomain,
-  instanceContext,
+  indexTargets,
   instanceName,
   preFillIdParam,
-  selectableTargets,
-  targetsById,
 } from "./component-targets.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -440,14 +438,18 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
       </p>`;
     }
     const byDomain = groupByDomain(items);
-    const byId = targetsById(this.devices);
+    // Filter once per domain, not once per entity: hundreds of entities share
+    // a handful of domains.
+    const filteredByDomain = q
+      ? new Map([...byDomain].map(([domain, list]) => [domain, filterItems(list, q)]))
+      : byDomain;
+    const index = indexTargets(this.devices);
     // A multi-entity container isn't itself a referenceable entity — its
     // sub-entities are surfaced as their own instances. The query matches
     // either axis: an entity hit lists all of that entity's actions.
-    const sections = selectableTargets(this.devices).flatMap((device) => {
+    const sections = index.selectable.flatMap((device) => {
       const entityMatch = q !== "" && navItemMatches(q, instanceName(device), device.id);
-      const candidates = itemsForDevice(byDomain, device);
-      const matching = entityMatch || !q ? candidates : filterItems(candidates, q);
+      const matching = itemsForDevice(entityMatch ? byDomain : filteredByDomain, device);
       return matching.length ? [{ device, matching, entityMatch }] : [];
     });
     if (sections.length === 0) {
@@ -465,8 +467,8 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
         onToggle: () => this._setTargetOpen(device.id, !open),
         localize: this._localize,
         labelText: this._renderGroupLabel(
-          device,
-          byId,
+          instanceName(device),
+          index.context(device),
           q && !entityMatch ? matching.length : null
         ),
         body: () =>
@@ -479,15 +481,10 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
     })}`;
   }
 
-  private _renderGroupLabel(
-    device: AvailableComponentInstance,
-    byId: ReadonlyMap<string, AvailableComponentInstance>,
-    count: number | null
-  ) {
-    const context = instanceContext(device, byId);
+  private _renderGroupLabel(name: string, context: string, count: number | null) {
     // Whitespace in this template would be a text node per header.
     // prettier-ignore
-    return html`<span class="picker-group-label">${instanceName(device)}<span class="ae-muted">(${context})</span>${count === null ? nothing : html`<span class="picker-group-count" aria-hidden="true">${count}</span>`}</span>`;
+    return html`<span class="picker-group-label">${name}<span class="ae-muted">(${context})</span>${count === null ? nothing : html`<span class="picker-group-count" aria-hidden="true">${count}</span>`}</span>`;
   }
 
   private _setTargetOpen(id: string, open: boolean) {

--- a/src/components/device/automation-editor/component-targets.ts
+++ b/src/components/device/automation-editor/component-targets.ts
@@ -28,24 +28,28 @@ export function componentDomain(componentId: string): string {
   return parseCatalogId(componentId).domain;
 }
 
-/** Instances keyed by id, built once per render for the per-row lookups. */
-export function targetsById(
-  devices: AvailableComponentInstance[]
-): Map<string, AvailableComponentInstance> {
-  return new Map(devices.map((d) => [d.id, d]));
+export interface TargetIndex {
+  /** The instances a picker offers; containers are excluded. */
+  readonly selectable: AvailableComponentInstance[];
+  /** The parenthetical context beside an instance's label: its domain, plus
+   *  the owning container's name when it's a sub-entity, so two readings
+   *  named alike (``Temperature``) read distinctly. */
+  context(device: AvailableComponentInstance): string;
 }
 
-/** The parenthetical context shown beside an instance's label: its domain,
- *  plus the owning container's name when it's a sub-entity, so two readings
- *  named alike (``Temperature``) read distinctly across the picker surfaces. */
-export function instanceContext(
-  device: AvailableComponentInstance,
-  byId: ReadonlyMap<string, AvailableComponentInstance>
-): string {
-  const parent = device.parent_id ? byId.get(device.parent_id) : undefined;
-  return parent
-    ? `${device.component_id} · ${instanceName(parent)}`
-    : device.component_id;
+/** Index the full instance list once per render; ``context`` resolves parents
+ *  against every instance, including the containers ``selectable`` drops. */
+export function indexTargets(devices: AvailableComponentInstance[]): TargetIndex {
+  const byId = new Map(devices.map((d) => [d.id, d]));
+  return {
+    selectable: selectableTargets(devices),
+    context(device) {
+      const parent = device.parent_id ? byId.get(device.parent_id) : undefined;
+      return parent
+        ? `${device.component_id} · ${instanceName(parent)}`
+        : device.component_id;
+    },
+  };
 }
 
 /** A multi-entity platform container holds no triggers of its own (its

--- a/src/components/device/automation-editor/component-targets.ts
+++ b/src/components/device/automation-editor/component-targets.ts
@@ -31,8 +31,8 @@ export function componentDomain(componentId: string): string {
 export interface TargetIndex {
   /** The instances a picker offers; containers are excluded. */
   readonly selectable: AvailableComponentInstance[];
-  /** The parenthetical context beside an instance's label: its domain, plus
-   *  the owning container's name when it's a sub-entity, so two readings
+  /** The parenthetical context beside an instance's label: its component id,
+   *  plus the owning container's name when it's a sub-entity, so two readings
    *  named alike (``Temperature``) read distinctly. */
   context(device: AvailableComponentInstance): string;
 }

--- a/src/components/device/automation-editor/component-targets.ts
+++ b/src/components/device/automation-editor/component-targets.ts
@@ -28,16 +28,21 @@ export function componentDomain(componentId: string): string {
   return parseCatalogId(componentId).domain;
 }
 
+/** Instances keyed by id, built once per render for the per-row lookups. */
+export function targetsById(
+  devices: AvailableComponentInstance[]
+): Map<string, AvailableComponentInstance> {
+  return new Map(devices.map((d) => [d.id, d]));
+}
+
 /** The parenthetical context shown beside an instance's label: its domain,
  *  plus the owning container's name when it's a sub-entity, so two readings
  *  named alike (``Temperature``) read distinctly across the picker surfaces. */
 export function instanceContext(
   device: AvailableComponentInstance,
-  devices: AvailableComponentInstance[]
+  byId: ReadonlyMap<string, AvailableComponentInstance>
 ): string {
-  const parent = device.parent_id
-    ? devices.find((p) => p.id === device.parent_id)
-    : undefined;
+  const parent = device.parent_id ? byId.get(device.parent_id) : undefined;
   return parent
     ? `${device.component_id} · ${instanceName(parent)}`
     : device.component_id;

--- a/src/components/device/automation-editor/component-targets.ts
+++ b/src/components/device/automation-editor/component-targets.ts
@@ -59,7 +59,7 @@ export function isSelectableTarget(device: AvailableComponentInstance): boolean 
 }
 
 /** The instances a picker may offer (containers dropped). */
-export function selectableTargets(
+function selectableTargets(
   devices: AvailableComponentInstance[]
 ): AvailableComponentInstance[] {
   return devices.filter(isSelectableTarget);

--- a/test/components/device/automation-editor/catalog-picker-dialog.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog.test.ts
@@ -393,4 +393,42 @@ describe("catalog-picker-dialog by-target groups", () => {
     await dialog.updateComplete;
     expect(expandedFlags(dialog)).toEqual(["false", "false"]);
   });
+
+  it("group labels carry the container name for same-named sub-entities", async () => {
+    const temperature = action({ id: "sensor.state", name: "State", domain: "sensor" });
+    const dialog = await mountDialog({
+      items: [temperature],
+      devices: [
+        {
+          component_id: "sensor.aht10",
+          id: "aht_a",
+          name: "AHT A",
+          is_entity_container: true,
+        },
+        {
+          component_id: "sensor",
+          id: "aht_a_temp",
+          name: "Temperature",
+          parent_id: "aht_a",
+        },
+        {
+          component_id: "sensor.aht10",
+          id: "aht_b",
+          name: "AHT B",
+          is_entity_container: true,
+        },
+        {
+          component_id: "sensor",
+          id: "aht_b_temp",
+          name: "Temperature",
+          parent_id: "aht_b",
+        },
+      ],
+      tab: "by-target",
+    });
+    const labels = groupLabels(dialog);
+    expect(labels).toHaveLength(2);
+    expect(labels[0]).toContain("AHT A");
+    expect(labels[1]).toContain("AHT B");
+  });
 });

--- a/test/components/device/automation-editor/component-targets.test.ts
+++ b/test/components/device/automation-editor/component-targets.test.ts
@@ -11,7 +11,6 @@ import {
   instanceName,
   isSelectableTarget,
   preFillIdParam,
-  selectableTargets,
   triggersForComponent,
 } from "../../../../src/components/device/automation-editor/component-targets.js";
 
@@ -53,7 +52,7 @@ describe("component-targets", () => {
 
   it("drops containers from the selectable list and the first-selectable lookup", () => {
     const devices = [container, temp, relay];
-    expect(selectableTargets(devices)).toEqual([temp, relay]);
+    expect(indexTargets(devices).selectable).toEqual([temp, relay]);
     expect(firstSelectableTarget(devices)).toBe(temp);
   });
 

--- a/test/components/device/automation-editor/component-targets.test.ts
+++ b/test/components/device/automation-editor/component-targets.test.ts
@@ -7,12 +7,11 @@ import type {
 import {
   componentDomain,
   firstSelectableTarget,
-  instanceContext,
+  indexTargets,
   instanceName,
   isSelectableTarget,
   preFillIdParam,
   selectableTargets,
-  targetsById,
   triggersForComponent,
 } from "../../../../src/components/device/automation-editor/component-targets.js";
 
@@ -104,15 +103,21 @@ describe("instance label helpers", () => {
     expect(componentDomain("sensor")).toBe("sensor");
   });
 
-  it("instanceContext appends the owning container for a sub-entity", () => {
-    const named = inst({ id: "aht20", component_id: "sensor.aht10", name: "AHT20" });
-    const byId = targetsById([named, temp]);
+  it("indexTargets resolves a sub-entity's container even though selectable drops it", () => {
+    const named = inst({
+      id: "aht20",
+      component_id: "sensor.aht10",
+      name: "AHT20",
+      is_entity_container: true,
+    });
+    const index = indexTargets([named, temp, relay]);
+    expect(index.selectable).toEqual([temp, relay]);
     // Sub-entity → domain · parent label; plain instance → bare domain only.
-    expect(instanceContext(temp, byId)).toBe("sensor · AHT20");
-    expect(instanceContext(relay, byId)).toBe("switch.gpio");
+    expect(index.context(temp)).toBe("sensor · AHT20");
+    expect(index.context(relay)).toBe("switch.gpio");
     // A dangling parent_id (parent absent) degrades to the bare domain.
     expect(
-      instanceContext(inst({ id: "o", component_id: "sensor", parent_id: "gone" }), byId)
+      index.context(inst({ id: "o", component_id: "sensor", parent_id: "gone" }))
     ).toBe("sensor");
   });
 });

--- a/test/components/device/automation-editor/component-targets.test.ts
+++ b/test/components/device/automation-editor/component-targets.test.ts
@@ -12,6 +12,7 @@ import {
   isSelectableTarget,
   preFillIdParam,
   selectableTargets,
+  targetsById,
   triggersForComponent,
 } from "../../../../src/components/device/automation-editor/component-targets.js";
 
@@ -105,16 +106,13 @@ describe("instance label helpers", () => {
 
   it("instanceContext appends the owning container for a sub-entity", () => {
     const named = inst({ id: "aht20", component_id: "sensor.aht10", name: "AHT20" });
-    const devices = [named, temp];
+    const byId = targetsById([named, temp]);
     // Sub-entity → domain · parent label; plain instance → bare domain only.
-    expect(instanceContext(temp, devices)).toBe("sensor · AHT20");
-    expect(instanceContext(relay, devices)).toBe("switch.gpio");
+    expect(instanceContext(temp, byId)).toBe("sensor · AHT20");
+    expect(instanceContext(relay, byId)).toBe("switch.gpio");
     // A dangling parent_id (parent absent) degrades to the bare domain.
     expect(
-      instanceContext(
-        inst({ id: "o", component_id: "sensor", parent_id: "gone" }),
-        devices
-      )
+      instanceContext(inst({ id: "o", component_id: "sensor", parent_id: "gone" }), byId)
     ).toBe("sensor");
   });
 });

--- a/test/components/device/automation-editor/component-targets.test.ts
+++ b/test/components/device/automation-editor/component-targets.test.ts
@@ -112,10 +112,10 @@ describe("instance label helpers", () => {
     });
     const index = indexTargets([named, temp, relay]);
     expect(index.selectable).toEqual([temp, relay]);
-    // Sub-entity → domain · parent label; plain instance → bare domain only.
+    // Sub-entity → component id · parent label; plain instance → component id only.
     expect(index.context(temp)).toBe("sensor · AHT20");
     expect(index.context(relay)).toBe("switch.gpio");
-    // A dangling parent_id (parent absent) degrades to the bare domain.
+    // A dangling parent_id (parent absent) degrades to the component id.
     expect(
       index.context(inst({ id: "o", component_id: "sensor", parent_id: "gone" }))
     ).toBe("sensor");


### PR DESCRIPTION
# What does this implement/fix?

`instanceContext` resolved a sub entity's parent with `devices.find(...)` on every call. The catalog picker's by target tab and the target picker's select both call it once per entity per render, so a fleet made mostly of multi entity platforms was quadratic in the number of entities: roughly 250k comparisons per keystroke at 500 entities.

`indexTargets(devices)` builds the index once per render and exposes `selectable` and `context(device)` together, so the parent lookup is always resolved against the full list; a caller cannot hand the context lookup a filtered list by mistake, which would silently drop every sub entity's container name. Both pickers use it; output is unchanged.

Same render path, same per keystroke cost class: the by target tab filtered the action catalog once per entity, so hundreds of entities in a few domains lowercased the same descriptions dozens of times per keystroke. It now filters once per domain and looks each entity's list up.

**Related issue or feature (if applicable):**

- fixes #1704

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

