### PR TITLE
Derive bare trigger keys from platform-scoped catalog ids

### DIFF
--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -47,6 +47,7 @@ import {
   scopeToContainer,
   triggersForComponent,
 } from "./automation-editor/component-targets.js";
+import { bareTriggerKey } from "./automation-editor/trigger-identity.js";
 import { dispatchAutomationAdded } from "./dispatch-automation-added.js";
 
 /** Kinds the wizard can produce. Mirrors a subset of
@@ -391,7 +392,7 @@ export class ESPHomeAddAutomationDialog extends LitElement {
       // already have a handler here; list-capable ones stay offerable.
       const takenComponentTriggers = this._existingComponentTriggers(this._componentId);
       return triggersForComponent(all, device).filter(
-        (t) => !takenComponentTriggers.has(this._bareTrigger(t.id)) || t.supports_list
+        (t) => !takenComponentTriggers.has(bareTriggerKey(t.id)) || t.supports_list
       );
     }
     return [];
@@ -422,14 +423,6 @@ export class ESPHomeAddAutomationDialog extends LitElement {
       if (s.id === componentId && s.eventKey) set.add(s.eventKey);
     }
     return set;
-  }
-
-  /** Strip the ``<domain>.`` prefix off a component-level catalog
-   *  trigger id (``switch.on_turn_on`` → ``on_turn_on``). The bare
-   *  key is what shows up under the component instance in YAML. */
-  private _bareTrigger(catalogId: string): string {
-    const dot = catalogId.indexOf(".");
-    return dot >= 0 ? catalogId.slice(dot + 1) : catalogId;
   }
 
   private _onKindChange(kind: string) {
@@ -528,12 +521,9 @@ export class ESPHomeAddAutomationDialog extends LitElement {
       return { kind: "device_on", trigger: this._triggerId! };
     }
     if (this._kind === "component_on") {
-      // Strip the ``<domain>.`` prefix to get the bare YAML key
-      // the writer splices under the component. ``component_on``
-      // catalog ids are always ``<domain>.<key>`` for non-device
-      // triggers.
-      const dotIdx = this._triggerId!.indexOf(".");
-      const bare = dotIdx >= 0 ? this._triggerId!.slice(dotIdx + 1) : this._triggerId!;
+      // The bare YAML key the writer splices under the component:
+      // ``component_on`` catalog ids always end in it.
+      const bare = bareTriggerKey(this._triggerId!);
       // List-capable triggers append a new indexed entry; an un-indexed
       // location would overwrite the block. Index = existing entry
       // count on this instance (mirrors the interval path).

--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -40,6 +40,7 @@ import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import { getErrorMessage } from "../../util/error-message.js";
 import { formatApiError } from "../../util/format-api-error.js";
 import { renderMarkdown } from "../../util/markdown.js";
+import { bareTriggerKey } from "../../util/trigger-scopes.js";
 import { parseYamlAutomations } from "../../util/yaml-sections.js";
 import { addAutomationDialogStyles } from "./add-automation-dialog.styles.js";
 import {
@@ -47,7 +48,6 @@ import {
   scopeToContainer,
   triggersForComponent,
 } from "./automation-editor/component-targets.js";
-import { bareTriggerKey } from "./automation-editor/trigger-identity.js";
 import { dispatchAutomationAdded } from "./dispatch-automation-added.js";
 
 /** Kinds the wizard can produce. Mirrors a subset of

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -39,6 +39,7 @@ import type {
 import type { ComponentCatalogEntry } from "../../../api/types/components.js";
 import { automationHeaderTitle } from "../../../util/automation-header-title.js";
 import { parseSubstitutions } from "../../../util/substitutions.js";
+import { bareTriggerKey } from "../../../util/trigger-scopes.js";
 import { actionsFocus, entryFieldFocus } from "./automation-focus.js";
 import { BaseAutomationEditor } from "./base-editor.js";
 import { loadIntervalComponent } from "./load-interval-component.js";
@@ -50,7 +51,7 @@ import {
   renderTriggerParamsForm,
 } from "./render-automation-sections.js";
 import { applyParamChange, emptyAutomationTree } from "./serialise.js";
-import { bareTriggerKey, effectiveTriggerIdFor } from "./trigger-identity.js";
+import { effectiveTriggerIdFor } from "./trigger-identity.js";
 
 @customElement("esphome-automation-editor")
 export class ESPHomeAutomationEditor extends BaseAutomationEditor<AutomationLocation> {

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -163,7 +163,12 @@ export class ESPHomeAutomationEditor extends BaseAutomationEditor<AutomationLoca
     const actions = this._available?.actions ?? [];
     const conditions = this._available?.conditions ?? [];
     const disabled = this._engine.deleting;
-    const effectiveTriggerId = effectiveTriggerIdFor(automation, target, devices);
+    const effectiveTriggerId = effectiveTriggerIdFor(
+      automation,
+      target,
+      devices,
+      triggers
+    );
     const activeTrigger = effectiveTriggerId
       ? (triggers.find((t) => t.id === effectiveTriggerId) ?? null)
       : null;

--- a/src/components/device/automation-editor/component-targets.ts
+++ b/src/components/device/automation-editor/component-targets.ts
@@ -102,8 +102,9 @@ export function preFillIdParam(
   return { [idEntry.key]: device.id };
 }
 
-/** Component-level triggers valid for *device*, matched on its bare or
- *  qualified domain; empty when *device* is absent or a container. */
+/** Component-level triggers the picker offers *device*, matched on its bare
+ *  or qualified domain; empty when *device* is absent or a container, whose
+ *  own platform-scoped triggers the picker does not offer yet. */
 export function triggersForComponent(
   triggers: AutomationTrigger[],
   device: AvailableComponentInstance | undefined

--- a/src/components/device/automation-editor/component-targets.ts
+++ b/src/components/device/automation-editor/component-targets.ts
@@ -9,6 +9,7 @@ import type {
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { stripRedundantComponentSuffix } from "../../../util/component-title.js";
 import { parseCatalogId } from "../../../util/config-entry-yaml-scan.js";
+import { targetScopes, triggerAppliesTo } from "../../../util/trigger-scopes.js";
 import { CORE_KEYS } from "../../../util/yaml-sections.js";
 
 /** The instance's display label: its ``name:`` when set, else the catalog
@@ -99,19 +100,6 @@ export function preFillIdParam(
   const idEntry = item.config_entries.find((e) => e.references_component === domain);
   if (!idEntry) return undefined;
   return { [idEntry.key]: device.id };
-}
-
-/** The ``applies_to`` scopes an instance matches: its qualified id and bare domain. */
-export function targetScopes(componentId: string): string[] {
-  return [componentId, componentDomain(componentId)];
-}
-
-/** True for a component-level trigger whose ``applies_to`` meets *scopes*. */
-export function triggerAppliesTo(
-  t: AutomationTrigger,
-  scopes: readonly string[]
-): boolean {
-  return !t.is_device_level && t.applies_to.some((a) => scopes.includes(a));
 }
 
 /** Component-level triggers valid for *device*, matched on its bare or

--- a/src/components/device/automation-editor/component-targets.ts
+++ b/src/components/device/automation-editor/component-targets.ts
@@ -101,6 +101,19 @@ export function preFillIdParam(
   return { [idEntry.key]: device.id };
 }
 
+/** The ``applies_to`` scopes an instance matches: its qualified id and bare domain. */
+export function targetScopes(componentId: string): string[] {
+  return [componentId, componentDomain(componentId)];
+}
+
+/** True for a component-level trigger whose ``applies_to`` meets *scopes*. */
+export function triggerAppliesTo(
+  t: AutomationTrigger,
+  scopes: readonly string[]
+): boolean {
+  return !t.is_device_level && t.applies_to.some((a) => scopes.includes(a));
+}
+
 /** Component-level triggers valid for *device*, matched on its bare or
  *  qualified domain; empty when *device* is absent or a container. */
 export function triggersForComponent(
@@ -108,10 +121,6 @@ export function triggersForComponent(
   device: AvailableComponentInstance | undefined
 ): AutomationTrigger[] {
   if (!device || !isSelectableTarget(device)) return [];
-  const domain = componentDomain(device.component_id);
-  return triggers.filter(
-    (t) =>
-      !t.is_device_level &&
-      (t.applies_to.includes(device.component_id) || t.applies_to.includes(domain))
-  );
+  const scopes = targetScopes(device.component_id);
+  return triggers.filter((t) => triggerAppliesTo(t, scopes));
 }

--- a/src/components/device/automation-editor/trigger-identity.ts
+++ b/src/components/device/automation-editor/trigger-identity.ts
@@ -9,10 +9,11 @@
  * ``"rotary_encoder.sensor.on_clockwise"`` — what
  * ``catalog.trigger_by_id`` returns a hit for), while
  * ``location.component_on.trigger`` is the BARE YAML key
- * (``"on_turn_on"``) the writer splices under the component; the
- * backend reconstructs the catalog id from the component's platform
- * and domain plus the bare key. Device-level catalog ids carry no
- * domain prefix, so the two forms coincide for ``device_on``.
+ * (``"on_turn_on"``, see ``util/trigger-scopes``) the writer splices
+ * under the component; the backend reconstructs the catalog id from
+ * the component's platform and domain plus the bare key. Device-level
+ * catalog ids carry no domain prefix, so the two forms coincide for
+ * ``device_on``.
  */
 import type {
   AutomationLocation,
@@ -21,39 +22,16 @@ import type {
   AvailableComponentInstance,
 } from "../../../api/types/automations.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
-import {
-  instanceName,
-  isSelectableTarget,
-  targetScopes,
-  triggerAppliesTo,
-} from "./component-targets.js";
-
-/**
- * The bare YAML key of a catalog trigger id: its last segment.
- * ``"switch.on_turn_on"`` and ``"rotary_encoder.sensor.on_clockwise"``
- * both give their ``on_*`` key; ids without a prefix pass through.
- */
-export function bareTriggerKey(catalogId: string): string {
-  return catalogId.slice(catalogId.lastIndexOf(".") + 1);
-}
-
-/** The component trigger offered within *scopes* whose bare YAML key is *key*. */
-export function triggerForKey(
-  triggers: AutomationTrigger[],
-  scopes: readonly string[],
-  key: string
-): AutomationTrigger | undefined {
-  return triggers.find(
-    (t) => bareTriggerKey(t.id) === key && triggerAppliesTo(t, scopes)
-  );
-}
+import { targetScopes, triggerForKey } from "../../../util/trigger-scopes.js";
+import { instanceName } from "./component-targets.js";
 
 /**
  * The catalog-qualified trigger id for a ``component_on`` location:
  * the trigger offered to the bound device under that bare key. Returns
  * ``null`` for other location kinds or when no trigger is picked, and
  * the bare key itself while the device or its triggers are unknown so
- * the caller still has a usable id.
+ * the caller still has a usable id. Containers resolve too: a
+ * multi-entity platform can host triggers on its own list item.
  */
 export function catalogTriggerIdFor(
   loc: AutomationLocation,
@@ -62,7 +40,7 @@ export function catalogTriggerIdFor(
 ): string | null {
   if (loc.kind !== "component_on" || !loc.trigger) return null;
   const device = devices.find((d) => d.id === loc.component_id);
-  if (!device || !isSelectableTarget(device)) return loc.trigger;
+  if (!device) return loc.trigger;
   return (
     triggerForKey(triggers, targetScopes(device.component_id), loc.trigger)?.id ??
     loc.trigger

--- a/src/components/device/automation-editor/trigger-identity.ts
+++ b/src/components/device/automation-editor/trigger-identity.ts
@@ -5,47 +5,68 @@
  * CodeMirror.
  *
  * Wire-shape background: ``AutomationTree.trigger_id`` is the
- * catalog-qualified id (``"switch.on_turn_on"`` — what
+ * catalog-qualified id (``"switch.on_turn_on"``, or the platform-scoped
+ * ``"rotary_encoder.sensor.on_clockwise"`` — what
  * ``catalog.trigger_by_id`` returns a hit for), while
  * ``location.component_on.trigger`` is the BARE YAML key
  * (``"on_turn_on"``) the writer splices under the component; the
- * backend reconstructs the catalog id by combining the component's
- * domain with the bare key. Device-level catalog ids carry no domain
- * prefix, so the two forms coincide for ``device_on``.
+ * backend reconstructs the catalog id from the component's platform
+ * and domain plus the bare key. Device-level catalog ids carry no
+ * domain prefix, so the two forms coincide for ``device_on``.
  */
 import type {
   AutomationLocation,
   AutomationTree,
+  AutomationTrigger,
   AvailableComponentInstance,
 } from "../../../api/types/automations.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
-import { componentDomain, instanceName } from "./component-targets.js";
+import {
+  instanceName,
+  isSelectableTarget,
+  targetScopes,
+  triggerAppliesTo,
+} from "./component-targets.js";
 
 /**
- * Drop the ``<domain>.`` prefix from a catalog trigger id to get
- * the bare YAML key. ``"switch.on_turn_on"`` → ``"on_turn_on"``.
- * Ids that already lack a domain are passed through.
+ * The bare YAML key of a catalog trigger id: its last segment.
+ * ``"switch.on_turn_on"`` and ``"rotary_encoder.sensor.on_clockwise"``
+ * both give their ``on_*`` key; ids without a prefix pass through.
  */
 export function bareTriggerKey(catalogId: string): string {
-  const dotIdx = catalogId.indexOf(".");
-  return dotIdx >= 0 ? catalogId.slice(dotIdx + 1) : catalogId;
+  return catalogId.slice(catalogId.lastIndexOf(".") + 1);
+}
+
+/** The component trigger offered within *scopes* whose bare YAML key is *key*. */
+export function triggerForKey(
+  triggers: AutomationTrigger[],
+  scopes: readonly string[],
+  key: string
+): AutomationTrigger | undefined {
+  return triggers.find(
+    (t) => bareTriggerKey(t.id) === key && triggerAppliesTo(t, scopes)
+  );
 }
 
 /**
- * Build the catalog-qualified trigger id for a ``component_on``
- * location, using the bound device's domain. Returns ``null``
- * for other location kinds or when no trigger is picked; while
- * the device list hasn't loaded yet the bare trigger key is
- * returned unqualified so the caller still has a usable id.
+ * The catalog-qualified trigger id for a ``component_on`` location:
+ * the trigger offered to the bound device under that bare key. Returns
+ * ``null`` for other location kinds or when no trigger is picked, and
+ * the bare key itself while the device or its triggers are unknown so
+ * the caller still has a usable id.
  */
 export function catalogTriggerIdFor(
   loc: AutomationLocation,
-  devices: AvailableComponentInstance[]
+  devices: AvailableComponentInstance[],
+  triggers: AutomationTrigger[]
 ): string | null {
   if (loc.kind !== "component_on" || !loc.trigger) return null;
   const device = devices.find((d) => d.id === loc.component_id);
-  const domain = device ? componentDomain(device.component_id) : null;
-  return domain ? `${domain}.${loc.trigger}` : loc.trigger;
+  if (!device || !isSelectableTarget(device)) return loc.trigger;
+  return (
+    triggerForKey(triggers, targetScopes(device.component_id), loc.trigger)?.id ??
+    loc.trigger
+  );
 }
 
 /**
@@ -59,14 +80,15 @@ export function catalogTriggerIdFor(
 export function effectiveTriggerIdFor(
   automation: AutomationTree,
   target: AutomationLocation | null,
-  devices: AvailableComponentInstance[]
+  devices: AvailableComponentInstance[],
+  triggers: AutomationTrigger[]
 ): string | null {
   return (
     automation.trigger_id ??
     (target?.kind === "device_on"
       ? target.trigger || null
       : target?.kind === "component_on"
-        ? catalogTriggerIdFor(target, devices) || null
+        ? catalogTriggerIdFor(target, devices, triggers) || null
         : null)
   );
 }

--- a/src/components/device/device-section-config/render-tables.ts
+++ b/src/components/device/device-section-config/render-tables.ts
@@ -3,9 +3,9 @@
  */
 import { html, nothing } from "lit";
 import { actionFieldLabel } from "../../../util/action-field-label.js";
+import { handlerScopes } from "../../../util/trigger-scopes.js";
 import { parseYamlAutomations, type YamlSection } from "../../../util/yaml-sections.js";
 import type { ESPHomeDeviceSectionConfig } from "../device-section-config.js";
-import { handlerScopes } from "../trigger-catalog-controller.js";
 import {
   selectActionFieldRows,
   selectApiActionRows,

--- a/src/components/device/device-section-config/render-tables.ts
+++ b/src/components/device/device-section-config/render-tables.ts
@@ -98,7 +98,7 @@ function triggerLabel(host: ESPHomeDeviceSectionConfig, item: YamlSection): stri
   const fallback = item.displayLabel || item.eventKey || "";
   if (!item.eventKey) return fallback;
   return host._triggerCatalog.resolveName(
-    handlerScopes(item.parentKey ?? "esphome", item.platform),
+    handlerScopes(item.parentKey ?? "esphome", item.hostPlatform),
     item.eventKey,
     fallback
   );

--- a/src/components/device/device-section-config/render-tables.ts
+++ b/src/components/device/device-section-config/render-tables.ts
@@ -5,6 +5,7 @@ import { html, nothing } from "lit";
 import { actionFieldLabel } from "../../../util/action-field-label.js";
 import { parseYamlAutomations, type YamlSection } from "../../../util/yaml-sections.js";
 import type { ESPHomeDeviceSectionConfig } from "../device-section-config.js";
+import { handlerScopes } from "../trigger-catalog-controller.js";
 import {
   selectActionFieldRows,
   selectApiActionRows,
@@ -97,7 +98,7 @@ function triggerLabel(host: ESPHomeDeviceSectionConfig, item: YamlSection): stri
   const fallback = item.displayLabel || item.eventKey || "";
   if (!item.eventKey) return fallback;
   return host._triggerCatalog.resolveName(
-    item.parentKey ?? "esphome",
+    handlerScopes(item.parentKey ?? "esphome", item.platform),
     item.eventKey,
     fallback
   );

--- a/src/components/device/device-section-config/shortcut-target.ts
+++ b/src/components/device/device-section-config/shortcut-target.ts
@@ -1,3 +1,4 @@
+import { handlerScopes } from "../../../util/trigger-scopes.js";
 import {
   instanceComponentId,
   parseYamlTopLevelSections,
@@ -84,8 +85,9 @@ export function resolveShortcutTarget(
   if (sectionKey === "esphome") return { kind: "device_on" };
   const matched = resolveComponentMatch(yaml, sectionKey, resolvedFromLine);
   if (matched === null) return null;
-  const scopes = [matched.match.parentKey ?? matched.match.key, sectionKey];
-  if (!hasTriggers(scopes)) return null;
+  const { match } = matched;
+  if (!hasTriggers(handlerScopes(match.parentKey ?? match.key, match.platform)))
+    return null;
   return {
     kind: "component_on",
     componentId: instanceComponentId(matched.sections, matched.match),

--- a/src/components/device/navigator-labels.ts
+++ b/src/components/device/navigator-labels.ts
@@ -3,12 +3,10 @@ import { actionFieldLabel } from "../../util/action-field-label.js";
 import { getCachedComponent } from "../../util/component-name-cache.js";
 import { stripRedundantComponentSuffix } from "../../util/component-title.js";
 import { resolveSubstitutions } from "../../util/substitutions.js";
+import { handlerScopes } from "../../util/trigger-scopes.js";
 import { sectionKeyOf, type YamlSection } from "../../util/yaml-sections.js";
 import type { NavigatorBuckets } from "./navigator-buckets.js";
-import {
-  handlerScopes,
-  type TriggerCatalogController,
-} from "./trigger-catalog-controller.js";
+import type { TriggerCatalogController } from "./trigger-catalog-controller.js";
 
 export type NavCategory = "core" | "component" | "automation";
 

--- a/src/components/device/navigator-labels.ts
+++ b/src/components/device/navigator-labels.ts
@@ -5,7 +5,10 @@ import { stripRedundantComponentSuffix } from "../../util/component-title.js";
 import { resolveSubstitutions } from "../../util/substitutions.js";
 import { sectionKeyOf, type YamlSection } from "../../util/yaml-sections.js";
 import type { NavigatorBuckets } from "./navigator-buckets.js";
-import type { TriggerCatalogController } from "./trigger-catalog-controller.js";
+import {
+  handlerScopes,
+  type TriggerCatalogController,
+} from "./trigger-catalog-controller.js";
 
 export type NavCategory = "core" | "component" | "automation";
 
@@ -137,7 +140,7 @@ function automationLabels(
   if (item.parentKey === "esphome" && item.eventKey) {
     const primary = eventOnly(
       ctx.triggerCatalog.resolveName(
-        "esphome",
+        ["esphome"],
         item.eventKey,
         humanizeEvent(item.eventKey)
       )
@@ -150,7 +153,7 @@ function automationLabels(
   if (item.parentKey && item.eventKey) {
     const primary = eventOnly(
       ctx.triggerCatalog.resolveName(
-        item.parentKey,
+        handlerScopes(item.parentKey, item.platform),
         item.eventKey,
         humanizeEvent(item.eventKey)
       )

--- a/src/components/device/navigator-labels.ts
+++ b/src/components/device/navigator-labels.ts
@@ -151,7 +151,7 @@ function automationLabels(
   if (item.parentKey && item.eventKey) {
     const primary = eventOnly(
       ctx.triggerCatalog.resolveName(
-        handlerScopes(item.parentKey, item.platform),
+        handlerScopes(item.parentKey, item.hostPlatform),
         item.eventKey,
         humanizeEvent(item.eventKey)
       )

--- a/src/components/device/trigger-catalog-controller.ts
+++ b/src/components/device/trigger-catalog-controller.ts
@@ -6,6 +6,7 @@ import {
   getCachedAutomationTriggers,
   subscribeAutomationCatalogCache,
 } from "../../util/automation-catalog-cache.js";
+import { triggerForKey } from "./automation-editor/trigger-identity.js";
 
 /** Host-supplied lookup keys, re-read per call since the host's
  *  api / platform / board can change after construction. */
@@ -13,6 +14,12 @@ export interface TriggerCatalogContext {
   api?: ESPHomeAPI;
   platform?: string;
   boardId?: string;
+}
+
+/** ``applies_to`` scopes of a handler row: its domain, plus
+ *  ``<domain>.<platform>`` when a platform item hosts it. */
+export function handlerScopes(parentKey: string, platform?: string): string[] {
+  return platform ? [parentKey, `${parentKey}.${platform}`] : [parentKey];
 }
 
 /**
@@ -57,14 +64,17 @@ export class TriggerCatalogController implements ReactiveController {
     });
   }
 
-  /** Catalog pretty name for ``<domain>.<event>`` (or the bare event
-   *  key for device-level ``esphome``), or ``fallback`` until cached. */
-  resolveName(domain: string, eventKey: string, fallback: string): string {
+  /** Catalog pretty name of the trigger hosting ``eventKey`` within
+   *  ``scopes`` (the bare event key is the id for device-level
+   *  ``esphome``), or ``fallback`` until cached. */
+  resolveName(scopes: readonly string[], eventKey: string, fallback: string): string {
     const { platform, boardId } = this._context();
     const triggers = getCachedAutomationTriggers(platform, boardId);
     if (!triggers) return fallback;
-    const catalogId = domain === "esphome" ? eventKey : `${domain}.${eventKey}`;
-    return triggers.find((t) => t.id === catalogId)?.name || fallback;
+    const match = scopes.includes("esphome")
+      ? triggers.find((t) => t.id === eventKey)
+      : triggerForKey(triggers, scopes, eventKey);
+    return match?.name || fallback;
   }
 
   /** True when the catalog has a component trigger scoped to any of

--- a/src/components/device/trigger-catalog-controller.ts
+++ b/src/components/device/trigger-catalog-controller.ts
@@ -6,7 +6,7 @@ import {
   getCachedAutomationTriggers,
   subscribeAutomationCatalogCache,
 } from "../../util/automation-catalog-cache.js";
-import { triggerForKey } from "./automation-editor/trigger-identity.js";
+import { triggerForKey } from "../../util/trigger-scopes.js";
 
 /** Host-supplied lookup keys, re-read per call since the host's
  *  api / platform / board can change after construction. */
@@ -14,12 +14,6 @@ export interface TriggerCatalogContext {
   api?: ESPHomeAPI;
   platform?: string;
   boardId?: string;
-}
-
-/** ``applies_to`` scopes of a handler row: its domain, plus
- *  ``<domain>.<platform>`` when a platform item hosts it. */
-export function handlerScopes(parentKey: string, platform?: string): string[] {
-  return platform ? [parentKey, `${parentKey}.${platform}`] : [parentKey];
 }
 
 /**

--- a/src/util/trigger-scopes.ts
+++ b/src/util/trigger-scopes.ts
@@ -1,0 +1,56 @@
+/**
+ * Trigger-catalog scoping shared by the automation editor, the add
+ * dialog, the navigator and the section list.
+ *
+ * A component trigger's ``applies_to`` names either a bare domain
+ * (``sensor``) or a qualified ``<domain>.<platform>`` scope
+ * (``sensor.rotary_encoder``); its id ends in the bare ``on_*`` YAML key.
+ * Scope lists are ordered most specific first so a platform-scoped
+ * trigger wins over a domain-level one sharing the same key.
+ */
+import type { AutomationTrigger } from "../api/types/automations.js";
+import { parseCatalogId } from "./config-entry-yaml-scan.js";
+import { qualifiedSectionKey } from "./yaml-sections.js";
+
+/**
+ * The bare YAML key of a catalog trigger id: its last segment.
+ * ``"switch.on_turn_on"`` and ``"rotary_encoder.sensor.on_clockwise"``
+ * both give their ``on_*`` key; ids without a prefix pass through.
+ */
+export function bareTriggerKey(catalogId: string): string {
+  return catalogId.slice(catalogId.lastIndexOf(".") + 1);
+}
+
+/** Scopes an instance matches: its qualified id, then its bare domain. */
+export function targetScopes(componentId: string): string[] {
+  return [componentId, parseCatalogId(componentId).domain];
+}
+
+/** Scopes of a handler row: ``<domain>.<platform>`` when a platform item
+ *  hosts it, then the bare domain. */
+export function handlerScopes(parentKey: string, platform?: string): string[] {
+  return platform ? [qualifiedSectionKey(parentKey, platform), parentKey] : [parentKey];
+}
+
+/** True for a component-level trigger whose ``applies_to`` meets *scopes*. */
+export function triggerAppliesTo(
+  t: AutomationTrigger,
+  scopes: readonly string[]
+): boolean {
+  return !t.is_device_level && t.applies_to.some((a) => scopes.includes(a));
+}
+
+/** The component trigger for bare key *key*, preferring the earliest scope. */
+export function triggerForKey(
+  triggers: AutomationTrigger[],
+  scopes: readonly string[],
+  key: string
+): AutomationTrigger | undefined {
+  for (const scope of scopes) {
+    const hit = triggers.find(
+      (t) => bareTriggerKey(t.id) === key && triggerAppliesTo(t, [scope])
+    );
+    if (hit) return hit;
+  }
+  return undefined;
+}

--- a/src/util/trigger-scopes.ts
+++ b/src/util/trigger-scopes.ts
@@ -10,7 +10,7 @@
  */
 import type { AutomationTrigger } from "../api/types/automations.js";
 import { parseCatalogId } from "./config-entry-yaml-scan.js";
-import { qualifiedSectionKey } from "./yaml-sections.js";
+import { qualifiedSectionKey } from "./yaml-sections-core.js";
 
 /**
  * The bare YAML key of a catalog trigger id: its last segment.
@@ -23,7 +23,8 @@ export function bareTriggerKey(catalogId: string): string {
 
 /** Scopes an instance matches: its qualified id, then its bare domain. */
 export function targetScopes(componentId: string): string[] {
-  return [componentId, parseCatalogId(componentId).domain];
+  const { domain } = parseCatalogId(componentId);
+  return domain === componentId ? [componentId] : [componentId, domain];
 }
 
 /** Scopes of a handler row: ``<domain>.<platform>`` when a platform item

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -149,7 +149,7 @@ function _parseYamlAutomations(yaml: string): YamlSection[] {
         // the trigger catalog scopes on either.
         parentKey: host.parentKey ?? host.key,
         eventKey: eventName,
-        ...(host.platform !== undefined ? { platform: host.platform } : {}),
+        ...(host.platform !== undefined ? { hostPlatform: host.platform } : {}),
         ...(parentComponentId !== undefined ? { parentComponentId } : {}),
       };
       // List-shaped trigger (``time.on_time``): one row per cron entry,

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -145,10 +145,11 @@ function _parseYamlAutomations(yaml: string): YamlSection[] {
       const base = {
         id: componentId,
         name: displayName,
-        // Domain (``key`` for a flat singleton) — the catalog is keyed
-        // ``<domain>.<event>``, so this resolves the trigger name.
+        // Domain (``key`` for a flat singleton) plus the host's platform:
+        // the trigger catalog scopes on either.
         parentKey: host.parentKey ?? host.key,
         eventKey: eventName,
+        ...(host.platform !== undefined ? { platform: host.platform } : {}),
         ...(parentComponentId !== undefined ? { parentComponentId } : {}),
       };
       // List-shaped trigger (``time.on_time``): one row per cron entry,

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -146,10 +146,13 @@ function _parseYamlAutomations(yaml: string): YamlSection[] {
         id: componentId,
         name: displayName,
         // Domain (``key`` for a flat singleton) plus the host's platform:
-        // the trigger catalog scopes on either.
+        // the trigger catalog scopes on either. A sub-entity hosts only
+        // domain-level triggers, so it carries no platform scope.
         parentKey: host.parentKey ?? host.key,
         eventKey: eventName,
-        ...(host.platform !== undefined ? { hostPlatform: host.platform } : {}),
+        ...(host.platform !== undefined && parentComponentId === undefined
+          ? { hostPlatform: host.platform }
+          : {}),
         ...(parentComponentId !== undefined ? { parentComponentId } : {}),
       };
       // List-shaped trigger (``time.on_time``): one row per cron entry,

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -53,7 +53,7 @@ export interface YamlSection {
   /**
    * Bare trigger event key (``on_press``, ``on_turn_on``) for
    * automation entries. The navigator resolves the trigger's pretty
-   * name by this key within the row's ``parentKey`` / ``platform``
+   * name by this key within the row's ``parentKey`` / ``hostPlatform``
    * scopes (see ``util/trigger-scopes``).
    */
   eventKey?: string;

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -31,8 +31,9 @@ export interface YamlSection {
   name?: string; // "name:" value from a YAML list item
   id?: string; // "id:" value from a YAML list item
   platform?: string; // "platform:" value from a YAML list item
-  /** The enclosing list item's ``platform:`` on an automation row, for
-   *  trigger scoping; never part of the row's section key. */
+  /** The hosting component's ``platform:`` on an automation row (a list
+   *  item's or a bare mapping's), for trigger scoping; never part of the
+   *  row's section key. */
   hostPlatform?: string;
   parentKey?: string; // top-level key when this is an expanded list item
   /**

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -48,9 +48,9 @@ export interface YamlSection {
   displayLabel?: string;
   /**
    * Bare trigger event key (``on_press``, ``on_turn_on``) for
-   * automation entries. The navigator combines this with
-   * ``parentKey`` to look up the trigger's pretty name in the
-   * catalog (``binary_sensor.on_press`` → "Pressed").
+   * automation entries. The navigator resolves the trigger's pretty
+   * name by this key within the row's ``parentKey`` / ``platform``
+   * scopes (see ``util/trigger-scopes``).
    */
   eventKey?: string;
   /**

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -31,6 +31,9 @@ export interface YamlSection {
   name?: string; // "name:" value from a YAML list item
   id?: string; // "id:" value from a YAML list item
   platform?: string; // "platform:" value from a YAML list item
+  /** The enclosing list item's ``platform:`` on an automation row, for
+   *  trigger scoping; never part of the row's section key. */
+  hostPlatform?: string;
   parentKey?: string; // top-level key when this is an expanded list item
   /**
    * For an automation on a nested sub-entity (``aht20_temperature`` under
@@ -570,4 +573,11 @@ export function collectIdsAtPath(
   const body = _sectionScanStart(lines, section);
   if (body !== null) walk(body.lo, body.hi, body.baseIndent, path);
   return out;
+}
+
+/** `<key>.<platform>` for a platform list item (de-duplicating an already
+ *  namespaced platform); the bare key otherwise. */
+export function qualifiedSectionKey(key: string, platform?: string): string {
+  if (!platform) return key;
+  return platform.startsWith(`${key}.`) ? platform : `${key}.${platform}`;
 }

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -7,6 +7,7 @@ import {
   findFieldLine,
   instanceComponentId,
   parseYamlTopLevelSections,
+  qualifiedSectionKey,
   smallestContainingSection,
   type YamlSection,
 } from "./yaml-sections-core.js";
@@ -307,13 +308,6 @@ function _firstItemForListHeader(
  */
 export function sectionKeyOf(section: YamlSection): string {
   return qualifiedSectionKey(section.key, section.platform);
-}
-
-/** `<key>.<platform>` for a platform list item (de-duplicating an already
- *  namespaced platform); the bare key otherwise. */
-export function qualifiedSectionKey(key: string, platform?: string): string {
-  if (!platform) return key;
-  return platform.startsWith(`${key}.`) ? platform : `${key}.${platform}`;
 }
 
 /**

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -306,10 +306,14 @@ function _firstItemForListHeader(
  * if the platform is already namespaced); otherwise just `key`.
  */
 export function sectionKeyOf(section: YamlSection): string {
-  if (!section.platform) return section.key;
-  return section.platform.startsWith(`${section.key}.`)
-    ? section.platform
-    : `${section.key}.${section.platform}`;
+  return qualifiedSectionKey(section.key, section.platform);
+}
+
+/** `<key>.<platform>` for a platform list item (de-duplicating an already
+ *  namespaced platform); the bare key otherwise. */
+export function qualifiedSectionKey(key: string, platform?: string): string {
+  if (!platform) return key;
+  return platform.startsWith(`${key}.`) ? platform : `${key}.${platform}`;
 }
 
 /**

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -295,6 +295,14 @@ const ahtAvailable = (): AvailableAutomations =>
         supports_list: false,
         config_entries: [],
       },
+      {
+        id: "rotary_encoder.sensor.on_clockwise",
+        name: "On Clockwise",
+        applies_to: ["sensor.rotary_encoder"],
+        is_device_level: false,
+        supports_list: true,
+        config_entries: [],
+      },
     ],
     actions: [],
     conditions: [],
@@ -319,6 +327,7 @@ const ahtAvailable = (): AvailableAutomations =>
         parent_id: "aht20",
       },
       { id: "relay", name: "Relay", component_id: "switch.gpio" },
+      { id: "dial", name: "Dial", component_id: "sensor.rotary_encoder" },
     ],
   }) as unknown as AvailableAutomations;
 
@@ -370,6 +379,37 @@ describe("add-automation-dialog sub-entity targets (#1263)", () => {
       component_id: "aht20_temperature",
       trigger: "on_value_range",
     });
+  });
+
+  it("builds a component_on location from a platform-scoped trigger id", async () => {
+    const dialog = await mountForComponentStep();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (dialog as any)._componentId = "dial";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (dialog as any)._triggerId = "rotary_encoder.sensor.on_clockwise";
+    dialog.yaml =
+      "sensor:\n  - platform: rotary_encoder\n    id: dial\n    on_clockwise:\n      - logger.log: cw\n";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((dialog as any)._buildLocation()).toEqual({
+      kind: "component_on",
+      component_id: "dial",
+      trigger: "on_clockwise",
+      index: 1,
+    });
+  });
+
+  it("offers a platform-scoped trigger and keeps it offerable when list-capable", async () => {
+    const dialog = await mountForComponentStep();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (dialog as any)._componentId = "dial";
+    dialog.yaml =
+      "sensor:\n  - platform: rotary_encoder\n    id: dial\n    on_clockwise:\n      - logger.log: cw\n";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const offered = (dialog as any)._filteredTriggers() as Array<{ id: string }>;
+    expect(offered.map((t) => t.id)).toEqual([
+      "sensor.on_value_range",
+      "rotary_encoder.sensor.on_clockwise",
+    ]);
   });
 
   it("defaults the component to the first non-container instance", async () => {

--- a/test/components/device/automation-editor/trigger-identity.test.ts
+++ b/test/components/device/automation-editor/trigger-identity.test.ts
@@ -8,7 +8,6 @@ import type {
 } from "../../../../src/api/types/automations.js";
 import type { LocalizeFunc } from "../../../../src/common/localize.js";
 import {
-  bareTriggerKey,
   catalogTriggerIdFor,
   effectiveTriggerIdFor,
   targetMetadataValue,
@@ -45,7 +44,13 @@ const clockwise = trigger("rotary_encoder.sensor.on_clockwise", [
 ]);
 const valueRange = trigger("sensor.on_value_range", ["sensor"]);
 const turnOn = trigger("switch.on_turn_on", ["switch"]);
-const triggers = [clockwise, valueRange, turnOn];
+const container = inst({
+  id: "ltr",
+  component_id: "sensor.ltr501",
+  is_entity_container: true,
+});
+const psHigh = trigger("ltr501.sensor.on_ps_high_threshold", ["sensor.ltr501"]);
+const triggers = [clockwise, psHigh, valueRange, turnOn];
 
 const tree = (trigger_id: string | null = null): AutomationTree => ({
   trigger_id,
@@ -59,20 +64,6 @@ const componentOn = (trigger: string, component_id = "relay_1"): AutomationLocat
   trigger,
 });
 
-describe("bareTriggerKey", () => {
-  it("drops the domain prefix from a catalog id", () => {
-    expect(bareTriggerKey("switch.on_turn_on")).toBe("on_turn_on");
-  });
-
-  it("drops the platform and domain prefix from a platform-scoped id", () => {
-    expect(bareTriggerKey("rotary_encoder.sensor.on_clockwise")).toBe("on_clockwise");
-  });
-
-  it("passes an already-bare key through", () => {
-    expect(bareTriggerKey("on_boot")).toBe("on_boot");
-  });
-});
-
 describe("catalogTriggerIdFor", () => {
   it("qualifies a component_on trigger with the bound device's domain", () => {
     expect(catalogTriggerIdFor(componentOn("on_turn_on"), devices, triggers)).toBe(
@@ -84,6 +75,16 @@ describe("catalogTriggerIdFor", () => {
     expect(
       catalogTriggerIdFor(componentOn("on_clockwise", "dial"), [rotary], triggers)
     ).toBe("rotary_encoder.sensor.on_clockwise");
+  });
+
+  it("resolves a trigger hosted on a multi-entity container's own item", () => {
+    expect(
+      catalogTriggerIdFor(
+        componentOn("on_ps_high_threshold", "ltr"),
+        [container],
+        triggers
+      )
+    ).toBe("ltr501.sensor.on_ps_high_threshold");
   });
 
   it("resolves a sub-entity's trigger to the domain-level id", () => {

--- a/test/components/device/automation-editor/trigger-identity.test.ts
+++ b/test/components/device/automation-editor/trigger-identity.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type {
   AutomationLocation,
   AutomationTree,
+  AutomationTrigger,
   AvailableComponentInstance,
 } from "../../../../src/api/types/automations.js";
 import type { LocalizeFunc } from "../../../../src/common/localize.js";
@@ -22,21 +23,49 @@ const inst = (
 const relay = inst({ id: "relay_1", component_id: "switch.gpio", name: "Warmtepomp" });
 const devices = [relay];
 
+const rotary = inst({ id: "dial", component_id: "sensor.rotary_encoder", name: "Dial" });
+const subSensor = inst({
+  id: "aht20_temperature",
+  component_id: "sensor",
+  parent_id: "aht20",
+});
+
+const trigger = (id: string, applies_to: string[]): AutomationTrigger => ({
+  id,
+  name: id,
+  description: "",
+  docs_url: "",
+  applies_to,
+  is_device_level: false,
+  supports_list: false,
+  config_entries: [],
+});
+const clockwise = trigger("rotary_encoder.sensor.on_clockwise", [
+  "sensor.rotary_encoder",
+]);
+const valueRange = trigger("sensor.on_value_range", ["sensor"]);
+const turnOn = trigger("switch.on_turn_on", ["switch"]);
+const triggers = [clockwise, valueRange, turnOn];
+
 const tree = (trigger_id: string | null = null): AutomationTree => ({
   trigger_id,
   trigger_params: {},
   actions: [],
 });
 
-const componentOn = (trigger: string): AutomationLocation => ({
+const componentOn = (trigger: string, component_id = "relay_1"): AutomationLocation => ({
   kind: "component_on",
-  component_id: "relay_1",
+  component_id,
   trigger,
 });
 
 describe("bareTriggerKey", () => {
   it("drops the domain prefix from a catalog id", () => {
     expect(bareTriggerKey("switch.on_turn_on")).toBe("on_turn_on");
+  });
+
+  it("drops the platform and domain prefix from a platform-scoped id", () => {
+    expect(bareTriggerKey("rotary_encoder.sensor.on_clockwise")).toBe("on_clockwise");
   });
 
   it("passes an already-bare key through", () => {
@@ -46,45 +75,89 @@ describe("bareTriggerKey", () => {
 
 describe("catalogTriggerIdFor", () => {
   it("qualifies a component_on trigger with the bound device's domain", () => {
-    expect(catalogTriggerIdFor(componentOn("on_turn_on"), devices)).toBe(
+    expect(catalogTriggerIdFor(componentOn("on_turn_on"), devices, triggers)).toBe(
       "switch.on_turn_on"
     );
   });
 
-  it("falls back to the bare key when the device isn't loaded yet", () => {
-    expect(catalogTriggerIdFor(componentOn("on_turn_on"), [])).toBe("on_turn_on");
+  it("resolves a platform-scoped id through the device's offered triggers", () => {
+    expect(
+      catalogTriggerIdFor(componentOn("on_clockwise", "dial"), [rotary], triggers)
+    ).toBe("rotary_encoder.sensor.on_clockwise");
+  });
+
+  it("resolves a sub-entity's trigger to the domain-level id", () => {
+    expect(
+      catalogTriggerIdFor(
+        componentOn("on_value_range", "aht20_temperature"),
+        [subSensor],
+        triggers
+      )
+    ).toBe("sensor.on_value_range");
+  });
+
+  it("falls back to the bare key when the device or its trigger is unknown", () => {
+    expect(catalogTriggerIdFor(componentOn("on_turn_on"), [], triggers)).toBe(
+      "on_turn_on"
+    );
+    expect(catalogTriggerIdFor(componentOn("on_turn_on"), devices, [])).toBe(
+      "on_turn_on"
+    );
   });
 
   it("returns null without a picked trigger or for other location kinds", () => {
-    expect(catalogTriggerIdFor(componentOn(""), devices)).toBeNull();
-    expect(catalogTriggerIdFor({ kind: "script", id: "s" }, devices)).toBeNull();
+    expect(catalogTriggerIdFor(componentOn(""), devices, triggers)).toBeNull();
+    expect(
+      catalogTriggerIdFor({ kind: "script", id: "s" }, devices, triggers)
+    ).toBeNull();
   });
 });
 
 describe("effectiveTriggerIdFor", () => {
   it("prefers the tree's own trigger_id", () => {
     expect(
-      effectiveTriggerIdFor(tree("binary_sensor.on_press"), componentOn("x"), devices)
+      effectiveTriggerIdFor(
+        tree("binary_sensor.on_press"),
+        componentOn("x"),
+        devices,
+        triggers
+      )
     ).toBe("binary_sensor.on_press");
   });
 
   it("mirrors a device_on location's trigger as-is (no domain prefix)", () => {
     expect(
-      effectiveTriggerIdFor(tree(), { kind: "device_on", trigger: "on_boot" }, devices)
+      effectiveTriggerIdFor(
+        tree(),
+        { kind: "device_on", trigger: "on_boot" },
+        devices,
+        triggers
+      )
     ).toBe("on_boot");
   });
 
   it("qualifies a component_on location's bare trigger key", () => {
-    expect(effectiveTriggerIdFor(tree(), componentOn("on_turn_on"), devices)).toBe(
-      "switch.on_turn_on"
-    );
+    expect(
+      effectiveTriggerIdFor(tree(), componentOn("on_turn_on"), devices, triggers)
+    ).toBe("switch.on_turn_on");
+  });
+
+  it("qualifies a platform-scoped trigger from the offered triggers", () => {
+    expect(
+      effectiveTriggerIdFor(
+        tree(),
+        componentOn("on_clockwise", "dial"),
+        [rotary],
+        triggers
+      )
+    ).toBe("rotary_encoder.sensor.on_clockwise");
   });
 
   it("returns null when neither the tree nor the location carries one", () => {
-    expect(effectiveTriggerIdFor(tree(), { kind: "interval", index: 0 }, devices)).toBe(
-      null
-    );
-    expect(effectiveTriggerIdFor(tree(), null, devices)).toBeNull();
+    expect(
+      effectiveTriggerIdFor(tree(), { kind: "interval", index: 0 }, devices, triggers)
+    ).toBeNull();
+    expect(effectiveTriggerIdFor(tree(), null, devices, triggers)).toBeNull();
   });
 });
 

--- a/test/components/device/navigator-labels.test.ts
+++ b/test/components/device/navigator-labels.test.ts
@@ -110,3 +110,26 @@ describe("resolveNavItemLabels substitution resolution", () => {
     expect(labels.secondary).toBe("gate_$upper_devicename");
   });
 });
+
+describe("resolveNavItemLabels trigger scopes", () => {
+  it("resolves a platform-hosted handler through its qualified and bare scopes", () => {
+    const resolveName = vi.fn(() => "Sensor.Rotary Encoder → On Clockwise");
+    const scoped: LabelContext = {
+      ...ctx,
+      triggerCatalog: { resolveName } as unknown as LabelContext["triggerCatalog"],
+    };
+    const row = {
+      key: "automation:component_on:dial:on_clockwise",
+      id: "dial",
+      parentKey: "sensor",
+      platform: "rotary_encoder",
+      eventKey: "on_clockwise",
+    } as unknown as YamlSection;
+    expect(resolveNavItemLabels(row, "automation", scoped).primary).toBe("On Clockwise");
+    expect(resolveName).toHaveBeenCalledWith(
+      ["sensor.rotary_encoder", "sensor"],
+      "on_clockwise",
+      "On Clockwise"
+    );
+  });
+});

--- a/test/components/device/navigator-labels.test.ts
+++ b/test/components/device/navigator-labels.test.ts
@@ -122,7 +122,7 @@ describe("resolveNavItemLabels trigger scopes", () => {
       key: "automation:component_on:dial:on_clockwise",
       id: "dial",
       parentKey: "sensor",
-      platform: "rotary_encoder",
+      hostPlatform: "rotary_encoder",
       eventKey: "on_clockwise",
     } as unknown as YamlSection;
     expect(resolveNavItemLabels(row, "automation", scoped).primary).toBe("On Clockwise");

--- a/test/components/device/shortcut-target.test.ts
+++ b/test/components/device/shortcut-target.test.ts
@@ -121,7 +121,7 @@ describe("resolveShortcutTarget", () => {
     expect(resolveShortcutTarget(yaml, "web_server", undefined, () => false)).toBeNull();
   });
 
-  it("passes the bare domain and qualified key to the gate", () => {
+  it("passes the qualified key and bare domain to the gate", () => {
     const yaml = `output:
   - platform: slow_pwm
     id: my_out
@@ -132,7 +132,7 @@ describe("resolveShortcutTarget", () => {
       seen.push(scopes);
       return true;
     });
-    // parentKey (bare domain "output") first, then the section key.
+    // Most specific first: the qualified section key, then the bare domain.
     expect(seen).toEqual([["output.slow_pwm", "output"]]);
   });
 });

--- a/test/components/device/shortcut-target.test.ts
+++ b/test/components/device/shortcut-target.test.ts
@@ -133,6 +133,6 @@ describe("resolveShortcutTarget", () => {
       return true;
     });
     // parentKey (bare domain "output") first, then the section key.
-    expect(seen).toEqual([["output", "output.slow_pwm"]]);
+    expect(seen).toEqual([["output.slow_pwm", "output"]]);
   });
 });

--- a/test/components/device/trigger-catalog-controller.test.ts
+++ b/test/components/device/trigger-catalog-controller.test.ts
@@ -4,15 +4,13 @@ import { flush } from "../../_dom.js";
 import { fakeHost } from "../../_fake-host.js";
 import type { ESPHomeAPI } from "../../../src/api/index.js";
 import type { AutomationTrigger } from "../../../src/api/types/automations.js";
-import {
-  handlerScopes,
-  TriggerCatalogController,
-} from "../../../src/components/device/trigger-catalog-controller.js";
+import { TriggerCatalogController } from "../../../src/components/device/trigger-catalog-controller.js";
 import {
   _clearAutomationCatalogCache,
   fetchAutomationTriggers,
   getCachedAutomationTriggers,
 } from "../../../src/util/automation-catalog-cache.js";
+import { handlerScopes } from "../../../src/util/trigger-scopes.js";
 
 const trigger = (id: string, name: string): AutomationTrigger => ({
   id,

--- a/test/components/device/trigger-catalog-controller.test.ts
+++ b/test/components/device/trigger-catalog-controller.test.ts
@@ -4,7 +4,10 @@ import { flush } from "../../_dom.js";
 import { fakeHost } from "../../_fake-host.js";
 import type { ESPHomeAPI } from "../../../src/api/index.js";
 import type { AutomationTrigger } from "../../../src/api/types/automations.js";
-import { TriggerCatalogController } from "../../../src/components/device/trigger-catalog-controller.js";
+import {
+  handlerScopes,
+  TriggerCatalogController,
+} from "../../../src/components/device/trigger-catalog-controller.js";
 import {
   _clearAutomationCatalogCache,
   fetchAutomationTriggers,
@@ -22,6 +25,16 @@ const trigger = (id: string, name: string): AutomationTrigger => ({
   config_entries: [],
 });
 
+const componentTrigger = (
+  id: string,
+  name: string,
+  applies_to: string[]
+): AutomationTrigger => ({
+  ...trigger(id, name),
+  applies_to,
+  is_device_level: false,
+});
+
 const fakeApi = (triggers: AutomationTrigger[]): ESPHomeAPI =>
   ({ getAutomationTriggers: vi.fn(async () => triggers) }) as unknown as ESPHomeAPI;
 
@@ -30,15 +43,19 @@ afterEach(() => _clearAutomationCatalogCache());
 describe("TriggerCatalogController", () => {
   it("returns the fallback before the catalog is cached", () => {
     const c = new TriggerCatalogController(fakeHost(), () => ({}));
-    expect(c.resolveName("binary_sensor", "on_state", "fallback")).toBe("fallback");
+    expect(c.resolveName(["binary_sensor"], "on_state", "fallback")).toBe("fallback");
   });
 
   it("resolves a component trigger to its catalog name once cached", async () => {
     await fetchAutomationTriggers(
-      fakeApi([trigger("binary_sensor.on_state", "Binary Sensor → On State")])
+      fakeApi([
+        componentTrigger("binary_sensor.on_state", "Binary Sensor → On State", [
+          "binary_sensor",
+        ]),
+      ])
     );
     const c = new TriggerCatalogController(fakeHost(), () => ({}));
-    expect(c.resolveName("binary_sensor", "on_state", "raw")).toBe(
+    expect(c.resolveName(["binary_sensor"], "on_state", "raw")).toBe(
       "Binary Sensor → On State"
     );
   });
@@ -46,7 +63,27 @@ describe("TriggerCatalogController", () => {
   it("resolves a device-level trigger by its bare event key", async () => {
     await fetchAutomationTriggers(fakeApi([trigger("on_boot", "On Boot")]));
     const c = new TriggerCatalogController(fakeHost(), () => ({}));
-    expect(c.resolveName("esphome", "on_boot", "raw")).toBe("On Boot");
+    expect(c.resolveName(["esphome"], "on_boot", "raw")).toBe("On Boot");
+  });
+
+  it("resolves a platform-scoped trigger through the row's platform scope", async () => {
+    await fetchAutomationTriggers(
+      fakeApi([
+        componentTrigger("sensor.on_value", "Sensor → On Value", ["sensor"]),
+        componentTrigger(
+          "rotary_encoder.sensor.on_clockwise",
+          "Sensor.Rotary Encoder → On Clockwise",
+          ["sensor.rotary_encoder"]
+        ),
+      ])
+    );
+    const c = new TriggerCatalogController(fakeHost(), () => ({}));
+    const scopes = handlerScopes("sensor", "rotary_encoder");
+    expect(c.resolveName(scopes, "on_clockwise", "raw")).toBe(
+      "Sensor.Rotary Encoder → On Clockwise"
+    );
+    expect(c.resolveName(scopes, "on_value", "raw")).toBe("Sensor → On Value");
+    expect(c.resolveName(["sensor"], "on_clockwise", "raw")).toBe("raw");
   });
 
   it("falls back when the cached catalog has no matching id", async () => {
@@ -54,7 +91,7 @@ describe("TriggerCatalogController", () => {
       fakeApi([trigger("switch.on_turn_on", "Switch → On Turn On")])
     );
     const c = new TriggerCatalogController(fakeHost(), () => ({}));
-    expect(c.resolveName("binary_sensor", "on_state", "raw")).toBe("raw");
+    expect(c.resolveName(["binary_sensor"], "on_state", "raw")).toBe("raw");
   });
 
   it("ensure() fetches once when uncached and is a no-op once cached", async () => {

--- a/test/util/trigger-scopes.test.ts
+++ b/test/util/trigger-scopes.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import type { AutomationTrigger } from "../../src/api/types/automations.js";
+import {
+  bareTriggerKey,
+  handlerScopes,
+  targetScopes,
+  triggerAppliesTo,
+  triggerForKey,
+} from "../../src/util/trigger-scopes.js";
+
+const trigger = (
+  id: string,
+  applies_to: string[],
+  is_device_level = false
+): AutomationTrigger => ({
+  id,
+  name: id,
+  description: "",
+  docs_url: "",
+  applies_to,
+  is_device_level,
+  supports_list: false,
+  config_entries: [],
+});
+
+const domainTouch = trigger("touchscreen.on_touch", ["touchscreen"]);
+const driverTouch = trigger("xpt2046.touchscreen.on_touch", ["touchscreen.xpt2046"]);
+const boot = trigger("on_boot", [], true);
+
+describe("bareTriggerKey", () => {
+  it("drops the domain prefix from a catalog id", () => {
+    expect(bareTriggerKey("switch.on_turn_on")).toBe("on_turn_on");
+  });
+
+  it("drops the platform and domain prefix from a platform-scoped id", () => {
+    expect(bareTriggerKey("rotary_encoder.sensor.on_clockwise")).toBe("on_clockwise");
+  });
+
+  it("passes an already-bare key through", () => {
+    expect(bareTriggerKey("on_boot")).toBe("on_boot");
+  });
+});
+
+describe("scopes", () => {
+  it("orders an instance's scopes most specific first", () => {
+    expect(targetScopes("sensor.rotary_encoder")).toEqual([
+      "sensor.rotary_encoder",
+      "sensor",
+    ]);
+    expect(targetScopes("sensor")).toEqual(["sensor", "sensor"]);
+  });
+
+  it("orders a handler row's scopes most specific first", () => {
+    expect(handlerScopes("sensor", "rotary_encoder")).toEqual([
+      "sensor.rotary_encoder",
+      "sensor",
+    ]);
+    expect(handlerScopes("sun")).toEqual(["sun"]);
+  });
+
+  it("keeps an already namespaced platform as the qualified scope", () => {
+    expect(handlerScopes("light", "light.rgb")).toEqual(["light.rgb", "light"]);
+  });
+
+  it("matches component triggers on any scope and never device-level ones", () => {
+    expect(triggerAppliesTo(driverTouch, ["touchscreen.xpt2046", "touchscreen"])).toBe(
+      true
+    );
+    expect(triggerAppliesTo(driverTouch, ["touchscreen"])).toBe(false);
+    expect(triggerAppliesTo(boot, ["esphome"])).toBe(false);
+  });
+});
+
+describe("triggerForKey", () => {
+  const triggers = [domainTouch, driverTouch];
+
+  it("prefers the platform-scoped trigger for a platform instance regardless of catalog order", () => {
+    const scopes = ["touchscreen.xpt2046", "touchscreen"];
+    expect(triggerForKey(triggers, scopes, "on_touch")).toBe(driverTouch);
+    expect(triggerForKey([driverTouch, domainTouch], scopes, "on_touch")).toBe(
+      driverTouch
+    );
+  });
+
+  it("falls back to the domain-level trigger for a bare domain scope", () => {
+    expect(triggerForKey(triggers, ["touchscreen"], "on_touch")).toBe(domainTouch);
+  });
+
+  it("returns undefined when no scope hosts the key", () => {
+    expect(triggerForKey(triggers, ["touchscreen"], "on_release")).toBeUndefined();
+    expect(triggerForKey(triggers, ["sensor"], "on_touch")).toBeUndefined();
+  });
+});

--- a/test/util/trigger-scopes.test.ts
+++ b/test/util/trigger-scopes.test.ts
@@ -48,7 +48,7 @@ describe("scopes", () => {
       "sensor.rotary_encoder",
       "sensor",
     ]);
-    expect(targetScopes("sensor")).toEqual(["sensor", "sensor"]);
+    expect(targetScopes("sensor")).toEqual(["sensor"]);
   });
 
   it("orders a handler row's scopes most specific first", () => {

--- a/test/util/yaml-automations.test.ts
+++ b/test/util/yaml-automations.test.ts
@@ -73,6 +73,7 @@ describe("parseYamlAutomations — component triggers", () => {
     expect(press?.key).toBe("automation:component_on:my_button:on_press");
     expect(press?.displayLabel).toBe("My Button → on_press");
     expect(press?.id).toBe("my_button");
+    expect(press?.platform).toBe("gpio");
     expect(press?.eventKey).toBe("on_press");
   });
 

--- a/test/util/yaml-automations.test.ts
+++ b/test/util/yaml-automations.test.ts
@@ -96,6 +96,7 @@ describe("parseYamlAutomations — component triggers", () => {
     const lfRows = parseYamlAutomations(doc("\n"));
     const row = lfRows.find((r) => r.id === "temp_1");
     expect(row?.name).toBe("Temp One");
+    expect(row?.hostPlatform).toBeUndefined();
     expect(parseYamlAutomations(doc("\r\n"))).toEqual(lfRows);
   });
 

--- a/test/util/yaml-automations.test.ts
+++ b/test/util/yaml-automations.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { parseYamlAutomations } from "../../src/util/yaml-automations.js";
 import { _clearYamlSectionsMemo } from "../../src/util/yaml-sections-core.js";
+import { sectionKeyOf } from "../../src/util/yaml-sections.js";
 
 // `parseYamlAutomations` leans on `parseYamlTopLevelSections`, which memoises on
 // the yaml string. Distinct fixtures key distinctly, but clear the memo between
@@ -73,7 +74,8 @@ describe("parseYamlAutomations — component triggers", () => {
     expect(press?.key).toBe("automation:component_on:my_button:on_press");
     expect(press?.displayLabel).toBe("My Button → on_press");
     expect(press?.id).toBe("my_button");
-    expect(press?.platform).toBe("gpio");
+    expect(press?.hostPlatform).toBe("gpio");
+    expect(sectionKeyOf(press!)).toBe("automation:component_on:my_button:on_press");
     expect(press?.eventKey).toBe("on_press");
   });
 


### PR DESCRIPTION
# What does this implement/fix?

Platform-scoped trigger ids (`rotary_encoder.sensor.on_clockwise`, `nextion.display.on_page`, the touchscreen drivers, `ezo`, `ltr501`, `speaker`, `sendspin`) are `<platform>.<domain>.<key>`. The editor assumed every component trigger id was `<domain>.<key>`, so picking one of them in the Add automation dialog posted `sensor.on_clockwise` as the location's trigger, and the editor rebuilt `sensor.on_clockwise` from the device's domain when it needed the catalog id back. Both spellings are unknown to the backend, which rejected the save.

- `bareTriggerKey` takes the last id segment, and it is now the one place the add dialog and the editor derive the YAML key from.
- `catalogTriggerIdFor` / `effectiveTriggerIdFor` resolve the location through the triggers offered to the bound device instead of rebuilding `<domain>.<key>`.
- The navigator and section-list labels resolve a handler through the row's `<domain>.<platform>` scope too, so platform-scoped rows read from the catalog like every other row.

Verified in the browser against the companion backend on the reporter's YAML: the two existing handlers list under the rotary encoder with their catalog names, the editor opens `On Clockwise` with the right header, and Add automation with `Sensor.Rotary Encoder → On Clockwise` appends the list entry and opens it. Against the current backend the same flow reproduces the issue's `Unknown trigger id 'on_clockwise'` error.

Follow-up, not in this PR: a multi-entity container (`ltr501`, `ezo`) can host platform-scoped triggers on its own list item. They now resolve on read, but the picker still drops containers, so they cannot be added from the dialog yet.

Companion backend PR: esphome/device-builder#2671

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2668

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
