### PR TITLE
Render the Firmware tasks dialog inside the layout

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -596,6 +596,11 @@ export class ESPHomeApp extends LitElement {
         @open-guided-tour=${this._onOpenGuidedTour}
       >
         ${this._router.outlet()}
+        <!-- Inside the layout on purpose: its nested command and install
+             dialogs fire open-* events the layout listeners above handle. -->
+        <esphome-firmware-jobs-dialog
+          @firmware-history-cleared=${() => onFirmwareHistoryCleared(this)}
+        ></esphome-firmware-jobs-dialog>
       </esphome-layout>
       <esphome-command-palette
         @set-theme=${(e: CustomEvent<string>) => onSetTheme(this, e)}
@@ -635,11 +640,6 @@ export class ESPHomeApp extends LitElement {
         @pair-request-sent=${(e: CustomEvent<{ summary: PairingSummary }>) =>
           onPairRequestSent(this, e)}
       ></esphome-settings-dialog>
-      <esphome-firmware-jobs-dialog
-        @firmware-history-cleared=${() => onFirmwareHistoryCleared(this)}
-        @open-settings=${(e: CustomEvent<{ section?: Section } | undefined>) =>
-          this._settingsDialog?.open(e.detail?.section)}
-      ></esphome-firmware-jobs-dialog>
       <esphome-feedback-dialog></esphome-feedback-dialog>
       <esphome-troubleshoot-dialog></esphome-troubleshoot-dialog>
       <esphome-onboarding-wifi-dialog></esphome-onboarding-wifi-dialog>

--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -54,7 +54,6 @@ import type { ESPHomeFirmwareInstallDialog } from "./firmware-install-dialog.js"
 import { firmwareJobsDialogStyles } from "./firmware-jobs-dialog/styles.js";
 import type { ESPHomeLogsDialog } from "./logs-dialog.js";
 import { canResetBuildEnv } from "./remote-build-hint.js";
-import type { Section } from "./settings-dialog/types.js";
 import { firmwareJobsListStyles } from "./shared/firmware-jobs-list-styles.js";
 import "./firmware-install-dialog.js";
 import "./logs-dialog.js";
@@ -155,20 +154,6 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
     this._resetPeerConfirmDialog.open();
   }
 
-  // Catch open-reset-build-env from the inner command-dialog so the
-  // post-failure hint works when reviewing a past failed install from this
-  // list. The app-shell listener sits on esphome-layout, but this dialog is
-  // a sibling of that layout — without local handling the event bubbles past.
-  private _onLocalResetEvent = (e: Event) => {
-    e.stopPropagation();
-    this.openResetBuildEnv();
-  };
-
-  private _onRemoteResetEvent = (e: CustomEvent<{ pin_sha256: string }>) => {
-    e.stopPropagation();
-    this.openResetPeerBuildEnv(e.detail.pin_sha256);
-  };
-
   private _onRequestDownloadFirmware = async (e: CustomEvent<ConfiguredDevice>) => {
     e.stopPropagation();
     this._installDialogMounted = true;
@@ -182,18 +167,11 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
     void navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
   };
 
-  // The nested dialogs' open-settings would bubble past app-shell's
-  // layout listener (this dialog is a layout sibling); re-fire from here.
-  private _onOpenSettings = (e: CustomEvent<{ section?: Section } | undefined>) => {
-    e.stopPropagation();
-    this.close();
-    fireEvent(this, "open-settings", { section: e.detail?.section });
-  };
+  private _onCleanBuild = (e: CustomEvent<ConfiguredDevice>) =>
+    this._commandDialog.openForDevice(e.detail, "clean");
 
-  private _onOpenFirmwareJobs = (e: Event) => {
-    e.stopPropagation();
-    this.open();
-  };
+  // Step aside for Settings; the event keeps bubbling to the layout listener.
+  private _onOpenSettings = () => this.close();
 
   static styles = [
     espHomeStyles,
@@ -249,8 +227,6 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
         ${hasJobs ? renderGroups(this, active, terminal) : renderEmpty(this._localize)}
       </esphome-base-dialog>
       <esphome-command-dialog
-        @open-reset-build-env=${this._onLocalResetEvent}
-        @open-reset-peer-build-env=${this._onRemoteResetEvent}
         @open-settings=${this._onOpenSettings}
         @request-open-editor=${this._onRequestOpenEditor}
         @request-show-logs-after-install=${this._onPostInstallShowLogs}
@@ -259,13 +235,9 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
       ${
         this._installDialogMounted
           ? html`<esphome-firmware-install-dialog
-              @open-reset-build-env=${this._onLocalResetEvent}
-              @open-reset-peer-build-env=${this._onRemoteResetEvent}
               @open-settings=${this._onOpenSettings}
-              @open-firmware-jobs=${this._onOpenFirmwareJobs}
               @request-open-editor=${this._onRequestOpenEditor}
-              @clean-build=${(e: CustomEvent<ConfiguredDevice>) =>
-                this._commandDialog.openForDevice(e.detail, "clean")}
+              @clean-build=${this._onCleanBuild}
             ></esphome-firmware-install-dialog>`
           : nothing
       }

--- a/src/components/firmware-jobs-dialog/styles.ts
+++ b/src/components/firmware-jobs-dialog/styles.ts
@@ -1,6 +1,11 @@
 import { css } from "lit";
 
 export const firmwareJobsDialogStyles = css`
+  :host {
+    /* Contribute no box to the layout slot's flow (see base-dialog). */
+    display: contents;
+  }
+
   esphome-base-dialog {
     --width: min(620px, 95vw);
   }

--- a/test/components/firmware-jobs-dialog-event-bubbling.test.ts
+++ b/test/components/firmware-jobs-dialog-event-bubbling.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The jobs dialog lives inside the layout so its nested dialogs' open-*
+ * events reach the layout listeners. Pins that open-reset-build-env escapes
+ * the dialog untouched, and both halves of open-settings: the event keeps
+ * bubbling past the dialog, and the dialog closes itself.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import "../_mock-webawesome.js";
+vi.mock("../../src/util/notify.js", () => ({
+  notifySuccess: vi.fn(),
+  notifyError: vi.fn(),
+}));
+
+import { dialogOpen, mount } from "../_dom.js";
+import { ESPHomeFirmwareJobsDialog } from "../../src/components/firmware-jobs-dialog.js";
+
+describe("firmware-jobs-dialog event bubbling", () => {
+  it("lets open-reset-build-env escape to an ancestor", async () => {
+    const seen = vi.fn();
+    document.addEventListener("open-reset-build-env", seen, { once: true });
+    const dialog = await mount(new ESPHomeFirmwareJobsDialog());
+    dialog
+      .shadowRoot!.querySelector("esphome-command-dialog")!
+      .dispatchEvent(
+        new CustomEvent("open-reset-build-env", { bubbles: true, composed: true })
+      );
+    expect(seen).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets open-settings through to an ancestor and closes itself", async () => {
+    const seen = vi.fn();
+    const onOpenSettings = (e: Event) => seen((e as CustomEvent).detail);
+    document.addEventListener("open-settings", onOpenSettings);
+    try {
+      const dialog = await mount(new ESPHomeFirmwareJobsDialog());
+      dialog.open();
+      await dialog.updateComplete;
+      expect(dialogOpen(dialog)).toBe(true);
+
+      dialog.shadowRoot!.querySelector("esphome-command-dialog")!.dispatchEvent(
+        new CustomEvent("open-settings", {
+          detail: { section: "build_offload" },
+          bubbles: true,
+          composed: true,
+        })
+      );
+
+      expect(seen).toHaveBeenCalledWith({ section: "build_offload" });
+      expect(dialogOpen(dialog)).toBe(false);
+    } finally {
+      document.removeEventListener("open-settings", onOpenSettings);
+    }
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The Firmware tasks dialog was rendered as a sibling of the layout, so events from its nested command and install dialogs bubbled past the listeners app-shell binds on the layout; the dialog re-fired them itself and app-shell carried a duplicate binding. This moves the dialog inside the layout so those events reach the existing listeners directly, and deletes the four forwarders plus the duplicate binding. The dialog still closes itself on open-settings so Settings does not stack over it; it just lets the event keep bubbling instead of re-firing it. A comment at the render site records why the placement matters, a happy-dom test pins the bubble-and-close behaviour, and the host gets display: contents now that it sits in the layout flow. Page-scoped events (open editor, clean build, download firmware, show logs) keep their local handlers; the clean-build one becomes a stable class property instead of an inline arrow, so the listener is not re-bound on every progress tick.

Verified in the browser: from the nested command dialog, open-settings opens Settings on the requested section, open-reset-build-env opens the reset confirm, and open-firmware-jobs still opens the dialog.

**Related issue or feature (if applicable):**

- follow-up to #1732

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).



