### PR TITLE
Close the migration preview and troubleshoot dialogs through the wrapper's hide

### DIFF
--- a/src/components/device/config-migration-preview-dialog.ts
+++ b/src/components/device/config-migration-preview-dialog.ts
@@ -60,13 +60,17 @@ export class ESPHomeConfigMigrationPreviewDialog extends LitElement {
     `,
   ];
 
+  /** Set on the first confirm; the button stays live through the hide animation. */
+  private _confirmed = false;
+
   open() {
     this._revealSensitive = false;
+    this._confirmed = false;
     this._dialog.open = true;
   }
 
   close() {
-    this._dialog.open = false;
+    this._dialog.requestClose();
   }
 
   protected render() {
@@ -76,7 +80,6 @@ export class ESPHomeConfigMigrationPreviewDialog extends LitElement {
         .label=${this._localize("device.config_migration_preview_title", {
           configuration: this.configuration,
         })}
-        @request-close=${this._dialog.onRequestClose}
         @after-hide=${this._dialog.onAfterHide}
       >
         ${
@@ -112,6 +115,8 @@ export class ESPHomeConfigMigrationPreviewDialog extends LitElement {
   };
 
   private _confirm() {
+    if (this._confirmed) return;
+    this._confirmed = true;
     this.close();
     fireEvent(this, "request-migrate-config");
   }

--- a/src/components/troubleshoot-dialog.ts
+++ b/src/components/troubleshoot-dialog.ts
@@ -164,7 +164,7 @@ export class ESPHomeTroubleshootDialog extends LitElement {
   }
 
   close(): void {
-    this._dialog.open = false;
+    this._dialog.requestClose();
   }
 
   protected render() {
@@ -184,7 +184,6 @@ export class ESPHomeTroubleshootDialog extends LitElement {
       <esphome-base-dialog
         ?open=${this._dialog.open}
         .label=${label}
-        @request-close=${this._dialog.onRequestClose}
         @after-hide=${this._onAfterHide}
       >
         ${

--- a/test/_dom.ts
+++ b/test/_dom.ts
@@ -98,6 +98,24 @@ export function baseDialog(host: HTMLElement): HTMLElement {
   return host.shadowRoot!.querySelector("esphome-base-dialog")!;
 }
 
+/** Replace the wrapper's ``requestClose`` with a spy so a host's programmatic
+ *  close can be asserted without the mocked wa-dialog; the returned wrapper
+ *  still takes ``after-hide`` dispatches. */
+export function stubDialogRequestClose(
+  host: HTMLElement
+): HTMLElement & { requestClose: ReturnType<typeof vi.fn> } {
+  const wrapper = baseDialog(host) as HTMLElement & {
+    requestClose: ReturnType<typeof vi.fn>;
+  };
+  wrapper.requestClose = vi.fn();
+  return wrapper;
+}
+
+/** The host's ``DialogOpenController`` flag. */
+export function dialogOpen(host: HTMLElement): boolean {
+  return (host as unknown as { _dialog: { open: boolean } })._dialog.open;
+}
+
 /**
  * The nested ``<esphome-device-name-inputs>`` inside ``host``'s shadow
  * root, settled. Suites reach its friendly/hostname inputs through the

--- a/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
@@ -16,7 +16,12 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("../../../../src/components/base-dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
-import { baseDialog, identityLocalize } from "../../../_dom.js";
+import {
+  baseDialog,
+  dialogOpen,
+  identityLocalize,
+  stubDialogRequestClose,
+} from "../../../_dom.js";
 import { ESPHomeCatalogPickerDialog } from "../../../../src/components/device/automation-editor/catalog-picker-dialog.js";
 
 async function mountDialog(
@@ -31,8 +36,6 @@ async function mountDialog(
   return dialog;
 }
 
-const isOpen = (d: ESPHomeCatalogPickerDialog): boolean =>
-  (d as unknown as { _dialog: { open: boolean } })._dialog.open;
 const activeTab = (d: ESPHomeCatalogPickerDialog): string =>
   (d as unknown as { _activeTab: string })._activeTab;
 const afterHide = (d: ESPHomeCatalogPickerDialog): void => {
@@ -42,10 +45,10 @@ const afterHide = (d: ESPHomeCatalogPickerDialog): void => {
 describe("esphome-catalog-picker-dialog base-dialog open contract", () => {
   it("open() drives the reactive _open flag and resets the search", async () => {
     const dialog = await mountDialog("action");
-    expect(isOpen(dialog)).toBe(false);
+    expect(dialogOpen(dialog)).toBe(false);
     (dialog as unknown as { _query: string })._query = "stale";
     dialog.open();
-    expect(isOpen(dialog)).toBe(true);
+    expect(dialogOpen(dialog)).toBe(true);
     expect(activeTab(dialog)).toBe("by-target");
     expect((dialog as unknown as { _query: string })._query).toBe("");
   });
@@ -59,9 +62,9 @@ describe("esphome-catalog-picker-dialog base-dialog open contract", () => {
   it("the controller's onAfterHide flips the open flag back to false", async () => {
     const dialog = await mountDialog();
     dialog.open();
-    expect(isOpen(dialog)).toBe(true);
+    expect(dialogOpen(dialog)).toBe(true);
     afterHide(dialog);
-    expect(isOpen(dialog)).toBe(false);
+    expect(dialogOpen(dialog)).toBe(false);
   });
 
   it("renders the body only while open", async () => {
@@ -98,21 +101,16 @@ describe("esphome-catalog-picker-dialog base-dialog open contract", () => {
     const dialog = await mountDialog();
     dialog.open();
     await dialog.updateComplete;
-    const wrapper = dialog.shadowRoot!.querySelector(
-      "esphome-base-dialog"
-    )! as HTMLElement & {
-      requestClose?: () => void;
-    };
-    wrapper.requestClose = vi.fn();
+    const wrapper = stubDialogRequestClose(dialog);
     (dialog as unknown as { _pick: (id: string) => void })._pick("switch.toggle");
     await dialog.updateComplete;
     expect(wrapper.requestClose).toHaveBeenCalledTimes(1);
-    expect(isOpen(dialog)).toBe(true);
+    expect(dialogOpen(dialog)).toBe(true);
     expect(dialog.shadowRoot!.querySelector(".picker-body")).not.toBeNull();
 
     afterHide(dialog);
     await dialog.updateComplete;
-    expect(isOpen(dialog)).toBe(false);
+    expect(dialogOpen(dialog)).toBe(false);
     expect(dialog.shadowRoot!.querySelector(".picker-body")).toBeNull();
   });
 
@@ -127,15 +125,15 @@ describe("esphome-catalog-picker-dialog base-dialog open contract", () => {
     const onPicked = vi.fn();
     dialog.open({ kind: "condition", items: [], devices: [], onPicked });
     // Rows are still live: nothing changes until the hide ends.
-    expect(isOpen(dialog)).toBe(true);
+    expect(dialogOpen(dialog)).toBe(true);
     expect(dialog.kind).toBe("action");
     expect((dialog as unknown as { _query: string })._query).toBe("still visible");
 
     afterHide(dialog);
-    expect(isOpen(dialog)).toBe(false);
+    expect(dialogOpen(dialog)).toBe(false);
     await dialog.updateComplete;
     await dialog.updateComplete;
-    expect(isOpen(dialog)).toBe(true);
+    expect(dialogOpen(dialog)).toBe(true);
     expect(dialog.kind).toBe("condition");
     expect((dialog as unknown as { _query: string })._query).toBe("");
     (dialog as unknown as { _pick: (id: string) => void })._pick("sensor.in_range");
@@ -154,10 +152,10 @@ describe("esphome-catalog-picker-dialog base-dialog open contract", () => {
     afterHide(dialog);
     // Same tick as after-hide: the closed state has not committed yet.
     dialog.open({ kind: "condition", items: [], devices: [], onPicked: newer });
-    expect(isOpen(dialog)).toBe(false);
+    expect(dialogOpen(dialog)).toBe(false);
     await dialog.updateComplete;
     await dialog.updateComplete;
-    expect(isOpen(dialog)).toBe(true);
+    expect(dialogOpen(dialog)).toBe(true);
     expect(dialog.kind).toBe("condition");
     (dialog as unknown as { _pick: (id: string) => void })._pick("sensor.in_range");
     expect(newer).toHaveBeenCalledTimes(1);
@@ -177,12 +175,7 @@ describe("esphome-catalog-picker-dialog base-dialog open contract", () => {
     const dialog = await mountDialog();
     dialog.open();
     await dialog.updateComplete;
-    const wrapper = dialog.shadowRoot!.querySelector(
-      "esphome-base-dialog"
-    )! as HTMLElement & {
-      requestClose?: () => void;
-    };
-    wrapper.requestClose = vi.fn();
+    stubDialogRequestClose(dialog);
     const picked = vi.fn();
     const request = { kind: "action" as const, items: [], devices: [], onPicked: picked };
     dialog.open(request);

--- a/test/components/device/config-migration-preview-dialog.test.ts
+++ b/test/components/device/config-migration-preview-dialog.test.ts
@@ -1,8 +1,10 @@
 /**
  * @vitest-environment happy-dom
  *
- * Pins the migration preview dialog's reveal toggle: the diff opens
- * masked, the eye button flips it, and reopening resets to masked.
+ * Pins the migration preview dialog's reveal toggle (the diff opens
+ * masked, the eye button flips it, reopening resets to masked), its
+ * close path (the body survives the hide, the flag drops at after-hide),
+ * and the one-shot confirm guard that re-arms on reopen.
  */
 import { describe, expect, it, vi } from "vitest";
 

--- a/test/components/device/config-migration-preview-dialog.test.ts
+++ b/test/components/device/config-migration-preview-dialog.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import "../../_mock-webawesome.js";
 
-import { baseDialog, mount } from "../../_dom.js";
+import { baseDialog, dialogOpen, mount, stubDialogRequestClose } from "../../_dom.js";
 import { expectTooltipsAnchored } from "../../_tooltip-anchors.js";
 import { ESPHomeConfigMigrationPreviewDialog } from "../../../src/components/device/config-migration-preview-dialog.js";
 import type { ESPHomeYamlDiff } from "../../../src/components/yaml-diff.js";
@@ -71,7 +71,9 @@ describe("config-migration preview dialog reveal toggle", () => {
     expect(diffEl(el).revealSensitive).toBe(true);
 
     el.close();
+    baseDialog(el).dispatchEvent(new CustomEvent("after-hide"));
     await el.updateComplete;
+    expect(el.shadowRoot!.querySelector("esphome-yaml-diff")).toBeNull();
     el.open();
     await el.updateComplete;
     expect(diffEl(el).revealSensitive).toBe(false);
@@ -79,37 +81,38 @@ describe("config-migration preview dialog reveal toggle", () => {
 });
 
 describe("config-migration preview dialog close path", () => {
-  const stubWrapper = (el: ESPHomeConfigMigrationPreviewDialog) => {
-    const wrapper = baseDialog(el) as HTMLElement & { requestClose?: () => void };
-    wrapper.requestClose = vi.fn();
-    return wrapper;
-  };
-  const isOpen = (el: ESPHomeConfigMigrationPreviewDialog): boolean =>
-    (el as unknown as { _dialog: { open: boolean } })._dialog.open;
-
   it("keeps the diff rendered until the wrapper has finished hiding", async () => {
     const el = await mountOpen();
-    const wrapper = stubWrapper(el);
+    const wrapper = stubDialogRequestClose(el);
     el.close();
     await el.updateComplete;
     expect(wrapper.requestClose).toHaveBeenCalledTimes(1);
-    expect(isOpen(el)).toBe(true);
+    expect(dialogOpen(el)).toBe(true);
     expect(diffEl(el)).not.toBeNull();
 
     wrapper.dispatchEvent(new CustomEvent("after-hide"));
     await el.updateComplete;
-    expect(isOpen(el)).toBe(false);
+    expect(dialogOpen(el)).toBe(false);
     expect(el.shadowRoot!.querySelector("esphome-yaml-diff")).toBeNull();
   });
 
   it("a second confirm during the hide does not request the migration again", async () => {
     const el = await mountOpen();
-    stubWrapper(el);
+    const wrapper = stubDialogRequestClose(el);
     const requested = vi.fn();
     el.addEventListener("request-migrate-config", requested);
-    const confirm = el.shadowRoot!.querySelector<HTMLButtonElement>(".btn--primary")!;
-    confirm.click();
-    confirm.click();
+    const confirm = () =>
+      el.shadowRoot!.querySelector<HTMLButtonElement>(".btn--primary")!.click();
+    confirm();
+    confirm();
     expect(requested).toHaveBeenCalledTimes(1);
+
+    // The same instance is reused across previews; a reopen re-arms the button.
+    wrapper.dispatchEvent(new CustomEvent("after-hide"));
+    await el.updateComplete;
+    el.open();
+    await el.updateComplete;
+    confirm();
+    expect(requested).toHaveBeenCalledTimes(2);
   });
 });

--- a/test/components/device/config-migration-preview-dialog.test.ts
+++ b/test/components/device/config-migration-preview-dialog.test.ts
@@ -4,11 +4,11 @@
  * Pins the migration preview dialog's reveal toggle: the diff opens
  * masked, the eye button flips it, and reopening resets to masked.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import "../../_mock-webawesome.js";
 
-import { mount } from "../../_dom.js";
+import { baseDialog, mount } from "../../_dom.js";
 import { expectTooltipsAnchored } from "../../_tooltip-anchors.js";
 import { ESPHomeConfigMigrationPreviewDialog } from "../../../src/components/device/config-migration-preview-dialog.js";
 import type { ESPHomeYamlDiff } from "../../../src/components/yaml-diff.js";
@@ -75,5 +75,41 @@ describe("config-migration preview dialog reveal toggle", () => {
     el.open();
     await el.updateComplete;
     expect(diffEl(el).revealSensitive).toBe(false);
+  });
+});
+
+describe("config-migration preview dialog close path", () => {
+  const stubWrapper = (el: ESPHomeConfigMigrationPreviewDialog) => {
+    const wrapper = baseDialog(el) as HTMLElement & { requestClose?: () => void };
+    wrapper.requestClose = vi.fn();
+    return wrapper;
+  };
+  const isOpen = (el: ESPHomeConfigMigrationPreviewDialog): boolean =>
+    (el as unknown as { _dialog: { open: boolean } })._dialog.open;
+
+  it("keeps the diff rendered until the wrapper has finished hiding", async () => {
+    const el = await mountOpen();
+    const wrapper = stubWrapper(el);
+    el.close();
+    await el.updateComplete;
+    expect(wrapper.requestClose).toHaveBeenCalledTimes(1);
+    expect(isOpen(el)).toBe(true);
+    expect(diffEl(el)).not.toBeNull();
+
+    wrapper.dispatchEvent(new CustomEvent("after-hide"));
+    await el.updateComplete;
+    expect(isOpen(el)).toBe(false);
+    expect(el.shadowRoot!.querySelector("esphome-yaml-diff")).toBeNull();
+  });
+
+  it("a second confirm during the hide does not request the migration again", async () => {
+    const el = await mountOpen();
+    stubWrapper(el);
+    const requested = vi.fn();
+    el.addEventListener("request-migrate-config", requested);
+    const confirm = el.shadowRoot!.querySelector<HTMLButtonElement>(".btn--primary")!;
+    confirm.click();
+    confirm.click();
+    expect(requested).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/components/troubleshoot-dialog.test.ts
+++ b/test/components/troubleshoot-dialog.test.ts
@@ -11,7 +11,7 @@ vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 
-import { baseDialogSettled, flush, mount } from "../_dom.js";
+import { baseDialog, baseDialogSettled, flush, mount } from "../_dom.js";
 import { makeConfiguredDevice } from "../_make-configured-device.js";
 import { makeReachabilityEvent } from "../_make-reachability-event.js";
 import type { DeviceTroubleshootResult } from "../../src/api/types/troubleshoot.js";
@@ -405,10 +405,21 @@ describe("troubleshoot-dialog", () => {
       "kitchen",
       expect.any(Function)
     );
-    el.shadowRoot!.querySelector("esphome-base-dialog")!.dispatchEvent(
-      new CustomEvent("after-hide")
-    );
+    baseDialog(el).dispatchEvent(new CustomEvent("after-hide"));
     await el.updateComplete;
     expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("close() runs the wrapper's hide and drops the flag only at after-hide", async () => {
+    const { el } = await openDialog();
+    const wrapper = baseDialog(el) as HTMLElement & { requestClose?: () => void };
+    wrapper.requestClose = vi.fn();
+    const isOpen = () => (el as unknown as { _dialog: { open: boolean } })._dialog.open;
+    el.close();
+    await el.updateComplete;
+    expect(wrapper.requestClose).toHaveBeenCalledTimes(1);
+    expect(isOpen()).toBe(true);
+    wrapper.dispatchEvent(new CustomEvent("after-hide"));
+    expect(isOpen()).toBe(false);
   });
 });

--- a/test/components/troubleshoot-dialog.test.ts
+++ b/test/components/troubleshoot-dialog.test.ts
@@ -11,7 +11,14 @@ vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 
-import { baseDialog, baseDialogSettled, flush, mount } from "../_dom.js";
+import {
+  baseDialog,
+  baseDialogSettled,
+  dialogOpen,
+  flush,
+  mount,
+  stubDialogRequestClose,
+} from "../_dom.js";
 import { makeConfiguredDevice } from "../_make-configured-device.js";
 import { makeReachabilityEvent } from "../_make-reachability-event.js";
 import type { DeviceTroubleshootResult } from "../../src/api/types/troubleshoot.js";
@@ -412,14 +419,12 @@ describe("troubleshoot-dialog", () => {
 
   it("close() runs the wrapper's hide and drops the flag only at after-hide", async () => {
     const { el } = await openDialog();
-    const wrapper = baseDialog(el) as HTMLElement & { requestClose?: () => void };
-    wrapper.requestClose = vi.fn();
-    const isOpen = () => (el as unknown as { _dialog: { open: boolean } })._dialog.open;
+    const wrapper = stubDialogRequestClose(el);
     el.close();
     await el.updateComplete;
     expect(wrapper.requestClose).toHaveBeenCalledTimes(1);
-    expect(isOpen()).toBe(true);
+    expect(dialogOpen(el)).toBe(true);
     wrapper.dispatchEvent(new CustomEvent("after-hide"));
-    expect(isOpen()).toBe(false);
+    expect(dialogOpen(el)).toBe(false);
   });
 });

--- a/test/components/update-all-dialog.test.ts
+++ b/test/components/update-all-dialog.test.ts
@@ -16,6 +16,7 @@ vi.mock("../../src/components/base-dialog.js", () => ({}));
 vi.mock("../../src/components/filters/filter-section.js", () => ({}));
 vi.mock("../../src/components/filters/labels-filter-section.js", () => ({}));
 
+import { stubDialogRequestClose } from "../_dom.js";
 import { makeConfiguredDevice } from "../_make-configured-device.js";
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import { DeviceState } from "../../src/api/types/devices.js";
@@ -120,12 +121,7 @@ describe("update-all-dialog", () => {
     const { api, firmwareInstallBulk } = fakeApi();
     const el = await mount([onlineUpdatable, onlineCurrent, offlineUpdatable], api);
     // With the wrapper routing the close, the button stays live until after-hide.
-    const wrapper = el.shadowRoot!.querySelector(
-      "esphome-base-dialog"
-    )! as HTMLElement & {
-      requestClose?: () => void;
-    };
-    wrapper.requestClose = vi.fn();
+    const wrapper = stubDialogRequestClose(el);
     primaryButton(el).click();
     primaryButton(el).click();
     expect(wrapper.requestClose).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #1707. The config migration preview and troubleshoot dialogs render their body only while open but bound `@request-close`, which the wrapper emits synchronously at the start of every hide, so the flag flipped and the body blanked on the first frame of the animation for every close path, Escape and the close button included.

Both now bind `@after-hide` only and route their programmatic `close()` through `DialogOpenController.requestClose()`, so the body stays through the hide and the flag drops when the wrapper reports the hide finished. The migration preview's confirm button gets the same one shot guard as the picker pick and the update all confirm, since it stays live through the animation. Checked live on the troubleshoot dialog: 50 ms after `close()` the body and the native dialog are still up, 1.5 s later both are closed.

**Related issue or feature (if applicable):**

- fixes #1708

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
