### PR TITLE
Gate flat bus dependencies on the config entry that references them

### DIFF
--- a/src/components/device/add-component-deps.ts
+++ b/src/components/device/add-component-deps.ts
@@ -1,15 +1,14 @@
 import type { ESPHomeAPI } from "../../api/index.js";
-import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import { ComponentCategory } from "../../api/types/components.js";
 import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { canonicalComponentKey, hasComponentKey } from "../../util/component-presence.js";
+import { dependsOnSatisfied, resolveDependsOn } from "../../util/config-validation.js";
 import { withMergedSourcePresence } from "../../util/merged-source-presence.js";
 import { providerIds } from "../../util/provides-cache.js";
 import {
   parseConfiguredPlatforms,
   parseTopLevelComponents,
 } from "../../util/yaml-serialize.js";
-import { addFormEntryVisible } from "./add-component-form-filter.js";
 
 // Platform domains (sensor, switch, number, ...) are satisfied only by
 // a top-level block of that name, never by a same-named platform under
@@ -17,12 +16,10 @@ import { addFormEntryVisible } from "./add-component-form-filter.js";
 // pass for a `switch:` dependency. Guards the stem-match branch below.
 const PLATFORM_DOMAINS: ReadonlySet<string> = new Set(Object.values(ComponentCategory));
 
-/** Form scope `liveDependencies` evaluates entry gates in. */
+/** Top-level entries and values `liveDependencies` reads value gates from. */
 export interface DepScope {
   entries: readonly ConfigEntry[];
   values: Record<string, unknown>;
-  board: BoardCatalogEntry | null;
-  presentComponents: ReadonlySet<string>;
 }
 
 /**
@@ -30,30 +27,21 @@ export interface DepScope {
  * referencing top-level entry.
  *
  * Only a `depends_on` gate that resolves (a value, or the gate field's
- * default) and hides the entry drops its dep. An unresolved gate, a
- * hidden entry, a component gate, or no referencing entry keeps it.
- * Nested entries are not walked.
+ * default) and fails drops a dep; an unresolved gate, any other
+ * visibility reason, or no referencing entry keeps it. Nested entries
+ * are not walked.
  */
 export function liveDependencies(
   dependencies: readonly string[],
   scope: DepScope
 ): string[] {
   if (dependencies.length === 0) return [];
-  const visible = addFormEntryVisible(
-    scope.entries,
-    scope.values,
-    scope.board,
-    scope.presentComponents
-  );
-  const valueGateHides = (entry: ConfigEntry): boolean => {
-    if (!entry.depends_on) return false;
-    const gate =
-      scope.values[entry.depends_on] ??
-      scope.entries.find((s) => s.key === entry.depends_on)?.default_value;
-    return gate != null && !visible(entry);
-  };
+  const { entries, values } = scope;
+  const valueGateHides = (entry: ConfigEntry): boolean =>
+    resolveDependsOn(entry, values, values, entries) != null &&
+    !dependsOnSatisfied(entry, values, values, entries);
   return dependencies.filter((dep) => {
-    const refs = scope.entries.filter((e) => e.references_component === dep);
+    const refs = entries.filter((e) => e.references_component === dep);
     return refs.length === 0 || refs.some((e) => !valueGateHides(e));
   });
 }

--- a/src/components/device/add-component-deps.ts
+++ b/src/components/device/add-component-deps.ts
@@ -1,8 +1,11 @@
 import type { ESPHomeAPI } from "../../api/index.js";
-import { ComponentCategory } from "../../api/types/components.js";
+import {
+  type ComponentCatalogEntry,
+  ComponentCategory,
+} from "../../api/types/components.js";
 import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { canonicalComponentKey, hasComponentKey } from "../../util/component-presence.js";
-import { dependsOnSatisfied, resolveDependsOn } from "../../util/config-validation.js";
+import { gateAccepts, resolveDependsOn } from "../../util/config-validation.js";
 import { withMergedSourcePresence } from "../../util/merged-source-presence.js";
 import { providerIds } from "../../util/provides-cache.js";
 import {
@@ -16,33 +19,23 @@ import {
 // pass for a `switch:` dependency. Guards the stem-match branch below.
 const PLATFORM_DOMAINS: ReadonlySet<string> = new Set(Object.values(ComponentCategory));
 
-/** Top-level entries and values `liveDependencies` reads value gates from. */
-export interface DepScope {
-  entries: readonly ConfigEntry[];
-  values: Record<string, unknown>;
-}
-
 /**
- * *dependencies* minus those a resolved value gate hides on every
- * referencing top-level entry.
- *
- * Only a `depends_on` gate that resolves (a value, or the gate field's
- * default) and fails drops a dep; an unresolved gate, any other
- * visibility reason, or no referencing entry keeps it. Nested entries
- * are not walked.
+ * *component*'s dependencies minus those every referencing top-level entry
+ * hides behind a resolved `depends_on` value gate. Nested entries are not
+ * walked.
  */
 export function liveDependencies(
-  dependencies: readonly string[],
-  scope: DepScope
+  component: Pick<ComponentCatalogEntry, "dependencies" | "config_entries">,
+  values: Record<string, unknown>
 ): string[] {
-  if (dependencies.length === 0) return [];
-  const { entries, values } = scope;
-  const valueGateHides = (entry: ConfigEntry): boolean =>
-    resolveDependsOn(entry, values, values, entries) != null &&
-    !dependsOnSatisfied(entry, values, values, entries);
-  return dependencies.filter((dep) => {
+  const entries = component.config_entries;
+  const valueGateHides = (entry: ConfigEntry): boolean => {
+    const gate = resolveDependsOn(entry, values, undefined, entries);
+    return gate != null && !gateAccepts(entry, gate);
+  };
+  return (component.dependencies ?? []).filter((dep) => {
     const refs = entries.filter((e) => e.references_component === dep);
-    return refs.length === 0 || refs.some((e) => !valueGateHides(e));
+    return refs.length === 0 || !refs.every(valueGateHides);
   });
 }
 

--- a/src/components/device/add-component-deps.ts
+++ b/src/components/device/add-component-deps.ts
@@ -29,7 +29,7 @@ export interface DepScope {
  * *dependencies* minus those every referencing top-level entry hides.
  *
  * A dep no top-level entry references is kept; nested entries are not
- * walked.
+ * walked. An unresolvable gate hides its entry, so the dep is dropped.
  */
 export function liveDependencies(
   dependencies: readonly string[],

--- a/src/components/device/add-component-deps.ts
+++ b/src/components/device/add-component-deps.ts
@@ -26,10 +26,13 @@ export interface DepScope {
 }
 
 /**
- * *dependencies* minus those every referencing top-level entry hides.
+ * *dependencies* minus those a resolved value gate hides on every
+ * referencing top-level entry.
  *
- * A dep no top-level entry references is kept; nested entries are not
- * walked. An unresolvable gate hides its entry, so the dep is dropped.
+ * Only a `depends_on` gate that resolves (a value, or the gate field's
+ * default) and hides the entry drops its dep. An unresolved gate, a
+ * hidden entry, a component gate, or no referencing entry keeps it.
+ * Nested entries are not walked.
  */
 export function liveDependencies(
   dependencies: readonly string[],
@@ -42,9 +45,16 @@ export function liveDependencies(
     scope.board,
     scope.presentComponents
   );
+  const valueGateHides = (entry: ConfigEntry): boolean => {
+    if (!entry.depends_on) return false;
+    const gate =
+      scope.values[entry.depends_on] ??
+      scope.entries.find((s) => s.key === entry.depends_on)?.default_value;
+    return gate != null && !visible(entry);
+  };
   return dependencies.filter((dep) => {
     const refs = scope.entries.filter((e) => e.references_component === dep);
-    return refs.length === 0 || refs.some(visible);
+    return refs.length === 0 || refs.some((e) => !valueGateHides(e));
   });
 }
 

--- a/src/components/device/add-component-deps.ts
+++ b/src/components/device/add-component-deps.ts
@@ -1,5 +1,7 @@
 import type { ESPHomeAPI } from "../../api/index.js";
+import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import { ComponentCategory } from "../../api/types/components.js";
+import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { canonicalComponentKey, hasComponentKey } from "../../util/component-presence.js";
 import { withMergedSourcePresence } from "../../util/merged-source-presence.js";
 import { providerIds } from "../../util/provides-cache.js";
@@ -7,12 +9,44 @@ import {
   parseConfiguredPlatforms,
   parseTopLevelComponents,
 } from "../../util/yaml-serialize.js";
+import { addFormEntryVisible } from "./add-component-form-filter.js";
 
 // Platform domains (sensor, switch, number, ...) are satisfied only by
 // a top-level block of that name, never by a same-named platform under
 // another domain: a `binary_sensor: - platform: switch` mirror must not
 // pass for a `switch:` dependency. Guards the stem-match branch below.
 const PLATFORM_DOMAINS: ReadonlySet<string> = new Set(Object.values(ComponentCategory));
+
+/** Form scope `liveDependencies` evaluates entry gates in. */
+export interface DepScope {
+  entries: readonly ConfigEntry[];
+  values: Record<string, unknown>;
+  board: BoardCatalogEntry | null;
+  presentComponents: ReadonlySet<string>;
+}
+
+/**
+ * *dependencies* minus those every referencing top-level entry hides.
+ *
+ * A dep no top-level entry references is kept; nested entries are not
+ * walked.
+ */
+export function liveDependencies(
+  dependencies: readonly string[],
+  scope: DepScope
+): string[] {
+  if (dependencies.length === 0) return [];
+  const visible = addFormEntryVisible(
+    scope.entries,
+    scope.values,
+    scope.board,
+    scope.presentComponents
+  );
+  return dependencies.filter((dep) => {
+    const refs = scope.entries.filter((e) => e.references_component === dep);
+    return refs.length === 0 || refs.some(visible);
+  });
+}
 
 /**
  * Catalog dependencies not yet satisfied by the current YAML.

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -556,8 +556,6 @@ export class ESPHomeAddComponentDialog extends LitElement {
     const live = liveDependencies(entry.dependencies ?? [], {
       entries: entry.config_entries,
       values: seeded,
-      board: this.board,
-      presentComponents: present,
     });
     // `findMissingDependencies` (dotted deps, platform stems) over a plain
     // top-level-block check, so a stem-satisfied dep doesn't keep a blank

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -32,7 +32,7 @@ import { notifyError, notifySuccess } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { findAddedSection } from "../../util/yaml-sections.js";
 import { parseTopLevelComponents } from "../../util/yaml-serialize.js";
-import { findMissingDependencies } from "./add-component-deps.js";
+import { findMissingDependencies, liveDependencies } from "./add-component-deps.js";
 import { chooseExcludeCategories } from "./add-component-dialog-categories.js";
 import {
   type DepNavHost,
@@ -543,17 +543,6 @@ export class ESPHomeAddComponentDialog extends LitElement {
       this.yaml,
       this._resolvedComponents
     );
-    // `findMissingDependencies` (dotted deps, platform stems) over a plain
-    // top-level-block check, so a stem-satisfied dep doesn't keep a blank
-    // form. The form's async `provides` subtraction isn't replicated — this
-    // stays stricter, only keeping the form a touch more often.
-    const missing = findMissingDependencies(
-      entry.dependencies ?? [],
-      this.yaml,
-      present,
-      this._resolvedPlatforms
-    );
-    if (missing.length > 0) return null;
     const seeded = buildInitialValues({
       entries: entry.config_entries,
       component: entry,
@@ -564,6 +553,23 @@ export class ESPHomeAddComponentDialog extends LitElement {
       restoredValues: null,
       localize: this._localize,
     });
+    const live = liveDependencies(entry.dependencies ?? [], {
+      entries: entry.config_entries,
+      values: seeded,
+      board: this.board,
+      presentComponents: present,
+    });
+    // `findMissingDependencies` (dotted deps, platform stems) over a plain
+    // top-level-block check, so a stem-satisfied dep doesn't keep a blank
+    // form. The form's async `provides` subtraction isn't replicated — this
+    // stays stricter, only keeping the form a touch more often.
+    const missing = findMissingDependencies(
+      live,
+      this.yaml,
+      present,
+      this._resolvedPlatforms
+    );
+    if (missing.length > 0) return null;
     if (
       addFormNeedsUserInput(
         entry.config_entries,

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -553,10 +553,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
       restoredValues: null,
       localize: this._localize,
     });
-    const live = liveDependencies(entry.dependencies ?? [], {
-      entries: entry.config_entries,
-      values: seeded,
-    });
+    const live = liveDependencies(entry, seeded);
     // `findMissingDependencies` (dotted deps, platform stems) over a plain
     // top-level-block check, so a stem-satisfied dep doesn't keep a blank
     // form. The form's async `provides` subtraction isn't replicated — this

--- a/src/components/device/add-component-form-filter.ts
+++ b/src/components/device/add-component-form-filter.ts
@@ -30,20 +30,6 @@ function addFormFilterOptions(
   });
 }
 
-/** Visibility predicate for *entries* in the add-component form's board and presence scope. */
-export function addFormEntryVisible(
-  entries: readonly ConfigEntry[],
-  values: Record<string, unknown>,
-  board: BoardCatalogEntry | null,
-  presentComponents: ReadonlySet<string>
-): (entry: ConfigEntry) => boolean {
-  return visibleUnder(
-    entries,
-    values,
-    addFormFilterOptions(values, board, presentComponents)
-  );
-}
-
 /**
  * Dotted paths the add-component form would paint for *entries* under its
  * fixed filter. The form's error-visibility check reads it so a validation
@@ -83,7 +69,16 @@ export function addFormNeedsUserInput(
   // Group/cluster members are unfiltered in the plan; gate them on the same
   // visibility the form uses so a hidden unlocked member can't keep the form
   // open when every rendered field is board-locked.
-  if (planNeedsUserInput(plan, visibleUnder(entries, values, opts))) return true;
+  const isVisible = (entry: ConfigEntry): boolean =>
+    isEntryVisible(
+      entry,
+      values,
+      opts.presentComponents,
+      opts.targetPlatform ?? null,
+      opts.rootValues,
+      entries
+    );
+  if (planNeedsUserInput(plan, isVisible)) return true;
   // Pure-cardinality groups with no cluster box surface a banner only when
   // unsatisfied; keys are irrelevant to presence, so format to "".
   return (
@@ -99,20 +94,4 @@ export function addFormNeedsUserInput(
       plan.memberKeys
     ).length > 0
   );
-}
-
-function visibleUnder(
-  entries: readonly ConfigEntry[],
-  values: Record<string, unknown>,
-  opts: RenderFilterOptions
-): (entry: ConfigEntry) => boolean {
-  return (entry) =>
-    isEntryVisible(
-      entry,
-      values,
-      opts.presentComponents,
-      opts.targetPlatform ?? null,
-      opts.rootValues,
-      entries
-    );
 }

--- a/src/components/device/add-component-form-filter.ts
+++ b/src/components/device/add-component-form-filter.ts
@@ -30,7 +30,7 @@ function addFormFilterOptions(
   });
 }
 
-/** Visibility predicate for *entries* under the add-component form's fixed filter. */
+/** Visibility predicate for *entries* in the add-component form's board and presence scope. */
 export function addFormEntryVisible(
   entries: readonly ConfigEntry[],
   values: Record<string, unknown>,

--- a/src/components/device/add-component-form-filter.ts
+++ b/src/components/device/add-component-form-filter.ts
@@ -30,6 +30,20 @@ function addFormFilterOptions(
   });
 }
 
+/** Visibility predicate for *entries* under the add-component form's fixed filter. */
+export function addFormEntryVisible(
+  entries: readonly ConfigEntry[],
+  values: Record<string, unknown>,
+  board: BoardCatalogEntry | null,
+  presentComponents: ReadonlySet<string>
+): (entry: ConfigEntry) => boolean {
+  return visibleUnder(
+    entries,
+    values,
+    addFormFilterOptions(values, board, presentComponents)
+  );
+}
+
 /**
  * Dotted paths the add-component form would paint for *entries* under its
  * fixed filter. The form's error-visibility check reads it so a validation
@@ -69,16 +83,7 @@ export function addFormNeedsUserInput(
   // Group/cluster members are unfiltered in the plan; gate them on the same
   // visibility the form uses so a hidden unlocked member can't keep the form
   // open when every rendered field is board-locked.
-  const isVisible = (entry: ConfigEntry): boolean =>
-    isEntryVisible(
-      entry,
-      values,
-      opts.presentComponents,
-      opts.targetPlatform ?? null,
-      opts.rootValues,
-      entries
-    );
-  if (planNeedsUserInput(plan, isVisible)) return true;
+  if (planNeedsUserInput(plan, visibleUnder(entries, values, opts))) return true;
   // Pure-cardinality groups with no cluster box surface a banner only when
   // unsatisfied; keys are irrelevant to presence, so format to "".
   return (
@@ -94,4 +99,20 @@ export function addFormNeedsUserInput(
       plan.memberKeys
     ).length > 0
   );
+}
+
+function visibleUnder(
+  entries: readonly ConfigEntry[],
+  values: Record<string, unknown>,
+  opts: RenderFilterOptions
+): (entry: ConfigEntry) => boolean {
+  return (entry) =>
+    isEntryVisible(
+      entry,
+      values,
+      opts.presentComponents,
+      opts.targetPlatform ?? null,
+      opts.rootValues,
+      entries
+    );
 }

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -286,8 +286,6 @@ export class ESPHomeAddComponentForm extends LitElement {
     const live = liveDependencies(this.component.dependencies ?? [], {
       entries: this._entries,
       values: this._values,
-      board: this.board,
-      presentComponents: present,
     });
     const missing = findMissingDependencies(
       live,

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -281,7 +281,7 @@ export class ESPHomeAddComponentForm extends LitElement {
 
   /** Net-missing deps driving the banner and submit gate: the widened
    *  scan minus those a present component provides (`_providedDeps`), plus
-   *  a bus dep present but with no attachable bus (`_busBlockedDep`). */
+   *  a live bus dep present but with no attachable bus (`_busBlockedDep`). */
   private _missingDeps(present: ReadonlySet<string>): string[] {
     const live = liveDependencies(this.component, this._values);
     const missing = findMissingDependencies(
@@ -290,9 +290,10 @@ export class ESPHomeAddComponentForm extends LitElement {
       present,
       this.resolvedPlatforms
     ).filter((d) => !this._providedDeps.has(d));
-    // _busBlockedDep is not value-gated.
     const blocked = this._busBlockedDep;
-    return blocked && !missing.includes(blocked) ? [...missing, blocked] : missing;
+    return blocked && live.includes(blocked) && !missing.includes(blocked)
+      ? [...missing, blocked]
+      : missing;
   }
 
   /** Refresh `_providedDeps` for the current `(component, yaml)`, dropping

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -295,6 +295,7 @@ export class ESPHomeAddComponentForm extends LitElement {
       present,
       this.resolvedPlatforms
     ).filter((d) => !this._providedDeps.has(d));
+    // The bus verdict reads the flat list; only uart carries one today.
     const blocked = this._busBlockedDep;
     return blocked && !missing.includes(blocked) ? [...missing, blocked] : missing;
   }

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -33,6 +33,7 @@ import {
 import {
   depsSatisfiedByProvides,
   findMissingDependencies,
+  liveDependencies,
 } from "./add-component-deps.js";
 import { NO_BUS_VERDICT, resolveBusVerdict } from "./add-component-form-bus.js";
 import { coerceFields } from "./add-component-form-coerce.js";
@@ -282,8 +283,14 @@ export class ESPHomeAddComponentForm extends LitElement {
    *  scan minus those a present component provides (`_providedDeps`), plus
    *  a bus dep present but with no attachable bus (`_busBlockedDep`). */
   private _missingDeps(present: ReadonlySet<string>): string[] {
+    const live = liveDependencies(this.component.dependencies ?? [], {
+      entries: this._entries,
+      values: this._values,
+      board: this.board,
+      presentComponents: present,
+    });
     const missing = findMissingDependencies(
-      this.component.dependencies ?? [],
+      live,
       this.yaml,
       present,
       this.resolvedPlatforms
@@ -307,6 +314,8 @@ export class ESPHomeAddComponentForm extends LitElement {
     // Common dep-free case: nothing to resolve, so skip the YAML parse too.
     if (!api || deps.length === 0) return;
     const present = this._visibilityPresence();
+    // Ungated on purpose: resolving provides for the whole flat list once
+    // covers any dep a later value change makes live.
     const missing = findMissingDependencies(
       deps,
       this.yaml,

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -283,17 +283,14 @@ export class ESPHomeAddComponentForm extends LitElement {
    *  scan minus those a present component provides (`_providedDeps`), plus
    *  a bus dep present but with no attachable bus (`_busBlockedDep`). */
   private _missingDeps(present: ReadonlySet<string>): string[] {
-    const live = liveDependencies(this.component.dependencies ?? [], {
-      entries: this._entries,
-      values: this._values,
-    });
+    const live = liveDependencies(this.component, this._values);
     const missing = findMissingDependencies(
       live,
       this.yaml,
       present,
       this.resolvedPlatforms
     ).filter((d) => !this._providedDeps.has(d));
-    // The bus verdict reads the flat list; only uart carries one today.
+    // _busBlockedDep is not value-gated.
     const blocked = this._busBlockedDep;
     return blocked && !missing.includes(blocked) ? [...missing, blocked] : missing;
   }
@@ -313,8 +310,7 @@ export class ESPHomeAddComponentForm extends LitElement {
     // Common dep-free case: nothing to resolve, so skip the YAML parse too.
     if (!api || deps.length === 0) return;
     const present = this._visibilityPresence();
-    // Ungated on purpose: resolving provides for the whole flat list once
-    // covers any dep a later value change makes live.
+    // Flat list, not live: a dep a later value change reveals is then already resolved.
     const missing = findMissingDependencies(
       deps,
       this.yaml,

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -105,7 +105,7 @@ export function isEntryVisible(
     return false;
   }
 
-  return dependsOnSatisfied(entry, values, rootValues, siblings);
+  return gateAccepts(entry, resolveDependsOn(entry, values, rootValues, siblings));
 }
 
 /**
@@ -127,17 +127,11 @@ export function resolveDependsOn(
   return depValue ?? siblings?.find((s) => s.key === entry.depends_on)?.default_value;
 }
 
-/** Whether *entry*'s `depends_on` gate passes; an entry without one passes. */
-export function dependsOnSatisfied(
-  entry: ConfigEntry,
-  values: Record<string, unknown>,
-  rootValues?: Record<string, unknown>,
-  siblings?: readonly ConfigEntry[]
-): boolean {
+/** Whether *depValue* passes *entry*'s `depends_on` gate; an entry without one passes. */
+export function gateAccepts(entry: ConfigEntry, depValue: unknown): boolean {
   if (!entry.depends_on) return true;
   // The backend sets at most one of the three gate fields, so the
   // check order below is immaterial.
-  const depValue = resolveDependsOn(entry, values, rootValues, siblings);
   // Type-insensitive across primitives: the parser hands back numbers /
   // booleans for plain scalars (#1360) while catalog gate values may be
   // strings. A non-primitive (or nullish) depValue never matches — so

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -119,6 +119,8 @@ export function resolveDependsOn(
   siblings?: readonly ConfigEntry[]
 ): unknown {
   if (!entry.depends_on) return undefined;
+  // Resolve the dependency in the local scope first, then fall back to
+  // the component root so a nested entry can gate on a top-level field.
   const depValue = Object.prototype.hasOwnProperty.call(values, entry.depends_on)
     ? values[entry.depends_on]
     : rootValues?.[entry.depends_on];
@@ -133,6 +135,8 @@ export function dependsOnSatisfied(
   siblings?: readonly ConfigEntry[]
 ): boolean {
   if (!entry.depends_on) return true;
+  // The backend sets at most one of the three gate fields, so the
+  // check order below is immaterial.
   const depValue = resolveDependsOn(entry, values, rootValues, siblings);
   // Type-insensitive across primitives: the parser hands back numbers /
   // booleans for plain scalars (#1360) while catalog gate values may be

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -105,15 +105,35 @@ export function isEntryVisible(
     return false;
   }
 
-  if (!entry.depends_on) return true;
-  // The backend sets at most one of the three gate fields, so the
-  // check order below is immaterial. Resolve the dependency in the
-  // local scope first, then fall back to the component root so a
-  // nested entry can gate on a top-level field.
-  let depValue = Object.prototype.hasOwnProperty.call(values, entry.depends_on)
+  return dependsOnSatisfied(entry, values, rootValues, siblings);
+}
+
+/**
+ * The value *entry*'s `depends_on` gate reads: the local sibling, else the
+ * component root, else the gate field's `default_value` from `siblings`.
+ */
+export function resolveDependsOn(
+  entry: ConfigEntry,
+  values: Record<string, unknown>,
+  rootValues?: Record<string, unknown>,
+  siblings?: readonly ConfigEntry[]
+): unknown {
+  if (!entry.depends_on) return undefined;
+  const depValue = Object.prototype.hasOwnProperty.call(values, entry.depends_on)
     ? values[entry.depends_on]
     : rootValues?.[entry.depends_on];
-  depValue ??= siblings?.find((s) => s.key === entry.depends_on)?.default_value;
+  return depValue ?? siblings?.find((s) => s.key === entry.depends_on)?.default_value;
+}
+
+/** Whether *entry*'s `depends_on` gate passes; an entry without one passes. */
+export function dependsOnSatisfied(
+  entry: ConfigEntry,
+  values: Record<string, unknown>,
+  rootValues?: Record<string, unknown>,
+  siblings?: readonly ConfigEntry[]
+): boolean {
+  if (!entry.depends_on) return true;
+  const depValue = resolveDependsOn(entry, values, rootValues, siblings);
   // Type-insensitive across primitives: the parser hands back numbers /
   // booleans for plain scalars (#1360) while catalog gate values may be
   // strings. A non-primitive (or nullish) depValue never matches — so

--- a/test/components/device/add-component-deps.test.ts
+++ b/test/components/device/add-component-deps.test.ts
@@ -1,13 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ESPHomeAPI } from "../../../src/api/index.js";
 import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import {
   depsSatisfiedByProvides,
   findMissingDependencies,
+  liveDependencies,
 } from "../../../src/components/device/add-component-deps.js";
 import { withMergedSourcePresence } from "../../../src/util/merged-source-presence.js";
 import { _clearProvidesCache } from "../../../src/util/provides-cache.js";
 import { parseTopLevelComponents } from "../../../src/util/yaml-serialize.js";
+import { makeConfigEntry } from "../../util/_make-config-entry.js";
+import { ethernetEntries } from "../../util/_make-ethernet-entry.js";
 
 function providersResponse(ids: string[]) {
   return {
@@ -251,5 +255,49 @@ describe("depsSatisfiedByProvides", () => {
     await depsSatisfiedByProvides(api, ...args);
     await depsSatisfiedByProvides(api, ...args);
     expect(getComponents).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("liveDependencies", () => {
+  const scope = (values: Record<string, unknown>, entries = ethernetEntries()) => ({
+    entries,
+    values,
+    board: null,
+    presentComponents: new Set<string>(),
+  });
+
+  it("drops a dep whose only referencing entry the chosen type hides", () => {
+    expect(liveDependencies(["spi"], scope({ type: "IP101" }))).toEqual([]);
+  });
+
+  it("keeps the dep once the chosen type shows the reference", () => {
+    expect(liveDependencies(["spi"], scope({ type: "W5500" }))).toEqual(["spi"]);
+  });
+
+  it("resolves an untouched gate through the sibling default", () => {
+    expect(liveDependencies(["spi"], scope({}, ethernetEntries("W5500")))).toEqual([
+      "spi",
+    ]);
+    expect(liveDependencies(["spi"], scope({}, ethernetEntries("IP101")))).toEqual([]);
+  });
+
+  it("drops the dep while the gate is unset with no default", () => {
+    expect(liveDependencies(["spi"], scope({}))).toEqual([]);
+  });
+
+  it("keeps a dep no entry references", () => {
+    expect(liveDependencies(["spi", "uart"], scope({ type: "IP101" }))).toEqual(["uart"]);
+  });
+
+  it("does not walk nested entries", () => {
+    const [type, spiId] = ethernetEntries();
+    const nested = makeConfigEntry({
+      key: "bus",
+      type: ConfigEntryType.NESTED,
+      config_entries: [spiId],
+    });
+    expect(liveDependencies(["spi"], scope({ type: "IP101" }, [type, nested]))).toEqual([
+      "spi",
+    ]);
   });
 });

--- a/test/components/device/add-component-deps.test.ts
+++ b/test/components/device/add-component-deps.test.ts
@@ -262,8 +262,6 @@ describe("liveDependencies", () => {
   const scope = (values: Record<string, unknown>, entries = ethernetEntries()) => ({
     entries,
     values,
-    board: null,
-    presentComponents: new Set<string>(),
   });
 
   it("drops a dep whose only referencing entry the chosen type hides", () => {
@@ -301,6 +299,17 @@ describe("liveDependencies", () => {
       depends_on_component: "uart",
     });
     expect(liveDependencies(["uart"], scope({}, [componentGated]))).toEqual(["uart"]);
+  });
+
+  it("keeps a dep whose hidden reference has a passing value gate", () => {
+    const [type, spiId] = ethernetEntries();
+    const hiddenGated = { ...spiId, hidden: true };
+    expect(
+      liveDependencies(["spi"], scope({ type: "W5500" }, [type, hiddenGated]))
+    ).toEqual(["spi"]);
+    expect(
+      liveDependencies(["spi"], scope({ type: "IP101" }, [type, hiddenGated]))
+    ).toEqual([]);
   });
 
   it("keeps a dep no entry references", () => {

--- a/test/components/device/add-component-deps.test.ts
+++ b/test/components/device/add-component-deps.test.ts
@@ -317,12 +317,13 @@ describe("liveDependencies", () => {
     ]);
   });
 
-  it("keeps a dep whose hidden reference has a passing value gate", () => {
+  it("reads only the value gate on a hidden reference", () => {
     const [type, spiId] = makeEthernetEntry().config_entries;
     const ethernet = {
       ...makeEthernetEntry(),
       config_entries: [type, { ...spiId, hidden: true }],
     };
     expect(liveDependencies(ethernet, { type: "W5500" })).toEqual(["spi"]);
+    expect(liveDependencies(ethernet, { type: "IP101" })).toEqual([]);
   });
 });

--- a/test/components/device/add-component-deps.test.ts
+++ b/test/components/device/add-component-deps.test.ts
@@ -281,8 +281,26 @@ describe("liveDependencies", () => {
     expect(liveDependencies(["spi"], scope({}, ethernetEntries("IP101")))).toEqual([]);
   });
 
-  it("drops the dep while the gate is unset with no default", () => {
-    expect(liveDependencies(["spi"], scope({}))).toEqual([]);
+  it("keeps the dep while the gate is unset with no default", () => {
+    expect(liveDependencies(["spi"], scope({}))).toEqual(["spi"]);
+  });
+
+  it("keeps a dep whose reference is hidden for a non-value reason", () => {
+    // improv_serial shape: a hidden uart_id reference still needs the bus.
+    const hidden = makeConfigEntry({
+      key: "uart_id",
+      type: ConfigEntryType.ID,
+      references_component: "uart",
+      hidden: true,
+    });
+    expect(liveDependencies(["uart"], scope({}, [hidden]))).toEqual(["uart"]);
+    const componentGated = makeConfigEntry({
+      key: "uart_id",
+      type: ConfigEntryType.ID,
+      references_component: "uart",
+      depends_on_component: "uart",
+    });
+    expect(liveDependencies(["uart"], scope({}, [componentGated]))).toEqual(["uart"]);
   });
 
   it("keeps a dep no entry references", () => {

--- a/test/components/device/add-component-deps.test.ts
+++ b/test/components/device/add-component-deps.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ESPHomeAPI } from "../../../src/api/index.js";
 import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
-import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import {
+  type ConfigEntry,
+  ConfigEntryType,
+} from "../../../src/api/types/config-entries.js";
 import {
   depsSatisfiedByProvides,
   findMissingDependencies,
@@ -10,8 +13,9 @@ import {
 import { withMergedSourcePresence } from "../../../src/util/merged-source-presence.js";
 import { _clearProvidesCache } from "../../../src/util/provides-cache.js";
 import { parseTopLevelComponents } from "../../../src/util/yaml-serialize.js";
+import { makeComponentEntry } from "../../util/_make-component-entry.js";
 import { makeConfigEntry } from "../../util/_make-config-entry.js";
-import { ethernetEntries } from "../../util/_make-ethernet-entry.js";
+import { makeEthernetEntry } from "../../util/_make-ethernet-entry.js";
 
 function providersResponse(ids: string[]) {
   return {
@@ -259,72 +263,66 @@ describe("depsSatisfiedByProvides", () => {
 });
 
 describe("liveDependencies", () => {
-  const scope = (values: Record<string, unknown>, entries = ethernetEntries()) => ({
-    entries,
-    values,
-  });
+  const uartRef = (extra: Partial<ConfigEntry>) =>
+    makeComponentEntry("x", {
+      dependencies: ["uart"],
+      config_entries: [
+        makeConfigEntry({
+          key: "uart_id",
+          type: ConfigEntryType.ID,
+          references_component: "uart",
+          ...extra,
+        }),
+      ],
+    });
 
   it("drops a dep whose only referencing entry the chosen type hides", () => {
-    expect(liveDependencies(["spi"], scope({ type: "IP101" }))).toEqual([]);
+    expect(liveDependencies(makeEthernetEntry(), { type: "IP101" })).toEqual([]);
   });
 
   it("keeps the dep once the chosen type shows the reference", () => {
-    expect(liveDependencies(["spi"], scope({ type: "W5500" }))).toEqual(["spi"]);
+    expect(liveDependencies(makeEthernetEntry(), { type: "W5500" })).toEqual(["spi"]);
   });
 
   it("resolves an untouched gate through the sibling default", () => {
-    expect(liveDependencies(["spi"], scope({}, ethernetEntries("W5500")))).toEqual([
-      "spi",
-    ]);
-    expect(liveDependencies(["spi"], scope({}, ethernetEntries("IP101")))).toEqual([]);
+    expect(liveDependencies(makeEthernetEntry("W5500"), {})).toEqual(["spi"]);
+    expect(liveDependencies(makeEthernetEntry("IP101"), {})).toEqual([]);
   });
 
   it("keeps the dep while the gate is unset with no default", () => {
-    expect(liveDependencies(["spi"], scope({}))).toEqual(["spi"]);
-  });
-
-  it("keeps a dep whose reference is hidden for a non-value reason", () => {
-    // improv_serial shape: a hidden uart_id reference still needs the bus.
-    const hidden = makeConfigEntry({
-      key: "uart_id",
-      type: ConfigEntryType.ID,
-      references_component: "uart",
-      hidden: true,
-    });
-    expect(liveDependencies(["uart"], scope({}, [hidden]))).toEqual(["uart"]);
-    const componentGated = makeConfigEntry({
-      key: "uart_id",
-      type: ConfigEntryType.ID,
-      references_component: "uart",
-      depends_on_component: "uart",
-    });
-    expect(liveDependencies(["uart"], scope({}, [componentGated]))).toEqual(["uart"]);
-  });
-
-  it("keeps a dep whose hidden reference has a passing value gate", () => {
-    const [type, spiId] = ethernetEntries();
-    const hiddenGated = { ...spiId, hidden: true };
-    expect(
-      liveDependencies(["spi"], scope({ type: "W5500" }, [type, hiddenGated]))
-    ).toEqual(["spi"]);
-    expect(
-      liveDependencies(["spi"], scope({ type: "IP101" }, [type, hiddenGated]))
-    ).toEqual([]);
+    expect(liveDependencies(makeEthernetEntry(), {})).toEqual(["spi"]);
   });
 
   it("keeps a dep no entry references", () => {
-    expect(liveDependencies(["spi", "uart"], scope({ type: "IP101" }))).toEqual(["uart"]);
+    const ethernet = { ...makeEthernetEntry(), dependencies: ["spi", "uart"] };
+    expect(liveDependencies(ethernet, { type: "IP101" })).toEqual(["uart"]);
   });
 
   it("does not walk nested entries", () => {
-    const [type, spiId] = ethernetEntries();
+    const [type, spiId] = makeEthernetEntry().config_entries;
     const nested = makeConfigEntry({
       key: "bus",
       type: ConfigEntryType.NESTED,
       config_entries: [spiId],
     });
-    expect(liveDependencies(["spi"], scope({ type: "IP101" }, [type, nested]))).toEqual([
-      "spi",
+    const ethernet = { ...makeEthernetEntry(), config_entries: [type, nested] };
+    expect(liveDependencies(ethernet, { type: "IP101" })).toEqual(["spi"]);
+  });
+
+  it("keeps a dep whose reference is hidden for a non-value reason", () => {
+    // improv_serial shape: a hidden uart_id reference still needs the bus.
+    expect(liveDependencies(uartRef({ hidden: true }), {})).toEqual(["uart"]);
+    expect(liveDependencies(uartRef({ depends_on_component: "uart" }), {})).toEqual([
+      "uart",
     ]);
+  });
+
+  it("keeps a dep whose hidden reference has a passing value gate", () => {
+    const [type, spiId] = makeEthernetEntry().config_entries;
+    const ethernet = {
+      ...makeEthernetEntry(),
+      config_entries: [type, { ...spiId, hidden: true }],
+    };
+    expect(liveDependencies(ethernet, { type: "W5500" })).toEqual(["spi"]);
   });
 });

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -91,6 +91,15 @@ describe("add-component-dialog skips the form for configless components", () => 
     );
   });
 
+  it("keeps the form when the seeded type shows the bus reference", async () => {
+    const { dialog, addComponent } = makeDialog(makeEthernetEntry("W5500"));
+
+    await select(dialog, "ethernet");
+
+    expect(addComponent).not.toHaveBeenCalled();
+    expect((dialog as unknown as { _selected: unknown })._selected).not.toBeNull();
+  });
+
   it("opens the form for a bus-constrained component even when input-free", async () => {
     // The bus-hostability verdict resolves async inside the form; the
     // fast path must not add before it can gate.

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -22,6 +22,7 @@ import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-co
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
 import { makeConfigEntry } from "../../util/_make-config-entry.js";
+import { makeEthernetEntry } from "../../util/_make-ethernet-entry.js";
 
 /** Dialog whose API hydrates to `entry` and records `addComponent` calls. */
 function makeDialog(entry: ReturnType<typeof makeComponentEntry>) {
@@ -75,6 +76,19 @@ describe("add-component-dialog skips the form for configless components", () => 
       false
     );
     expect((dialog as unknown as { _selected: unknown })._selected).toBeNull();
+  });
+
+  it("fast-paths a component whose bus dep the seeded type hides", async () => {
+    const { dialog, addComponent } = makeDialog(makeEthernetEntry("IP101"));
+
+    await select(dialog, "ethernet");
+
+    // At-default fields are omitted from the payload.
+    expect(addComponent).toHaveBeenCalledWith(
+      "foo.yaml",
+      { component_id: "ethernet", fields: {} },
+      "esphome:\n  name: foo\n"
+    );
   });
 
   it("opens the form for a bus-constrained component even when input-free", async () => {

--- a/test/components/device/add-component-form-gated-dep.test.ts
+++ b/test/components/device/add-component-form-gated-dep.test.ts
@@ -3,9 +3,11 @@
  *
  * Pins the value-gated dependency banner following the chosen type.
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import "../../_mock-webawesome.js";
+
+vi.mock("../../../src/components/device/config-entry-form.js", () => ({}));
 
 import type { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";

--- a/test/components/device/add-component-form-gated-dep.test.ts
+++ b/test/components/device/add-component-form-gated-dep.test.ts
@@ -1,9 +1,7 @@
 /**
  * @vitest-environment happy-dom
  *
- * Pins the value-gated dependency banner: a bus dep the catalog flattens off
- * a type-gated reference (ethernet's spi_id) is asked for only while the
- * chosen type shows that reference, and follows the type as it changes.
+ * Pins the value-gated dependency banner following the chosen type.
  */
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -41,14 +39,11 @@ describe("add-component-form value-gated dependency", () => {
     _clearProvidesCache();
   });
 
-  it("does not ask for spi while the type hides the spi reference", async () => {
+  it("follows the type: W5500 asks for spi, IP101 clears it", async () => {
     const el = await mountEthernet("IP101");
     expect(depsBanner(el)).toBeNull();
     expect(submitButton(el).disabled).toBe(false);
-  });
 
-  it("follows the type: W5500 asks for spi, IP101 clears it", async () => {
-    const el = await mountEthernet("IP101");
     await setType(el, "W5500");
     expect(depsBanner(el)).not.toBeNull();
     expect(submitButton(el).disabled).toBe(true);

--- a/test/components/device/add-component-form-gated-dep.test.ts
+++ b/test/components/device/add-component-form-gated-dep.test.ts
@@ -55,6 +55,21 @@ describe("add-component-form value-gated dependency", () => {
     expect(submitButton(el).disabled).toBe(false);
   });
 
+  it("drops a bus verdict on a dep the type hides", async () => {
+    const el = await mountEthernet("IP101");
+    const inst = el as unknown as {
+      _busBlockedDep: string | null;
+      requestUpdate: () => void;
+    };
+    inst._busBlockedDep = "spi";
+    inst.requestUpdate();
+    await el.updateComplete;
+    expect(depsBanner(el)).toBeNull();
+
+    await setType(el, "W5500");
+    expect(depsBanner(el)).not.toBeNull();
+  });
+
   it("still asks for spi when the type shows the reference", async () => {
     const el = await mountEthernet("W5500");
     expect(depsBanner(el)).not.toBeNull();

--- a/test/components/device/add-component-form-gated-dep.test.ts
+++ b/test/components/device/add-component-form-gated-dep.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the value-gated dependency banner: a bus dep the catalog flattens off
+ * a type-gated reference (ethernet's spi_id) is asked for only while the
+ * chosen type shows that reference, and follows the type as it changes.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import type { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
+import { _clearProvidesCache } from "../../../src/util/provides-cache.js";
+import { makeEthernetEntry } from "../../util/_make-ethernet-entry.js";
+import {
+  depsBanner,
+  mountAddComponentForm,
+  submitButton,
+} from "./_add-component-form-host.js";
+import { makeTestBoard } from "./_renderer-fixtures.js";
+
+function mountEthernet(typeDefault: string) {
+  return mountAddComponentForm({
+    component: makeEthernetEntry(typeDefault),
+    board: makeTestBoard(),
+    yaml: "esp32:\n",
+  });
+}
+
+function setType(el: ESPHomeAddComponentForm, value: string) {
+  el.shadowRoot!.querySelector("esphome-config-entry-form")!.dispatchEvent(
+    new CustomEvent("value-change", { detail: { path: ["type"], value } })
+  );
+  return el.updateComplete;
+}
+
+describe("add-component-form value-gated dependency", () => {
+  afterEach(() => {
+    _clearComponentCache();
+    _clearProvidesCache();
+  });
+
+  it("does not ask for spi while the type hides the spi reference", async () => {
+    const el = await mountEthernet("IP101");
+    expect(depsBanner(el)).toBeNull();
+    expect(submitButton(el).disabled).toBe(false);
+  });
+
+  it("follows the type: W5500 asks for spi, IP101 clears it", async () => {
+    const el = await mountEthernet("IP101");
+    await setType(el, "W5500");
+    expect(depsBanner(el)).not.toBeNull();
+    expect(submitButton(el).disabled).toBe(true);
+
+    await setType(el, "IP101");
+    expect(depsBanner(el)).toBeNull();
+    expect(submitButton(el).disabled).toBe(false);
+  });
+
+  it("still asks for spi when the type shows the reference", async () => {
+    const el = await mountEthernet("W5500");
+    expect(depsBanner(el)).not.toBeNull();
+    expect(submitButton(el).disabled).toBe(true);
+  });
+});

--- a/test/components/device/add-component-form-gated-dep.test.ts
+++ b/test/components/device/add-component-form-gated-dep.test.ts
@@ -5,9 +5,9 @@
  * a type-gated reference (ethernet's spi_id) is asked for only while the
  * chosen type shows that reference, and follows the type as it changes.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
-vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+import "../../_mock-webawesome.js";
 
 import type { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";

--- a/test/util/_make-ethernet-entry.ts
+++ b/test/util/_make-ethernet-entry.ts
@@ -1,4 +1,4 @@
-/** Ethernet-shaped fixture: a ``type`` select plus an ``spi_id`` reference gated on it. */
+/** Ethernet-shaped fixture: a ``type`` select plus a ``spi_id`` reference gated on it. */
 import type { ComponentCatalogEntry } from "../../src/api/types/components.js";
 import { ConfigEntryType } from "../../src/api/types/config-entries.js";
 import { makeComponentEntry } from "./_make-component-entry.js";

--- a/test/util/_make-ethernet-entry.ts
+++ b/test/util/_make-ethernet-entry.ts
@@ -1,33 +1,8 @@
-/**
- * Ethernet-shaped fixture: a ``type`` select plus an ``spi_id`` reference
- * gated on the SPI PHY type, the catalog shape whose flat ``spi`` dependency
- * only applies for some ``type`` values.
- */
+/** Ethernet-shaped fixture: a ``type`` select plus an ``spi_id`` reference gated on it. */
 import type { ComponentCatalogEntry } from "../../src/api/types/components.js";
-import { type ConfigEntry, ConfigEntryType } from "../../src/api/types/config-entries.js";
+import { ConfigEntryType } from "../../src/api/types/config-entries.js";
 import { makeComponentEntry } from "./_make-component-entry.js";
 import { makeConfigEntry } from "./_make-config-entry.js";
-
-export function ethernetEntries(typeDefault: string | null = null): ConfigEntry[] {
-  return [
-    makeConfigEntry({
-      key: "type",
-      type: ConfigEntryType.SELECT,
-      options: [
-        { value: "IP101", label: "IP101" },
-        { value: "W5500", label: "W5500" },
-      ],
-      default_value: typeDefault,
-    }),
-    makeConfigEntry({
-      key: "spi_id",
-      type: ConfigEntryType.ID,
-      references_component: "spi",
-      depends_on: "type",
-      depends_on_value_any: ["W5500"],
-    }),
-  ];
-}
 
 export function makeEthernetEntry(
   typeDefault: string | null = null
@@ -35,6 +10,23 @@ export function makeEthernetEntry(
   return makeComponentEntry("ethernet", {
     name: "Ethernet",
     dependencies: ["spi"],
-    config_entries: ethernetEntries(typeDefault),
+    config_entries: [
+      makeConfigEntry({
+        key: "type",
+        type: ConfigEntryType.SELECT,
+        options: [
+          { value: "IP101", label: "IP101" },
+          { value: "W5500", label: "W5500" },
+        ],
+        default_value: typeDefault,
+      }),
+      makeConfigEntry({
+        key: "spi_id",
+        type: ConfigEntryType.ID,
+        references_component: "spi",
+        depends_on: "type",
+        depends_on_value_any: ["W5500"],
+      }),
+    ],
   });
 }

--- a/test/util/_make-ethernet-entry.ts
+++ b/test/util/_make-ethernet-entry.ts
@@ -1,0 +1,40 @@
+/**
+ * Ethernet-shaped fixture: a ``type`` select plus an ``spi_id`` reference
+ * gated on the SPI PHY type, the catalog shape whose flat ``spi`` dependency
+ * only applies for some ``type`` values.
+ */
+import type { ComponentCatalogEntry } from "../../src/api/types/components.js";
+import { type ConfigEntry, ConfigEntryType } from "../../src/api/types/config-entries.js";
+import { makeComponentEntry } from "./_make-component-entry.js";
+import { makeConfigEntry } from "./_make-config-entry.js";
+
+export function ethernetEntries(typeDefault: string | null = null): ConfigEntry[] {
+  return [
+    makeConfigEntry({
+      key: "type",
+      type: ConfigEntryType.SELECT,
+      options: [
+        { value: "IP101", label: "IP101" },
+        { value: "W5500", label: "W5500" },
+      ],
+      default_value: typeDefault,
+    }),
+    makeConfigEntry({
+      key: "spi_id",
+      type: ConfigEntryType.ID,
+      references_component: "spi",
+      depends_on: "type",
+      depends_on_value_any: ["W5500"],
+    }),
+  ];
+}
+
+export function makeEthernetEntry(
+  typeDefault: string | null = null
+): ComponentCatalogEntry {
+  return makeComponentEntry("ethernet", {
+    name: "Ethernet",
+    dependencies: ["spi"],
+    config_entries: ethernetEntries(typeDefault),
+  });
+}


### PR DESCRIPTION
# What does this implement/fix?

Some components carry a bus dependency that only applies for certain values of a field; ethernet's `spi_id` is gated on the SPI PHY types, and `sn74hc595` and `ds248x` have the same shape. The catalog flattens that gated reference into a plain `spi` dependency and the add form only checked YAML presence, so the Onboard Ethernet featured component (IP101, an RMII PHY) demanded an SPI bus and blocked Add.

The add form and the dialog fast path now drop a dependency only when every config entry referencing it has a `depends_on` value gate that resolves against the current values and fails, reusing the form's own gate evaluation. Anything unresolved or hidden for another reason keeps the dependency. IP101 adds without an SPI bus; switching a plain ethernet to W5500 still asks for one.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2662

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

