### PR TITLE
Offer a container its own platform-scoped triggers

### DIFF
--- a/src/api/types/automations.ts
+++ b/src/api/types/automations.ts
@@ -303,7 +303,8 @@ export interface AvailableComponentInstance {
   /** Catalog title for ``component_id`` — the display name when ``name`` is unset. */
   title?: string;
   /** True for a multi-entity platform container; its sub-entities carry the
-   *  triggers, so the picker shows it as a non-selectable header. */
+   *  entity triggers, so the picker offers it only for triggers scoped to
+   *  its own platform. */
   is_entity_container?: boolean;
   /** A sub-entity's owning container id, for grouping it under that container. */
   parent_id?: string;

--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -149,6 +149,14 @@ export class ESPHomeAddAutomationDialog extends LitElement {
     void this._loadAvailable();
   }
 
+  private get _devices(): AvailableComponentInstance[] {
+    return this._available?.devices ?? [];
+  }
+
+  private get _triggers(): AutomationTrigger[] {
+    return this._available?.triggers ?? [];
+  }
+
   private async _loadAvailable() {
     if (!this._api || !this.configuration) return;
     this._loading = true;
@@ -158,12 +166,15 @@ export class ESPHomeAddAutomationDialog extends LitElement {
         this.yaml
       );
       // A per-section shortcut on a multi-entity container prefills the
-      // container id, which has no triggers of its own; land on its first
-      // sub-entity so the user sees a real target instead of an empty list.
+      // container id; land on the first real target in it (the container
+      // itself when a trigger is scoped to its platform, else a sub-entity).
       const container = this._prefillContainer();
       if (container) {
         this._componentId =
-          this._available.devices.find((d) => d.parent_id === container.id)?.id ?? "";
+          firstSelectableTarget(
+            scopeToContainer(this._devices, container),
+            this._triggers
+          )?.id ?? "";
       }
       this._preselectUniqueTrigger();
     } catch (err) {
@@ -224,8 +235,8 @@ export class ESPHomeAddAutomationDialog extends LitElement {
     const containerEmpty =
       !!prefillContainer &&
       !firstSelectableTarget(
-        scopeToContainer(this._available?.devices ?? [], prefillContainer),
-        this._available?.triggers ?? []
+        scopeToContainer(this._devices, prefillContainer),
+        this._triggers
       );
     return html`
       <p class="intro">
@@ -292,10 +303,10 @@ export class ESPHomeAddAutomationDialog extends LitElement {
   private _renderComponentRow(container?: AvailableComponentInstance) {
     // Scope the picker to one container's sub-entities when launched from
     // that component's section; otherwise offer every configured instance.
-    const devices = scopeToContainer(this._available?.devices ?? [], container);
+    const devices = scopeToContainer(this._devices, container);
     return html`<esphome-component-target-picker
       .devices=${devices}
-      .triggers=${this._available?.triggers ?? []}
+      .triggers=${this._triggers}
       .value=${this._componentId}
       ?disabled=${this._saving}
       @component-change=${(e: CustomEvent<{ componentId: string }>) =>
@@ -378,7 +389,7 @@ export class ESPHomeAddAutomationDialog extends LitElement {
   }
 
   private _filteredTriggers(): AutomationTrigger[] {
-    const all = this._available?.triggers ?? [];
+    const all = this._triggers;
     if (this._kind === "device_on") {
       // Device-level handlers fire once unless ESPHome accepts a list
       // (supports_list, e.g. multiple on_boot priorities); list-capable ones
@@ -432,11 +443,9 @@ export class ESPHomeAddAutomationDialog extends LitElement {
     this._kind = k;
     this._triggerId = null;
     if (k === "component_on") {
-      const devices = this._available?.devices ?? [];
       // A container is a target only for its own platform-scoped
       // triggers; default to the first real target.
-      this._componentId =
-        firstSelectableTarget(devices, this._available?.triggers ?? [])?.id ?? "";
+      this._componentId = firstSelectableTarget(this._devices, this._triggers)?.id ?? "";
     } else {
       this._componentId = "";
     }

--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -44,7 +44,7 @@ import { bareTriggerKey } from "../../util/trigger-scopes.js";
 import { parseYamlAutomations } from "../../util/yaml-sections.js";
 import { addAutomationDialogStyles } from "./add-automation-dialog.styles.js";
 import {
-  firstSelectableTarget,
+  firstTriggerTarget,
   scopeToContainer,
   triggersForComponent,
 } from "./automation-editor/component-targets.js";
@@ -171,10 +171,8 @@ export class ESPHomeAddAutomationDialog extends LitElement {
       const container = this._prefillContainer();
       if (container) {
         this._componentId =
-          firstSelectableTarget(
-            scopeToContainer(this._devices, container),
-            this._triggers
-          )?.id ?? "";
+          firstTriggerTarget(scopeToContainer(this._devices, container), this._triggers)
+            ?.id ?? "";
       }
       this._preselectUniqueTrigger();
     } catch (err) {
@@ -234,7 +232,7 @@ export class ESPHomeAddAutomationDialog extends LitElement {
     // explain instead of showing an empty picker with a dead Add button.
     const containerEmpty =
       !!prefillContainer &&
-      !firstSelectableTarget(
+      !firstTriggerTarget(
         scopeToContainer(this._devices, prefillContainer),
         this._triggers
       );
@@ -445,7 +443,7 @@ export class ESPHomeAddAutomationDialog extends LitElement {
     if (k === "component_on") {
       // A container is a target only for its own platform-scoped
       // triggers; default to the first real target.
-      this._componentId = firstSelectableTarget(this._devices, this._triggers)?.id ?? "";
+      this._componentId = firstTriggerTarget(this._devices, this._triggers)?.id ?? "";
     } else {
       this._componentId = "";
     }

--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -174,7 +174,7 @@ export class ESPHomeAddAutomationDialog extends LitElement {
   }
 
   /** The prefilled component when it's a multi-entity container (its
-   *  triggers live on its sub-entities), else undefined. */
+   *  entity triggers live on its sub-entities), else undefined. */
   private _prefillContainer(): AvailableComponentInstance | undefined {
     if (!this._prefilled || this._kind !== "component_on" || !this._prefillComponentId) {
       return undefined;
@@ -224,7 +224,8 @@ export class ESPHomeAddAutomationDialog extends LitElement {
     const containerEmpty =
       !!prefillContainer &&
       !firstSelectableTarget(
-        scopeToContainer(this._available?.devices ?? [], prefillContainer)
+        scopeToContainer(this._available?.devices ?? [], prefillContainer),
+        this._available?.triggers ?? []
       );
     return html`
       <p class="intro">
@@ -294,6 +295,7 @@ export class ESPHomeAddAutomationDialog extends LitElement {
     const devices = scopeToContainer(this._available?.devices ?? [], container);
     return html`<esphome-component-target-picker
       .devices=${devices}
+      .triggers=${this._available?.triggers ?? []}
       .value=${this._componentId}
       ?disabled=${this._saving}
       @component-change=${(e: CustomEvent<{ componentId: string }>) =>
@@ -431,9 +433,10 @@ export class ESPHomeAddAutomationDialog extends LitElement {
     this._triggerId = null;
     if (k === "component_on") {
       const devices = this._available?.devices ?? [];
-      // A container isn't selectable (entity triggers go on its
-      // sub-entities); default to the first real target.
-      this._componentId = firstSelectableTarget(devices)?.id ?? "";
+      // A container is a target only for its own platform-scoped
+      // triggers; default to the first real target.
+      this._componentId =
+        firstSelectableTarget(devices, this._available?.triggers ?? [])?.id ?? "";
     } else {
       this._componentId = "";
     }

--- a/src/components/device/automation-editor/automation-target-picker.ts
+++ b/src/components/device/automation-editor/automation-target-picker.ts
@@ -44,6 +44,7 @@ import {
   firstSelectableTarget,
   indexTargets,
   instanceName,
+  isSelectableTarget,
 } from "./component-targets.js";
 
 import "@home-assistant/webawesome/dist/components/option/option.js";
@@ -172,7 +173,9 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
         this.value?.kind === "component_on" ? this.value.component_id : "";
       // A multi-entity container is a trigger target only for its own
       // platform-scoped triggers; its sub-entities carry the rest.
-      const index = indexTargets(this.devices, this.triggers);
+      const index = indexTargets(this.devices, (d) =>
+        isSelectableTarget(d, this.triggers)
+      );
       const targets = index.selectable;
       if (targets.length === 0) {
         return html`<p class="ae-empty" role="status">

--- a/src/components/device/automation-editor/automation-target-picker.ts
+++ b/src/components/device/automation-editor/automation-target-picker.ts
@@ -42,7 +42,7 @@ import { espHomeStyles } from "../../../styles/shared.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import {
   firstTriggerTarget,
-  indexTargets,
+  instanceContext,
   instanceName,
   isTriggerTarget,
 } from "./component-targets.js";
@@ -173,8 +173,8 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
         this.value?.kind === "component_on" ? this.value.component_id : "";
       // A multi-entity container is a trigger target only for its own
       // platform-scoped triggers; its sub-entities carry the rest.
-      const index = indexTargets(this.devices, (d) => isTriggerTarget(d, this.triggers));
-      const targets = index.selectable;
+      const targets = this.devices.filter((d) => isTriggerTarget(d, this.triggers));
+      const context = instanceContext(this.devices);
       if (targets.length === 0) {
         return html`<p class="ae-empty" role="status">
           ${this._localize("device.automation_target_no_components")}
@@ -195,7 +195,7 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
             (d) =>
               html`<wa-option value=${d.id} ?selected=${d.id === selectedId}
                 >${instanceName(d)}
-                <span class="ae-muted">(${index.context(d)})</span></wa-option
+                <span class="ae-muted">(${context(d)})</span></wa-option
               >`
           )}
         </wa-select>

--- a/src/components/device/automation-editor/automation-target-picker.ts
+++ b/src/components/device/automation-editor/automation-target-picker.ts
@@ -41,10 +41,10 @@ import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import {
-  firstSelectableTarget,
+  firstTriggerTarget,
   indexTargets,
   instanceName,
-  isSelectableTarget,
+  isTriggerTarget,
 } from "./component-targets.js";
 
 import "@home-assistant/webawesome/dist/components/option/option.js";
@@ -173,9 +173,7 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
         this.value?.kind === "component_on" ? this.value.component_id : "";
       // A multi-entity container is a trigger target only for its own
       // platform-scoped triggers; its sub-entities carry the rest.
-      const index = indexTargets(this.devices, (d) =>
-        isSelectableTarget(d, this.triggers)
-      );
+      const index = indexTargets(this.devices, (d) => isTriggerTarget(d, this.triggers));
       const targets = index.selectable;
       if (targets.length === 0) {
         return html`<p class="ae-empty" role="status">
@@ -292,7 +290,7 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
         case "interval":
           return { kind, index: 0 };
         case "component_on": {
-          const target = firstSelectableTarget(this.devices, this.triggers);
+          const target = firstTriggerTarget(this.devices, this.triggers);
           return target ? { kind, component_id: target.id, trigger: "" } : null;
         }
         case "script":

--- a/src/components/device/automation-editor/automation-target-picker.ts
+++ b/src/components/device/automation-editor/automation-target-picker.ts
@@ -31,6 +31,7 @@ import { customElement, property, state } from "lit/decorators.js";
 
 import type {
   AutomationLocation,
+  AutomationTrigger,
   AvailableComponentInstance,
   AvailableScript,
 } from "../../../api/types/automations.js";
@@ -86,6 +87,11 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
    *  ``component_on`` and ``light_effect`` pickers. */
   @property({ attribute: false })
   devices: AvailableComponentInstance[] = [];
+
+  /** Triggers offered on this device; decides whether a container is
+   *  itself a ``component_on`` target. */
+  @property({ attribute: false })
+  triggers: AutomationTrigger[] = [];
 
   /** Declared ``script:`` ids on this device. Empty list disables
    *  the ``script`` kind. */
@@ -164,9 +170,9 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
     if (kind === "component_on") {
       const selectedId =
         this.value?.kind === "component_on" ? this.value.component_id : "";
-      // A multi-entity container isn't a valid trigger target — its
-      // sub-entities are (offered as their own instances).
-      const index = indexTargets(this.devices);
+      // A multi-entity container is a trigger target only for its own
+      // platform-scoped triggers; its sub-entities carry the rest.
+      const index = indexTargets(this.devices, this.triggers);
       const targets = index.selectable;
       if (targets.length === 0) {
         return html`<p class="ae-empty" role="status">
@@ -283,7 +289,7 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
         case "interval":
           return { kind, index: 0 };
         case "component_on": {
-          const target = firstSelectableTarget(this.devices);
+          const target = firstSelectableTarget(this.devices, this.triggers);
           return target ? { kind, component_id: target.id, trigger: "" } : null;
         }
         case "script":

--- a/src/components/device/automation-editor/automation-trigger-picker.ts
+++ b/src/components/device/automation-editor/automation-trigger-picker.ts
@@ -170,8 +170,8 @@ export class ESPHomeAutomationTriggerPicker extends LitElement {
       const componentId = this.target.component_id;
       const device = this.devices.find((d) => d.id === componentId);
       // Matches either the bare domain (``binary_sensor``) or the
-      // domain.platform tuple; a multi-entity container yields none (its
-      // triggers belong on its sub-entities).
+      // domain.platform tuple; a multi-entity container yields only the
+      // triggers scoped to its platform (the rest belong to its sub-entities).
       return triggersForComponent(this.triggers, device);
     }
     return [];

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -67,7 +67,7 @@ import {
 } from "./catalog-picker-filter.js";
 import {
   componentDomain,
-  indexTargets,
+  instanceContext,
   instanceName,
   isActionTarget,
   preFillIdParam,
@@ -283,8 +283,8 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
     // A multi-entity container isn't itself a referenceable entity — its
     // sub-entities are surfaced as their own instances. The query matches
     // either axis: an entity hit lists all of that entity's actions.
-    const index = indexTargets(this.devices, isActionTarget);
-    const sections = index.selectable.flatMap((device) => {
+    const context = instanceContext(this.devices);
+    const sections = this.devices.filter(isActionTarget).flatMap((device) => {
       const name = instanceName(device);
       const entityMatch = q !== "" && navItemMatches(q, name, device.id);
       const matching = itemsForDevice(entityMatch ? byDomain : filteredByDomain, device);
@@ -306,7 +306,7 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
         localize: this._localize,
         labelText: this._renderGroupLabel(
           name,
-          index.context(device),
+          context(device),
           q && !entityMatch ? matching.length : null
         ),
         body: () =>

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -279,10 +279,10 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
     const filteredByDomain = q
       ? new Map([...byDomain].map(([domain, list]) => [domain, filterItems(list, q)]))
       : byDomain;
-    const index = indexTargets(this.devices);
     // A multi-entity container isn't itself a referenceable entity — its
     // sub-entities are surfaced as their own instances. The query matches
     // either axis: an entity hit lists all of that entity's actions.
+    const index = indexTargets(this.devices, []);
     const sections = index.selectable.flatMap((device) => {
       const name = instanceName(device);
       const entityMatch = q !== "" && navItemMatches(q, name, device.id);

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -69,6 +69,7 @@ import {
   componentDomain,
   indexTargets,
   instanceName,
+  isEntityTarget,
   preFillIdParam,
 } from "./component-targets.js";
 
@@ -282,7 +283,7 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
     // A multi-entity container isn't itself a referenceable entity — its
     // sub-entities are surfaced as their own instances. The query matches
     // either axis: an entity hit lists all of that entity's actions.
-    const index = indexTargets(this.devices, []);
+    const index = indexTargets(this.devices, isEntityTarget);
     const sections = index.selectable.flatMap((device) => {
       const name = instanceName(device);
       const entityMatch = q !== "" && navItemMatches(q, name, device.id);

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -69,7 +69,7 @@ import {
   componentDomain,
   indexTargets,
   instanceName,
-  isEntityTarget,
+  isActionTarget,
   preFillIdParam,
 } from "./component-targets.js";
 
@@ -283,7 +283,7 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
     // A multi-entity container isn't itself a referenceable entity — its
     // sub-entities are surfaced as their own instances. The query matches
     // either axis: an entity hit lists all of that entity's actions.
-    const index = indexTargets(this.devices, isEntityTarget);
+    const index = indexTargets(this.devices, isActionTarget);
     const sections = index.selectable.flatMap((device) => {
       const name = instanceName(device);
       const entityMatch = q !== "" && navItemMatches(q, name, device.id);

--- a/src/components/device/automation-editor/component-target-picker.styles.ts
+++ b/src/components/device/automation-editor/component-target-picker.styles.ts
@@ -47,6 +47,9 @@ export const componentTargetPickerStyles = css`
   .component-group-wrap .component-choice {
     padding-left: var(--wa-space-m);
   }
+  .component-group-wrap .component-choice--group {
+    padding-left: var(--wa-space-2xs);
+  }
   .component-group {
     font-size: var(--wa-font-size-2xs);
     font-weight: var(--wa-font-weight-semibold);

--- a/src/components/device/automation-editor/component-target-picker.styles.ts
+++ b/src/components/device/automation-editor/component-target-picker.styles.ts
@@ -47,9 +47,6 @@ export const componentTargetPickerStyles = css`
   .component-group-wrap .component-choice {
     padding-left: var(--wa-space-m);
   }
-  .component-group-wrap .component-choice--group {
-    padding-left: var(--wa-space-2xs);
-  }
   .component-group {
     font-size: var(--wa-font-size-2xs);
     font-weight: var(--wa-font-weight-semibold);

--- a/src/components/device/automation-editor/component-target-picker.styles.ts
+++ b/src/components/device/automation-editor/component-target-picker.styles.ts
@@ -2,9 +2,10 @@ import { css } from "lit";
 
 /**
  * Styles for <esphome-component-target-picker>: a grouped radiogroup of
- * configured component instances (a multi-entity platform is a header, its
- * sub-entities the rows), mirroring the catalog by-target picker and the
- * nested-form domain badge.
+ * configured component instances (a multi-entity platform is a header, or a
+ * row of its own when it hosts platform-scoped triggers, its sub-entities the
+ * rows), mirroring the catalog by-target picker and the nested-form domain
+ * badge.
  */
 export const componentTargetPickerStyles = css`
   .field {

--- a/src/components/device/automation-editor/component-target-picker.ts
+++ b/src/components/device/automation-editor/component-target-picker.ts
@@ -1,6 +1,7 @@
 /**
  * Single-select radiogroup over configured component instances: a
- * multi-entity platform renders as a group header with its sub-entity rows.
+ * multi-entity platform renders as a group header with its sub-entity rows,
+ * or as its own row ahead of them when it hosts platform-scoped triggers.
  * Emits ``component-change`` with the picked id; controlled via ``value``.
  */
 import { consume } from "@lit/context";

--- a/src/components/device/automation-editor/component-target-picker.ts
+++ b/src/components/device/automation-editor/component-target-picker.ts
@@ -17,9 +17,9 @@ import { espHomeStyles } from "../../../styles/shared.js";
 import { textStyles } from "../../../styles/text.js";
 import { fireEvent } from "../../../util/fire-event.js";
 import { componentTargetPickerStyles } from "./component-target-picker.styles.js";
-import { instanceName, isSelectableTarget } from "./component-targets.js";
+import { instanceName, isTriggerTarget } from "./component-targets.js";
 
-/** The id ``aria-labelledby`` points a group at: its container's row or heading. */
+/** The id of a group's visible heading, for ``aria-labelledby``. */
 function groupHeaderId(container: AvailableComponentInstance): string {
   return `component-group-${container.id}`;
 }
@@ -27,8 +27,9 @@ function groupHeaderId(container: AvailableComponentInstance): string {
 type Group = {
   header: AvailableComponentInstance;
   subs: AvailableComponentInstance[];
-  /** The container is itself a target (it hosts platform-scoped triggers). */
-  selectable: boolean;
+  /** Render the container as the group's heading; false when it is a
+   *  target itself and already rendered as the row preceding the group. */
+  heading: boolean;
 };
 
 /** Arrow key → step through the flat row order (Left/Up back, Right/Down on). */
@@ -76,15 +77,16 @@ export class ESPHomeComponentTargetPicker extends LitElement {
           return html`<div
             class="component-group-wrap"
             role="group"
-            aria-labelledby=${headerId}
+            aria-labelledby=${item.heading ? headerId : nothing}
+            aria-label=${item.heading ? nothing : instanceName(item.header)}
           >
             ${
-              item.selectable
-                ? this._renderChoice(item.header, order, true)
-                : html`<p class="component-group" id=${headerId}>
+              item.heading
+                ? html`<p class="component-group" id=${headerId}>
                     ${instanceName(item.header)}
                     <span class="component-group-id">(${item.header.component_id})</span>
                   </p>`
+                : nothing
             }
             ${item.subs.map((s) => this._renderChoice(s, order))}
           </div>`;
@@ -111,10 +113,13 @@ export class ESPHomeComponentTargetPicker extends LitElement {
     for (const d of this.devices) {
       if (d.is_entity_container) {
         const subs = subsByParent.get(d.id) ?? [];
-        const selectable = isSelectableTarget(d, this.triggers);
-        if (subs.length === 0 && !selectable) continue;
-        plan.push({ header: d, subs, selectable });
-        if (selectable) order.push(d.id);
+        const target = isTriggerTarget(d, this.triggers);
+        if (target) {
+          plan.push(d);
+          order.push(d.id);
+        }
+        if (subs.length === 0) continue;
+        plan.push({ header: d, subs, heading: !target });
         order.push(...subs.map((s) => s.id));
       } else if (!(d.parent_id && containerIds.has(d.parent_id))) {
         // Orphan sub (parent absent) or plain instance → standalone row.
@@ -125,16 +130,13 @@ export class ESPHomeComponentTargetPicker extends LitElement {
     return { plan, order };
   }
 
-  private _renderChoice(d: AvailableComponentInstance, order: string[], header = false) {
+  private _renderChoice(d: AvailableComponentInstance, order: string[]) {
     const selected = d.id === this.value;
     // Roving tabindex: the checked row is the single tab stop; before any
     // pick, the first selectable row holds it.
     const tabbable = selected || (!order.includes(this.value) && order[0] === d.id);
     return html`<div
-      class="component-choice ${selected ? "component-choice--selected" : ""} ${
-        header ? "component-choice--group" : ""
-      }"
-      id=${header ? groupHeaderId(d) : nothing}
+      class="component-choice ${selected ? "component-choice--selected" : ""}"
       role="radio"
       aria-checked=${selected ? "true" : "false"}
       aria-disabled=${this.disabled ? "true" : "false"}

--- a/src/components/device/automation-editor/component-target-picker.ts
+++ b/src/components/device/automation-editor/component-target-picker.ts
@@ -4,19 +4,27 @@
  * Emits ``component-change`` with the picked id; controlled via ``value``.
  */
 import { consume } from "@lit/context";
-import { html, LitElement } from "lit";
+import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
-import type { AvailableComponentInstance } from "../../../api/types/automations.js";
+import type {
+  AutomationTrigger,
+  AvailableComponentInstance,
+} from "../../../api/types/automations.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { espHomeStyles } from "../../../styles/shared.js";
 import { textStyles } from "../../../styles/text.js";
 import { fireEvent } from "../../../util/fire-event.js";
 import { componentTargetPickerStyles } from "./component-target-picker.styles.js";
-import { instanceName } from "./component-targets.js";
+import { instanceName, isSelectableTarget } from "./component-targets.js";
 
-type Group = { header: AvailableComponentInstance; subs: AvailableComponentInstance[] };
+type Group = {
+  header: AvailableComponentInstance;
+  subs: AvailableComponentInstance[];
+  /** The container is itself a target (it hosts platform-scoped triggers). */
+  selectable: boolean;
+};
 
 /** Arrow key → step through the flat row order (Left/Up back, Right/Down on). */
 const ARROW_DELTA: Record<string, number> = {
@@ -33,6 +41,8 @@ export class ESPHomeComponentTargetPicker extends LitElement {
   private _localize: LocalizeFunc = (key) => key;
 
   @property({ attribute: false }) devices: AvailableComponentInstance[] = [];
+  /** Offered triggers; decides whether a container is itself a target. */
+  @property({ attribute: false }) triggers: AutomationTrigger[] = [];
   @property() value = "";
   @property({ type: Boolean }) disabled = false;
 
@@ -63,10 +73,14 @@ export class ESPHomeComponentTargetPicker extends LitElement {
             role="group"
             aria-labelledby=${headerId}
           >
-            <p class="component-group" id=${headerId}>
-              ${instanceName(item.header)}
-              <span class="component-group-id">(${item.header.component_id})</span>
-            </p>
+            ${
+              item.selectable
+                ? this._renderChoice(item.header, order, headerId)
+                : html`<p class="component-group" id=${headerId}>
+                    ${instanceName(item.header)}
+                    <span class="component-group-id">(${item.header.component_id})</span>
+                  </p>`
+            }
             ${item.subs.map((s) => this._renderChoice(s, order))}
           </div>`;
         })}
@@ -92,8 +106,10 @@ export class ESPHomeComponentTargetPicker extends LitElement {
     for (const d of this.devices) {
       if (d.is_entity_container) {
         const subs = subsByParent.get(d.id) ?? [];
-        if (subs.length === 0) continue;
-        plan.push({ header: d, subs });
+        const selectable = isSelectableTarget(d, this.triggers);
+        if (subs.length === 0 && !selectable) continue;
+        plan.push({ header: d, subs, selectable });
+        if (selectable) order.push(d.id);
         order.push(...subs.map((s) => s.id));
       } else if (!(d.parent_id && containerIds.has(d.parent_id))) {
         // Orphan sub (parent absent) or plain instance → standalone row.
@@ -104,13 +120,16 @@ export class ESPHomeComponentTargetPicker extends LitElement {
     return { plan, order };
   }
 
-  private _renderChoice(d: AvailableComponentInstance, order: string[]) {
+  private _renderChoice(d: AvailableComponentInstance, order: string[], id?: string) {
     const selected = d.id === this.value;
     // Roving tabindex: the checked row is the single tab stop; before any
     // pick, the first selectable row holds it.
     const tabbable = selected || (!order.includes(this.value) && order[0] === d.id);
     return html`<div
-      class="component-choice ${selected ? "component-choice--selected" : ""}"
+      class="component-choice ${selected ? "component-choice--selected" : ""} ${
+        id ? "component-choice--group" : ""
+      }"
+      id=${id ?? nothing}
       role="radio"
       aria-checked=${selected ? "true" : "false"}
       aria-disabled=${this.disabled ? "true" : "false"}

--- a/src/components/device/automation-editor/component-target-picker.ts
+++ b/src/components/device/automation-editor/component-target-picker.ts
@@ -19,6 +19,11 @@ import { fireEvent } from "../../../util/fire-event.js";
 import { componentTargetPickerStyles } from "./component-target-picker.styles.js";
 import { instanceName, isSelectableTarget } from "./component-targets.js";
 
+/** The id ``aria-labelledby`` points a group at: its container's row or heading. */
+function groupHeaderId(container: AvailableComponentInstance): string {
+  return `component-group-${container.id}`;
+}
+
 type Group = {
   header: AvailableComponentInstance;
   subs: AvailableComponentInstance[];
@@ -67,7 +72,7 @@ export class ESPHomeComponentTargetPicker extends LitElement {
       >
         ${plan.map((item) => {
           if (!("header" in item)) return this._renderChoice(item, order);
-          const headerId = `component-group-${item.header.id}`;
+          const headerId = groupHeaderId(item.header);
           return html`<div
             class="component-group-wrap"
             role="group"
@@ -75,7 +80,7 @@ export class ESPHomeComponentTargetPicker extends LitElement {
           >
             ${
               item.selectable
-                ? this._renderChoice(item.header, order, headerId)
+                ? this._renderChoice(item.header, order, true)
                 : html`<p class="component-group" id=${headerId}>
                     ${instanceName(item.header)}
                     <span class="component-group-id">(${item.header.component_id})</span>
@@ -120,16 +125,16 @@ export class ESPHomeComponentTargetPicker extends LitElement {
     return { plan, order };
   }
 
-  private _renderChoice(d: AvailableComponentInstance, order: string[], id?: string) {
+  private _renderChoice(d: AvailableComponentInstance, order: string[], header = false) {
     const selected = d.id === this.value;
     // Roving tabindex: the checked row is the single tab stop; before any
     // pick, the first selectable row holds it.
     const tabbable = selected || (!order.includes(this.value) && order[0] === d.id);
     return html`<div
       class="component-choice ${selected ? "component-choice--selected" : ""} ${
-        id ? "component-choice--group" : ""
+        header ? "component-choice--group" : ""
       }"
-      id=${id ?? nothing}
+      id=${header ? groupHeaderId(d) : nothing}
       role="radio"
       aria-checked=${selected ? "true" : "false"}
       aria-disabled=${this.disabled ? "true" : "false"}

--- a/src/components/device/automation-editor/component-targets.ts
+++ b/src/components/device/automation-editor/component-targets.ts
@@ -9,7 +9,7 @@ import type {
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { stripRedundantComponentSuffix } from "../../../util/component-title.js";
 import { parseCatalogId } from "../../../util/config-entry-yaml-scan.js";
-import { targetScopes, triggerAppliesTo } from "../../../util/trigger-scopes.js";
+import { instanceScopes, triggerAppliesTo } from "../../../util/trigger-scopes.js";
 import { CORE_KEYS } from "../../../util/yaml-sections.js";
 
 /** The instance's display label: its ``name:`` when set, else the catalog
@@ -30,7 +30,7 @@ export function componentDomain(componentId: string): string {
 }
 
 export interface TargetIndex {
-  /** The instances a picker offers; containers are excluded. */
+  /** The instances a picker offers, per its ``selectable`` rule. */
   readonly selectable: AvailableComponentInstance[];
   /** The parenthetical context beside an instance's label: its component id,
    *  plus the owning container's name when it's a sub-entity, so two readings
@@ -39,14 +39,14 @@ export interface TargetIndex {
 }
 
 /** Index the full instance list once per render; ``context`` resolves parents
- *  against every instance, including the containers ``selectable`` drops. */
+ *  against every instance, including any container ``selectable`` drops. */
 export function indexTargets(
   devices: AvailableComponentInstance[],
-  triggers: AutomationTrigger[]
+  selectable: (device: AvailableComponentInstance) => boolean
 ): TargetIndex {
   const byId = new Map(devices.map((d) => [d.id, d]));
   return {
-    selectable: selectableTargets(devices, triggers),
+    selectable: devices.filter(selectable),
     context(device) {
       const parent = device.parent_id ? byId.get(device.parent_id) : undefined;
       return parent
@@ -56,22 +56,21 @@ export function indexTargets(
   };
 }
 
-/** A multi-entity platform container is a target only when a trigger is
- *  scoped to its own platform (``sensor.ltr501``); the entity triggers
- *  belong to its sub-entities. */
+/** A trigger target: any instance but a multi-entity container, which
+ *  qualifies only when a trigger is scoped to its own platform
+ *  (``sensor.ltr501``); the entity triggers belong to its sub-entities. */
 export function isSelectableTarget(
   device: AvailableComponentInstance,
   triggers: AutomationTrigger[]
 ): boolean {
-  return !device.is_entity_container || triggersForComponent(triggers, device).length > 0;
+  if (!device.is_entity_container) return true;
+  const scopes = instanceScopes(device);
+  return triggers.some((t) => triggerAppliesTo(t, scopes));
 }
 
-/** The instances a picker may offer. */
-function selectableTargets(
-  devices: AvailableComponentInstance[],
-  triggers: AutomationTrigger[]
-): AvailableComponentInstance[] {
-  return devices.filter((d) => isSelectableTarget(d, triggers));
+/** A referenceable entity for actions: never a multi-entity container. */
+export function isEntityTarget(device: AvailableComponentInstance): boolean {
+  return !device.is_entity_container;
 }
 
 /** The first selectable instance, for defaulting a freshly-chosen kind. */
@@ -111,16 +110,13 @@ export function preFillIdParam(
   return { [idEntry.key]: device.id };
 }
 
-/** Component-level triggers the picker offers *device*: matched on its bare
- *  or qualified domain, or on the qualified domain alone for a container,
- *  whose entity triggers belong to its sub-entities. */
+/** Component-level triggers the picker offers *device*, matched on the
+ *  scopes it hosts triggers under. */
 export function triggersForComponent(
   triggers: AutomationTrigger[],
   device: AvailableComponentInstance | undefined
 ): AutomationTrigger[] {
   if (!device) return [];
-  const scopes = device.is_entity_container
-    ? [device.component_id]
-    : targetScopes(device.component_id);
+  const scopes = instanceScopes(device);
   return triggers.filter((t) => triggerAppliesTo(t, scopes));
 }

--- a/src/components/device/automation-editor/component-targets.ts
+++ b/src/components/device/automation-editor/component-targets.ts
@@ -29,30 +29,21 @@ export function componentDomain(componentId: string): string {
   return parseCatalogId(componentId).domain;
 }
 
-export interface TargetIndex {
-  /** The instances a picker offers, per its ``selectable`` rule. */
-  readonly selectable: AvailableComponentInstance[];
-  /** The parenthetical context beside an instance's label: its component id,
-   *  plus the owning container's name when it's a sub-entity, so two readings
-   *  named alike (``Temperature``) read distinctly. */
-  context(device: AvailableComponentInstance): string;
-}
-
-/** Index the full instance list once per render; ``context`` resolves parents
- *  against every instance, including any container ``selectable`` drops. */
-export function indexTargets(
-  devices: AvailableComponentInstance[],
-  selectable: (device: AvailableComponentInstance) => boolean
-): TargetIndex {
+/**
+ * The parenthetical context beside an instance's label: its component id,
+ * plus the owning container's name when it's a sub-entity, so two readings
+ * named alike (``Temperature``) read distinctly. Resolves parents against
+ * every instance, including containers a picker filters out.
+ */
+export function instanceContext(
+  devices: AvailableComponentInstance[]
+): (device: AvailableComponentInstance) => string {
   const byId = new Map(devices.map((d) => [d.id, d]));
-  return {
-    selectable: devices.filter(selectable),
-    context(device) {
-      const parent = device.parent_id ? byId.get(device.parent_id) : undefined;
-      return parent
-        ? `${device.component_id} · ${instanceName(parent)}`
-        : device.component_id;
-    },
+  return (device) => {
+    const parent = device.parent_id ? byId.get(device.parent_id) : undefined;
+    return parent
+      ? `${device.component_id} · ${instanceName(parent)}`
+      : device.component_id;
   };
 }
 

--- a/src/components/device/automation-editor/component-targets.ts
+++ b/src/components/device/automation-editor/component-targets.ts
@@ -56,10 +56,12 @@ export function indexTargets(
   };
 }
 
-/** A trigger target: any instance but a multi-entity container, which
- *  qualifies only when a trigger is scoped to its own platform
- *  (``sensor.ltr501``); the entity triggers belong to its sub-entities. */
-export function isSelectableTarget(
+/** A ``component_on`` target: any instance but a multi-entity container,
+ *  which qualifies only when a trigger is scoped to its own platform
+ *  (``sensor.ltr501``); the entity triggers belong to its sub-entities.
+ *  A plain instance never has to prove it hosts a trigger, so a domain
+ *  without triggers still lists its instances. */
+export function isTriggerTarget(
   device: AvailableComponentInstance,
   triggers: AutomationTrigger[]
 ): boolean {
@@ -68,17 +70,17 @@ export function isSelectableTarget(
   return triggers.some((t) => triggerAppliesTo(t, scopes));
 }
 
-/** A referenceable entity for actions: never a multi-entity container. */
-export function isEntityTarget(device: AvailableComponentInstance): boolean {
+/** An entity an action can reference: never a multi-entity container. */
+export function isActionTarget(device: AvailableComponentInstance): boolean {
   return !device.is_entity_container;
 }
 
-/** The first selectable instance, for defaulting a freshly-chosen kind. */
-export function firstSelectableTarget(
+/** The first ``component_on`` target, for defaulting a freshly-chosen kind. */
+export function firstTriggerTarget(
   devices: AvailableComponentInstance[],
   triggers: AutomationTrigger[]
 ): AvailableComponentInstance | undefined {
-  return devices.find((d) => isSelectableTarget(d, triggers));
+  return devices.find((d) => isTriggerTarget(d, triggers));
 }
 
 /** *container* plus its direct sub-entities, for scoping a picker to one

--- a/src/components/device/automation-editor/component-targets.ts
+++ b/src/components/device/automation-editor/component-targets.ts
@@ -40,10 +40,13 @@ export interface TargetIndex {
 
 /** Index the full instance list once per render; ``context`` resolves parents
  *  against every instance, including the containers ``selectable`` drops. */
-export function indexTargets(devices: AvailableComponentInstance[]): TargetIndex {
+export function indexTargets(
+  devices: AvailableComponentInstance[],
+  triggers: AutomationTrigger[]
+): TargetIndex {
   const byId = new Map(devices.map((d) => [d.id, d]));
   return {
-    selectable: selectableTargets(devices),
+    selectable: selectableTargets(devices, triggers),
     context(device) {
       const parent = device.parent_id ? byId.get(device.parent_id) : undefined;
       return parent
@@ -53,24 +56,30 @@ export function indexTargets(devices: AvailableComponentInstance[]): TargetIndex
   };
 }
 
-/** A multi-entity platform container holds no triggers of its own (its
- *  sub-entities do), so it isn't directly selectable as a target. */
-export function isSelectableTarget(device: AvailableComponentInstance): boolean {
-  return !device.is_entity_container;
+/** A multi-entity platform container is a target only when a trigger is
+ *  scoped to its own platform (``sensor.ltr501``); the entity triggers
+ *  belong to its sub-entities. */
+export function isSelectableTarget(
+  device: AvailableComponentInstance,
+  triggers: AutomationTrigger[]
+): boolean {
+  return !device.is_entity_container || triggersForComponent(triggers, device).length > 0;
 }
 
-/** The instances a picker may offer (containers dropped). */
+/** The instances a picker may offer. */
 function selectableTargets(
-  devices: AvailableComponentInstance[]
+  devices: AvailableComponentInstance[],
+  triggers: AutomationTrigger[]
 ): AvailableComponentInstance[] {
-  return devices.filter(isSelectableTarget);
+  return devices.filter((d) => isSelectableTarget(d, triggers));
 }
 
 /** The first selectable instance, for defaulting a freshly-chosen kind. */
 export function firstSelectableTarget(
-  devices: AvailableComponentInstance[]
+  devices: AvailableComponentInstance[],
+  triggers: AutomationTrigger[]
 ): AvailableComponentInstance | undefined {
-  return devices.find(isSelectableTarget);
+  return devices.find((d) => isSelectableTarget(d, triggers));
 }
 
 /** *container* plus its direct sub-entities, for scoping a picker to one
@@ -102,14 +111,16 @@ export function preFillIdParam(
   return { [idEntry.key]: device.id };
 }
 
-/** Component-level triggers the picker offers *device*, matched on its bare
- *  or qualified domain; empty when *device* is absent or a container, whose
- *  own platform-scoped triggers the picker does not offer yet. */
+/** Component-level triggers the picker offers *device*: matched on its bare
+ *  or qualified domain, or on the qualified domain alone for a container,
+ *  whose entity triggers belong to its sub-entities. */
 export function triggersForComponent(
   triggers: AutomationTrigger[],
   device: AvailableComponentInstance | undefined
 ): AutomationTrigger[] {
-  if (!device || !isSelectableTarget(device)) return [];
-  const scopes = targetScopes(device.component_id);
+  if (!device) return [];
+  const scopes = device.is_entity_container
+    ? [device.component_id]
+    : targetScopes(device.component_id);
   return triggers.filter((t) => triggerAppliesTo(t, scopes));
 }

--- a/src/components/device/automation-editor/render-automation-sections.ts
+++ b/src/components/device/automation-editor/render-automation-sections.ts
@@ -52,6 +52,7 @@ export function renderAddModePickers(opts: {
     <esphome-automation-target-picker
       .value=${opts.target}
       .devices=${opts.devices}
+      .triggers=${opts.triggers}
       .scripts=${opts.scripts}
       ?disabled=${opts.disabled}
       @target-change=${opts.onTargetChange}

--- a/src/components/device/automation-editor/trigger-identity.ts
+++ b/src/components/device/automation-editor/trigger-identity.ts
@@ -22,7 +22,7 @@ import type {
   AvailableComponentInstance,
 } from "../../../api/types/automations.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
-import { targetScopes, triggerForKey } from "../../../util/trigger-scopes.js";
+import { instanceScopes, triggerForKey } from "../../../util/trigger-scopes.js";
 import { instanceName } from "./component-targets.js";
 
 /**
@@ -30,8 +30,8 @@ import { instanceName } from "./component-targets.js";
  * the trigger offered to the bound device under that bare key. Returns
  * ``null`` for other location kinds or when no trigger is picked, and
  * the bare key itself while the device or its triggers are unknown so
- * the caller still has a usable id. Containers resolve too: a
- * multi-entity platform can host triggers on its own list item.
+ * the caller still has a usable id. A container resolves only the
+ * triggers scoped to its own platform.
  */
 export function catalogTriggerIdFor(
   loc: AutomationLocation,
@@ -41,10 +41,7 @@ export function catalogTriggerIdFor(
   if (loc.kind !== "component_on" || !loc.trigger) return null;
   const device = devices.find((d) => d.id === loc.component_id);
   if (!device) return loc.trigger;
-  return (
-    triggerForKey(triggers, targetScopes(device.component_id), loc.trigger)?.id ??
-    loc.trigger
-  );
+  return triggerForKey(triggers, instanceScopes(device), loc.trigger)?.id ?? loc.trigger;
 }
 
 /**

--- a/src/util/trigger-scopes.ts
+++ b/src/util/trigger-scopes.ts
@@ -8,7 +8,10 @@
  * Scope lists are ordered most specific first so a platform-scoped
  * trigger wins over a domain-level one sharing the same key.
  */
-import type { AutomationTrigger } from "../api/types/automations.js";
+import type {
+  AutomationTrigger,
+  AvailableComponentInstance,
+} from "../api/types/automations.js";
 import { parseCatalogId } from "./config-entry-yaml-scan.js";
 import { qualifiedSectionKey } from "./yaml-sections-core.js";
 
@@ -25,6 +28,14 @@ export function bareTriggerKey(catalogId: string): string {
 export function targetScopes(componentId: string): string[] {
   const { domain } = parseCatalogId(componentId);
   return domain === componentId ? [componentId] : [componentId, domain];
+}
+
+/** Scopes an instance hosts triggers under: a multi-entity container only
+ *  its qualified id (its sub-entities carry the entity triggers). */
+export function instanceScopes(device: AvailableComponentInstance): string[] {
+  return device.is_entity_container
+    ? [device.component_id]
+    : targetScopes(device.component_id);
 }
 
 /** Scopes of a handler row: ``<domain>.<platform>`` when a platform item

--- a/src/util/trigger-scopes.ts
+++ b/src/util/trigger-scopes.ts
@@ -30,8 +30,9 @@ export function targetScopes(componentId: string): string[] {
   return domain === componentId ? [componentId] : [componentId, domain];
 }
 
-/** Scopes an instance hosts triggers under: a multi-entity container only
- *  its qualified id (its sub-entities carry the entity triggers). */
+/** Scopes an instance hosts triggers under. A multi-entity container's
+ *  list item is not an entity, so it drops the bare domain deliberately:
+ *  the entity triggers belong to its sub-entities. */
 export function instanceScopes(device: AvailableComponentInstance): string[] {
   return device.is_entity_container
     ? [device.component_id]

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -444,6 +444,18 @@ describe("add-automation-dialog sub-entity targets (#1263)", () => {
     });
   });
 
+  it("lands a container prefill on the container when it hosts its own trigger", async () => {
+    const api = {
+      getAvailableAutomations: vi.fn(() => Promise.resolve(ahtAvailable())),
+    } as unknown as ESPHomeAPI;
+    const dialog = await mountDialog(api);
+    dialog.open({ kind: "component_on", componentId: "ltr" });
+    await dialog.updateComplete;
+    await flush();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((dialog as any)._componentId).toBe("ltr");
+  });
+
   it("defaults the component to the first non-container instance", async () => {
     const dialog = await mountForComponentStep();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -303,6 +303,14 @@ const ahtAvailable = (): AvailableAutomations =>
         supports_list: true,
         config_entries: [],
       },
+      {
+        id: "ltr501.sensor.on_ps_high_threshold",
+        name: "On Ps High Threshold",
+        applies_to: ["sensor.ltr501"],
+        is_device_level: false,
+        supports_list: false,
+        config_entries: [],
+      },
     ],
     actions: [],
     conditions: [],
@@ -328,6 +336,13 @@ const ahtAvailable = (): AvailableAutomations =>
       },
       { id: "relay", name: "Relay", component_id: "switch.gpio" },
       { id: "dial", name: "Dial", component_id: "sensor.rotary_encoder" },
+      {
+        id: "ltr",
+        name: "LTR501",
+        component_id: "sensor.ltr501",
+        is_entity_container: true,
+      },
+      { id: "ltr_als", name: "Ambient", component_id: "sensor", parent_id: "ltr" },
     ],
   }) as unknown as AvailableAutomations;
 
@@ -410,6 +425,23 @@ describe("add-automation-dialog sub-entity targets (#1263)", () => {
       "sensor.on_value_range",
       "rotary_encoder.sensor.on_clockwise",
     ]);
+  });
+
+  it("offers a container its own platform-scoped trigger and targets it directly", async () => {
+    const dialog = await mountForComponentStep();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (dialog as any)._componentId = "ltr";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const offered = (dialog as any)._filteredTriggers() as Array<{ id: string }>;
+    expect(offered.map((t) => t.id)).toEqual(["ltr501.sensor.on_ps_high_threshold"]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (dialog as any)._triggerId = "ltr501.sensor.on_ps_high_threshold";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((dialog as any)._buildLocation()).toEqual({
+      kind: "component_on",
+      component_id: "ltr",
+      trigger: "on_ps_high_threshold",
+    });
   });
 
   it("defaults the component to the first non-container instance", async () => {

--- a/test/components/device/automation-editor/automation-target-picker.test.ts
+++ b/test/components/device/automation-editor/automation-target-picker.test.ts
@@ -9,23 +9,64 @@ vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}
 import { identityLocalize } from "../../../_dom.js";
 import type {
   AutomationLocation,
+  AutomationTrigger,
   AvailableComponentInstance,
 } from "../../../../src/api/types/automations.js";
 import { ESPHomeAutomationTargetPicker } from "../../../../src/components/device/automation-editor/automation-target-picker.js";
 
 async function mount(
   devices: AvailableComponentInstance[],
-  value: AutomationLocation
+  value: AutomationLocation,
+  triggers: AutomationTrigger[] = []
 ): Promise<ESPHomeAutomationTargetPicker> {
   const el = new ESPHomeAutomationTargetPicker();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (el as any)._localize = identityLocalize;
   el.devices = devices;
+  el.triggers = triggers;
   el.value = value;
   document.body.appendChild(el);
   await el.updateComplete;
   return el;
 }
+
+describe("automation-target-picker container options", () => {
+  it("offers a container only when a trigger is scoped to its platform", async () => {
+    const devices: AvailableComponentInstance[] = [
+      {
+        id: "ltr",
+        name: "LTR501",
+        component_id: "sensor.ltr501",
+        is_entity_container: true,
+      },
+      { id: "ltr_als", name: "Ambient", component_id: "sensor", parent_id: "ltr" },
+    ];
+    const location: AutomationLocation = {
+      kind: "component_on",
+      component_id: "ltr_als",
+      trigger: "",
+    };
+    const values = (el: ESPHomeAutomationTargetPicker) =>
+      [...el.shadowRoot!.querySelectorAll("wa-option")].map((o) =>
+        o.getAttribute("value")
+      );
+    const without = await mount(devices, location);
+    expect(values(without)).not.toContain("ltr");
+    const withTrigger = await mount(devices, location, [
+      {
+        id: "ltr501.sensor.on_ps_high_threshold",
+        name: "On Ps High",
+        description: "",
+        docs_url: "",
+        applies_to: ["sensor.ltr501"],
+        is_device_level: false,
+        supports_list: false,
+        config_entries: [],
+      },
+    ]);
+    expect(values(withTrigger)).toContain("ltr");
+  });
+});
 
 describe("automation-target-picker sub-entity options", () => {
   it("disambiguates same-named sub-entities by their parent", async () => {

--- a/test/components/device/automation-editor/component-target-picker.test.ts
+++ b/test/components/device/automation-editor/component-target-picker.test.ts
@@ -3,7 +3,10 @@
  */
 import { describe, expect, it } from "vitest";
 
-import type { AvailableComponentInstance } from "../../../../src/api/types/automations.js";
+import type {
+  AutomationTrigger,
+  AvailableComponentInstance,
+} from "../../../../src/api/types/automations.js";
 import { ESPHomeComponentTargetPicker } from "../../../../src/components/device/automation-editor/component-target-picker.js";
 
 const aht = (): AvailableComponentInstance[] => [
@@ -21,10 +24,12 @@ const aht = (): AvailableComponentInstance[] => [
 async function mount(
   devices: AvailableComponentInstance[],
   value = "",
-  disabled = false
+  disabled = false,
+  triggers: AutomationTrigger[] = []
 ): Promise<ESPHomeComponentTargetPicker> {
   const el = new ESPHomeComponentTargetPicker();
   el.devices = devices;
+  el.triggers = triggers;
   el.value = value;
   el.disabled = disabled;
   document.body.appendChild(el);
@@ -73,28 +78,31 @@ describe("component-target-picker", () => {
   });
 
   it("renders a container as a selectable row when a trigger is scoped to its platform", async () => {
-    const el = await mount([
-      {
-        id: "ltr",
-        name: "LTR501",
-        component_id: "sensor.ltr501",
-        is_entity_container: true,
-      },
-      { id: "ltr_als", name: "Ambient", component_id: "sensor", parent_id: "ltr" },
-    ]);
-    el.triggers = [
-      {
-        id: "ltr501.sensor.on_ps_high_threshold",
-        name: "On Ps High",
-        description: "",
-        docs_url: "",
-        applies_to: ["sensor.ltr501"],
-        is_device_level: false,
-        supports_list: false,
-        config_entries: [],
-      },
-    ];
-    await el.updateComplete;
+    const el = await mount(
+      [
+        {
+          id: "ltr",
+          name: "LTR501",
+          component_id: "sensor.ltr501",
+          is_entity_container: true,
+        },
+        { id: "ltr_als", name: "Ambient", component_id: "sensor", parent_id: "ltr" },
+      ],
+      "",
+      false,
+      [
+        {
+          id: "ltr501.sensor.on_ps_high_threshold",
+          name: "On Ps High",
+          description: "",
+          docs_url: "",
+          applies_to: ["sensor.ltr501"],
+          is_device_level: false,
+          supports_list: false,
+          config_entries: [],
+        },
+      ]
+    );
     expect(choiceIds(el)).toEqual(["ltr", "ltr_als"]);
     expect(tabStops(el)).toEqual(["ltr"]);
     const group = el.shadowRoot!.querySelector('[role="group"]')!;

--- a/test/components/device/automation-editor/component-target-picker.test.ts
+++ b/test/components/device/automation-editor/component-target-picker.test.ts
@@ -105,12 +105,42 @@ describe("component-target-picker", () => {
     );
     expect(choiceIds(el)).toEqual(["ltr", "ltr_als"]);
     expect(tabStops(el)).toEqual(["ltr"]);
+    // The container row stands outside the sub-entity group, which keeps
+    // the container's name as its accessible label but shows no heading.
     const group = el.shadowRoot!.querySelector('[role="group"]')!;
-    const headerId = group.getAttribute("aria-labelledby")!;
-    expect(el.shadowRoot!.querySelector(`#${headerId}`)!.getAttribute("role")).toBe(
-      "radio"
-    );
+    expect(group.querySelector('[data-id="ltr"]')).toBeNull();
+    expect(group.querySelector(".component-group")).toBeNull();
+    expect(group.getAttribute("aria-label")).toBe("LTR501");
     expect(pressOn(el, "ltr", "Enter")).toBe("ltr");
+  });
+
+  it("renders a lone platform-scoped container as a plain row with no group", async () => {
+    const el = await mount(
+      [
+        {
+          id: "ltr",
+          name: "LTR501",
+          component_id: "sensor.ltr501",
+          is_entity_container: true,
+        },
+      ],
+      "",
+      false,
+      [
+        {
+          id: "ltr501.sensor.on_ps_high_threshold",
+          name: "On Ps High",
+          description: "",
+          docs_url: "",
+          applies_to: ["sensor.ltr501"],
+          is_device_level: false,
+          supports_list: false,
+          config_entries: [],
+        },
+      ]
+    );
+    expect(choiceIds(el)).toEqual(["ltr"]);
+    expect(el.shadowRoot!.querySelector('[role="group"]')).toBeNull();
   });
 
   it("is a radiogroup of radios", async () => {

--- a/test/components/device/automation-editor/component-target-picker.test.ts
+++ b/test/components/device/automation-editor/component-target-picker.test.ts
@@ -72,6 +72,39 @@ describe("component-target-picker", () => {
     expect(el.shadowRoot!.querySelector(`#${headerId}`)!.textContent).toContain("AHT20");
   });
 
+  it("renders a container as a selectable row when a trigger is scoped to its platform", async () => {
+    const el = await mount([
+      {
+        id: "ltr",
+        name: "LTR501",
+        component_id: "sensor.ltr501",
+        is_entity_container: true,
+      },
+      { id: "ltr_als", name: "Ambient", component_id: "sensor", parent_id: "ltr" },
+    ]);
+    el.triggers = [
+      {
+        id: "ltr501.sensor.on_ps_high_threshold",
+        name: "On Ps High",
+        description: "",
+        docs_url: "",
+        applies_to: ["sensor.ltr501"],
+        is_device_level: false,
+        supports_list: false,
+        config_entries: [],
+      },
+    ];
+    await el.updateComplete;
+    expect(choiceIds(el)).toEqual(["ltr", "ltr_als"]);
+    expect(tabStops(el)).toEqual(["ltr"]);
+    const group = el.shadowRoot!.querySelector('[role="group"]')!;
+    const headerId = group.getAttribute("aria-labelledby")!;
+    expect(el.shadowRoot!.querySelector(`#${headerId}`)!.getAttribute("role")).toBe(
+      "radio"
+    );
+    expect(pressOn(el, "ltr", "Enter")).toBe("ltr");
+  });
+
   it("is a radiogroup of radios", async () => {
     const el = await mount(aht());
     expect(el.shadowRoot!.querySelector('[role="radiogroup"]')).not.toBeNull();

--- a/test/components/device/automation-editor/component-targets.test.ts
+++ b/test/components/device/automation-editor/component-targets.test.ts
@@ -42,18 +42,33 @@ const trigger = (over: Partial<AutomationTrigger> & { id: string }): AutomationT
 
 const onValueRange = trigger({ id: "sensor.on_value_range", applies_to: ["sensor"] });
 const onBoot = trigger({ id: "on_boot", is_device_level: true });
+const ltr = inst({ id: "ltr", component_id: "sensor.ltr501", is_entity_container: true });
+const onPsHigh = trigger({
+  id: "ltr501.sensor.on_ps_high_threshold",
+  applies_to: ["sensor.ltr501"],
+});
 
 describe("component-targets", () => {
-  it("treats only non-containers as selectable", () => {
-    expect(isSelectableTarget(temp)).toBe(true);
-    expect(isSelectableTarget(relay)).toBe(true);
-    expect(isSelectableTarget(container)).toBe(false);
+  it("treats non-containers as selectable and containers only with their own triggers", () => {
+    expect(isSelectableTarget(temp, [onValueRange])).toBe(true);
+    expect(isSelectableTarget(relay, [])).toBe(true);
+    expect(isSelectableTarget(container, [onValueRange])).toBe(false);
+    expect(isSelectableTarget(ltr, [onValueRange])).toBe(false);
+    expect(isSelectableTarget(ltr, [onValueRange, onPsHigh])).toBe(true);
   });
 
-  it("drops containers from the selectable list and the first-selectable lookup", () => {
+  it("drops trigger-less containers from the selectable list and the first-selectable lookup", () => {
     const devices = [container, temp, relay];
-    expect(indexTargets(devices).selectable).toEqual([temp, relay]);
-    expect(firstSelectableTarget(devices)).toBe(temp);
+    expect(indexTargets(devices, [onValueRange]).selectable).toEqual([temp, relay]);
+    expect(firstSelectableTarget(devices, [onValueRange])).toBe(temp);
+    expect(indexTargets([ltr, temp], [onValueRange, onPsHigh]).selectable).toEqual([
+      ltr,
+      temp,
+    ]);
+  });
+
+  it("offers a container only the triggers scoped to its platform", () => {
+    expect(triggersForComponent([onValueRange, onPsHigh], ltr)).toEqual([onPsHigh]);
   });
 
   it("matches component triggers by bare sub-domain", () => {
@@ -66,7 +81,7 @@ describe("component-targets", () => {
     expect(triggersForComponent([onTurnOn], relay)).toEqual([onTurnOn]);
   });
 
-  it("offers nothing for a container or a missing device", () => {
+  it("offers nothing for a trigger-less container or a missing device", () => {
     expect(triggersForComponent([onValueRange], container)).toEqual([]);
     expect(triggersForComponent([onValueRange], undefined)).toEqual([]);
   });
@@ -109,7 +124,7 @@ describe("instance label helpers", () => {
       name: "AHT20",
       is_entity_container: true,
     });
-    const index = indexTargets([named, temp, relay]);
+    const index = indexTargets([named, temp, relay], []);
     expect(index.selectable).toEqual([temp, relay]);
     // Sub-entity → component id · parent label; plain instance → component id only.
     expect(index.context(temp)).toBe("sensor · AHT20");

--- a/test/components/device/automation-editor/component-targets.test.ts
+++ b/test/components/device/automation-editor/component-targets.test.ts
@@ -6,11 +6,11 @@ import type {
 } from "../../../../src/api/types/automations.js";
 import {
   componentDomain,
-  firstSelectableTarget,
+  firstTriggerTarget,
   indexTargets,
   instanceName,
-  isEntityTarget,
-  isSelectableTarget,
+  isActionTarget,
+  isTriggerTarget,
   preFillIdParam,
   triggersForComponent,
 } from "../../../../src/components/device/automation-editor/component-targets.js";
@@ -51,24 +51,23 @@ const onPsHigh = trigger({
 
 describe("component-targets", () => {
   it("treats non-containers as selectable and containers only with their own triggers", () => {
-    expect(isSelectableTarget(temp, [onValueRange])).toBe(true);
-    expect(isSelectableTarget(relay, [])).toBe(true);
-    expect(isSelectableTarget(container, [onValueRange])).toBe(false);
-    expect(isSelectableTarget(ltr, [onValueRange])).toBe(false);
-    expect(isSelectableTarget(ltr, [onValueRange, onPsHigh])).toBe(true);
+    expect(isTriggerTarget(temp, [onValueRange])).toBe(true);
+    expect(isTriggerTarget(relay, [])).toBe(true);
+    expect(isTriggerTarget(container, [onValueRange])).toBe(false);
+    expect(isTriggerTarget(ltr, [onValueRange])).toBe(false);
+    expect(isTriggerTarget(ltr, [onValueRange, onPsHigh])).toBe(true);
   });
 
   it("drops trigger-less containers from the selectable list and the first-selectable lookup", () => {
     const devices = [container, temp, relay];
-    const hosting = (d: AvailableComponentInstance) =>
-      isSelectableTarget(d, [onValueRange]);
+    const hosting = (d: AvailableComponentInstance) => isTriggerTarget(d, [onValueRange]);
     expect(indexTargets(devices, hosting).selectable).toEqual([temp, relay]);
-    expect(firstSelectableTarget(devices, [onValueRange])).toBe(temp);
+    expect(firstTriggerTarget(devices, [onValueRange])).toBe(temp);
     expect(
-      indexTargets([ltr, temp], (d) => isSelectableTarget(d, [onValueRange, onPsHigh]))
+      indexTargets([ltr, temp], (d) => isTriggerTarget(d, [onValueRange, onPsHigh]))
         .selectable
     ).toEqual([ltr, temp]);
-    expect(indexTargets([ltr, temp], isEntityTarget).selectable).toEqual([temp]);
+    expect(indexTargets([ltr, temp], isActionTarget).selectable).toEqual([temp]);
   });
 
   it("offers a container only the triggers scoped to its platform", () => {
@@ -128,7 +127,7 @@ describe("instance label helpers", () => {
       name: "AHT20",
       is_entity_container: true,
     });
-    const index = indexTargets([named, temp, relay], isEntityTarget);
+    const index = indexTargets([named, temp, relay], isActionTarget);
     expect(index.selectable).toEqual([temp, relay]);
     // Sub-entity → component id · parent label; plain instance → component id only.
     expect(index.context(temp)).toBe("sensor · AHT20");

--- a/test/components/device/automation-editor/component-targets.test.ts
+++ b/test/components/device/automation-editor/component-targets.test.ts
@@ -9,6 +9,7 @@ import {
   firstSelectableTarget,
   indexTargets,
   instanceName,
+  isEntityTarget,
   isSelectableTarget,
   preFillIdParam,
   triggersForComponent,
@@ -59,12 +60,15 @@ describe("component-targets", () => {
 
   it("drops trigger-less containers from the selectable list and the first-selectable lookup", () => {
     const devices = [container, temp, relay];
-    expect(indexTargets(devices, [onValueRange]).selectable).toEqual([temp, relay]);
+    const hosting = (d: AvailableComponentInstance) =>
+      isSelectableTarget(d, [onValueRange]);
+    expect(indexTargets(devices, hosting).selectable).toEqual([temp, relay]);
     expect(firstSelectableTarget(devices, [onValueRange])).toBe(temp);
-    expect(indexTargets([ltr, temp], [onValueRange, onPsHigh]).selectable).toEqual([
-      ltr,
-      temp,
-    ]);
+    expect(
+      indexTargets([ltr, temp], (d) => isSelectableTarget(d, [onValueRange, onPsHigh]))
+        .selectable
+    ).toEqual([ltr, temp]);
+    expect(indexTargets([ltr, temp], isEntityTarget).selectable).toEqual([temp]);
   });
 
   it("offers a container only the triggers scoped to its platform", () => {
@@ -124,7 +128,7 @@ describe("instance label helpers", () => {
       name: "AHT20",
       is_entity_container: true,
     });
-    const index = indexTargets([named, temp, relay], []);
+    const index = indexTargets([named, temp, relay], isEntityTarget);
     expect(index.selectable).toEqual([temp, relay]);
     // Sub-entity → component id · parent label; plain instance → component id only.
     expect(index.context(temp)).toBe("sensor · AHT20");

--- a/test/components/device/automation-editor/component-targets.test.ts
+++ b/test/components/device/automation-editor/component-targets.test.ts
@@ -7,7 +7,7 @@ import type {
 import {
   componentDomain,
   firstTriggerTarget,
-  indexTargets,
+  instanceContext,
   instanceName,
   isActionTarget,
   isTriggerTarget,
@@ -61,13 +61,12 @@ describe("component-targets", () => {
   it("drops trigger-less containers from the selectable list and the first-selectable lookup", () => {
     const devices = [container, temp, relay];
     const hosting = (d: AvailableComponentInstance) => isTriggerTarget(d, [onValueRange]);
-    expect(indexTargets(devices, hosting).selectable).toEqual([temp, relay]);
+    expect(devices.filter(hosting)).toEqual([temp, relay]);
     expect(firstTriggerTarget(devices, [onValueRange])).toBe(temp);
     expect(
-      indexTargets([ltr, temp], (d) => isTriggerTarget(d, [onValueRange, onPsHigh]))
-        .selectable
+      [ltr, temp].filter((d) => isTriggerTarget(d, [onValueRange, onPsHigh]))
     ).toEqual([ltr, temp]);
-    expect(indexTargets([ltr, temp], isActionTarget).selectable).toEqual([temp]);
+    expect([ltr, temp].filter(isActionTarget)).toEqual([temp]);
   });
 
   it("offers a container only the triggers scoped to its platform", () => {
@@ -120,22 +119,21 @@ describe("instance label helpers", () => {
     expect(componentDomain("sensor")).toBe("sensor");
   });
 
-  it("indexTargets resolves a sub-entity's container even though selectable drops it", () => {
+  it("instanceContext resolves a sub-entity's container even when a picker drops it", () => {
     const named = inst({
       id: "aht20",
       component_id: "sensor.aht10",
       name: "AHT20",
       is_entity_container: true,
     });
-    const index = indexTargets([named, temp, relay], isActionTarget);
-    expect(index.selectable).toEqual([temp, relay]);
+    const context = instanceContext([named, temp, relay]);
     // Sub-entity → component id · parent label; plain instance → component id only.
-    expect(index.context(temp)).toBe("sensor · AHT20");
-    expect(index.context(relay)).toBe("switch.gpio");
+    expect(context(temp)).toBe("sensor · AHT20");
+    expect(context(relay)).toBe("switch.gpio");
     // A dangling parent_id (parent absent) degrades to the component id.
-    expect(
-      index.context(inst({ id: "o", component_id: "sensor", parent_id: "gone" }))
-    ).toBe("sensor");
+    expect(context(inst({ id: "o", component_id: "sensor", parent_id: "gone" }))).toBe(
+      "sensor"
+    );
   });
 });
 

--- a/test/components/device/automation-editor/trigger-identity.test.ts
+++ b/test/components/device/automation-editor/trigger-identity.test.ts
@@ -87,6 +87,12 @@ describe("catalogTriggerIdFor", () => {
     ).toBe("ltr501.sensor.on_ps_high_threshold");
   });
 
+  it("leaves a domain-level key unresolved on a container", () => {
+    expect(
+      catalogTriggerIdFor(componentOn("on_value_range", "ltr"), [container], triggers)
+    ).toBe("on_value_range");
+  });
+
   it("resolves a sub-entity's trigger to the domain-level id", () => {
     expect(
       catalogTriggerIdFor(


### PR DESCRIPTION
# What does this implement/fix?

Stacked on #1719. A multi-entity container (`sensor.ltr501`, `sensor.ezo`) can host platform-scoped triggers on its own list item (`on_ps_high_threshold`). After #1719 such handlers resolve and open in the editor, but the picker still dropped every container, so they could not be added.

A container is now a target when a trigger is scoped to its qualified id, and it is offered exactly those triggers; the entity triggers keep belonging to its sub-entities. The component target picker renders such a container as a radio row in place of its group heading, ahead of its sub-entities, and the add dialog, the editor's target picker and the container prefill path all read the same rule. The action catalog picker still excludes containers, which are not referenceable entities.

Verified in the browser on an `ltr501` config with two sub-sensors: the add dialog lists the container as a selectable row above its sub-entities, offers it only `on_ps_high_threshold` / `on_ps_low_threshold`, and Continue splices the handler under the platform item and opens it in the editor.

**Related issue or feature (if applicable):**

- follow-up to https://github.com/esphome/device-builder/issues/2668

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
