### PR TITLE
Share the baseDialog and AutomationAction test helpers

### DIFF
--- a/test/_dom.ts
+++ b/test/_dom.ts
@@ -92,6 +92,12 @@ export async function baseDialogSettled(el: HTMLElement): Promise<void> {
   await (base as { updateComplete?: Promise<unknown> } | null)?.updateComplete;
 }
 
+/** The ``<esphome-base-dialog>`` wrapper inside *host*'s shadow root, for
+ *  dispatching its ``request-close`` / ``after-hide`` events in tests. */
+export function baseDialog(host: HTMLElement): HTMLElement {
+  return host.shadowRoot!.querySelector("esphome-base-dialog")!;
+}
+
 /**
  * The nested ``<esphome-device-name-inputs>`` inside ``host``'s shadow
  * root, settled. Suites reach its friendly/hostname inputs through the

--- a/test/_make-automation-action.ts
+++ b/test/_make-automation-action.ts
@@ -1,0 +1,20 @@
+import type { AutomationAction } from "../src/api/types/automations.js";
+
+/** An action catalog entry; ``domain`` defaults to the id's prefix, or
+ *  ``core`` for a bare id like ``delay``. */
+export function makeAutomationAction(
+  overrides: Partial<AutomationAction> & { id: string }
+): AutomationAction {
+  const { id } = overrides;
+  return {
+    name: id,
+    description: "",
+    docs_url: "",
+    domain: id.includes(".") ? id.split(".")[0] : "core",
+    config_entries: [],
+    is_control_flow: false,
+    has_else_branch: false,
+    accepts_action_list: [],
+    ...overrides,
+  };
+}

--- a/test/components/confirm-dialog.test.ts
+++ b/test/components/confirm-dialog.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
-import { baseDialogSettled, mount } from "../_dom.js";
+import { baseDialog, baseDialogSettled, mount } from "../_dom.js";
 import { pressEnter } from "../_press-enter.js";
 import { ESPHomeConfirmDialog } from "../../src/components/confirm-dialog.js";
 
@@ -62,9 +62,6 @@ describe("confirm-dialog ENTER", () => {
 // the request-close handler, and the after-hide -> cancel path. Pin them so the
 // dismiss-cancels contract can't silently regress.
 describe("confirm-dialog dismiss / request-close", () => {
-  const baseDialog = (el: ESPHomeConfirmDialog): HTMLElement =>
-    el.shadowRoot!.querySelector("esphome-base-dialog")!;
-
   it("fires a single cancel when dismissed without a decision", async () => {
     const el = await mount(new ESPHomeConfirmDialog());
     el.open();

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -17,7 +17,7 @@ vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}
 vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
 vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
 
-import { flushMicrotasks, identityLocalize } from "../../_dom.js";
+import { baseDialog, flushMicrotasks, identityLocalize } from "../../_dom.js";
 import type { ESPHomeAPI } from "../../../src/api/index.js";
 import type { AvailableAutomations } from "../../../src/api/types/automations.js";
 import { ESPHomeAddAutomationDialog } from "../../../src/components/device/add-automation-dialog.js";
@@ -566,8 +566,6 @@ describe("add-automation-dialog unique-trigger preselect (device-builder#2214)",
 // contract — request-close flipping _open is what makes a user-driven close
 // (Escape / X / outside-click) actually dismiss.
 describe("add-automation-dialog open/close contract", () => {
-  const baseDialog = (d: ESPHomeAddAutomationDialog): HTMLElement =>
-    d.shadowRoot!.querySelector("esphome-base-dialog")!;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const isOpen = (d: ESPHomeAddAutomationDialog): boolean => (d as any)._dialog.open;
 

--- a/test/components/device/automation-editor/automation-action-node-delay-lambda.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-delay-lambda.test.ts
@@ -31,10 +31,9 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
 
-import type {
-  ActionNode,
-  AutomationAction,
-} from "../../../../src/api/types/automations.js";
+import { makeAutomationAction } from "../../../_make-automation-action.js";
+import type { ActionNode } from "../../../../src/api/types/automations.js";
+import type { ConfigEntry } from "../../../../src/api/types/config-entries.js";
 import { ESPHomeAutomationActionNode } from "../../../../src/components/device/automation-editor/automation-action-node.js";
 
 const DELAY_FIELDS = [
@@ -46,19 +45,17 @@ const DELAY_FIELDS = [
   "seconds",
 ] as const;
 
-const DELAY_ACTION: AutomationAction = {
+const DELAY_ACTION = makeAutomationAction({
   id: "delay",
   name: "Delay",
-  description: "",
   config_entries: DELAY_FIELDS.map((key) => ({
     key,
     advanced: true,
     type: "string",
     label: key,
     required: false,
-  })),
-  accepts_action_list: [],
-} as unknown as AutomationAction;
+  })) as unknown as ConfigEntry[],
+});
 
 async function mountDelay(
   params: Record<string, unknown>

--- a/test/components/device/automation-editor/automation-action-node-legacy-alias.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-legacy-alias.test.ts
@@ -23,23 +23,19 @@ vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}
 vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}));
 
-import type {
-  ActionNode,
-  AutomationAction,
-} from "../../../../src/api/types/automations.js";
+import { makeAutomationAction } from "../../../_make-automation-action.js";
+import type { ActionNode } from "../../../../src/api/types/automations.js";
 import type { ConfigEntry } from "../../../../src/api/types/config-entries.js";
 import { ESPHomeAutomationActionNode } from "../../../../src/components/device/automation-editor/automation-action-node.js";
 
-const LEGACY_DEF = {
+const LEGACY_DEF = makeAutomationAction({
   id: "homeassistant.service",
   name: "Homeassistant → Service",
-  description: "",
   config_entries: [
     { key: "action", type: "string", label: "Action", required: false },
     { key: "service", type: "string", label: "Service", required: false, hidden: true },
   ] as unknown as ConfigEntry[],
-  accepts_action_list: [],
-} as unknown as AutomationAction;
+});
 
 describe("automation-action-node — legacy alias compatibility", () => {
   it("renders the params form for an existing homeassistant.service node", async () => {

--- a/test/components/device/automation-editor/automation-action-node-reset.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-reset.test.ts
@@ -35,6 +35,7 @@ vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}
 vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}));
 
+import { makeAutomationAction } from "../../../_make-automation-action.js";
 import type {
   ActionNode,
   AutomationAction,
@@ -58,14 +59,11 @@ function entry(key: string, advanced: boolean): ConfigEntry {
  *  "Show advanced" toggle renders and ``show-advanced`` tracks the
  *  user's ``_showAdvanced`` choice. */
 function action(id: string): AutomationAction {
-  return {
+  return makeAutomationAction({
     id,
-    name: id,
-    description: "",
     config_entries: [entry("plain", false), entry("secret", true)],
-    accepts_action_list: [],
     required_groups: [{ kind: "exactly_one", keys: ["plain", "secret"] }],
-  } as unknown as AutomationAction;
+  });
 }
 
 function node(action_id: string): ActionNode {

--- a/test/components/device/automation-editor/automation-focus-plumbing.test.ts
+++ b/test/components/device/automation-editor/automation-focus-plumbing.test.ts
@@ -31,10 +31,10 @@ vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => (
 vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
 
 import { flushMicrotasks, mount } from "../../../_dom.js";
+import { makeAutomationAction } from "../../../_make-automation-action.js";
 import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type {
   ActionNode,
-  AutomationAction,
   AutomationCondition,
   AvailableAutomations,
   ConditionNode,
@@ -49,21 +49,19 @@ import type { AutomationFocus } from "../../../../src/components/device/automati
 const entry = (key: string, advanced = false) =>
   ({ key, type: "string", label: key, advanced }) as unknown as ConfigEntry;
 
-const IF_DEF = {
+const IF_DEF = makeAutomationAction({
   id: "if",
   name: "If",
-  description: "",
-  config_entries: [],
+  is_control_flow: true,
+  has_else_branch: true,
   accepts_action_list: ["then", "else"],
-} as unknown as AutomationAction;
+});
 
-const LOG_DEF = {
+const LOG_DEF = makeAutomationAction({
   id: "logger.log",
   name: "Log",
-  description: "",
   config_entries: [entry("format"), entry("level", true)],
-  accepts_action_list: [],
-} as unknown as AutomationAction;
+});
 
 const IN_RANGE_DEF = {
   id: "sensor.in_range",

--- a/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("../../../../src/components/base-dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
-import { identityLocalize } from "../../../_dom.js";
+import { baseDialog, identityLocalize } from "../../../_dom.js";
 import { ESPHomeCatalogPickerDialog } from "../../../../src/components/device/automation-editor/catalog-picker-dialog.js";
 
 async function mountDialog(
@@ -36,9 +36,7 @@ const isOpen = (d: ESPHomeCatalogPickerDialog): boolean =>
 const activeTab = (d: ESPHomeCatalogPickerDialog): string =>
   (d as unknown as { _activeTab: string })._activeTab;
 const afterHide = (d: ESPHomeCatalogPickerDialog): void => {
-  d.shadowRoot!.querySelector("esphome-base-dialog")!.dispatchEvent(
-    new CustomEvent("after-hide")
-  );
+  baseDialog(d).dispatchEvent(new CustomEvent("after-hide"));
 };
 
 describe("esphome-catalog-picker-dialog base-dialog open contract", () => {
@@ -120,7 +118,7 @@ describe("esphome-catalog-picker-dialog base-dialog open contract", () => {
 
   it("a request arriving mid-hide shows once that hide ends, with fresh state", async () => {
     const dialog = await mountDialog();
-    const wrapper = dialog.shadowRoot!.querySelector("esphome-base-dialog")!;
+    const wrapper = baseDialog(dialog);
     dialog.open();
     await dialog.updateComplete;
     (dialog as unknown as { _query: string })._query = "still visible";
@@ -146,7 +144,7 @@ describe("esphome-catalog-picker-dialog base-dialog open contract", () => {
 
   it("a request landing between after-hide and the deferred re-show wins", async () => {
     const dialog = await mountDialog();
-    const wrapper = dialog.shadowRoot!.querySelector("esphome-base-dialog")!;
+    const wrapper = baseDialog(dialog);
     dialog.open();
     await dialog.updateComplete;
     wrapper.dispatchEvent(new CustomEvent("request-close"));

--- a/test/components/device/automation-editor/catalog-picker-dialog.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog.test.ts
@@ -21,6 +21,7 @@ vi.mock("../../../../src/components/base-dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { identityLocalize } from "../../../_dom.js";
+import { makeAutomationAction } from "../../../_make-automation-action.js";
 import type {
   AutomationAction,
   AvailableComponentInstance,
@@ -29,19 +30,7 @@ import type { CatalogPickedDetail } from "../../../../src/components/device/auto
 import { ESPHomeCatalogPickerDialog } from "../../../../src/components/device/automation-editor/catalog-picker-dialog.js";
 import { makeConfigEntry } from "../../../../src/util/config-entry-defaults.js";
 
-function action(
-  over: Pick<AutomationAction, "id" | "name" | "domain"> & Partial<AutomationAction>
-): AutomationAction {
-  return {
-    description: "",
-    docs_url: "",
-    config_entries: [],
-    is_control_flow: false,
-    has_else_branch: false,
-    accepts_action_list: [],
-    ...over,
-  };
-}
+const action = makeAutomationAction;
 
 async function mountDialog(opts: {
   kind?: "action" | "condition";

--- a/test/components/unsaved-changes-dialog.test.ts
+++ b/test/components/unsaved-changes-dialog.test.ts
@@ -12,12 +12,9 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
-import { baseDialogSettled, mount } from "../_dom.js";
+import { baseDialog, baseDialogSettled, mount } from "../_dom.js";
 import { pressEnter } from "../_press-enter.js";
 import { ESPHomeUnsavedChangesDialog } from "../../src/components/unsaved-changes-dialog.js";
-
-const baseDialog = (el: ESPHomeUnsavedChangesDialog): HTMLElement =>
-  el.shadowRoot!.querySelector("esphome-base-dialog")!;
 
 describe("unsaved-changes-dialog ENTER", () => {
   it("saves and leaves on Enter (never discards)", async () => {

--- a/test/components/yaml-validation-dialog.test.ts
+++ b/test/components/yaml-validation-dialog.test.ts
@@ -11,12 +11,9 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
-import { baseDialogSettled, mount } from "../_dom.js";
+import { baseDialog, baseDialogSettled, mount } from "../_dom.js";
 import { pressEnter } from "../_press-enter.js";
 import { ESPHomeYamlValidationDialog } from "../../src/components/yaml-validation-dialog.js";
-
-const baseDialog = (el: ESPHomeYamlValidationDialog): HTMLElement =>
-  el.shadowRoot!.querySelector("esphome-base-dialog")!;
 
 describe("yaml-validation-dialog ENTER", () => {
   it("goes to the first error on Enter when a line is known", async () => {

--- a/test/util/automation-catalog-cache.test.ts
+++ b/test/util/automation-catalog-cache.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { makeAutomationAction } from "../_make-automation-action.js";
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import type {
   AutomationAction,
@@ -35,17 +36,8 @@ const trigger = (id: string): AutomationTrigger => ({
   config_entries: [],
 });
 
-const action = (id: string): AutomationAction => ({
-  id,
-  name: id,
-  description: "",
-  docs_url: "",
-  domain: "core",
-  config_entries: [],
-  is_control_flow: false,
-  has_else_branch: false,
-  accepts_action_list: [],
-});
+const action = (id: string): AutomationAction =>
+  makeAutomationAction({ id, domain: "core" });
 
 const condition = (id: string): AutomationCondition => ({
   id,


### PR DESCRIPTION
# What does this implement/fix?

Two test helpers were copied per file. `baseDialog(host)` now lives in `test/_dom.ts` beside `baseDialogSettled`, and the five local lambdas in the confirm, unsaved changes, yaml validation, add automation and catalog picker open contract suites call it. `makeAutomationAction(overrides)` lives in `test/_make-automation-action.ts` following the other `_make-*` factories, with the catalog fields defaulted and the domain derived from the id, and the six suites that spelled the full `AutomationAction` literal out (or wrapped their own factory around it) build through it, so a new required field on the type breaks one file instead of six.

No behaviour change; every migrated assertion is unchanged. One-off inline `esphome-base-dialog` lookups in other suites are left as they are.

**Related issue or feature (if applicable):**

- fixes #1701

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
