### PR TITLE
Mount id reference options on open and share the provider cache

### DIFF
--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -285,7 +285,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
 
   private _unsubscribeProviders?: () => void;
 
-  /** Dotted paths of lazy option lists the user has opened. */
+  /** Field keys (``fieldKeyAttr``) of lazy option lists the user has opened. */
   private _expandedOptionFields: Set<string> = new Set();
 
   /** Scrolls the YAML-cursor-selected field into view (the structured side
@@ -1086,9 +1086,9 @@ export class ESPHomeConfigEntryForm extends LitElement {
       requestAddComponent: (domain) => this._requestAddComponent(domain),
       resolveInterfaceProviders: (interfaceName) =>
         this._resolveInterfaceProviders(interfaceName),
-      isOptionsExpanded: (path) => this._expandedOptionFields.has(path.join(".")),
+      isOptionsExpanded: (path) => this._expandedOptionFields.has(fieldKeyAttr(path)),
       expandOptions: (path) => {
-        const key = path.join(".");
+        const key = fieldKeyAttr(path);
         if (this._expandedOptionFields.has(key)) return;
         this._expandedOptionFields.add(key);
         this.requestUpdate();

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -1243,7 +1243,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // The full dropdown candidate set, distinct from the Add-component
     // picker's paginated grid. The cache dedupes in-flight fetches and
     // logs a failure once.
-    if (this._api) fetchInterfaceProviders(this._api, interfaceName).catch(() => {});
+    if (this._api) void fetchInterfaceProviders(this._api, interfaceName).catch(() => {});
     // Unsettled: no api yet, fetch in flight, or the last fetch failed.
     // Distinct from a cached [] so consumers don't treat an incomplete
     // candidate list as complete.

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -656,9 +656,6 @@ export class ESPHomeConfigEntryForm extends LitElement {
     );
   }
 
-  /** Stable-partition so required entries lead. An exclusive_group is
-   *  treated atomically (required if any member is) so its members stay
-   *  contiguous and ``orderExclusiveGroups`` folds them at the same slot. */
   connectedCallback() {
     super.connectedCallback();
     // Repaint the id-reference pickers once a shared provider fetch lands.
@@ -671,6 +668,9 @@ export class ESPHomeConfigEntryForm extends LitElement {
     this._unsubscribeProviders = undefined;
   }
 
+  /** Stable-partition so required entries lead. An exclusive_group is
+   *  treated atomically (required if any member is) so its members stay
+   *  contiguous and ``orderExclusiveGroups`` folds them at the same slot. */
   protected willUpdate(changed: PropertyValues) {
     // A different entry list means the form was re-targeted to a
     // different component (e.g. the dep-flow detour swapping
@@ -746,12 +746,11 @@ export class ESPHomeConfigEntryForm extends LitElement {
    * rather than a dotted string keeps user-supplied map keys that
    * contain a dot (a `logger.logs` row keyed `i2c.idf`) intact.
    *
-   * We wait for each select's `updateComplete` (and one frame after
-   * that) to make sure wa-select's own first-render bookkeeping —
-   * `handleDefaultSlotChange`, `setSelectedOptions`, etc. — has run
-   * before we set `.value`. Otherwise our imperative set fights with
-   * wa-select's own initial value resolution and the displayed label
-   * stays blank.
+   * Before a select's first update we wait for its `updateComplete`, so
+   * wa-select's initial value resolution has run before we set `.value`
+   * and can't overwrite it. Later renders set synchronously: the options
+   * are connected, and wa-select re-derives its selection on any option
+   * change. A select already showing the value is skipped.
    */
   private async _syncSelectValues() {
     if (!this.shadowRoot) return;
@@ -847,8 +846,8 @@ export class ESPHomeConfigEntryForm extends LitElement {
   }
 
   /**
-   * Push the option marked `selected` onto `select.value` after
-   * wa-select's first paint. Used for selects whose value isn't
+   * Push the option marked `selected` onto `select.value`, waiting for
+   * wa-select's first update only. Used for selects whose value isn't
    * bound to the form's path (FLOAT_WITH_UNIT's unit picker), where
    * the `?selected` Lit binding loses the race against wa-select's
    * own selectionChanged hook.

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -41,6 +41,7 @@ import { overlayBoardLockedPresets } from "../../util/featured-locks.js";
 import { fireEvent } from "../../util/fire-event.js";
 import { hasMaterialValue } from "../../util/material-value.js";
 import { getIn, isPrimitiveOrNullish } from "../../util/nested-values.js";
+import { parseBoardGpio } from "../../util/pin/gpio.js";
 import {
   fetchPinRegistryModes,
   getCachedPinRegistryModes,
@@ -821,11 +822,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
       //
       // Pin entries are a second mismatch: the seeded YAML value is
       // a bare int (`9`, from `seedBoardPinDefaults` reading the
-      // board manifest's pin features) or a string alias (`"SCL"`),
-      // but the option values are always `"GPIOn"`. Normalise both
-      // into the bare GPIO number for comparison so a freshly seeded
-      // i2c bus on ESP32-C3 lands on the right option instead of
-      // showing an empty select.
+      // board manifest's pin features) or a board spelling (`"P0.27"`,
+      // `"PB03"`) that differs from the option's. Normalise both sides
+      // through the shared pin parser so a freshly seeded i2c bus lands
+      // on the right option instead of showing an empty select.
       const desired = this._matchOptionValue(select, raw);
       if (current !== desired) {
         select.value = desired;
@@ -838,12 +838,12 @@ export class ESPHomeConfigEntryForm extends LitElement {
     const options = Array.from(
       select.querySelectorAll<HTMLElement & { value: string }>("wa-option")
     );
-    const rawGpio = raw.match(/^\s*(?:GPIO)?(\d+)\s*$/i)?.[1];
-    const findByValue = (v: string) =>
-      options.find((o) => o.value?.toLowerCase() === v.toLowerCase());
-    const matched =
-      findByValue(raw) ?? (rawGpio ? findByValue(`GPIO${rawGpio}`) : undefined);
-    return matched?.value ?? raw;
+    const lower = raw.toLowerCase();
+    const exact = options.find((o) => o.value?.toLowerCase() === lower);
+    if (exact) return exact.value;
+    const gpio = parseBoardGpio(raw);
+    if (gpio === null) return raw;
+    return options.find((o) => parseBoardGpio(o.value) === gpio)?.value ?? raw;
   }
 
   /**

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -812,6 +812,9 @@ export class ESPHomeConfigEntryForm extends LitElement {
       const current = Array.isArray(select.value)
         ? (select.value[0] ?? "")
         : (select.value ?? "");
+      // A select holding the raw value as its own spelling never re-syncs,
+      // so a late-mounting option list must always include the value's
+      // option (the lazy id-reference list keeps the selected one mounted).
       if (this._showsValue(current, raw)) continue;
       // wa-select filters its `value` against the exact string of an
       // option's `value`; case mismatches between YAML and catalog

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -812,7 +812,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
       const current = Array.isArray(select.value)
         ? (select.value[0] ?? "")
         : (select.value ?? "");
-      if (current === raw) continue;
+      if (this._showsValue(current, raw)) continue;
       // wa-select filters its `value` against the exact string of an
       // option's `value`; case mismatches between YAML and catalog
       // would silently drop the value. Look up the matching option
@@ -830,6 +830,15 @@ export class ESPHomeConfigEntryForm extends LitElement {
         select.value = desired;
       }
     }
+  }
+
+  /** Whether a select's value is the raw value or its option spelling. */
+  private _showsValue(current: string, raw: string): boolean {
+    if (current === raw) return true;
+    if (!current || !raw) return false;
+    if (current.toLowerCase() === raw.toLowerCase()) return true;
+    const gpio = parseBoardGpio(raw);
+    return gpio !== null && parseBoardGpio(current) === gpio;
   }
 
   private _matchOptionValue(select: HTMLElement, raw: string): string {

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -33,15 +33,11 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, devicesContext, localizeContext } from "../../context/index.js";
 import { floatRequiredFirst } from "../../util/config-entry-ordering.js";
 import { anyAdvancedEntry, pathIsAdvanced } from "../../util/config-entry-tree.js";
-import {
-  catalogEntryToProvider,
-  type ComponentProvider,
-} from "../../util/config-entry-yaml-scan.js";
+import type { ComponentProvider } from "../../util/config-entry-yaml-scan.js";
 import { isEntryVisible, type ValidationError } from "../../util/config-validation.js";
 import { resolveDeviceName } from "../../util/device-name.js";
 import { getErrorMessage } from "../../util/error-message.js";
 import { overlayBoardLockedPresets } from "../../util/featured-locks.js";
-import { fetchAllComponents } from "../../util/fetch-all-components.js";
 import { fireEvent } from "../../util/fire-event.js";
 import { hasMaterialValue } from "../../util/material-value.js";
 import { getIn, isPrimitiveOrNullish } from "../../util/nested-values.js";
@@ -50,6 +46,11 @@ import {
   getCachedPinRegistryModes,
   subscribePinRegistryModes,
 } from "../../util/pin/registry-modes-cache.js";
+import {
+  fetchInterfaceProviders,
+  getCachedInterfaceProviders,
+  subscribeInterfaceProviders,
+} from "../../util/provides-cache.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { nearestScrollContainer } from "../../util/scroll-container.js";
 import { SessionBlobCacheController } from "../../util/session-blob-cache-controller.js";
@@ -281,10 +282,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
    *  once and a later user collapse isn't re-overridden. */
   private _seededNestedOpen: Set<string> = new Set();
 
-  /** Resolved providers per interface name, and the in-flight set, for the
-   *  id-reference dropdown's cross-domain lookup. */
-  private _interfaceProviders: Map<string, ComponentProvider[]> = new Map();
-  private _interfaceProvidersPending: Set<string> = new Set();
+  private _unsubscribeProviders?: () => void;
+
+  /** Dotted paths of lazy option lists the user has opened. */
+  private _expandedOptionFields: Set<string> = new Set();
 
   /** Scrolls the YAML-cursor-selected field into view (the structured side
    *  of the field sync); driven from ``updated``. */
@@ -657,6 +658,18 @@ export class ESPHomeConfigEntryForm extends LitElement {
   /** Stable-partition so required entries lead. An exclusive_group is
    *  treated atomically (required if any member is) so its members stay
    *  contiguous and ``orderExclusiveGroups`` folds them at the same slot. */
+  connectedCallback() {
+    super.connectedCallback();
+    // Repaint the id-reference pickers once a shared provider fetch lands.
+    this._unsubscribeProviders = subscribeInterfaceProviders(() => this.requestUpdate());
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._unsubscribeProviders?.();
+    this._unsubscribeProviders = undefined;
+  }
+
   protected willUpdate(changed: PropertyValues) {
     // A different entry list means the form was re-targeted to a
     // different component (e.g. the dep-flow detour swapping
@@ -667,6 +680,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
       this._editingMagnitudes.clear();
       this._openAdvancedPlacement.clear();
       this._constraintClusters.reset();
+      this._expandedOptionFields.clear();
       // Re-seed disclosures for the new component; a key like "pin:pin-advanced"
       // recurs across sections, and the form instance is reused.
       this._seededNestedOpen.clear();
@@ -746,6 +760,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
         | (HTMLElement & {
             value: string | string[] | null;
             updateComplete?: Promise<unknown>;
+            hasUpdated?: boolean;
           })
         | null;
       if (!select) continue;
@@ -762,7 +777,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
       // Let wa-select finish its own initial update before we set
       // anything — otherwise its post-render selectionChanged
       // overwrites whatever we wrote.
-      if (select.updateComplete) {
+      if (!select.hasUpdated && select.updateComplete) {
         try {
           await select.updateComplete;
         } catch {
@@ -794,6 +809,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
         continue;
       }
       const raw = String(value ?? "");
+      const current = Array.isArray(select.value)
+        ? (select.value[0] ?? "")
+        : (select.value ?? "");
+      if (current === raw) continue;
       // wa-select filters its `value` against the exact string of an
       // option's `value`; case mismatches between YAML and catalog
       // would silently drop the value. Look up the matching option
@@ -807,23 +826,24 @@ export class ESPHomeConfigEntryForm extends LitElement {
       // into the bare GPIO number for comparison so a freshly seeded
       // i2c bus on ESP32-C3 lands on the right option instead of
       // showing an empty select.
-      const options = Array.from(
-        select.querySelectorAll<HTMLElement & { value: string }>("wa-option")
-      );
-      const rawGpio = raw.match(/^\s*(?:GPIO)?(\d+)\s*$/i)?.[1];
-      const findByValue = (v: string) =>
-        options.find((o) => o.value?.toLowerCase() === v.toLowerCase());
-      const matched = raw
-        ? (findByValue(raw) ?? (rawGpio ? findByValue(`GPIO${rawGpio}`) : undefined))
-        : null;
-      const desired = matched?.value ?? raw;
-      const current = Array.isArray(select.value)
-        ? (select.value[0] ?? "")
-        : (select.value ?? "");
+      const desired = this._matchOptionValue(select, raw);
       if (current !== desired) {
         select.value = desired;
       }
     }
+  }
+
+  private _matchOptionValue(select: HTMLElement, raw: string): string {
+    if (!raw) return raw;
+    const options = Array.from(
+      select.querySelectorAll<HTMLElement & { value: string }>("wa-option")
+    );
+    const rawGpio = raw.match(/^\s*(?:GPIO)?(\d+)\s*$/i)?.[1];
+    const findByValue = (v: string) =>
+      options.find((o) => o.value?.toLowerCase() === v.toLowerCase());
+    const matched =
+      findByValue(raw) ?? (rawGpio ? findByValue(`GPIO${rawGpio}`) : undefined);
+    return matched?.value ?? raw;
   }
 
   /**
@@ -837,9 +857,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
     select: HTMLElement & {
       value: string | string[] | null;
       updateComplete?: Promise<unknown>;
+      hasUpdated?: boolean;
     }
   ) {
-    if (select.updateComplete) {
+    if (!select.hasUpdated && select.updateComplete) {
       try {
         await select.updateComplete;
       } catch {
@@ -1066,6 +1087,13 @@ export class ESPHomeConfigEntryForm extends LitElement {
       requestAddComponent: (domain) => this._requestAddComponent(domain),
       resolveInterfaceProviders: (interfaceName) =>
         this._resolveInterfaceProviders(interfaceName),
+      isOptionsExpanded: (path) => this._expandedOptionFields.has(path.join(".")),
+      expandOptions: (path) => {
+        const key = path.join(".");
+        if (this._expandedOptionFields.has(key)) return;
+        this._expandedOptionFields.add(key);
+        this.requestUpdate();
+      },
       scopeValues: (path) => this._scopeValues(path),
       filterRenderable: this._filterRenderable,
       getPendingUnit: (path) => this._pendingUnits.get(path.join(".")),
@@ -1190,43 +1218,24 @@ export class ESPHomeConfigEntryForm extends LitElement {
   }
 
   /**
-   * Providers of an interface reference, from a per-form cache.
+   * Providers of an interface reference, from the session cache shared by
+   * every form.
    *
-   * A miss fetches the catalog by ``provides`` once and re-renders on
-   * resolve; an empty *success* caches ``[]`` (a same-domain reference has
-   * no extra providers). A *failure* is logged and left uncached so a later
-   * render retries rather than permanently dropping candidates.
+   * A miss kicks the shared fetch and the subscription repaints on resolve;
+   * an empty *success* caches ``[]`` (a same-domain reference has no extra
+   * providers). A *failure* is left uncached so a later render retries
+   * rather than permanently dropping candidates.
    */
   private _resolveInterfaceProviders(
     interfaceName: string
   ): readonly ComponentProvider[] | null {
     if (!interfaceName) return [];
-    const cached = this._interfaceProviders.get(interfaceName);
+    const cached = getCachedInterfaceProviders(interfaceName);
     if (cached) return cached;
-    if (this._api && !this._interfaceProvidersPending.has(interfaceName)) {
-      this._interfaceProvidersPending.add(interfaceName);
-      // The full dropdown candidate set, distinct from the
-      // Add-component picker's paginated grid.
-      fetchAllComponents(this._api, { provides: interfaceName })
-        .then((components) => {
-          this._interfaceProviders.set(
-            interfaceName,
-            components.map((c) => catalogEntryToProvider(c, interfaceName))
-          );
-          this.requestUpdate();
-        })
-        .catch((err) =>
-          // Warn (not debug) so the dropped-candidate path is observable, and
-          // don't cache [] — that's indistinguishable from "no providers" and
-          // would silently omit candidates for the form's lifetime.
-          console.warn(
-            "[config-entry-form] provider fetch failed for",
-            interfaceName,
-            err
-          )
-        )
-        .finally(() => this._interfaceProvidersPending.delete(interfaceName));
-    }
+    // The full dropdown candidate set, distinct from the Add-component
+    // picker's paginated grid. The cache dedupes in-flight fetches and
+    // logs a failure once.
+    if (this._api) fetchInterfaceProviders(this._api, interfaceName).catch(() => {});
     // Unsettled: no api yet, fetch in flight, or the last fetch failed.
     // Distinct from a cached [] so consumers don't treat an incomplete
     // candidate list as complete.

--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -3,6 +3,10 @@
  * a sentinel value so the form can intercept the select's `change`
  * event and route to the add-component flow instead of writing the
  * literal sentinel as a config value.
+ *
+ * The candidate list mounts only once the select has opened
+ * (``ctx.expandOptions``); until then only the selected candidate is
+ * rendered.
  */
 
 import { mdiPlus } from "@mdi/js";
@@ -68,7 +72,13 @@ export function renderIdReferenceField(
   // include / another file the scan can't see, or a dangling reference (typo,
   // deleted id). We can't tell which, so surface it as a selected option with
   // provenance-neutral copy rather than dropping it on save.
-  const hasOrphanValue = value !== "" && !candidates.some((c) => c.id === value);
+  const selected = candidates.find((c) => c.id === value);
+  const hasOrphanValue = value !== "" && !selected;
+  const shownCandidates = ctx.isOptionsExpanded(path)
+    ? candidates
+    : selected
+      ? [selected]
+      : [];
   const orphanOption = hasOrphanValue
     ? idOption(value, value, ctx.localize("device.id_reference_unresolved", { domain }))
     : nothing;
@@ -188,10 +198,11 @@ export function renderIdReferenceField(
               defaultCandidate.id
             : nothing
         }
+        @wa-show=${() => ctx.expandOptions(path)}
         @change=${onChange}
       >
         ${autoOption} ${orphanOption}
-        ${candidates.map((c) => {
+        ${shownCandidates.map((c) => {
           const secondary = c.name ? `${c.id} · ${domain}` : domain;
           // The label is display-only; the stored value stays c.id. Resolve
           // ${...} so the picker shows the same name the text field previews.

--- a/src/components/device/config-entry-renderers-types.ts
+++ b/src/components/device/config-entry-renderers-types.ts
@@ -69,7 +69,7 @@ export interface RenderCtx {
   requestAddComponent: (domain: string) => void;
   /**
    * Providers of a cross-domain interface reference. Returns synchronously
-   * from a per-form cache; a miss kicks an async catalog fetch and
+   * from the session cache; a miss kicks an async catalog fetch and
    * re-renders. ``null`` while unsettled (no api yet, fetch in flight, or
    * the last fetch failed) — the candidate list is incomplete then, not
    * empty. ``[]`` is a settled same-domain reference.
@@ -77,6 +77,10 @@ export interface RenderCtx {
   resolveInterfaceProviders: (
     interfaceName: string
   ) => ReadonlyArray<ComponentProvider> | null;
+  /** Whether a lazy option list at *path* has been opened once; the full
+   *  candidate set mounts only then, and stays for the form's lifetime. */
+  isOptionsExpanded: (path: string[]) => boolean;
+  expandOptions: (path: string[]) => void;
   scopeValues: (path: string[]) => Record<string, unknown>;
   filterRenderable: (
     entries: ConfigEntry[],

--- a/src/util/provides-cache.ts
+++ b/src/util/provides-cache.ts
@@ -1,6 +1,11 @@
 import type { ESPHomeAPI } from "../api/index.js";
+import {
+  catalogEntryToProvider,
+  type ComponentProvider,
+} from "./config-entry-yaml-scan.js";
 import { fetchAllComponents } from "./fetch-all-components.js";
 import { KeyedPromiseCache } from "./keyed-promise-cache.js";
+import { createSessionBlobCache } from "./session-blob-cache.js";
 
 /** Ids of the components that provide an interface, board-scoped and cached
  *  for the process lifetime. The backend catalog is immutable for that
@@ -27,4 +32,41 @@ export function providerIds(
 
 export function _clearProvidesCache(): void {
   _cache.clear();
+  _providers.reset();
+}
+
+/** Providers of an interface, shared by every form for the session. */
+const _providers = createSessionBlobCache<readonly ComponentProvider[], [string]>({
+  name: "interface-providers",
+  key: (interfaceName) => interfaceName,
+  fetch: (api, interfaceName) =>
+    fetchAllComponents(api, { provides: interfaceName })
+      .then((components) =>
+        components.map((c) => catalogEntryToProvider(c, interfaceName))
+      )
+      .catch((err: unknown) => {
+        // Warn (not debug) so the dropped-candidate path is observable.
+        console.warn("[provides-cache] provider fetch failed for", interfaceName, err);
+        throw err;
+      }),
+});
+
+/** Resolved providers of `interfaceName`, or `undefined` until fetched. */
+export function getCachedInterfaceProviders(
+  interfaceName: string
+): readonly ComponentProvider[] | undefined {
+  return _providers.getCached(interfaceName);
+}
+
+/** Subscribe to provider cache population; returns an unsubscribe function. */
+export function subscribeInterfaceProviders(cb: () => void): () => void {
+  return _providers.subscribe(cb);
+}
+
+/** Fetch the providers of `interfaceName` once; concurrent callers share it. */
+export function fetchInterfaceProviders(
+  api: ESPHomeAPI,
+  interfaceName: string
+): Promise<readonly ComponentProvider[]> {
+  return _providers.fetch(api, interfaceName);
 }

--- a/src/util/provides-cache.ts
+++ b/src/util/provides-cache.ts
@@ -35,7 +35,9 @@ export function _clearProvidesCache(): void {
   _providers.reset();
 }
 
-/** Providers of an interface, shared by every form for the session. */
+/** Providers of an interface, shared by every form for the session.
+ *  Board-agnostic on purpose: the id-reference candidates come from the
+ *  YAML, unlike the board-scoped ``providerIds`` above. */
 const _providers = createSessionBlobCache<readonly ComponentProvider[], [string]>({
   name: "interface-providers",
   key: (interfaceName) => interfaceName,

--- a/test/components/device/_renderer-fixtures.ts
+++ b/test/components/device/_renderer-fixtures.ts
@@ -110,6 +110,8 @@ export function makeRenderCtx(
     seedNestedOpen: vi.fn(),
     requestAddComponent: vi.fn(),
     resolveInterfaceProviders: () => [],
+    isOptionsExpanded: () => true,
+    expandOptions: vi.fn(),
     scopeValues: () => ({}),
     filterRenderable: (entries) => entries,
     renderEntry: vi.fn(),

--- a/test/components/device/config-entry-form-providers.test.ts
+++ b/test/components/device/config-entry-form-providers.test.ts
@@ -47,7 +47,10 @@ function response(ids: string[]) {
 
 describe("config-entry-form _resolveInterfaceProviders", () => {
   beforeEach(() => _clearProvidesCache());
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    _clearProvidesCache();
+  });
 
   it("returns null on the first miss, then the fetched providers, fetching once", async () => {
     const getComponents = vi

--- a/test/components/device/config-entry-form-providers.test.ts
+++ b/test/components/device/config-entry-form-providers.test.ts
@@ -6,7 +6,7 @@
  * ``provides`` fetch shared by every form, and a failed fetch left uncached
  * so a later render can retry.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("sonner-js", () => ({
   default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
@@ -47,6 +47,7 @@ function response(ids: string[]) {
 
 describe("config-entry-form _resolveInterfaceProviders", () => {
   beforeEach(() => _clearProvidesCache());
+  afterEach(() => vi.restoreAllMocks());
 
   it("returns null on the first miss, then the fetched providers, fetching once", async () => {
     const getComponents = vi

--- a/test/components/device/config-entry-form-providers.test.ts
+++ b/test/components/device/config-entry-form-providers.test.ts
@@ -2,21 +2,22 @@
  * @vitest-environment happy-dom
  *
  * ``_resolveInterfaceProviders`` backs the id-reference dropdown's
- * cross-domain lookup: a per-form cache fed by one paged ``provides``
- * fetch, deduped while in flight, and — crucially — NOT poisoned with
- * ``[]`` on a failed fetch so a later render can retry.
+ * cross-domain lookup through the session provider cache: one paged
+ * ``provides`` fetch shared by every form, and a failed fetch left uncached
+ * so a later render can retry.
  */
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("sonner-js", () => ({
   default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
 }));
 
-import { flushMicrotasks } from "../../_dom.js";
+import { flush } from "../../_dom.js";
 import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
 import { ESPHomeConfigEntryForm } from "../../../src/components/device/config-entry-form.js";
 import type { ComponentProvider } from "../../../src/util/config-entry-yaml-scan.js";
 import { COMPONENT_FETCH_PAGE } from "../../../src/util/fetch-all-components.js";
+import { _clearProvidesCache } from "../../../src/util/provides-cache.js";
 
 const resolve = (
   form: ESPHomeConfigEntryForm,
@@ -27,9 +28,6 @@ const resolve = (
       _resolveInterfaceProviders(n: string): readonly ComponentProvider[] | null;
     }
   )._resolveInterfaceProviders(name);
-
-// Let the getComponents promise's then/catch/finally chain settle.
-const flush = () => flushMicrotasks(3);
 
 function withApi(getComponents: ReturnType<typeof vi.fn>): ESPHomeConfigEntryForm {
   const form = new ESPHomeConfigEntryForm();
@@ -48,6 +46,8 @@ function response(ids: string[]) {
 }
 
 describe("config-entry-form _resolveInterfaceProviders", () => {
+  beforeEach(() => _clearProvidesCache());
+
   it("returns null on the first miss, then the fetched providers, fetching once", async () => {
     const getComponents = vi
       .fn()
@@ -91,7 +91,7 @@ describe("config-entry-form _resolveInterfaceProviders", () => {
     const form = withApi(getComponents as unknown as ReturnType<typeof vi.fn>);
 
     resolve(form, "sensor");
-    await flushMicrotasks(8);
+    await flush();
 
     expect(getComponents).toHaveBeenCalledTimes(2);
     const providers = resolve(form, "sensor");
@@ -103,6 +103,7 @@ describe("config-entry-form _resolveInterfaceProviders", () => {
   });
 
   it("does not cache [] on a failed fetch, so a later render retries", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     const getComponents = vi
       .fn()
       .mockRejectedValueOnce(new Error("ws down"))
@@ -111,11 +112,27 @@ describe("config-entry-form _resolveInterfaceProviders", () => {
 
     resolve(form, "voltage_sampler");
     await flush();
-    // Failure left the cache unset — the next call retries (still
+    // Failure left the cache unset; the next call retries (still
     // unsettled) rather than returning a poisoned empty list forever.
     expect(resolve(form, "voltage_sampler")).toBeNull();
     await flush();
     expect(getComponents).toHaveBeenCalledTimes(2);
     expect(resolve(form, "voltage_sampler")).toEqual([{ domain: "sensor", stem: "adc" }]);
+  });
+
+  it("shares one fetch across form instances", async () => {
+    const getComponents = vi.fn().mockResolvedValue(response(["sensor.adc"]));
+    const a = withApi(getComponents);
+    const b = withApi(getComponents);
+    expect(resolve(a, "voltage_sampler")).toBeNull();
+    expect(resolve(b, "voltage_sampler")).toBeNull();
+    await flush();
+    expect(getComponents).toHaveBeenCalledTimes(1);
+    expect(resolve(b, "voltage_sampler")).toEqual([{ domain: "sensor", stem: "adc" }]);
+    // A form built after the fetch settled reads the cache synchronously.
+    expect(resolve(withApi(getComponents), "voltage_sampler")).toEqual([
+      { domain: "sensor", stem: "adc" },
+    ]);
+    expect(getComponents).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/components/device/config-entry-form-select-sync.test.ts
+++ b/test/components/device/config-entry-form-select-sync.test.ts
@@ -105,6 +105,18 @@ describe("_syncSelectValues", () => {
     expect(select.value).toBe(expected);
   });
 
+  it.each([
+    ["GPIO9", 9],
+    ["ESP32C6", "esp32c6"],
+    ["P0.27", 27],
+    ["PB03", "GPIO19"],
+  ])("skips the scan when the select shows %s for %s", async (current, raw) => {
+    const select = fakeSelect({ value: current, options: ["x", current] });
+    await sync(select, raw);
+    expect(select.scans).toBe(0);
+    expect(select.value).toBe(current);
+  });
+
   it("leaves a pin with no matching option untouched", async () => {
     const select = fakeSelect({ value: "", options: ["GPIO1", "GPIO2"] });
     await sync(select, "P0.30");

--- a/test/components/device/config-entry-form-select-sync.test.ts
+++ b/test/components/device/config-entry-form-select-sync.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * ``_syncSelectValues`` pushes each field's value onto its wa-select after
+ * every render: it waits for the select's first update only, skips a select
+ * already showing the value, and otherwise scans the options for a case or
+ * GPIO match.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { ESPHomeConfigEntryForm } from "../../../src/components/device/config-entry-form.js";
+
+interface FakeSelect {
+  value: string;
+  hasUpdated: boolean;
+  /** Thenable that counts awaits. */
+  updateComplete: { then: (onFulfilled: (v: unknown) => unknown) => Promise<unknown> };
+  awaited: number;
+  scans: number;
+  hasAttribute: (name: string) => boolean;
+  querySelectorAll: (sel: string) => Array<{ value: string }>;
+}
+
+function fakeSelect(opts: {
+  value: string;
+  options: string[];
+  hasUpdated?: boolean;
+}): FakeSelect {
+  const select: FakeSelect = {
+    value: opts.value,
+    hasUpdated: opts.hasUpdated ?? true,
+    awaited: 0,
+    scans: 0,
+    hasAttribute: () => false,
+    querySelectorAll: () => {
+      select.scans++;
+      return opts.options.map((value) => ({ value }));
+    },
+    updateComplete: {
+      then(onFulfilled: (v: unknown) => unknown) {
+        select.awaited++;
+        return Promise.resolve(true).then(onFulfilled);
+      },
+    },
+  };
+  return select;
+}
+
+async function sync(select: FakeSelect, value: unknown): Promise<void> {
+  const form = new ESPHomeConfigEntryForm();
+  form.values = { field: value };
+  const field = { querySelector: () => select };
+  Object.defineProperty(form, "shadowRoot", {
+    value: { querySelectorAll: () => [field] },
+  });
+  vi.spyOn(
+    form as unknown as { _pathOf: (f: unknown) => string[] },
+    "_pathOf"
+  ).mockReturnValue(["field"]);
+  await (
+    form as unknown as { _syncSelectValues: () => Promise<void> }
+  )._syncSelectValues();
+}
+
+describe("_syncSelectValues", () => {
+  it("awaits updateComplete only before the select's first update", async () => {
+    const fresh = fakeSelect({ value: "", options: ["a"], hasUpdated: false });
+    await sync(fresh, "a");
+    expect(fresh.awaited).toBe(1);
+    const settled = fakeSelect({ value: "", options: ["a"] });
+    await sync(settled, "a");
+    expect(settled.awaited).toBe(0);
+  });
+
+  it("skips the option scan when the select already shows the value", async () => {
+    const select = fakeSelect({ value: "a", options: ["a", "b"] });
+    await sync(select, "a");
+    expect(select.scans).toBe(0);
+    expect(select.value).toBe("a");
+  });
+
+  it("case-folds onto an option", async () => {
+    const select = fakeSelect({ value: "", options: ["ESP32C6", "ESP32S3"] });
+    await sync(select, "esp32c6");
+    expect(select.value).toBe("ESP32C6");
+  });
+
+  it("maps a bare GPIO number onto its GPIO option", async () => {
+    const select = fakeSelect({ value: "", options: ["GPIO8", "GPIO9"] });
+    await sync(select, 9);
+    expect(select.value).toBe("GPIO9");
+  });
+});

--- a/test/components/device/config-entry-form-select-sync.test.ts
+++ b/test/components/device/config-entry-form-select-sync.test.ts
@@ -90,4 +90,24 @@ describe("_syncSelectValues", () => {
     await sync(select, 9);
     expect(select.value).toBe("GPIO9");
   });
+
+  it.each([
+    ["P0.27", ["P0.26", "P0.27"], "P0.27"],
+    [27, ["P0.26", "P0.27"], "P0.27"],
+    ["P0.27", ["GPIO26", "GPIO27"], "GPIO27"],
+    ["P23", ["GPIO22", "GPIO23"], "GPIO23"],
+    ["PA02", ["GPIO1", "GPIO2"], "GPIO2"],
+    ["PB03", ["GPIO18", "GPIO19"], "GPIO19"],
+    ["GPIO19", ["PB02", "PB03"], "PB03"],
+  ])("maps pin %s onto its board option", async (raw, options, expected) => {
+    const select = fakeSelect({ value: "", options });
+    await sync(select, raw);
+    expect(select.value).toBe(expected);
+  });
+
+  it("leaves a pin with no matching option untouched", async () => {
+    const select = fakeSelect({ value: "", options: ["GPIO1", "GPIO2"] });
+    await sync(select, "P0.30");
+    expect(select.value).toBe("P0.30");
+  });
 });

--- a/test/components/device/config-entry-id-reference-renderer.test.ts
+++ b/test/components/device/config-entry-id-reference-renderer.test.ts
@@ -5,7 +5,7 @@
  * a selected option so it displays and round-trips instead of vanishing.
  */
 import { nothing } from "lit";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { findTemplatesByAnchor } from "../../_lit-template-walker.js";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import {
@@ -16,6 +16,9 @@ import {
 import { findElementBindings, makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
 
 const LOCAL_SCRIPT_YAML = "script:\n  - id: local_script\n";
+
+const optionValues = (tmpl: unknown): unknown[] =>
+  findElementBindings(tmpl, "wa-option").map((o) => o.value);
 
 function renderFor(yaml: string, value: string) {
   const entry = makeEntry(ConfigEntryType.STRING, { references_component: "script" });
@@ -337,9 +340,6 @@ describe("renderIdReferenceField — revert-to-auto option (#2208)", () => {
     return renderIdReferenceField(entry, ["logger_id"], ctx);
   }
 
-  const optionValues = (tmpl: unknown): unknown[] =>
-    findElementBindings(tmpl, "wa-option").map((o) => o.value);
-
   it("offers Auto on an optional reference with a committed value", () => {
     // The dangling `logger_id: logger` older builds pre-filled has no other
     // visual-editor way out.
@@ -373,5 +373,53 @@ describe("renderIdReferenceField — revert-to-auto option (#2208)", () => {
     expect(optionValues(renderRef("logger", { required: true }))).not.toContain(
       AUTO_SENTINEL
     );
+  });
+});
+
+describe("renderIdReferenceField — lazy option list", () => {
+  const YAML = "script:\n  - id: s1\n  - id: s2\n  - id: s3\n";
+  const entry = makeEntry(ConfigEntryType.STRING, { references_component: "script" });
+
+  function renderLazy(value: string, overrides: Record<string, unknown> = {}) {
+    return renderIdReferenceField(
+      entry,
+      ["id"],
+      makeRenderCtx(
+        { id: value },
+        { overrides: { yaml: YAML, isOptionsExpanded: () => false, ...overrides } }
+      )
+    );
+  }
+
+  it("mounts only the selected candidate and the actions while closed", () => {
+    const opts = findElementBindings(renderLazy("s2"), "wa-option");
+    expect(opts.map((o) => o.value)).toEqual([AUTO_SENTINEL, "s2", ADD_NEW_SENTINEL]);
+    const selected = opts.find((o) => o.value === "s2")!;
+    expect(selected["?selected"]).toBe(true);
+    expect(selected[".label"]).toBe("s2");
+  });
+
+  it("mounts no candidate while closed and empty", () => {
+    expect(optionValues(renderLazy(""))).toEqual([ADD_NEW_SENTINEL]);
+  });
+
+  it("expands the list when the select opens", () => {
+    const expandOptions = vi.fn();
+    const select = findElementBindings(
+      renderLazy("s2", { expandOptions }),
+      "wa-select"
+    )[0];
+    (select["@wa-show"] as () => void)();
+    expect(expandOptions).toHaveBeenCalledWith(["id"]);
+  });
+
+  it("mounts every candidate once expanded", () => {
+    expect(optionValues(renderLazy("s2", { isOptionsExpanded: () => true }))).toEqual([
+      AUTO_SENTINEL,
+      "s1",
+      "s2",
+      "s3",
+      ADD_NEW_SENTINEL,
+    ]);
   });
 });

--- a/test/util/provides-cache.test.ts
+++ b/test/util/provides-cache.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Session cache of interface providers: one shared fetch per interface,
+ * subscribers notified on resolve, a failure warned once and left uncached.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import type { ComponentCatalogEntry } from "../../src/api/types/components.js";
+import {
+  _clearProvidesCache,
+  fetchInterfaceProviders,
+  getCachedInterfaceProviders,
+  subscribeInterfaceProviders,
+} from "../../src/util/provides-cache.js";
+
+function api(getComponents: ReturnType<typeof vi.fn>): ESPHomeAPI {
+  return { getComponents } as unknown as ESPHomeAPI;
+}
+
+function response(ids: string[]) {
+  return {
+    components: ids.map((id) => ({ id }) as ComponentCatalogEntry),
+    categories: [],
+    total: ids.length,
+    offset: 0,
+    limit: 200,
+  };
+}
+
+describe("interface providers cache", () => {
+  beforeEach(() => _clearProvidesCache());
+
+  it("fetches once per interface and notifies subscribers", async () => {
+    const getComponents = vi.fn().mockResolvedValue(response(["sensor.adc"]));
+    const onChange = vi.fn();
+    subscribeInterfaceProviders(onChange);
+    expect(getCachedInterfaceProviders("voltage_sampler")).toBeUndefined();
+
+    const [a, b] = await Promise.all([
+      fetchInterfaceProviders(api(getComponents), "voltage_sampler"),
+      fetchInterfaceProviders(api(getComponents), "voltage_sampler"),
+    ]);
+    expect(getComponents).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+    expect(getCachedInterfaceProviders("voltage_sampler")).toBe(a);
+    expect(a).toEqual([{ domain: "sensor", stem: "adc" }]);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns once on a failed fetch and leaves it uncached", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const getComponents = vi.fn().mockRejectedValue(new Error("ws down"));
+    const first = fetchInterfaceProviders(api(getComponents), "uart");
+    const second = fetchInterfaceProviders(api(getComponents), "uart");
+    await expect(first).rejects.toThrow("ws down");
+    await expect(second).rejects.toThrow("ws down");
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(getCachedInterfaceProviders("uart")).toBeUndefined();
+    await expect(fetchInterfaceProviders(api(getComponents), "uart")).rejects.toThrow();
+    expect(getComponents).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/util/provides-cache.test.ts
+++ b/test/util/provides-cache.test.ts
@@ -2,7 +2,7 @@
  * Session cache of interface providers: one shared fetch per interface,
  * subscribers notified on resolve, a failure warned once and left uncached.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import type { ComponentCatalogEntry } from "../../src/api/types/components.js";
@@ -29,6 +29,7 @@ function response(ids: string[]) {
 
 describe("interface providers cache", () => {
   beforeEach(() => _clearProvidesCache());
+  afterEach(() => vi.restoreAllMocks());
 
   it("fetches once per interface and notifies subscribers", async () => {
     const getComponents = vi.fn().mockResolvedValue(response(["sensor.adc"]));

--- a/test/util/provides-cache.test.ts
+++ b/test/util/provides-cache.test.ts
@@ -29,7 +29,10 @@ function response(ids: string[]) {
 
 describe("interface providers cache", () => {
   beforeEach(() => _clearProvidesCache());
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    _clearProvidesCache();
+  });
 
   it("fetches once per interface and notifies subscribers", async () => {
     const getComponents = vi.fn().mockResolvedValue(response(["sensor.adc"]));


### PR DESCRIPTION
# What does this implement/fix?

An id reference field rendered one wa-option per matching id in the YAML, and wa-option is a full element with its own shadow root, built while the select is closed. Every automation action node and condition row carries its own form, so an automation with a dozen light actions on a config with a few hundred lights held over a thousand option elements before anything was opened. Same shape as #1698 and #1702. The form also walked every option of every select after each render, and each form instance fetched the interface providers on its own, so a rebuilt form re-issued the query.

Candidates now mount when the select first opens; until then only the selected one is rendered, which wa-select needs to show the value. The select sync skips a select already showing its value, waits for the first update only, and never scans a lazy list. Interface providers live in a session cache shared by every form, with one in-flight fetch per interface and failures left uncached.

Measured on an automation with 12 light.turn_on nodes and 100 lights: 24 option elements while closed instead of 1212, opening one select mounts its 101, and the twelve forms issued one provider fetch between them.

Known keyboard quirks: on an empty field the first ArrowDown while closed lands on the Add or Auto row, and the first type to select keystroke only sees the stub options; both self correct on the next key.

The expanded flag lives on the form beside its other per path state; if the pin or registry selects go lazy next, that is the point to extract a shared lazy select and drop the ctx pair. The candidate scan memo being single slot is pre existing and left alone here.

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/device-builder/issues/2657

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
