### PR TITLE
Keep the compile running when the install dialog is dismissed

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -17,7 +17,7 @@ import { EnterController } from "../util/enter-controller.js";
 import { fireEvent } from "../util/fire-event.js";
 import { formatApiError } from "../util/format-api-error.js";
 import { markJustCreated } from "../util/just-created.js";
-import { notifyWarning } from "../util/notify.js";
+import { LONG_TOAST_DURATION_MS, notifyWarning } from "../util/notify.js";
 import { previewPackageImportUrl } from "../util/package-import-url.js";
 import { fetchSecretKeys, hasSharedWifiSecret } from "../util/secrets-cache.js";
 import type { AdoptedDetail } from "./dashboard/actions-ui.js";
@@ -565,7 +565,7 @@ export class ESPHomeAdoptDialog extends LitElement {
       if (warning) {
         notifyWarning(this._localize("dashboard.adopt_package_warning"), {
           description: warning,
-          duration: 8000,
+          duration: LONG_TOAST_DURATION_MS,
         });
       }
       const detail: AdoptedDetail = {

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -67,7 +67,7 @@ import {
   themeIsDark,
 } from "../util/dark-mode.js";
 import { isExpert } from "../util/experience.js";
-import { notifyInfo } from "../util/notify.js";
+import { LONG_TOAST_DURATION_MS, notifyInfo } from "../util/notify.js";
 import { isRecentSerialActivity, markSerialActivity } from "../util/web-serial.js";
 import { onLoginSubmit } from "./app-shell/auth.js";
 import {
@@ -402,7 +402,7 @@ export class ESPHomeApp extends LitElement {
       // toast instead of stacking — defence in depth on top of the
       // time-window suppression above.
       id: "esphome-usb-device-connected",
-      duration: 8000,
+      duration: LONG_TOAST_DURATION_MS,
       action: {
         label: this._localize("layout.usb_device_setup"),
         onClick: () => {
@@ -637,6 +637,8 @@ export class ESPHomeApp extends LitElement {
       ></esphome-settings-dialog>
       <esphome-firmware-jobs-dialog
         @firmware-history-cleared=${() => onFirmwareHistoryCleared(this)}
+        @open-settings=${(e: CustomEvent<{ section?: Section } | undefined>) =>
+          this._settingsDialog?.open(e.detail?.section)}
       ></esphome-firmware-jobs-dialog>
       <esphome-feedback-dialog></esphome-feedback-dialog>
       <esphome-troubleshoot-dialog></esphome-troubleshoot-dialog>

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -2,6 +2,7 @@ import { consume } from "@lit/context";
 import {
   mdiClose,
   mdiDownload,
+  mdiFileDownloadOutline,
   mdiKey,
   mdiKeyOutline,
   mdiPlaylistCheck,
@@ -88,6 +89,7 @@ registerMdiIcons({
   close: mdiClose,
   "text-box-outline": mdiTextBoxOutline,
   download: mdiDownload,
+  "file-download-outline": mdiFileDownloadOutline,
   key: mdiKey,
   "key-outline": mdiKeyOutline,
   stop: mdiStop,
@@ -467,6 +469,20 @@ export class ESPHomeCommandDialog extends LitElement {
     this.close();
     if (!configuration) return;
     fireEvent(this, "request-open-editor", { configuration });
+  };
+
+  // The device behind this dialog's configuration; undefined for a build
+  // whose YAML isn't on this dashboard (a receiver-side job).
+  get _localDevice(): ConfiguredDevice | undefined {
+    return this._devices.find((d) => d.configuration === this.configuration);
+  }
+
+  // Hand the finished build to the host's download flow (the three-dot
+  // Download path), which compiles only when nothing is built.
+  _requestDownloadFirmware = () => {
+    const device = this._localDevice;
+    this.close();
+    if (device) fireEvent(this, "request-download-firmware", device);
   };
 
   // Per-device clean: same dialog instance, same configuration. Non-

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -282,9 +282,8 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
         // A never-flashed device can't come online by itself, so
         // "installs when it comes back online" would be a dead promise
         // — point at the USB first-install instead.
-        const device = host._devices.find((d) => d.configuration === host.configuration);
         host._statusMessage = host._localize(
-          isNeverFlashed(device)
+          isNeverFlashed(host._localDevice)
             ? "dashboard.queued_first_install"
             : "dashboard.queued_successfully"
         );

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -8,7 +8,7 @@ import {
   jobBuildServerDisplay,
   pairingDisplayNameForPin,
 } from "../../util/pairing-display-name.js";
-import type { ESPHomeCommandDialog } from "../command-dialog.js";
+import type { CommandType, ESPHomeCommandDialog } from "../command-dialog.js";
 import {
   renderOffloadHint,
   shouldShowOffloadHint,
@@ -359,10 +359,18 @@ export function renderToolbar(host: ESPHomeCommandDialog): TemplateResult {
   `;
 }
 
+// Command types whose success leaves downloadable build artifacts.
+const COMPILE_COMMANDS: ReadonlySet<CommandType> = new Set([
+  "compile",
+  "offline_compile",
+]);
+
 // Retry only makes sense for command types _start knows how to re-run.
 // RENAME jobs come in via followJob — the user originally launched from the
 // rename dialog; surfacing Retry would no-op.
-function renderActions(host: ESPHomeCommandDialog): TemplateResult | typeof nothing {
+export function renderActions(
+  host: ESPHomeCommandDialog
+): TemplateResult | typeof nothing {
   const close = renderTermButton({
     label: host._localize("command.close"),
     onClick: host.close,
@@ -386,17 +394,25 @@ function renderActions(host: ESPHomeCommandDialog): TemplateResult | typeof noth
             onClick: () => void host._start(),
           })}
           ${close}`;
-    case "success":
+    case "success": {
       // Show-logs is a ghost (not term-btn--start) so it doesn't look like
       // the toolbar toggle "stayed on".
-      return host._commandType === "install"
-        ? html`${renderTermButton({
-            icon: "text-box-outline",
-            label: host._localize("command.show_logs"),
-            onClick: host._flipToLogs,
-          })}
-          ${close}`
-        : close;
+      const extra =
+        host._commandType === "install"
+          ? renderTermButton({
+              icon: "text-box-outline",
+              label: host._localize("command.show_logs"),
+              onClick: host._flipToLogs,
+            })
+          : COMPILE_COMMANDS.has(host._commandType) && host._localDevice
+            ? renderTermButton({
+                icon: "file-download-outline",
+                label: host._localize("command.download_firmware"),
+                onClick: host._requestDownloadFirmware,
+              })
+            : nothing;
+      return html`${extra} ${close}`;
+    }
     default:
       return nothing;
   }

--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -7,7 +7,12 @@ import { fetchBoard } from "../../util/board-body-cache.js";
 import { downloadBlob } from "../../util/download-text.js";
 import { getErrorMessage } from "../../util/error-message.js";
 import { navigate } from "../../util/navigation.js";
-import { notifyError, type NotifyOptions, notifySuccess } from "../../util/notify.js";
+import {
+  LONG_TOAST_DURATION_MS,
+  notifyError,
+  type NotifyOptions,
+  notifySuccess,
+} from "../../util/notify.js";
 import { streamSerialLines } from "../../util/serial-log-stream.js";
 import {
   connectToPort,
@@ -76,7 +81,7 @@ export async function archiveDevice(
      support thread. */
   notifySuccess(localize("dashboard.action_archive_success", { name }), {
     description: localize("dashboard.action_archive_success_hint"),
-    duration: 8000,
+    duration: LONG_TOAST_DURATION_MS,
   });
   return true;
 }
@@ -247,7 +252,7 @@ export async function archiveBulkDevices(
       failureKey: "dashboard.action_archive_failed",
       successOptions: {
         description: localize("dashboard.action_archive_success_hint"),
-        duration: 8000,
+        duration: LONG_TOAST_DURATION_MS,
       },
     }
   );

--- a/src/components/dashboard/render-dialogs.ts
+++ b/src/components/dashboard/render-dialogs.ts
@@ -246,6 +246,7 @@ export function renderDialogs(host: ESPHomePageDashboard): TemplateResult {
     <esphome-command-dialog
       @request-show-logs-after-install=${host._onPostInstallShowLogs}
       @request-open-editor=${host._onRequestOpenEditor}
+      @request-download-firmware=${host._onRequestDownloadFirmware}
     ></esphome-command-dialog>
     <esphome-firmware-install-dialog
       @request-show-logs-after-install=${host._onPostInstallShowLogs}

--- a/src/components/dashboard/render-stacks.ts
+++ b/src/components/dashboard/render-stacks.ts
@@ -15,6 +15,7 @@ export function renderRemoteStack(host: ESPHomePageDashboard): TemplateResult {
       .collapsed=${host._stacks.remoteCollapsed}
       .solo=${host._stacks.builderHidden}
       @toggle-collapsed=${host._stacks.swap}
+      @request-download-firmware=${host._onRequestDownloadFirmware}
     ></esphome-remote-build-panel>
   `;
 }

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -31,7 +31,9 @@ import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { initialDarkMode } from "../util/dark-mode.js";
 import { fireEvent } from "../util/fire-event.js";
+import { cancelFirmwareJob } from "../util/firmware-job-actions.js";
 import { LogBuffer } from "../util/log-buffer.js";
+import { LONG_TOAST_DURATION_MS, notifyInfo } from "../util/notify.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { RunTimerController } from "../util/run-timer-controller.js";
 import type { DetectedChip } from "../util/web-serial.js";
@@ -305,10 +307,9 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
 
   // Tear down active follow_job: client-side (drop local handler) and
   // backend-side (stop pushing lines). Settles a pending _compileAndWait so
-  // the parent flow doesn't hang. Cancels the underlying job so the backend
-  // stops working for a dismissed dialog, unless ``cancelJob: false`` —
-  // then the job is released to finish in the background queue.
-  _detachStream({ cancelJob = true }: { cancelJob?: boolean } = {}) {
+  // the parent flow doesn't hang. Pure teardown: the job itself keeps
+  // running in the background queue; only Stop (_cancel) cancels it.
+  _detachStream() {
     // Land any buffered lines before teardown so nothing streamed is lost.
     this._log.flush();
     // Tear down an in-flight USB-flasher hand-off (message listener + timers)
@@ -327,10 +328,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
       this._compileReject = null;
       reject(new Error("Install dialog dismissed"));
     }
-    if (this._jobId) {
-      if (cancelJob) this._api.firmwareCancel(this._jobId).catch(() => {});
-      this._jobId = "";
-    }
+    this._jobId = "";
   }
 
   protected willUpdate(changedProperties: Map<string, unknown>) {
@@ -343,13 +341,30 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   }
 
   // Close the dialog and open Settings → Send builds. The install flow ends
-  // (the flash needs this dialog), but the compile itself is released to
-  // finish in the background queue, so its artifacts warm the next install.
+  // (the flash needs this dialog), but the compile itself finishes in the
+  // background queue, so its artifacts warm the next install.
   _tryOpenBuildOffloadSettings = () => {
-    this._detachStream({ cancelJob: false });
+    this._releaseJobToBackground();
     this._close();
     fireEvent(this, "open-settings", { section: "build_offload" });
   };
+
+  // Detach from a compile the dialog still owns and say where it went.
+  // Not folded into _detachStream: _init calls that on every reopen.
+  _releaseJobToBackground() {
+    const compiling = this._step === "queued" || this._step === "compiling";
+    if (this._jobId && compiling) {
+      notifyInfo(this._localize("firmware.compile_continues_background"), {
+        id: "esphome-compile-continues-background",
+        duration: LONG_TOAST_DURATION_MS,
+        action: {
+          label: this._localize("firmware_jobs.menu_item"),
+          onClick: () => fireEvent(this, "open-firmware-jobs"),
+        },
+      });
+    }
+    this._detachStream();
+  }
 
   // Drop into red error state. detail is optional — render skips it entirely
   // when empty so a single-string call doesn't paint the same text twice.
@@ -442,21 +457,19 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   };
 
   _cancel = async () => {
-    if (this._jobId) {
-      try {
-        await this._api.firmwareCancel(this._jobId);
-      } catch {
-        /* ignore */
-      }
-    }
+    // Stop owns the job from here: a dismissal racing the round-trip must
+    // not announce a build that is being cancelled.
+    const jobId = this._jobId;
+    this._jobId = "";
+    if (jobId) await cancelFirmwareJob(this._api, this._localize, jobId);
     this._close();
   };
 
   _close = () => {
     this._open = false;
     this._device = null;
-    // _detachStream already clears _jobId (and cancels the backend job +
-    // settles any pending compile promise) — no need to clear it here.
+    // _detachStream already clears _jobId and settles any pending compile
+    // promise — no need to clear it here.
     this._detachStream();
     fireEvent(this, "close");
   };
@@ -472,10 +485,11 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   // base-dialog's after-hide fires once the dialog has fully hidden (header X,
   // Escape, or a programmatic close). Same stream teardown as _close —
   // otherwise a header-X-then-reopen leaves the prior followJob attached and
-  // lines duplicate into the new session.
+  // lines duplicate into the new session. A compile still attached here was
+  // dismissed mid-build (a programmatic close already detached).
   _onClose = () => {
     this._open = false;
-    this._detachStream();
+    this._releaseJobToBackground();
   };
 
   protected render() {

--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -39,6 +39,7 @@ import { getErrorMessage } from "../util/error-message.js";
 import { fireEvent } from "../util/fire-event.js";
 import { cancelFirmwareJob } from "../util/firmware-job-actions.js";
 import { firmwareJobDisplayName } from "../util/firmware-job-display.js";
+import { navigate } from "../util/navigation.js";
 import { notifyError } from "../util/notify.js";
 import { NowTickController } from "../util/now-tick-controller.js";
 import { pairingDisplayName } from "../util/pairing-display-name.js";
@@ -49,10 +50,13 @@ import { registerMdiIcons } from "../util/register-icons.js";
 import "./confirm-dialog.js";
 import type { ESPHomeCommandDialog } from "./command-dialog.js";
 import type { ESPHomeConfirmDialog } from "./confirm-dialog.js";
+import type { ESPHomeFirmwareInstallDialog } from "./firmware-install-dialog.js";
 import { firmwareJobsDialogStyles } from "./firmware-jobs-dialog/styles.js";
 import type { ESPHomeLogsDialog } from "./logs-dialog.js";
 import { canResetBuildEnv } from "./remote-build-hint.js";
+import type { Section } from "./settings-dialog/types.js";
 import { firmwareJobsListStyles } from "./shared/firmware-jobs-list-styles.js";
+import "./firmware-install-dialog.js";
 import "./logs-dialog.js";
 import { bucketJobs, renderEmpty, renderGroups } from "./shared/firmware-jobs-list.js";
 
@@ -96,6 +100,12 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
   // Logs dialog for the post-install hand-off when reattaching from this
   // surface. Without one, request-show-logs-after-install would no-op. (#139)
   @query("esphome-logs-dialog") private _logsDialog!: ESPHomeLogsDialog;
+  // Download flow for a finished compile reviewed from this list. Mounted
+  // on first use, since most sessions never open it from here and it
+  // re-renders on every job progress tick once mounted.
+  @query("esphome-firmware-install-dialog")
+  private _firmwareInstallDialog?: ESPHomeFirmwareInstallDialog;
+  @state() private _installDialogMounted = false;
   @query("#reset-local-confirm") private _confirmDialog!: ESPHomeConfirmDialog;
   @query("#reset-peer-confirm") private _resetPeerConfirmDialog!: ESPHomeConfirmDialog;
 
@@ -159,6 +169,32 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
     this.openResetPeerBuildEnv(e.detail.pin_sha256);
   };
 
+  private _onRequestDownloadFirmware = async (e: CustomEvent<ConfiguredDevice>) => {
+    e.stopPropagation();
+    this._installDialogMounted = true;
+    await this.updateComplete;
+    this._firmwareInstallDialog?.downloadArtifacts(e.detail);
+  };
+
+  private _onRequestOpenEditor = (e: CustomEvent<{ configuration: string }>) => {
+    e.stopPropagation();
+    this.close();
+    void navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
+  };
+
+  // The nested dialogs' open-settings would bubble past app-shell's
+  // layout listener (this dialog is a layout sibling); re-fire from here.
+  private _onOpenSettings = (e: CustomEvent<{ section?: Section } | undefined>) => {
+    e.stopPropagation();
+    this.close();
+    fireEvent(this, "open-settings", { section: e.detail?.section });
+  };
+
+  private _onOpenFirmwareJobs = (e: Event) => {
+    e.stopPropagation();
+    this.open();
+  };
+
   static styles = [
     espHomeStyles,
     primaryDialogHeaderStyles,
@@ -215,8 +251,24 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
       <esphome-command-dialog
         @open-reset-build-env=${this._onLocalResetEvent}
         @open-reset-peer-build-env=${this._onRemoteResetEvent}
+        @open-settings=${this._onOpenSettings}
+        @request-open-editor=${this._onRequestOpenEditor}
         @request-show-logs-after-install=${this._onPostInstallShowLogs}
+        @request-download-firmware=${this._onRequestDownloadFirmware}
       ></esphome-command-dialog>
+      ${
+        this._installDialogMounted
+          ? html`<esphome-firmware-install-dialog
+              @open-reset-build-env=${this._onLocalResetEvent}
+              @open-reset-peer-build-env=${this._onRemoteResetEvent}
+              @open-settings=${this._onOpenSettings}
+              @open-firmware-jobs=${this._onOpenFirmwareJobs}
+              @request-open-editor=${this._onRequestOpenEditor}
+              @clean-build=${(e: CustomEvent<ConfiguredDevice>) =>
+                this._commandDialog.openForDevice(e.detail, "clean")}
+            ></esphome-firmware-install-dialog>`
+          : nothing
+      }
       <esphome-logs-dialog></esphome-logs-dialog>
       <esphome-confirm-dialog
         id="reset-local-confirm"

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -17,7 +17,7 @@ import { buildFeaturedId } from "../../util/featured-id.js";
 import { featuredComponentName, fullSetupComponentIds } from "../../util/full-setup.js";
 import { markJustCreated } from "../../util/just-created.js";
 import { navigate } from "../../util/navigation.js";
-import { notifyWarning } from "../../util/notify.js";
+import { LONG_TOAST_DURATION_MS, notifyWarning } from "../../util/notify.js";
 import { markPendingHighlight } from "../../util/pending-highlight.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import {
@@ -596,7 +596,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
       if (warning) {
         notifyWarning(this._localize("dashboard.create_package_warning"), {
           description: warning,
-          duration: 8000,
+          duration: LONG_TOAST_DURATION_MS,
         });
       }
     } catch (err) {

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -976,6 +976,8 @@ export class ESPHomePageDashboard extends LitElement {
   };
   _downloadFirmware = (device: ConfiguredDevice) =>
     this._firmwareDialog.downloadArtifacts(device);
+  _onRequestDownloadFirmware = (e: CustomEvent<ConfiguredDevice>) =>
+    this._downloadFirmware(e.detail);
 
   _toggleDrawerForDevice(device: ConfiguredDevice) {
     if (this._drawerOpen && this._drawerDevice?.configuration === device.configuration) {

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1298,6 +1298,9 @@ export class ESPHomePageDevice extends LitElement {
     void navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
   };
 
+  private _onRequestDownloadFirmware = (e: CustomEvent<ConfiguredDevice>) =>
+    this._firmwareDialog.downloadArtifacts(e.detail);
+
   static styles = [espHomeStyles, loadMessageStyles, devicePageStyles];
 
   protected render() {
@@ -1378,6 +1381,7 @@ export class ESPHomePageDevice extends LitElement {
         <esphome-command-dialog
           @request-show-logs-after-install=${this._onPostInstallShowLogs}
           @request-open-editor=${this._onRequestOpenEditor}
+          @request-download-firmware=${this._onRequestDownloadFirmware}
         ></esphome-command-dialog>
         <esphome-firmware-install-dialog
           @request-show-logs-after-install=${this._onPostInstallShowLogs}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -418,6 +418,7 @@
     "retry": "Retry",
     "close": "Close",
     "download": "Download output",
+    "download_firmware": "Download firmware",
     "done": "Done",
     "failed": "Failed",
     "stopped": "Stopped by user.",
@@ -473,6 +474,7 @@
   "firmware": {
     "install_title": "Install — {name}",
     "download_title": "Download — {name}",
+    "compile_continues_background": "The build keeps running in the background. Find it under Firmware tasks.",
     "download_type_factory": "Factory image",
     "download_type_factory_desc": "Full image for ESPHome Web and other flashing tools.",
     "download_type_ota": "OTA update",

--- a/src/util/notify.ts
+++ b/src/util/notify.ts
@@ -6,6 +6,10 @@ import toast from "sonner-js";
 // directly instead of reaching through a wrapper's signature.
 export type NotifyOptions = NonNullable<Parameters<typeof toast.error>[1]>;
 
+// For toasts carrying a description or an action; sonner's default is
+// too short to read a sentence and click.
+export const LONG_TOAST_DURATION_MS = 8000;
+
 /**
  * Thin wrappers over sonner's toast helpers that default
  * `richColors: true`, the house style for every user-readable

--- a/test/components/_command-dialog-host.ts
+++ b/test/components/_command-dialog-host.ts
@@ -74,6 +74,11 @@ export function makeCommandDialogHost(
     configuration: "kitchen.yaml",
     name: "kitchen",
     _devices: [] as ConfiguredDevice[],
+    get _localDevice(): ConfiguredDevice | undefined {
+      return this._devices.find(
+        (d: ConfiguredDevice) => d.configuration === this.configuration
+      );
+    },
     _port: "OTA",
     _log: fakeLogBuffer(),
     _showLogsAfterInstall: true,

--- a/test/components/adopt-dialog.test.ts
+++ b/test/components/adopt-dialog.test.ts
@@ -9,6 +9,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/util/notify.js", () => ({
+  LONG_TOAST_DURATION_MS: 8000,
   notifyWarning: vi.fn(),
 }));
 

--- a/test/components/command-dialog-compile-download.test.ts
+++ b/test/components/command-dialog-compile-download.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * A finished compile (plain or deferred-install) for a device on this
+ * dashboard offers Download firmware beside Close; install success, the
+ * error state, and a build for a configuration this dashboard doesn't
+ * know do not. The button hands the resolved device off through
+ * request-download-firmware so the host's download flow lists the
+ * artifacts without recompiling.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import "../_mock-webawesome.js";
+import { identityLocalize } from "../_dom.js";
+import { visitTemplates } from "../_lit-template-walker.js";
+import type { ConfiguredDevice } from "../../src/api/types/devices.js";
+import { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
+import { renderActions } from "../../src/components/command-dialog/renderers.js";
+
+const DEVICE = { configuration: "kitchen.yaml", name: "kitchen" } as ConfiguredDevice;
+
+function renderFor(commandType: string, state: string, localDevice?: ConfiguredDevice) {
+  const host = {
+    _commandType: commandType,
+    _state: state,
+    _localDevice: localDevice,
+    _localize: identityLocalize,
+    close: vi.fn(),
+    _flipToLogs: vi.fn(),
+    _requestDownloadFirmware: vi.fn(),
+  };
+  const values: unknown[] = [];
+  visitTemplates(renderActions(host as unknown as ESPHomeCommandDialog), (t) =>
+    values.push(...t.values)
+  );
+  return { host, values };
+}
+
+describe("command-dialog compile download action", () => {
+  it.each(["compile", "offline_compile"])(
+    "offers Download firmware and Close after a successful %s",
+    (type) => {
+      const { host, values } = renderFor(type, "success", DEVICE);
+      expect(values).toContain(host._requestDownloadFirmware);
+      expect(values).toContain(host.close);
+    }
+  );
+
+  it.each([
+    ["install", "success", DEVICE],
+    ["compile", "error", DEVICE],
+    ["validate", "success", DEVICE],
+    ["compile", "success", undefined],
+  ])("does not offer it for %s in the %s state (device %o)", (type, state, device) => {
+    const { host, values } = renderFor(type, state, device);
+    expect(values).not.toContain(host._requestDownloadFirmware);
+  });
+
+  it("_requestDownloadFirmware closes and fires the resolved device", () => {
+    const dialog = new ESPHomeCommandDialog();
+    dialog.configuration = "kitchen.yaml";
+    dialog._devices = [DEVICE];
+    const close = vi.spyOn(dialog, "close").mockImplementation(() => {});
+    const seen: unknown[] = [];
+    dialog.addEventListener("request-download-firmware", (e) =>
+      seen.push((e as CustomEvent).detail)
+    );
+    dialog._requestDownloadFirmware();
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(seen).toEqual([DEVICE]);
+  });
+
+  it("_requestDownloadFirmware fires nothing for an unknown configuration", () => {
+    const dialog = new ESPHomeCommandDialog();
+    dialog.configuration = "peer-only.yaml";
+    dialog._devices = [DEVICE];
+    vi.spyOn(dialog, "close").mockImplementation(() => {});
+    const seen: unknown[] = [];
+    dialog.addEventListener("request-download-firmware", (e) =>
+      seen.push((e as CustomEvent).detail)
+    );
+    dialog._requestDownloadFirmware();
+    expect(seen).toEqual([]);
+  });
+});

--- a/test/components/firmware-install-dialog/dismiss-release.test.ts
+++ b/test/components/firmware-install-dialog/dismiss-release.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the dismiss semantics: X / Escape / backdrop (after-hide, _onClose)
+ * and the offload hand-off leave the compile running in the background
+ * queue and say so, a programmatic _close never cancels, and the footer
+ * Stop (_cancel) is the only path that cancels.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import "../../_mock-webawesome.js";
+vi.mock("../../../src/util/web-serial.js", () => ({
+  connectToPort: vi.fn(),
+  detectChip: vi.fn(),
+  disconnect: vi.fn(),
+  flashFirmware: vi.fn(),
+  resetAndDisconnect: vi.fn(),
+  SERIAL_ACTIVITY_WINDOW_MS: 6000,
+}));
+const { notifyInfo, notifyError } = vi.hoisted(() => ({
+  notifyInfo: vi.fn(),
+  notifyError: vi.fn(),
+}));
+vi.mock("../../../src/util/notify.js", () => ({
+  LONG_TOAST_DURATION_MS: 8000,
+  notifyInfo,
+  notifyError,
+  notify: { error: notifyError },
+}));
+
+import { deferred, identityLocalize } from "../../_dom.js";
+import { ESPHomeFirmwareInstallDialog } from "../../../src/components/firmware-install-dialog.js";
+
+const TOAST_KEY = "firmware.compile_continues_background";
+
+function makeDialog() {
+  const api = {
+    firmwareCancel: vi.fn().mockResolvedValue(undefined),
+    stopStream: vi.fn().mockResolvedValue(undefined),
+  };
+  const dialog = new ESPHomeFirmwareInstallDialog();
+  const reject = vi.fn();
+  Object.assign(dialog, {
+    _localize: identityLocalize,
+    _api: api,
+    _step: "compiling",
+    _jobId: "j1",
+    _streamId: "s1",
+    _compileReject: reject,
+  });
+  return { dialog, api, reject };
+}
+
+describe("install-dialog dismissal", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("_onClose keeps the compile running and offers Firmware tasks", () => {
+    const { dialog, api, reject } = makeDialog();
+    dialog._onClose();
+    expect(api.firmwareCancel).not.toHaveBeenCalled();
+    expect(api.stopStream).toHaveBeenCalledWith("s1");
+    expect(dialog._jobId).toBe("");
+    expect(reject).toHaveBeenCalledTimes(1);
+    expect(notifyInfo).toHaveBeenCalledWith(
+      TOAST_KEY,
+      expect.objectContaining({ id: expect.any(String), action: expect.any(Object) })
+    );
+    const opened = vi.fn();
+    dialog.addEventListener("open-firmware-jobs", opened);
+    notifyInfo.mock.calls[0][1].action.onClick();
+    expect(opened).toHaveBeenCalledTimes(1);
+  });
+
+  it("_onClose without an attached compile stays silent", () => {
+    const { dialog, api } = makeDialog();
+    dialog._jobId = "";
+    dialog._onClose();
+    expect(api.firmwareCancel).not.toHaveBeenCalled();
+    expect(notifyInfo).not.toHaveBeenCalled();
+  });
+
+  it("_onClose past the compile steps stays silent", () => {
+    const { dialog } = makeDialog();
+    dialog._step = "download-ready";
+    dialog._onClose();
+    expect(notifyInfo).not.toHaveBeenCalled();
+  });
+
+  it("_close never cancels", () => {
+    const { dialog, api } = makeDialog();
+    dialog._close();
+    expect(api.firmwareCancel).not.toHaveBeenCalled();
+    expect(dialog._jobId).toBe("");
+  });
+
+  it("the offload hand-off releases the compile with the same toast", () => {
+    const { dialog, api } = makeDialog();
+    dialog._tryOpenBuildOffloadSettings();
+    expect(api.firmwareCancel).not.toHaveBeenCalled();
+    expect(notifyInfo).toHaveBeenCalledTimes(1);
+    expect(notifyInfo.mock.calls[0][0]).toBe(TOAST_KEY);
+  });
+
+  it("Stop cancels the compile exactly once", async () => {
+    const { dialog, api } = makeDialog();
+    await dialog._cancel();
+    expect(api.firmwareCancel).toHaveBeenCalledTimes(1);
+    expect(api.firmwareCancel).toHaveBeenCalledWith("j1");
+    expect(dialog._jobId).toBe("");
+    expect(notifyInfo).not.toHaveBeenCalled();
+  });
+
+  it("a failed Stop tells the user instead of closing quietly", async () => {
+    const { dialog, api } = makeDialog();
+    api.firmwareCancel.mockRejectedValue(new Error("boom"));
+    await dialog._cancel();
+    expect(notifyError).toHaveBeenCalledTimes(1);
+  });
+
+  it("a dismissal racing Stop's round-trip stays silent", async () => {
+    const { dialog, api } = makeDialog();
+    const cancel = deferred<void>();
+    api.firmwareCancel.mockReturnValue(cancel.promise);
+    const stopped = dialog._cancel();
+    dialog._onClose();
+    expect(notifyInfo).not.toHaveBeenCalled();
+    cancel.resolve();
+    await stopped;
+    expect(api.firmwareCancel).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Closing the install dialog with X, Escape, or the backdrop cancelled the running compile, the same as pressing Stop. Now a dismissal releases the compile to the background queue and shows a toast pointing at Firmware tasks; only Stop cancels. The command dialog also offers a Download firmware button once a compile finishes, so a build that finished in the background, or one retried from Firmware tasks, still hands over the binary. The button reuses the three-dot Download flow, which compiles only when nothing is built.

Verified in the browser against a local backend: dismiss mid-compile leaves the job running to completion, Stop still cancels it, and both the background build and the retried build offer Download firmware from Firmware tasks.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2677

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

