### PR TITLE
Resolve codeberg:// package_import_url shorthands to a browse link

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -128,10 +128,10 @@ export class ESPHomeAdoptDialog extends LitElement {
       }
 
       /* Anchor variant of the URL block for when the value is a
-         recognised github / gitlab shorthand and we can resolve a
-         clickable browse URL. Same monospace + wrap shape as the
-         plain-text variant; just adds hover affordance and the
-         primary-colour underline so the user can tell it's
+         recognised github / gitlab / codeberg shorthand and we can
+         resolve a clickable browse URL. Same monospace + wrap shape
+         as the plain-text variant; just adds hover affordance and
+         the primary-colour underline so the user can tell it's
          interactive. */
       a.source-info-url {
         color: var(--esphome-primary);

--- a/src/util/package-import-url.ts
+++ b/src/util/package-import-url.ts
@@ -43,9 +43,10 @@ export interface PackageImportUrlPreview {
   /** A browser-friendly URL the user can click, or ``null`` when
    *  the raw URL isn't a recognised shorthand. */
   browseUrl: string | null;
-  /** Service the URL points at, when known. Used for the small
-   *  badge ("GitHub", "GitLab", "Codeberg") next to the URL.
-   *  ``null`` for unrecognised shorthands. */
+  /** Service the URL points at, when known. Intended for a small
+   *  badge ("GitHub", "GitLab", "Codeberg") next to the URL; no
+   *  consumer renders one yet. ``null`` for unrecognised
+   *  shorthands. */
   service: "github" | "gitlab" | "codeberg" | null;
 }
 

--- a/src/util/package-import-url.ts
+++ b/src/util/package-import-url.ts
@@ -8,6 +8,7 @@
  *
  *   * ``github://owner/repo/path/file.yaml[@ref][?query]``
  *   * ``gitlab://owner/repo/path/file.yaml[@ref][?query]``
+ *   * ``codeberg://owner/repo/path/file.yaml[@ref][?query]``
  *
  * (Source: ``esphome/git.py:from_shorthand`` + ``GIT_DOMAINS`` —
  * keep this util's regex in lockstep with upstream.)
@@ -43,9 +44,9 @@ export interface PackageImportUrlPreview {
    *  the raw URL isn't a recognised shorthand. */
   browseUrl: string | null;
   /** Service the URL points at, when known. Used for the small
-   *  badge ("GitHub", "GitLab") next to the URL. ``null`` for
-   *  unrecognised shorthands. */
-  service: "github" | "gitlab" | null;
+   *  badge ("GitHub", "GitLab", "Codeberg") next to the URL.
+   *  ``null`` for unrecognised shorthands. */
+  service: "github" | "gitlab" | "codeberg" | null;
 }
 
 export function previewPackageImportUrl(
@@ -78,6 +79,20 @@ export function previewPackageImportUrl(
       raw,
       browseUrl: `https://gitlab.com/${owner}/${repo}/-/blob/${refSegment}/${filename}`,
       service: "gitlab",
+    };
+  }
+  if (domain === "codeberg") {
+    // Forgejo's browse routes are typed (``src/branch/<ref>``,
+    // ``src/tag/<ref>``, ``src/commit/<sha>``) and the shorthand
+    // doesn't say which kind of ref it carries - ``src/branch/<tag>``
+    // 404s. The untyped ``src/<ref>/<path>`` route makes Forgejo
+    // resolve the ref kind itself and redirect to the typed URL,
+    // and ``src/HEAD/<path>`` redirects to the default branch, so
+    // it also covers the ``HEAD`` fallback when ``@ref`` is omitted.
+    return {
+      raw,
+      browseUrl: `https://codeberg.org/${owner}/${repo}/src/${refSegment}/${filename}`,
+      service: "codeberg",
     };
   }
 

--- a/test/util/package-import-url.test.ts
+++ b/test/util/package-import-url.test.ts
@@ -5,9 +5,9 @@
  * The shorthand grammar mirrors ESPHome's
  * ``git.GitFile.from_shorthand`` (``esphome/git.py:289``). These
  * tests pin both halves: the recognised shapes resolve to a real
- * github.com / gitlab.com ``blob/<ref>/<file>`` URL the browser
- * can open, and unrecognised values fall back to ``browseUrl: null``
- * so the dialog renders them as plain text.
+ * github.com / gitlab.com / codeberg.org ``blob/<ref>/<file>`` URL
+ * the browser can open, and unrecognised values fall back to
+ * ``browseUrl: null`` so the dialog renders them as plain text.
  */
 
 import { describe, expect, it } from "vitest";
@@ -90,6 +90,49 @@ describe("previewPackageImportUrl — gitlab://", () => {
     expect(out.browseUrl).toBe(
       "https://gitlab.com/example-group/example-repo/-/blob/HEAD/configs/device.yaml"
     );
+  });
+});
+
+describe("previewPackageImportUrl - codeberg://", () => {
+  it("resolves a basic shorthand with @ref", () => {
+    // Forgejo's browse routes are typed (``src/branch/<ref>`` vs
+    // ``src/tag/<ref>`` vs ``src/commit/<sha>``) and the shorthand
+    // doesn't say which kind of ref ``@v1.0.0`` is. We use the
+    // untyped ``src/<ref>/<path>`` form instead, which Forgejo
+    // resolves server-side and redirects to the right typed route -
+    // ``src/branch/<tag>`` would 404 for a tag ref.
+    const out = previewPackageImportUrl(
+      "codeberg://example-owner/example-repo/configs/device.yaml@v1.0.0"
+    );
+    expect(out.browseUrl).toBe(
+      "https://codeberg.org/example-owner/example-repo/src/v1.0.0/configs/device.yaml"
+    );
+    expect(out.service).toBe("codeberg");
+    expect(out.raw).toBe(
+      "codeberg://example-owner/example-repo/configs/device.yaml@v1.0.0"
+    );
+  });
+
+  it("falls back to HEAD when @ref is omitted", () => {
+    // Forgejo redirects ``src/HEAD/<path>`` to the repo's default
+    // branch, so ``HEAD`` works as the untyped-route fallback too.
+    const out = previewPackageImportUrl(
+      "codeberg://example-owner/example-repo/configs/device.yaml"
+    );
+    expect(out.browseUrl).toBe(
+      "https://codeberg.org/example-owner/example-repo/src/HEAD/configs/device.yaml"
+    );
+    expect(out.service).toBe("codeberg");
+  });
+
+  it("ignores ?query suffixes (?full_config)", () => {
+    const out = previewPackageImportUrl(
+      "codeberg://example-owner/example-repo/configs/device.yaml@v1.0.0?full_config"
+    );
+    expect(out.browseUrl).toBe(
+      "https://codeberg.org/example-owner/example-repo/src/v1.0.0/configs/device.yaml"
+    );
+    expect(out.service).toBe("codeberg");
   });
 });
 

--- a/test/util/package-import-url.test.ts
+++ b/test/util/package-import-url.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from "vitest";
 
 import { previewPackageImportUrl } from "../../src/util/package-import-url.js";
 
-describe("previewPackageImportUrl — github://", () => {
+describe("previewPackageImportUrl - github://", () => {
   it("resolves a basic shorthand with @ref", () => {
     const out = previewPackageImportUrl(
       "github://athom-tech/athom-configs/athom-rgbct-light.yaml@v1.0.0"
@@ -72,7 +72,7 @@ describe("previewPackageImportUrl — github://", () => {
   });
 });
 
-describe("previewPackageImportUrl — gitlab://", () => {
+describe("previewPackageImportUrl - gitlab://", () => {
   it("resolves a basic shorthand with @ref", () => {
     // GitLab's blob route is ``-/blob/<ref>/<path>`` — note the
     // ``-/`` segment that GitHub doesn't have.
@@ -138,7 +138,7 @@ describe("previewPackageImportUrl - codeberg://", () => {
   });
 });
 
-describe("previewPackageImportUrl — fall-through to plain text", () => {
+describe("previewPackageImportUrl - fall-through to plain text", () => {
   it("returns null browseUrl for empty / null / undefined input", () => {
     expect(previewPackageImportUrl("").browseUrl).toBe(null);
     expect(previewPackageImportUrl(null).browseUrl).toBe(null);

--- a/test/util/package-import-url.test.ts
+++ b/test/util/package-import-url.test.ts
@@ -5,9 +5,11 @@
  * The shorthand grammar mirrors ESPHome's
  * ``git.GitFile.from_shorthand`` (``esphome/git.py:289``). These
  * tests pin both halves: the recognised shapes resolve to a real
- * github.com / gitlab.com / codeberg.org ``blob/<ref>/<file>`` URL
- * the browser can open, and unrecognised values fall back to
- * ``browseUrl: null`` so the dialog renders them as plain text.
+ * github.com / gitlab.com / codeberg.org file-browse URL the browser
+ * can open (``blob/<ref>/<file>`` on GitHub and GitLab,
+ * ``src/<ref>/<file>`` on Codeberg), and unrecognised values fall
+ * back to ``browseUrl: null`` so the dialog renders them as plain
+ * text.
  */
 
 import { describe, expect, it } from "vitest";


### PR DESCRIPTION
# What does this implement/fix?

ESPHome's `esphome/git.py` `GIT_DOMAINS` accepts `github`, `gitlab` and `codeberg`, but `src/util/package-import-url.ts` only resolved the first two, so a device advertising a `codeberg://owner/repo/file.yaml[@ref]` import URL showed up in the Take-Control dialog as plain text with no click target. This adds the missing Codeberg case and widens the `service` union to include `"codeberg"`.

Codeberg (Forgejo) browse routes are typed (`src/branch/<ref>`, `src/tag/<ref>`, `src/commit/<sha>`) and the shorthand does not say which kind of ref it carries. Checked against codeberg.org in a browser: `src/branch/<tag>` returns 404, while the untyped `src/<ref>/<path>` route is resolved server-side and redirected to the correct typed URL, and `src/HEAD/<path>` redirects to the default branch. Since vendor shorthands usually pin a tag, the helper emits the untyped form for both the `@ref` and the `HEAD` fallback cases; the reasoning is documented in a comment next to the branch.

No badge label was added in `adopt-dialog.ts` because nothing currently reads `preview.service`; the dialog only uses `browseUrl` and `raw`. The CSS comment listing recognised shorthands now mentions codeberg. Tests cover the codeberg shorthand with `@ref`, without `@ref`, and with a `?full_config` query; the existing unknown-domain (`bitbucket://`) fallback test is unchanged.

No backend change is needed; the backend already accepts `codeberg://` via upstream ESPHome.

**Related issue or feature (if applicable):**

- fixes N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).