### PR TITLE
Isolate the registerMdiIcons tests from shared mock history

### DIFF
--- a/test/util/register-icons.test.ts
+++ b/test/util/register-icons.test.ts
@@ -1,8 +1,8 @@
-import { beforeAll, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 // Capture the resolver handed to webawesome's icon-library registry so we
-// can drive it directly — registering the resolver is the only observable
-// output of ``registerMdiIcons`` (it returns void and mutates a wa-icon
+// can drive it directly: registering the resolver is the only observable
+// output of registerMdiIcons (it returns void and mutates a wa-icon
 // library side table).
 const { registerIconLibrary } = vi.hoisted(() => ({
   registerIconLibrary: vi.fn(),
@@ -11,19 +11,28 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/library.js", () => ({
   registerIconLibrary,
 }));
 
-import { mdiIconSrc, registerMdiIcons } from "../../src/util/register-icons.js";
+import { mdiIconSrc } from "../../src/util/register-icons.js";
 
 type Resolver = (name: string) => string;
+type IconsModule = typeof import("../../src/util/register-icons.js");
 
-/** Decode a ``data:image/svg+xml,...`` URI back to its SVG markup. */
+/** Decode a data:image/svg+xml URI back to its SVG markup. */
 function decode(dataUri: string): string {
   const prefix = "data:image/svg+xml,";
   expect(dataUri.startsWith(prefix)).toBe(true);
   return decodeURIComponent(dataUri.slice(prefix.length));
 }
 
+/** The resolver the module handed to the registry on its single registration. */
+function capturedResolver(): Resolver {
+  expect(registerIconLibrary).toHaveBeenCalledTimes(1);
+  const [library, options] = registerIconLibrary.mock.calls[0]!;
+  expect(library).toBe("mdi");
+  return (options as { resolver: Resolver }).resolver;
+}
+
 // Throwaway MDI-style path strings; their values are opaque to the helpers,
-// they just get interpolated into the SVG ``d`` attribute.
+// they just get interpolated into the SVG d attribute.
 const HOME = "M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z";
 const SQUARE = "M3 3h18v18H3z";
 
@@ -38,9 +47,9 @@ describe("mdiIconSrc", () => {
 
   test("percent-encodes the markup so it survives as a URI", () => {
     const src = mdiIconSrc(HOME);
-    // The raw SVG contains ``<``, ``"`` and spaces — none may appear
-    // literally in a well-formed data URI, and the ``<svg`` opener must
-    // come through escaped.
+    // The raw SVG contains <, " and spaces, none of which may appear
+    // literally in a well-formed data URI, and the <svg opener must come
+    // through escaped.
     expect(src).not.toContain("<");
     expect(src).not.toContain('"');
     expect(src).not.toContain(" ");
@@ -49,27 +58,26 @@ describe("mdiIconSrc", () => {
 });
 
 describe("registerMdiIcons", () => {
-  // The module keeps a single process-wide ``registered`` guard and shared
-  // icon map. Trigger the one-and-only registration here and reuse the
-  // captured resolver across every assertion below.
-  let resolver: Resolver;
+  // The module keeps a process-wide registered guard and a shared icon map,
+  // so every test loads a fresh copy and owns its own registration; no test
+  // depends on what an earlier one did or on how mock call history is
+  // carried between tests.
+  let registerMdiIcons: IconsModule["registerMdiIcons"];
 
-  beforeAll(() => {
-    registerMdiIcons({ home: HOME });
-    const call = registerIconLibrary.mock.calls[0];
-    expect(call).toBeDefined();
-    expect(call![0]).toBe("mdi");
-    resolver = (call![1] as { resolver: Resolver }).resolver;
+  beforeEach(async () => {
+    vi.resetModules();
+    registerIconLibrary.mockClear();
+    ({ registerMdiIcons } = await import("../../src/util/register-icons.js"));
   });
 
   test("resolves a registered icon name to its data URI", () => {
-    expect(resolver("home")).toBe(mdiIconSrc(HOME));
+    registerMdiIcons({ home: HOME });
+    expect(capturedResolver()("home")).toBe(mdiIconSrc(HOME));
   });
 
   test("returns an empty string and warns for an unknown name", () => {
-    // Restore the spy locally rather than in an ``afterEach`` so the
-    // once-guard assertion below stays decoupled from how vitest treats the
-    // hoisted ``registerIconLibrary`` mock's call history.
+    registerMdiIcons({ home: HOME });
+    const resolver = capturedResolver();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
       expect(resolver("does-not-exist")).toBe("");
@@ -81,16 +89,19 @@ describe("registerMdiIcons", () => {
   });
 
   test("registers the library exactly once across repeated calls", () => {
+    registerMdiIcons({ home: HOME });
     registerMdiIcons({ square: SQUARE });
     registerMdiIcons({ another: HOME });
-    // The ``registered`` guard means the registry only ever sees one ``mdi``
+    // The registered guard means the registry only ever sees one mdi
     // library; later calls just extend the shared map.
     expect(registerIconLibrary).toHaveBeenCalledTimes(1);
   });
 
   test("a later call extends the same map the captured resolver reads", () => {
-    // ``late`` is unknown until registered after the resolver closed over
-    // the map, yet the resolver reads the live shared map, so once added it
+    registerMdiIcons({ home: HOME });
+    const resolver = capturedResolver();
+    // late is unknown until registered after the resolver closed over the
+    // map, yet the resolver reads the live shared map, so once added it
     // resolves all the same.
     expect(resolver("late")).toBe("");
     registerMdiIcons({ late: SQUARE });


### PR DESCRIPTION
# What does this implement/fix?

The registerMdiIcons tests registered the library once in a beforeAll and then asserted on that call count from a later test. Vitest 5 turns on clearMocks by default, so the call history is wiped before each test and the "exactly once" assertion sees zero calls, which is what fails on #1729.

Each test now loads a fresh copy of the module and makes its own registration, so no test depends on an earlier one or on how mock history is carried between tests; the suite passes on vitest 4 and 5.

**Related issue or feature (if applicable):**

- unblocks https://github.com/esphome/device-builder-frontend/pull/1729

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pnpm run lint` passes.
- [x] `pnpm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
